### PR TITLE
Add coverage to circle ci unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             PROXY=debug-$PROXYVERSION
             wget -qO- https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xvz
             ln -sf ~/envoy/usr/local/bin/envoy /go/src/istio.io/istio/pilot/proxy/envoy/envoy
-      - run: cd /go/src/istio.io/istio; maxprocs=2 bin/codecov.sh
+      - run: cd /go/src/istio.io/istio; maxprocs=1 bin/codecov.sh
       - run:
           command: |
             bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,10 @@ jobs:
             PROXY=debug-$PROXYVERSION
             wget -qO- https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xvz
             ln -sf ~/envoy/usr/local/bin/envoy /go/src/istio.io/istio/pilot/proxy/envoy/envoy
-      - run: cd /go/src/istio.io/istio; go test ./pilot/...
-      - run: cd /go/src/istio.io/istio; go test ./security/...
-      - run: cd /go/src/istio.io/istio; go test ./broker/...
+      - run: cd /go/src/istio.io/istio; bin/codecov.sh
+      - run:
+          command: |
+            bash <(curl -s https://codecov.io/bash)
       - save_cache:
           key: dep-cache-{{ checksum "Gopkg.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             PROXY=debug-$PROXYVERSION
             wget -qO- https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xvz
             ln -sf ~/envoy/usr/local/bin/envoy /go/src/istio.io/istio/pilot/proxy/envoy/envoy
-      - run: cd /go/src/istio.io/istio; bin/codecov.sh
+      - run: cd /go/src/istio.io/istio; maxprocs=2 bin/codecov.sh
       - run:
           command: |
             bash <(curl -s https://codecov.io/bash)

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -24,11 +24,9 @@ declare -A pkgs
 
 for d in $(go list ./... | grep -v vendor); do
     i=$[$i+1]
-    if [[ $d == *"bootstrapgen" ]];then
-      echo "Skipped $d"
-      continue
-    fi
-    if [[ $d == "istio.io/istio/tests"* ]];then
+    #FIXME remove mixer tools exclusion after tests can be run without bazel
+    if [[ $d == "istio.io/istio/tests"* || \
+      $d == "istio.io/istio/mixer/tools/codegen"* ]];then
       echo "Skipped $d"
       continue
     fi

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -17,7 +17,9 @@ TMPDIR=$(mktemp -d)
 
 i=0
 # half the number of cpus seem to saturate
-max=$[$(getconf _NPROCESSORS_ONLN)/2] 
+if [[ -z ${maxprocs:-} ]];then
+  maxprocs=$[$(getconf _NPROCESSORS_ONLN)/2]
+fi
 num=0
 pids=""
 declare -A pkgs
@@ -35,7 +37,7 @@ for d in $(go list ./... | grep -v vendor); do
     pkgs[$pid]=$d
     pids+=" $pid"
     num=$(jobs -p|wc -l)
-    while [ $num -gt $max ]
+    while [ $num -gt $maxprocs ]
     do
       sleep 2
       num=$(jobs -p|wc -l)

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -28,7 +28,10 @@ for d in $(go list ./... | grep -v vendor); do
       echo "Skipped $d"
       continue
     fi
-    echo $d
+    if [[ $d == "istio.io/istio/tests"* ]];then
+      echo "Skipped $d"
+      continue
+    fi
     go test -coverprofile=$TMPDIR/$i $d &
     pid=$!
     pkgs[$pid]=$d

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -50,7 +50,7 @@ ret=0
 for p in $pids; do
     if ! wait $p; then
         echo "${pkgs[$p]} failed"
-	ret=1
+        ret=1
     fi
 done
 

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -x
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+ROOTDIR=$(dirname $SCRIPTPATH)
+cd $ROOTDIR
+
+echo "Code coverage test"
+TMPDIR=$(mktemp -d)
+
+# coverage test needs to run one package per command.
+# This script runs nproc/2 in parallel.
+# Script fails if any one of the tests fail.
+# FIXME: Bootstrapgen test can only be run with bazel at this time,
+# It is excluded from the test packages.
+
+i=0
+# half the number of cpus seem to saturate
+max=$[$(getconf _NPROCESSORS_ONLN)/2] 
+num=0
+pids=""
+declare -A pkgs
+
+for d in $(go list ./... | grep -v vendor); do
+    i=$[$i+1]
+    if [[ $d == *"bootstrapgen" ]];then
+      echo "Skipped $d"
+      continue
+    fi
+    echo $d
+    go test -coverprofile=$TMPDIR/$i $d &
+    pid=$!
+    pkgs[$pid]=$d
+    pids+=" $pid"
+    num=$(jobs -p|wc -l)
+    while [ $num -gt $max ]
+    do
+      sleep 2
+      num=$(jobs -p|wc -l)
+    done
+done
+touch $TMPDIR/empty
+cat $TMPDIR/* > coverage.txt
+
+ret=0
+for p in $pids; do
+    if ! wait $p; then
+        echo "${pkgs[$p]} failed"
+	ret=1
+    fi
+done
+
+exit $ret


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds coverage to circle ci unit tests.

a plain go test $pkgs take a very long time, so this script parallelizes it.

```release-note
NONE
```
