### PR TITLE
Update cleanup script to ignore not found errors

### DIFF
--- a/samples/apps/bookinfo/cleanup.sh
+++ b/samples/apps/bookinfo/cleanup.sh
@@ -16,14 +16,26 @@
 
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-for rule in $(istioctl get route-rules); do
-  istioctl delete route-rule $rule;
+# only ask if in interactive mode
+if [[ -t 0 ]];then
+  echo -n "namespace ? [default] "
+  read NAMESPACE
+fi
+
+if [[ -z ${NAMESPACE} ]];then
+  NAMESPACE=default
+fi
+
+echo "using NAMESPACE=${NAMESPACE}"
+
+for rule in $(istioctl get -n ${NAMESPACE}  route-rules); do
+  istioctl delete -n ${NAMESPACE} route-rule $rule;
 done
 #istioctl delete mixer-rule ratings-ratelimit
 
 export OUTPUT=$(mktemp)
 echo "Application cleanup may take up to one minute"
-kubectl delete -f $SCRIPTDIR/bookinfo.yaml > ${OUTPUT} 2>&1
+kubectl delete -n ${NAMESPACE} -f $SCRIPTDIR/bookinfo.yaml > ${OUTPUT} 2>&1
 ret=$?
 function cleanup() {
   rm -f ${OUTPUT}


### PR DESCRIPTION
* Iterates over rules and deletes them
* While deleting deployment, ignores NotFound errors.
* Ask for namespace as input in interactive mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/istio/267)
<!-- Reviewable:end -->
