### PR TITLE
need to capture mixer stdout too because of accesslog adapter

### DIFF
--- a/devel/setup_run
+++ b/devel/setup_run
@@ -9,7 +9,7 @@ cd mixer; set +x; source bin/use_bazel_go.sh ; set -x; cd ..
 ./istio/bazel-bin/devel/fortio/cmd/fortio/fortio server &
 ( cd proxy/src/envoy/mixer; ./start_envoy > /tmp/envoy.log ) &
 # add -v=5 for verbose/debug
-./mixer/bazel-bin/cmd/server/mixs server --configStore2URL=fs://$(pwd)/mixerconfig --configStoreURL=fs://$(pwd)/emptydir --logtostderr 2> /tmp/mixs.2.log &
+./mixer/bazel-bin/cmd/server/mixs server --configStore2URL=fs://$(pwd)/mixerconfig --configStoreURL=fs://$(pwd)/emptydir --logtostderr 2> /tmp/mixs.2.log > /tmp/mixs.1.log &
 echo "starting everything..."
 sleep 3
 curl -v http://localhost:9090/debug


### PR DESCRIPTION
only applies to perf testing env, capture stdout too which is now where the mixer accesslog goes
avoids flooding the console / reduces slow down

```release-note
NONE
```

