### PR TITLE
make http runner available as library, take 2

### DIFF
--- a/devel/fortio/BUILD.bazel
+++ b/devel/fortio/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     size = "small",
     srcs = [
         "http_test.go",
+        "httprunner_test.go",
         "logger_test.go",
         "periodic_test.go",
         "stats_test.go",

--- a/devel/fortio/BUILD.bazel
+++ b/devel/fortio/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "http.go",
+        "httprunner.go",
         "logger.go",
         "periodic.go",
         "stats.go",

--- a/devel/fortio/cmd/fortio/main.go
+++ b/devel/fortio/cmd/fortio/main.go
@@ -17,38 +17,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
 	"os"
 	"runtime"
-	"runtime/pprof"
-	"sort"
 
 	"istio.io/istio/devel/fortio"
 )
-
-type threadState struct {
-	client      fortio.Fetcher
-	retCodes    map[int]int64
-	sizes       *fortio.Histogram
-	headerSizes *fortio.Histogram
-}
-
-// Used globally / in test() TODO: change periodic.go to carry caller defined context
-var (
-	url   string
-	state []threadState
-)
-
-// Main call being run at the target QPS
-func test(t int) {
-	fortio.Debugf("Calling in %d", t)
-	code, body, headerSize := state[t].client.Fetch()
-	size := len(body)
-	fortio.Debugf("Got in %3d hsz %d sz %d", code, headerSize, size)
-	state[t].retCodes[code]++
-	state[t].sizes.Record(float64(size))
-	state[t].headerSizes.Record(float64(headerSize))
-}
 
 // -- Support for multiple instances of -H flag on cmd line:
 type flagList struct {
@@ -101,98 +74,32 @@ func main() {
 	if len(flag.Args()) != 1 {
 		usage()
 	}
-	url = flag.Arg(0)
+	url := flag.Arg(0)
 	prevGoMaxProcs := runtime.GOMAXPROCS(*goMaxProcsFlag)
 	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
 		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
-	o := fortio.RunnerOptions{
-		QPS:         *qpsFlag,
-		Function:    test,
-		Duration:    *durationFlag,
-		NumThreads:  *numThreadsFlag,
-		Percentiles: pList,
-		Resolution:  *resolutionFlag,
+	o := fortio.HTTPRunnerOptions{
+		URL:         url,
+		HTTP10:      *http10Flag,
+		StdClient:   *stdClientFlag,
+		NoKeepAlive: !*keepAliveFlag,
+		Profiler:    *profileFlag,
+		Compression: *compressionFlag,
 	}
-	r := fortio.NewPeriodicRunner(&o)
-	numThreads := r.Options().NumThreads
-	total := threadState{
-		retCodes:    make(map[int]int64),
-		sizes:       fortio.NewHistogram(0, 100),
-		headerSizes: fortio.NewHistogram(0, 5),
-	}
+	o.QPS = *qpsFlag
+	o.Duration = *durationFlag
+	o.NumThreads = *numThreadsFlag
+	o.Percentiles = pList
+	o.Resolution = *resolutionFlag
 
-	state = make([]threadState, numThreads)
-	for i := 0; i < numThreads; i++ {
-		// Create a client (and transport) and connect once for each 'thread'
-		if *stdClientFlag {
-			state[i].client = fortio.NewStdClient(url, 1, *compressionFlag)
-		} else {
-			if *http10Flag {
-				state[i].client = fortio.NewBasicClient(url, "1.0", *keepAliveFlag)
-			} else {
-				state[i].client = fortio.NewBasicClient(url, "1.1", *keepAliveFlag)
-			}
-		}
-		if state[i].client == nil {
-			fmt.Printf("Aborting because of being unable to create client %d for %s\n", i, url)
-			os.Exit(1)
-		}
-		code, data, headerSize := state[i].client.Fetch()
-		if code != http.StatusOK {
-			fmt.Printf("Aborting because of error %d for %s\n%s\n", code, url, string(data))
-			os.Exit(1)
-		}
-		if i == 0 && fortio.LogVerbose() {
-			fortio.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", url, code, headerSize, len(data), string(data))
-		}
-		// Setup the stats for each 'thread'
-		state[i].sizes = total.sizes.Clone()
-		state[i].headerSizes = total.headerSizes.Clone()
-		state[i].retCodes = make(map[int]int64)
+	res, err := fortio.HTTPRunner(&o)
+	if err != nil {
+		fmt.Printf("Aborting because %v\n", err)
+		os.Exit(1)
 	}
-
-	if *profileFlag != "" {
-		fc, err := os.Create(*profileFlag + ".cpu")
-		if err != nil {
-			fortio.Fatalf("Unable to create .cpu profile: %v", err)
-		}
-		pprof.StartCPUProfile(fc) //nolint: gas,errcheck
-	}
-	r.Run()
-	if *profileFlag != "" {
-		pprof.StopCPUProfile()
-		fm, err := os.Create(*profileFlag + ".mem")
-		if err != nil {
-			fortio.Fatalf("Unable to create .mem profile: %v", err)
-		}
-		runtime.GC()               // get up-to-date statistics
-		pprof.WriteHeapProfile(fm) // nolint:gas,errcheck
-		fm.Close()                 // nolint:gas,errcheck
-		fmt.Printf("Wrote profile data to %s.{cpu|mem}\n", *profileFlag)
-	}
-	// Numthreads may have reduced
-	numThreads = r.Options().NumThreads
-	keys := []int{}
-	for i := 0; i < numThreads; i++ {
-		// Q: is there some copying each time stats[i] is used?
-		for k := range state[i].retCodes {
-			if _, exists := total.retCodes[k]; !exists {
-				keys = append(keys, k)
-			}
-			total.retCodes[k] += state[i].retCodes[k]
-		}
-		total.sizes.Transfer(state[i].sizes)
-		total.headerSizes.Transfer(state[i].headerSizes)
-	}
-	sort.Ints(keys)
-	for _, k := range keys {
-		fmt.Printf("Code %3d : %d\n", k, total.retCodes[k])
-	}
-	if fortio.LogVerbose() {
-		total.headerSizes.Print(os.Stdout, "Response Header Sizes Histogram", 50)
-		total.sizes.Print(os.Stdout, "Response Body/Total Sizes Histogram", 50)
-	} else {
-		total.headerSizes.Counter.Print(os.Stdout, "Response Header Sizes")
-		total.sizes.Counter.Print(os.Stdout, "Response Body/Total Sizes")
-	}
+	fmt.Printf("All done %d calls (plus %d warmup) %.3f ms avg, %.1f qps\n",
+		res.DurationHistogram.Count,
+		*numThreadsFlag,
+		1000.*res.DurationHistogram.Avg(),
+		res.ActualQPS)
 }

--- a/devel/fortio/cmd/fortio/main.go
+++ b/devel/fortio/cmd/fortio/main.go
@@ -79,12 +79,12 @@ func main() {
 	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
 		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
 	o := fortio.HTTPRunnerOptions{
-		URL:         url,
-		HTTP10:      *http10Flag,
-		StdClient:   *stdClientFlag,
-		NoKeepAlive: !*keepAliveFlag,
-		Profiler:    *profileFlag,
-		Compression: *compressionFlag,
+		URL:               url,
+		HTTP10:            *http10Flag,
+		DisableFastClient: *stdClientFlag,
+		DisableKeepAlive:  !*keepAliveFlag,
+		Profiler:          *profileFlag,
+		Compression:       *compressionFlag,
 	}
 	o.QPS = *qpsFlag
 	o.Duration = *durationFlag
@@ -92,7 +92,7 @@ func main() {
 	o.Percentiles = pList
 	o.Resolution = *resolutionFlag
 
-	res, err := fortio.HTTPRunner(&o)
+	res, err := fortio.RunHTTPTest(&o)
 	if err != nil {
 		fmt.Printf("Aborting because %v\n", err)
 		os.Exit(1)

--- a/devel/fortio/cmd/fortio/main.go
+++ b/devel/fortio/cmd/fortio/main.go
@@ -79,6 +79,13 @@ func main() {
 	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
 		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
 	o := fortio.HTTPRunnerOptions{
+		RunnerOptions: fortio.RunnerOptions{
+			QPS:         *qpsFlag,
+			Duration:    *durationFlag,
+			NumThreads:  *numThreadsFlag,
+			Percentiles: pList,
+			Resolution:  *resolutionFlag,
+		},
 		URL:               url,
 		HTTP10:            *http10Flag,
 		DisableFastClient: *stdClientFlag,
@@ -86,12 +93,6 @@ func main() {
 		Profiler:          *profileFlag,
 		Compression:       *compressionFlag,
 	}
-	o.QPS = *qpsFlag
-	o.Duration = *durationFlag
-	o.NumThreads = *numThreadsFlag
-	o.Percentiles = pList
-	o.Resolution = *resolutionFlag
-
 	res, err := fortio.RunHTTPTest(&o)
 	if err != nil {
 		fmt.Printf("Aborting because %v\n", err)

--- a/devel/fortio/httprunner.go
+++ b/devel/fortio/httprunner.go
@@ -58,16 +58,18 @@ func TestHTTP(t int) {
 // options.
 type HTTPRunnerOptions struct {
 	RunnerOptions
-	URL         string
-	Compression bool   // defaults to no compression, only used by std client
-	StdClient   bool   // defaults to fast client
-	HTTP10      bool   // defaults to http1.1
-	NoKeepAlive bool   // so default is keep alive
-	Profiler    string // file to save profiles to. defaults to no profiling
+	URL               string
+	Compression       bool   // defaults to no compression, only used by std client
+	DisableFastClient bool   // defaults to fast client
+	HTTP10            bool   // defaults to http1.1
+	DisableKeepAlive  bool   // so default is keep alive
+	Profiler          string // file to save profiles to. defaults to no profiling
 }
 
-// HTTPRunner runs an http test and returns the aggregated stats.
-func HTTPRunner(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
+// RunHTTPTest runs an http test and returns the aggregated stats.
+func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
+	// TODO 1. use std client automatically when https url
+	// TODO 2. lock
 	if o.Function == nil {
 		o.Function = TestHTTP
 	}
@@ -81,13 +83,13 @@ func HTTPRunner(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	state = make([]HTTPRunnerResults, numThreads)
 	for i := 0; i < numThreads; i++ {
 		// Create a client (and transport) and connect once for each 'thread'
-		if o.StdClient {
+		if o.DisableFastClient {
 			state[i].client = NewStdClient(o.URL, 1, o.Compression)
 		} else {
 			if o.HTTP10 {
-				state[i].client = NewBasicClient(o.URL, "1.0", !o.NoKeepAlive)
+				state[i].client = NewBasicClient(o.URL, "1.0", !o.DisableKeepAlive)
 			} else {
-				state[i].client = NewBasicClient(o.URL, "1.1", !o.NoKeepAlive)
+				state[i].client = NewBasicClient(o.URL, "1.1", !o.DisableKeepAlive)
 			}
 		}
 		if state[i].client == nil {

--- a/devel/fortio/httprunner.go
+++ b/devel/fortio/httprunner.go
@@ -12,187 +12,145 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package fortio
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	"runtime"
 	"runtime/pprof"
 	"sort"
-
-	"istio.io/istio/devel/fortio"
 )
 
-type threadState struct {
-	client      fortio.Fetcher
-	retCodes    map[int]int64
-	sizes       *fortio.Histogram
-	headerSizes *fortio.Histogram
+// Most of the code in this file is the library-fication of code originally
+// in cmd/fortio/main.go
+
+// HTTPRunnerResults is the aggregated result of an HTTPRunner.
+// Also is the internal type used per thread/goroutine.
+type HTTPRunnerResults struct {
+	client            Fetcher
+	RetCodes          map[int]int64
+	Sizes             *Histogram
+	HeaderSizes       *Histogram
+	DurationHistogram *Histogram
+	ActualQPS         float64
 }
 
-// Used globally / in test() TODO: change periodic.go to carry caller defined context
+// Used globally / in TestHttp() TODO: change periodic.go to carry caller defined context
 var (
-	url   string
-	state []threadState
+	state []HTTPRunnerResults
 )
 
-// Main call being run at the target QPS
-func test(t int) {
-	fortio.Debugf("Calling in %d", t)
+// TestHTTP http request fetching. Main call being run at the target QPS.
+// To be set as the Function in RunnerOptions.
+func TestHTTP(t int) {
+	Debugf("Calling in %d", t)
 	code, body, headerSize := state[t].client.Fetch()
 	size := len(body)
-	fortio.Debugf("Got in %3d hsz %d sz %d", code, headerSize, size)
-	state[t].retCodes[code]++
-	state[t].sizes.Record(float64(size))
-	state[t].headerSizes.Record(float64(headerSize))
+	Debugf("Got in %3d hsz %d sz %d", code, headerSize, size)
+	state[t].RetCodes[code]++
+	state[t].Sizes.Record(float64(size))
+	state[t].HeaderSizes.Record(float64(headerSize))
 }
 
-// -- Support for multiple instances of -H flag on cmd line:
-type flagList struct {
+// HTTPRunnerOptions includes the base RunnerOptions plus http specific
+// options.
+type HTTPRunnerOptions struct {
+	RunnerOptions
+	URL         string
+	Compression bool   // defaults to no compression, only used by std client
+	StdClient   bool   // defaults to fast client
+	HTTP10      bool   // defaults to http1.1
+	NoKeepAlive bool   // so default is keep alive
+	Profiler    string // file to save profiles to. defaults to no profiling
 }
 
-// Unclear when/why this is called and necessary
-func (f *flagList) String() string {
-	return ""
-}
-func (f *flagList) Set(value string) error {
-	return fortio.AddAndValidateExtraHeader(value)
-}
-
-// -- end of functions for -H support
-
-// Prints usage
-func usage() {
-	fmt.Fprintf(os.Stderr, "Φορτίο %s usage:\n\n%s [flags] url\n", fortio.Version, os.Args[0]) // nolint(gas)
-	flag.PrintDefaults()
-	os.Exit(1)
-}
-
-func main() {
-	var (
-		defaults = &fortio.DefaultRunnerOptions
-		// Very small default so people just trying with random URLs don't affect the target
-		qpsFlag         = flag.Float64("qps", 8.0, "Queries Per Seconds or 0 for no wait")
-		numThreadsFlag  = flag.Int("c", defaults.NumThreads, "Number of connections/goroutine/threads")
-		durationFlag    = flag.Duration("t", defaults.Duration, "How long to run the test")
-		percentilesFlag = flag.String("p", "50,75,99,99.9", "List of pXX to calculate")
-		resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
-		compressionFlag = flag.Bool("compression", false, "Enable http compression")
-		goMaxProcsFlag  = flag.Int("gomaxprocs", 0, "Setting for runtime.GOMAXPROCS, <1 doesn't change the default")
-		profileFlag     = flag.String("profile", "", "write .cpu and .mem profiles to file")
-		keepAliveFlag   = flag.Bool("keepalive", true, "Keep connection alive (only for fast http 1.1)")
-		stdClientFlag   = flag.Bool("stdclient", false, "Use the slower net/http standard client (works for TLS)")
-		http10Flag      = flag.Bool("http1.0", false, "Use http1.0 (instead of http 1.1)")
-
-		headersFlags flagList
-	)
-	flag.Var(&headersFlags, "H", "Additional Header(s)")
-	flag.IntVar(&fortio.BufferSizeKb, "httpbufferkb", fortio.BufferSizeKb, "Size of the buffer (max data size) for the optimized http client in kbytes")
-	flag.BoolVar(&fortio.CheckConnectionClosedHeader, "httpccch", fortio.CheckConnectionClosedHeader, "Check for Connection: Close Header")
-	flag.Parse()
-	pList, err := fortio.ParsePercentiles(*percentilesFlag)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to extract percentiles from -p: %v\n", err) // nolint(gas)
-		usage()
+// HTTPRunner runs an http test and returns the aggregated stats.
+func HTTPRunner(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
+	if o.Function == nil {
+		o.Function = TestHTTP
 	}
-	if len(flag.Args()) != 1 {
-		usage()
-	}
-	url = flag.Arg(0)
-	prevGoMaxProcs := runtime.GOMAXPROCS(*goMaxProcsFlag)
-	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
-		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
-	o := fortio.RunnerOptions{
-		QPS:         *qpsFlag,
-		Function:    test,
-		Duration:    *durationFlag,
-		NumThreads:  *numThreadsFlag,
-		Percentiles: pList,
-		Resolution:  *resolutionFlag,
-	}
-	r := fortio.NewPeriodicRunner(&o)
+	r := NewPeriodicRunner(&o.RunnerOptions)
 	numThreads := r.Options().NumThreads
-	total := threadState{
-		retCodes:    make(map[int]int64),
-		sizes:       fortio.NewHistogram(0, 100),
-		headerSizes: fortio.NewHistogram(0, 5),
+	total := HTTPRunnerResults{
+		RetCodes:    make(map[int]int64),
+		Sizes:       NewHistogram(0, 100),
+		HeaderSizes: NewHistogram(0, 5),
 	}
-
-	state = make([]threadState, numThreads)
+	state = make([]HTTPRunnerResults, numThreads)
 	for i := 0; i < numThreads; i++ {
 		// Create a client (and transport) and connect once for each 'thread'
-		if *stdClientFlag {
-			state[i].client = fortio.NewStdClient(url, 1, *compressionFlag)
+		if o.StdClient {
+			state[i].client = NewStdClient(o.URL, 1, o.Compression)
 		} else {
-			if *http10Flag {
-				state[i].client = fortio.NewBasicClient(url, "1.0", *keepAliveFlag)
+			if o.HTTP10 {
+				state[i].client = NewBasicClient(o.URL, "1.0", !o.NoKeepAlive)
 			} else {
-				state[i].client = fortio.NewBasicClient(url, "1.1", *keepAliveFlag)
+				state[i].client = NewBasicClient(o.URL, "1.1", !o.NoKeepAlive)
 			}
 		}
 		if state[i].client == nil {
-			fmt.Printf("Aborting because of being unable to create client %d for %s\n", i, url)
-			os.Exit(1)
+			return nil, fmt.Errorf("unable to create client %d for %s", i, o.URL)
 		}
 		code, data, headerSize := state[i].client.Fetch()
 		if code != http.StatusOK {
-			fmt.Printf("Aborting because of error %d for %s\n%s\n", code, url, string(data))
-			os.Exit(1)
+			return nil, fmt.Errorf("error %d for %s: %q", code, o.URL, string(data))
 		}
-		if i == 0 && fortio.LogVerbose() {
-			fortio.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", url, code, headerSize, len(data), string(data))
+		if i == 0 && LogVerbose() {
+			LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", o.URL, code, headerSize, len(data), data)
 		}
 		// Setup the stats for each 'thread'
-		state[i].sizes = total.sizes.Clone()
-		state[i].headerSizes = total.headerSizes.Clone()
-		state[i].retCodes = make(map[int]int64)
+		state[i].Sizes = total.Sizes.Clone()
+		state[i].HeaderSizes = total.HeaderSizes.Clone()
+		state[i].RetCodes = make(map[int]int64)
 	}
 
-	if *profileFlag != "" {
-		fc, err := os.Create(*profileFlag + ".cpu")
+	if o.Profiler != "" {
+		fc, err := os.Create(o.Profiler + ".cpu")
 		if err != nil {
-			fortio.Fatalf("Unable to create .cpu profile: %v", err)
+			Critf("Unable to create .cpu profile: %v", err)
+			return nil, err
 		}
 		pprof.StartCPUProfile(fc) //nolint: gas,errcheck
 	}
-	r.Run()
-	if *profileFlag != "" {
+	total.ActualQPS, total.DurationHistogram = r.Run()
+	if o.Profiler != "" {
 		pprof.StopCPUProfile()
-		fm, err := os.Create(*profileFlag + ".mem")
+		fm, err := os.Create(o.Profiler + ".mem")
 		if err != nil {
-			fortio.Fatalf("Unable to create .mem profile: %v", err)
+			Critf("Unable to create .mem profile: %v", err)
+			return nil, err
 		}
 		runtime.GC()               // get up-to-date statistics
 		pprof.WriteHeapProfile(fm) // nolint:gas,errcheck
 		fm.Close()                 // nolint:gas,errcheck
-		fmt.Printf("Wrote profile data to %s.{cpu|mem}\n", *profileFlag)
+		fmt.Printf("Wrote profile data to %s.{cpu|mem}\n", o.Profiler)
 	}
 	// Numthreads may have reduced
 	numThreads = r.Options().NumThreads
 	keys := []int{}
 	for i := 0; i < numThreads; i++ {
 		// Q: is there some copying each time stats[i] is used?
-		for k := range state[i].retCodes {
-			if _, exists := total.retCodes[k]; !exists {
+		for k := range state[i].RetCodes {
+			if _, exists := total.RetCodes[k]; !exists {
 				keys = append(keys, k)
 			}
-			total.retCodes[k] += state[i].retCodes[k]
+			total.RetCodes[k] += state[i].RetCodes[k]
 		}
-		total.sizes.Transfer(state[i].sizes)
-		total.headerSizes.Transfer(state[i].headerSizes)
+		total.Sizes.Transfer(state[i].Sizes)
+		total.HeaderSizes.Transfer(state[i].HeaderSizes)
 	}
 	sort.Ints(keys)
 	for _, k := range keys {
-		fmt.Printf("Code %3d : %d\n", k, total.retCodes[k])
+		fmt.Printf("Code %3d : %d\n", k, total.RetCodes[k])
 	}
-	if fortio.LogVerbose() {
-		total.headerSizes.Print(os.Stdout, "Response Header Sizes Histogram", 50)
-		total.sizes.Print(os.Stdout, "Response Body/Total Sizes Histogram", 50)
+	if LogVerbose() {
+		total.HeaderSizes.Print(os.Stdout, "Response Header Sizes Histogram", 50)
+		total.Sizes.Print(os.Stdout, "Response Body/Total Sizes Histogram", 50)
 	} else {
-		total.headerSizes.Counter.Print(os.Stdout, "Response Header Sizes")
-		total.sizes.Counter.Print(os.Stdout, "Response Body/Total Sizes")
+		total.HeaderSizes.Counter.Print(os.Stdout, "Response Header Sizes")
+		total.Sizes.Counter.Print(os.Stdout, "Response Body/Total Sizes")
 	}
+	return &total, nil
 }

--- a/devel/fortio/httprunner.go
+++ b/devel/fortio/httprunner.go
@@ -1,0 +1,198 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+
+	"istio.io/istio/devel/fortio"
+)
+
+type threadState struct {
+	client      fortio.Fetcher
+	retCodes    map[int]int64
+	sizes       *fortio.Histogram
+	headerSizes *fortio.Histogram
+}
+
+// Used globally / in test() TODO: change periodic.go to carry caller defined context
+var (
+	url   string
+	state []threadState
+)
+
+// Main call being run at the target QPS
+func test(t int) {
+	fortio.Debugf("Calling in %d", t)
+	code, body, headerSize := state[t].client.Fetch()
+	size := len(body)
+	fortio.Debugf("Got in %3d hsz %d sz %d", code, headerSize, size)
+	state[t].retCodes[code]++
+	state[t].sizes.Record(float64(size))
+	state[t].headerSizes.Record(float64(headerSize))
+}
+
+// -- Support for multiple instances of -H flag on cmd line:
+type flagList struct {
+}
+
+// Unclear when/why this is called and necessary
+func (f *flagList) String() string {
+	return ""
+}
+func (f *flagList) Set(value string) error {
+	return fortio.AddAndValidateExtraHeader(value)
+}
+
+// -- end of functions for -H support
+
+// Prints usage
+func usage() {
+	fmt.Fprintf(os.Stderr, "Φορτίο %s usage:\n\n%s [flags] url\n", fortio.Version, os.Args[0]) // nolint(gas)
+	flag.PrintDefaults()
+	os.Exit(1)
+}
+
+func main() {
+	var (
+		defaults = &fortio.DefaultRunnerOptions
+		// Very small default so people just trying with random URLs don't affect the target
+		qpsFlag         = flag.Float64("qps", 8.0, "Queries Per Seconds or 0 for no wait")
+		numThreadsFlag  = flag.Int("c", defaults.NumThreads, "Number of connections/goroutine/threads")
+		durationFlag    = flag.Duration("t", defaults.Duration, "How long to run the test")
+		percentilesFlag = flag.String("p", "50,75,99,99.9", "List of pXX to calculate")
+		resolutionFlag  = flag.Float64("r", defaults.Resolution, "Resolution of the histogram lowest buckets in seconds")
+		compressionFlag = flag.Bool("compression", false, "Enable http compression")
+		goMaxProcsFlag  = flag.Int("gomaxprocs", 0, "Setting for runtime.GOMAXPROCS, <1 doesn't change the default")
+		profileFlag     = flag.String("profile", "", "write .cpu and .mem profiles to file")
+		keepAliveFlag   = flag.Bool("keepalive", true, "Keep connection alive (only for fast http 1.1)")
+		stdClientFlag   = flag.Bool("stdclient", false, "Use the slower net/http standard client (works for TLS)")
+		http10Flag      = flag.Bool("http1.0", false, "Use http1.0 (instead of http 1.1)")
+
+		headersFlags flagList
+	)
+	flag.Var(&headersFlags, "H", "Additional Header(s)")
+	flag.IntVar(&fortio.BufferSizeKb, "httpbufferkb", fortio.BufferSizeKb, "Size of the buffer (max data size) for the optimized http client in kbytes")
+	flag.BoolVar(&fortio.CheckConnectionClosedHeader, "httpccch", fortio.CheckConnectionClosedHeader, "Check for Connection: Close Header")
+	flag.Parse()
+	pList, err := fortio.ParsePercentiles(*percentilesFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to extract percentiles from -p: %v\n", err) // nolint(gas)
+		usage()
+	}
+	if len(flag.Args()) != 1 {
+		usage()
+	}
+	url = flag.Arg(0)
+	prevGoMaxProcs := runtime.GOMAXPROCS(*goMaxProcsFlag)
+	fmt.Printf("Fortio running at %g queries per second, %d->%d procs, for %v: %s\n",
+		*qpsFlag, prevGoMaxProcs, runtime.GOMAXPROCS(0), *durationFlag, url)
+	o := fortio.RunnerOptions{
+		QPS:         *qpsFlag,
+		Function:    test,
+		Duration:    *durationFlag,
+		NumThreads:  *numThreadsFlag,
+		Percentiles: pList,
+		Resolution:  *resolutionFlag,
+	}
+	r := fortio.NewPeriodicRunner(&o)
+	numThreads := r.Options().NumThreads
+	total := threadState{
+		retCodes:    make(map[int]int64),
+		sizes:       fortio.NewHistogram(0, 100),
+		headerSizes: fortio.NewHistogram(0, 5),
+	}
+
+	state = make([]threadState, numThreads)
+	for i := 0; i < numThreads; i++ {
+		// Create a client (and transport) and connect once for each 'thread'
+		if *stdClientFlag {
+			state[i].client = fortio.NewStdClient(url, 1, *compressionFlag)
+		} else {
+			if *http10Flag {
+				state[i].client = fortio.NewBasicClient(url, "1.0", *keepAliveFlag)
+			} else {
+				state[i].client = fortio.NewBasicClient(url, "1.1", *keepAliveFlag)
+			}
+		}
+		if state[i].client == nil {
+			fmt.Printf("Aborting because of being unable to create client %d for %s\n", i, url)
+			os.Exit(1)
+		}
+		code, data, headerSize := state[i].client.Fetch()
+		if code != http.StatusOK {
+			fmt.Printf("Aborting because of error %d for %s\n%s\n", code, url, string(data))
+			os.Exit(1)
+		}
+		if i == 0 && fortio.LogVerbose() {
+			fortio.LogVf("first hit of url %s: status %03d, headers %d, total %d\n%s\n", url, code, headerSize, len(data), string(data))
+		}
+		// Setup the stats for each 'thread'
+		state[i].sizes = total.sizes.Clone()
+		state[i].headerSizes = total.headerSizes.Clone()
+		state[i].retCodes = make(map[int]int64)
+	}
+
+	if *profileFlag != "" {
+		fc, err := os.Create(*profileFlag + ".cpu")
+		if err != nil {
+			fortio.Fatalf("Unable to create .cpu profile: %v", err)
+		}
+		pprof.StartCPUProfile(fc) //nolint: gas,errcheck
+	}
+	r.Run()
+	if *profileFlag != "" {
+		pprof.StopCPUProfile()
+		fm, err := os.Create(*profileFlag + ".mem")
+		if err != nil {
+			fortio.Fatalf("Unable to create .mem profile: %v", err)
+		}
+		runtime.GC()               // get up-to-date statistics
+		pprof.WriteHeapProfile(fm) // nolint:gas,errcheck
+		fm.Close()                 // nolint:gas,errcheck
+		fmt.Printf("Wrote profile data to %s.{cpu|mem}\n", *profileFlag)
+	}
+	// Numthreads may have reduced
+	numThreads = r.Options().NumThreads
+	keys := []int{}
+	for i := 0; i < numThreads; i++ {
+		// Q: is there some copying each time stats[i] is used?
+		for k := range state[i].retCodes {
+			if _, exists := total.retCodes[k]; !exists {
+				keys = append(keys, k)
+			}
+			total.retCodes[k] += state[i].retCodes[k]
+		}
+		total.sizes.Transfer(state[i].sizes)
+		total.headerSizes.Transfer(state[i].headerSizes)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		fmt.Printf("Code %3d : %d\n", k, total.retCodes[k])
+	}
+	if fortio.LogVerbose() {
+		total.headerSizes.Print(os.Stdout, "Response Header Sizes Histogram", 50)
+		total.sizes.Print(os.Stdout, "Response Body/Total Sizes Histogram", 50)
+	} else {
+		total.headerSizes.Counter.Print(os.Stdout, "Response Header Sizes")
+		total.sizes.Counter.Print(os.Stdout, "Response Body/Total Sizes")
+	}
+}

--- a/devel/fortio/httprunner_test.go
+++ b/devel/fortio/httprunner_test.go
@@ -29,9 +29,11 @@ func TestHTTPRunner(t *testing.T) {
 	http.HandleFunc("/", EchoHandler)
 	port := DynamicHTTPServer()
 	opts := HTTPRunnerOptions{
+		RunnerOptions: RunnerOptions{
+			QPS: 100,
+		},
 		URL: fmt.Sprintf("http://localhost:%d/foo/bar", port),
 	}
-	opts.QPS = 100
 	res, err := RunHTTPTest(&opts)
 	if err != nil {
 		t.Error(err)

--- a/devel/fortio/httprunner_test.go
+++ b/devel/fortio/httprunner_test.go
@@ -26,15 +26,23 @@ import (
 )
 
 func TestHTTPRunner(t *testing.T) {
-	http.HandleFunc("/", EchoHandler)
+	SetLogLevel(Info)
+	http.HandleFunc("/foo/", EchoHandler)
 	port := DynamicHTTPServer()
+	baseURL := fmt.Sprintf("http://localhost:%d/", port)
+
 	opts := HTTPRunnerOptions{
 		RunnerOptions: RunnerOptions{
 			QPS: 100,
 		},
-		URL: fmt.Sprintf("http://localhost:%d/foo/bar", port),
+		URL: baseURL,
 	}
 	res, err := RunHTTPTest(&opts)
+	if err == nil {
+		t.Error("Expecting an error but didn't get it when not using full url")
+	}
+	opts.URL = baseURL + "foo/bar"
+	res, err = RunHTTPTest(&opts)
 	if err != nil {
 		t.Error(err)
 		return

--- a/devel/fortio/periodic.go
+++ b/devel/fortio/periodic.go
@@ -33,7 +33,10 @@ import (
 	"time"
 )
 
-// DefaultRunnerOptions ar the default values for options (do not mutate!).
+// DefaultRunnerOptions are the default values for options (do not mutate!).
+// This is only useful for initializing flag default values.
+// You do not need to use this directly, you can pass a newly created
+// RunnerOptions and 0 valued fields will be reset to these defaults.
 var DefaultRunnerOptions = RunnerOptions{
 	Duration:    5 * time.Second,
 	NumThreads:  4,
@@ -60,8 +63,8 @@ type RunnerOptions struct {
 // PeriodicRunner let's you exercise the Function at the given QPS and collect
 // statistics and histogram about the run.
 type PeriodicRunner interface {
-	// Starts the run
-	Run()
+	// Starts the run. Returns actual QPS and Histogram of function durations.
+	Run() (float64, *Histogram)
 	// Returns the options normalized by constructor - do not mutate
 	// (where is const when you need it...)
 	Options() *RunnerOptions
@@ -109,7 +112,7 @@ func (r *periodicRunner) Options() *RunnerOptions {
 }
 
 // Run starts the runner.
-func (r *periodicRunner) Run() {
+func (r *periodicRunner) Run() (float64, *Histogram) {
 	useQPS := (r.QPS > 0)
 	var numCalls int64
 	if useQPS {
@@ -183,6 +186,7 @@ func (r *periodicRunner) Run() {
 	for _, p := range r.Percentiles[1:] {
 		fmt.Printf("# target %g%% %.6g\n", p, functionDuration.CalcPercentile(p))
 	}
+	return actualQPS, functionDuration
 }
 
 // runOne runs in 1 go routine.


### PR DESCRIPTION
Moved a lot of the code from fortio main to the library so #517 can be
better/easier

(This is same as #519 with attempt at preserving history and without
the grpc wip)