### PR TITLE
change liveness probe to temporarily use exec method

### DIFF
--- a/pilot/test/integration/testdata/app.yaml.tmpl
+++ b/pilot/test/integration/testdata/app.yaml.tmpl
@@ -89,15 +89,20 @@ spec:
         - name: tcp-health-port
           containerPort: 3333
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 3333
+          exec:
+            command:
+            - /usr/local/bin/client
+            - -url
+            - http://localhost:3333/healthz
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 10
         readinessProbe:
-          tcpSocket:
-            port: tcp-health-port
+          exec:
+            command:
+            - /usr/local/bin/client
+            - -url
+            - http://localhost:3333/healthz
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 10


### PR DESCRIPTION
**What this PR does / why we need it**:
Change liveness probe to temporarily use exec method to isolate presubmit failures.
We have observed that http liveness probe fails when a local one succeeds. We have also seen that this happens only when running with auth enabled.

```release-note
NONE
```

@cc @wattli 
