### PR TITLE
fixed the broken link in contribution guideline doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ interest in working on it. This helps other people know that the issue is
 active, and hopefully prevents duplicated efforts.
 
 To submit a proposed change:
-- Setup your [development environment](devel/README.md).
+- Setup your [development environment](DEV-GUIDE.md).
 - Fork the repository.
 - Create a new branch for your changes.
 - Develop the code/fix.


### PR DESCRIPTION
fixed the broken link in contribution guideline document
fix for #1637 

- fixed setup dev. environment document link

