### PR TITLE
Add test for TCP Metrics

### DIFF
--- a/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
@@ -99,4 +99,18 @@ spec:
         valueType: STRING
       destination.serviceAccount:
         valueType: STRING
+      destination.ip:
+        valueType: IP_ADDRESS
+      destination.port:
+        valueType: INT64
+      destination.labels:
+        valueType: STRING_MAP
+      destination.name:
+        valueType: STRING
+      destination.namespace:
+        valueType: STRING
+      destination.service:
+        valueType: STRING
+      destination.serviceAccount:
+        valueType: STRING
 

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
@@ -99,18 +99,3 @@ spec:
         valueType: STRING
       destination.serviceAccount:
         valueType: STRING
-      destination.ip:
-        valueType: IP_ADDRESS
-      destination.port:
-        valueType: INT64
-      destination.labels:
-        valueType: STRING_MAP
-      destination.name:
-        valueType: STRING
-      destination.namespace:
-        valueType: STRING
-      destination.service:
-        valueType: STRING
-      destination.serviceAccount:
-        valueType: STRING
-

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
@@ -34,6 +34,14 @@ spec:
         numFiniteBuckets: 8
         scale: 1
         growthFactor: 10
+  - name: tcp_bytes_sent
+    instance_name: tcpbytesent.metric.istio-config-default
+    kind: COUNTER
+    label_names: [ source_service, source_version, destination_service, destination_version ]
+  - name: tcp_bytes_received
+    instance_name: tcpbytereceived.metric.istio-config-default
+    kind: COUNTER
+    label_names: [ source_service, source_version, destination_service, destination_version ]
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
@@ -100,10 +108,44 @@ spec:
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpbytesent
+  namespace: istio-config-default
+  labels:
+    istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp
+spec:
+  value: connection.sent.bytes | 0
+  dimensions:
+    source_service: source.service | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_service: target.service | "unknown"
+    destination_version: target.labels["version"] | "unknown"
+  monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpbytereceived
+  namespace: istio-config-default
+  labels:
+    istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp 
+spec:
+  value: connection.received.bytes | 0
+  dimensions:
+    source_service: source.service | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_service: target.service | "unknown"
+    destination_version: target.labels["version"] | "unknown"
+  monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: prommetrics
   namespace: istio-config-default
+  labels:
+    istio-protocol: http
 spec:
   actions:
   - handler: handler.prometheus.istio-config-default
@@ -117,8 +159,25 @@ kind: rule
 metadata:
   name: prommetricsresponse
   namespace: istio-config-default
+  labels:
+    istio-protocol: http
 spec:
   actions:
   - handler: handler.prometheus.istio-config-default
     instances:
     - responsesize.metric.istio-config-default
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcp
+  namespace: istio-config-default
+  labels:
+    istio-protocol: tcp # needed so that mixer will only generate when context.protocol == tcp
+spec:
+  actions:
+  - handler: handler.prometheus.istio-config-default
+    instances:
+    - tcpbytesent.metric.istio-config-default
+    - tcpbytereceived.metric.istio-config-default
+---

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
@@ -119,8 +119,8 @@ spec:
   dimensions:
     source_service: source.service | "unknown"
     source_version: source.labels["version"] | "unknown"
-    destination_service: target.service | "unknown"
-    destination_version: target.labels["version"] | "unknown"
+    destination_service: destination.service | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -135,8 +135,8 @@ spec:
   dimensions:
     source_service: source.service | "unknown"
     source_version: source.labels["version"] | "unknown"
-    destination_service: target.service | "unknown"
-    destination_version: target.labels["version"] | "unknown"
+    destination_service: destination.service | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -567,7 +567,7 @@ func TestRateLimit(t *testing.T) {
 	}
 	glog.Infof("promvalue := %s", value.String())
 
