### PR TITLE
Updated v1alpha to use fine grain RBAC rules

### DIFF
--- a/install/kubernetes/istio-rbac-alpha.yaml
+++ b/install/kubernetes/istio-rbac-alpha.yaml
@@ -1,14 +1,109 @@
 # Permissions and roles for istio
+# To debug: start the cluster with -vmodule=rbac,3 to enable verbose logging on RBAC DENY
+# Also helps to enable logging on apiserver 'wrap' to see the URLs.
+# Each RBAC deny needs to be mapped into a rule for the role.
+# If using minikube, start with '--extra-config=apiserver.Authorization.Mode=RBAC'
+#
+# NOTE: If deploying istio to a namespace other than 'default' then change the
+# ClusterRoleBinding namspace target appropriately.
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1alpha1
-kind: RoleBinding
 metadata:
-  name: istio-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin-role-resourceURLSs
+  name: istio-manager
+rules:
+- apiGroups: ["istio.io"]
+  resources: ["istioconfigs", "istioconfigs.istio.io"]
+  verbs: ["*"]
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-ca
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["watch", "list"]
+---
+# Permissions for the sidecar proxy.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-sidecar
+rules:
+- apiGroups: ["istio.io"]
+  resources: ["istioconfigs"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["configmaps", "pods", "endpoints", "services"]
+  verbs: ["get", "watch", "list"]
+---
+# Grant permissions to the Manager/discovery.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-manager-admin-role-binding
 subjects:
 - kind: ServiceAccount
   name: istio-manager-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: istio-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# Grant permissions to the Manager/discovery.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-ca-role-binding
+subjects:
+- kind: ServiceAccount
+  name: istio-ca-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: istio-ca
+  apiGroup: rbac.authorization.k8s.io
+---
+# Grant permissions to the Ingress controller.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-ingress-admin-role-binding
+subjects:
 - kind: ServiceAccount
   name: istio-ingress-service-account
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: istio-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# Grant permissions to the sidecar.
+# TEMPORARY: the istioctl should generate a separate service account for the proxy, and permission
+# granted only to that account !
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: istio-sidecar-role-binding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: istio-sidecar
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/install/kubernetes/istio-rbac-alpha.yaml
+++ b/install/kubernetes/istio-rbac-alpha.yaml
@@ -18,8 +18,11 @@ rules:
   resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses"]
   verbs: ["*"]
 - apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces"]
+  resources: ["configmaps", "endpoints", "pods", "services"]
   verbs: ["*"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1alpha1
@@ -28,7 +31,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list"]
+  verbs: ["create", "get", "watch", "list", "update"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["watch", "list"]
@@ -57,7 +60,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-manager-service-account
-  namespace: default
+  namespace: istio
 roleRef:
   kind: ClusterRole
   name: istio-manager
@@ -71,7 +74,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-ca-service-account
-  namespace: default
+  namespace: istio
 roleRef:
   kind: ClusterRole
   name: istio-ca
@@ -85,7 +88,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-ingress-service-account
-  namespace: default
+  namespace: istio
 roleRef:
   kind: ClusterRole
   name: istio-manager
@@ -101,7 +104,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: default
+  namespace: istio
 roleRef:
   kind: ClusterRole
   name: istio-sidecar

--- a/install/kubernetes/istio-rbac-alpha.yaml
+++ b/install/kubernetes/istio-rbac-alpha.yaml
@@ -60,7 +60,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-manager-service-account
-  namespace: istio
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: istio-manager
@@ -74,7 +74,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-ca-service-account
-  namespace: istio
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: istio-ca
@@ -88,7 +88,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-ingress-service-account
-  namespace: istio
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: istio-manager
@@ -104,7 +104,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: istio
+  namespace: default
 roleRef:
   kind: ClusterRole
   name: istio-sidecar


### PR DESCRIPTION
This is the fix for issue #217 .

Note, I had to add the "namespaces" resource type to the istio-manager ClusterRole. I'm guessing that the istio-rbac-beta.yaml has the same issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/istio/272)
<!-- Reviewable:end -->
