### PR TITLE
Update README about flags on cluster logs

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -19,7 +19,7 @@ Tests could be built and drove manually as a single test or automatically detect
 * `--verbose` debug level noise from proxies
 * `--istioctl_url` the location of an `istioctl` binary
 * `--skip_cleanup` if skip cleanup steps
-* `--log_provider` where cluster logs are hosted, only support stackdriver for now
+* `--log_provider` where cluster logs are hosted, only support `stackdriver` for now
 * `--project_id=` project id used to filter logs from provider
 
 Default values for the `mixer_hub/tag`, `pilot_hub/tag`, and `istioctl_url` are as specified in
@@ -30,7 +30,7 @@ Look at [Integration Test](https://github.com/istio/istio/tree/master/tests#upda
 
 If not specify `namespace`, a randomly namespace would be generated for each test.
 
-`log_provider` and `project_id` must both be specified if one wish to collects cluster logs.
+`log_provider` and `project_id` must both be specified if one wishes to collect cluster logs.
 
 ### Example
 From the repo checkout root directory

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -19,6 +19,8 @@ Tests could be built and drove manually as a single test or automatically detect
 * `--verbose` debug level noise from proxies
 * `--istioctl_url` the location of an `istioctl` binary
 * `--skip_cleanup` if skip cleanup steps
+* `--log_provider` where cluster logs are hosted, only support stackdriver for now
+* `--project_id=` project id used to filter logs from provider
 
 Default values for the `mixer_hub/tag`, `pilot_hub/tag`, and `istioctl_url` are as specified in
 [istio.VERSION](../../istio.VERSION), which are latest tested stable version pairs.
@@ -27,6 +29,8 @@ istio.VERSION can be updated by [updateVersion.sh](../../updateVersion.sh).
 Look at [Integration Test](https://github.com/istio/istio/tree/master/tests#updateversionsh) for more information.
 
 If not specify `namespace`, a randomly namespace would be generated for each test.
+
+`log_provider` and `project_id` must both be specified if one wish to collects cluster logs.
 
 ### Example
 From the repo checkout root directory


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

