### PR TITLE
[ci skip] Remove incorrect documentation around git push -f

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -220,7 +220,7 @@ reviews much easier.
 Please do not use force push after submitting a PR to resolve review
 feedback. Doing so results in an inability to see what has changed between
 revisions of the PR. Instead submit additional commits until the PR is
-suitable for merging. Once the PR is suitable for merging, the commits may
+suitable for merging. Once the PR is suitable for merging, the commits will
 be squashed to simplify the commit.
 
 ## Using the code base

--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -187,7 +187,7 @@ follow [these instructions](https://help.github.com/articles/caching-your-github
 if you want to cache the token.
 
 ```shell
-git push -f origin my-feature
+git push origin my-feature
 ```
 
 ### Creating a pull request
@@ -216,6 +216,12 @@ pass tests independently, but it is worth striving for. For mass automated
 fixups (e.g. automated doc formatting), use one or more commits for the
 changes to tooling and a final commit to apply the fixup en masse. This makes
 reviews much easier.
+
+Please do not use force push after submitting a PR to resolve review
+feedback. Doing so results in an inability to see what has changed between
+revisions of the PR. Instead submit additional commits until the PR is
+suitable for merging. Once the PR is suitable for merging, the commits may
+be squashed to simplify the commit.
 
 ## Using the code base
 


### PR DESCRIPTION
Fixes #1174

Also add explination as to why force push shouldn't be used.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
