### PR TITLE
Add pre-test request to prime system

### DIFF
--- a/devel/rules.yml
+++ b/devel/rules.yml
@@ -24,7 +24,7 @@ rules:
           version: target.labels["version"] | "unknown"
           response_code: response.code | 200
       - descriptor_name:  request_duration
-        value: response.latency | response.duration | "0ms"
+        value: response.duration | "0ms"
         labels:
           source: source.labels["app"] | "unknown"
           target: target.service | "unknown"

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-attributes.yaml
@@ -39,8 +39,6 @@ spec:
         valueType: DURATION
       response.headers:
         valueType: STRING_MAP
-      response.latency:
-        valueType: DURATION
       response.size:
         valueType: INT64
       response.time:
@@ -69,9 +67,6 @@ spec:
         valueType: TIMESTAMP
       context.time:
         valueType: TIMESTAMP
-      # DEPRECATED, to be removed. Use request.useragent instead.
-      request.user-agent:
-        valueType: STRING
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest

--- a/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
+++ b/samples/apps/bookinfo/rules/mixer-rule-standard-metrics.yaml
@@ -57,7 +57,7 @@ metadata:
   name: requestduration
   namespace: istio-config-default
 spec:
-  value: response.latency | response.duration | "0ms"
+  value: response.duration | "0ms"
   dimensions:
     source: source.labels["app"] | "unknown"
     target: destination.service | "unknown"

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -291,8 +291,8 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	t.Logf("Baseline established: prior200s = %f", prior200s)
 	t.Log("Visiting product page...")
 
-	if err = visitProductPage(productPageTimeout, http.StatusOK); err != nil {
-		t.Fatalf("Test app setup failure: %v", err)
+	if errNew := visitProductPage(productPageTimeout, http.StatusOK); errNew != nil {
+		t.Fatalf("Test app setup failure: %v", errNew)
 	}
 	allowPrometheusSync()
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -111,6 +111,14 @@ func (t *testConfig) Setup() (err error) {
 	}
 
 	err = createDefaultRoutingRules()
+
+	// pre-warm the system. we don't care about what happens with this
+	// request, but we want Mixer, etc., to be ready to go when the actual
+	// Tests start.
+	if err = visitProductPage(30*time.Second, 200); err != nil {
+		glog.Infof("initial product page request failed: %v", err)
+	}
+
 	return
 }
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -291,7 +291,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	t.Logf("Baseline established: prior200s = %f", prior200s)
 	t.Log("Visiting product page...")
 
-	if err := visitProductPage(productPageTimeout, http.StatusOK); err != nil {
+	if err = visitProductPage(productPageTimeout, http.StatusOK); err != nil {
 		t.Fatalf("Test app setup failure: %v", err)
 	}
 	allowPrometheusSync()
@@ -312,6 +312,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 		fatalf(t, "Could not find metric value: %v", err)
 	}
 	t.Logf("Got request_count (200s) of: %f", got)
+	t.Logf("Actual new requests observed: %f", got-prior200s)
 
 	want := float64(1)
 	if (got - prior200s) < want {


### PR DESCRIPTION
This PR adds logic to send a single request to `/productpage` before the testing begins. This should result in initializing connections throughout the mesh. In particular, this is aimed at triggering full Mixer initialization in advance of test conditions. This will help reduce potential flakiness around Mixer preprocess adapter initialization and sync (which may extend beyond deadlines for Report(), etc.)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
NONE
```

