### PR TITLE
VM support : Removing temp workaround, better output and faster install, added rules for vm

### DIFF
--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -31,8 +31,10 @@ function istioVersionSource() {
 # Will use the generated "kubedns" file.
 function istioNetworkInit() {
   if [[ ! -r /etc/dnsmasq.d ]] ; then
-    apt-get update
-    sudo apt-get -y install dnsmasq
+    echo "*** Running apt-get update..."
+    apt-get update > /dev/null
+    echo "*** Running apt-get install dnsmasq..."
+    apt-get --no-install-recommends -y install dnsmasq
   fi
 
   # Copy config files for DNS
@@ -52,7 +54,7 @@ function istioNetworkInit() {
 # Install istio components and certificates. The admin (directly or using tools like ansible)
 # will generate and copy the files and install the packages on each machine.
 function istioInstall() {
-
+  echo "*** Fetching istio packages..."
   # Current URL for the debian files artifacts. Will be replaced by a proper apt repo.
   curl -L ${PILOT_DEBIAN_URL}/istio-agent.deb > ${ISTIO_STAGING}/istio-agent.deb
   curl -L ${AUTH_DEBIAN_URL}/istio-auth-node-agent.deb > ${ISTIO_STAGING}/istio-auth-node-agent.deb
@@ -72,8 +74,6 @@ function istioInstall() {
 
   chown -R istio-proxy /etc/certs
   chown -R istio-proxy /var/lib/istio/envoy
-  # temp workaround for wrong name (for 0.2.7 auth package)
-  ln -s /usr/local/bin/node_agent /usr/local/bin/node-agent > /dev/null
 }
 
 function istioRestart() {

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -78,6 +78,7 @@ function istioDnsmasq() {
   echo "address=/istio-ca.$NS/$CA_IP" >> kubedns
 
   echo "Generated Dnsmaq config file 'kubedns'. Install it in /etc/dnsmasq.d and restart dnsmasq."
+  echo "$0 machineSetup does this for you."
 }
 
 # Generate a cluster.env config file.
@@ -91,7 +92,8 @@ function istioClusterEnv() {
    echo "ISTIO_SERVICE_CIDR=$CIDR" > cluster.env
 
   echo "Generated cluster.env, needs to be installed in each VM as /var/lib/istio/envoy/cluster.env"
-  echo "The /var/lib/istio/envoy/ directory and files must be readable by 'istio-proxy' user"
+  echo "the /var/lib/istio/envoy/ directory and files must be readable by 'istio-proxy' user"
+  echo "$0 machineSetup does this for you."
 }
 
 
@@ -115,7 +117,8 @@ function istio_provision_certs() {
   kubectl get $NS secret $CERT_NAME -o jsonpath='{.data.key\.pem}' | $B64_DECODE   > key.pem
 
   echo "Generated cert-chain.pem, root-cert.pem and key.pem. Please install them on /etc/certs"
-  echo "The directory and files must be owned by 'istio-proxy' user"
+  echo "the directory and files must be owned by 'istio-proxy' user"
+  echo "$0 machineSetup does this for you."
 }
 
 

--- a/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -1,0 +1,46 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ratings-v2-mysql-vm
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ratings
+        version: v2-mysql-vm
+    spec:
+      containers:
+      - name: ratings
+        image: gcr.io/istio-testing/examples-bookinfo-ratings-v2:0.2.8
+        imagePullPolicy: IfNotPresent
+        env:
+          # This assumes you registered your mysql vm as
+          # istioctl register -n vm mysqldb 1.2.3.4 3306
+          - name: DB_TYPE
+            value: "mysql"
+          - name: MYSQL_DB_HOST
+            value: mysqldb.vm.svc.cluster.local
+          - name: MYSQL_DB_PORT
+            value: "3306"
+          - name: MYSQL_DB_USER
+            value: root
+          - name: MYSQL_DB_PASSWORD
+            value: password
+        ports:
+        - containerPort: 9080
+---

--- a/samples/bookinfo/kube/route-rule-ratings-mysql-vm.yaml
+++ b/samples/bookinfo/kube/route-rule-ratings-mysql-vm.yaml
@@ -1,0 +1,23 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ratings-test-v2-mysql-vm
+spec:
+  destination:
+    name: ratings
+  precedence: 4
+  route:
+  - labels:
+      version: v2-mysql-vm
+---
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: reviews-test-ratings-v2-vm
+spec:
+  destination:
+    name: reviews
+  precedence: 2
+  route:
+  - labels:
+      version: v3


### PR DESCRIPTION
Cherry pick of #1141

```release-note
VM support:
Adding rules/yaml for on prem/vm mysql
Removing temp workaround + slightly better output and faster install
```

(cherry picked from commit d905ade244a2728285638c194e7d2c4b7c144d2b)