### PR TITLE
Monorepo: Enable plain go build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Bazel
 /bazel-*
 vendor
+*.descriptor_set
 # vi backups
 *.bak
 # Vm setup generated files

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -51,4 +51,4 @@ linkpkg ${ROOT} ${genfiles} security
 
 
 # Remove doubly-vendorized k8s dependencies
-rm -rf {ROOT}/vendor/k8s.io/*/vendor
+rm -rf ${ROOT}/vendor/k8s.io/*/vendor

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+ROOT=$(dirname $WD)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+# Ensure expected GOPATH setup
+if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
+       echo "Istio not found in GOPATH/src/istio.io/"
+       exit 1
+fi
+
+bazel build //...
+
+source "${ROOT}/bin/use_bazel_go.sh"
+
+# Clean up vendor dir
+rm -rf ${ROOT}/vendor
+mkdir -p ${ROOT}/vendor
+
+# Vendorize bazel dependencies
+${ROOT}/mixer/bin/bazel_to_go.py ${ROOT}
+
+# link Pilot specific stuff
+genfiles=$(bazel info bazel-genfiles)
+# Link CRD generated files
+ln -sf "$genfiles/pilot/adapter/config/crd/types.go" \
+  ${ROOT}/pilot/adapter/config/crd/
+
+# Link envoy binary
+ln -sf "$genfiles/pilot/proxy/envoy/envoy" ${ROOT}/pilot/proxy/envoy/
+
+ln -sf "$genfiles/security/proto/ca_service.pb.go" ${ROOT}/security/proto
+
+# Remove doubly-vendorized k8s dependencies
+rm -rf {ROOT}/vendor/k8s.io/*/vendor
+
+

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -15,6 +15,22 @@ if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
+function linkpkg() {
+  root=$1
+  shift
+  genfiles=$1
+  shift
+  comp=$1
+
+  pushd $genfiles
+  for fl in $(find $comp -type f);do
+    ln -sf ${genfiles}/$fl ${root}/$(dirname $fl)
+  done
+
+  popd
+}
+
+# This step is to fetch resources and create genfiles
 bazel build //...
 
 source "${ROOT}/bin/use_bazel_go.sh"
@@ -26,18 +42,13 @@ mkdir -p ${ROOT}/vendor
 # Vendorize bazel dependencies
 ${ROOT}/mixer/bin/bazel_to_go.py ${ROOT}
 
-# link Pilot specific stuff
 genfiles=$(bazel info bazel-genfiles)
-# Link CRD generated files
-ln -sf "$genfiles/pilot/adapter/config/crd/types.go" \
-  ${ROOT}/pilot/adapter/config/crd/
+# Link generated files
 
-# Link envoy binary
-ln -sf "$genfiles/pilot/proxy/envoy/envoy" ${ROOT}/pilot/proxy/envoy/
+linkpkg ${ROOT} ${genfiles} pilot
+linkpkg ${ROOT} ${genfiles} broker
+linkpkg ${ROOT} ${genfiles} security
 
-ln -sf "$genfiles/security/proto/ca_service.pb.go" ${ROOT}/security/proto
 
 # Remove doubly-vendorized k8s dependencies
 rm -rf {ROOT}/vendor/k8s.io/*/vendor
-
-

--- a/bin/use_bazel_go.sh
+++ b/bin/use_bazel_go.sh
@@ -3,10 +3,15 @@
 
 BAZEL_DIR="$(bazel info execution_root)"
 
-export GOROOT="$(find ${BAZEL_DIR}/external -type d -name 'go1_*')"
+GOROOT="$(find ${BAZEL_DIR}/external -type d -name 'go_sdk')"
+if [[ -z $GOROOT ]];then
+  GOROOT="$(find ${BAZEL_DIR}/external -type d -name 'go1_*')"
+fi
+
 export PATH=$GOROOT/bin:$PATH
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   echo "*** Calling ${BASH_SOURCE[0]} directly has no effect. It should be sourced."
   echo "Using GOROOT: $GOROOT"
+  go version
 fi

--- a/mixer/bin/bazel_to_go.py
+++ b/mixer/bin/bazel_to_go.py
@@ -129,11 +129,12 @@ def makelink(target, linksrc):
 def bazel_to_vendor(WKSPC):
     WKSPC = os.path.abspath(WKSPC)
     workspace = WKSPC + "/WORKSPACE"
+    root = os.path.join(WKSPC, "bazel-%s" % os.path.basename(WKSPC))
     if not os.path.isfile(workspace):
         print "WORKSPACE file not found in " + WKSPC
         print "prog BAZEL_WORKSPACE_DIR"
         return -1
