### PR TITLE
Disable stackdriver logs gathering

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ def presubmit(gitUtils, bazel, utils) {
     stage('Smoke Test') {
       def logHost = 'stackdriver'
       def projID = utils.failIfNullOrEmpty(env.PROJECT)
-      def e2eArgs = "--logs_bucket_path ${gitUtils.logsPath()} --log_provider=${logHost} --project_id=${projID} "
+      def e2eArgs = "--logs_bucket_path ${gitUtils.logsPath()} "
       sh("tests/e2e.sh ${e2eArgs}")
     }
   }
@@ -49,7 +49,7 @@ def smokeTest(gitUtils, bazel, utils) {
     utils.initTestingCluster()
     def logHost = 'stackdriver'
     def projID = utils.failIfNullOrEmpty(env.PROJECT)
-    def e2eArgs = "--logs_bucket_path ${gitUtils.logsPath()} --log_provider=${logHost} --project_id=${projID} "
+    def e2eArgs = "--logs_bucket_path ${gitUtils.logsPath()} "
     if (utils.getParam('GITHUB_PR_HEAD_SHA') != '') {
       def prSha = utils.failIfNullOrEmpty(env.GITHUB_PR_HEAD_SHA)
       def prUrl = utils.failIfNullOrEmpty(env.GITHUB_PR_URL)

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -38,7 +38,7 @@ if [ "${CI}" == 'bootstrap' ]; then
   ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
   LOG_HOST="stackdriver"
   PROJ_ID="istio-testing"
-  E2E_ARGS+=(--test_logs_path="${ARTIFACTS_DIR}" --log_provider=${LOG_HOST} --project_id=${PROJ_ID})
+  E2E_ARGS+=(--test_logs_path="${ARTIFACTS_DIR}")
 fi
 
 echo 'Running Linters'


### PR DESCRIPTION
Turns out logs are not usable, and it take up to 30 minutes to get them.