### PR TITLE
Use correct image for init-container (s/runtime/init)

### DIFF
--- a/doc/frontend-and-proxy.yaml
+++ b/doc/frontend-and-proxy.yaml
@@ -14,7 +14,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: >
           [{
             "name": "iptables",
-            "image": "docker.io/istio/runtime:2017-03-17-22.11.25",
+            "image": "docker.io/istio/init:2017-03-17-22.11.25",
             "imagePullPolicy": "Always",
             "securityContext": { "capabilities" : { "add" : ["NET_ADMIN"] } }
           }]

--- a/doc/hello-and-proxy.yaml
+++ b/doc/hello-and-proxy.yaml
@@ -33,7 +33,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: >
           [{
             "name": "iptables",
-            "image": "docker.io/istio/runtime:2017-03-17-22.11.25",
+            "image": "docker.io/istio/init:2017-03-17-22.11.25",
             "imagePullPolicy": "Always",
             "securityContext": { "capabilities" : { "add" : ["NET_ADMIN"] } }
           }]


### PR DESCRIPTION
The `doc/getting-started.md` instructions didn't work for me with this fix, but we weren't really going through the proxy anyway because the iptable rules weren't setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/istio/86)
<!-- Reviewable:end -->
