### PR TITLE
fortio update

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -358,13 +358,11 @@ Assuming you did (once):
    git clone https://github.com/istio/proxy.git
    git clone https://github.com/istio/mixer.git
    git clone https://github.com/istio/istio.git
-   # if you want to do load tests:
-   git clone https://github.com/wg/wrk.git
    ```
 4. You can then use
    - [update_all](update_all) : script to build from source
    - [setup_run](setup_run) : run locally
-   - [fortio](fortio/) (φορτίο) : load testing
+   - [fortio](fortio/) (φορτίο) : load testing and minimal echo server
    - Also found in this directory: [rules.yml](rules.yml) : the version of  mixer/testdata/configroot/scopes/global/subjects/global/rules.yml that works locally and [quota.yml](quota.yml) a very simple 1 qps quota example used below.
    - And an unrelated tool to aggregate [GitHub Contributions](githubContrib/) statistics.
 5. And run things like

--- a/devel/fortio/BUILD.bazel
+++ b/devel/fortio/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "http_test.go",
         "periodic_test.go",
         "stats_test.go",
     ],

--- a/devel/fortio/README.md
+++ b/devel/fortio/README.md
@@ -59,70 +59,71 @@ Response Body Sizes : count 40 avg 10720.675 +/- 526.9 min 10403 max 11848 sum 4
 
 Fortio is written in the [Go](https://golang.org) language and includes a scalable semi log histogram in [stats.go](stats.go) and a periodic runner engine in [periodic.go](periodic.go).
 
-You can run the histogram code standalone as a command line in [cmd/histogram/](cmd/histogram/) and a basic echo http server in [cmd/echosrv/](cmd/echosrv/) and the main [cmd/fortio/](cmd/fortio/) 
+You can run the histogram code standalone as a command line in [cmd/histogram/](cmd/histogram/) and a basic echo http server in [cmd/echosrv/](cmd/echosrv/) and the main [cmd/fortio/](cmd/fortio/)
 
 ## Another example output
 
 With 5k qps: (includes envoy and mixer in the calls)
 ```
 $ time fortio -qps 5000 -t 60s -c 8 -r 0.0001 -H "Host: perf-cluster" http://benchmark-2:9090/echo
-2017/07/04 23:23:17 will be setting special Host header to perf-cluster
-Running at 5000 queries per second for 1m0s: http://benchmark-2:9090/echo
+2017/07/09 02:31:05 Will be setting special Host header to perf-cluster
+Fortio running at 5000 queries per second for 1m0s: http://benchmark-2:9090/echo
 Starting at 5000 qps with 8 thread(s) [gomax 4] for 1m0s : 37500 calls each (total 300000)
-2017/07/04 23:24:18 T003 ended after 1m0.001167643s : 37500 calls. qps=624.9878372887783
-2017/07/04 23:24:18 T005 ended after 1m0.001495277s : 37500 calls. qps=624.984424586076
-2017/07/04 23:24:18 T002 ended after 1m0.001912089s : 37500 calls. qps=624.9800830409666
-2017/07/04 23:24:18 T007 ended after 1m0.002169199s : 37500 calls. qps=624.9774049939678
-2017/07/04 23:24:18 T004 ended after 1m0.005409967s : 37500 calls. qps=624.9436512578307
-2017/07/04 23:24:18 T006 ended after 1m0.005477967s : 37500 calls. qps=624.9429430530179
-2017/07/04 23:24:18 T001 ended after 1m0.006298151s : 37500 calls. qps=624.9344011462747
-2017/07/04 23:24:18 T000 ended after 1m0.009879778s : 37500 calls. qps=624.8971025892263
-Ended after 1m0.009899223s : 300000 calls. qps=4999.2
-Aggregated Sleep Time : count 299992 avg -0.000109038 +/- 0.002748 min -0.04674458 max 0.000959315 sum -32.7105262
+2017/07/09 02:32:05 T004 ended after 1m0.000907812s : 37500 calls. qps=624.9905437680746
+2017/07/09 02:32:05 T000 ended after 1m0.000922222s : 37500 calls. qps=624.9903936684861
+2017/07/09 02:32:05 T005 ended after 1m0.00094454s : 37500 calls. qps=624.9901611965524
+2017/07/09 02:32:05 T006 ended after 1m0.000944816s : 37500 calls. qps=624.9901583216429
+2017/07/09 02:32:05 T001 ended after 1m0.00102094s : 37500 calls. qps=624.9893653892883
+2017/07/09 02:32:05 T007 ended after 1m0.001096292s : 37500 calls. qps=624.9885805003184
+2017/07/09 02:32:05 T003 ended after 1m0.001045342s : 37500 calls. qps=624.9891112105419
+2017/07/09 02:32:05 T002 ended after 1m0.001044416s : 37500 calls. qps=624.9891208560392
+Ended after 1m0.00112695s : 300000 calls. qps=4999.9
+Aggregated Sleep Time : count 299992 avg 8.8889218e-05 +/- 0.002326 min -0.03490402 max 0.001006041 sum 26.6660543
 # range, mid point, percentile, count
