### PR TITLE
Fix linter issues and remove shell e2e tests run from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,8 @@ def presubmit(gitUtils, bazel, utils) {
     stage('Bazel Test') {
       bazel.test('//...')
     }
-    stage('Demo Test') {
-      sh("tests/kubeTest.sh")
-    }
     stage('Smoke Test') {
-        sh("tests/e2e.sh --logs_bucket_path ${gitUtils.logsPath()}")
+      sh("tests/e2e.sh --logs_bucket_path ${gitUtils.logsPath()}")
     }
   }
 }
@@ -47,7 +44,6 @@ def smokeTest(gitUtils, bazel, utils) {
   goBuildNode(gitUtils, 'istio.io/istio') {
     bazel.updateBazelRc()
     utils.initTestingCluster()
-    def kubeTestArgs = ''
     def e2eArgs = "--logs_bucket_path ${gitUtils.logsPath()} "
     if (utils.getParam('GITHUB_PR_HEAD_SHA') != '') {
       def prSha = utils.failIfNullOrEmpty(env.GITHUB_PR_HEAD_SHA)
@@ -57,14 +53,11 @@ def smokeTest(gitUtils, bazel, utils) {
       switch (repo) {
         case 'pilot':
           def istioctlUrl = "https://storage.googleapis.com/istio-artifacts/${repo}/${prSha}/artifacts/istioctl"
-          kubeTestArgs = "-m ${hub},${prSha} " +
-              "-i ${istioctlUrl}"
           e2eArgs += "--pilot_hub=${hub}  " +
               "--pilot_tag=${prSha} " +
               "--istioctl_url=${istioctlUrl}"
           break
         case 'mixer':
-          kubeTestArgs = "-x ${hub},${prSha}"
           e2eArgs += "--mixer_hub=${hub}  " +
               "--mixer_tag=${prSha}"
           break
@@ -72,10 +65,8 @@ def smokeTest(gitUtils, bazel, utils) {
           break
       }
     }
-    stage('Demo Test') {
-      sh("tests/kubeTest.sh ${kubeTestArgs}")
+    stage('Smoke Test') {
+      sh("tests/e2e.sh ${e2eArgs}")
     }
-    stage('Smoke Test')
-    sh("tests/e2e.sh ${e2eArgs}")
   }
 }

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -13,9 +13,9 @@ cd ${ROOT}
 
 PARENT_BRANCH=''
 
-while getopts :c: arg; do
+while getopts :s: arg; do
   case ${arg} in
-    c) PARENT_BRANCH="${OPTARG}";;
+    s) LAST_GOOD_GITSHA="${OPTARG}";;
     *) error_exit "Unrecognized argument ${OPTARG}";;
   esac
 done
@@ -26,6 +26,7 @@ prep_linters() {
         go get -u github.com/alecthomas/gometalinter
         go get -u github.com/bazelbuild/buildifier/buildifier
         go get -u github.com/3rf/codecoroner
+        go get -u honnef.co/go/tools/cmd/megacheck
         gometalinter --install --vendored-linters >/dev/null
     fi
     bin/bazel_to_go.py
@@ -49,15 +50,30 @@ go_metalinter() {
     fi
 
     # default: lint everything. This runs on the main build
-    PKGS="./tests/e2e/..."
+    PKGS=('./tests/e2e/...' './devel/githubContrib')
+
+    echo "All known packages are ${PKGS[@]}"
 
     # convert LAST_GOOD_GITSHA to list of packages.
     if [[ ! -z ${LAST_GOOD_GITSHA} ]];then
         echo "Using ${LAST_GOOD_GITSHA} to compare files to."
-        PKGS=$(for fn in $(git diff --name-only ${LAST_GOOD_GITSHA}); do fd="${fn%/*}"; [ -d ${fd} ] && echo $fd; done | sort | uniq)
-    else
-        echo 'Running linters on all files.'
+        CHANGED_DIRS=($(for fn in $(git diff --name-only ${LAST_GOOD_GITSHA}); do fd="./${fn%/*}"; [ -d ${fd} ] && echo $fd; done | sort | uniq))
+        # Using a hash map to prevent duplicates.
+        declare -A NEW_PKGS
+        for d in ${CHANGED_DIRS[@]}; do
+          for p in ${PKGS[@]}; do
+            if [[ ${d} =~ ${p} ]]; then
+              NEW_PKGS[${p}]=
+            fi
+          done
+        done
+        # Getting only keys from hash map.
+        PKGS=(${!NEW_PKGS[@]})
     fi
+
+    echo "Running linters on packages ${PKGS[@]}."
+
+    [[ -z ${PKGS[@]} ]] && return
 
     # updated to avoid WARNING: staticcheck, gosimple, and unused are all set, using megacheck instead
     gometalinter\
@@ -83,7 +99,7 @@ go_metalinter() {
         --enable=varcheck\
         --enable=vet\
         --enable=vetshadow\
-        $PKGS
+        ${PKGS[@]}
 
     # TODO: These generate warnings which we should fix, and then should enable the linters
     # --enable=dupl\

--- a/devel/githubContrib/BUILD.bazel
+++ b/devel/githubContrib/BUILD.bazel
@@ -14,7 +14,7 @@ go_binary(
 
 go_test(
     name = "small_test",
-    srcs = ["githubContrib_test.go"],
     size = "small",
+    srcs = ["githubContrib_test.go"],
     library = ":go_default_library",
 )


### PR DESCRIPTION
Fix linters by only linting go packages
Removed shell e2e tests call as it is duplicated in the go framework. Not removing the shell tests just yet as it still being used by IBM CI.

