### PR TITLE
mixer: add a //docker/:mixer_fedora

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1125,6 +1125,21 @@ docker_build(
     url = "https://codeload.github.com/tianon/docker-brew-ubuntu-core/zip/b6f1fe19228e5b6b7aed98dcba02f18088282f90",
 )
 
+new_http_archive(
+    name = "docker_fedora",
+    build_file_content = """
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+docker_build(
+    name = "f26",
+    tars = ["e5d3ad043980461b9cedbbcdbbf48ac6cec6045114c296fbc35fbfc2c894a491/layer.tar"],
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "c8b427ead6823cd561ae7a875a852ceed75b900dbb56ca4253c52d83b1485fa6",
+    type = "tar.xz",
+    url = "https://mirrors.cat.pdx.edu/fedora/linux/releases/26/Docker/x86_64/images/Fedora-Container-Minimal-Base-26-1.5.x86_64.tar.xz",
+)
+
 go_repository(
     name = "com_github_google_uuid",
     commit = "6a5e28554805e78ea6141142aba763936c4761c0",

--- a/mixer/BUILD.fedora
+++ b/mixer/BUILD.fedora
@@ -1,0 +1,9 @@
+# build base docker ubuntu image
+
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
+docker_build(
+    name = "f26",
+    tars = ["e5d3ad043980461b9cedbbcdbbf48ac6cec6045114c296fbc35fbfc2c894a491/layer.tar"],
+    visibility = ["//visibility:public"],
+)

--- a/mixer/docker/BUILD
+++ b/mixer/docker/BUILD
@@ -2,7 +2,8 @@
 # gazelle:ignore
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//mixer/docker:mixer_docker.bzl", "mixer_docker_build")
+load("//mixer/docker:mixer_docker.bzl", "mixer_docker_ubuntu_build")
+load("//mixer/docker:mixer_docker.bzl", "mixer_docker_fedora_build")
 load("//mixer/docker:cacerts.bzl", "cacerts")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
@@ -27,7 +28,7 @@ cacerts(
     name = "cacerts",
 )
 
-mixer_docker_build(
+mixer_docker_ubuntu_build(
     cmd = [
         "--configStoreURL=fs:///etc/opt/mixer/configroot",
         "--configStore2URL=k8s://",
@@ -51,6 +52,39 @@ mixer_docker_build(
         {
             "name": "mixer_debug",
             "base": "@ubuntu_xenial_debug//file",
+        },
+    ],
+    ports = [
+        "9091",
+        "9093",
+        "9094",
+        "42422",
+    ],
+    repository = "istio",
+    tags = ["manual"],
+    tars = [
+        ":mixer_tar",
+        "//mixer/testdata:configs_tar",
+        ":cacerts.tar",
+    ],
+)
+
+mixer_docker_fedora_build(
+    entrypoint = [
+        "/usr/local/bin/mixs",
+        "server",
+    ],
+    cmd = [
+        "--configStoreURL=fs:///etc/opt/mixer/configroot",
+        "--configStore2URL=k8s://",
+        "--logtostderr",
+        "--v=2",
+        "--traceOutput=http://zipkin:9411/api/v1/spans",
+    ],
+    images = [
+        {
+            "name": "mixer_fedora",
+            "base": "@docker_fedora//:f26",
         },
     ],
     ports = [

--- a/mixer/docker/mixer_docker.bzl
+++ b/mixer/docker/mixer_docker.bzl
@@ -1,6 +1,14 @@
 load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 
-def mixer_docker_build(images, **kwargs):
+def mixer_docker_ubuntu_build(images, **kwargs):
+    for image in images:
+        docker_build(
+            name = image['name'],
+            base = image['base'],
+            **kwargs
+        )
+
+def mixer_docker_fedora_build(images, **kwargs):
     for image in images:
         docker_build(
             name = image['name'],

--- a/mixer/example/servicegraph/docker/BUILD
+++ b/mixer/example/servicegraph/docker/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("//mixer/docker:mixer_docker.bzl", "mixer_docker_build")
+load("//mixer/docker:mixer_docker.bzl", "mixer_docker_ubuntu_build")
 
 # Use "manual" target tag to skip rules in the wildcard expansion
 
@@ -15,7 +15,7 @@ pkg_tar(
     tags = ["manual"],
 )
 
-mixer_docker_build(
+mixer_docker_ubuntu_build(
     entrypoint = [
         "/usr/local/bin/servicegraph",
         "--assetDir=/example/servicegraph",


### PR DESCRIPTION
**What this PR does / why we need it**:
As `bazel run //mixer/docker:mixer_fedora` produces a docker image of
`istio/docker:mixer_fedora`

A rebase of
https://github.com/istio/old_mixer_repo/pull/1511

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Added a bazel target to produce a fedora based mixer image
```
