### PR TITLE
Fix injecting into CronJobs causing a panic

### DIFF
--- a/pilot/platform/kube/inject/inject.go
+++ b/pilot/platform/kube/inject/inject.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
 	v1 "k8s.io/api/core/v1"
+	v2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -505,16 +506,27 @@ func intoObject(c *Config, in interface{}) (interface{}, error) {
 	// `in` is a pointer to an Object. Dereference it.
 	outValue := reflect.ValueOf(out).Elem()
 
-	templateValue := outValue.FieldByName("Spec").FieldByName("Template")
-	// `Template` is defined as a pointer in some older API
-	// definitions, e.g. ReplicationController
-	if templateValue.Kind() == reflect.Ptr {
-		templateValue = templateValue.Elem()
+	var objectMeta *metav1.ObjectMeta;
+	var templateObjectMeta *metav1.ObjectMeta;
+	var templatePodSpec *v1.PodSpec;
+	// CronJobs have JobTemplates in them, instead of Templates, so we
+	// special case them.
+	if job, ok := out.(*v2alpha1.CronJob); ok {
+		objectMeta = &job.ObjectMeta
+		templateObjectMeta = &job.Spec.JobTemplate.ObjectMeta
+		templatePodSpec = &job.Spec.JobTemplate.Spec.Template.Spec
+	} else {
+		templateValue := outValue.FieldByName("Spec").FieldByName("Template")
+		// `Template` is defined as a pointer in some older API
+		// definitions, e.g. ReplicationController
+		if templateValue.Kind() == reflect.Ptr {
+			templateValue = templateValue.Elem()
+		}
+		objectMeta = outValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)
+		templateObjectMeta = templateValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)
+		templatePodSpec = templateValue.FieldByName("Spec").Addr().Interface().(*v1.PodSpec)
 	}
 
-	objectMeta := outValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)
-	templateObjectMeta := templateValue.FieldByName("ObjectMeta").Addr().Interface().(*metav1.ObjectMeta)
-	templatePodSpec := templateValue.FieldByName("Spec").Addr().Interface().(*v1.PodSpec)
 
 	// Skip injection when host networking is enabled. The problem is
 	// that the iptable changes are assumed to be within the pod when,

--- a/pilot/platform/kube/inject/inject_test.go
+++ b/pilot/platform/kube/inject/inject_test.go
@@ -170,6 +170,11 @@ func TestIntoResourceFile(t *testing.T) {
 			include: []string{v1.NamespaceAll},
 		},
 		{
+			in:      "testdata/cronjob.yaml",
+			want:    "testdata/cronjob.yaml.injected",
+			include: []string{v1.NamespaceAll},
+		},
+		{
 			in:      "testdata/hello-host-network.yaml",
 			want:    "testdata/hello-host-network.yaml.injected",
 			include: []string{v1.NamespaceAll},

--- a/pilot/platform/kube/inject/testdata/cronjob.yaml
+++ b/pilot/platform/kube/inject/testdata/cronjob.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: hello
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox
+            args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure

--- a/pilot/platform/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/platform/kube/inject/testdata/cronjob.yaml.injected
@@ -1,0 +1,110 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  annotations:
+    sidecar.istio.io/status: injected-version-12345678
+  creationTimestamp: null
+  name: hello
+spec:
+  jobTemplate:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: injected-version-12345678
+      creationTimestamp: null
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+        spec:
+          containers:
+          - args:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+            image: busybox
+            name: hello
+            resources: {}
+          - args:
+            - proxy
+            - sidecar
+            - -v
+            - "2"
+            - --configPath
+            - /etc/istio/proxy
+            - --binaryPath
+            - /usr/local/bin/envoy
+            - --serviceCluster
+            - istio-proxy
+            - --drainDuration
+            - 2s
+            - --parentShutdownDuration
+            - 3s
+            - --discoveryAddress
+            - istio-pilot:15003
+            - --discoveryRefreshDelay
+            - 1s
+            - --zipkinAddress
+            - ""
+            - --connectTimeout
+            - 1s
+            - --statsdUdpAddress
+            - ""
+            - --proxyAdminPort
+            - "15000"
+            - --controlPlaneAuthPolicy
+            - NONE
+            env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            image: docker.io/istio/proxy:unittest
+            imagePullPolicy: IfNotPresent
+            name: istio-proxy
+            resources: {}
+            securityContext:
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsUser: 1337
+            volumeMounts:
+            - mountPath: /etc/istio/proxy
+              name: istio-envoy
+            - mountPath: /etc/certs/
+              name: istio-certs
+              readOnly: true
+          initContainers:
+          - args:
+            - -p
+            - "15001"
+            - -u
+            - "1337"
+            image: docker.io/istio/proxy_init:unittest
+            imagePullPolicy: IfNotPresent
+            name: istio-init
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+              privileged: true
+          restartPolicy: OnFailure
+          volumes:
+          - emptyDir:
+              medium: Memory
+              sizeLimit: "0"
+            name: istio-envoy
+          - name: istio-certs
+            secret:
+              optional: true
+              secretName: istio.default
+  schedule: '*/1 * * * *'
+status: {}
+---


### PR DESCRIPTION
CronJobs have JobTemplates instead of Templates, causing injecting to fail.

**What this PR does / why we need it**: [Injecting into a CronJob causes a panic](https://github.com/istio/issues/issues/106)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/istio/issues/issues/106

**Special notes for your reviewer**: Replication steps are in https://github.com/istio/issues/issues/106

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix kube-injecting CronJobs causing a panic
```
