### PR TITLE
add zipkin to consul and templatize, update consul bookinfo images

### DIFF
--- a/install/consul/istio.yaml
+++ b/install/consul/istio.yaml
@@ -1,3 +1,5 @@
+# GENERATED FILE. Use with Docker-Compose and Consul
+# TO UPDATE, modify files in install/consul/templates and run install/updateVersion.sh
 version: '2'
 services:
   etcd:
@@ -36,7 +38,7 @@ services:
           - consul
     ports:
       - "8500:8500"
-      - "172.28.0.1:53:8600/udp"
+      - "53:8600/udp"
       - "8400:8400"
     environment:
       - SERVICE_IGNORE=1
@@ -51,7 +53,7 @@ services:
     command: ["-internal", "-retry-attempts=-1", "consul://consul:8500"]
 
   pilot:
-    image: istio/pilot:0.2.4
+    image: gcr.io/istio-testing/pilot:e6d7b75869ac4ecc1fa055ebd70b462159537a5d
     networks:
       istiomesh:
         aliases:
@@ -60,9 +62,22 @@ services:
       - "8080"
     ports:
       - "8081:8080"
-    command: ["discovery", "-v", "2", "--registries", "Consul", "--consulserverURL", "http://consul:8500", "--kubeconfig", "/istio/config"]
+    command: ["discovery", "-v", "2",
+              "--registries", "Consul",
+              "--consulserverURL", "http://consul:8500",
+              "--kubeconfig", "/etc/istio/config/kubeconfig"
+              ]
     volumes:
-      - ~/.kube/config:/istio/config
+      - ~/.kube/config:/etc/istio/config/kubeconfig
+
+  zipkin:
+    image: docker.io/openzipkin/zipkin:latest
+    networks:
+      istiomesh:
+        aliases:
+          - zipkin
+    ports:
+      - "9411:9411"
 
 networks:
   istiomesh:

--- a/install/consul/istio.yaml
+++ b/install/consul/istio.yaml
@@ -38,7 +38,7 @@ services:
           - consul
     ports:
       - "8500:8500"
-      - "53:8600/udp"
+      - "${DOCKER_GATEWAY}53:8600/udp"
       - "8400:8400"
     environment:
       - SERVICE_IGNORE=1

--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -36,7 +36,7 @@ services:
           - consul
     ports:
       - "8500:8500"
-      - "53:8600/udp"
+      - "${DOCKER_GATEWAY}53:8600/udp"
       - "8400:8400"
     environment:
       - SERVICE_IGNORE=1

--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -1,0 +1,86 @@
+version: '2'
+services:
+  etcd:
+    image: quay.io/coreos/etcd:latest
+    networks:
+      istiomesh:
+        aliases:
+          - etcd
+    ports:
+      - "4001:4001"
+      - "2380:2380"
+      - "2379:2379"
+    environment:
+      - SERVICE_IGNORE=1
+    command: ["/usr/local/bin/etcd", "-advertise-client-urls=http://0.0.0.0:2379", "-listen-client-urls=http://0.0.0.0:2379"]
+
+  istio-apiserver:
+    image: gcr.io/google_containers/kube-apiserver-amd64:v1.7.3
+    networks:
+      istiomesh:
+        ipv4_address: 172.28.0.13
+        aliases:
+          - apiserver
+    ports:
+      - "8080:8080"
+    privileged: true
+    environment:
+      - SERVICE_IGNORE=1
+    command: ["kube-apiserver", "--etcd-servers", "http://etcd:2379", "--service-cluster-ip-range", "10.99.0.0/16", "--insecure-port", "8080", "-v", "2", "--insecure-bind-address", "0.0.0.0"]
+
+  consul:
+    image: gliderlabs/consul-server
+    networks:
+      istiomesh:
+        aliases:
+          - consul
+    ports:
+      - "8500:8500"
+      - "53:8600/udp"
+      - "8400:8400"
+    environment:
+      - SERVICE_IGNORE=1
+    command: ["-bootstrap"]
+
+  registrator:
+    image: gliderlabs/registrator:latest
+    networks:
+      istiomesh:
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock
+    command: ["-internal", "-retry-attempts=-1", "consul://consul:8500"]
+
+  pilot:
+    image: {PILOT_HUB}/pilot:{PILOT_TAG}
+    networks:
+      istiomesh:
+        aliases:
+          - istio-pilot
+    expose:
+      - "8080"
+    ports:
+      - "8081:8080"
+    command: ["discovery", "-v", "2",
+              "--registries", "Consul",
+              "--consulserverURL", "http://consul:8500",
+              "--kubeconfig", "/etc/istio/config/kubeconfig"
+              ]
+    volumes:
+      - ~/.kube/config:/etc/istio/config/kubeconfig
+
+  zipkin:
+    image: docker.io/openzipkin/zipkin:latest
+    networks:
+      istiomesh:
+        aliases:
+          - zipkin
+    ports:
+      - "9411:9411"
+
+networks:
+  istiomesh:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16
+          gateway: 172.28.0.1

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -213,6 +213,24 @@ function update_istio_addons() {
   popd
 }
 
