### PR TITLE
Correct match with clusterrole

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -91,7 +91,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the CA.
@@ -105,7 +105,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-ca
+  name: istio-ca-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Ingress controller.
@@ -119,7 +119,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Egress controller.
@@ -133,7 +133,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the sidecar.
@@ -149,7 +149,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to Mixer.
@@ -163,7 +163,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-mixer
+  name: istio-mixer-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Mixer

--- a/install/kubernetes/istio-cluster-wide.yaml
+++ b/install/kubernetes/istio-cluster-wide.yaml
@@ -91,7 +91,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the CA.
@@ -105,7 +105,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-ca
+  name: istio-ca-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Ingress controller.
@@ -119,7 +119,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Egress controller.
@@ -133,7 +133,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the sidecar.
@@ -149,7 +149,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to Mixer.
@@ -163,7 +163,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-mixer
+  name: istio-mixer-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Mixer

--- a/install/kubernetes/istio-rbac-beta.yaml
+++ b/install/kubernetes/istio-rbac-beta.yaml
@@ -84,7 +84,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the CA.
@@ -98,7 +98,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-ca
+  name: istio-ca-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Ingress controller.
@@ -112,7 +112,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Egress controller.
@@ -126,7 +126,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the sidecar.
@@ -142,7 +142,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to Mixer.
@@ -156,6 +156,6 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-mixer
+  name: istio-mixer-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -91,7 +91,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the CA.
@@ -105,7 +105,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-ca
+  name: istio-ca-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Ingress controller.
@@ -119,7 +119,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Egress controller.
@@ -133,7 +133,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the sidecar.
@@ -149,7 +149,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-sidecar
+  name: istio-sidecar-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to Mixer.
@@ -163,7 +163,7 @@ subjects:
   namespace: istio-system
 roleRef:
   kind: ClusterRole
-  name: istio-mixer
+  name: istio-mixer-istio-system
   apiGroup: rbac.authorization.k8s.io
 ---
 # Mixer

--- a/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
+++ b/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
@@ -84,7 +84,7 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the CA.
@@ -98,7 +98,7 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-ca
+  name: istio-ca-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Ingress controller.
@@ -112,7 +112,7 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the Egress controller.
@@ -126,7 +126,7 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-pilot
+  name: istio-pilot-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to the sidecar.
@@ -142,7 +142,7 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-sidecar
+  name: istio-sidecar-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---
 # Grant permissions to Mixer.
@@ -156,6 +156,6 @@ subjects:
   namespace: {ISTIO_NAMESPACE}
 roleRef:
   kind: ClusterRole
-  name: istio-mixer
+  name: istio-mixer-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---


### PR DESCRIPTION
Use the correct unique clusterrole in the clusterrolebinding.