-    lf = os.readlink(WKSPC + "/bazel-mixer")
+    lf = os.readlink(root)
     EXEC_ROOT = os.path.dirname(lf)
     BLD_DIR = os.path.dirname(EXEC_ROOT)
     external =  BLD_DIR + "/external"
@@ -203,78 +204,78 @@ def main(args):
     bazel_to_vendor(WKSPC)
 
 def adapter_protos(WKSPC):
-    for adapter in os.listdir(WKSPC + "/bazel-genfiles/adapter/"):
-        if os.path.exists(WKSPC + "/bazel-genfiles/adapter/"+ adapter + "/config"):
-            for file in os.listdir(WKSPC + "/bazel-genfiles/adapter/" + adapter + "/config"):
+    for adapter in os.listdir(WKSPC + "/bazel-genfiles/mixer/adapter/"):
+        if os.path.exists(WKSPC + "/bazel-genfiles/mixer/adapter/"+ adapter + "/config"):
+            for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/adapter/" + adapter + "/config"):
                 if file.endswith(".pb.go"):
-                    makelink(WKSPC + "/bazel-genfiles/adapter/"+ adapter + "/config/" + file, WKSPC + "/adapter/" +adapter + "/config/" + file)
+                    makelink(WKSPC + "/bazel-genfiles/mixer/adapter/"+ adapter + "/config/" + file, WKSPC + "/mixer/adapter/" +adapter + "/config/" + file)
 
 # link pb.go files 2 levels down the dir
 def template_protos(WKSPC):
-    for file in os.listdir(WKSPC + "/bazel-genfiles/pkg/adapter/template"):
+    for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/pkg/adapter/template"):
         if file.endswith(".pb.go"):
-            makelink(WKSPC + "/bazel-genfiles/pkg/adapter/template/" + file, WKSPC + "/pkg/adapter/template/" + file)
-    for template in os.listdir(WKSPC + "/bazel-genfiles/template"):
+            makelink(WKSPC + "/bazel-genfiles/mixer/pkg/adapter/template/" + file, WKSPC + "/mixer/pkg/adapter/template/" + file)
+    for template in os.listdir(WKSPC + "/bazel-genfiles/mixer/template"):
         if template.endswith(".gen.go"):
-            makelink(WKSPC + "/bazel-genfiles/template/" + template, WKSPC + "/template/" + template)
-        if os.path.isdir(WKSPC + "/bazel-genfiles/template/" + template):
-            for file in os.listdir(WKSPC + "/bazel-genfiles/template/" + template):
+            makelink(WKSPC + "/bazel-genfiles/mixer/template/" + template, WKSPC + "/mixer/template/" + template)
+        if os.path.isdir(WKSPC + "/bazel-genfiles/mixer/template/" + template):
+            for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/template/" + template):
                 # check if there are files under /template/<some template dir>
                 if file.endswith("_tmpl.pb.go") or file.endswith("handler.gen.go") or file.endswith("template.gen.go"):
-                    makelink(WKSPC + "/bazel-genfiles/template/" + template + "/" + file, WKSPC + "/template/" +template + "/" + file)
-                if os.path.isdir(WKSPC + "/bazel-genfiles/template/" + template + "/" + file):
-                    for file2 in os.listdir(WKSPC + "/bazel-genfiles/template/" + template + "/" + file):
+                    makelink(WKSPC + "/bazel-genfiles/mixer/template/" + template + "/" + file, WKSPC + "/mixer/template/" +template + "/" + file)
+                if os.path.isdir(WKSPC + "/bazel-genfiles/mixer/template/" + template + "/" + file):
+                    for file2 in os.listdir(WKSPC + "/bazel-genfiles/mixer/template/" + template + "/" + file):
                         # check if there are files under /template/<some uber dir>/<some template dir>
                         if file2.endswith("_tmpl.pb.go") or file2.endswith("handler.gen.go"):
-                            makelink(WKSPC + "/bazel-genfiles/template/" + template + "/" + file + "/" + file2, WKSPC + "/template/" + template + "/" + file + "/" + file2)
-    for template in os.listdir(WKSPC + "/bazel-genfiles/test/template"):
+                            makelink(WKSPC + "/bazel-genfiles/mixer/template/" + template + "/" + file + "/" + file2, WKSPC + "/mixer/template/" + template + "/" + file + "/" + file2)
+    for template in os.listdir(WKSPC + "/bazel-genfiles/mixer/test/template"):
         if template.endswith(".gen.go"):
-            makelink(WKSPC + "/bazel-genfiles/test/template/" + template, WKSPC + "/test/template/" + template)
-        if os.path.isdir(WKSPC + "/bazel-genfiles/test/template/" + template):
-            for file in os.listdir(WKSPC + "/bazel-genfiles/test/template/" + template):
+            makelink(WKSPC + "/bazel-genfiles/mixer/test/template/" + template, WKSPC + "/mixer/test/template/" + template)
+        if os.path.isdir(WKSPC + "/bazel-genfiles/mixer/test/template/" + template):
+            for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/test/template/" + template):
                 # check if there are files under /template/<some template dir>
                 if file.endswith("_tmpl.pb.go") or file.endswith("handler.gen.go"):
