### PR TITLE
Add traceOutput startup flag to Mixer template

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -273,7 +273,11 @@ spec:
         args:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
+<<<<<<< HEAD
           - --configDefaultNamespace=istio-system
+=======
+          - --traceOutput=http://zipkin.istio-system:9411/api/v1/spans
+>>>>>>> Add zipkin tracing configuration for Mixer
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -273,11 +273,8 @@ spec:
         args:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
-<<<<<<< HEAD
           - --configDefaultNamespace=istio-system
-=======
-          - --traceOutput=http://zipkin.istio-system:9411/api/v1/spans
->>>>>>> Add zipkin tracing configuration for Mixer
+          - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -273,7 +273,11 @@ spec:
         args:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
+<<<<<<< HEAD
           - --configDefaultNamespace=istio-system
+=======
+          - --traceOutput=http://zipkin.istio-system:9411/api/v1/spans
+>>>>>>> Add zipkin tracing configuration for Mixer
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -273,11 +273,8 @@ spec:
         args:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
-<<<<<<< HEAD
           - --configDefaultNamespace=istio-system
-=======
-          - --traceOutput=http://zipkin.istio-system:9411/api/v1/spans
->>>>>>> Add zipkin tracing configuration for Mixer
+          - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/istio-one-namespace.yaml
+++ b/install/kubernetes/istio-one-namespace.yaml
@@ -274,6 +274,7 @@ spec:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
           - --configDefaultNamespace=istio-system
+          - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -274,6 +274,7 @@ spec:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
           - --configDefaultNamespace=istio-system
+          - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
           - "4"

--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -77,6 +77,7 @@ spec:
           - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStore2URL=k8s://
           - --configDefaultNamespace={ISTIO_NAMESPACE}
+          - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
           - "4"


### PR DESCRIPTION
This PR adds configuration to the Mixer install template to enable trace output. The destination for the trace output is selected to be the address of the zipkin install.

Example trace output with this flag added: https://files.slack.com/files-pri/T382U9E4U-F79NKFNR0/zipkin-trace.png

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add zipkin config to Mixer template.
```