### PR TITLE
use istio-system in setupMeshEx.sh

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dns-ilb
-  namespace: istio-system
+  namespace: kube-system
   annotations:
     cloud.google.com/load-balancer-type: "internal"
   labels:

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -48,7 +48,7 @@ function istioDnsmasq() {
   for i in {1..10}
   do
     PILOT_IP=$(kubectl get -n $NS service istio-pilot-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    ISTIO_DNS=$(kubectl get -n istio-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    ISTIO_DNS=$(kubectl get -n kube-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     MIXER_IP=$(kubectl get -n $NS service mixer-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     CA_IP=$(kubectl get -n $NS service istio-ca-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -48,7 +48,7 @@ function istioDnsmasq() {
   for i in {1..10}
   do
     PILOT_IP=$(kubectl get -n $NS service istio-pilot-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    ISTIO_DNS=$(kubectl get -n kube-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    ISTIO_DNS=$(kubectl get -n istio-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     MIXER_IP=$(kubectl get -n $NS service mixer-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     CA_IP=$(kubectl get -n $NS service istio-ca-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`dns-ilb` service exists in `istio-system`. Use that namespace in `setupMeshex.sh` to query the ingress IP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes https://groups.google.com/forum/#!topic/istio-users/FOiz20tDZEk

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
