### PR TITLE
Fix typo in console logs

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -203,7 +203,7 @@ func (c *CommonConfig) RunTest(m runnable) int {
 		ret = m.Run()
 	}
 	if err := c.saveLogs(ret); err != nil {
-		glog.Warning("Log saving inconplete: %s", err)
+		glog.Warning("Log saving incomplete")
 	}
 	c.Cleanup.cleanup()
 	return ret

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -203,7 +203,7 @@ func (c *CommonConfig) RunTest(m runnable) int {
 		ret = m.Run()
 	}
 	if err := c.saveLogs(ret); err != nil {
-		glog.Warning("Log saving incomplete")
+		glog.Warningf("Log saving incomplete: %v", err)
 	}
 	c.Cleanup.cleanup()
 	return ret


### PR DESCRIPTION
The error passed in to Warning is no longer printed since it has been printed in saveLogs and duplication can be avoid.