### PR TITLE
Add mysql db access to productpage sample.

### DIFF
--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -40,6 +40,11 @@ if [ "${CI}" == 'bootstrap' ]; then
   LOG_HOST="stackdriver"
   PROJ_ID="istio-testing"
   E2E_ARGS+=(--test_logs_path="${ARTIFACTS_DIR}" --log_provider=${LOG_HOST} --project_id=${PROJ_ID})
+
+  # We are running e2e tests in a specific cluster.
+  # Using volume mount from istio-presubmit job's pod spec
+  mkdir -p ${HOME}/.kube
+  ln -s /etc/e2e-testing-kubeconfig/e2e-testing-kubeconfig ${HOME}/.kube/config
 fi
 
 echo 'Running Linters'

--- a/samples/apps/bookinfo/BUILD
+++ b/samples/apps/bookinfo/BUILD
@@ -11,6 +11,7 @@ filegroup(
         "route-rule-reviews-50-v3.yaml",
         "route-rule-reviews-test-v2.yaml",
         "route-rule-reviews-v2-v3.yaml",
+	"route-rule-productpage-v2.yaml"
     ],
     visibility = ["//visibility:public"],
 )

--- a/samples/apps/bookinfo/bookinfo.yaml
+++ b/samples/apps/bookinfo/bookinfo.yaml
@@ -156,7 +156,43 @@ spec:
         - containerPort: 9080
 ---
 ##################################################################################################
-# Productpage service
+# Mysql db services
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysqldb
+  labels:
+    app: mysqldb
+spec:
+  ports:
+  - port: 3306
+    name: mysql
+  selector:
+    app: mysqldb
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mysqldb-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mysqldb
+        version: v1
+    spec:
+      containers:
+      - name: mysqldb
+        image: istio/examples-bookinfo-mysqldb-v1
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3306
+---
+##################################################################################################
+# Productpage services
+# ver2: uses a mysql db
 ##################################################################################################
 apiVersion: v1
 kind: Service
@@ -186,9 +222,31 @@ spec:
       containers:
       - name: productpage
         image: istio/examples-bookinfo-productpage-v1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always 
         ports:
         - containerPort: 9080
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: productpage-v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: productpage
+        version: v2
+    spec:
+      containers:
+      - name: productpage
+        image: istio/examples-bookinfo-productpage-v2
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9080
+        env:
+        - name: MYSQL_DB_HOST
+          value: mysqldb
 ---
 ###########################################################################
 # Ingress resource (gateway)

--- a/samples/apps/bookinfo/route-rule-productpage-v2.yaml
+++ b/samples/apps/bookinfo/route-rule-productpage-v2.yaml
@@ -1,0 +1,8 @@
+type: route-rule
+spec:
+  name: productpage-test-v2
+  destination: productpage.default.svc.cluster.local
+  precedence: 2
+  route:
+  - tags:
+      version: v2

--- a/samples/apps/bookinfo/src/build-services.sh
+++ b/samples/apps/bookinfo/src/build-services.sh
@@ -19,7 +19,10 @@ set -o errexit
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd $SCRIPTDIR/productpage
-  docker build -t istio/examples-bookinfo-productpage-v1 .
+  # python app without mysql db access.
+  docker build -t istio/examples-bookinfo-productpage-v1 --build-arg service_version=v1 .
+  # app with mysql db access.
+  docker build -t istio/examples-bookinfo-productpage-v2 --build-arg service_version=v2 .
 popd
 
 pushd $SCRIPTDIR/details
@@ -42,3 +45,8 @@ popd
 pushd $SCRIPTDIR/ratings
   docker build -t istio/examples-bookinfo-ratings-v1 .
 popd
+
+pushd $SCRIPTDIR/mysql
+  docker build -t istio/examples-bookinfo-mysqldb-v1 .
+popd
+

--- a/samples/apps/bookinfo/src/mysql/Dockerfile
+++ b/samples/apps/bookinfo/src/mysql/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM mysql:8
+ENV MYSQL_ROOT_PASSWORD "password"
+ENV MYSQL_DATABASE "test"
+
+COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d/mysqldb-init.sql

--- a/samples/apps/bookinfo/src/mysql/mysqldb-init.sql
+++ b/samples/apps/bookinfo/src/mysql/mysqldb-init.sql
@@ -1,0 +1,8 @@
+/*
+ * Initialize a mysql db with a 'test' db and be able test productpage with it.
+ * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
+ */
+USE test;
+CREATE TABLE price (name VARCHAR(20), price INT);
+INSERT INTO price VALUES('comedy', 20);
+SELECT * FROM price;

--- a/samples/apps/bookinfo/src/productpage/Dockerfile
+++ b/samples/apps/bookinfo/src/productpage/Dockerfile
@@ -25,4 +25,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 EXPOSE 9080
+ARG service_version
+ENV SERVICE_VERSION ${service_version:-v1}
 CMD python productpage.py 9080 $MYSQLADDR

