### PR TITLE
Fix VM auth (for 0.2 branch)

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -1281,4 +1281,9 @@ spec:
       - name: istio-ca
         image: gcr.io/istio-testing/istio-ca:d4bbb5ab873ca3d877c2880a4b9cf70fee776dd8
         imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --grpc-port=8060
+          - --grpc-hostname=istio-ca
+          - --self-signed-ca=true
 ---

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -1281,4 +1281,9 @@ spec:
       - name: istio-ca
         image: gcr.io/istio-testing/istio-ca:d4bbb5ab873ca3d877c2880a4b9cf70fee776dd8
         imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --grpc-port=8060
+          - --grpc-hostname=istio-ca
+          - --self-signed-ca=true
 ---

--- a/install/kubernetes/templates/istio-ca.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ca.yaml.tmpl
@@ -29,4 +29,9 @@ spec:
       - name: istio-ca
         image: {CA_HUB}/istio-ca:{CA_TAG}
         imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --grpc-port=8060
+          - --grpc-hostname=istio-ca
+          - --self-signed-ca=true
 ---

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -17,7 +17,6 @@
 ################################################################################
 
 # Script to install istio components for the raw VM.
-set -x
 
 # Environment variable pointing to the generated Istio configs and binaries.
 # TODO: use curl or tar to fetch the artifacts.
@@ -73,10 +72,19 @@ function istioInstall() {
 
   chown -R istio-proxy /etc/certs
   chown -R istio-proxy /var/lib/istio/envoy
+  # temp workaround for wrong name (for 0.2.7 auth package)
+  ln -s /usr/local/bin/node_agent /usr/local/bin/node-agent > /dev/null
 }
 
 function istioRestart() {
-    # Start or restart istio
+    # Node agent
+    systemctl status istio-auth-node-agent > /dev/null
+    if [[ $? = 0 ]]; then
+      systemctl restart istio-auth-node-agent
+    else
+      systemctl start istio-auth-node-agent
+    fi
+    # Start or restart istio envoy
     systemctl status istio > /dev/null
     if [[ $? = 0 ]]; then
       systemctl restart istio


### PR DESCRIPTION
Cherry pick of #1133
Fix VM auth

- services wasn’t started on VM
- path issue in the package (fixed in
https://github.com/istio/auth/pull/270)
- port issue on the CA pod
```release-note
fixes for mesh expansion auth
```

(cherry picked from commit 68b08b75dc361568a6c538d618c4f23d3f576de1)