### PR TITLE
Remove Jason from the API management list and reflow doc content.

### DIFF
--- a/GROUPS.md
+++ b/GROUPS.md
@@ -1,12 +1,16 @@
 # Working Groups
 
-Most community activity is organized into Working Groups.
+Most community activity is organized into *working groups*.
 
-Working Groups follow the [contributing](CONTRIBUTING.md) guidelines although each of these groups may operate a little differently depending on their needs and workflow.
+Working groups follow the [contributing](CONTRIBUTING.md) guidelines although each of these groups may operate a little differently depending on
+their needs and workflow.
 
-When the need arises, a new working group can be created, please contact the [istio-core](https://groups.google.com/forum/#!forum/istio-core) working group if you think a new group is necessary.
+When the need arises, a new working group can be created, please contact the [istio-core](https://groups.google.com/forum/#!forum/istio-core)
+working group if you think a new group is necessary.
 
-The working groups generate design docs which are kept in a [shared drive](https://drive.google.com/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) and are available for anyone to read. You have to request access to the drive, something we're stuck with sadly, but once you do you'll have access to all the docs and won't need to request access for each of them individually.
+The working groups generate design docs which are kept in a [shared drive](https://drive.google.com/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) and
+are available for anyone to read. You have to request access to the drive, something we're stuck with sadly, but once you do
+you'll have access to all the docs and won't need to request access for each of them individually.
 
 ## Master Working Group List
 
@@ -17,5 +21,5 @@ The working groups generate design docs which are kept in a [shared drive](https
 | Networking | Andra Cismaru (Google), Kuat Yessenov (Google), Shriram Rajagopalan (IBM), Christopher Luciano (IBM) | [istio-networking@](https://groups.google.com/forum/#!forum/istio-networking) | Pilot integration, TCP Support, Additional L7 protocols, Proxy injection |
 | Environments | Costin Manolache (Google), Laurent Demailly (Google), Jose Ortiz (IBM) | [istio-environments@](https://groups.google.com/forum/#!forum/istio-environments) | Raw VM support, Hybrid Mesh, Mac/Windows support, Cloud Foundry integration |
 | Integrations | Martin Taillefer (Google), Todd Kaplinger (IBM) | [istio-integrations@](https://groups.google.com/forum/#!forum/istio-integrations) | Mixer Adapter Model, Rate Limiting, Tracing, Monitoring, Logging |
-| API Management | Martin Taillefer (Google), Jason Allor (Google), Tony Ffrench (IBM) | [istio-api-management@](https://groups.google.com/forum/#!forum/istio-api-management) | API Keys, Content Mediation, Content Translation, OpenAPI Ingestion |
+| API Management | Martin Taillefer (Google), Tony Ffrench (IBM) | [istio-api-management@](https://groups.google.com/forum/#!forum/istio-api-management) | API Keys, Content Mediation, Content Translation, OpenAPI Ingestion |
 | Test & Release | Andy Lai (Google), Vicky Xu (Google), Lin Sun (IBM) | [istio-test-release@](https://groups.google.com/forum/#!forum/istio-test-release) | Build, test, release |


### PR DESCRIPTION
After chatting with Jason, remove him as an owner of the API working group.