### PR TITLE
Change grafana port name to http

### DIFF
--- a/install/kubernetes/addons/grafana.yaml
+++ b/install/kubernetes/addons/grafana.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 3000
     protocol: TCP
-    name: grafana
+    name: http
   selector:
     app: grafana
 ---


### PR DESCRIPTION
Istio conventions are to use 'http' for http ports. 

This allows adding ingress rules for grafana.

```release-note
NONE
```

