### PR TITLE
Introduce a cache package

### DIFF
--- a/mixer/pkg/cache/BUILD
+++ b/mixer/pkg/cache/BUILD
@@ -1,0 +1,24 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cache.go",
+        "lruCache.go",
+        "ttlCache.go",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "cache_test.go",
+        "lruCache_test.go",
+        "ttlCache_test.go",
+    ],
+    library = ":go_default_library",
+)

--- a/mixer/pkg/cache/cache.go
+++ b/mixer/pkg/cache/cache.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The cache package provides general-purpose in-memory caches.
+// Different caches provide different eviction policies suitable for
+// specific use cases.
+package cache
+
+import (
+	"io"
+	"time"
+)
+
+// Stats returns usage statistics about an individual cache, useful to assess the
+// efficiency of a cache.
+//
+// The values returned in this struct are eventually consistent approximations of
+// the current state of the cache.
+type Stats struct {
+	// Writes captures the number of times state in the cache was mutated. This
+	// includes setting and removing entries.
+	Writes uint64
+
+	// Hits captures the number of times a Get operation succeeded to find an entry in the cache.
+	Hits uint64
+
+	// Misses captures the number of times a Get operation failed to find an entry in the cache.
+	Misses uint64
+}
+
+// Cache defines the standard behavior of in-memory caches.
+//
+// Different caches can have different eviction policies which determine
+// when and how entries are automatically removed from the cache.
+//
+// Ideas for the future:
+//   - Return the number of entries in the cache in stats.
+//   - Provide an eviction callback to know when entries are evicted.
+//   - Have Set and Remove return the previous value for the key, if any.
+//   - Have Get return the expiration time for entries.
+//   - Add a Clear method to empty a cache.
+//   - Eliminate the Close method by using an internal finalizer to stop background goroutines.
+type Cache interface {
+	io.Closer
+
+	// Set inserts an entry in the cache. This will replace any entry with
+	// the same key that is already in the cache. The entry may be automatically
+	// expunged from the cache at some point, depending on the eviction policies
+	// of the cache and the options specified when the cache was created.
+	Set(key interface{}, value interface{})
+
+	// Get retrieves the value associated with the supplied key if the key
+	// is present in the cache.
+	Get(key interface{}) (value interface{}, ok bool)
+
+	// Remove synchronously deletes the given key from the cache. This has no effect if the key is not
+	// currently in the cache.
+	Remove(key interface{})
+
+	// Stats returns information about the efficiency of the cache.
+	Stats() Stats
+}
+
+// ExpiringCache is a cache with items that are evicted over time
+//
+// Ideas for the future:
+//	 - Add an Evict method to force eviction of stale items
+type ExpiringCache interface {
+	Cache
+
+	// SetWithExpiration inserts an entry in the cache with a requested expiration time.
+	// This will replace any entry with the same key that is already in the cache.
+	// The entry will be automatically expunged from the cache at or slightly after the
+	// requested expiration time.
+	SetWithExpiration(key interface{}, value interface{}, expiration time.Duration)
+}

--- a/mixer/pkg/cache/cache.go
+++ b/mixer/pkg/cache/cache.go
@@ -18,7 +18,6 @@
 package cache
 
 import (
-	"io"
 	"time"
 )
 
@@ -50,10 +49,7 @@ type Stats struct {
 //   - Have Set and Remove return the previous value for the key, if any.
 //   - Have Get return the expiration time for entries.
 //   - Add a Clear method to empty a cache.
-//   - Eliminate the Close method by using an internal finalizer to stop background goroutines.
 type Cache interface {
-	io.Closer
-
 	// Set inserts an entry in the cache. This will replace any entry with
 	// the same key that is already in the cache. The entry may be automatically
 	// expunged from the cache at some point, depending on the eviction policies
@@ -75,7 +71,7 @@ type Cache interface {
 // ExpiringCache is a cache with items that are evicted over time
 //
 // Ideas for the future:
-//	 - Add an Evict method to force eviction of stale items
+//   - Add an Evict method to force immediate eviction of stale items
 type ExpiringCache interface {
 	Cache
 

--- a/mixer/pkg/cache/cache_test.go
+++ b/mixer/pkg/cache/cache_test.go
@@ -105,8 +105,6 @@ func testCacheBasic(c Cache, t *testing.T) {
 			}
 		})
 	}
-
-	_ = c.Close()
 }
 
 func testCacheConcurrent(c Cache, t *testing.T) {
@@ -148,7 +146,6 @@ func testCacheConcurrent(c Cache, t *testing.T) {
 		t.Errorf("Got %d writes, expecting %d", stats.Writes, workers*numIters*2)
 	}
 
-	_ = c.Close()
 }
 
 func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testing.T) {
@@ -192,8 +189,6 @@ func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testi
 	if ok {
 		t.Errorf("Got value, expected LATER to have been evicted")
 	}
-
-	_ = c.Close()
 }
 
 func testCacheEvicter(c ExpiringCache, t *testing.T) {
@@ -208,6 +203,19 @@ func testCacheEvicter(c ExpiringCache, t *testing.T) {
 	}
 }
 
