### PR TITLE
Change mixer selector to use a wildcard instead of a regex.

### DIFF
--- a/demos/mixer-config-quota-bookinfo.yaml
+++ b/demos/mixer-config-quota-bookinfo.yaml
@@ -77,7 +77,7 @@ data:
     subject: namespace:ns
     revision: "2022"
     rules:
-    - selector: target.service == "ratings.*"
+    - selector: target.service == "ratings*"
       aspects:
       - kind: quotas
         params:


### PR DESCRIPTION
The mixer does not yet support regex matches in expressions, but has special handling for wildcards.

I tested the mixer in isolation with exactly the config in this file and rate limiting was applied as expected, and also tested by setting up the book demo app:

1. `kubeTest.sh -s`
2. `kubectl apply -f demos/mixer-config-quota-bookinfo.yaml`
3. `while true; do curl -s -o /dev/null http://$GATEWAY_URL/productpage; done`

Unlike before, the stars disappear 100% of the page reloads. 