### PR TITLE
Distribute new protobuf representation of mixerclient configuration 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -595,8 +595,8 @@
 [[projects]]
   branch = "master"
   name = "istio.io/api"
-  packages = ["broker/v1/config","mixer/v1","mixer/v1/config/descriptor","mixer/v1/template","proxy/v1/config"]
-  revision = "e221bec09b5c2723fc8a89f2359925aa3963bfbb"
+  packages = ["broker/v1/config","mixer/v1","mixer/v1/config/client","mixer/v1/config/descriptor","mixer/v1/template","proxy/v1/config"]
+  revision = "32b82b99a7777d89e61612ff81e4eb09666686aa"
 
 [[projects]]
   name = "istio.io/fortio"
@@ -637,6 +637,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "122ae8133e32b22f805d465281656bd2129d5ad83261d729c7b59df046d31cd5"
+  inputs-digest = "febbd605efb5288e21ec93dcb564cf435c2f6efd458a25d5b6f45f1ac7d18fd0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-# dummy line 2 - circli cache is keyed off the checksum of the top level WORKSPACE file -
+# dummy line 3 - circli cache is keyed off the checksum of the top level WORKSPACE file -
 
 workspace(name = "io_istio_istio")
 

--- a/mixer/istio_api.bzl
+++ b/mixer/istio_api.bzl
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-ISTIO_API_SHA = "73a204e9501544c77e4084f66d13ebd3b757f29f"
+ISTIO_API_SHA = "32b82b99a7777d89e61612ff81e4eb09666686aa"
 
 def go_istio_api_repositories(use_local=False):
     ISTIO_API_BUILD_FILE = """

--- a/pilot/proxy/envoy/BUILD
+++ b/pilot/proxy/envoy/BUILD
@@ -25,6 +25,8 @@ go_library(
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_howeyc_fsnotify//:go_default_library",
+        "@io_istio_api//:mixer/v1",
+        "@io_istio_api//:mixer/v1/config/client",
         "@io_istio_api//:proxy/v1/config",
     ],
 )

--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -337,22 +337,16 @@ func buildHTTPListener(mesh *proxyconfig.MeshConfig, node proxy.Node, instances 
 	})
 
 	// This is the mixer 'destination.service'
-	// TODO: use canonical name, comma separated list is not actually supported by mixer.
-
-	service := ""
+	var services []string
 	if instances != nil {
-		// join service names with a comma
 		serviceSet := make(map[string]bool, len(instances))
 		for _, instance := range instances {
 			serviceSet[instance.Service.Hostname] = true
 		}
-		services := make([]string, 0, len(serviceSet))
 		for service := range serviceSet {
 			services = append(services, service)
 		}
-
 		sort.Strings(services)
-		service = strings.Join(services, ",")
 	}
 
 	filter := HTTPFilter{
@@ -362,7 +356,7 @@ func buildHTTPListener(mesh *proxyconfig.MeshConfig, node proxy.Node, instances 
 	filters = append([]HTTPFilter{filter}, filters...)
 
 	if mesh.MixerAddress != "" {
-		mixerConfig := mixerHTTPRouteConfig(node, service)
+		mixerConfig := mixerHTTPRouteConfig(node, services)
 		filter := HTTPFilter{
 			Type:   decoder,
 			Name:   MixerFilter,
@@ -735,7 +729,8 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 
 			// set server-side mixer filter config for inbound HTTP routes
 			if mesh.MixerAddress != "" {
-				defaultRoute.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false)
+				defaultRoute.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false,
+					instance.Service.Hostname)
 			}
 
 			host := &VirtualHost{
@@ -758,7 +753,8 @@ func buildInboundListeners(mesh *proxyconfig.MeshConfig, sidecar proxy.Node,
 						// Note: websocket routes do not call the filter chain. Will be
 						// resolved in future.
 						if mesh.MixerAddress != "" {
-							route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false)
+							route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, false,
+								instance.Service.Hostname)
 						}
 
 						host.Routes = append(host.Routes, route)

--- a/pilot/proxy/envoy/ingress.go
+++ b/pilot/proxy/envoy/ingress.go
@@ -175,7 +175,7 @@ func buildIngressRoute(mesh *proxyconfig.MeshConfig,
 	for _, route := range routes {
 		// enable mixer check on the route
 		if mesh.MixerAddress != "" {
-			route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, true)
+			route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, true, service.Hostname)
 		}
 
 		if applied := route.CombinePathPrefix(ingressRoute.Path, ingressRoute.Prefix); applied != nil {

--- a/pilot/proxy/envoy/testdata/lds-httpproxy.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-httpproxy.json.golden
@@ -33,7 +33,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-ingress.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-ingress.json.golden
@@ -33,7 +33,30 @@
            "source.ip": "10.3.3.3",
            "source.uid": "kubernetes://ingress.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDAw=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://ingress.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDAw=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://ingress.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -90,7 +113,30 @@
            "source.ip": "10.3.3.3",
            "source.uid": "kubernetes://ingress.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDAw=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://ingress.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDAw=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://ingress.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
@@ -79,7 +79,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -136,7 +159,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -193,7 +239,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-router.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router.json.golden
@@ -79,7 +79,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -136,7 +159,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -193,7 +239,30 @@
            "source.ip": "10.3.3.5",
            "source.uid": "kubernetes://router.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {},
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgMDBQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://router.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -211,7 +313,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -334,6 +470,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -360,7 +497,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -401,6 +572,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -441,6 +624,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -488,6 +683,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -561,6 +768,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -587,7 +795,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -211,7 +313,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -334,6 +470,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -360,7 +497,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -395,6 +566,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -429,6 +612,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -470,6 +665,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -537,6 +744,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -563,7 +771,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -186,7 +254,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -341,6 +443,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -367,7 +470,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -408,6 +545,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -448,6 +597,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -495,6 +656,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -568,6 +741,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -594,7 +768,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -186,7 +254,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -341,6 +443,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -367,7 +470,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -402,6 +539,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -436,6 +585,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -477,6 +638,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -544,6 +717,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -570,7 +744,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -211,7 +313,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -334,6 +470,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -360,7 +497,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -401,6 +572,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -441,6 +624,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -488,6 +683,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -561,6 +768,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -587,7 +795,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -211,7 +313,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -334,6 +470,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -360,7 +497,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -395,6 +566,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -429,6 +612,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -470,6 +665,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -537,6 +744,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -563,7 +771,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -344,6 +481,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -384,6 +533,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -431,6 +592,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -504,6 +677,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -530,7 +704,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -303,7 +406,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -338,6 +475,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -372,6 +521,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -413,6 +574,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.1",
         "destination.uid": "kubernetes://v1.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.1"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v1.default"
+          }
+         }
+        }
        }
       }
      },
@@ -480,6 +653,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -506,7 +680,41 @@
            "source.ip": "10.1.1.1",
            "source.uid": "kubernetes://v1.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAQ=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v1.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-websocket.json.golden
@@ -40,7 +40,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -97,7 +131,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -154,7 +222,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -277,6 +379,7 @@
             "prefix": "/websocket",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -287,6 +390,7 @@
             "prefix": "/",
             "cluster": "in.1081",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -313,7 +417,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {
@@ -348,6 +486,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -382,6 +532,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -423,6 +585,18 @@
        "mixer_attributes": {
         "destination.ip": "10.1.1.0",
         "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        }
        }
       }
      },
@@ -490,6 +664,7 @@
             "prefix": "/websocket",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -500,6 +675,7 @@
             "prefix": "/",
             "cluster": "in.80",
             "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
              "mixer_check": "on",
              "mixer_forward": "off",
              "mixer_report": "on"
@@ -526,7 +702,41 @@
            "source.ip": "10.1.1.0",
            "source.uid": "kubernetes://v0.default"
           },
-          "quota_name": "RequestCount"
+          "quota_name": "RequestCount",
+          "v2": {
+           "controlConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           }
+          }
          }
         },
         {

--- a/pilot/proxy/envoy/testdata/rds-ingress-ssl.json.golden
+++ b/pilot/proxy/envoy/testdata/rds-ingress-ssl.json.golden
@@ -10,6 +10,7 @@
       "prefix": "/bar",
       "cluster": "out.hello.default.svc.cluster.local|http-status",
       "opaque_config": {
+       "destination.service": "hello.default.svc.cluster.local",
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"

--- a/pilot/proxy/envoy/testdata/rds-ingress-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/rds-ingress-weighted.json.golden
@@ -22,6 +22,7 @@
        ]
       },
       "opaque_config": {
+       "destination.service": "world.default.svc.cluster.local",
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"

--- a/pilot/proxy/envoy/testdata/rds-ingress.json.golden
+++ b/pilot/proxy/envoy/testdata/rds-ingress.json.golden
@@ -11,6 +11,7 @@
       "path": "/hello",
       "cluster": "out.world.default.svc.cluster.local|http",
       "opaque_config": {
+       "destination.service": "world.default.svc.cluster.local",
        "mixer_check": "on",
        "mixer_forward": "on",
        "mixer_report": "on"


### PR DESCRIPTION
NOTE: this is a rebase of https://github.com/istio/old_pilot_repo/pull/1644 onto istio/istio. It has already be reviewed. 

1) Distribute the new protobuf mixerclient configuration as part of
the existing mixer filter configuration. The protobuf is encoded as a
JSON map value under "v2" key in the filter config struct map
alongside the legacy ad-hoc configuration. This is a backwards
compatible change to allow proxies to incrementally adopt the new
configuration. The legacy ad-hoc config is deprecated and will
eventually be removed.

2) Annotate inbound route's opaque_config with the destination.service
of the server instance. Mixerclient can use this to look-up
per-service quota/api in the filter configuration.