### PR TITLE
Clean up ClusterRoleBindings

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -140,10 +140,10 @@ func (k *KubeInfo) Teardown() error {
 	var err error
 
 	if *rbacfile != "" {
-		baseRbacYaml := util.GetResourcePath(*rbacfile)
+
 		testRbacYaml := filepath.Join(k.TmpDir, "yaml", filepath.Base(*rbacfile))
-		if err = k.generateRbac(baseRbacYaml, testRbacYaml); err != nil {
-			glog.Errorf("Generating rbac yaml failed")
+		if _, err = os.Stat(testRbacYaml); os.IsNotExist(err) {
+			glog.Errorf("%s File does not exist", testRbacYaml)
 		} else if err = util.KubeDelete(k.Namespace, testRbacYaml); err != nil {
 			glog.Errorf("Rbac deletion failed, please remove stale ClusterRoleBindings")
 		}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -142,12 +142,10 @@ func (k *KubeInfo) Teardown() error {
 	if *rbacfile != "" {
 		baseRbacYaml := util.GetResourcePath(*rbacfile)
 		testRbacYaml := filepath.Join(k.TmpDir, "yaml", filepath.Base(*rbacfile))
-		if err := k.generateRbac(baseRbacYaml, testRbacYaml); err != nil {
+		if err = k.generateRbac(baseRbacYaml, testRbacYaml); err != nil {
 			glog.Errorf("Generating rbac yaml failed")
-		}
-		if err := util.KubeDelete(k.Namespace, testRbacYaml); err != nil {
-			glog.Errorf("Rbac deployment deletion failed")
-			return err
+		} else if err = util.KubeDelete(k.Namespace, testRbacYaml); err != nil {
+			glog.Errorf("Rbac deletion failed, please remove stale ClusterRoleBindings")
 		}
 	}
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -138,6 +138,19 @@ func (k *KubeInfo) Setup() error {
 func (k *KubeInfo) Teardown() error {
 	glog.Info("Cleaning up kubeInfo")
 	var err error
+
+	if *rbacfile != "" {
+		baseRbacYaml := util.GetResourcePath(*rbacfile)
+		testRbacYaml := filepath.Join(k.TmpDir, "yaml", filepath.Base(*rbacfile))
+		if err := k.generateRbac(baseRbacYaml, testRbacYaml); err != nil {
+			glog.Errorf("Generating rbac yaml failed")
+		}
+		if err := util.KubeDelete(k.Namespace, testRbacYaml); err != nil {
+			glog.Errorf("Rbac deployment deletion failed")
+			return err
+		}
+	}
+
 	if k.namespaceCreated {
 		if err = util.DeleteNamespace(k.Namespace); err != nil {
 			glog.Errorf("Failed to delete namespace %s", k.Namespace)


### PR DESCRIPTION
Fixes  istio/pilot#1239

The only cleanup done by the tests is to delete the namespaces, but this leaves behind resources which are not namespaced, like ClusterRoleBinding.
Added code to delete them.

Matches istio/pilot#1240