### PR TITLE
[ci] run only pilot unit tests and only build pilot images for e2etest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           key: bazel-cache-{{ checksum "WORKSPACE" }}
           paths:
             - /home/circleci/.cache/bazel      
-      - run: make docker HUB=docker.io/rshriram TAG=test  # make docker images for everything
+      - run: pilot/bin/push-docker docker.io/rshriram test -build-only  # make docker images for pilot only
       - run: cd pilot; mkdir /home/circleci/logs; make e2etest HUB=docker.io/rshriram TAG=test TESTOPTS="-mixer=false -errorlogsdir=/home/circleci/logs"
       - run:
           command: |
@@ -61,8 +61,6 @@ jobs:
             tar xvzf envoy.tar.gz
             ln -sf ~/envoy/usr/local/bin/envoy /go/src/istio.io/istio/pilot/proxy/envoy/envoy
       - run: cd /go/src/istio.io/istio; go test ./pilot/...
-      - run: cd /go/src/istio.io/istio; go test ./security/...
-      - run: cd /go/src/istio.io/istio; go test ./broker/...
       - save_cache:
           key: dep-cache-{{ checksum "Gopkg.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           key: bazel-cache-{{ checksum "WORKSPACE" }}
           paths:
             - /home/circleci/.cache/bazel      
-      - run: pilot/bin/push-docker docker.io/rshriram test -build-only  # make docker images for pilot only
+      - run: pilot/bin/push-docker -hub docker.io/rshriram -tag test -build-only  # make docker images for pilot only
       - run: cd pilot; mkdir /home/circleci/logs; make e2etest HUB=docker.io/rshriram TAG=test TESTOPTS="-mixer=false -errorlogsdir=/home/circleci/logs"
       - run:
           command: |


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes broken circleci job which was introduced by PR #1560.  Run only pilot unit tests now and build only pilot images

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
