### PR TITLE
Add pilot integration to prow presubmit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,4 @@ docker:
 
 .PHONY: push
 push: checkvars
-	@$(TOP)/pilot/bin/push-docker ${hub} ${tag}
-	@$(TOP)/mixer/bin/push-docker ${hub} ${tag}
-	@$(TOP)/security/bin/push-docker ${hub} ${tag}
-	@$(TOP)/pilot/bin/upload-istioctl -p "gs://istio-artifacts/pilot/$(TAG)/artifacts/istioctl"
-	@$(TOP)/pilot/bin/push-debian.sh -c opt -p "gs://istio-artifacts/pilot/$(TAG)/artifacts/debs"
-	@$(TOP)/security/bin/push-debian.sh -c opt -p "gs://istio-artifacts/auth/${TAG}/artifacts/debs"
+	@$(TOP)/bin/push $(HUB) $(TAG)

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -16,7 +16,9 @@ if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
 fi
 
 # This step is to fetch resources and create genfiles
-bazel build //...
+if [[ -z $SKIP_BUILD ]];then
+  bazel build //...
+fi
 
 source "${ROOT}/bin/use_bazel_go.sh"
 

--- a/bin/push
+++ b/bin/push
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -exu
+HUB=${1:?"1st arg hub is required"}
+TAG=${2:?"2nd arg tag is required"}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd $ROOT
+
+pilot/bin/push-docker -hub ${HUB} -tag ${TAG} &
+mixer/bin/push-docker -hub ${HUB} -tag ${TAG} &
+security/bin/push-docker -hub ${HUB} -tag ${TAG} &
+pilot/bin/upload-istioctl -p "gs://istio-artifacts/pilot/${TAG}/artifacts/istioctl" &
+pilot/bin/push-debian.sh -c opt -p "gs://istio-artifacts/pilot/${TAG}/artifacts/debs" &
+security/bin/push-debian.sh -c opt -p "gs://istio-artifacts/auth/${TAG}/artifacts/debs" &
+
+FAIL=0
+for job in `jobs -p`
+do
+  echo $job
+  wait $job || let "FAIL+=1"
+done
+
+if [ "$FAIL" != "0" ];
+then
+  echo "FAIL! ($FAIL)"
+  exit $FAIL
+fi

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -65,24 +65,17 @@ fi
 cd $ROOT
 
 echo 'Running Unit Tests'
-bazel test --test_output=all //...
+time bazel test --test_output=all //...
 
 # ensure that source remains go buildable
-${ROOT}/bin/init.sh
+SKIP_BUILD=1 ${ROOT}/bin/init.sh
 
 # run linters in advisory mode
 SKIP_INIT=1 ${ROOT}/bin/linters.sh
 
-#
-#source "${ROOT}/bin/use_bazel_go.sh"
-#echo "building mixer"
-#time go build -o mixer.bin mixer/cmd/server/*.go
-#echo "building pilot"
-#time go build -o pilot.bin pilot/cmd/pilot-discovery/*.go
-#echo "building security"
-#time go build -o security.bin security/cmd/istio_ca/*.go
-#echo "building broker"
-#time go build -o broker.bin broker/cmd/brks/*.go
-
+HUB="gcr.io/istio-testing"
+TAG="${GIT_SHA}"
 # upload images
-make push HUB=gcr.io/istio-testing TAG="${GIT_SHA}"
+time make push HUB="${HUB}" TAG="${TAG}"
+
+time cd ${ROOT}/pilot; make e2etest HUB="${HUB}" TAG="${TAG}" TESTOPTS="-mixer=false"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds pilot integration test to prow presubmit
It also parallelizes docker push jobs to save time.

@sebastienvas We need to create separate Build step for integration where this can run *after* presubmit and then remove it from here.
```release-note
NONE
```
