### PR TITLE
add template merge for cluster-ca

### DIFF
--- a/install/kubernetes/istio-auth-with-cluster-ca.yaml
+++ b/install/kubernetes/istio-auth-with-cluster-ca.yaml
@@ -258,3 +258,37 @@ spec:
           secretName: istio.default
 ---
 
+# istio-system namespace for Istio CA.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+---
+# Service account CA runs in.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ca-service-account
+  namespace: istio-system
+---
+# Istio CA in istio-system namespace.
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: istio-ca
+  namespace: istio-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: istio-ca
+    spec:
+      serviceAccountName: istio-ca-service-account
+      containers:
+      - name: istio-ca
+        image: docker.io/istio/istio-ca:0.1.5
+        imagePullPolicy: IfNotPresent
+---
+

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -121,6 +121,7 @@ function merge_files() {
   cat $AUTH_SRC/istio-egress-auth.yaml >> $ISTIO_AUTH
   cp $ISTIO_AUTH $ISTIO_AUTH_WITH_CLUSTER_CA
   cat $AUTH_SRC/istio-namespace-ca.yaml >> $ISTIO_AUTH
+  cat $AUTH_SRC/istio-cluster-ca.yaml >> $ISTIO_AUTH_WITH_CLUSTER_CA
 }
 
 function update_version_file() {


### PR DESCRIPTION
It appears that updateVersion.sh is missing a concatenation for `install/kubernetes/istio-auth-with-cluster-ca.yaml`

This PR adds it in, to allow a cluster-wide CA. 