-	got, err := vectorValue(value, map[string]string{responseCodeLabel: "429"})
+	got, err := vectorValue(value, map[string]string{responseCodeLabel: "429", "version": "v1"})
 	if err != nil {
 		t.Logf("prometheus values for request_count:\n%s", promDump(promAPI, "request_count"))
 		fatalf(t, "Could not find rate limit value: %v", err)
@@ -586,7 +586,7 @@ func TestRateLimit(t *testing.T) {
 		errorf(t, "Bad metric value for rate-limited requests (429s): got %f, want at least %f", got, want)
 	}
 
-	got, err = vectorValue(value, map[string]string{responseCodeLabel: "200"})
+	got, err = vectorValue(value, map[string]string{responseCodeLabel: "200", "version": "v1"})
 	if err != nil {
 		t.Logf("prometheus values for request_count:\n%s", promDump(promAPI, "request_count"))
 		fatalf(t, "Could not find successes value: %v", err)

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -41,6 +41,8 @@ import (
 
 const (
 	bookinfoYaml             = "samples/apps/bookinfo/bookinfo.yaml"
+	bookinfoRatingsv2Yaml    = "samples/apps/bookinfo/bookinfo-ratings-v2.yaml"
+	bookinfoDbYaml           = "samples/apps/bookinfo/bookinfo-db.yaml"
 	rulesDir                 = "samples/apps/bookinfo/rules"
 	rateLimitRule            = "mixer-rule-ratings-ratelimit.yaml"
 	denialRule               = "mixer-rule-ratings-denial.yaml"
@@ -52,6 +54,7 @@ const (
 	preProcessOnlyRule       = "mixer-rule-preprocess-only.yaml"
 	standardMetrics          = "mixer-rule-standard-metrics.yaml"
 	standardAttributes       = "mixer-rule-standard-attributes.yaml"
+	tcpDbRule                = "route-rule-ratings-db.yaml"
 
 	prometheusPort   = "9090"
 	mixerMetricsPort = "42422"
@@ -78,7 +81,7 @@ var (
 	productPageTimeout = 60 * time.Second
 	rules              = []string{rateLimitRule, denialRule, newTelemetryRule, routeAllRule,
 		routeReviewsVersionsRule, routeReviewsV3Rule, emptyRule, preProcessOnlyRule,
-		standardAttributes, standardMetrics}
+		standardAttributes, standardMetrics, tcpDbRule}
 )
 
 func (t *testConfig) Setup() (err error) {
@@ -318,6 +321,68 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	if (got - prior200s) < want {
 		t.Logf("prometheus values for request_count:\n%s", promDump(promAPI, "request_count"))
 		errorf(t, "Bad metric value: got %f, want at least %f", got-prior200s, want)
+	}
+}
+
+func TestTcpMetrics(t *testing.T) {
+	if err := replaceRouteRule(tcpDbRule); err != nil {
+		t.Fatalf("Could not update reviews routing rule: %v", err)
+	}
+	defer func() {
+		if err := deleteRouteRule(tcpDbRule); err != nil {
+			t.Fatalf("Could not delete reviews routing rule: %v", err)
+		}
+	}()
+	allowRuleSync()
+
+	if err := visitProductPage(productPageTimeout, http.StatusOK); err != nil {
+		t.Fatalf("Test app setup failure: %v", err)
+	}
+	allowPrometheusSync()
+
+	glog.Info("Successfully sent request(s) to /productpage; checking metrics...")
+
+	promAPI, err := promAPI()
+	if err != nil {
+		fatalf(t, "Could not build prometheus API client: %v", err)
+	}
+	query := fmt.Sprintf("tcp_bytes_sent{destination_service=\"%s\"}", fqdn("mongodb"))
+	t.Logf("prometheus query: %s", query)
+	value, err := promAPI.Query(context.Background(), query, time.Now())
+	if err != nil {
+		fatalf(t, "Could not get metrics from prometheus: %v", err)
+	}
+	glog.Infof("promvalue := %s", value.String())
+
+	got, err := vectorValue(value, map[string]string{})
+	if err != nil {
+		t.Logf("prometheus values for tcp_bytes_sent:\n%s", promDump(promAPI, "tcp_bytes_sent"))
+		fatalf(t, "Could not find metric value: %v", err)
+	}
+	t.Logf("tcp_bytes_sent: %f", got)
+	want := float64(1)
+	if got < want {
+		t.Logf("prometheus values for tcp_bytes_sent:\n%s", promDump(promAPI, "tcp_bytes_sent"))
+		errorf(t, "Bad metric value: got %f, want at least %f", got, want)
+	}
+
+	query = fmt.Sprintf("tcp_bytes_received{destination_service=\"%s\"}", fqdn("mongodb"))
+	t.Logf("prometheus query: %s", query)
+	value, err = promAPI.Query(context.Background(), query, time.Now())
+	if err != nil {
+		fatalf(t, "Could not get metrics from prometheus: %v", err)
+	}
+	glog.Infof("promvalue := %s", value.String())
+
+	got, err = vectorValue(value, map[string]string{})
+	if err != nil {
+		t.Logf("prometheus values for tcp_bytes_received:\n%s", promDump(promAPI, "tcp_bytes_received"))
+		fatalf(t, "Could not find metric value: %v", err)
+	}
+	t.Logf("tcp_bytes_received: %f", got)
+	if got < want {
+		t.Logf("prometheus values for tcp_bytes_received:\n%s", promDump(promAPI, "tcp_bytes_received"))
+		errorf(t, "Bad metric value: got %f, want at least %f", got, want)
 	}
 }
 
@@ -747,11 +812,23 @@ func setTestConfig() error {
 		return err
 	}
 	tc.rulesDir = tmpDir
-	demoApp := &framework.App{
-		AppYaml:    util.GetResourcePath(bookinfoYaml),
-		KubeInject: true,
+	demoApps := []framework.App{
+		{
+			AppYaml:    util.GetResourcePath(bookinfoYaml),
+			KubeInject: true,
+		},
+		{
+			AppYaml:    util.GetResourcePath(bookinfoRatingsv2Yaml),
+			KubeInject: true,
+		},
+		{
+			AppYaml:    util.GetResourcePath(bookinfoDbYaml),
+			KubeInject: true,
+		},
 	}
-	tc.Kube.AppManager.AddApp(demoApp)
+	for i := range demoApps {
+		tc.Kube.AppManager.AddApp(&demoApps[i])
+	}
 	mp := newPromProxy(tc.Kube.Namespace)
 	tc.Cleanup.RegisterCleanable(mp)
 	return nil


### PR DESCRIPTION
This PR adds a basic test to check that TCP metrics can be generated for TCP services. It uses the bookinfo sample app, including the mongodb service.

It also adds:
- attributes to the required manifest
- rules and metrics definitions to the standard-metrics (and prometheus)
- the kube-inject for the db rules.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
NONE
```

