### PR TITLE
Add sleep time into default route testing

### DIFF
--- a/tests/kubeTest.sh
+++ b/tests/kubeTest.sh
@@ -106,7 +106,7 @@ do
         echo "Success!"
         break
     fi
-    sleep 10
+    sleep 60
 done
 
 # Test version routing


### PR DESCRIPTION
For mixer e2e-smoketest, we have been observing near constant failures. They seem to be related to failure to resolve default routes. This change increases the sleep time between retries in an attempt to make the tests more resilient.