### PR TITLE
Ingress bug fix

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -953,6 +953,8 @@ data:
     rdsRefreshDelay: 1s
     #
     defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress and istio-egress pods.
       # See rdsRefreshDelay for explanation about this setting.
       discoveryRefreshDelay: 1s
       #
@@ -1151,6 +1153,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-ingress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1229,6 +1247,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-egress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -1154,13 +1154,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-ingress
         - --zipkinAddress
@@ -1168,7 +1168,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1248,13 +1248,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-egress
         - --zipkinAddress
@@ -1262,7 +1262,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -953,6 +953,8 @@ data:
     rdsRefreshDelay: 1s
     #
     defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress and istio-egress pods.
       # See rdsRefreshDelay for explanation about this setting.
       discoveryRefreshDelay: 1s
       #
@@ -1151,6 +1153,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-ingress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1229,6 +1247,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-egress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -1154,13 +1154,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-ingress
         - --zipkinAddress
@@ -1168,7 +1168,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1248,13 +1248,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-egress
         - --zipkinAddress
@@ -1262,7 +1262,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio-one-namespace.yaml
+++ b/install/kubernetes/istio-one-namespace.yaml
@@ -953,6 +953,8 @@ data:
     rdsRefreshDelay: 1s
     #
     defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress and istio-egress pods.
       # See rdsRefreshDelay for explanation about this setting.
       discoveryRefreshDelay: 1s
       #
@@ -1151,6 +1153,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-ingress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1229,6 +1247,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-egress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio-one-namespace.yaml
+++ b/install/kubernetes/istio-one-namespace.yaml
@@ -1154,13 +1154,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-ingress
         - --zipkinAddress
@@ -1168,7 +1168,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1248,13 +1248,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-egress
         - --zipkinAddress
@@ -1262,7 +1262,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -953,6 +953,8 @@ data:
     rdsRefreshDelay: 1s
     #
     defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress and istio-egress pods.
       # See rdsRefreshDelay for explanation about this setting.
       discoveryRefreshDelay: 1s
       #
@@ -1151,6 +1153,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-ingress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1229,6 +1247,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-egress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -1154,13 +1154,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-ingress
         - --zipkinAddress
@@ -1168,7 +1168,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80
@@ -1248,13 +1248,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-egress
         - --zipkinAddress
@@ -1262,7 +1262,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/templates/istio-config.yaml.tmpl
+++ b/install/kubernetes/templates/istio-config.yaml.tmpl
@@ -32,6 +32,8 @@ data:
     rdsRefreshDelay: 1s
     #
     defaultConfig:
+      # NOTE: If you change any values in this section, make sure to make
+      # the same changes in start up args in istio-ingress and istio-egress pods.
       # See rdsRefreshDelay for explanation about this setting.
       discoveryRefreshDelay: 1s
       #

--- a/install/kubernetes/templates/istio-egress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-egress.yaml.tmpl
@@ -45,13 +45,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-egress
         - --zipkinAddress
@@ -59,7 +59,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/templates/istio-egress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-egress.yaml.tmpl
@@ -44,6 +44,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-egress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/templates/istio-ingress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ingress.yaml.tmpl
@@ -50,6 +50,22 @@ spec:
         - "2"
         - --discoveryAddress
         - istio-pilot:8080
+        - --discoveryRefreshDelay
+        - 1s #discoveryRefreshDelay
+        - --drainDuration
+        - 45s #drainDuration
+        - --parentShutdownDuration
+        - 1m0s #parentShutdownDuration
+        - --connectTimeout
+        - 10s #connectTimeout
+        - --serviceCluster
+        - istio-ingress
+        - --zipkinAddress
+        - zipkin:9411
+        - --statsdUdpAddress
+        - istio-mixer:9125
+        - --proxyAdminPort
+        - 15000
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/install/kubernetes/templates/istio-ingress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ingress.yaml.tmpl
@@ -51,13 +51,13 @@ spec:
         - --discoveryAddress
         - istio-pilot:8080
         - --discoveryRefreshDelay