-< 0 , 0 , 10.14, 30428
->= 0 < 0.001 , 0.0005 , 100.00, 269564
-# target 50% 0.000425514
-WARNING 10.14% of sleep were falling behind
-Aggregated Function Time : count 300000 avg 0.0010281581 +/- 0.0008435 min 0.000532125 max 0.031632753 sum 308.447442
+< 0 , 0 , 8.58, 25726
+>= 0 < 0.001 , 0.0005 , 100.00, 274265
+>= 0.001 < 0.002 , 0.0015 , 100.00, 1
+# target 50% 0.000453102
+WARNING 8.58% of sleep were falling behind
+Aggregated Function Time : count 300000 avg 0.00094608764 +/- 0.0007901 min 0.000510522 max 0.029267604 sum 283.826292
 # range, mid point, percentile, count
->= 0.0005 < 0.0006 , 0.00055 , 0.02, 54
->= 0.0006 < 0.0007 , 0.00065 , 0.98, 2873
->= 0.0007 < 0.0008 , 0.00075 , 8.23, 21753
->= 0.0008 < 0.0009 , 0.00085 , 33.09, 74599
->= 0.0009 < 0.001 , 0.00095 , 66.75, 100972
->= 0.001 < 0.0011 , 0.00105 , 86.81, 60193
->= 0.0011 < 0.0012 , 0.00115 , 93.41, 19790
->= 0.0012 < 0.0014 , 0.0013 , 96.54, 9400
->= 0.0014 < 0.0016 , 0.0015 , 97.67, 3373
->= 0.0016 < 0.0018 , 0.0017 , 98.19, 1574
->= 0.0018 < 0.002 , 0.0019 , 98.51, 936
->= 0.002 < 0.0025 , 0.00225 , 98.96, 1369
->= 0.0025 < 0.003 , 0.00275 , 99.19, 674
->= 0.003 < 0.0035 , 0.00325 , 99.33, 434
->= 0.0035 < 0.004 , 0.00375 , 99.43, 302
->= 0.004 < 0.0045 , 0.00425 , 99.52, 271
->= 0.0045 < 0.005 , 0.00475 , 99.62, 307
->= 0.005 < 0.006 , 0.0055 , 99.76, 395
->= 0.006 < 0.007 , 0.0065 , 99.81, 156
->= 0.007 < 0.008 , 0.0075 , 99.82, 25
->= 0.008 < 0.009 , 0.0085 , 99.82, 11
->= 0.009 < 0.01 , 0.0095 , 99.82, 7
->= 0.01 < 0.012 , 0.011 , 99.83, 10
->= 0.012 < 0.014 , 0.013 , 99.83, 8
->= 0.014 < 0.016 , 0.015 , 99.89, 186
->= 0.016 < 0.018 , 0.017 , 99.94, 141
->= 0.018 < 0.02 , 0.019 , 99.94, 22
->= 0.02 < 0.025 , 0.0225 , 99.98, 95
->= 0.025 < 0.03 , 0.0275 , 100.00, 64
->= 0.03 < 0.035 , 0.0325 , 100.00, 6
-# target 50% 0.000950233
-# target 75% 0.00104112
-# target 99% 0.00258457
-# target 99.9% 0.0163972
+>= 0.0005 < 0.0006 , 0.00055 , 0.15, 456
+>= 0.0006 < 0.0007 , 0.00065 , 3.25, 9295
+>= 0.0007 < 0.0008 , 0.00075 , 24.23, 62926
+>= 0.0008 < 0.0009 , 0.00085 , 62.73, 115519
+>= 0.0009 < 0.001 , 0.00095 , 85.68, 68854
+>= 0.001 < 0.0011 , 0.00105 , 93.11, 22293
+>= 0.0011 < 0.0012 , 0.00115 , 95.38, 6792
+>= 0.0012 < 0.0014 , 0.0013 , 97.18, 5404
+>= 0.0014 < 0.0016 , 0.0015 , 97.94, 2275
+>= 0.0016 < 0.0018 , 0.0017 , 98.34, 1198
+>= 0.0018 < 0.002 , 0.0019 , 98.60, 775
+>= 0.002 < 0.0025 , 0.00225 , 98.98, 1161
+>= 0.0025 < 0.003 , 0.00275 , 99.21, 671
+>= 0.003 < 0.0035 , 0.00325 , 99.36, 449
+>= 0.0035 < 0.004 , 0.00375 , 99.47, 351
+>= 0.004 < 0.0045 , 0.00425 , 99.57, 290
+>= 0.0045 < 0.005 , 0.00475 , 99.66, 280
+>= 0.005 < 0.006 , 0.0055 , 99.79, 380
+>= 0.006 < 0.007 , 0.0065 , 99.82, 92
+>= 0.007 < 0.008 , 0.0075 , 99.83, 15
+>= 0.008 < 0.009 , 0.0085 , 99.83, 5
+>= 0.009 < 0.01 , 0.0095 , 99.83, 1
+>= 0.01 < 0.012 , 0.011 , 99.83, 8
+>= 0.012 < 0.014 , 0.013 , 99.84, 35
+>= 0.014 < 0.016 , 0.015 , 99.92, 231
+>= 0.016 < 0.018 , 0.017 , 99.94, 65
+>= 0.018 < 0.02 , 0.019 , 99.95, 26
+>= 0.02 < 0.025 , 0.0225 , 100.00, 139
+>= 0.025 < 0.03 , 0.0275 , 100.00, 14
+# target 50% 0.000866935
+# target 75% 0.000953452
+# target 99% 0.00253875
+# target 99.9% 0.0155152
 Code 200 : 300000
