### PR TITLE
Use parent directory of cwd for WKSPC

### DIFF
--- a/mixer/bin/bazel_to_go.py
+++ b/mixer/bin/bazel_to_go.py
@@ -202,7 +202,7 @@ def get_external_links(external):
     return [file for file in os.listdir(external) if os.path.isdir(external+"/"+file)]
 
 def main(args):
-    WKSPC = os.getcwd()
+    WKSPC = os.path.dirname(os.getcwd())
     if len(args) > 0:
         WKSPC = args[0]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Executing `./bin/bazel_to_go.py` in Step 8 of the adapter developer guide results in the following error:

```
me@mymachine ~/go/src/istio.io/istio/mixer $ ./bin/bazel_to_go.py
WORKSPACE file not found in /Users/me/go/src/istio.io/istio/mixer
prog BAZEL_WORKSPACE_DIR
```

This change calls the parent directory instead of current directory, where the `WORKSPACE` file has been moved to in the recent restructure. Might be a better way to do this, or alternate approach - this solution worked for me.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE```
