### PR TITLE
support of bazel 0.7.0

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
 


### PR DESCRIPTION
Noticed that //docker/ fails to build with bazel 0.7.0 for a missing
file on load(); others (like //mixer/docker/) have a slightly
different load(). This PR copies load() from //mixer.

I confirmed this builds well with bazel 0.7.0 on my local machine.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
