### PR TITLE
remove reference of namespace istio-system

### DIFF
--- a/samples/bookinfo/kube/mixer-rule-deny-label.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-label.yaml
@@ -2,7 +2,6 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: denier
 metadata:
   name: denyreviewsv3handler
-  namespace: istio-system
 spec:
   status:
     code: 7
@@ -12,16 +11,14 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: checknothing
 metadata:
   name: denyreviewsv3request
-  namespace: istio-system
 spec:
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: denyreviewsv3
-  namespace: istio-system
 spec:
   match: destination.labels["app"] == "ratings" && source.labels["app"]=="reviews" && source.labels["version"] == "v3"
   actions:
-  - handler: denyreviewsv3handler.denier.istio-system
-    instances: [ denyreviewsv3request.checknothing.istio-system ]
+  - handler: denyreviewsv3handler.denier.default
+    instances: [ denyreviewsv3request.checknothing.default ]

--- a/samples/bookinfo/kube/mixer-rule-deny-label.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-label.yaml
@@ -20,5 +20,5 @@ metadata:
 spec:
   match: destination.labels["app"] == "ratings" && source.labels["app"]=="reviews" && source.labels["version"] == "v3"
   actions:
-  - handler: denyreviewsv3handler.denier.default
-    instances: [ denyreviewsv3request.checknothing.default ]
+  - handler: denyreviewsv3handler.denier
+    instances: [ denyreviewsv3request.checknothing ]

--- a/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
@@ -20,5 +20,5 @@ metadata:
 spec:
   match: destination.labels["app"] == "details" && source.user == "spiffe://cluster.local/ns/default/sa/bookinfo-productpage"
   actions:
-  - handler: denyproductpagehandler.denier.istio-system
-    instances: [ denyproductpagerequest.checknothing.istio-system ]
+  - handler: denyproductpagehandler.denier.default
+    instances: [ denyproductpagerequest.checknothing.default ]

--- a/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
@@ -20,5 +20,5 @@ metadata:
 spec:
   match: destination.labels["app"] == "details" && source.user == "spiffe://cluster.local/ns/default/sa/bookinfo-productpage"
   actions:
-  - handler: denyproductpagehandler.denier.default
-    instances: [ denyproductpagerequest.checknothing.default ]
+  - handler: denyproductpagehandler.denier
+    instances: [ denyproductpagerequest.checknothing ]

--- a/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
@@ -2,7 +2,6 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: denier
 metadata:
   name: denyproductpagehandler
-  namespace: istio-system
 spec:
   status:
     code: 7
@@ -12,14 +11,12 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: checknothing
 metadata:
   name: denyproductpagerequest
-  namespace: istio-system
 spec:
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: denyproductpage
-  namespace: istio-system
 spec:
   match: destination.labels["app"] == "details" && source.user == "spiffe://cluster.local/ns/default/sa/bookinfo-productpage"
   actions:


### PR DESCRIPTION
**What this PR does / why we need it**:

User should be creating the rules in whatever namespace they would like... so that they can actually view them.  Else, if I don't have access to istio-system, I won't be able to view my rules.

I noticed later on in the actions section, we still have namespace reference in there.  Given default is the namespace we use in bookinfo, it makes sense start with that namespace.

I've tested this, and it works for me.

**Release note**:

```release-note
NONE
```