### PR TITLE
re-enable pilot integration tests on real kubecluster

### DIFF
--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -77,3 +77,5 @@ HUB="gcr.io/istio-testing"
 TAG="${GIT_SHA}"
 # upload images
 time make push HUB="${HUB}" TAG="${TAG}"
+
+time cd ${ROOT}/pilot; make e2etest HUB="${HUB}" TAG="${TAG}" TESTOPTS="-mixer=false"


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-enable pilot integration tests on istio-presubmit.

```release-note
NONE
```
