### PR TITLE
[mixer] Cleanup ineffassign warning

### DIFF
--- a/mixer/test/server_test.go
+++ b/mixer/test/server_test.go
@@ -83,7 +83,7 @@ func TestCheck(t *testing.T) {
 		t.Fatalf("Failed to connect: %v", err)
 	}
 	defer func() {
-		err = conn.Close()
+		conn.Close()
 		grpcSrv.GracefulStop()
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**: Cleanup ineffassign warning

/release-note-none