### PR TITLE
Remove unused configmap from ingress and egress

### DIFF
--- a/install/kubernetes/templates/istio-egress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-egress.yaml.tmpl
@@ -37,7 +37,13 @@ spec:
       - name: proxy
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
         imagePullPolicy: IfNotPresent
-        args: ["proxy", "egress", "-v", "2"]
+        args:
+        - proxy
+        - egress
+        - -v
+        - "2"
+        - --discoveryAddress
+        - istio-pilot:8080
         env:
         - name: POD_NAME
           valueFrom:
@@ -50,15 +56,10 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         volumeMounts:
-        - name: config-volume
-          mountPath: /etc/istio/config
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio
       - name: istio-certs
         secret:
           secretName: istio.default

--- a/install/kubernetes/templates/istio-ingress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ingress.yaml.tmpl
@@ -1,16 +1,4 @@
 ################################
-# Empty secret for Istio ingress controller
-################################
-apiVersion: v1
-kind: Secret
-metadata:
-  name: istio-ingress-certs
-  namespace: {ISTIO_NAMESPACE}
-data:
-  tls.key:
-  tls.crt:
----
-################################
 # Istio ingress controller
 ################################
 apiVersion: v1
@@ -57,7 +45,13 @@ spec:
       containers:
       - name: istio-ingress
         image: {PROXY_HUB}/proxy_debug:{PROXY_TAG}
-        args: ["proxy", "ingress", "-v", "2"]
+        args:
+        - proxy
+        - ingress
+        - -v
+        - "2"
+        - --discoveryAddress
+        - istio-pilot:8080
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -74,8 +68,6 @@ spec:
               apiVersion: v1
               fieldPath: metadata.namespace
         volumeMounts:
-        - name: config-volume
-          mountPath: /etc/istio/config
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
@@ -83,9 +75,6 @@ spec:
           mountPath: /etc/istio/ingress-certs
           readOnly: true
       volumes:
-      - name: config-volume
-        configMap:
-          name: istio
       - name: istio-certs
         secret:
           secretName: istio.default


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
<PLEASE PUT RELEASE-NOTE HERE, PUT NONE if NO RELEASE-NOTE>
```

