### PR TITLE
Add owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - geeknoid
+  - andraxylia
+  - Douglas-reid
+  - ldemailly
+  - rshriram
+  - sebastienvas
+approvers:
+  - geeknoid
+  - andraxylia
+  - Douglas-reid
+  - ldemailly
+  - rshriram

--- a/tests/e2e/OWNERS
+++ b/tests/e2e/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sebastienvas


### PR DESCRIPTION
Initial add OWNERS files to root and e2e-test framework, preparing for Mungegithub. People can always add more OWNERS files to any directory and will affect this directory and all sub-directories. 