### PR TITLE
Update grafana.yaml

### DIFF
--- a/kubernetes/addons/grafana.yaml
+++ b/kubernetes/addons/grafana.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/istio-testing/grafana:demo
+        image: gcr.io/istio-testing/grafana:alpha
         ports:
           - containerPort: 3000
         env:
@@ -41,8 +41,6 @@ spec:
           value: Admin
         - name: GF_PATHS_DATA
           value: /data/grafana
-        - name: DASHBOARD_URL
-          value: https://raw.githubusercontent.com/istio/mixer/3047e660a4dff073b0138af48c073b4de3651b7d/deploy/kube/conf/grafana-dashboard.json
         volumeMounts:
         - mountPath: /data/grafana
           name: grafana-data

--- a/kubernetes/addons/grafana.yaml
+++ b/kubernetes/addons/grafana.yaml
@@ -28,6 +28,7 @@ spec:
       containers:
       - name: grafana
         image: gcr.io/istio-testing/grafana:alpha
+        imagePullPolicy: Always
         ports:
           - containerPort: 3000
         env:


### PR DESCRIPTION
Remove hardcoded dashboard URL. Update to newer alpha-tagged build image.