### PR TITLE
Correct istio.deps

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -14,7 +14,7 @@
 		"lastStableSHA": "87cdc595-689d-4779-be29-ac845d47492e"
 	},
 	{
-		"name": "PILOT_HUB",
+		"name": "PILOT_TAG",
 		"repoName": "pilot",
 		"prodBranch": "stable",
 		"file": "istio.VERSION",


### PR DESCRIPTION
Fixed the typo hub->tag

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

