### PR TITLE
Refactors How Function Metadata is handled in Mixer evaluator.

### DIFF
--- a/mixer/pkg/aspect/BUILD
+++ b/mixer/pkg/aspect/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//mixer/pkg/config/descriptor:go_default_library",
         "//mixer/pkg/config/proto:go_default_library",
         "//mixer/pkg/expr:go_default_library",
+        "//mixer/pkg/il/evaluator:go_default_library",
         "//mixer/pkg/status:go_default_library",
         "@io_istio_api//:mixer/v1/config/descriptor",
     ],

--- a/mixer/pkg/aspect/attrgenmgr_test.go
+++ b/mixer/pkg/aspect/attrgenmgr_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/mixer/pkg/config"
 	cfgpb "istio.io/istio/mixer/pkg/config/proto"
 	"istio.io/istio/mixer/pkg/expr"
+	"istio.io/istio/mixer/pkg/il/evaluator"
 	"istio.io/istio/mixer/pkg/status"
 )
 
@@ -72,7 +73,7 @@ func TestAttributeGeneratorManager(t *testing.T) {
 	if m.Kind() != config.AttributesKind {
 		t.Errorf("m.Kind() = %s; wanted %s", m.Kind(), config.AttributesKindName)
 	}
-	eval, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+	eval, _ := evaluator.NewTypeChecker(evaluator.DefaultCacheSize)
 	if err := m.ValidateConfig(m.DefaultConfig(), eval, nil); err != nil {
 		t.Errorf("ValidateConfig(DefaultConfig()) produced an error: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestAttrGenMgr_ValidateConfig(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			eval, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+			eval, _ := evaluator.NewTypeChecker(evaluator.DefaultCacheSize)
 			err := m.ValidateConfig(v.params, eval, dfind)
 			if err != nil && !v.wantErr {
 				t.Errorf("Unexpected error '%v' for config: %#v", err, v.params)

--- a/mixer/pkg/aspect/common_test.go
+++ b/mixer/pkg/aspect/common_test.go
@@ -27,7 +27,7 @@ import (
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/config"
 	cfgpb "istio.io/istio/mixer/pkg/config/proto"
-	"istio.io/istio/mixer/pkg/expr"
+	"istio.io/istio/mixer/pkg/il/evaluator"
 )
 
 func TestEvalAll(t *testing.T) {
@@ -107,7 +107,7 @@ func TestValidateLabels(t *testing.T) {
 	})
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			eval, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+			eval, _ := evaluator.NewTypeChecker(evaluator.DefaultCacheSize)
 			if err := validateLabels(tt.name, tt.labels, tt.descs, eval, dfind); err != nil || tt.err != "" {
 				if tt.err == "" {
 					t.Fatalf("validateLabels() = '%s', wanted no err", err.Error())

--- a/mixer/pkg/aspect/quotasManager_test.go
+++ b/mixer/pkg/aspect/quotasManager_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/mixer/pkg/config/descriptor"
 	cfgpb "istio.io/istio/mixer/pkg/config/proto"
 	"istio.io/istio/mixer/pkg/expr"
+	"istio.io/istio/mixer/pkg/il/evaluator"
 	"istio.io/istio/mixer/pkg/status"
 )
 
@@ -165,7 +166,7 @@ func TestQuotasManager_ValidateConfig(t *testing.T) {
 		"string":   &cfgpb.AttributeManifest_AttributeInfo{ValueType: dpb.STRING},
 		"int64":    &cfgpb.AttributeManifest_AttributeInfo{ValueType: dpb.INT64},
 	})
-	v, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+	v, _ := evaluator.NewTypeChecker(evaluator.DefaultCacheSize)
 
 	validParam := aconfig.QuotasParams_Quota{
 		DescriptorName: quotaWithLabels.Name,

--- a/mixer/pkg/config/handler_test.go
+++ b/mixer/pkg/config/handler_test.go
@@ -111,7 +111,9 @@ func TestDispatchToHandlers(t *testing.T) {
 		},
 	}
 
-	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+	// TODO: This should be replaced with pkg/il/evaluator.NewTypeChecker once dependency cycle between il/evaluator
+	// and config packages is broken.
+	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize, expr.FuncMap())
 	for _, tt := range tests {
 		actualCallTrackInfo := make(instancesPerCall, 0)
 		tmplRepo := newFakeTmplRepo2("", &actualCallTrackInfo)
@@ -177,7 +179,9 @@ func TestDispatchToHandlersPanicRecover(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+		// TODO: This should be replaced with pkg/il/evaluator.NewTypeChecker once dependency cycle between il/evaluator
+		// and config packages is broken.
+		ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize, expr.FuncMap())
 		actualCallTrackInfo := make(instancesPerCall, 0)
 		tmplRepo := newFakeTmplRepo2(tt.cnfgTypePanicsForTmpl, &actualCallTrackInfo)
 		hc := handlerFactory{typeChecker: ex, tmplRepo: tmplRepo}
@@ -230,7 +234,9 @@ func TestInferTypes(t *testing.T) {
 			wantError: "cannot infer type information",
 		},
 	}
-	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+	// TODO: This should be replaced with pkg/il/evaluator.NewTypeChecker once dependency cycle between il/evaluator
+	// and config packages is broken.
+	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize, expr.FuncMap())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hc := handlerFactory{typeChecker: ex, tmplRepo: tt.tmplRepo}
@@ -336,7 +342,10 @@ func TestGroupByTmpl(t *testing.T) {
 			},
 		},
 	}
