### PR TITLE
Check return value of RunTest in framework unit test

### DIFF
--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -214,6 +214,7 @@ func TestDeInitFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.s.failTearDown = true
+	log.Printf("Expecting error after RunTest, testing teardown failure case")
 	if ret := c.RunTest(tc.t); ret != 0 {
 		t.Errorf("RunTest should have passed")
 	}

--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -214,7 +214,7 @@ func TestDeInitFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.s.failTearDown = true
-	log.Printf("Expecting error after RunTest, testing teardown failure case")
+	log.Printf("Expecting error after RunTest, testing deInit failure case")
 	if ret := c.RunTest(tc.t); ret != 0 {
 		t.Errorf("RunTest should have passed")
 	}

--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"errors"
+	"log"
 	"reflect"
 	"testing"
 )
@@ -136,6 +137,7 @@ func TestFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failRun = true
+	log.Printf("Expecting error, testing failure case")
 	if ret := c.RunTest(tc.t); ret == 0 {
 		t.Errorf("RunTest should have failed")
 	}
@@ -155,6 +157,7 @@ func TestInitFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failRun = true
+	log.Printf("Expecting error, testing init failure case")
 	if ret := c.RunTest(tc.t); ret == 0 {
 		t.Errorf("init should have failed during RunTest")
 	}
@@ -173,6 +176,7 @@ func TestSetupFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failSetup = true
+	log.Printf("Expecting error, testing setup failure case")
 	if ret := c.RunTest(tc.t); ret == 0 {
 		t.Errorf("RunTest should have failed")
 	}
@@ -191,6 +195,7 @@ func TestTearDownFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failTearDown = true
+	log.Printf("Expecting error after RunTest, testing teardown failure case")
 	if ret := c.RunTest(tc.t); ret != 0 {
 		t.Errorf("RunTest should have passed since teardown happens after")
 	}

--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -118,7 +118,9 @@ func TestSuccess(t *testing.T) {
 	tc := newTestConfig()
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret != 0 {
+		t.Errorf("non zero return value from RunTest")
+	}
 	b := []int{1, 2, 3, 4, 5}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)
@@ -134,7 +136,9 @@ func TestFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failRun = true
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret == 0 {
+		t.Errorf("RunTest should have failed")
+	}
 	b := []int{1, 2, 4, 5}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)
@@ -151,7 +155,9 @@ func TestInitFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failRun = true
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret == 0 {
+		t.Errorf("init should have failed during RunTest")
+	}
 	b := []int{5}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)
@@ -167,7 +173,9 @@ func TestSetupFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failSetup = true
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret == 0 {
+		t.Errorf("RunTest should have failed")
+	}
 	b := []int{1, 4, 5}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)
@@ -183,7 +191,9 @@ func TestTearDownFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.t.failTearDown = true
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret != 0 {
+		t.Errorf("RunTest should have passed since teardown happens after")
+	}
 	b := []int{1, 2, 3, 5}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)
@@ -199,7 +209,9 @@ func TestDeInitFailure(t *testing.T) {
 	c.Cleanup.RegisterCleanable(tc.s)
 	c.Cleanup.RegisterCleanable(tc.t)
 	tc.s.failTearDown = true
-	c.RunTest(tc.t)
+	if ret := c.RunTest(tc.t); ret != 0 {
+		t.Errorf("RunTest should have passed")
+	}
 	b := []int{1, 2, 3, 4}
 	if !reflect.DeepEqual(*tc.q, b) {
 		t.Errorf("Order is not as expected %d %d", *tc.q, b)


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

