### PR TITLE
Use unique ClusterRole names

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -13,7 +13,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-pilot
+  name: istio-pilot-istio-system
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -40,7 +40,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-mixer
+  name: istio-mixer-istio-system
 rules:
 - apiGroups: ["config.istio.io"] # Istio CRD watcher
   resources: ["*"]
@@ -55,7 +55,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-ca
+  name: istio-ca-istio-system
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -68,7 +68,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
 rules:
 - apiGroups: ["istio.io"]
   resources: ["istioconfigs"]

--- a/install/kubernetes/istio-cluster-wide.yaml
+++ b/install/kubernetes/istio-cluster-wide.yaml
@@ -13,7 +13,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-pilot
+  name: istio-pilot-istio-system
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -40,7 +40,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-mixer
+  name: istio-mixer-istio-system
 rules:
 - apiGroups: ["config.istio.io"] # Istio CRD watcher
   resources: ["*"]
@@ -55,7 +55,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-ca
+  name: istio-ca-istio-system
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -68,7 +68,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
 rules:
 - apiGroups: ["istio.io"]
   resources: ["istioconfigs"]

--- a/install/kubernetes/istio-rbac-beta.yaml
+++ b/install/kubernetes/istio-rbac-beta.yaml
@@ -6,7 +6,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-pilot
+  name: istio-pilot-istio-system
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -33,7 +33,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-mixer
+  name: istio-mixer-istio-system
 rules:
 - apiGroups: ["config.istio.io"] # Istio CRD watcher
   resources: ["*"]
@@ -48,7 +48,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-ca
+  name: istio-ca-istio-system
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -61,7 +61,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
 rules:
 - apiGroups: ["istio.io"]
   resources: ["istioconfigs"]

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -13,7 +13,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-pilot
+  name: istio-pilot-istio-system
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -40,7 +40,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-mixer
+  name: istio-mixer-istio-system
 rules:
 - apiGroups: ["config.istio.io"] # Istio CRD watcher
   resources: ["*"]
@@ -55,7 +55,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-ca
+  name: istio-ca-istio-system
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -68,7 +68,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
 rules:
 - apiGroups: ["istio.io"]
   resources: ["istioconfigs"]

--- a/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
+++ b/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
@@ -6,7 +6,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{ISTIO_NAMESPACE}
 rules:
 - apiGroups: ["config.istio.io"]
   resources: ["*"]
@@ -33,7 +33,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-mixer
+  name: istio-mixer-{ISTIO_NAMESPACE}
 rules:
 - apiGroups: ["config.istio.io"] # Istio CRD watcher
   resources: ["*"]
@@ -48,7 +48,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-ca
+  name: istio-ca-{ISTIO_NAMESPACE}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -61,7 +61,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: istio-sidecar
+  name: istio-sidecar-{ISTIO_NAMESPACE}
 rules:
 - apiGroups: ["istio.io"]
   resources: ["istioconfigs"]


### PR DESCRIPTION
Use unique ClusterRole names so a test in the shared test cluster does not delete the clusterrole from another test.