### PR TITLE
move to 0.2.9 in download script

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -12,7 +12,7 @@
 
 # This is the latest release candidate (matches ../istio.VERSION after basic
 # sanity checks)
-ISTIO_VERSION=${ISTIO_VERSION:-0.2.7}
+ISTIO_VERSION=${ISTIO_VERSION:-0.2.9}
 
 NAME="istio-$ISTIO_VERSION"
 OS="$(uname)"


### PR DESCRIPTION
Is this supposed to be covered by a script?

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
A user reported this on slack:

btw: it looks like `curl -L https://git.io/getLatestIstio | sh -` still gets you 0.2.7.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```