### PR TITLE
Add link to community drive for design docs

### DIFF
--- a/GROUPS.md
+++ b/GROUPS.md
@@ -6,6 +6,8 @@ Working Groups follow the [contributing](CONTRIBUTING.md) guidelines although ea
 
 When the need arises, a new working group can be created, please contact the [istio-core](https://groups.google.com/forum/#!forum/istio-core) working group if you think a new group is necessary.
 
+The working groups generate design docs which are kept in a [shared drive](https://drive.google.com/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) and are available for anyone to read. You have to request access to the drive, something we're stuck with sadly, but once you do you'll have access to all the docs and won't need to request access for each of them individually.
+
 ## Master Working Group List
 
 | Name | Leads | Mailing List | Example Topics |


### PR DESCRIPTION
Get folks to join the drive rather than requesting access for each doc. :/

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
<PLEASE PUT RELEASE-NOTE HERE, PUT NONE if NO RELEASE-NOTE>
```

