### PR TITLE
Do not log error if kubectl log fails with 'no previous container'

### DIFF
--- a/tests/e2e/util/commonUtils.go
+++ b/tests/e2e/util/commonUtils.go
@@ -73,11 +73,11 @@ func Shell(format string, args ...interface{}) (string, error) {
 	glog.V(2).Infof("Running command %s", command)
 	c := exec.Command(parts[0], parts[1:]...) // #nosec
 	bytes, err := c.CombinedOutput()
-	glog.V(2).Infof("Command output: \n %s, err: %v", string(bytes[:]), err)
 	if err != nil {
 		return string(bytes), fmt.Errorf("command failed: %q %v", string(bytes), err)
 	}
 
+	glog.V(2).Infof("Command output: \n %s", string(bytes[:]))
 	return string(bytes), nil
 }
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

