### PR TITLE
Remove LoadBalancers from addons

### DIFF
--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: grafana
 spec:
-  type: LoadBalancer
+#  type: LoadBalancer
   ports:
   - port: 3000
     protocol: TCP

--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -4,7 +4,6 @@ kind: Service
 metadata:
   name: grafana
 spec:
-#  type: LoadBalancer
   ports:
   - port: 3000
     protocol: TCP

--- a/install/kubernetes/addons/prometheus.yaml
+++ b/install/kubernetes/addons/prometheus.yaml
@@ -44,7 +44,6 @@ metadata:
 spec:
   selector:
     app: prometheus
-#  type: LoadBalancer
   ports:
   - name: prometheus
     protocol: TCP

--- a/install/kubernetes/addons/servicegraph.yaml
+++ b/install/kubernetes/addons/servicegraph.yaml
@@ -25,7 +25,6 @@ kind: Service
 metadata:
   name: servicegraph
 spec:
-#  type: LoadBalancer
   ports:
   - name: http
     port: 8088

--- a/install/kubernetes/addons/servicegraph.yaml
+++ b/install/kubernetes/addons/servicegraph.yaml
@@ -25,7 +25,7 @@ kind: Service
 metadata:
   name: servicegraph
 spec:
-  type: LoadBalancer
+#  type: LoadBalancer
   ports:
   - name: http
     port: 8088

--- a/install/kubernetes/addons/zipkin.yaml
+++ b/install/kubernetes/addons/zipkin.yaml
@@ -29,7 +29,6 @@ kind: Service
 metadata:
   name: zipkin
 spec:
-  # type: LoadBalancer
   ports:
   - name: http
     port: 9411

--- a/install/kubernetes/addons/zipkin.yaml
+++ b/install/kubernetes/addons/zipkin.yaml
@@ -29,12 +29,10 @@ kind: Service
 metadata:
   name: zipkin
 spec:
-  #type: NodePort
-  type: LoadBalancer
+  # type: LoadBalancer
   ports:
   - name: http
     port: 9411
-    #nodePort: 30411
   selector:
     app: zipkin
 ---

--- a/install/kubernetes/istio-auth-with-cluster-ca.yaml
+++ b/install/kubernetes/istio-auth-with-cluster-ca.yaml
@@ -1,14 +1,12 @@
 # GENERATED FILE. Use with Kubernetes 1.5+
 # TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh
 # Mixer
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-mixer
 data:
-  mapping.conf:
-
+  mapping.conf: |-
 ---
 apiVersion: v1
 kind: Service

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -1,14 +1,12 @@
 # GENERATED FILE. Use with Kubernetes 1.5+
 # TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh
 # Mixer
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-mixer
 data:
-  mapping.conf:
-
+  mapping.conf: |-
 ---
 apiVersion: v1
 kind: Service

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -1,14 +1,12 @@
 # GENERATED FILE. Use with Kubernetes 1.5+
 # TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh
 # Mixer
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-mixer
 data:
-  mapping.conf:
-
+  mapping.conf: |-
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This removes LoadBalancer types from all addons.  When this PR goes in, a follow-on PR to update the docs at istio.github.com will be created and pushed.

Fixes #255.