### PR TITLE
[ci skip] VM e2e test framework on GCP

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -75,6 +75,18 @@ go_repository(
 )
 
 go_repository(
+    name = "com_github_google_go_github",
+    commit = "fbfee053c26dab3772adfc7799d995eed379133e",  # Dec 2, 2017 (no releases)
+    importpath = "github.com/google/go-github",
+)
+
+go_repository(
+    name = "com_github_google_go_querystring",
+    commit = "53e6ce116135b80d037921a7fdd5138cf32d7a8a",  # Jan 11, 2017 (no releases)
+    importpath = "github.com/google/go-querystring",
+)
+
+go_repository(
     name = "com_github_hashicorp_errwrap",
     commit = "7554cd9344cec97297fa6649b055a8c98c2a1e55",  # Oct 27, 2014 (no releases)
     importpath = "github.com/hashicorp/errwrap",
@@ -1099,7 +1111,7 @@ go_repository(
 
 git_repository(
     name = "com_github_istio_test_infra",
-    commit = "67e73ad01f9d1074a7d787a91201d41938ad4310",  # Aug 25, 2017
+    commit = "470646bb988771c3bac655b1acf9aa70d68db5e4",  # Dec 5, 2017
     remote = "https://github.com/istio/test-infra.git",
 )
 

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -24,6 +24,7 @@ ISTIO_STAGING=${ISTIO_STAGING:-.}
 
 function istioVersionSource() {
   echo "Sourced ${ISTIO_STAGING}/istio.VERSION"
+  cat ${ISTIO_STAGING}/istio.VERSION
   source ${ISTIO_STAGING}/istio.VERSION
 }
 
@@ -56,9 +57,9 @@ function istioNetworkInit() {
 function istioInstall() {
   echo "*** Fetching istio packages..."
   # Current URL for the debian files artifacts. Will be replaced by a proper apt repo.
-  curl -L ${PILOT_DEBIAN_URL}/istio-agent.deb > ${ISTIO_STAGING}/istio-agent.deb
-  curl -L ${AUTH_DEBIAN_URL}/istio-auth-node-agent.deb > ${ISTIO_STAGING}/istio-auth-node-agent.deb
-  curl -L ${PROXY_DEBIAN_URL}/istio-proxy.deb > ${ISTIO_STAGING}/istio-proxy.deb
+  curl -f -L ${PILOT_DEBIAN_URL}/istio-agent.deb > ${ISTIO_STAGING}/istio-agent.deb
+  curl -f -L ${AUTH_DEBIAN_URL}/istio-auth-node-agent.deb > ${ISTIO_STAGING}/istio-auth-node-agent.deb
+  curl -f -L ${PROXY_DEBIAN_URL}/istio-proxy.deb > ${ISTIO_STAGING}/istio-proxy.deb
 
   # Install istio binaries
   dpkg -i ${ISTIO_STAGING}/istio-proxy.deb
@@ -74,9 +75,13 @@ function istioInstall() {
 
   chown -R istio-proxy /etc/certs
   chown -R istio-proxy /var/lib/istio/envoy
+
+  # Useful to test VM extension to istio
+  apt-get --no-install-recommends -y install host
 }
 
 function istioRestart() {
+    echo "*** Restarting istio proxy..."
     # Node agent
     systemctl status istio-auth-node-agent > /dev/null
     if [[ $? = 0 ]]; then

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -46,25 +46,24 @@
 # Generate a 'kubedns' Dnsmasq config file using the internal load balancer.
 # It will need to be installed on each machine expanding the mesh.
 function istioDnsmasq() {
-   local NS=${ISTIO_NAMESPACE:-istio-system}
-
+  local NS=${ISTIO_NAMESPACE:-istio-system}
   # Multiple tries, it may take some time until the controllers generate the IPs
-  for i in {1..10}
+  for i in {1..20}
   do
     PILOT_IP=$(kubectl get -n $NS service istio-pilot-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     ISTIO_DNS=$(kubectl get -n kube-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     MIXER_IP=$(kubectl get -n $NS service mixer-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     CA_IP=$(kubectl get -n $NS service istio-ca-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
-    if [ "${PILOT_IP}" == "" -o  "${ISTIO_DNS}" == "" -o "${MIXER_IP}" == "" ] ; then
-        echo "Waiting for ILBs, pilot=$PILOT_IP, MIXER_IP=$MIXER_IP, CA_IP=$CA_IP, DNS=$ISTIO_DNS - kubectl get -n $NS service: $(kubectl get -n $NS service)"
-        sleep 5
+    if [ "${PILOT_IP}" == "" -o  "${ISTIO_DNS}" == "" -o "${MIXER_IP}" == "" -o "${CA_IP}" == "" ] ; then
+      echo "Waiting for ILBs, pilot=$PILOT_IP, MIXER_IP=$MIXER_IP, CA_IP=$CA_IP, DNS=$ISTIO_DNS - kubectl get -n $NS service: $(kubectl get -n $NS service)"
+      sleep 30
     else
-        break
+      break
     fi
   done
 
-  if [ "${PILOT_IP}" == "" -o  "${ISTIO_DNS}" == "" -o "${MIXER_IP}" == "" ] ; then
+  if [ "${PILOT_IP}" == "" -o  "${ISTIO_DNS}" == "" -o "${MIXER_IP}" == "" -o "${CA_IP}" == "" ] ; then
     echo "Failed to create ILBs"
     exit 1
   fi
@@ -88,16 +87,15 @@ function istioDnsmasq() {
 # Parameters:
 # - name of the k8s cluster.
 function istioClusterEnv() {
-   local K8S_CLUSTER=${1:-${K8S_CLUSTER}}
-   local ISTIO_NS=${ISTIO_NAMESPACE:-istio-system}
-   local CP_AUTH_POLICY=${CONTROL_PLANE_AUTH_POLICY:-MUTUAL_TLS}
+  local K8S_CLUSTER=${1:-${K8S_CLUSTER}}
+  local ISTIO_NS=${ISTIO_NAMESPACE:-istio-system}
+  local CP_AUTH_POLICY=${CONTROL_PLANE_AUTH_POLICY:-MUTUAL_TLS}
 
-   # TODO: parse it all from $(kubectl config current-context)
-   CIDR=$(gcloud container clusters describe ${K8S_CLUSTER} ${GCP_OPTS:-} --format "value(servicesIpv4Cidr)")
-   echo "ISTIO_SERVICE_CIDR=$CIDR" > cluster.env
-   echo "ISTIO_SYSTEM_NAMESPACE=$ISTIO_NS" >> cluster.env
-   echo "CONTROL_PLANE_AUTH_POLICY=$CP_AUTH_POLICY" >> cluster.env
-
+  # TODO: parse it all from $(kubectl config current-context)
+  CIDR=$(gcloud container clusters describe ${K8S_CLUSTER} ${GCP_OPTS:-} --format "value(servicesIpv4Cidr)")
+  echo "ISTIO_SERVICE_CIDR=$CIDR" > cluster.env
+  echo "ISTIO_SYSTEM_NAMESPACE=$ISTIO_NS" >> cluster.env
+  echo "CONTROL_PLANE_AUTH_POLICY=$CP_AUTH_POLICY" >> cluster.env
 
   echo "Generated cluster.env, needs to be installed in each VM as /var/lib/istio/envoy/cluster.env"
   echo "the /var/lib/istio/envoy/ directory and files must be readable by 'istio-proxy' user"
@@ -140,23 +138,37 @@ function istio_provision_certs() {
 #
 # Expected to be run from the release directory (ie istio-0.2.8/ or istio/)
 function istioBootstrapVM() {
- local DESTINATION=${1}
+  local DESTINATION=${1}
+  local SA=${2:-${SERVICE_ACCOUNT:-default}}
+  local NS=${3:-${SERVICE_NAMESPACE:-}}
 
- local SA=${2:-${SERVICE_ACCOUNT:-default}}
- local NS=${3:-${SERVICE_NAMESPACE:-}}
- echo "Making certs for service account $SA (namespace $NS)"
- istio_provision_certs $SA $NS
+  DEFAULT_SCRIPT="install/tools/setupIstioVM.sh"
+  SETUP_ISTIO_VM_SCRIPT=${SETUP_ISTIO_VM_SCRIPT:-${DEFAULT_SCRIPT}}
+  echo "Making certs for service account $SA (namespace $NS)"
+  istio_provision_certs $SA $NS
 
- # Copy deb, helper and config files
- istioCopy $DESTINATION \
-   kubedns \
-   *.pem \
-   cluster.env \
-   istio.VERSION \
-   install/tools/setupIstioVM.sh
+  for i in {1..10}; do
+    # Copy deb, helper and config files
+    istioCopy $DESTINATION \
+      kubedns \
+      *.pem \
+      cluster.env \
+      istio.VERSION \
+      ${SETUP_ISTIO_VM_SCRIPT}
 
- # Run the setup script.
- istioRun $DESTINATION "sudo bash -c -x ./setupIstioVM.sh"
+    if [[ $? -ne 0 ]]; then
+      echo "scp failed, retry in 10 sec"
+      sleep 10
+    else
+      echo "scp succeeded"
+      break
+    fi
+  done
+
+  istioRun $DESTINATION "ls -a"
+
+  # Run the setup script.
+  istioRun $DESTINATION "sudo bash -c -x ./setupIstioVM.sh"
 }
 
 

--- a/tests/e2e/framework/BUILD
+++ b/tests/e2e/framework/BUILD
@@ -7,6 +7,7 @@ go_library(
         "framework.go",
         "istioctl.go",
         "kubernetes.go",
+        "rawVM.go",
         "testInfo.go",
     ],
     data = [

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -25,6 +25,8 @@ import (
 
 var (
 	skipCleanup = flag.Bool("skip_cleanup", false, "Debug, skip clean up")
+	// TestVM is true if in this test run user wants to test VM on istio
+	TestVM = flag.Bool("test_vm", false, "whether to test VM on istio")
 )
 
 type testCleanup struct {
@@ -164,7 +166,7 @@ func (t *testCleanup) cleanup() {
 }
 
 // Save test logs to tmp dir
-// Fetch and save cluster tracing logs if logProvider specified
+// Fetch and save cluster pod logs using kuebctl
 // Logs are uploaded during test tear down
 func (c *CommonConfig) saveLogs(r int) error {
 	if c.Cleanup.skipCleanup {

--- a/tests/e2e/framework/rawVM.go
+++ b/tests/e2e/framework/rawVM.go
@@ -1,0 +1,295 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"time"
+
+	u "istio.io/istio/tests/util"
+)
+
+// RawVM interfaces different cloud venders to support e2e testing with VM
+type RawVM interface {
+	Cleanable
+	GetInternalIP() (string, error)
+	GetExternalIP() (string, error)
+	SecureShell(cmd string) (string, error)
+	SecureCopy(files ...string) (string, error)
+}
+
+var (
+	// flags to select vm with specific configuration
+	projectID     = flag.String("project_id", "istio-testing", "Project ID")
+	projectNumber = flag.String("project_number", "450874614208", "Project Number")
+	zone          = flag.String("zone", "us-east4-c", "The zone in which the VM and cluster resides")
+	clusterName   = flag.String("cluster_name", "", "The name of the istio cluster that the VM extends")
+	image         = flag.String("image", "debian-9-stretch-v20170816", "Image Name")
+	imageProject  = flag.String("image_project", "debian-cloud", "Image Project")
+	proxyTag      = flag.String("proxy_tag", "", "proxy tag that identifies a debian pkg")
+	// paths
+	setupMeshExScript  = ""
+	mashExpansionYaml  = ""
+	setupIstioVMScript = ""
+	// kubectl delete resources on tear down
+	kubeDeleteYaml = []string{}
+)
+
+const (
+	debURL = "https://storage.googleapis.com/istio-artifacts/%s/%s/artifacts/debs"
+)
+
+// GCPRawVM is hosted on Google Cloud Platform
+type GCPRawVM struct {
+	Name        string
+	ClusterName string
+	Namespace   string
+	// ServiceAccount must have iam.serviceAccountActor or owner permissions
+	// to the project. Use IAM settings.
+	ServiceAccount string
+	ProjectID      string
+	Zone           string
+	Image          string
+	ImageProject   string
+}
+
+// NewGCPRawVM creates a new vm on GCP
+func NewGCPRawVM(namespace string) *GCPRawVM {
+	// TODO (chx) generate by vm pool server
+	vmName := fmt.Sprintf("vm-%v", time.Now().UnixNano())
+	if *clusterName == "" {
+		// Use default cluster. Determine clusterName at run time since cluster that
+		// enables alpha features expires every month and is recreated with different
+		// rotation number
+		*clusterName = "istio-e2e-rbac-rotation-1"
+		cmd := fmt.Sprintf("gcloud container clusters describe %s --project %s --zone %s",
+			*clusterName, *projectID, *zone)
+		if _, err := u.ShellMuteOutput(cmd); err != nil { // use rotation-2 if 1 is not up
+			*clusterName = "istio-e2e-rbac-rotation-2"
+		}
+	}
+	return &GCPRawVM{
+		Name:           vmName,
+		ClusterName:    *clusterName,
+		Namespace:      namespace,
+		ServiceAccount: fmt.Sprintf("%s-compute@developer.gserviceaccount.com", *projectNumber),
+		ProjectID:      *projectID,
+		Zone:           *zone,
+		Image:          *image,
+		ImageProject:   *imageProject,
+	}
+}
+
+// GetInternalIP returns the internal IP of the VM
+func (vm *GCPRawVM) GetInternalIP() (string, error) {
+	cmd := vm.baseCommand("describe") +
+		" --format='value(networkInterfaces[0].accessConfigs[0].natIP)'"
+	o, e := u.Shell(cmd)
+	return strings.Trim(o, "\n"), e
+}
+
+// GetExternalIP returns the internal IP of the VM
+func (vm *GCPRawVM) GetExternalIP() (string, error) {
+	cmd := vm.baseCommand("describe") +
+		" --format='value(networkInterfaces[0].networkIP)'"
+	o, e := u.Shell(cmd)
+	return strings.Trim(o, "\n"), e
+}
+
+// SecureShell execeutes cmd on vm through ssh
+func (vm *GCPRawVM) SecureShell(cmd string) (string, error) {
+	ssh := fmt.Sprintf("gcloud compute ssh --project %s --zone %s %s --command \"%s\"",
+		vm.ProjectID, vm.Zone, vm.Name, cmd)
+	return u.Shell(ssh)
+}
+
+// SecureCopy copies files to vm via scp
+func (vm *GCPRawVM) SecureCopy(files ...string) (string, error) {
+	filesStr := strings.Join(files, " ")
+	scp := fmt.Sprintf("gcloud compute scp --project %s --zone %s %s %s",
+		vm.ProjectID, vm.Zone, filesStr, vm.Name)
+	return u.Shell(scp)
+}
+
+// Teardown releases the VM to resource manager
+func (vm *GCPRawVM) Teardown() error {
+	for _, yaml := range kubeDeleteYaml {
+		cmd := fmt.Sprintf("cat <<EOF | kubectl delete -f -\n%sEOF", yaml)
+		if _, err := u.Shell(cmd); err != nil {
+			return err
+		}
+	}
+	if _, err := u.Shell(vm.baseCommand("delete")); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Setup initialize the VM
+func (vm *GCPRawVM) Setup() error {
+	if err := prepareConstants(); err != nil {
+		return err
+	}
+	if err := vm.provision(); err != nil {
+		return err
+	}
+	if err := vm.prepareCluster(); err != nil {
+		return err
+	}
+	if err := vm.setupMeshEx("generateClusterEnv", vm.ClusterName); err != nil {
+		return err
+	}
+	if _, err := u.Shell("cat cluster.env"); err != nil {
+		return err
+	}
+	if err := vm.setupMeshEx("generateDnsmasq"); err != nil {
+		return err
+	}
+	if _, err := u.Shell("cat kubedns"); err != nil {
+		return err
+	}
+	if err := buildIstioVersion(); err != nil {
+		return err
+	}
+	if _, err := u.Shell("cat istio.VERSION"); err != nil {
+		return err
+	}
+	return vm.setupMeshEx("machineSetup", vm.Name)
+}
+
+func buildIstioVersion() error {
+	currentIstioCommit, err := u.Shell("git rev-parse HEAD")
+	if err != nil {
+		return err
+	}
+	currentIstioCommit = strings.Trim(currentIstioCommit, "\n")
+	auth := *caTag
+	pilot := *pilotTag
+	proxy := *proxyTag
+	if auth == "" {
+		auth = currentIstioCommit
+	}
+	if pilot == "" {
+		pilot = currentIstioCommit
+	}
+	if proxy == "" {
+		// Use debian pkg built from proxy master
+		proxy, err = u.GetHeadCommitSHA("istio", "proxy", "master")
+		if err != nil {
+			return err
+		}
+	}
+	authURL := fmt.Sprintf(debURL, "auth", auth)
+	pilotURL := fmt.Sprintf(debURL, "pilot", pilot)
+	proxyURL := fmt.Sprintf(debURL, "proxy", proxy)
+	urls := fmt.Sprintf(`
+		export AUTH_DEBIAN_URL="%s";
+		export PILOT_DEBIAN_URL="%s";
+		export PROXY_DEBIAN_URL="%s";`, authURL, pilotURL, proxyURL)
+	return u.WriteTextFile("istio.VERSION", urls)
+}
+
+func (vm *GCPRawVM) provision() error {
+	// Create the VM
+	createVMcmd := vm.baseCommand("create") + fmt.Sprintf(
+		`--machine-type "n1-standard-1" \
+			 --subnet default \
+			 --can-ip-forward \
+			 --service-account %s \
+			 --scopes "https://www.googleapis.com/auth/cloud-platform" \
+			 --tags "http-server","https-server" \
+			 --image %s \
+			 --image-project %s \
+			 --boot-disk-size "10" \
+			 --boot-disk-type "pd-standard" \
+			 --boot-disk-device-name "debtest"`,
+		vm.ServiceAccount, vm.Image, vm.ImageProject)
+	if _, err := u.Shell(createVMcmd); err != nil {
+		return err
+	}
+	// create firewall rule that allow access to VM
+	if _, err := u.Shell("gcloud compute firewall-rules describe allow-vm-ssh-http"); err != nil {
+		if _, err = u.Shell(`gcloud compute firewall-rules create allow-vm-ssh-http \
+		 	--allow tcp:22,tcp:80,tcp:443,tcp:8080,udp:5228,icmp \
+		 	--source-ranges 0.0.0.0/0`); err != nil {
+			return err
+		}
+	}
+	// wait until VM is up and ready
+	isVMLive := func() (bool, error) {
+		_, err := vm.SecureShell("echo hello")
+		return (err == nil), nil
+	}
+	return u.Poll(20*time.Second, 10, isVMLive)
+}
+
+func (vm *GCPRawVM) baseCommand(action string) string {
+	return fmt.Sprintf("gcloud compute --project %s instances %s %s --zone %s ",
+		vm.ProjectID, action, vm.Name, vm.Zone)
+}
+
+func (vm *GCPRawVM) setupMeshEx(op string, args ...string) error {
+	argsStr := strings.Join(args, " ")
+	env := fmt.Sprintf(`
+		export ISTIO_NAMESPACE=%s;
+		export GCP_OPTS="--project %s --zone %s";
+		export SETUP_ISTIO_VM_SCRIPT="%s";`,
+		vm.Namespace, vm.ProjectID, vm.Zone, setupIstioVMScript)
+	cmd := fmt.Sprintf("%s %s %s", setupMeshExScript, op, argsStr)
+	_, err := u.Shell(env + cmd)
+	return err
+}
+
+// Initialize the K8S cluster, generating config files for the raw VMs.
+// Must be run once, will generate files in the CWD. The files must be installed on the VM.
+// This assumes the recommended dnsmasq config option.
+func (vm *GCPRawVM) prepareCluster() error {
+	kv := map[string]string{
+		"istio-system": vm.Namespace,
+	}
+	return replaceKVInYamlThenKubectlApply(mashExpansionYaml, kv)
+}
+
+func replaceKVInYamlThenKubectlApply(yamlPath string, kv map[string]string) error {
+	bytes, err := ioutil.ReadFile(yamlPath)
+	if err != nil {
+		return err
+	}
+	yaml := string(bytes)
+	for k, v := range kv {
+		yaml = strings.Replace(yaml, k, v, -1)
+	}
+	cmd := fmt.Sprintf("cat <<EOF | kubectl apply -f -\n%sEOF", yaml)
+	if _, err = u.Shell(cmd); err != nil {
+		return err
+	}
+	kubeDeleteYaml = append(kubeDeleteYaml, yaml)
+	return nil
+}
+
+func prepareConstants() error {
+	root, err := u.GitRootDir()
+	if err != nil {
+		return err
+	}
+	setupMeshExScript = filepath.Join(root, "install/tools/setupMeshEx.sh")
+	mashExpansionYaml = filepath.Join(root, "install/kubernetes/mesh-expansion.yaml")
+	setupIstioVMScript = filepath.Join(root, "install/tools/setupIstioVM.sh")
+	return nil
+}

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -450,6 +450,24 @@ func TestDbRoutingMysql(t *testing.T) {
 		fmt.Sprintf("Success! Response matches with expected! %s", respExpr), t)
 }
 
+func TestVMExtendsIstio(t *testing.T) {
+	if *framework.TestVM {
+		// TODO (chx) vm_provider flag to select venders
+		vm := framework.NewGCPRawVM(tc.CommonConfig.Kube.Namespace)
+		// VM setup and teardown is manual for now
+		// will be replaced with preprovision server calls
+		err := vm.Setup()
+		inspect(err, "VM setup failed", "VM setup succeeded", t)
+		_, err = vm.SecureShell("curl -v istio-pilot:8080")
+		inspect(err, "VM failed to extend istio", "VM extends istio service mesh", t)
+		_, err2 := vm.SecureShell(fmt.Sprintf(
+			"host istio-pilot.%s.svc.cluster.local.", vm.Namespace))
+		inspect(err2, "VM failed to extend istio", "VM extends istio service mesh", t)
+		err = vm.Teardown()
+		inspect(err, "VM teardown failed", "VM teardown succeeded", t)
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	check(framework.InitGlog(), "cannot setup glog")

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
         "@com_github_pmezard_go_difflib//difflib:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The VM service mesh extension feature has been tested manually and this PR extends the e2e test framework so tests on VM could be automated. 

Currently VM testing feature is disabled unless `--test_vm` is given when running the e2e tests. The reason is that vm preprovisioning is still under development. I will first set up daily test jobs to run the test (that ensures mutual exclusion on VM) and dev may start using the framework and add more tests in the meantime before it integrates with the release qualification and perhaps presubmit. 

Remaining TODOs and setting up daily test jobs will be done in separate PR. 

This PR is migrated from https://github.com/istio/istio/pull/1039 due to repo reorg under istio. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
