### PR TITLE
WIP: Mitigate overloading stackdriver api until quota increased

### DIFF
--- a/tests/e2e/framework/testInfo.go
+++ b/tests/e2e/framework/testInfo.go
@@ -64,7 +64,7 @@ const (
 	tmpPrefix            = "istio.e2e."
 	idMaxLength          = 36
 	pageSize             = 1000 // number of log entries for each paginated request to fetch logs
-	maxConcurrentWorkers = 2    //avoid overloading stackdriver api
+	maxConcurrentWorkers = 1    //avoid overloading stackdriver api
 )
 
 // TestInfo gathers Test Information


### PR DESCRIPTION
We are trying to increase the stackdriver api quota limit. This is plan b if that does pass.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

