### PR TITLE
Remove pilot test from presubmit, it is contained in circleci

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -16,10 +16,8 @@ if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
 fi
 
 # This step is to fetch resources and create genfiles
-if [[ -z ${SKIP_BUILD:""} ]];then
-  bazel build //...
-  time bazel build $(bazel query 'tests(//...)')
-fi
+time bazel build //...
+time bazel build $(bazel query 'tests(//...)')
 
 source "${ROOT}/bin/use_bazel_go.sh"
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -16,8 +16,9 @@ if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
 fi
 
 # This step is to fetch resources and create genfiles
-if [[ -z $SKIP_BUILD ]];then
+if [[ -z ${SKIP_BUILD:""} ]];then
   bazel build //...
+  time bazel build $(bazel query 'tests(//...)')
 fi
 
 source "${ROOT}/bin/use_bazel_go.sh"

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -64,11 +64,11 @@ else
 fi
 cd $ROOT
 
+# Build
+${ROOT}/bin/init.sh
+
 echo 'Running Unit Tests'
 time bazel test --test_output=all //...
-
-# ensure that source remains go buildable
-SKIP_BUILD=1 ${ROOT}/bin/init.sh
 
 # run linters in advisory mode
 SKIP_INIT=1 ${ROOT}/bin/linters.sh
@@ -77,5 +77,3 @@ HUB="gcr.io/istio-testing"
 TAG="${GIT_SHA}"
 # upload images
 time make push HUB="${HUB}" TAG="${TAG}"
-
-time cd ${ROOT}/pilot; make e2etest HUB="${HUB}" TAG="${TAG}" TESTOPTS="-mixer=false"


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Remove pilot test from presubmit, it is contained in circle-ci
2. Fix unset `SKIP_BUILD`- If SKIP_BUILD was not set script was failing.

```release-note
NONE
```