-        - 1s #discoveryRefreshDelay
+        - '1s' #discoveryRefreshDelay
         - --drainDuration
-        - 45s #drainDuration
+        - '45s' #drainDuration
         - --parentShutdownDuration
-        - 1m0s #parentShutdownDuration
+        - '1m0s' #parentShutdownDuration
         - --connectTimeout
-        - 10s #connectTimeout
+        - '10s' #connectTimeout
         - --serviceCluster
         - istio-ingress
         - --zipkinAddress
@@ -65,7 +65,7 @@ spec:
         - --statsdUdpAddress
         - istio-mixer:9125
         - --proxyAdminPort
-        - 15000
+        - "15000"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 80

--- a/samples/bookinfo/kube/bookinfo.yaml
+++ b/samples/bookinfo/kube/bookinfo.yaml
@@ -203,24 +203,28 @@ spec:
   rules:
   - http:
       paths:
-      - path: /productpage
+      - path: /.*
         backend:
           serviceName: productpage
           servicePort: 9080
-      - path: /login
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /logout
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /api/v1/products
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /api/v1/products/.*
-        backend:
-          serviceName: productpage
-          servicePort: 9080
+      # - path: /productpage
+      #   backend:
+      #     serviceName: productpage
+      #     servicePort: 9080
+      # - path: /login
+      #   backend:
+      #     serviceName: productpage
+      #     servicePort: 9080
+      # - path: /logout
+      #   backend:
+      #     serviceName: productpage
+      #     servicePort: 9080
+      # - path: /api/v1/products
+      #   backend:
+      #     serviceName: productpage
+      #     servicePort: 9080
+      # - path: /api/v1/products/.*
+      #   backend:
+      #     serviceName: productpage
+      #     servicePort: 9080
 ---

--- a/samples/bookinfo/kube/route-rule-all-v1.yaml
+++ b/samples/bookinfo/kube/route-rule-all-v1.yaml
@@ -1,6 +1,105 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
 metadata:
+  name: ingress-deny-all
+spec:
+  destination:
+    name: productpage
+  match:
+    source:
+      labels:
+        istio: ingress
+  precedence: 1
+  route:
+  - weight: 100
+  httpFault:
+    abort:
+      percent: 100
+      httpStatus: 403
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ingress-products-api
+spec:
+  destination:
+    name: productpage
+  match:
+    source:
+      labels:
+        istio: ingress
+    request:
+      headers:
+        uri:
+          prefix: /api/v1/products
+  precedence: 2
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ingress-productpage-logout
+spec:
+  destination:
+    name: productpage
+  match:
+    source:
+      labels:
+        istio: ingress
+    request:
+      headers:
+        uri:
+          exact: /logout
+  precedence: 3
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ingress-productpage-login
+spec:
+  destination:
+    name: productpage
+  match:
+    source:
+      labels:
+        istio: ingress
+    request:
+      headers:
+        uri:
+          exact: /login
+  precedence: 4
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ingress-productpage-landing
+spec:
+  destination:
+    name: productpage
+  match:
+    source:
+      labels:
+        istio: ingress
+    request:
+      headers:
+        uri:
+          exact: /productpage
+  precedence: 5
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
   name: productpage-default
 spec:
   destination:

--- a/samples/bookinfo/kube/route-rule-all-v1.yaml
+++ b/samples/bookinfo/kube/route-rule-all-v1.yaml
@@ -52,7 +52,7 @@ spec:
       headers:
         uri:
           exact: /logout
-  precedence: 3
+  precedence: 2
   route:
   - labels:
       version: v1
@@ -72,7 +72,7 @@ spec:
       headers:
         uri:
           exact: /login
-  precedence: 4
+  precedence: 2
   route:
   - labels:
       version: v1
