### PR TITLE
Change unnecessary t.Error

### DIFF
--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -305,7 +305,7 @@ func TestFaultDelay(t *testing.T) {
 			break
 		}
 
-		if i == testRetryTimes - 1 {
+		if i == testRetryTimes-1 {
 			t.Errorf("Fault delay failed! Delay in %ds while expected between %ds and %ds, %s",
 				duration, minDuration, maxDuration, err)
 			break
@@ -371,7 +371,7 @@ func TestVersionMigration(t *testing.T) {
 			break
 		}
 
-		if i == testRetryTimes - 1 {
+		if i == testRetryTimes-1 {
 			t.Errorf("Failed version migration test, "+
 				"old version hit %d, new version hit %d", c1, c3)
 		}

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -305,7 +305,7 @@ func TestFaultDelay(t *testing.T) {
 			break
 		}
 
-		if i == 4 {
+		if i == testRetryTimes - 1 {
 			t.Errorf("Fault delay failed! Delay in %ds while expected between %ds and %ds, %s",
 				duration, minDuration, maxDuration, err)
 			break
@@ -347,12 +347,12 @@ func TestVersionMigration(t *testing.T) {
 			resp, err := getWithCookie(fmt.Sprintf("%s/productpage", tc.gateway), cookies)
 			inspect(err, "Failed to record", "", t)
 			if resp.StatusCode != http.StatusOK {
-				t.Errorf("unexpected response status %d", resp.StatusCode)
+				glog.Errorf("unexpected response status %d", resp.StatusCode)
 				continue
 			}
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				t.Error(err)
+				glog.Error(err)
 				continue
 			}
 			if err = util.CompareToFile(body, modelV1); err == nil {
@@ -371,7 +371,7 @@ func TestVersionMigration(t *testing.T) {
 			break
 		}
 
-		if i == 4 {
+		if i == testRetryTimes - 1 {
 			t.Errorf("Failed version migration test, "+
 				"old version hit %d, new version hit %d", c1, c3)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Inside the retry loop, before we hit the max retry limit, we shouldn't use `t.Error()` to indicate a test failure.

An example here: https://k8s-gubernator.appspot.com/build/istio-prow/pull/istio_istio/950/e2e-cluster_wide-auth/56/

```
W1002 20:31:34.171] I1002 20:31:34.170548    2659 demo_test.go:370] Success! Version migration acts as expected, old version hit 49, new version hit 50
W1002 20:31:34.171] I1002 20:31:34.170580    2659 commonUtils.go:82] Running command kubectl delete -n istio-system -f /tmp/demo_test175913297/route-rule-reviews-50-v3.yaml
W1002 20:31:34.620] I1002 20:31:34.619802    2659 commonUtils.go:86] Command output: 
W1002 20:31:34.620]  routerule "reviews-default" deleted
W1002 20:31:34.620] , err: <nil>
W1002 20:31:34.621] I1002 20:31:34.619829    2659 demo_test.go:248] Waiting for rule to be cleaned up...
I1002 20:32:04.622] --- FAIL: TestVersionMigration (77.75s)
I1002 20:32:04.622] 	demo_test.go:350: unexpected response status 503
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
