### PR TITLE
Update promgen deps

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -108,14 +108,8 @@ http_file(
 )
 
 go_repository(
-    name = "com_github_prometheus_client_golang_v08",
-    commit = "c5b7fccd204277076155f10851dad72b76a49317",  # Aug 17, 2016 (v0.8.0)
-    importpath = "github.com/prometheus/client_golang",
-)
-
-go_repository(
     name = "com_github_prometheus_client_golang",
-    commit = "de4d4ffe63b9eff7f27484fdef6e421597e6abb4",  # June 6, 2017
+    commit = "5cec1d0429b02e4323e042eb04dafdb079ddf568",  # Jun 30, 2017 (latest, pending 0.9 release)
     importpath = "github.com/prometheus/client_golang",
 )
 

--- a/mixer/example/servicegraph/promgen/BUILD
+++ b/mixer/example/servicegraph/promgen/BUILD
@@ -6,11 +6,10 @@ go_library(
     name = "go_default_library",
     srcs = ["promgen.go"],
     visibility = ["//visibility:public"],
-    deps = [
+    deps = [        
         "//mixer/example/servicegraph:go_default_library",
-        # FIXME remove v08 dependency from promgen and then remove the dependency from WORKSPACE.
-        #"@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",
-        "@com_github_prometheus_client_golang_v08//api/prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//api:go_default_library",
+        "@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",
         "@com_github_prometheus_common//model:go_default_library",
     ],
 )

--- a/mixer/example/servicegraph/promgen/promgen.go
+++ b/mixer/example/servicegraph/promgen/promgen.go
@@ -24,7 +24,8 @@ import (
 	"strings"
 	"time"
 
-	prometheus "github.com/prometheus/client_golang/api/prometheus"
+	"github.com/prometheus/client_golang/api"
+	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
 	"istio.io/istio/mixer/example/servicegraph"
@@ -86,11 +87,12 @@ func writeError(w http.ResponseWriter, err error) {
 }
 
 func (p *promHandler) generate(opts genOpts) (*servicegraph.Dynamic, error) {
-	client, err := prometheus.New(prometheus.Config{Address: p.addr})
+
+	client, err := api.NewClient(api.Config{Address: p.addr})
 	if err != nil {
 		return nil, err
 	}
-	api := prometheus.NewQueryAPI(client)
+	api := v1.NewAPI(client)
 	query := fmt.Sprintf(reqsFmt, opts.timeHorizon)
 	if opts.filterEmpty {
 		query += emptyFilter
@@ -125,7 +127,7 @@ func merge(g1, g2 *servicegraph.Dynamic) (*servicegraph.Dynamic, error) {
 	return &d, nil
 }
 
-func extractGraph(api prometheus.QueryAPI, query, label string) (*servicegraph.Dynamic, error) {
+func extractGraph(api v1.API, query, label string) (*servicegraph.Dynamic, error) {
 	val, err := api.Query(context.Background(), query, time.Now())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the servicegraph promgen deps to the common v1 version of the prometheus API in client_go. This standardizes the entire istio/istio repo on a single verison of hte API code.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #1307

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```