@@ -92,7 +92,7 @@ spec:
       headers:
         uri:
           exact: /productpage
-  precedence: 5
+  precedence: 2
   route:
   - labels:
       version: v1

--- a/samples/bookinfo/kube/route-rule-all-v1.yaml
+++ b/samples/bookinfo/kube/route-rule-all-v1.yaml
@@ -1,6 +1,19 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
 metadata:
+  name: productpage-default
+spec:
+  ## Used by services inside the Kubernetes cluster
+  destination:
+    name: productpage
+  precedence: 1
+  route:
+  - labels:
+      version: v1
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
   name: ingress-deny-all
 spec:
   destination:
@@ -9,7 +22,7 @@ spec:
     source:
       labels:
         istio: ingress
-  precedence: 1
+  precedence: 2
   route:
   - weight: 100
   httpFault:
@@ -32,7 +45,7 @@ spec:
       headers:
         uri:
           prefix: /api/v1/products
-  precedence: 2
+  precedence: 3
   route:
   - labels:
       version: v1
@@ -52,7 +65,7 @@ spec:
       headers:
         uri:
           exact: /logout
-  precedence: 2
+  precedence: 3
   route:
   - labels:
       version: v1
@@ -72,7 +85,7 @@ spec:
       headers:
         uri:
           exact: /login
-  precedence: 2
+  precedence: 3
   route:
   - labels:
       version: v1
@@ -92,19 +105,7 @@ spec:
       headers:
         uri:
           exact: /productpage
-  precedence: 2
-  route:
-  - labels:
-      version: v1
----
-apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
-metadata:
-  name: productpage-default
-spec:
-  destination:
-    name: productpage
-  precedence: 1
+  precedence: 3
   route:
   - labels:
       version: v1

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -348,9 +348,10 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 	content = replacePattern(k, content, "parentShutdownDuration: 1m0s", "parentShutdownDuration: 3s")
 
 	// A very flimsy and unreliable regexp to replace delays in ingress/egress pod Spec
-	content = replacePattern(k, content, "10s #connectTimeout", "1s #connectTimeout")
-	content = replacePattern(k, content, "45s #drainDuration", "2s #drainDuration")
-	content = replacePattern(k, content, "1m0s #parentShutdownDuration", "3s #parentShutdownDuration")
+	content = replacePattern(k, content, "'30s' #discoveryRefreshDelay", "'1s' #discoveryRefreshDelay")
+	content = replacePattern(k, content, "'10s' #connectTimeout", "'1s' #connectTimeout")
+	content = replacePattern(k, content, "'45s' #drainDuration", "'2s' #drainDuration")
+	content = replacePattern(k, content, "'1m0s' #parentShutdownDuration", "'3s' #parentShutdownDuration")
 
 	if *mixerHub != "" && *mixerTag != "" {
 		content = updateIstioYaml("mixer", *mixerHub, *mixerTag, content)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -347,6 +347,11 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 	content = replacePattern(k, content, "drainDuration: 45s", "drainDuration: 2s")
 	content = replacePattern(k, content, "parentShutdownDuration: 1m0s", "parentShutdownDuration: 3s")
 
+	// A very flimsy and unreliable regexp to replace delays in ingress/egress pod Spec
+	content = replacePattern(k, content, "10s #connectTimeout", "1s #connectTimeout")
+	content = replacePattern(k, content, "45s #drainDuration", "2s #drainDuration")
+	content = replacePattern(k, content, "1m0s #parentShutdownDuration", "3s #parentShutdownDuration")
+
 	if *mixerHub != "" && *mixerTag != "" {
 		content = updateIstioYaml("mixer", *mixerHub, *mixerTag, content)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
While sidecars get the config settings from istio config map, Ingress and Egress still use default values (and the defaults disable tracing, stats, and have high refresh rates). In addition, this PR cleans up the ingress resource, to use route rules [as shown in our docs] and have a simple namesake ingress.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