-                    makelink(WKSPC + "/bazel-genfiles/test/template/" + template + "/" + file, WKSPC + "/test/template/" +template + "/" + file)
+                    makelink(WKSPC + "/bazel-genfiles/mixer/test/template/" + template + "/" + file, WKSPC + "/mixer/test/template/" +template + "/" + file)
 
 def aspect_protos(WKSPC):
-    for aspect in os.listdir(WKSPC + "/bazel-genfiles/pkg/aspect/"):
-        for file in os.listdir(WKSPC + "/bazel-genfiles/pkg/aspect/config"):
+    for aspect in os.listdir(WKSPC + "/bazel-genfiles/mixer/pkg/aspect/"):
+        for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/pkg/aspect/config"):
             if file.endswith(".pb.go"):
-                makelink(WKSPC + "/bazel-genfiles/pkg/aspect/config/" + file, WKSPC + "/pkg/aspect/config/" + file)
+                makelink(WKSPC + "/bazel-genfiles/mixer/pkg/aspect/config/" + file, WKSPC + "/mixer/pkg/aspect/config/" + file)
 
 def tools_protos(WKSPC):
-    if os.path.exists(WKSPC + "/bazel-genfiles/pkg/adapter/template/"):
-        for file in os.listdir(WKSPC + "/bazel-genfiles/pkg/adapter/template/"):
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/pkg/adapter/template/"):
+        for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/pkg/adapter/template/"):
             if file.endswith(".pb.go"):
-                makelink(WKSPC + "/bazel-genfiles/pkg/adapter/template/" + file, WKSPC + "/pkg/adapter/template/" + file)
+                makelink(WKSPC + "/bazel-genfiles/mixer/pkg/adapter/template/" + file, WKSPC + "/mixer/pkg/adapter/template/" + file)
 
 def tools_generated_files(WKSPC):
-    if os.path.exists(WKSPC + "/bazel-genfiles/tools/codegen/pkg/interfacegen/testdata"):
-        for file in os.listdir(WKSPC + "/bazel-genfiles/tools/codegen/pkg/interfacegen/testdata"):
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/interfacegen/testdata"):
+        for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/interfacegen/testdata"):
             if file.endswith("_proto.descriptor_set") or file.endswith("error_template.descriptor_set"):
