### PR TITLE
Clean Makefile and bazel build warnings and debug messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,6 @@ docker:
 push: checkvars
 	@$(TOP)/bin/push $(HUB) $(TAG)
 
-clean:
-	@bazel clean
-
-
 artifacts: docker
 	@echo 'To be added'
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ ifneq ($(strip $(TAG)),)
 	tag =-tag ${TAG}
 endif
 
+.DEFAULT_GOAL := build
+
 checkvars:
 	@if test -z "$(TAG)"; then echo "TAG missing"; exit 1; fi
 	@if test -z "$(HUB)"; then echo "HUB missing"; exit 1; fi

--- a/broker/docker/BUILD
+++ b/broker/docker/BUILD
@@ -6,7 +6,7 @@ load("//broker/docker:broker_docker.bzl", "broker_docker_build")
 pkg_tar(
     name = "broker_tar",
     extension = "tar.gz",
-    files = [
+    srcs = [
         "//broker/cmd/brks",
     ],
     mode = "0755",

--- a/docker/BUILD
+++ b/docker/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 pkg_tar(
     name = "hop_tar",
     extension = "tar.gz",
-    files = [
+    srcs = [
         "//tests/e2e/apps/hop/hop-server",
     ],
     mode = "0755",

--- a/mixer/docker/BUILD
+++ b/mixer/docker/BUILD
@@ -10,7 +10,7 @@ load("//mixer/docker:cacerts.bzl", "cacerts")
 pkg_tar(
     name = "mixer_tar",
     extension = "tar.gz",
-    files = [
+    srcs = [
         "//mixer/cmd/server:mixs",
     ],
     mode = "0755",

--- a/mixer/example/servicegraph/docker/BUILD
+++ b/mixer/example/servicegraph/docker/BUILD
@@ -6,7 +6,7 @@ load("//mixer/docker:mixer_docker.bzl", "mixer_docker_build")
 pkg_tar(
     name = "mixer_servicegraph_tar",
     extension = "tar.gz",
-    files = [
+    srcs = [
         "//mixer/example/servicegraph/cmd/server",
     ],
     mode = "0755",

--- a/mixer/example/servicegraph/js/BUILD
+++ b/mixer/example/servicegraph/js/BUILD
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "js_tar",
     extension = "tar.gz",
-    files = glob(
+    srcs = glob(
         ["**"],
         exclude = ["BUILD"],
     ),

--- a/mixer/testdata/BUILD
+++ b/mixer/testdata/BUILD
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 pkg_tar(
     name = "configs_tar",
     extension = "tar.gz",
-    files = glob([
+    srcs = glob([
         "**/*.yml",
     ]),
     mode = "0755",

--- a/pilot/tools/deb/BUILD
+++ b/pilot/tools/deb/BUILD
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 
 pkg_tar(
     name = "agent-bin",
-    files = [
+    srcs = [
         "//pilot/cmd/pilot-agent",
     ],
     mode = "0755",


### PR DESCRIPTION
**What this PR does / why we need it**:
Running make generates some warnings and bazel debug messages. These could clutter output and make new warnings and messages harder to spot.

This PR cleans up 'make' output by:

- removes the duplicate 'clean' target in the Makefile
- replaces 'files' attribute with 'srcs' in 'BUILD' files
- adds a default Makefile target so that 'make' with no arguments is possible

**Which issue this PR fixes**: fixes #1537

**Special notes for your reviewer**:
NA

**Release note**:
```release-note
NONE
```
