### PR TITLE
Add http-apiserver port 8081 to istio-manager service

### DIFF
--- a/kubernetes/istio-15.yaml
+++ b/kubernetes/istio-15.yaml
@@ -68,6 +68,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -205,4 +207,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-

--- a/kubernetes/istio-16.yaml
+++ b/kubernetes/istio-16.yaml
@@ -68,6 +68,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -311,4 +313,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-

--- a/kubernetes/istio-auth-15.yaml
+++ b/kubernetes/istio-auth-15.yaml
@@ -68,6 +68,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -255,4 +257,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-

--- a/kubernetes/istio-auth-16.yaml
+++ b/kubernetes/istio-auth-16.yaml
@@ -68,6 +68,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -361,4 +363,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-

--- a/kubernetes/istio-auth.yaml
+++ b/kubernetes/istio-auth.yaml
@@ -68,6 +68,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -255,4 +257,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-

--- a/kubernetes/istio-install/istio-manager.yaml
+++ b/kubernetes/istio-install/istio-manager.yaml
@@ -21,6 +21,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     istio: manager
 ---
@@ -69,4 +71,3 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
 ---
-


### PR DESCRIPTION
This is necessary to access the Manager API server via Kubernetes
service instead of through pod with `kubectl port-forward` (see
https://github.com/istio/manager/pull/669 for corresponding istioctl
changes)