-                makelink(WKSPC + "/bazel-genfiles/tools/codegen/pkg/interfacegen/testdata/" + file, WKSPC + "/tools/codegen/pkg/interfacegen/testdata/" + file)
-    if os.path.exists(WKSPC + "/bazel-genfiles/tools/codegen/pkg/bootstrapgen/testdata"):
-        for file in os.listdir(WKSPC + "/bazel-genfiles/tools/codegen/pkg/bootstrapgen/testdata"):
+                makelink(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/interfacegen/testdata/" + file, WKSPC + "/mixer/tools/codegen/pkg/interfacegen/testdata/" + file)
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/bootstrapgen/testdata"):
+        for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/bootstrapgen/testdata"):
             if file.endswith("_proto.descriptor_set"):
-                makelink(WKSPC + "/bazel-genfiles/tools/codegen/pkg/bootstrapgen/testdata/" + file, WKSPC + "/tools/codegen/pkg/bootstrapgen/testdata/" + file)
-    if os.path.exists(WKSPC + "/bazel-genfiles/tools/codegen/pkg/modelgen/testdata"):
-            for file in os.listdir(WKSPC + "/bazel-genfiles/tools/codegen/pkg/modelgen/testdata"):
+                makelink(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/bootstrapgen/testdata/" + file, WKSPC + "/mixer/tools/codegen/pkg/bootstrapgen/testdata/" + file)
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/modelgen/testdata"):
+            for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/modelgen/testdata"):
                 if file.endswith(".descriptor_set"):
-                    makelink(WKSPC + "/bazel-genfiles/tools/codegen/pkg/modelgen/testdata/" + file, WKSPC + "/tools/codegen/pkg/modelgen/testdata/" + file)
+                    makelink(WKSPC + "/bazel-genfiles/mixer/tools/codegen/pkg/modelgen/testdata/" + file, WKSPC + "/mixer/tools/codegen/pkg/modelgen/testdata/" + file)
 
 def config_proto(WKSPC, genfiles):
     if os.path.exists(genfiles + "io_istio_api/fixed_cfg.pb.go"):
-        makelink(genfiles + "io_istio_api/fixed_cfg.pb.go", WKSPC + "/pkg/config/proto/fixed_cfg.pb.go")
+        makelink(genfiles + "io_istio_api/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go")
 
 def attributes_list(WKSPC, genfiles):
-    if os.path.exists(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go"):
-        makelink(WKSPC + "/bazel-genfiles/pkg/attribute/list.gen.go", WKSPC + "/pkg/attribute/list.gen.go")
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/pkg/attribute/list.gen.go"):
+        makelink(WKSPC + "/bazel-genfiles/mixer/pkg/attribute/list.gen.go", WKSPC + "/mixer/pkg/attribute/list.gen.go")
 
 def inventory(WKSPC):
-    if os.path.exists(WKSPC + "/bazel-genfiles/adapter/"):
-        for file in os.listdir(WKSPC + "/bazel-genfiles/adapter/"):
+    if os.path.exists(WKSPC + "/bazel-genfiles/mixer/adapter/"):
+        for file in os.listdir(WKSPC + "/bazel-genfiles/mixer/adapter/"):
             if file.endswith(".gen.go"):
-                makelink(WKSPC + "/bazel-genfiles/adapter/" + file, WKSPC + "/adapter/" + file)
+                makelink(WKSPC + "/bazel-genfiles/mixer/adapter/" + file, WKSPC + "/mixer/adapter/" + file)
 
 if __name__ == "__main__":
     import sys

--- a/mixer/bin/bazel_to_go.py
+++ b/mixer/bin/bazel_to_go.py
@@ -84,6 +84,7 @@ def process(fl, external, genfiles, vendor):
     lst = []
     wksp = WORKSPACE(external, genfiles, vendor)
 
+    dd = {}
     for stmt in ast.walk(tree):
         stmttype = type(stmt)
         if stmttype == ast.Call:
@@ -97,6 +98,10 @@ def process(fl, external, genfiles, vendor):
                 path = path[:-4]
             path = pathmap.get(path, path)
             tup = fn(name, path)
+
+            if name in dd:
+              print "duplicate name", tup, dd[name]
+            dd[name] = path
             lst.append(tup)
 
     return lst

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -69,9 +69,6 @@ fi
 echo 'Running Unit Tests'
 bazel test --test_output=all //...
 
-echo 'Checking that updateVersion has been called'
-install/updateVersion.sh -s
-
 # ensure that source remains go buildable
 ${ROOT}/bin/init.sh
 

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -32,7 +32,7 @@ set -x
 if [ "${CI:-}" == 'bootstrap' ]; then
   # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
   # but we depend on being at path $GOPATH/src/istio.io/istio for imports
-  ln -sf ${GOPATH}/src/github.com/istio ${GOPATH}/src/istio.io
+  mv ${GOPATH}/src/github.com/istio ${GOPATH}/src/istio.io
   cd ${GOPATH}/src/istio.io/istio
 
   # Use the provided pull head sha, from prow.

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -14,6 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+WD=$(dirname $0)
+WD=$(cd $WD; pwd)
+ROOT=$(dirname $WD)
 
 #######################################
 # Presubmit script triggered by Prow. #
@@ -61,7 +64,7 @@ fi
 
 # disabling linters, WIP
 #echo 'Running Linters'
-#./bin/linters.sh
+#${ROOT}/bin/linters.sh
 
 echo 'Running Unit Tests'
 bazel test --test_output=all //...
@@ -69,3 +72,15 @@ bazel test --test_output=all //...
 echo 'Checking that updateVersion has been called'
 install/updateVersion.sh -s
 
+# ensure that source remains go buildable
+${ROOT}/bin/init.sh
+
+source "${ROOT}/bin/use_bazel_go.sh"
+echo "building mixer"
+time go build -o mixer.bin mixer/cmd/server/*.go
+echo "building pilot"
+time go build -o pilot.bin pilot/cmd/pilot-discovery/*.go
+echo "building security"
+time go build -o security.bin security/cmd/istio_ca/*.go
+echo "building broker"
+time go build -o broker.bin broker/cmd/brks/*.go

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -32,7 +32,8 @@ set -x
 if [ "${CI:-}" == 'bootstrap' ]; then
   # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
   # but we depend on being at path $GOPATH/src/istio.io/istio for imports
-  mv ${GOPATH}/src/github.com/istio ${GOPATH}/src/istio.io
+  ln -sf ${GOPATH}/src/github.com/istio ${GOPATH}/src/istio.io
+  ROOT=${GOPATH}/src/istio.io/istio
   cd ${GOPATH}/src/istio.io/istio
 
   # Use the provided pull head sha, from prow.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add top level bin/init.sh to setup go build environment.
presubmit ensures go buildability.  

This code can be refactored later.

```release-note
NONE
```
