### PR TITLE
Monorepo: Fix Mixer deps and add mixer to pilot e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,5 +34,6 @@ jobs:
             ln -s ~/.kube/config pilot/platform/kube/
       - run: bazel build //pilot/...
       - run: bazel test //pilot/...
+      - run: bazel run //mixer/docker:mixer
       - run: cd pilot; make docker HUB=docker.io/rshriram TAG=test
       - run: cd pilot; make e2etest HUB=docker.io/rshriram TAG=test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ jobs:
       - run: bazel build //pilot/...
       - run: bazel test //pilot/...
       - run: bazel run //mixer/docker:mixer
-      - run: cd pilot; make docker HUB=docker.io/rshriram TAG=test
-      - run: cd pilot; make e2etest HUB=docker.io/rshriram TAG=test
       - save_cache:
           key: bazel-cache-{{ checksum "WORKSPACE" }}
           paths:
             - /home/circleci/.cache/bazel
+      - run: cd pilot; make docker HUB=docker.io/rshriram TAG=test
+      - run: cd pilot; make e2etest HUB=docker.io/rshriram TAG=test
  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,16 @@ jobs:
       - run:
           command: |
             ln -s ~/.kube/config pilot/platform/kube/
+      - restore_cache:
+          keys:
+            - bazel-cache-{{ checksum "WORKSPACE" }}      
       - run: bazel build //pilot/...
       - run: bazel test //pilot/...
       - run: bazel run //mixer/docker:mixer
       - run: cd pilot; make docker HUB=docker.io/rshriram TAG=test
       - run: cd pilot; make e2etest HUB=docker.io/rshriram TAG=test
+      - save_cache:
+          key: bazel-cache-{{ checksum "WORKSPACE" }}
+          paths:
+            - /home/circleci/.cache/bazel
+ 

--- a/mixer/adapter/prometheus/BUILD
+++ b/mixer/adapter/prometheus/BUILD
@@ -14,8 +14,8 @@ go_library(
         "//mixer/pkg/adapter:go_default_library",
         "//mixer/template/metric:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
-        "@com_github_prometheus_client_golang_v08//prometheus:go_default_library",
-        "@com_github_prometheus_client_golang_v08//prometheus/promhttp:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
     ],
 )
 
@@ -32,7 +32,7 @@ go_test(
         "//mixer/pkg/adapter:go_default_library",
         "//mixer/pkg/adapter/test:go_default_library",
         "//mixer/template/metric:go_default_library",
-        "@com_github_prometheus_client_golang_v08//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_model//go:go_default_library",
     ],
 )

--- a/mixer/adapter/prometheus/prometheus_test.go
+++ b/mixer/adapter/prometheus/prometheus_test.go
@@ -358,7 +358,7 @@ func TestProm_Record(t *testing.T) {
 						continue
 					}
 				case *prometheus.HistogramVec:
-					if err := c.(*prometheus.HistogramVec).With(promLabels(adapterVal.Dimensions)).Write(m); err != nil {
+					if err := c.(*prometheus.HistogramVec).With(promLabels(adapterVal.Dimensions)).(prometheus.Metric).Write(m); err != nil {
 						t.Errorf("Error writing metric value to proto: %v", err)
 						continue
 					}

--- a/mixer/example/servicegraph/promgen/BUILD
+++ b/mixer/example/servicegraph/promgen/BUILD
@@ -8,6 +8,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//mixer/example/servicegraph:go_default_library",
+        # FIXME remove v08 dependency from promgen and then remove the dependency from WORKSPACE.
+        #"@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",
         "@com_github_prometheus_client_golang_v08//api/prometheus:go_default_library",
         "@com_github_prometheus_common//model:go_default_library",
     ],

--- a/mixer/example/servicegraph/promgen/promgen.go
+++ b/mixer/example/servicegraph/promgen/promgen.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/client_golang/api/prometheus"
+	prometheus "github.com/prometheus/client_golang/api/prometheus"
 	"github.com/prometheus/common/model"
 
 	"istio.io/istio/mixer/example/servicegraph"

--- a/pilot/bin/push-docker
+++ b/pilot/bin/push-docker
@@ -78,7 +78,7 @@ pushd docker
   for image in app proxy proxy_init proxy_debug pilot sidecar_initializer eurekamirror mixer; do
     if [[ $image == "mixer" ]];then
       # build mixer docker image, it is tagged as istio/mixer/docker:mixer
