### PR TITLE
Add empty  monitored resource type to metric crd objs

### DIFF
--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/istio-testing/grafana:49ad083ba35943880f57a16a475c50b1e037dde8
+        image: gcr.io/istio-testing/grafana:a6e8b94c9217394139f41acb5c9bfdc19426690d
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 3000

--- a/install/kubernetes/istio-auth-with-cluster-ca.yaml
+++ b/install/kubernetes/istio-auth-with-cluster-ca.yaml
@@ -59,7 +59,7 @@ spec:
         - name: config-volume
           mountPath: /etc/statsd
       - name: mixer
-        image: gcr.io/istio-testing/mixer:49ad083ba35943880f57a16a475c50b1e037dde8
+        image: gcr.io/istio-testing/mixer:a6e8b94c9217394139f41acb5c9bfdc19426690d
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -59,7 +59,7 @@ spec:
         - name: config-volume
           mountPath: /etc/statsd
       - name: mixer
-        image: gcr.io/istio-testing/mixer:49ad083ba35943880f57a16a475c50b1e037dde8
+        image: gcr.io/istio-testing/mixer:a6e8b94c9217394139f41acb5c9bfdc19426690d
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -59,7 +59,7 @@ spec:
         - name: config-volume
           mountPath: /etc/statsd
       - name: mixer
-        image: gcr.io/istio-testing/mixer:49ad083ba35943880f57a16a475c50b1e037dde8
+        image: gcr.io/istio-testing/mixer:a6e8b94c9217394139f41acb5c9bfdc19426690d
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9091

--- a/istio.VERSION
+++ b/istio.VERSION
@@ -3,7 +3,7 @@
 export CA_HUB="docker.io/istio"
 export CA_TAG="0.2.1"
 export MIXER_HUB="gcr.io/istio-testing"
-export MIXER_TAG="49ad083ba35943880f57a16a475c50b1e037dde8"
+export MIXER_TAG="a6e8b94c9217394139f41acb5c9bfdc19426690d"
 export ISTIOCTL_URL="https://storage.googleapis.com/istio-artifacts/pilot/fb947d4c6d0902a841e0e82ffa3bee16786be0df/artifacts/istioctl"
 export PILOT_HUB="gcr.io/istio-testing"
 export PILOT_TAG="fb947d4c6d0902a841e0e82ffa3bee16786be0df"

--- a/samples/apps/bookinfo/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/mixer-rule-standard-metrics.yaml
@@ -49,7 +49,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -65,7 +65,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -81,7 +81,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -97,7 +97,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/samples/apps/bookinfo/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/mixer-rule-standard-metrics.yaml
@@ -49,6 +49,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -64,6 +65,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -79,6 +81,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -94,6 +97,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
@@ -49,7 +49,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -65,7 +65,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -81,7 +81,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -97,7 +97,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
-  monitored_resource_type: '"empty_temporary"'
+  monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
@@ -49,6 +49,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -64,6 +65,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -79,6 +81,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -94,6 +97,7 @@ spec:
     method: request.path | "unknown"
     version: target.labels["version"] | "unknown"
     response_code: response.code | 200
+  monitored_resource_type: '"empty_temporary"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule


### PR DESCRIPTION
Mixer PR https://github.com/istio/mixer/pull/1205 is adding a breaking change that needs instance config for metric template to have monitored_resource_type set as a string. This PR first fixes the test and updates the istio.VERSION to point to the mixer with the breaking change. Once this PR is in, I will commit the mixer code as well.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

