### PR TITLE
Updated setupMeshEx.sh to support Mac as well as Linux

### DIFF
--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -109,9 +109,7 @@ function istio_provision_certs() {
   if [[ -n "$NS" ]] ; then
     NS="-n $NS"
   fi
-  # on mac make sure you brew install base64 and use that one in path
-  # or change BASE64_DECODE="/usr/bin/base64 -D"
-  local B64_DECODE=${BASE64_DECODE:-base64 -d}
+  local B64_DECODE=${BASE64_DECODE:-base64 --decode}
   kubectl get $NS secret $CERT_NAME -o jsonpath='{.data.cert-chain\.pem}' | $B64_DECODE  > cert-chain.pem
   kubectl get $NS secret $CERT_NAME -o jsonpath='{.data.root-cert\.pem}' | $B64_DECODE   > root-cert.pem
   kubectl get $NS secret $CERT_NAME -o jsonpath='{.data.key\.pem}' | $B64_DECODE   > key.pem


### PR DESCRIPTION
Second attempt.

Change params for base64 to the cross-platform --decode. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
```