+function update_istio_install_consul() {
+  pushd $TEMP_DIR/templates
+  sed -i=.bak "s|image: {PILOT_HUB}/\(.*\):{PILOT_TAG}|image: ${PILOT_HUB}/\1:${PILOT_TAG}|" istio.yaml.tmpl
+  popd
+}
+
+# Generated merge yaml files for easy installation
+function merge_files_consul() {
+  SRC=$TEMP_DIR/templates
+  DEST=$ROOT/install/consul
+
+  ISTIO=$DEST/istio.yaml
+
+  echo "# GENERATED FILE. Use with Docker-Compose and Consul" > $ISTIO
+  echo "# TO UPDATE, modify files in install/consul/templates and run install/updateVersion.sh" >> $ISTIO
+  cat $SRC/istio.yaml.tmpl >> $ISTIO
+}
+
 if [[ ${GIT_COMMIT} == true ]]; then
     check_git_status \
       || error_exit "You have modified files. Please commit or reset your workspace."
@@ -223,6 +241,11 @@ update_version_file
 update_istio_install
 update_istio_addons
 merge_files
+rm -R $TEMP_DIR/templates
+
+cp -R $ROOT/install/consul/templates $TEMP_DIR/templates
+update_istio_install_consul
+merge_files_consul
 rm -R $TEMP_DIR/templates
 
 if [[ ${GIT_COMMIT} == true ]]; then

--- a/samples/bookinfo/consul/bookinfo.yaml
+++ b/samples/bookinfo/consul/bookinfo.yaml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1-envoy:0.2.4
+    image: istio/examples-bookinfo-details-v1-envoy:0.2.7
     networks:
       istiomesh:
     dns:
@@ -9,7 +9,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_NAME=details
       - SERVICE_TAGS=version|v1
@@ -18,7 +19,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1-envoy:0.2.4
+    image: istio/examples-bookinfo-ratings-v1-envoy:0.2.7
     networks:
       istiomesh:
     dns:
@@ -26,7 +27,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_NAME=ratings
       - SERVICE_TAGS=version|v1
@@ -35,7 +37,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1-envoy:0.2.4
+    image: istio/examples-bookinfo-reviews-v1-envoy:0.2.7
     networks:
       istiomesh:
     dns:
@@ -43,7 +45,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_9080_NAME=reviews
       - SERVICE_TAGS=version|v1
@@ -53,7 +56,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2-envoy:0.2.4
+    image: istio/examples-bookinfo-reviews-v2-envoy:0.2.7
     networks:
       istiomesh:
     dns:
@@ -61,7 +64,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_9080_NAME=reviews
       - SERVICE_TAGS=version|v2
@@ -71,7 +75,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3-envoy:0.2.4
+    image: istio/examples-bookinfo-reviews-v3-envoy:0.2.7
     networks:
       istiomesh:
     dns:
@@ -79,7 +83,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_9080_NAME=reviews
       - SERVICE_TAGS=version|v3
@@ -89,7 +94,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1-envoy:0.2.4
+    image: istio/examples-bookinfo-productpage-v1-envoy:0.2.7
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14
@@ -98,7 +103,8 @@ services:
       - 8.8.8.8
     dns_search:
         - service.consul
-    privileged: true
+    cap_add:
+      - NET_ADMIN
     environment:
       - SERVICE_NAME=productpage
       - SERVICE_TAGS=version|v1

--- a/samples/bookinfo/consul/build-docker-services.sh
+++ b/samples/bookinfo/consul/build-docker-services.sh
@@ -20,7 +20,7 @@
 # Set required env vars. Ensure you have checked out the pilot project
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 HUB=istio
-VERSION=0.2.4
+VERSION=0.2.7
 WORKSPACE=$GOPATH/src/istio.io/pilot
 BINDIR=$WORKSPACE/bazel-bin
 APPSDIR=$GOPATH/src/istio.io/istio/samples/bookinfo/src

--- a/samples/bookinfo/src/details/start_service.sh
+++ b/samples/bookinfo/src/details/start_service.sh
@@ -1,4 +1,4 @@
 
 /opt/istio/prepare_proxy.sh -p 15001 -u 1337
 ruby /opt/microservices/details.rb 9080 &
-su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul > /tmp/envoy.log"
+su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411  > /tmp/envoy.log"

--- a/samples/bookinfo/src/productpage/start_service.sh
+++ b/samples/bookinfo/src/productpage/start_service.sh
@@ -1,4 +1,4 @@
 
 /opt/istio/prepare_proxy.sh -p 15001 -u 1337
 python /opt/microservices/productpage.py 9080 &
-su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul > /tmp/envoy.log"
+su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 > /tmp/envoy.log"

--- a/samples/bookinfo/src/ratings/start_service.sh
+++ b/samples/bookinfo/src/ratings/start_service.sh
@@ -1,4 +1,4 @@
 
 /opt/istio/prepare_proxy.sh -p 15001 -u 1337
 node /opt/microservices/ratings.js 9080 &
-su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul > /tmp/envoy.log"
+su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul  --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 > /tmp/envoy.log"

--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/start_service.sh
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/start_service.sh
@@ -1,4 +1,4 @@
 
 /opt/istio/prepare_proxy.sh -p 15001 -u 1337
 /opt/ibm/wlp/bin/server run defaultServer &
-su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul > /tmp/envoy.log"
+su istio-proxy -c "/opt/istio/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster reviews-${SERVICE_VERSION} --zipkinAddress zipkin:9411 > /tmp/envoy.log"


### PR DESCRIPTION
**What this PR does / why we need it**:
templatize consul install file so that the Pilot version is automatically updated during release. Also, update bookinfo images with latest proxy-debug, and add Zipkin to Consul install (tested and works very well).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Needed before 0.2.7 release.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
