### PR TITLE
reduce warning messages during compilation

### DIFF
--- a/mixer/tools/codegen/generate.bzl
+++ b/mixer/tools/codegen/generate.bzl
@@ -24,7 +24,6 @@ MIXER_IMPORT_MAP = {
 # that depends on mixer proper.
 MIXER_IMPORTS = [
     "external/io_istio_api",
-    "../../external/io_istio_api",
 ]
 
 # TODO: fill in with complete set of GOGO DEPS and IMPORT MAPPING
@@ -46,7 +45,6 @@ GOGO_IMPORT_MAP = {
 # that depends on mixer proper.
 PROTO_IMPORTS = [
     "external/com_github_google_protobuf/src",
-    "../../external/com_github_google_protobuf/src",
 ]
 
 PROTO_INPUTS = ["@com_github_google_protobuf//:well_known_protos"]


### PR DESCRIPTION
This '../external' lines create warning messages, but they are
simply unnecessary. It can compile without them and reduces
the warning messages.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
