### PR TITLE
Fixes e2e cluster wide

### DIFF
--- a/prow/e2e-cluster_wide-auth.sh
+++ b/prow/e2e-cluster_wide-auth.sh
@@ -28,15 +28,11 @@ set -u
 # Print commands
 set -x
 
-ROOT=(bazel info workspace)
+ROOT="$(bazel info workspace)"
 source "${ROOT}/prow/cluster_lib.sh"
 
 trap delete_cluster EXIT
 create_cluster 'cluster-wide-auth'
 
-if [ -f /home/bootstrap/.kube/config ]; then
-  sudo rm /home/bootstrap/.kube/config
-fi
-
 echo 'Running cluster-wide e2e rbac, auth Tests'
-./prow/e2e-suite-rbac-auth.sh --cluster_wide "$@"
+${ROOT}/prow/e2e-suite-rbac-auth.sh --cluster_wide "$@"

--- a/tests/util/commonUtils.go
+++ b/tests/util/commonUtils.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	testSrcDir     = "TEST_SRCDIR"
-	pathPrefix     = "com_github_istio_istio"
+	pathPrefix     = "io_istio_istio"
 	runfilesSuffix = ".runfiles"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix typo in the e2e cluster wide test that prevented from running.

**Special notes for your reviewer**:
Removing the kubeconfig should not be needed as there should not be one to start with since we do not mount it in the [job](https://github.com/istio/test-infra/blob/master/prow/config.yaml#L517).

```release-note
none
```
