### PR TITLE
git ls-files|xargs sed -i .bak -e 's/PullPolicy: Always/PullPolicy: IfNotPresent/g'

### DIFF
--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: grafana
         image: gcr.io/istio-io/grafana:0.2.0-c570a67
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 3000
         env:

--- a/install/kubernetes/istio-auth-with-cluster-ca.yaml
+++ b/install/kubernetes/istio-auth-with-cluster-ca.yaml
@@ -60,7 +60,7 @@ spec:
           mountPath: /etc/statsd
       - name: mixer
         image: gcr.io/istio-io/mixer:0.2.0-c570a67
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091
         - containerPort: 9094
@@ -127,7 +127,7 @@ spec:
       containers:
       - name: discovery
         image: gcr.io/istio-testing/pilot:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["discovery", "-v", "2"]
         ports:
         - containerPort: 8080
@@ -193,7 +193,7 @@ spec:
       - name: istio-ingress
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
         args: ["proxy", "ingress", "-v", "2"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443
@@ -240,7 +240,7 @@ spec:
       containers:
       - name: proxy
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["proxy", "egress", "-v", "2"]
         env:
         - name: POD_NAMESPACE

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -60,7 +60,7 @@ spec:
           mountPath: /etc/statsd
       - name: mixer
         image: gcr.io/istio-io/mixer:0.2.0-c570a67
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091
         - containerPort: 9094
@@ -127,7 +127,7 @@ spec:
       containers:
       - name: discovery
         image: gcr.io/istio-testing/pilot:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["discovery", "-v", "2"]
         ports:
         - containerPort: 8080
@@ -193,7 +193,7 @@ spec:
       - name: istio-ingress
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
         args: ["proxy", "ingress", "-v", "2"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443
@@ -240,7 +240,7 @@ spec:
       containers:
       - name: proxy
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["proxy", "egress", "-v", "2"]
         env:
         - name: POD_NAMESPACE

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -60,7 +60,7 @@ spec:
           mountPath: /etc/statsd
       - name: mixer
         image: gcr.io/istio-io/mixer:0.2.0-c570a67
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091
         - containerPort: 9094
@@ -127,7 +127,7 @@ spec:
       containers:
       - name: discovery
         image: gcr.io/istio-testing/pilot:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["discovery", "-v", "2"]
         ports:
         - containerPort: 8080
@@ -193,7 +193,7 @@ spec:
       - name: istio-ingress
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
         args: ["proxy", "ingress", "-v", "2"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443
@@ -245,7 +245,7 @@ spec:
       containers:
       - name: proxy
         image: gcr.io/istio-testing/proxy_debug:5633d45a99138892a0ba0d380dff5c587583edd3
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["proxy", "egress", "-v", "2"]
         env:
         - name: POD_NAMESPACE

--- a/install/kubernetes/templates/istio-auth/istio-egress-auth.yaml
+++ b/install/kubernetes/templates/istio-auth/istio-egress-auth.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: proxy
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["proxy", "egress", "-v", "2"]
         env:
         - name: POD_NAMESPACE

--- a/install/kubernetes/templates/istio-auth/istio-ingress-auth.yaml
+++ b/install/kubernetes/templates/istio-auth/istio-ingress-auth.yaml
@@ -41,7 +41,7 @@ spec:
       - name: istio-ingress
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
         args: ["proxy", "ingress", "-v", "2"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/install/kubernetes/templates/istio-egress.yaml
+++ b/install/kubernetes/templates/istio-egress.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: proxy
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["proxy", "egress", "-v", "2"]
         env:
         - name: POD_NAMESPACE

--- a/install/kubernetes/templates/istio-ingress.yaml
+++ b/install/kubernetes/templates/istio-ingress.yaml
@@ -41,7 +41,7 @@ spec:
       - name: istio-ingress
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
         args: ["proxy", "ingress", "-v", "2"]
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
         - containerPort: 443

--- a/install/kubernetes/templates/istio-mixer.yaml
+++ b/install/kubernetes/templates/istio-mixer.yaml
@@ -58,7 +58,7 @@ spec:
           mountPath: /etc/statsd
       - name: mixer
         image: {MIXER_HUB}/mixer:{MIXER_TAG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091
         - containerPort: 9094

--- a/install/kubernetes/templates/istio-pilot.yaml
+++ b/install/kubernetes/templates/istio-pilot.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
       - name: discovery
         image: {PILOT_HUB}/pilot:{PILOT_TAG}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: ["discovery", "-v", "2"]
         ports:
         - containerPort: 8080

--- a/samples/apps/helloworld/helloworld.yaml
+++ b/samples/apps/helloworld/helloworld.yaml
@@ -30,7 +30,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-        imagePullPolicy: Always #IfNotPresent
+        imagePullPolicy: IfNotPresent #IfNotPresent
         ports:
         - containerPort: 5000
 ---
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-        imagePullPolicy: Always #IfNotPresent
+        imagePullPolicy: IfNotPresent #IfNotPresent
         ports:
         - containerPort: 5000
 ---

--- a/samples/apps/helloworld/helloworld.yaml
+++ b/samples/apps/helloworld/helloworld.yaml
@@ -30,7 +30,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-        imagePullPolicy: IfNotPresent #IfNotPresent
+        imagePullPolicy: IfNotPresent #Always
         ports:
         - containerPort: 5000
 ---
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-        imagePullPolicy: IfNotPresent #IfNotPresent
+        imagePullPolicy: IfNotPresent #Always
         ports:
         - containerPort: 5000
 ---


### PR DESCRIPTION
git ls-files|xargs sed -i .bak -e 's/PullPolicy: Always/PullPolicy:
IfNotPresent/g'

Fixes #441 

Should save a fair bit of network and overhead in tests and deployments
```release-note
Now using imagePullPolicy: IfNotPresent consistently to avoid redownloading the same image over and over again. Fixes #441.
```