### PR TITLE
Add support for submessages in template - part1. 

### DIFF
--- a/mixer/tools/codegen/pkg/interfacegen/generator.go
+++ b/mixer/tools/codegen/pkg/interfacegen/generator.go
@@ -35,8 +35,8 @@ const (
 	ResourceMsgTypeSuffix      = "Type"
 	ResourceMsgInstParamSuffix = "InstanceParam"
 	fullGoNameOfValueTypeEnum  = "istio_mixer_v1_config_descriptor.ValueType"
-	goFileImportFmt            = "\"%s\""
-	protoFileImportFmt         = "import \"%s\";"
+	goFileImportFmt            = `"%s"`
+	protoFileImportFmt         = `import "%s";`
 	protoValueTypeImport       = "mixer/v1/config/descriptor/value_type.proto"
 )
 

--- a/mixer/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/mixer/tools/codegen/pkg/interfacegen/template/interface.go
@@ -44,6 +44,16 @@ type Instance struct {
   {{end}}
 }
 
+{{range .ResourceMessages}}
+{{.Comment}}
+type {{.Name}} struct {
+  {{range .Fields}}
+  {{.Comment}}
+  {{.GoName}} {{replaceGoValueTypeToInterface .GoType}}{{reportTypeUsed .GoType}}
+  {{end}}
+}
+{{end}}
+
 // HandlerBuilder must be implemented by adapters if they want to
 // process data associated with the '{{.TemplateName}}' template.
 //

--- a/mixer/tools/codegen/pkg/interfacegen/template/templateproto.go
+++ b/mixer/tools/codegen/pkg/interfacegen/template/templateproto.go
@@ -30,16 +30,36 @@ option (istio.mixer.v1.template.template_variety) = {{.VarietyName}};
 {{.TemplateMessage.Comment}}
 message Type {
   {{range .TemplateMessage.Fields -}}
-  {{- if containsValueType .ProtoType}}
+  {{- if valueTypeOrResMsg .ProtoType}}
   {{.Comment}}
-  {{.ProtoType.Name}} {{.ProtoName}} = {{.Number}};{{reportTypeUsed .ProtoType}}
+  {{valueTypeOrResMsgFieldTypeName .ProtoType}} {{.ProtoName}} = {{.Number}};{{reportTypeUsed .ProtoType}}
   {{- end}}
   {{- end}}
 }
+
+{{range .ResourceMessages}}
+{{.Comment}}
+message {{getResourcMessageTypeName .Name}} {
+  {{range .Fields}}
+  {{- if valueTypeOrResMsg .ProtoType}}
+  {{.Comment}}
+  {{valueTypeOrResMsgFieldTypeName .ProtoType}} {{.ProtoName}} = {{.Number}};{{reportTypeUsed .ProtoType}}
+  {{- end}}
+  {{- end}}
+}
+{{end}}
 
 message InstanceParam {
   {{range .TemplateMessage.Fields}}
   {{stringify .ProtoType}} {{.ProtoName}} = {{.Number}};
   {{end}}
 }
