### PR TITLE
Update e2e doc about parallel flag

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -22,6 +22,7 @@ Tests could be built and drove manually as a single test or automatically detect
 * `--log_provider` where cluster logs are hosted, only support `stackdriver` for now
 * `--project_id` project id used to filter logs from provider
 * `--use_local_cluster` whether the cluster is local or not
+* `--parallel` run tests in parallel (sequentially if without flag)
 
 Default values for the `mixer_hub/tag`, `pilot_hub/tag`, and `istioctl_url` are as specified in
 [istio.VERSION](../../istio.VERSION), which are latest tested stable version pairs.


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

