### PR TITLE
install: remove `http-` prefix from admission-webhook port name

### DIFF
--- a/install/kubernetes/istio-auth.yaml
+++ b/install/kubernetes/istio-auth.yaml
@@ -1075,7 +1075,7 @@ spec:
   - port: 15003
     name: http-discovery
   - port: 443
-    name: http-admission-webhook
+    name: admission-webhook
   selector:
     istio: pilot
 ---

--- a/install/kubernetes/istio-one-namespace-auth.yaml
+++ b/install/kubernetes/istio-one-namespace-auth.yaml
@@ -1075,7 +1075,7 @@ spec:
   - port: 15003
     name: http-discovery
   - port: 443
-    name: http-admission-webhook
+    name: admission-webhook
   selector:
     istio: pilot
 ---

--- a/install/kubernetes/istio-one-namespace.yaml
+++ b/install/kubernetes/istio-one-namespace.yaml
@@ -1075,7 +1075,7 @@ spec:
   - port: 15003
     name: http-discovery
   - port: 443
-    name: http-admission-webhook
+    name: admission-webhook
   selector:
     istio: pilot
 ---

--- a/install/kubernetes/istio.yaml
+++ b/install/kubernetes/istio.yaml
@@ -1075,7 +1075,7 @@ spec:
   - port: 15003
     name: http-discovery
   - port: 443
-    name: http-admission-webhook
+    name: admission-webhook
   selector:
     istio: pilot
 ---

--- a/install/kubernetes/templates/istio-pilot.yaml.tmpl
+++ b/install/kubernetes/templates/istio-pilot.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
   - port: 15003
     name: http-discovery
   - port: 443
-    name: http-admission-webhook
+    name: admission-webhook
   selector:
     istio: pilot
 ---


### PR DESCRIPTION
Use of `http-` prefix for admission-webhook port 443 is interfering
with other tcp services running on port 443. Remove the prefix so the
service is treated by Istio as a normal TCP service.

