### PR TITLE
Fix DNS namespace

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dns-ilb
-  namespace: istio-system
+  namespace: kube-system
   annotations:
     cloud.google.com/load-balancer-type: "internal"
   labels:


### PR DESCRIPTION
Backport from master, kubedns runs in kube-system.

```release-note
- Fix DNS ILB for mesh expansion.
```
