### PR TITLE
Add volumeMount for /etc/istio/config in istio-auth.yaml

### DIFF
--- a/install/kubernetes/istio-auth-with-cluster-ca.yaml
+++ b/install/kubernetes/istio-auth-with-cluster-ca.yaml
@@ -202,10 +202,15 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 
 ################################
@@ -247,9 +252,14 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -202,10 +202,15 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 
 ################################
@@ -247,10 +252,15 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 
 # This CA only issues certs/keys for the namespace it runs in.

--- a/install/kubernetes/templates/istio-auth/istio-egress-auth.yaml
+++ b/install/kubernetes/templates/istio-auth/istio-egress-auth.yaml
@@ -37,9 +37,14 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 

--- a/install/kubernetes/templates/istio-auth/istio-ingress-auth.yaml
+++ b/install/kubernetes/templates/istio-auth/istio-ingress-auth.yaml
@@ -55,9 +55,14 @@ spec:
         - mountPath: /etc/certs
           name: istio-certs
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/istio/config
       volumes:
       - name: istio-certs
         secret:
           secretName: istio.default
+      - name: config-volume
+        configMap:
+          name: istio
 ---
 


### PR DESCRIPTION
Without this PR if I do:
```
kubectl apply -f ./kubernetes/istio-auth.yaml
```
I get ingress/egress pods in error state and in pod's log I see:

```
Error: failed to read mesh configuration. cannot read mesh config file open /etc/istio/config/mesh: no such file or directory
```