+func testCacheFinalizer(gate *bool, t *testing.T) {
+	for i := 0; i < 100; i++ {
+		runtime.GC()
+		if *gate {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Errorf("Expecting eviction loop to have been terminated")
+}
+
 func benchmarkCacheGet(c Cache, b *testing.B) {
 	c.Set("foo", "bar")
 
@@ -215,8 +223,6 @@ func benchmarkCacheGet(c Cache, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.Get("foo")
 	}
-
-	_ = c.Close()
 }
 
 func benchmarkCacheGetConcurrent(c Cache, b *testing.B) {
@@ -249,8 +255,6 @@ func benchmarkCacheGetConcurrent(c Cache, b *testing.B) {
 		}()
 	}
 	wg.Wait()
-
-	_ = c.Close()
 }
 
 func benchmarkCacheSet(c Cache, b *testing.B) {
@@ -258,8 +262,6 @@ func benchmarkCacheSet(c Cache, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		c.Set("foo", "bar")
 	}
-
-	_ = c.Close()
 }
 
 func benchmarkCacheSetConcurrent(c Cache, b *testing.B) {
@@ -284,8 +286,6 @@ func benchmarkCacheSetConcurrent(c Cache, b *testing.B) {
 		}()
 	}
 	wg.Wait()
-
-	_ = c.Close()
 }
 
 func benchmarkCacheSetRemove(c Cache, b *testing.B) {
@@ -295,6 +295,4 @@ func benchmarkCacheSetRemove(c Cache, b *testing.B) {
 		c.Set(name, "bar")
 		c.Remove(name)
 	}
-
-	_ = c.Close()
 }