-	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize)
+
+	// TODO: This should be replaced with pkg/il/evaluator.NewTypeChecker once dependency cycle between il/evaluator
+	// and config packages is broken.
+	ex, _ := expr.NewTypeChecker(expr.DefaultCacheSize, expr.FuncMap())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 

--- a/mixer/pkg/config/validator.go
+++ b/mixer/pkg/config/validator.go
@@ -808,7 +808,10 @@ func convertAspectParams(f AspectValidatorFinder, name string, params interface{
 	if err := decode(params, ap, strict); err != nil {
 		return nil, ce.Appendf(name, "failed to decode aspect params: %v", err)
 	}
-	eval, err := expr.NewTypeChecker(expr.DefaultCacheSize)
+
+	// TODO: This should be replaced with pkg/il/evaluator.NewTypeChecker once dependency cycle between il/evaluator
+	// and config packages is broken.
+	eval, err := expr.NewTypeChecker(expr.DefaultCacheSize, expr.FuncMap())
 	if err != nil {
 		return nil, ce.Appendf(name, "failed to create expression evaluator: %v", err)
 	}

--- a/mixer/pkg/expr/evaluator.go
+++ b/mixer/pkg/expr/evaluator.go
@@ -26,9 +26,6 @@ type (
 		// Eval evaluates given expression using the attribute bag
 		Eval(expr string, attrs attribute.Bag) (interface{}, error)
 
-		// Eval evaluates given expression using the attribute bag to a string
-		EvalString(expr string, attrs attribute.Bag) (string, error)
-
 		PredicateEvaluator
 
 		TypeChecker

--- a/mixer/pkg/expr/expr.go
+++ b/mixer/pkg/expr/expr.go
@@ -93,7 +93,7 @@ type AttributeDescriptorFinder interface {
 }
 
 // EvalType Function an expression using fMap and attribute vocabulary. Returns the type that this expression evaluates to.
-func (e *Expression) EvalType(attrs AttributeDescriptorFinder, fMap map[string]FuncBase) (valueType dpb.ValueType, err error) {
+func (e *Expression) EvalType(attrs AttributeDescriptorFinder, fMap map[string]FunctionMetadata) (valueType dpb.ValueType, err error) {
 	if e.Const != nil {
 		return e.Const.Type, nil
 	}
@@ -197,14 +197,14 @@ func (f *Function) String() string {
 }
 
 // EvalType Function using fMap and attribute vocabulary. Return static or computed return type if all args have correct type.
-func (f *Function) EvalType(attrs AttributeDescriptorFinder, fMap map[string]FuncBase) (valueType dpb.ValueType, err error) {
-	fn := fMap[f.Name]
-	if fn == nil {
+func (f *Function) EvalType(attrs AttributeDescriptorFinder, fMap map[string]FunctionMetadata) (valueType dpb.ValueType, err error) {
+	fn, found := fMap[f.Name]
+	if !found {
 		return valueType, fmt.Errorf("unknown function: %s", f.Name)
 	}
 
 	var idx int
-	argTypes := fn.ArgTypes()
+	argTypes := fn.ArgumentTypes
 
 	if len(f.Args) < len(argTypes) {
 		return valueType, fmt.Errorf("%s arity mismatch. Got %d arg(s), expected %d arg(s)", f, len(f.Args), len(argTypes))
@@ -234,9 +234,9 @@ func (f *Function) EvalType(attrs AttributeDescriptorFinder, fMap map[string]Fun
 
 	// TODO check if we have excess args, only works when Fn is Variadic
 
-	retType := fn.ReturnType()
+	retType := fn.ReturnType
 	if retType == dpb.VALUE_TYPE_UNSPECIFIED {
-		// if return type is unspecified, you the discovered type
+		// if return type is unspecified, use the discovered type
 		retType = tmplType
 	}
 
@@ -425,7 +425,7 @@ const DefaultCacheSize = 1024
 type cexl struct {
 	cache *lru.Cache
 	// function Map
-	fMap map[string]FuncBase
+	fMap map[string]FunctionMetadata
 }
 
 func (e *cexl) cacheGetExpression(exprStr string) (ex *Expression, err error) {

--- a/mixer/pkg/expr/expr.go
+++ b/mixer/pkg/expr/expr.go
@@ -470,12 +470,15 @@ func (e *cexl) AssertType(expr string, finder AttributeDescriptorFinder, expecte
 }
 
 // NewTypeChecker returns a new TypeChecker.
-func NewTypeChecker(cacheSize int) (TypeChecker, error) {
+// Warning: This version of the type checker should only be called by the il-code.
+// TODO(ozben): This version of the type checker should eventually be subsumed into the il/compiler code.
+func NewTypeChecker(cacheSize int, functions map[string]FunctionMetadata) (TypeChecker, error) {
 	cache, err := lru.New(cacheSize)
 	if err != nil {
 		return nil, err
 	}
 	return &cexl{
-		fMap: FuncMap(), cache: cache,
+		fMap: functions,
+		cache: cache,
 	}, nil
 }

--- a/mixer/pkg/expr/expr_test.go
+++ b/mixer/pkg/expr/expr_test.go
@@ -276,7 +276,7 @@ func TestTypeCheck(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.in), func(t *testing.T) {
-			ev, er := NewTypeChecker(DefaultCacheSize)
+			ev, er := NewTypeChecker(DefaultCacheSize, FuncMap())
 			if er != nil {
 				t.Errorf("Failed to create expression evaluator: %v", er)
 			}
@@ -313,7 +313,7 @@ func TestAssertType(t *testing.T) {
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			ev, er := NewTypeChecker(DefaultCacheSize)
+			ev, er := NewTypeChecker(DefaultCacheSize, FuncMap())
 			if er != nil {
 				t.Errorf("Failed to create expression evaluator: %v", er)
 			}

--- a/mixer/pkg/expr/func.go
+++ b/mixer/pkg/expr/func.go
@@ -18,85 +18,82 @@ import (
 	config "istio.io/api/mixer/v1/config/descriptor"
 )
 
-// FuncBase defines the interface that every expression function must implement.
-type FuncBase interface {
-	// Name uniquely identifies the function.
-	Name() string
+// FunctionMetadata contains type metadata for functions.
+type FunctionMetadata struct {
+	// Name is the name of the function.
+	Name    string
 
-	// ReturnType specifies the return type of this function.
-	ReturnType() config.ValueType
+	// ReturnType is the return type of the function.
+	ReturnType config.ValueType
 
-	// ArgTypes specifies the argument types in order expected by the function.
-	ArgTypes() []config.ValueType
+	// ArgumentTypes is the types of the arguments in the order that is expected by the function.
+	ArgumentTypes []config.ValueType
 }
 
-// baseFunc is basetype for many funcs
-type baseFunc struct {
-	name         string
-	argTypes     []config.ValueType
-	retType      config.ValueType
-	acceptsNulls bool
+func intrinsics() []FunctionMetadata {
+	return []FunctionMetadata{
+		{
+			Name:     "EQ",
+			ReturnType:  config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:     "NEQ",
+			ReturnType:  config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:     "OR",
+			ReturnType:  config.VALUE_TYPE_UNSPECIFIED,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:     "LOR",
+			ReturnType:  config.BOOL,
+			ArgumentTypes: []config.ValueType{config.BOOL, config.BOOL},
+		},
+		{
+			Name:     "LAND",
+			ReturnType:  config.BOOL,
+			ArgumentTypes: []config.ValueType{config.BOOL, config.BOOL},
+		},
+		{
+			Name:     "INDEX",
+			ReturnType:  config.STRING,
+			ArgumentTypes: []config.ValueType{config.STRING_MAP, config.STRING},
+		},
+	}
 }
 
-func (f *baseFunc) Name() string                 { return f.name }
-func (f *baseFunc) ReturnType() config.ValueType { return f.retType }
-func (f *baseFunc) ArgTypes() []config.ValueType { return f.argTypes }
 
-func inventory() []FuncBase {
-	return []FuncBase{
-		&baseFunc{
-			name:     "EQ",
-			retType:  config.BOOL,
-			argTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+func externs() []FunctionMetadata {
+	return []FunctionMetadata{
+		{
+			Name:     "ip",
+			ReturnType:  config.IP_ADDRESS,
+			ArgumentTypes: []config.ValueType{config.STRING},
 		},
-		&baseFunc{
-			name:     "NEQ",
-			retType:  config.BOOL,
-			argTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		{
+			Name:     "timestamp",
+			ReturnType:  config.TIMESTAMP,
+			ArgumentTypes: []config.ValueType{config.STRING},
 		},
-		&baseFunc{
-			name:     "OR",
-			retType:  config.VALUE_TYPE_UNSPECIFIED,
-			argTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
-		},
-		&baseFunc{
-			name:     "LOR",
-			retType:  config.BOOL,
-			argTypes: []config.ValueType{config.BOOL, config.BOOL},
-		},
-		&baseFunc{
-			name:     "LAND",
-			retType:  config.BOOL,
-			argTypes: []config.ValueType{config.BOOL, config.BOOL},
-		},
-		&baseFunc{
-			name:     "INDEX",
-			retType:  config.STRING,
-			argTypes: []config.ValueType{config.STRING_MAP, config.STRING},
-		},
-		&baseFunc{
-			name:     "ip",
-			retType:  config.IP_ADDRESS,
-			argTypes: []config.ValueType{config.STRING},
-		},
-		&baseFunc{
-			name:     "timestamp",
-			retType:  config.TIMESTAMP,
-			argTypes: []config.ValueType{config.STRING},
-		},
-		&baseFunc{
-			name:     "match",
-			retType:  config.BOOL,
-			argTypes: []config.ValueType{config.STRING, config.STRING},
+		{
+			Name:     "match",
+			ReturnType:  config.BOOL,
+			ArgumentTypes: []config.ValueType{config.STRING, config.STRING},
 		},
 	}
 }
 
 // FuncMap provides inventory of available functions.
-func FuncMap() map[string]FuncBase {
-	m := make(map[string]FuncBase)
-	for _, fn := range inventory() {
-		m[fn.Name()] = fn
+func FuncMap() map[string]FunctionMetadata {
+	m := make(map[string]FunctionMetadata)
+	for _, fn := range intrinsics() {
+		m[fn.Name] = fn
+	}
+	for _, fn := range externs() {
+		m[fn.Name] = fn
 	}
 	return m
 }

--- a/mixer/pkg/il/compiler/compiler_test.go
+++ b/mixer/pkg/il/compiler/compiler_test.go
@@ -45,7 +45,7 @@ func TestCompile(t *testing.T) {
 			}
 			finder := descriptor.NewFinder(conf)
 
-			result, err := Compile(test.E, finder)
+			result, err := Compile(test.E, finder, expr.FuncMap())
 
 			if err != nil {
 				if err.Error() != test.CompileErr {

--- a/mixer/pkg/il/compiler/compiler_test.go
+++ b/mixer/pkg/il/compiler/compiler_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/mixer/pkg/il/runtime"
 	ilt "istio.io/istio/mixer/pkg/il/testing"
 	"istio.io/istio/mixer/pkg/il/text"
+	"istio.io/istio/mixer/pkg/expr"
 )
 
 func TestCompile(t *testing.T) {

--- a/mixer/pkg/il/evaluator/BUILD
+++ b/mixer/pkg/il/evaluator/BUILD
@@ -4,7 +4,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["evaluator.go"],
+    srcs = [
+        "checker.go",
+        "evaluator.go",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//mixer/pkg/attribute:go_default_library",

--- a/mixer/pkg/il/evaluator/checker.go
+++ b/mixer/pkg/il/evaluator/checker.go
@@ -1,0 +1,24 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluator
+
+import (
+	"istio.io/istio/mixer/pkg/expr"
+)
+
+// NewTypeChecker returns a new TypeChecker.
+func NewTypeChecker(cacheSize int) (expr.TypeChecker, error) {
+	return expr.NewTypeChecker(cacheSize, expr.FuncMap())
+}

--- a/mixer/pkg/il/evaluator/evaluator.go
+++ b/mixer/pkg/il/evaluator/evaluator.go
@@ -39,7 +39,7 @@ type IL struct {
 	maxStringTableSizeForPurge int
 	context                    *attrContext
 	contextLock                sync.RWMutex
-	fMap                       map[string]expr.FuncBase
+	fMap                       map[string]expr.FunctionMetadata
 }
 
 // attrContext captures the set of fields that needs to be kept & evicted together based on

--- a/mixer/pkg/il/evaluator/evaluator.go
+++ b/mixer/pkg/il/evaluator/evaluator.go
@@ -39,7 +39,7 @@ type IL struct {
 	maxStringTableSizeForPurge int
 	context                    *attrContext
 	contextLock                sync.RWMutex
-	fMap                       map[string]expr.FunctionMetadata
+	functions                  map[string]expr.FunctionMetadata
 }
 
 // attrContext captures the set of fields that needs to be kept & evicted together based on
@@ -96,12 +96,12 @@ func (e *IL) EvalType(expr string, finder expr.AttributeDescriptorFinder) (pb.Va
 
 	var entry cacheEntry
 	var err error
-	if entry, err = ctx.getOrCreateCacheEntry(expr); err != nil {
+	if entry, err = ctx.getOrCreateCacheEntry(expr, e.functions); err != nil {
 		glog.Infof("evaluator.EvalType failed expr:'%s', err: %v", expr, err)
 		return pb.VALUE_TYPE_UNSPECIFIED, err
 	}
 
-	return entry.expression.EvalType(finder, e.fMap)
+	return entry.expression.EvalType(finder, e.functions)
 }
 
 // AssertType evaluates the type of expr using the attribute set; if the evaluated type is equal to
@@ -152,15 +152,18 @@ func (e *IL) getAttrContext() *attrContext {
 
 func (e *IL) evalResult(expr string, attrs attribute.Bag) (interpreter.Result, error) {
 	ctx := e.getAttrContext()
-	return ctx.evalResult(expr, attrs, e.maxStringTableSizeForPurge)
+	return ctx.evalResult(expr, attrs, e.functions, e.maxStringTableSizeForPurge)
 }
 
 func (ctx *attrContext) evalResult(
-	expr string, attrs attribute.Bag, maxStringTableSizeForPurge int) (interpreter.Result, error) {
+	expr string,
+	attrs attribute.Bag,
+	functions map[string]expr.FunctionMetadata,
+	maxStringTableSizeForPurge int) (interpreter.Result, error) {
 
 	var entry cacheEntry
 	var err error
-	if entry, err = ctx.getOrCreateCacheEntry(expr); err != nil {
+	if entry, err = ctx.getOrCreateCacheEntry(expr, functions); err != nil {
 		glog.Infof("evaluator.evalResult failed expr:'%s', err: %v", expr, err)
 		return interpreter.Result{}, err
 	}
@@ -172,7 +175,7 @@ func (ctx *attrContext) evalResult(
 	return r, err
 }
 
-func (ctx *attrContext) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
+func (ctx *attrContext) getOrCreateCacheEntry(expr string, functions map[string]expr.FunctionMetadata) (cacheEntry, error) {
 	// TODO: add normalization for exprStr string, so that 'a | b' is same as 'a|b', and  'a == b' is same as 'b == a'
 	if entry, found := ctx.cache.Get(expr); found {
 		return entry.(cacheEntry), nil
@@ -184,7 +187,7 @@ func (ctx *attrContext) getOrCreateCacheEntry(expr string) (cacheEntry, error) {
 
 	var err error
 	var result compiler.Result
-	if result, err = compiler.Compile(expr, ctx.finder); err != nil {
+	if result, err = compiler.Compile(expr, ctx.finder, functions); err != nil {
 		glog.Infof("evaluator.getOrCreateCacheEntry failed expr:'%s', err: %v", expr, err)
 		return cacheEntry{}, err
 	}
@@ -221,6 +224,6 @@ func NewILEvaluator(cacheSize int, maxStringTableSizeForPurge int) (*IL, error) 
 	return &IL{
 		cacheSize:                  cacheSize,
 		maxStringTableSizeForPurge: maxStringTableSizeForPurge,
-		fMap: expr.FuncMap(),
+		functions:                  expr.FuncMap(),
 	}, nil
 }

--- a/mixer/pkg/il/evaluator/evaluator_test.go
+++ b/mixer/pkg/il/evaluator/evaluator_test.go
@@ -276,7 +276,7 @@ func Test_StringTableSizeBasedEviction(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		entry, err := e.getAttrContext().getOrCreateCacheEntry(expr)
+		entry, err := e.getAttrContext().getOrCreateCacheEntry(expr, e.functions)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the internal function metadata model of the Mixer evaluator, to unblock upcoming feature changes.
Particularly:
- Removes EvalString method from the Evaluator interface: This is simply not used at this point.
- Changes the FuncBase interface to be a FunctionMetadata struct (i.e. a pure-data only struct that keeps the metadata).
- Removes the internal dependency of the compiler to the extern function set: All the metadata for externs need to be supplied externally now.
- Moves the TypeChecker instantiation code to the il/evaluator package, reducing the surface area, and also making sure that the metadata is supplied consistently to both TypeChecker and the Evaluator.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
