### PR TITLE
Replace wait with communicate in bazel_to_go. Avoid deadlock in the script.

### DIFF
--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -218,12 +218,12 @@ def should_copy(src, dest):
     if not os.path.exists(dest):
         return True
     p = subprocess.Popen(['diff', '-u', src, dest], stdout=subprocess.PIPE)
-    p.wait()
+    (stdout, _) = p.communicate()
     if src.endswith('.pb.go'):
         # there might be diffs for 'source:' lines and others.
         has_diff = False
         linecount = 0
-        for l in p.stdout:
+        for l in stdout:
             linecount += 1
             if linecount < 3:
                 # first two lines are headers, skipping
@@ -249,7 +249,7 @@ def should_copy(src, dest):
             has_diff = True
             break
     else:
-        has_diff = (p.stdout.read() != '')
+        has_diff = (stdout.read() != '')
     return has_diff
 
 def protos(WKSPC, genfiles, genfiles_external):


### PR DESCRIPTION
In case the diff is huge, process.wait() causes the write to stop until the pipe is cleared. Use communicate to overcome the deadlock.

https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
