### PR TITLE
apiVersion not set

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -1,6 +1,6 @@
 # Currently specific to GKE. Annotations specific to other providers should be added
 # after they get tested.
-Version: v1
+apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot-ilb


### PR DESCRIPTION
apiVersion not set in istio-pilot-ilb

**What this PR does / why we need it**:

Fixes the error below:
```
kubectl apply -f install/kubernetes/mesh-expansion.yaml
error: error validating "install/kubernetes/mesh-expansion.yaml": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1574 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix typo/bug in mesh-expansion.yaml
```
