### PR TITLE
Lower rate limit to 1rps

### DIFF
--- a/samples/apps/bookinfo/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/apps/bookinfo/mixer-rule-ratings-ratelimit.yaml
@@ -4,5 +4,5 @@ rules:
     params:
       quotas:
       - descriptorName: RequestCount
-        maxAmount: 5
+        maxAmount: 1
         expiration: 1s

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -320,8 +320,8 @@ func TestRateLimit(t *testing.T) {
 	if err := replaceRouteRule(routeReviewsV3Rule); err != nil {
 		t.Fatalf("Could not create replace reviews routing rule: %v", err)
 	}
-	// the rate limit rule applies a max rate limit of 5 rps. Here we apply it
-	// to the "ratings" service (without a selector -- meaning for all versions).
+	// the rate limit rule applies a max rate limit of 1 rps. Here we apply it
+	// to the "ratings" service (without a selector).
 	ratings := fqdn("ratings")
 	if err := createMixerRule(global, ratings, rateLimitRule); err != nil {
 		t.Fatalf("Could not create required mixer rule: %got", err)
@@ -340,7 +340,7 @@ func TestRateLimit(t *testing.T) {
 	// traffic is generated to trigger 429s from the rate limit rule
 	opts := fortio.HTTPRunnerOptions{
 		RunnerOptions: fortio.RunnerOptions{
-			QPS:        100,
+			QPS:        10,
 			Duration:   1 * time.Minute,
 			NumThreads: 8,
 		},
@@ -371,9 +371,8 @@ func TestRateLimit(t *testing.T) {
 	// consider only successful requests (as recorded at productpage service)
 	callsToRatings := float64(succReqs)
 
-	// the rate-limit is 5 rps, but observed actuals are [4-5) in experimental
-	// testing. opt for leniency here to decrease flakiness of testing.
-	want200s := opts.Duration.Seconds() * 4
+	// the rate-limit is 1 rps
+	want200s := opts.Duration.Seconds()
 
 	// everything in excess of 200s should be 429s (ideally)
 	want429s := callsToRatings - want200s


### PR DESCRIPTION
Apparently, with the sample app, generating more than 5 rps is problematic for a variety of test clusters. This PR lowers the enforced rate limit to 1 rps. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

