### PR TITLE
Makefile minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,6 @@ docker:
 push: checkvars
 	@$(TOP)/bin/push $(HUB) $(TAG)
 
-clean:
-	@bazel clean
-
-
 artifacts: docker
 	@echo 'To be added'
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ checkvars:
 	@if test -z "$(TAG)"; then echo "TAG missing"; exit 1; fi
 	@if test -z "$(HUB)"; then echo "HUB missing"; exit 1; fi
 
-setup:
-	@[[ -f pilot/platform/kube/config ]] || ln -s ~/.kube/config pilot/platform/kube/
+setup: pilot/platform/kube/config
 
 check:
 	echo 'To be added'
@@ -63,5 +62,8 @@ clean:
 
 artifacts: docker
 	@echo 'To be added'
+
+pilot/platform/kube/config:
+	@ln -s ~/.kube/config pilot/platform/kube/
 
 .PHONY: artifacts build checkvars clean docker test setup push


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes a duplicate target in Makefile and uses makefile target instead of bash conditional

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
