### PR TITLE
Switch to fortio for RateLimit testing

### DIFF
--- a/tests/e2e/tests/mixer/BUILD
+++ b/tests/e2e/tests/mixer/BUILD
@@ -10,9 +10,9 @@ go_test(
     ],
     tags = ["manual"],
     deps = [
+        "//devel/fortio:go_default_library",
         "//tests/e2e/framework:go_default_library",
         "//tests/e2e/util:go_default_library",
-        "//devel/fortio:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_prometheus_client_golang//api:go_default_library",
         "@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",

--- a/tests/e2e/tests/mixer/BUILD
+++ b/tests/e2e/tests/mixer/BUILD
@@ -12,6 +12,7 @@ go_test(
     deps = [
         "//tests/e2e/framework:go_default_library",
         "//tests/e2e/util:go_default_library",
+        "//devel/fortio:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_prometheus_client_golang//api:go_default_library",
         "@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -302,7 +302,7 @@ func TestRateLimit(t *testing.T) {
 		RunnerOptions: fortio.RunnerOptions{
 			QPS:        100,
 			Duration:   1 * time.Minute,
-			NumThreads: 10,
+			NumThreads: 8,
 		},
 		URL: url,
 	}

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -300,15 +300,15 @@ func TestRateLimit(t *testing.T) {
 	opts := fortio.DefaultRunnerOptions
 	opts.Duration = 30 * time.Second
 	opts.QPS = 30
-	clients := make([]*fortio.Client, 0, opts.NumThreads)
+	clients := make([]fortio.Fetcher, 0, opts.NumThreads)
 	for i := 0; i < opts.NumThreads; i++ {
-		clients = append(clients, fortio.NewClient(url, 15, true))
+		clients = append(clients, fortio.NewBasicClient(url, "1.1", true))
 	}
 
 	var totalReqs, successReqs, errReqs int64
 
 	opts.Function = func(tid int) {
-		code, _ := clients[tid].Fetch()
+		code, _, _ := clients[tid].Fetch()
 		atomic.AddInt64(&totalReqs, 1)
 
 		if code >= http.StatusOK && code < http.StatusMultipleChoices {

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -351,10 +352,11 @@ func TestRateLimit(t *testing.T) {
 		t.Errorf("Could not find rate limit value: %v", err)
 	}
 
-	// establish some baseline for rejections
-	want := perSvc / 2
-	// allow some leeway for rejections
-	if got <= (want * .9) {
+	// establish some baseline (40% of expected counts)
+	want := math.Floor(perSvc * .4)
+
+	// check rejections
+	if got < want {
 		t.Errorf("Bad metric value for rate-limited requests (429s): got %f, want at least %f", got, want)
 	}
 
@@ -362,13 +364,9 @@ func TestRateLimit(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not find successes value: %v", err)
 	}
-	// expected OKs, assuming 30qps for 30s
-	want = 900.0
-	if perSvc < 900 {
-		want = perSvc
-	}
-	// allow some leeway
-	if got < (want * .9) {
+
+	// check successes
+	if got < want {
 		t.Errorf("Bad metric value for successful requests (200s): got %f, want at least %f", got, want)
 	}
 }


### PR DESCRIPTION
Running with WRK seems to cause issues in local runs, related to amount of traffic generated. It also is yet another dep for the framework to establish.

This PR removes these concerns (hopefully) and reduces wait times inside of `TestRateLimit`, also reducing the amount of time running the load test down from `2m` to `30s`.

Fixes: #494 

```release-note
Use fortio instead of wrk in e2e tests
```