### PR TITLE
[ci skip] Fix typo in manifest

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -1,6 +1,6 @@
 # Currently specific to GKE. Annotations specific to other providers should be added
 # after they get tested.
-Version: v1
+apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot-ilb


### PR DESCRIPTION
Typo, causes validation errors in k8s 1.8.

```release-note
NONE
```
