### PR TITLE
Fetch more logs from stackdriver

### DIFF
--- a/tests/e2e/framework/testInfo.go
+++ b/tests/e2e/framework/testInfo.go
@@ -51,12 +51,30 @@ var (
 	}
 	testLogsPath = flag.String("test_logs_path", "", "Local path to store logs in")
 	logIDs       = []string{
-		"apiserver",
+		"app",
+		"autoscaler",
+		"calico-typha",
+		"details",
 		"discovery",
+		"dnsmasq",
+		"event-exporter",
+		"fluentd-gcp",
+		"heapster",
+		"heapster-nanny",
+		"istio-ca",
+		"istio-ca-container",
 		"istio-ingress",
+		"istio-proxy",
 		"mixer",
-		"prometheus",
-		"statesd-to-prometheus",
+		"kubedns",
+		"mongodb",
+		"mysqldb",
+		"proxy",
+		"ratings",
+		"reviews",
+		"sidecar",
+		"sidecar-initializer",
+		"zipkin",
 	}
 )
 


### PR DESCRIPTION
Fetching all these logs take about one minute given the latest presubmits. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

