### PR TITLE
Initial import of istio.deps

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -1,0 +1,23 @@
+[
+	{
+		"name": "CA_TAG",
+		"repoName": "auth",
+		"prodBranch": "stable",
+		"file": "istio.VERSION",
+		"lastStableSHA": "0.1.5"
+	},
+	{
+		"name": "MIXER_TAG",
+		"repoName": "mixer",
+		"prodBranch": "stable",
+		"file": "istio.VERSION",
+		"lastStableSHA": "87cdc595-689d-4779-be29-ac845d47492e"
+	},
+	{
+		"name": "PILOT_HUB",
+		"repoName": "pilot",
+		"prodBranch": "stable",
+		"file": "istio.VERSION",
+		"lastStableSHA": "5633d45a99138892a0ba0d380dff5c587583edd3"
+	}
+]


### PR DESCRIPTION
@sebastienvas @yutongz PTAL

This change is required for auto upate on dependency as in [istio/infra PR#336](https://github.com/istio/test-infra/pull/336). With stable SHAs built-in, it also makes metrics much easy to get. If this looks good, similar changes will be rolled out to other istio repos.