### PR TITLE
add additional files to release bundle

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -76,7 +76,7 @@ function create_windows_archive() {
 
 pushd ${ROOT}
 cp istio.VERSION "${COMMON_FILES_DIR}"/
-find samples install -type f -name "*.yaml" \
+find samples install -type f -name "*.yaml" -o -name "cleanup*" \
   -exec cp --parents {} "${COMMON_FILES_DIR}" \;
 popd
 

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -76,7 +76,7 @@ function create_windows_archive() {
 
 pushd ${ROOT}
 cp istio.VERSION "${COMMON_FILES_DIR}"/
-find samples install -type f -name "*.yaml" -o -name "cleanup*" \
+find samples install -type f \( -name "*.yaml" -o -name "cleanup*" \) \
   -exec cp --parents {} "${COMMON_FILES_DIR}" \;
 popd
 

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -75,8 +75,8 @@ function create_windows_archive() {
 }
 
 pushd ${ROOT}
-cp istio.VERSION "${COMMON_FILES_DIR}"/
-find samples install -type f \( -name "*.yaml" -o -name "cleanup*" \) \
+cp istio.VERSION LICENSE "${COMMON_FILES_DIR}"/
+find samples install -type f \( -name "*.yaml" -o -name "cleanup*" -o -name "README.md" \) \
   -exec cp --parents {} "${COMMON_FILES_DIR}" \;
 popd
 


### PR DESCRIPTION
currently only the istio.VERSION and `*.yaml` files are getting added to the release.  This will copy all current and future `cleanup*` scripts

Added root level LICENSE and README's to release as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/istio/290)
<!-- Reviewable:end -->
