### PR TITLE
Add use_local_cluster flag to e2e test readme

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,8 @@ Tests could be built and drove manually as a single test or automatically detect
 * `--istioctl_url` the location of an `istioctl` binary
 * `--skip_cleanup` if skip cleanup steps
 * `--log_provider` where cluster logs are hosted, only support `stackdriver` for now
-* `--project_id=` project id used to filter logs from provider
+* `--project_id` project id used to filter logs from provider
+* `--use_local_cluster` whether the cluster is local or not
 
 Default values for the `mixer_hub/tag`, `pilot_hub/tag`, and `istioctl_url` are as specified in
 [istio.VERSION](../../istio.VERSION), which are latest tested stable version pairs.


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

