### PR TITLE
Add missing kubeconfig file to Consul install dir

### DIFF
--- a/install/consul/kubeconfig
+++ b/install/consul/kubeconfig
@@ -1,0 +1,11 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: http://istio-apiserver:8080
+  name: istio
+contexts:
+- context:
+    cluster: istio
+    user: ""
+  name: istio
+current-context: istio

--- a/install/eureka/istio.yaml
+++ b/install/eureka/istio.yaml
@@ -45,3 +45,8 @@ services:
     command: ["discovery", "-v", "2", "--registries", "Eureka", "--eurekaserverURL", "http://eureka:8080", "--kubeconfig", "/istio/config"]
     volumes:
       - ./kubeconfig:/istio/config
+
+  zipkin:
+    image: docker.io/openzipkin/zipkin:latest
+    ports:
+      - "9411:9411"

--- a/install/eureka/istio.yaml
+++ b/install/eureka/istio.yaml
@@ -53,9 +53,5 @@ services:
 
   zipkin:
     image: docker.io/openzipkin/zipkin:latest
-    networks:
-      istiomesh:
-        aliases:
-          - zipkin
     ports:
       - "9411:9411"

--- a/install/eureka/templates/istio.yaml.tmpl
+++ b/install/eureka/templates/istio.yaml.tmpl
@@ -51,9 +51,5 @@ services:
 
   zipkin:
     image: docker.io/openzipkin/zipkin:latest
-    networks:
-      istiomesh:
-        aliases:
-          - zipkin
     ports:
       - "9411:9411"


### PR DESCRIPTION
**What this PR does / why we need it**: Added missing kubeconfig file to Consul dir. Should have been inside this PR: https://github.com/istio/istio/pull/1012/files. Also removes unnecessary network/alias definition from zipkin in eureka.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