-      bazel run //mixer/docker:mixer
+      bazel run ${BUILD_FLAGS} //mixer/docker:mixer
       local_image=${MIXER_LOCAL_IMG}
     else
       local_image="${image}:${local_tag}"

--- a/pilot/bin/push-docker
+++ b/pilot/bin/push-docker
@@ -72,10 +72,19 @@ bazel build ${BUILD_FLAGS} //pilot/cmd/... //pilot/test/...
 IFS=',' read -ra tags <<< "${tags}"
 IFS=',' read -ra hubs <<< "${hubs}"
 
+MIXER_LOCAL_IMG="istio/mixer/docker:mixer"
+
 pushd docker
-  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer eurekamirror; do
-    local_image="${image}:${local_tag}"
-    docker build -q -f "Dockerfile.${image}" -t "${local_image}" .
+  for image in app proxy proxy_init proxy_debug pilot sidecar_initializer eurekamirror mixer; do
+    if [[ $image == "mixer" ]];then
+      # build mixer docker image, it is tagged as istio/mixer/docker:mixer
+      bazel run //mixer/docker:mixer
+      local_image=${MIXER_LOCAL_IMG}
+    else
+      local_image="${image}:${local_tag}"
+      docker build -q -f "Dockerfile.${image}" -t "${local_image}" .
+    fi
+
     for tag in ${tags[@]}; do
       for hub in ${hubs[@]}; do
         tagged_image="${hub}/${image}:${tag}"

--- a/pilot/bin/push-docker
+++ b/pilot/bin/push-docker
@@ -77,8 +77,9 @@ MIXER_LOCAL_IMG="istio/mixer/docker:mixer"
 pushd docker
   for image in app proxy proxy_init proxy_debug pilot sidecar_initializer eurekamirror mixer; do
     if [[ $image == "mixer" ]];then
+      # use bazel run //mixer/docker:mixer to build mixer docker image. in CircleCI this is
+      # built as a separate step
       # build mixer docker image, it is tagged as istio/mixer/docker:mixer
-      bazel run ${BUILD_FLAGS} //mixer/docker:mixer
       local_image=${MIXER_LOCAL_IMG}
     else
       local_image="${image}:${local_tag}"

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -131,7 +131,7 @@ func main() {
 
 	params.Name = "(default infra)"
 	params.Auth = proxyconfig.MeshConfig_NONE
-	params.Mixer = false
+	params.Mixer = true
 	params.Ingress = true
 	params.Zipkin = true
 	params.MixerCustomConfigFile = mixerConfigFile

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -131,7 +131,7 @@ func main() {
 
 	params.Name = "(default infra)"
 	params.Auth = proxyconfig.MeshConfig_NONE
-	params.Mixer = true
+	params.Mixer = false
 	params.Ingress = true
 	params.Zipkin = true
 	params.MixerCustomConfigFile = mixerConfigFile

--- a/pilot/test/integration/infra.go
+++ b/pilot/test/integration/infra.go
@@ -207,9 +207,9 @@ func (infra *infra) setup() error {
 	if err := deploy("pilot.yaml.tmpl", infra.IstioNamespace); err != nil {
 		return err
 	}
-	// if err := deploy("mixer.yaml.tmpl", infra.IstioNamespace); err != nil {
-	// 	return err
-	// }
+	if err := deploy("mixer.yaml.tmpl", infra.IstioNamespace); err != nil {
+		return err
+	}
 	if platform.ServiceRegistry(infra.Registry) == platform.EurekaRegistry {
 		if err := deploy("eureka.yaml.tmpl", infra.IstioNamespace); err != nil {
 			return err

--- a/pilot/test/integration/testdata/mixer.yaml.tmpl
+++ b/pilot/test/integration/testdata/mixer.yaml.tmpl
@@ -33,7 +33,7 @@ spec:
       serviceAccountName: istio-mixer-service-account
       containers:
       - name: mixer
-        image: {{.Hub}}/testmixer:{{.Tag}}
+        image: {{.Hub}}/mixer:{{.Tag}}
         imagePullPolicy: IfNotPresent
       - name: istio-proxy
         image: {{.Hub}}/proxy_debug:{{.Tag}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes Mixer Segv by using only one prometheus dep in the binary.


```release-note
NONE
```
