### PR TITLE
Add "client" program description in e2e tests README

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -128,9 +128,11 @@ Follow the sample of demo_test.go
 ### Debugging
 The requests from the containers deployed in tests are performed by `client` program.
 For example, to perform a call from a deployed test container to https://console.bluemix.net/, run:
-`kubectl exec -it <test pod> -n <test namespace> -c app -- client -url https://console.bluemix.net/``
-`
+
+`kubectl exec -it <test pod> -n <test namespace> -c app -- client -url https://console.bluemix.net/`
+
 To see its usage run:
+
 `kubectl exec -it <test pod> -n <test namespace> -c app -- client -h`
 
 ## Framework

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -125,6 +125,13 @@ Follow the sample of demo_test.go
 4. Each test file is supposed to have a `BUILD` and is built as a go_test target in its own director. Target must have
    `tags =  ["manual"]`, since tests cannot ran by `bazel test` who runs tests in sandbox where you can't connect to cluster.
 
+### Debugging
+The requests from the containers deployed in tests are performed by `client` program.
+For example, to perform a call from a deployed test container to https://console.bluemix.net/, run:
+`kubectl exec -it <test pod> -n <test namespace> -c app -- client -url https://console.bluemix.net/``
+`
+To see its usage run:
+`kubectl exec -it <test pod> -n <test namespace> -c app -- client -h`
 
 ## Framework
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add "client" program description in e2e tests README - to explain how the deployed test containers can be debugged.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```