+Response Body Sizes : count 300000 avg 0 +/- 0 min 0 max 0 sum 0
 ```
 
 Or graphically:
 
-![Chart](https://user-images.githubusercontent.com/3664595/27844778-3776e1e6-60db-11e7-99fa-8899e21be047.png)
+![Chart](https://user-images.githubusercontent.com/3664595/27990803-490a618c-6417-11e7-9773-12e0d051128f.png)

--- a/devel/fortio/cmd/fortio/BUILD.bazel
+++ b/devel/fortio/cmd/fortio/BUILD.bazel
@@ -1,8 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_binary(
     name = "fortio",
-    srcs = ["main.go"],
+    library = ":go_default_library",
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    visibility = ["//visibility:private"],
     deps = ["//devel/fortio:go_default_library"],
 )

--- a/devel/fortio/cmd/fortio/main.go
+++ b/devel/fortio/cmd/fortio/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime"
 	"sort"
 
 	"istio.io/istio/devel/fortio"
@@ -82,6 +83,7 @@ func main() {
 		percentilesFlag = flag.String("p", "50,75,99,99.9", "List of pXX to calculate")
 		resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
 		compressionFlag = flag.Bool("compression", false, "Enable http compression")
+		goMaxProcsFlag  = flag.Int("gomaxprocs", 0, "Setting for runtime.GOMAXPROCS, <1 doesn't change the default")
 		headersFlags    flagList
 	)
 	flag.Var(&headersFlags, "H", "Additional Header(s)")
@@ -98,7 +100,9 @@ func main() {
 		usage()
 	}
 	url = flag.Arg(0)
-	fmt.Printf("Fortio running at %g queries per second for %v: %s\n", *qpsFlag, *durationFlag, url)
+	prevGoMaxProcs := runtime.GOMAXPROCS(*goMaxProcsFlag)
+	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
+		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
 	o := fortio.RunnerOptions{
 		QPS:         *qpsFlag,
 		Function:    test,

--- a/devel/fortio/cmd/fortio/main.go
+++ b/devel/fortio/cmd/fortio/main.go
@@ -81,6 +81,7 @@ func main() {
 		durationFlag    = flag.Duration("t", defaults.Duration, "How long to run the test")
 		percentilesFlag = flag.String("p", "50,75,99,99.9", "List of pXX to calculate")
 		resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
+		compressionFlag = flag.Bool("compression", false, "Enable http compression")
 		headersFlags    flagList
 	)
 	flag.Var(&headersFlags, "H", "Additional Header(s)")
@@ -109,7 +110,7 @@ func main() {
 	}
 	r := fortio.NewPeriodicRunner(&o)
 	numThreads := r.Options().NumThreads
-	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = numThreads + 1
+	fortio.TuneHTTPClient(numThreads, *compressionFlag) // set pool size etc
 	// 1 Warm up / smoke test:  TODO: warm up all threads/connections
 	code, body := fortio.FetchURL(url)
 	if code != http.StatusOK {

--- a/devel/fortio/http.go
+++ b/devel/fortio/http.go
@@ -18,9 +18,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 )
 
 // ExtraHeaders to be added to each request.
@@ -85,16 +87,28 @@ func newHTTPRequest(url string) *http.Request {
 	return req
 }
 
+// Client object for making repeated requests of the same URL using the same
+// http client
+type Client struct {
+	url    string
+	req    *http.Request
+	client *http.Client
+}
+
 // FetchURL fetches URL contenty and does error handling/logging.
 func FetchURL(url string) (int, []byte) {
-	req := newHTTPRequest(url)
-	if req == nil {
+	client := NewClient(url, 1, true)
+	if client == nil {
 		return http.StatusBadRequest, []byte("bad url")
 	}
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	return client.Fetch()
+}
+
+// Fetch fetches the byte and code for pre created client
+func (c *Client) Fetch() (int, []byte) {
+	resp, err := c.client.Do(c.req)
 	if err != nil {
-		log.Printf("Unable to send request for %s : %v", url, err)
+		log.Printf("Unable to send request for %s : %v", c.url, err)
 		return http.StatusBadRequest, []byte(err.Error())
 	}
 	var data []byte
@@ -102,13 +116,13 @@ func FetchURL(url string) (int, []byte) {
 		if data, err = httputil.DumpResponse(resp, false); err != nil {
 			log.Printf("Unable to dump response %v", err)
 		} else {
-			log.Printf("For URL %s, received:\n%s", url, data)
+			log.Printf("For URL %s, received:\n%s", c.url, data)
 		}
 	}
 	data, err = ioutil.ReadAll(resp.Body)
 	resp.Body.Close() //nolint(errcheck)
 	if err != nil {
-		log.Printf("Unable to read response for %s : %v", url, err)
+		log.Printf("Unable to read response for %s : %v", c.url, err)
 		code := resp.StatusCode
 		if code == http.StatusOK {
 			code = http.StatusNoContent
@@ -118,15 +132,32 @@ func FetchURL(url string) (int, []byte) {
 	}
 	code := resp.StatusCode
 	if Verbosity > 1 {
-		log.Printf("Got %d : %s for %s - response is %d bytes", code, resp.Status, url, len(data))
+		log.Printf("Got %d : %s for %s - response is %d bytes", code, resp.Status, c.url, len(data))
 	}
 	return code, data
 }
 
-// TuneHTTPClient tunes the client for a given expected number of connections.
-func TuneHTTPClient(numConnections int, compression bool) {
-	ht := http.DefaultTransport.(*http.Transport)
-	ht.MaxIdleConns = numConnections
-	ht.MaxIdleConnsPerHost = numConnections
-	ht.DisableCompression = !compression
+// NewClient creates a client object
+func NewClient(url string, numConnections int, compression bool) *Client {
+	req := newHTTPRequest(url)
+	if req == nil {
+		return nil
+	}
+	client := Client{
+		url,
+		req,
+		&http.Client{
+			Timeout: 3 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        numConnections,
+				MaxIdleConnsPerHost: numConnections,
+				DisableCompression:  !compression,
+				Dial: (&net.Dialer{
+					Timeout: 1 * time.Second,
+				}).Dial,
+				TLSHandshakeTimeout: 1 * time.Second,
+			},
+		},
+	}
+	return &client
 }

--- a/devel/fortio/http.go
+++ b/devel/fortio/http.go
@@ -122,3 +122,11 @@ func FetchURL(url string) (int, []byte) {
 	}
 	return code, data
 }
+
+// TuneHTTPClient tunes the client for a given expected number of connections.
+func TuneHTTPClient(numConnections int, compression bool) {
+	ht := http.DefaultTransport.(*http.Transport)
+	ht.MaxIdleConns = numConnections
+	ht.MaxIdleConnsPerHost = numConnections
+	ht.DisableCompression = !compression
+}

--- a/devel/fortio/periodic.go
+++ b/devel/fortio/periodic.go
@@ -170,7 +170,7 @@ func (r *periodicRunner) Run() {
 	fmt.Printf("Ended after %v : %d calls. qps=%.5g\n", elapsed, functionDuration.Count, actualQPS)
 	if useQPS {
 		percentNegative := 100. * float64(sleepTime.hdata[0]) / float64(sleepTime.Count)
-		if percentNegative > 3 {
+		if percentNegative > 5 {
 			sleepTime.Print(os.Stdout, "Aggregated Sleep Time", 50)
 			fmt.Printf("WARNING %.2f%% of sleep were falling behind\n", percentNegative)
 		} else {

--- a/devel/setup_run
+++ b/devel/setup_run
@@ -3,7 +3,7 @@ set -x
 ulimit -n 16384
 cp istio/devel/rules.yml  mixer/testdata/configroot/scopes/global/subjects/global/rules.yml
 cd mixer; set +x; source bin/use_bazel_go.sh ; set -x; cd ..
-( cd proxy/test/backend/echo; go run echo.go > /tmp/echo.log ) &
+./istio/bazel-bin/devel/fortio/cmd/echosrv/echosrv &
 ( cd proxy/src/envoy/mixer; ./start_envoy > /tmp/envoy.log ) &
 # add -v=5 for verbose/debug
 ./mixer/bazel-bin/cmd/server/mixs server --configStoreURL=fs://$(pwd)/mixer/testdata/configroot --logtostderr 2> /tmp/mixs.2.log &

--- a/devel/setup_run
+++ b/devel/setup_run
@@ -13,4 +13,4 @@ curl -v http://localhost:9090/echo
 curl -v http://localhost:42422/metrics
 set +x
 export PATH=$PATH:$(pwd)/wrk
-echo "you can now run: wrk http://localhost:9090/echo"
+echo "you can now run: fortio -qps 0 -c 16 http://localhost:9090/echo"

--- a/devel/update_all
+++ b/devel/update_all
@@ -4,16 +4,12 @@ set -e
 set -x
 cd istio
 git pull
+bazel build -c opt devel/fortio/...
 cd ../mixer
 git pull
-cd ../proxy
-git pull
-cd ../wrk
-git pull
-make
-cd ../proxy
-bazel build -c opt src/envoy/mixer:envoy
-cd ../mixer
 bazel build -c opt cmd/server:mixs
+cd ../proxy
+git pull
+bazel build -c opt src/envoy/mixer:envoy
 set +x
 echo "### All done... source istio/devel/setup_run   now"


### PR DESCRIPTION
- build and use fortio in perf/standalone scripts
- fix for having more connections than requested
- disabling compression by default (saves cpu), re-enable using new `-compression` flag
- updating sample in README.md to a test using echosrv (slightly lower latency)
- (misc/minor) also changing threshold for sleep time histogram to 5%