### PR TITLE
Update rate limit test

### DIFF
--- a/samples/apps/bookinfo/rules/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-ratings-ratelimit.yaml
@@ -4,5 +4,5 @@ rules:
     params:
       quotas:
       - descriptorName: RequestCount
-        maxAmount: 5
+        maxAmount: 1
         expiration: 1s


### PR DESCRIPTION
This PR does a few things:
- fixes the 5rps v 1rps issue in the rules file that was leading to unexpected behavior in TestRateLimit
- adds more debug/info to TestRateLimit to enable better insight into behavior
- adds a check that the expected rate limit is not exceeded (which requires baselining to ensure metrics aren't added from a prior run).

Example run of TestRateLimit now:
```
--- PASS: TestRateLimit (153.74s)
	mixer_test.go:374: Establishing metrics baseline for test...
	mixer_test.go:376: prometheus query: request_count{target="ratings.mixer-test-1e8dc68d6d774f679cf9123857.svc.cluster.local"}
	mixer_test.go:384: error getting prior 429s, using 0 as value (msg: value not found for map[string]string{"response_code":"429"})
	mixer_test.go:390: error getting prior 200s, using 0 as value (msg: value not found for map[string]string{"response_code":"200"})
	mixer_test.go:393: Baseline established: prior200s = 0.000000, prior429s = 0.000000
	mixer_test.go:395: Sending traffic...
	mixer_test.go:423: Fortio Summary: 600 reqs (600.000000 200s (10.000000 rps), 0 400s)
	mixer_test.go:434: Expected Totals: 200s: 60.000000 (1.000000 rps), 429s: 540.000000 (9.000000 rps)
	mixer_test.go:445: prometheus query: request_count{target="ratings.mixer-test-1e8dc68d6d774f679cf9123857.svc.cluster.local"}
	mixer_test.go:463: Actual 429s: 569.000000 (9.483333 rps)
	mixer_test.go:479: Actual 200s: 39.000000 (0.650000 rps)
PASS
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
NONE
```

