### PR TITLE
[pilot] Fixing linter errors introduced by ac16f02d3574b7c21d08dd3fc71e2cf13056ebda

### DIFF
--- a/pilot/adapter/config/file/config.go
+++ b/pilot/adapter/config/file/config.go
@@ -27,17 +27,17 @@ const (
 )
 
 var (
-	// A function that applies a default namespace and domain to new ConfigRef instances
+	// Defaults is a function that applies a default namespace and domain to new ConfigRef instances
 	Defaults = WithDefaults(defaultNamespace, defaultDomain)
 )
 
-// Information for a single element of configuration stored in a file.
+// ConfigRef provides information for a single element of configuration stored in a file.
 type ConfigRef struct {
 	Meta     *model.ConfigMeta
 	FilePath string
 }
 
-// Returns a function that applies the provided namespace and domain to ConfigRef instances.
+// WithDefaults applies the provided namespace and domain to ConfigRef instances.
 func WithDefaults(namespace, domain string) func(*ConfigRef) *ConfigRef {
 	return func(c *ConfigRef) *ConfigRef {
 		c.Meta.Namespace = namespace
@@ -46,11 +46,11 @@ func WithDefaults(namespace, domain string) func(*ConfigRef) *ConfigRef {
 	}
 }
 
-// A decorator around another ConfigStore that adds support for loading configuration elements from files.
+// ConfigStore is a decorator around another config store that adds support for loading configuration elements from files.
 type ConfigStore interface {
 	model.ConfigStore
 
-	// Create a new configuration element from the specified file.
+	// CreateFromFile create a new configuration element from the specified file.
 	CreateFromFile(config ConfigRef) error
 }
 
@@ -58,11 +58,12 @@ type configStore struct {
 	model.ConfigStore
 }
 
-// Creates a new file-based config store.
+// NewConfigStore creates a new file-based config store.
 func NewConfigStore(store model.ConfigStore) ConfigStore {
 	return &configStore{store}
 }
 
+// CreateFromFile create a new configuration element from the specified file.
 func (store *configStore) CreateFromFile(config ConfigRef) error {
 	schema, ok := model.IstioConfigTypes.GetByType(config.Meta.Type)
 	if !ok {
@@ -82,9 +83,5 @@ func (store *configStore) CreateFromFile(config ConfigRef) error {
 	}
 
 	_, err = store.Create(out)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/pilot/adapter/config/file/config_test.go
+++ b/pilot/adapter/config/file/config_test.go
@@ -54,9 +54,9 @@ func TestAllConfigs(t *testing.T) {
 			configStore := file.NewConfigStore(mockStore)
 			inputMeta := input.Meta
 			if err := configStore.CreateFromFile(*input); err != nil {
-				t.Fatalf("failed creating config ", input)
+				t.Fatalf("failed creating config %v", input)
 			} else if _, exists := configStore.Get(inputMeta.Type, inputMeta.Name, inputMeta.Namespace); !exists {
-				t.Fatalf("missing config ", input)
+				t.Fatalf("missing config %v", input)
 			}
 		})
 		// TODO(nmittler): Do we care about doing a deep comparison?


### PR DESCRIPTION
**What this PR does / why we need it**:
Linter errors were introduced by commit: ac16f02d3574b7c21d08dd3fc71e2cf13056ebda.
