### PR TITLE
stop the presubmit failure of uncommitted autogen files

### DIFF
--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -77,7 +77,10 @@ diff=`git diff`
 if [[ -n "$diff" ]]; then
   echo "Some uncommitted changes are found. Maybe miss committing some generated files? Here's the diff"
   echo $diff
-  exit -1
+  # Do not fail for the changes for now; presubmit bot may share the bazel-genfiles, and that will cause
+  # unrelated failure here randomly. See https://github.com/istio/istio/issues/1689 for the details.
+  # TODO: fix the problem and fail here again.
+  # exit -1
 fi
 
 HUB="gcr.io/istio-testing"


### PR DESCRIPTION
See #1689 for the details.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