+
+{{range .ResourceMessages}}
+message {{getResourcMessageInterfaceParamTypeName  .Name}} {
+  {{range .Fields}}
+  {{stringify .ProtoType}} {{.ProtoName}} = {{.Number}};
+  {{end}}
+}
+{{end}}
 `

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
@@ -60,6 +60,54 @@ type Instance struct {
 	TimeStamp time.Time
 
 	Duration time.Duration
+
+	Res3List []*Resource3
+
+	Res3Map map[string]*Resource3
+}
+
+type Resource1 struct {
+	Str string
+
+	SelfRefRes1 *Resource1
+
+	ResRef2 *Resource2
+}
+
+type Resource2 struct {
+	Str string
+
+	Res3 *Resource3
+
+	Res3List []*Resource3
+
+	Res3Map map[string]*Resource3
+}
+
+// resource3 comment
+type Resource3 struct {
+
+	// value is ...
+	Value interface{}
+
+	// dimensions are ...
+	Dimensions map[string]interface{}
+
+	Int64Primitive int64
+
+	BoolPrimitive bool
+
+	DoublePrimitive float64
+
+	StringPrimitive string
+
+	AnotherValueType interface{}
+
+	DimensionsFixedInt64ValueDType map[string]int64
+
+	TimeStamp time.Time
+
+	Duration time.Duration
 }
 
 // HandlerBuilder must be implemented by adapters if they want to

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
@@ -37,7 +37,44 @@ message Type {
   map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
   
   istio.mixer.v1.config.descriptor.ValueType anotherValueType = 7;
+  
+  repeated istio.mixer.adapter.metric.Resource3Type res3_list = 11;
+  
+  map<string, istio.mixer.adapter.metric.Resource3Type> res3_map = 12;
 }
+
+
+
+message Resource1Type {
+  
+  
+  istio.mixer.adapter.metric.Resource1Type self_ref_res1 = 3;
+  
+  istio.mixer.adapter.metric.Resource2Type resRef2 = 2;
+}
+
+
+message Resource2Type {
+  
+  
+  istio.mixer.adapter.metric.Resource3Type res3 = 2;
+  
+  repeated istio.mixer.adapter.metric.Resource3Type res3_list = 4;
+  
+  map<string, istio.mixer.adapter.metric.Resource3Type> res3_map = 5;
+}
+
+// resource3 comment
+message Resource3Type {
+  
+  // value is ...
+  istio.mixer.v1.config.descriptor.ValueType value = 1;
+  // dimensions are ...
+  map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
+  
+  istio.mixer.v1.config.descriptor.ValueType anotherValueType = 7;
+}
+
 
 message InstanceParam {
   
@@ -61,4 +98,56 @@ message InstanceParam {
   
   string duration = 10;
   
+  repeated istio.mixer.adapter.metric.Resource3InstanceParam res3_list = 11;
+  
+  map<string, istio.mixer.adapter.metric.Resource3InstanceParam> res3_map = 12;
+  
 }
+
+
+message Resource1InstanceParam {
+  
+  string str = 1;
+  
+  istio.mixer.adapter.metric.Resource1InstanceParam self_ref_res1 = 3;
+  
+  istio.mixer.adapter.metric.Resource2InstanceParam resRef2 = 2;
+  
+}
+
+message Resource2InstanceParam {
+  
+  string str = 1;
+  
+  istio.mixer.adapter.metric.Resource3InstanceParam res3 = 2;
+  
+  repeated istio.mixer.adapter.metric.Resource3InstanceParam res3_list = 4;
+  
+  map<string, istio.mixer.adapter.metric.Resource3InstanceParam> res3_map = 5;
+  
+}
+
+message Resource3InstanceParam {
+  
+  string value = 1;
+  
+  map<string, string> dimensions = 2;
+  
+  string int64Primitive = 3;
+  
+  string boolPrimitive = 4;
+  
+  string doublePrimitive = 5;
+  
+  string stringPrimitive = 6;
+  
+  string anotherValueType = 7;
+  
+  map<string, string> dimensionsFixedInt64ValueDType = 8;
+  
+  string timeStamp = 9;
+  
+  string duration = 10;
+  
+}
+

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
@@ -39,4 +39,48 @@ message Template {
     google.protobuf.Timestamp timeStamp = 9;
 
     google.protobuf.Duration duration = 10;
+
+    repeated Resource3 res3_list = 11;
+    map<string, Resource3> res3_map = 12;
 }
+
+message Resource1 {
+    string str = 1;
+    istio.mixer.adapter.metric.Resource1 self_ref_res1 = 3;
+    Resource2 resRef2 = 2;
+}
+
+message Resource2 {
+    string str = 1;
+    Resource3 res3 = 2;
+    repeated Resource3 res3_list = 4;
+    map<string, Resource3> res3_map = 5;
+}
+
+// resource3 comment
+message Resource3 {
+    // value is ...
+    istio.mixer.v1.config.descriptor.ValueType value = 1;
+    // dimensions are ...
+    map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
+
+    int64 int64Primitive = 3;
+
+    bool boolPrimitive = 4;
+
+    double doublePrimitive = 5;
+
+    string stringPrimitive = 6;
+
+    istio.mixer.v1.config.descriptor.ValueType anotherValueType = 7;
+
+    map<string, int64> dimensionsFixedInt64ValueDType = 8;
+
+    google.protobuf.Timestamp timeStamp = 9;
+
+    google.protobuf.Duration duration = 10;
+}
+
+// Tests
+// - Ref template
+

--- a/mixer/tools/codegen/pkg/modelgen/diag.go
+++ b/mixer/tools/codegen/pkg/modelgen/diag.go
@@ -80,10 +80,10 @@ func stringifyDiags(diags []diag) string {
 }
 
 func (m *Model) addError(file string, line string, format string, a ...interface{}) {
-	m.diags = append(m.diags, createError(file, line, format, a))
+	m.diags = append(m.diags, createError(file, line, format, a...))
 }
 
-func createError(file string, line string, format string, a []interface{}) diag {
+func createError(file string, line string, format string, a ...interface{}) diag {
 	if len(a) == 0 {
 		return diag{kind: errorDiag, location: location{file: file, line: line}, message: format}
 	}

--- a/mixer/tools/codegen/pkg/modelgen/model.go
+++ b/mixer/tools/codegen/pkg/modelgen/model.go
@@ -68,6 +68,8 @@ type (
 		PackageName     string
 		TemplateMessage MessageInfo
 
+		ResourceMessages []MessageInfo
+
 		// Warnings/Errors in the Template proto file.
 		diags []diag
 	}
@@ -85,17 +87,19 @@ type (
 
 	// TypeInfo contains the data about the field
 	TypeInfo struct {
-		Name        string
-		IsRepeated  bool
-		IsMap       bool
-		IsValueType bool
-		MapKey      *TypeInfo
-		MapValue    *TypeInfo
-		Import      string
+		Name              string
+		IsRepeated        bool
+		IsResourceMessage bool
+		IsMap             bool
+		IsValueType       bool
+		MapKey            *TypeInfo
+		MapValue          *TypeInfo
+		Import            string
 	}
 
 	// MessageInfo contains the data about the type/message
 	MessageInfo struct {
+		Name    string
 		Comment string
 		Fields  []FieldInfo
 	}
@@ -114,14 +118,15 @@ func Create(parser *FileDescriptorSetParser) (*Model, error) {
 		return nil, createGoError(diags)
 	}
 
+	resourceFileDescs := getResourceDesc(parser.allFiles, templateProto.GetPackage())
+
 	// set the current generated code package to the package of the
 	// templateProto. This will make sure references within the
 	// generated file into the template's pb.go file are fully qualified.
 	parser.packageName = goPackageName(templateProto.GetPackage())
 
-	model := &Model{diags: make([]diag, 0)}
-
-	model.fillModel(templateProto, parser)
+	model := &Model{diags: make([]diag, 0), ResourceMessages: make([]MessageInfo, 0)}
+	model.fillModel(templateProto, resourceFileDescs, parser)
 	if len(model.diags) > 0 {
 		return nil, createGoError(model.diags)
 	}
@@ -133,51 +138,87 @@ func createGoError(diags []diag) error {
 	return fmt.Errorf("errors during parsing:\n%s", stringifyDiags(diags))
 }
 
-func (m *Model) fillModel(templateProto *FileDescriptor, parser *FileDescriptorSetParser) {
-
+func (m *Model) fillModel(templateProto *FileDescriptor, resourceProtos []*FileDescriptor, parser *FileDescriptorSetParser) {
 	m.PackageImportPath = parser.PackageImportPath
 
 	m.addTopLevelFields(templateProto)
 	// ensure Template is present
-	if tmplDesc, ok := getRequiredTmplMsg(templateProto); !ok {
+	if tmplDesc, ok := getMsg(templateProto, "Template"); !ok {
 		m.addError(templateProto.GetName(), unknownLine, "message 'Template' not defined")
 	} else {
-		m.addTemplateMessage(parser, templateProto, tmplDesc)
+		diags := addMessageFields(parser,
+			templateProto,
+			tmplDesc,
+			map[string]bool{"name": true},
+			&m.TemplateMessage,
+		)
+		m.TemplateMessage.Name = "Template"
+		m.diags = append(m.diags, diags...)
+	}
+
+	for _, resourceProto := range resourceProtos {
+		for _, desc := range resourceProto.desc {
+			if desc.GetName() != "Template" && !desc.GetOptions().GetMapEntry() {
+				rescMsg := MessageInfo{Name: desc.GetName()}
+				diags := addMessageFields(parser,
+					resourceProto,
+					desc,
+					map[string]bool{"name": true},
+					&rescMsg,
+				)
+				m.ResourceMessages = append(m.ResourceMessages, rescMsg)
+				m.diags = append(m.diags, diags...)
+			}
+		}
 	}
 }
 
-func (m *Model) addTemplateMessage(parser *FileDescriptorSetParser, tmplProto *FileDescriptor, tmplDesc *Descriptor) {
-	m.TemplateMessage.Comment = tmplProto.getComment(tmplDesc.path)
-	m.TemplateMessage.Fields = make([]FieldInfo, 0)
-	for i, fieldDesc := range tmplDesc.Field {
+func addMessageFields(parser *FileDescriptorSetParser, fileDesc *FileDescriptor, msgDesc *Descriptor,
+	reservedNames map[string]bool, outMessage *MessageInfo) []diag {
+	diags := make([]diag, 0)
+	outMessage.Comment = fileDesc.getComment(msgDesc.path)
+	outMessage.Fields = make([]FieldInfo, 0)
+	for i, fieldDesc := range msgDesc.Field {
 		fieldName := fieldDesc.GetName()
 
-		// Name field is a reserved field that will be injected in the Instance object. The user defined
-		// Template should not have a Name field, else there will be a name clash.
-		// 'Name' within the Instance object would represent the name of the Instance:name
-		// specified in the operator Yaml file.
-		if strings.ToLower(fieldName) == "name" {
-			m.addError(tmplDesc.file.GetName(),
-				tmplProto.getLineNumber(getPathForField(tmplDesc, i)),
-				"Template message must not contain the reserved filed name '%s'", fieldDesc.GetName())
+		if _, ok := reservedNames[strings.ToLower(fieldName)]; ok {
+			err := createError(
+				msgDesc.file.GetName(),
+				fileDesc.getLineNumber(getPathForField(msgDesc, i)),
+				"%s message must not contain the reserved field name '%s'",
+				msgDesc.GetName(), fieldDesc.GetName())
+
+			diags = append(diags, err)
 			continue
 		}
 
 		protoTypeInfo, goTypeInfo, err := getTypeName(parser, fieldDesc)
 		if err != nil {
-			m.addError(tmplDesc.file.GetName(),
-				tmplProto.getLineNumber(getPathForField(tmplDesc, i)),
-				err.Error())
+			err := createError(msgDesc.file.GetName(), fileDesc.getLineNumber(getPathForField(msgDesc, i)), err.Error())
+			diags = append(diags, err)
 		}
-		m.TemplateMessage.Fields = append(m.TemplateMessage.Fields, FieldInfo{
+		outMessage.Fields = append(outMessage.Fields, FieldInfo{
 			ProtoName: fieldName,
 			GoName:    camelCase(fieldName),
 			GoType:    goTypeInfo,
 			ProtoType: protoTypeInfo,
 			Number:    strconv.Itoa(int(fieldDesc.GetNumber())),
-			Comment:   tmplProto.getComment(getPathForField(tmplDesc, i)),
+			Comment:   fileDesc.getComment(getPathForField(msgDesc, i)),
 		})
 	}
+
+	return diags
+}
+
+// get all file descriptors that has the same package as the Template message.
+func getResourceDesc(fds []*FileDescriptor, pkg string) []*FileDescriptor {
+	result := make([]*FileDescriptor, 0)
+	for _, fd := range fds {
+		if fd.GetPackage() == pkg {
+			result = append(result, fd)
+		}
+	}
+	return result
 }
 
 // Find the file that has the options TemplateVariety and TemplateName. There should only be one such file.
@@ -195,7 +236,7 @@ func getTmplFileDesc(fds []*FileDescriptor) (*FileDescriptor, []diag) {
 		if templateDescriptorProto != nil {
 			diags = append(diags, createError(fd.GetName(), unknownLine,
 				"Proto files %s and %s, both have the option %s. Only one proto file is allowed with this options",
-				[]interface{}{fd.GetName(), templateDescriptorProto.Name, tmpl.E_TemplateVariety.Name}))
+				fd.GetName(), templateDescriptorProto.Name, tmpl.E_TemplateVariety.Name))
 			continue
 		}
 
@@ -204,7 +245,7 @@ func getTmplFileDesc(fds []*FileDescriptor) (*FileDescriptor, []diag) {
 
 	if templateDescriptorProto == nil {
 		diags = append(diags, createError(unknownFile, unknownLine, "There has to be one proto file that has the extension %s",
-			[]interface{}{tmpl.E_TemplateVariety.Name}))
+			tmpl.E_TemplateVariety.Name))
 	}
 
 	if len(diags) != 0 {
@@ -256,10 +297,10 @@ func getLastSegment(pkg string) (string, error) {
 	return "", fmt.Errorf("the last segment of package name '%s' must match the reges '%s'", pkg, pkgLaskSeg)
 }
 
-func getRequiredTmplMsg(fdp *FileDescriptor) (*Descriptor, bool) {
+func getMsg(fdp *FileDescriptor, msgName string) (*Descriptor, bool) {
 	var cstrDesc *Descriptor
 	for _, desc := range fdp.desc {
-		if desc.GetName() == "Template" {
+		if desc.GetName() == msgName {
 			cstrDesc = desc
 			break
 		}
@@ -268,15 +309,47 @@ func getRequiredTmplMsg(fdp *FileDescriptor) (*Descriptor, bool) {
 	return cstrDesc, cstrDesc != nil
 }
 
-func createInvalidTypeError(field string, err error) error {
-	errStr := fmt.Sprintf("unsupported type for field '%s'. Supported types are '%s'", field, supportedTypes)
-	if err == nil {
+func createInvalidTypeError(field string, extraErr error) error {
+	errStr := fmt.Sprintf("unsupported type for field '%s'. Supported types are '%s'", field, getAllSupportedTypes(simpleTypes))
+	if extraErr == nil {
 		return fmt.Errorf(errStr)
 	}
-	return fmt.Errorf(errStr+": %v", err)
-
+	return fmt.Errorf(errStr+"; %v", extraErr)
 }
+
+var simpleTypes = []string{
+	"string",
+	"int64",
+	"double",
+	"bool",
+	fullProtoNameOfValueTypeEnum,
+	"other messages defined within the same package",
+}
+
+func getAllSupportedTypes(simpleTypes []string) string {
+	return strings.Join(simpleTypes, ", ") + ", map<string, any of the listed supported types>"
+}
+
 func getTypeName(g *FileDescriptorSetParser, field *descriptor.FieldDescriptorProto) (protoType TypeInfo, goType TypeInfo, err error) {
+	proto, golang, err := getTypeNameRec(g, field)
+	// `repeated` is not part of the type descriptor, instead it is on the field. So we have to separately set it on
+	// the TypeInfo object.
+	if err == nil && !proto.IsMap && field.IsRepeated() {
+		proto.IsRepeated = true
+		proto.Name = getProtoArray(proto.Name)
+		golang.IsRepeated = true
+		golang.Name = getGoArray(golang.Name)
+	}
+	return proto, golang, err
+}
+func getGoArray(typeName string) string {
+	return "[]" + typeName
+}
+func getProtoArray(typeName string) string {
+	return "repeated " + typeName
+}
+
+func getTypeNameRec(g *FileDescriptorSetParser, field *descriptor.FieldDescriptorProto) (protoType TypeInfo, goType TypeInfo, err error) {
 	switch *field.Type {
 	case descriptor.FieldDescriptorProto_TYPE_STRING:
 		return TypeInfo{Name: "string"}, TypeInfo{Name: sSTRING}, nil
@@ -301,11 +374,11 @@ func getTypeName(g *FileDescriptorSetParser, field *descriptor.FieldDescriptorPr
 		if d, ok := desc.(*Descriptor); ok && d.GetOptions().GetMapEntry() {
 			keyField, valField := d.Field[0], d.Field[1]
 
-			protoKeyType, goKeyType, err := getTypeName(g, keyField)
+			protoKeyType, goKeyType, err := getTypeNameRec(g, keyField)
 			if err != nil {
 				return TypeInfo{}, TypeInfo{}, createInvalidTypeError(field.GetName(), err)
 			}
-			protoValType, goValType, err := getTypeName(g, valField)
+			protoValType, goValType, err := getTypeNameRec(g, valField)
 			if err != nil {
 				return TypeInfo{}, TypeInfo{}, createInvalidTypeError(field.GetName(), err)
 			}
@@ -327,6 +400,8 @@ func getTypeName(g *FileDescriptorSetParser, field *descriptor.FieldDescriptorPr
 					},
 					nil
 			}
+		} else {
+			return TypeInfo{Name: field.GetTypeName()[1:], IsResourceMessage: true}, TypeInfo{Name: "*" + g.TypeName(desc), IsResourceMessage: true}, nil
 		}
 	default:
 		return TypeInfo{}, TypeInfo{}, createInvalidTypeError(field.GetName(), nil)

--- a/mixer/tools/codegen/pkg/modelgen/parser.go
+++ b/mixer/tools/codegen/pkg/modelgen/parser.go
@@ -314,12 +314,6 @@ const (
 	sSTRING  = "string"
 )
 
-// protoType returns a Proto type name for a Field's DescriptorProto.
-// We only support primitives that can be represented as ValueTypes,ValueType itself, or map<string, ValueType>.
-var supportedPrimitives = []string{"string", "int64", "double", "bool"}
-var supportedTypes = strings.Join(supportedPrimitives, ", ") + ", " + fullProtoNameOfValueTypeEnum + ", " +
-	fmt.Sprintf("map<string, %s | %s>", fullProtoNameOfValueTypeEnum, strings.Join(supportedPrimitives, " | "))
-
 // TypeName returns a full name for the underlying Object type.
 func (g *FileDescriptorSetParser) TypeName(obj Object) string {
 	return g.DefaultPackageName(obj) + camelCaseSlice(obj.TypeName())

--- a/mixer/tools/codegen/pkg/modelgen/testdata/BUILD
+++ b/mixer/tools/codegen/pkg/modelgen/testdata/BUILD
@@ -46,28 +46,6 @@ proto_compile(
 )
 
 proto_compile(
-    name = "unsupported_field_type_message",
-    testonly = True,
-    args = [
-        "--include_imports",
-        "--include_source_info",
-    ],
-    imports = [
-        "external/com_github_google_protobuf/src",
-        "external/io_istio_api",
-    ],
-    inputs = [
-        "@io_istio_api//:mixer/v1/template_protos",
-        "@com_github_google_protobuf//:well_known_protos",
-        "@io_istio_api//:mixer/v1/config/descriptor_protos",  # keep
-    ],
-    protos = [
-        "UnsupportedFieldTypeMessage.proto",
-    ],
-    verbose = 0,
-)
-
-proto_compile(
     name = "unsupported_field_type_as_map",
     testonly = True,
     args = [
@@ -315,7 +293,6 @@ filegroup(
         "simple_template.descriptor_set",
         "unsupported_field_type_as_map.descriptor_set",
         "unsupported_field_type_enum.descriptor_set",
-        "unsupported_field_type_message.descriptor_set",
         "unsupported_field_type_primitive.descriptor_set",
         "wrong_pkg_name.descriptor_set",
     ],

--- a/mixer/tools/codegen/pkg/modelgen/testdata/SimpleTemplate.proto
+++ b/mixer/tools/codegen/pkg/modelgen/testdata/SimpleTemplate.proto
@@ -28,4 +28,33 @@ message Template {
     map<string, string> dimensionsConstStringVal = 8;
     map<string, bool> dimensionsConstBoolVal = 9;
     map<string, double> dimensionsConstDoubleVal = 10;
+
+
+    repeated Resource3 res3_list = 11;
+    map<string, Resource3> res3_map = 12;
+}
+
+message Resource3 {
+    /*
+    multi line comment
+    multi line comment line 2
+    */
+    bool blacklist = 1;
+    int64 fieldInt64 = 2;
+    string fieldString = 3;
+    double fieldDouble = 4;
+
+    /*single line block comment*/
+    istio.mixer.v1.config.descriptor.ValueType val = 5;
+
+    // single line comment
+    map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 6;
+
+    map<string, int64> dimensionsConstInt64Val = 7;
+    map<string, string> dimensionsConstStringVal = 8;
+    map<string, bool> dimensionsConstBoolVal = 9;
+    map<string, double> dimensionsConstDoubleVal = 10;
+
+    repeated Resource3 res3_list = 11;
+    map<string, Resource3> res3_map = 12;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Note this is part 1 of sub message support. It is based on the proposal https://docs.google.com/document/d/1GL_EOitfBJDfgbQJOSROceK5RdqNPuiggeAebaNqyf8/edit#
This PR contains the code generation for the go Instances and the augmented proto messages (Type and InstanceParam)

Part 2 (following PR) will contain the bootstraping code generation (code that runs at run-time, inside Mixer framework and instantiates these sub-message artifacts generated in this PR).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
supports submessages inside the Mixer Template system.
```
