### PR TITLE
add bin/OWNERS

### DIFF
--- a/bin/OWNERS
+++ b/bin/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - sebastienvas
+  - yutongz


### PR DESCRIPTION
Any changes on bin/ requires toplevel owners currently, which
looks stupid to me. This new OWNERS content is a copy of
prow/OWNERS.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
