### PR TITLE
Cleanup tagging of add-on images

### DIFF
--- a/install/kubernetes/addons/servicegraph.yaml
+++ b/install/kubernetes/addons/servicegraph.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: servicegraph
-        image: gcr.io/istio-testing/servicegraph:latest
+        image: gcr.io/istio-testing/servicegraph:de6e9312fb3dbe696ab353e54688b8fc71419afd
         ports:
           - containerPort: 8088
         args:

--- a/install/kubernetes/templates/addons/grafana.yaml.tmpl
+++ b/install/kubernetes/templates/addons/grafana.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: docker.io/istio/grafana:0.2.1
+        image: {MIXER_HUB}/grafana:{MIXER_TAG}
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 3000

--- a/install/kubernetes/templates/addons/servicegraph.yaml.tmpl
+++ b/install/kubernetes/templates/addons/servicegraph.yaml.tmpl
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: servicegraph
-        image: gcr.io/istio-testing/servicegraph:latest
+        image: {MIXER_HUB}/servicegraph:{MIXER_TAG}
         ports:
           - containerPort: 8088
         args:

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -203,7 +203,8 @@ function update_istio_install() {
 function update_istio_addons() {
   DEST=$ROOT/install/kubernetes/addons
   pushd $TEMP_DIR/templates/addons
-  sed -i=.bak "s|image: .*/\(.*\):.*|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" grafana.yaml.tmpl
+  sed -i=.bak "s|image: {MIXER_HUB}/\(.*\):{MIXER_TAG}|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" grafana.yaml.tmpl
+  sed -i=.bak "s|image: {MIXER_HUB}/\(.*\):{MIXER_TAG}|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" servicegraph.yaml.tmpl
   sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" grafana.yaml.tmpl  > $DEST/grafana.yaml
   sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" prometheus.yaml.tmpl > $DEST/prometheus.yaml
   sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" servicegraph.yaml.tmpl > $DEST/servicegraph.yaml


### PR DESCRIPTION
This PR alters the servicegraph.yaml.tmpl to use the mixer hub and tag (instead of `:latest`). It also transitions the grafana tmpl over to the same template style. Both grafana and servicegraph are built from the mixer repo.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update tagging of servicegraph and grafana images.
```