### PR TITLE
Fix misplaced serviceAccoutName in istio-egress

### DIFF
--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -222,8 +222,8 @@ spec:
       labels:
         istio: egress
     spec:
-      containers:
       serviceAccountName: istio-egress-service-account
+      containers:
       - name: proxy
         image: gcr.io/istio-testing/proxy_debug:06ee3635b2f10716abe3d59f625e0000649ccc59
         imagePullPolicy: Always


### PR DESCRIPTION
`kubectl apply install/kubernetes/istio.yaml` causes an error after merging #481
