### PR TITLE
Update incorrect DNS names in productpage/reviews

### DIFF
--- a/demos/apps/bookinfo/README.md
+++ b/demos/apps/bookinfo/README.md
@@ -51,6 +51,9 @@ $ cp istioctl-osx /usr/local/bin/istioctl
    
    This command launches the Istio manager, mixer, and an envoy-based ingress controller, which will be used
    to implement the gateway for the application. 
+   
+   **Note:** If you have a load balancer attached to the Ingress
+   controller, change the ingress controller service type from NodePort to LoadBalancer accordingly.
 
 1. Bring up the application containers:
 

--- a/demos/apps/bookinfo/src/productpage/productpage.py
+++ b/demos/apps/bookinfo/src/productpage/productpage.py
@@ -28,25 +28,25 @@ from flask_bootstrap import Bootstrap
 Bootstrap(app)
 
 details = {
-    "name" : "http://details.default.svc:9080",
+    "name" : "http://details:9080",
     "endpoint" : "details",
     "children" : []
 }
 
 ratings = {
-    "name" : "http://ratings.default.svc:9080",
+    "name" : "http://ratings:9080",
     "endpoint" : "ratings",
     "children" : []
 }
 
 reviews = {
-    "name" : "http://reviews.default.svc:9080",
+    "name" : "http://reviews:9080",
     "endpoint" : "reviews",
     "children" : [ratings]
 }
 
 productpage = {
-    "name" : "http://productpage.default.svc:9080",
+    "name" : "http://productpage:9080",
     "endpoint" : "details",
     "children" : [details, reviews]
 }

--- a/demos/apps/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/demos/apps/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -41,7 +41,7 @@ public class LibertyRestEndpoint extends Application {
 
     private final static Boolean ratings_enabled = Boolean.valueOf(System.getenv("ENABLE_RATINGS"));
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
-    private final static String ratings_service = "http://ratings.default.svc:9080/ratings";
+    private final static String ratings_service = "http://ratings:9080/ratings";
 
     private final static String review_resp = ""+
       "<blockquote>"+

--- a/demos/istio/ingress-controller.yaml
+++ b/demos/istio/ingress-controller.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     infra: istio-ingress-controller
 spec:
-  type: LoadBalancer
+  type: NodePort
   ports:
   - port: 80
     nodePort: 32000


### PR DESCRIPTION
The DNS names in productpage and reviews hardcoded the namespace to default (e.g., reviews.default.svc.cluster.local), making the demo not portable across namespaces. This PR fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/istio/60)
<!-- Reviewable:end -->