--- a/mixer/pkg/cache/cache_test.go
+++ b/mixer/pkg/cache/cache_test.go
@@ -1,0 +1,300 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cache
+
+import (
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+type cacheOp int
+
+const (
+	Get = iota
+	Set
+	Remove
+)
+
+func testCacheBasic(c Cache, t *testing.T) {
+	cases := []struct {
+		op     cacheOp
+		key    string
+		value  string
+		result bool
+		stats  Stats
+	}{
+		// try to get when the entry isn't present
+		{Get, "X", "", false, Stats{Misses: 1}},
+
+		// add an entry and make sure we can get it
+		{Set, "X", "12", false, Stats{Misses: 1, Writes: 1}},
+		{Get, "X", "12", true, Stats{Misses: 1, Writes: 1, Hits: 1}},
+		{Get, "X", "12", true, Stats{Misses: 1, Writes: 1, Hits: 2}},
+
+		// check interference between get/set
+		{Get, "Y", "", false, Stats{Misses: 2, Writes: 1, Hits: 2}},
+		{Set, "X", "23", false, Stats{Misses: 2, Writes: 2, Hits: 2}},
+		{Get, "X", "23", true, Stats{Misses: 2, Writes: 2, Hits: 3}},
+		{Set, "Y", "34", false, Stats{Misses: 2, Writes: 3, Hits: 3}},
+		{Get, "X", "23", true, Stats{Misses: 2, Writes: 3, Hits: 4}},
+		{Get, "Y", "34", true, Stats{Misses: 2, Writes: 3, Hits: 5}},
+
+		// ensure removing X works and doesn't affect Y
+		{Remove, "X", "", false, Stats{Misses: 2, Writes: 4, Hits: 5}},
+		{Get, "X", "", false, Stats{Misses: 3, Writes: 4, Hits: 5}},
+		{Get, "Y", "34", true, Stats{Misses: 3, Writes: 4, Hits: 6}},
+
+		// make sure everything recovers from remove and then get/set
+		{Remove, "X", "", false, Stats{Misses: 3, Writes: 5, Hits: 6}},
+		{Remove, "Y", "", false, Stats{Misses: 3, Writes: 6, Hits: 6}},
+		{Get, "Y", "", false, Stats{Misses: 4, Writes: 6, Hits: 6}},
+		{Set, "X", "45", false, Stats{Misses: 4, Writes: 7, Hits: 6}},
+		{Get, "X", "45", true, Stats{Misses: 4, Writes: 7, Hits: 7}},
+		{Get, "Y", "", false, Stats{Misses: 5, Writes: 7, Hits: 7}},
+
+		// remove a missing entry, should be a nop
+		{Remove, "Z", "", false, Stats{Misses: 5, Writes: 8, Hits: 7}},
+	}
+
+	for i, tc := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			switch tc.op {
+			case Get:
+				value, result := c.Get(tc.key)
+
+				if result != tc.result {
+					t.Errorf("Got result %v, expected %v", result, tc.result)
+				}
+
+				if result {
+					str := value.(string)
+
+					if str != tc.value {
+						t.Errorf("Got value %v, expected %v", str, tc.value)
+					}
+				} else {
+					if value != nil {
+						t.Error("Got value %v, expected nil", value)
+					}
+				}
+
+			case Set:
+				c.Set(tc.key, tc.value)
+
+			case Remove:
+				c.Remove(tc.key)
+			}
+
+			s := c.Stats()
+			if s != tc.stats {
+				t.Errorf("Got stats of %v, expected %v", s, tc.stats)
+			}
+		})
+	}
+
+	_ = c.Close()
+}
+
+func testCacheConcurrent(c Cache, t *testing.T) {
+	wg := new(sync.WaitGroup)
+	workers := runtime.NumCPU()
+	wg.Add(workers)
+
+	const numIters = 100000
+	for i := 0; i < workers; i++ {
+		workerNum := i
+		go func() {
+			for j := 0; j < numIters; j++ {
+
+				key := "X" + strconv.Itoa(workerNum) + "." + strconv.Itoa(workerNum)
+				c.Set(key, j)
+				v, ok := c.Get(key)
+				if !ok {
+					t.Errorf("Got false for key %s, expecting true", key)
+				} else if v.(int) != j {
+					t.Errorf("Got %d for key %s, expecting %d", v, key, j)
+				}
+				c.Remove(key)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	stats := c.Stats()
+	if stats.Misses != 0 {
+		t.Errorf("Got %d misses, expecting %d", stats.Misses, 0)
+	}
+
+	if stats.Hits != uint64(workers*numIters) {
+		t.Errorf("Got %d hits, expecting %d", stats.Hits, workers*numIters)
+	}
+
+	if stats.Writes != uint64(workers*numIters*2) {
+		t.Errorf("Got %d writes, expecting %d", stats.Writes, workers*numIters*2)
+	}
+
+	_ = c.Close()
+}
+
+func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testing.T) {
+	now := time.Now()
+
+	c.SetWithExpiration("EARLY", "123", 10*time.Millisecond)
+	c.SetWithExpiration("LATER", "123", 20*time.Millisecond+123*time.Nanosecond)
+
+	evictExpired(now)
+
+	_, ok := c.Get("EARLY")
+	if !ok {
+		t.Errorf("Got no value, expected EARLY to be present")
+	}
+
+	_, ok = c.Get("LATER")
+	if !ok {
+		t.Errorf("Got no value, expected LATER to be present")
+	}
+
+	evictExpired(now.Add(15 * time.Millisecond))
+
+	_, ok = c.Get("EARLY")
+	if ok {
+		t.Errorf("Got value, expected EARLY to have been evicted")
+	}
+
+	_, ok = c.Get("LATER")
+	if !ok {
+		t.Errorf("Got no value, expected LATER to still be present")
+	}
+
+	evictExpired(now.Add(25 * time.Millisecond))
+
+	_, ok = c.Get("EARLY")
+	if ok {
+		t.Errorf("Got value, expected EARLY to have been evicted")
+	}
+
+	_, ok = c.Get("LATER")
+	if ok {
+		t.Errorf("Got value, expected LATER to have been evicted")
+	}
+
+	_ = c.Close()
+}
+
+func testCacheEvicter(c ExpiringCache, t *testing.T) {
+	c.SetWithExpiration("A", "A", 1*time.Millisecond)
+
+	// this is racy, but we're being generous enough that it should be fine
+	time.Sleep(10 * time.Millisecond)
+
+	_, ok := c.Get("A")
+	if ok {
+		t.Error("Got entry, expecting it to have been flushed")
+	}
+}
+
+func benchmarkCacheGet(c Cache, b *testing.B) {
+	c.Set("foo", "bar")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Get("foo")
+	}
+
+	_ = c.Close()
+}
+
+func benchmarkCacheGetConcurrent(c Cache, b *testing.B) {
+	c.Set("foo1", "bar")
+	c.Set("foo2", "bar")
+	c.Set("foo3", "bar")
+	c.Set("foo4", "bar")
+	c.Set("foo5", "bar")
+	c.Set("foo6", "bar")
+	c.Set("foo7", "bar")
+
+	wg := new(sync.WaitGroup)
+	workers := runtime.NumCPU()
+	each := b.N / workers
+	wg.Add(workers)
+
+	b.ResetTimer()
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := 0; j < each; j++ {
+				c.Get("foo1")
+				c.Get("foo2")
+				c.Get("foo3")
+				c.Get("foo5")
+				c.Get("foo6")
+				c.Get("foo7")
+				c.Get("foo8") // doesn't exist
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	_ = c.Close()
+}
+
+func benchmarkCacheSet(c Cache, b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set("foo", "bar")
+	}
+
+	_ = c.Close()
+}
+
+func benchmarkCacheSetConcurrent(c Cache, b *testing.B) {
+	wg := new(sync.WaitGroup)
+	workers := runtime.NumCPU()
+	each := b.N / workers
+	wg.Add(workers)
+
+	b.ResetTimer()
+	for i := 0; i < workers; i++ {
+		go func() {
+			for j := 0; j < each; j++ {
+				c.Set("foo1", "bar")
+				c.Set("foo2", "bar")
+				c.Set("foo3", "bar")
+				c.Set("foo4", "bar")
+				c.Set("foo5", "bar")
+				c.Set("foo6", "bar")
+				c.Set("foo7", "bar")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	_ = c.Close()
+}
+
+func benchmarkCacheSetRemove(c Cache, b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := "foo" + strconv.Itoa(i)
+		c.Set(name, "bar")
+		c.Remove(name)
+	}
+
+	_ = c.Close()
+}

--- a/mixer/pkg/cache/lruCache.go
+++ b/mixer/pkg/cache/lruCache.go
@@ -1,0 +1,276 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cache
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// We keep a slice of entries representing all items currently in the cache.
+// The entries in this slice are organized in a doubly-linked circular list. The list
+// is created via next/prev fields that contain indices into the slice. Using a slice
+// with indices in this way is considerably more efficient, in both time and space, than
+// it would be to allocate distinct objects for each cache entry and use pointers to
+// link them.
+//
+// The first entry in the slice is a sentinel entry and serves as anchor and is both the
+// beginning and end of the list. This arrangement makes it so insertion and removal
+// from the list can be done without conditionals. The sentinel's prev field holds the
+// index of the last entry in the list, while the sentinel's next field holds the index of
+// the first entry in the list.
+//
+// The LRU algorithm we currently use is classically simple. Both getting and setting
+// a cache entry puts that entry at the head of the LRU list. When we need to make
+// room in the cache, we always just plop the current tail from the list.
+//
+// Once this code has been in active use for a while in a real system, we
+// should evaluate whether fancier LRU regimes would improve overall perf.
+// For example, we could merely bump entries up in the list by one slot per
+// use instead of putting them at the head of the list. Or we could require
+// N accesses before promoting an entry to the head. Etc.
+//
+// If we do get more sophisticated, we could consider introducing an explicit MRU section
+// of the list (MRU=Most Recently Used). Entries in that portion of the list wouldn't be shuffled
+// around upon use, they would be treated as a whole distinct class. The idea is that for frequently
+// used entries, we can avoid messing up processor caches by moving these entries and can use
+// read/write locks to increase scalability.
+//
+// Due to the use of the time.Time.UnixNano function in this code, expiration
+// will fail after the year 2262. Sorry, you'll need to upgrade to a newer version
+// of Istio at that time :-)
+
+type lruCache struct {
+	sync.Mutex
+	entries           []lruEntry
+	sentinel          *lruEntry
+	lookup            map[interface{}]int // keys => entry index
+	stats             Stats
+	defaultExpiration time.Duration
+	evictionTicker    *time.Ticker
+	baseTimeNanos     int64
+}
+
+// lruEntry is used to hold a value in the ordered lru list represented by the entry slice
+type lruEntry struct {
+	next       int         // index of next entry
+	prev       int         // index of previous entry
+	key        interface{} // cache key associated with this entry
+	value      interface{} // cache value associated with this entry
+	expiration int64       // nanoseconds
+}
+
+// entry 0 in the slice is the sentinel node
+const sentinelIndex = 0
+
+// NewLRU creates a new cache with an LRU and time-based eviction model.
+//
+// Cache eviction is done on a periodic basis. Individual cache entries are evicted
+// after their expiration time has passed. The periodic nature of eviction means that
+// cache entries tend to survive around (expirationTime + (evictionInterval / 2))
+//
+// In addition, when the cache is full, adding a new item will displace the item that has
+// been referenced least recently.
+//
+// defaultExpiration specifies the default minimum amount of time a cached
+// entry remains in the cache before eviction. This value is used with the
+// Set function. Explicit per-entry expiration times can be set with the
+// SetWithExpiration function instead.
+//
+// evictionInterval specifies the frequency at which eviction activities take
+// place. This should likely be >= 1 second.
+func NewLRU(defaultExpiration time.Duration, evictionInterval time.Duration, maxEntries int) ExpiringCache {
+	c := &lruCache{
+		entries:           make([]lruEntry, maxEntries+1),
+		lookup:            make(map[interface{}]int, maxEntries),
+		defaultExpiration: defaultExpiration,
+	}
+
+	// create the linked list of entries
+	for i := 0; i < maxEntries+1; i++ {
+		c.entries[i].next = i + 1
+		c.entries[i].prev = i - 1
+		c.entries[i].expiration = math.MaxInt64
+	}
+	c.sentinel = &c.entries[0]
+
+	// finish things off, making the list circular
+	c.entries[maxEntries].next = sentinelIndex
+	c.sentinel.prev = maxEntries
+
+	if evictionInterval > 0 {
+		c.baseTimeNanos = time.Now().UTC().UnixNano()
+		c.evictionTicker = time.NewTicker(evictionInterval)
+		go c.evicter()
+	}
+
+	return c
+}
+
+func (c *lruCache) Close() error {
+	if c.evictionTicker != nil {
+		c.evictionTicker.Stop()
+	}
+
+	return nil
+}
+
+func (c *lruCache) evicter() {
+	// Wake up once in a while and evict stale items
+	for now := range c.evictionTicker.C {
+		c.evictExpired(now)
+	}
+}
+
+func (c *lruCache) evictExpired(t time.Time) {
+	// We snapshot a base time here such that the time doesn't need to be
+	// sampled in the Set call as calling time.Now() is relatively expensive.
+	// Doing it here provides enough precision for our needs and tends to have
+	// much lower call frequency.
+	n := t.UTC().UnixNano()
+	atomic.StoreInt64(&c.baseTimeNanos, n)
+
+	for i := 1; i < len(c.entries); i++ {
+		ent := &c.entries[i]
+
+		if ent.expiration <= n {
+			c.Lock()
+
+			if ent.expiration <= n {
+				c.remove(ent.key)
+			}
+
+			c.Unlock()
+		}
+	}
+}
+
+func (c *lruCache) unlinkEntry(index int) {
+	ent := &c.entries[index]
+
+	c.entries[ent.prev].next = ent.next
+	c.entries[ent.next].prev = ent.prev
+}
+
+func (c *lruCache) linkEntryAtHead(index int) {
+	ent := &c.entries[index]
+
+	ent.next = c.sentinel.next
+	ent.prev = sentinelIndex
+	c.entries[ent.next].prev = index
+	c.sentinel.next = index
+}
+
+func (c *lruCache) linkEntryAtTail(index int) {
+	ent := &c.entries[index]
+
+	ent.next = sentinelIndex
+	ent.prev = c.sentinel.prev
+	c.entries[ent.prev].next = index
+	c.sentinel.prev = index
+}
+
+func (c *lruCache) Set(key interface{}, value interface{}) {
+	c.SetWithExpiration(key, value, c.defaultExpiration)
+}
+
+func (c *lruCache) SetWithExpiration(key interface{}, value interface{}, expiration time.Duration) {
+	exp := atomic.LoadInt64(&c.baseTimeNanos) + expiration.Nanoseconds()
+
+	c.Lock()
+
+	index, ok := c.lookup[key]
+	if !ok {
+		index = c.sentinel.prev
+		delete(c.lookup, c.entries[index].key)
+		c.lookup[key] = index
+	}
+
+	c.unlinkEntry(index)
+	c.linkEntryAtHead(index)
+	ent := &c.entries[index]
+	ent.key = key
+	ent.value = value
+	ent.expiration = exp
+
+	c.stats.Writes++
+	c.Unlock()
+}
+
+func (c *lruCache) Get(key interface{}) (interface{}, bool) {
+	c.Lock()
+
+	var value interface{}
+	index, ok := c.lookup[key]
+	if ok {
+		c.unlinkEntry(index)
+		c.linkEntryAtHead(index)
+		value = c.entries[index].value
+		c.stats.Hits++
+	} else {
+		c.stats.Misses++
+	}
+
+	c.Unlock()
+
+	return value, ok
+}
+
+func (c *lruCache) Remove(key interface{}) {
+	c.Lock()
+	c.remove(key)
+	c.Unlock()
+}
+
+func (c *lruCache) remove(key interface{}) {
+	if index, ok := c.lookup[key]; ok {
+		delete(c.lookup, key)
+		c.unlinkEntry(index)
+		c.linkEntryAtTail(index)
+		c.entries[index].key = nil
+		c.entries[index].value = nil
+		c.entries[index].expiration = math.MaxInt64
+	}
+
+	c.stats.Writes++
+}
+
+func (c *lruCache) Stats() Stats {
+	return c.stats
+}
+
+/* debugging aid
+func (c *lruCache) dumpList(banner string) {
+	fmt.Printf("%s\n", banner)
+	index := c.entries[0].next
+	count := 8
+	for {
+		fmt.Printf("  %d: prev %d, next %d, payload {%v:%v}\n",
+			index, c.entries[index].prev, c.entries[index].next, c.entries[index].key, c.entries[index].value)
+
+		count--
+		if count == 0 {
+			break
+		}
+
+		index = c.entries[index].next
+		if index == 0 {
+			break
+		}
+	}
+	fmt.Println()
+}
+*/

--- a/mixer/pkg/cache/lruCache_test.go
+++ b/mixer/pkg/cache/lruCache_test.go
@@ -29,13 +29,19 @@ func TestLRUConcurrent(t *testing.T) {
 }
 
 func TestLRUExpiration(t *testing.T) {
-	lru := NewLRU(5*time.Second, 100*time.Second, 500).(*lruCache)
+	lru := NewLRU(5*time.Second, 100*time.Second, 500).(*lruWrapper)
 	testCacheExpiration(lru, lru.evictExpired, t)
 }
 
 func TestLRUEvicter(t *testing.T) {
 	lru := NewLRU(5*time.Second, 1*time.Millisecond, 500)
 	testCacheEvicter(lru, t)
+}
+
+func TestLRUFinalizer(t *testing.T) {
+	lruEvictionLoopTerminated = false
+	_ = NewLRU(5*time.Second, 1*time.Millisecond, 500)
+	testCacheFinalizer(&lruEvictionLoopTerminated, t)
 }
 
 func TestLRUBehavior(t *testing.T) {

--- a/mixer/pkg/cache/lruCache_test.go
+++ b/mixer/pkg/cache/lruCache_test.go
@@ -1,0 +1,97 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLRUBasic(t *testing.T) {
+	lru := NewLRU(5*time.Minute, 1*time.Millisecond, 500)
+	testCacheBasic(lru, t)
+}
+
+func TestLRUConcurrent(t *testing.T) {
+	lru := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	testCacheConcurrent(lru, t)
+}
+
+func TestLRUExpiration(t *testing.T) {
+	lru := NewLRU(5*time.Second, 100*time.Second, 500).(*lruCache)
+	testCacheExpiration(lru, lru.evictExpired, t)
+}
+
+func TestLRUEvicter(t *testing.T) {
+	lru := NewLRU(5*time.Second, 1*time.Millisecond, 500)
+	testCacheEvicter(lru, t)
+}
+
+func TestLRUBehavior(t *testing.T) {
+	lru := NewLRU(5*time.Minute, 1*time.Millisecond, 3)
+
+	lru.Set("1", "1")
+	lru.Set("2", "2")
+	lru.Set("3", "3")
+	lru.Set("4", "4")
+
+	// make sure only the expected entries are there
+	_, ok1 := lru.Get("1")
+	_, ok2 := lru.Get("2")
+	_, ok3 := lru.Get("3")
+	_, ok4 := lru.Get("4")
+	if ok1 || !ok2 || !ok3 || !ok4 {
+		t.Errorf("Got %v %v %v %v, expected false, true, true, true", ok1, ok2, ok3, ok4)
+	}
+
+	// make "2" the MRU
+	_, _ = lru.Get("2")
+
+	// push something new in and make sure "2" is still there
+	lru.Set("5", "5")
+
+	_, ok1 = lru.Get("1")
+	_, ok2 = lru.Get("2")
+	_, ok3 = lru.Get("3")
+	_, ok4 = lru.Get("4")
+	_, ok5 := lru.Get("5")
+	if ok1 || !ok2 || ok3 || !ok4 || !ok5 {
+		t.Errorf("Got %v %v %v %v %v, expected false, true, false, true, true", ok1, ok2, ok3, ok4, ok5)
+	}
+}
+
+func BenchmarkLRUGet(b *testing.B) {
+	c := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	benchmarkCacheGet(c, b)
+}
+
+func BenchmarkLRUGetConcurrent(b *testing.B) {
+	c := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	benchmarkCacheGetConcurrent(c, b)
+}
+
+func BenchmarkLRUSet(b *testing.B) {
+	c := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	benchmarkCacheSet(c, b)
+}
+
+func BenchmarkLRUSetConcurrent(b *testing.B) {
+	c := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	benchmarkCacheSetConcurrent(c, b)
+}
+
+func BenchmarkLRUSetRemove(b *testing.B) {
+	c := NewLRU(5*time.Minute, 1*time.Minute, 500)
+	benchmarkCacheSetRemove(c, b)
+}

--- a/mixer/pkg/cache/ttlCache.go
+++ b/mixer/pkg/cache/ttlCache.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Due to the use of the time.Time.UnixNano function in this code, expiration
+// will fail after the year 2262. Sorry, you'll need to upgrade to a newer version
+// of Istio at that time :-)
+
+type ttlCache struct {
+	entries           sync.Map
+	stats             Stats
+	defaultExpiration time.Duration
+	evictionTicker    *time.Ticker
+	baseTimeNanos     int64
+}
+
+// A single cache entry. This is the values we use in our storage map
+type entry struct {
+	value      interface{}
+	expiration int64 // nanoseconds
+}
+
+// NewTTL creates a new cache with a time-based eviction model.
+//
+// Cache eviction is done on a periodic basis. Individual cache entries are evicted
+// after their expiration time has passed. The periodic nature of eviction means that
+// cache entries tend to survive around (expirationTime + (evictionInterval / 2))
+//
+// defaultExpiration specifies the default minimum amount of time a cached
+// entry remains in the cache before eviction. This value is used with the
+// Set function. Explicit per-entry expiration times can be set with the
+// SetWithExpiration function instead.
+//
+// evictionInterval specifies the frequency at which eviction activities take
+// place. This should likely be >= 1 second.
+//
+// Since TTL caches only evict data based on the passage of time, it's possible to
+// use up all available memory by continuing to add entries to the cache with a
+// long enough expiration time. Don't do that.
+func NewTTL(defaultExpiration time.Duration, evictionInterval time.Duration) ExpiringCache {
+	c := &ttlCache{
+		defaultExpiration: defaultExpiration,
+	}
+
+	c.baseTimeNanos = time.Now().UTC().UnixNano()
+
+	if evictionInterval > 0 {
+		c.evictionTicker = time.NewTicker(evictionInterval)
+		go c.evicter()
+	}
+
+	return c
+}
+
+func (c ttlCache) Close() error {
+	if c.evictionTicker != nil {
+		c.evictionTicker.Stop()
+	}
+
+	return nil
+}
+
+func (c *ttlCache) evicter() {
+	// Wake up once in a while and evict stale items
+	for now := range c.evictionTicker.C {
+		c.evictExpired(now)
+	}
+}
+
+func (c *ttlCache) evictExpired(t time.Time) {
+	// We snapshot a base time here such that the time doesn't need to be
+	// sampled in the Set call as calling time.Now() is relatively expensive.
+	// Doing it here provides enough precision for our needs and tends to have
+	// much lower call frequency.
+	n := t.UTC().UnixNano()
+	atomic.StoreInt64(&c.baseTimeNanos, n)
+
+	var count uint64
+
+	c.entries.Range(func(key interface{}, value interface{}) bool {
+		e := value.(*entry)
+		if e.expiration <= n {
+			c.entries.Delete(key)
+			count++
+		}
+		return true
+	})
+
+	atomic.AddUint64(&c.stats.Writes, count)
+}
+
+func (c *ttlCache) Set(key interface{}, value interface{}) {
+	c.SetWithExpiration(key, value, c.defaultExpiration)
+}
+
+func (c *ttlCache) SetWithExpiration(key interface{}, value interface{}, expiration time.Duration) {
+	e := &entry{
+		value:      value,
+		expiration: atomic.LoadInt64(&c.baseTimeNanos) + expiration.Nanoseconds(),
+	}
+
+	c.entries.Store(key, e)
+	atomic.AddUint64(&c.stats.Writes, 1)
+}
+
+func (c *ttlCache) Get(key interface{}) (interface{}, bool) {
+	e, ok := c.entries.Load(key)
+	if !ok {
+		atomic.AddUint64(&c.stats.Misses, 1)
+		return nil, false
+	}
+
+	// Note that we could check the current time here and discard the returned value
+	// if the expiration time has passed. But this would increase this function's execution
+	// time by > 50% (since time.Now is relatively expensive). Instead, we don't check time
+	// here and accept some imprecision in actual eviction times.
+
+	atomic.AddUint64(&c.stats.Hits, 1)
+	return e.(*entry).value, true
+}
+
+func (c *ttlCache) Remove(key interface{}) {
+	c.entries.Delete(key)
+	atomic.AddUint64(&c.stats.Writes, 1)
+}
+
+func (c *ttlCache) Stats() Stats {
+	return c.stats
+}

--- a/mixer/pkg/cache/ttlCache_test.go
+++ b/mixer/pkg/cache/ttlCache_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTTLBasic(t *testing.T) {
+	ttl := NewTTL(5*time.Second, 1*time.Millisecond)
+	testCacheBasic(ttl, t)
+}
+
+func TestTTLConcurrent(t *testing.T) {
+	ttl := NewTTL(5*time.Second, 1*time.Second)
+	testCacheConcurrent(ttl, t)
+}
+
+func TestTTLExpiration(t *testing.T) {
+	ttl := NewTTL(5*time.Second, 100*time.Second).(*ttlCache)
+	testCacheExpiration(ttl, ttl.evictExpired, t)
+}
+
+func TestTTLEvicter(t *testing.T) {
+	ttl := NewTTL(5*time.Second, 1*time.Millisecond)
+	testCacheEvicter(ttl, t)
+}
+
+func BenchmarkTTLGet(b *testing.B) {
+	c := NewTTL(5*time.Minute, 1*time.Minute)
+	benchmarkCacheGet(c, b)
+}
+
+func BenchmarkTTLGetConcurrent(b *testing.B) {
+	c := NewTTL(5*time.Minute, 1*time.Minute)
+	benchmarkCacheGetConcurrent(c, b)
+}
+
+func BenchmarkTTLSet(b *testing.B) {
+	c := NewTTL(5*time.Minute, 1*time.Minute)
+	benchmarkCacheSet(c, b)
+}
+
+func BenchmarkTTLSetConcurrent(b *testing.B) {
+	c := NewTTL(5*time.Minute, 1*time.Minute)
+	benchmarkCacheSetConcurrent(c, b)
+}
+
+func BenchmarkTTLSetRemove(b *testing.B) {
+	c := NewTTL(5*time.Minute, 1*time.Minute)
+	benchmarkCacheSetRemove(c, b)
+}

--- a/mixer/pkg/cache/ttlCache_test.go
+++ b/mixer/pkg/cache/ttlCache_test.go
@@ -29,13 +29,19 @@ func TestTTLConcurrent(t *testing.T) {
 }
 
 func TestTTLExpiration(t *testing.T) {
-	ttl := NewTTL(5*time.Second, 100*time.Second).(*ttlCache)
+	ttl := NewTTL(5*time.Second, 100*time.Second).(*ttlWrapper)
 	testCacheExpiration(ttl, ttl.evictExpired, t)
 }
 
 func TestTTLEvicter(t *testing.T) {
 	ttl := NewTTL(5*time.Second, 1*time.Millisecond)
 	testCacheEvicter(ttl, t)
+}
+
+func TestTTLFinalizer(t *testing.T) {
+	ttlEvictionLoopTerminated = false
+	_ = NewTTL(5*time.Second, 1*time.Millisecond)
+	testCacheFinalizer(&ttlEvictionLoopTerminated, t)
 }
 
 func BenchmarkTTLGet(b *testing.B) {


### PR DESCRIPTION
This cache package exposes two distinct caches. The TTL cache evicts entries
from the cache based strictly on expiration time. It has excellent performance
in a highly threaded environment.

The LRU cache evists entries both as a result of expiration time and LRU semantics.
Although still very efficient, this cache doesn't perform as well under high contention.

We'll be using these caches in a veriety of places in Mixer over the coming weeks. We can
replace the few ad hoc caches we have with these as they're more efficient, and they expose
usage stats to let us fine tune their use over time.