### PR TITLE
Reduce default logging in Mixer.

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -277,7 +277,7 @@ spec:
           - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
-          - "4"
+          - "2"
       volumes:
       - name: config-volume
         configMap:

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -277,7 +277,7 @@ spec:
           - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
-          - "4"
+          - "2"
       volumes:
       - name: config-volume
         configMap:

--- a/install/kubernetes/istio-one-namespace.yaml
+++ b/install/kubernetes/istio-one-namespace.yaml
@@ -277,7 +277,7 @@ spec:
           - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
-          - "4"
+          - "2"
       volumes:
       - name: config-volume
         configMap:

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -277,7 +277,7 @@ spec:
           - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
-          - "4"
+          - "2"
       volumes:
       - name: config-volume
         configMap:

--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -80,7 +80,7 @@ spec:
           - --traceOutput=http://zipkin:9411/api/v1/spans
           - --logtostderr
           - -v
-          - "4"
+          - "2"
       volumes:
       - name: config-volume
         configMap:


### PR DESCRIPTION
This PR reduces the verbosity level from 4 down to 2. This should generally reduce the amount of log lines generated by Mixer, while still preserving a bit of debuggability.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Reduce default Mixer logs verbosity.
```