--- a/samples/apps/bookinfo/src/productpage/Dockerfile
+++ b/samples/apps/bookinfo/src/productpage/Dockerfile
@@ -12,10 +12,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM python:2-onbuild
+# Ref: https://hub.docker.com/_/python/
+
+FROM python:2
+
+RUN apt-get install libmysqlclient-dev
 
 RUN mkdir -p /opt/microservices
-COPY . /opt/microservices/
-EXPOSE 9080
 WORKDIR /opt/microservices
-CMD python productpage.py 9080
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+EXPOSE 9080
+CMD python productpage.py 9080 $MYSQLADDR

--- a/samples/apps/bookinfo/src/productpage/Dockerfile
+++ b/samples/apps/bookinfo/src/productpage/Dockerfile
@@ -20,11 +20,10 @@ RUN apt-get install libmysqlclient-dev
 
 RUN mkdir -p /opt/microservices
 WORKDIR /opt/microservices
-COPY requirements.txt ./
+COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
 EXPOSE 9080
 ARG service_version
 ENV SERVICE_VERSION ${service_version:-v1}
-CMD python productpage.py 9080 $MYSQLADDR
+CMD python productpage.py 9080

--- a/samples/apps/bookinfo/src/productpage/mysqldb-init.sql
+++ b/samples/apps/bookinfo/src/productpage/mysqldb-init.sql
@@ -1,0 +1,9 @@
+/*
+ * Initialize a mysql db with a 'test' db and be able test productpage with it.
+ * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
+ */
+CREATE DATABASE test;
+USE test;
+CREATE TABLE price (name VARCHAR(20), price INT);
+INSERT INTO price VALUES('comedy', 20);
+SELECT * FROM price;

--- a/samples/apps/bookinfo/src/productpage/mysqldb-init.sql
+++ b/samples/apps/bookinfo/src/productpage/mysqldb-init.sql
@@ -1,9 +1,0 @@
-/*
- * Initialize a mysql db with a 'test' db and be able test productpage with it.
- * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
- */
-CREATE DATABASE test;
-USE test;
-CREATE TABLE price (name VARCHAR(20), price INT);
-INSERT INTO price VALUES('comedy', 20);
-SELECT * FROM price;

--- a/samples/apps/bookinfo/src/productpage/productpage.py
+++ b/samples/apps/bookinfo/src/productpage/productpage.py
@@ -19,6 +19,7 @@ from flask import Flask, request, render_template, redirect, url_for
 import simplejson as json
 import requests
 import sys
+import os
 from json2html import *
 import logging
 import requests
@@ -201,14 +202,19 @@ class Mydb(object):
         self.cursor.close()
         self.cnx.close()
 
+def print_usage():
+    print "usage: %s port [dbserver]" % (sys.argv[0])
+    sys.exit(-1)
 
 if __name__ == '__main__':
-    use_db = True
+    use_db = False
+    if 'SERVICE_VERSION' in os.environ and os.environ['SERVICE_VERSION'] == 'v2':
+        use_db = True
+
     if len(sys.argv) < 2:
-        print "usage: %s port [dbserver]" % (sys.argv[0])
-        sys.exit(-1)
-    if len(sys.argv) < 3:
-        use_db = False
+        print_usage()
+    if use_db and len(sys.argv) < 3:
+        print_usage()
 
     p = int(sys.argv[1])
     sys.stderr = Writer('stderr.log')

--- a/samples/apps/bookinfo/src/productpage/requirements.txt
+++ b/samples/apps/bookinfo/src/productpage/requirements.txt
@@ -5,4 +5,4 @@ flask_bootstrap
 json2html
 simplejson
 gevent
-
+mysql

--- a/samples/apps/bookinfo/src/productpage/templates/productpage.html
+++ b/samples/apps/bookinfo/src/productpage/templates/productpage.html
@@ -101,6 +101,10 @@ $('#login-modal').on('shown.bs.modal', function () {
     most farcical comedies, with a major part of the humour coming
     from slapstick and mistaken identity, in addition to puns and word
     play.</p>
+{% if price != 0 %}
+    <p><b>Price:</b> ${{ price }}
+    </p>
+{% endif %}
 </div>
 </div>
 


### PR DESCRIPTION
The sample bookinfo app has productpage as one of the micro services. This patch optionally add's a mysql db access from the productpage microservice. This could be helpful in checking out the following use cases of a service mesh:
- Envoy tcp proxy.
- Bypassing Envoy for mysql db access
- hybrid use case where the db is not part of k8s infrastructure.

I'd be happy to change this pr request to make it more useful for general consumption.
One option that was discussed was to create a rev. (v2) of productpage micro service which includes the db access and leave v1 version as is.
