### PR TITLE
Removes the expression cache lookup from the type-checker.

### DIFF
--- a/mixer/pkg/il/evaluator/evaluator.go
+++ b/mixer/pkg/il/evaluator/evaluator.go
@@ -91,17 +91,13 @@ func (e *IL) EvalPredicate(expr string, attrs attribute.Bag) (bool, error) {
 }
 
 // EvalType evaluates expr using the attr attribute bag and returns the type of the result.
-func (e *IL) EvalType(expr string, finder expr.AttributeDescriptorFinder) (pb.ValueType, error) {
-	ctx := e.getAttrContext()
-
-	var entry cacheEntry
-	var err error
-	if entry, err = ctx.getOrCreateCacheEntry(expr, e.functions); err != nil {
-		glog.Infof("evaluator.EvalType failed expr:'%s', err: %v", expr, err)
+func (e *IL) EvalType(expression string, finder expr.AttributeDescriptorFinder) (pb.ValueType, error) {
+	exp, err := expr.Parse(expression)
+	if err != nil {
 		return pb.VALUE_TYPE_UNSPECIFIED, err
 	}
 
-	return entry.expression.EvalType(finder, e.functions)
+	return exp.EvalType(finder, e.functions)
 }
 
 // AssertType evaluates the type of expr using the attribute set; if the evaluated type is equal to

--- a/mixer/pkg/il/evaluator/evaluator_test.go
+++ b/mixer/pkg/il/evaluator/evaluator_test.go
@@ -318,6 +318,29 @@ func Test_Stress(t *testing.T) {
 	}
 }
 
+func Test_TypeChecker_Uninitialized(t *testing.T) {
+	e, err := NewILEvaluator(10, maxStringTableSizeForPurge)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	aType, err := e.EvalType("attr", descriptor.NewFinder(&configString))
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	if aType != pbv.STRING {
+		t.Fatalf("attr should have been a string: %s", aType)
+	}
+
+	aType, err = e.EvalType("attr", descriptor.NewFinder(&configInt))
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	if aType != pbv.INT64 {
+		t.Fatalf("attr should have been an int: %s", aType)
+	}
+}
+
 func generateRandomStr(r *rand.Rand) string {
 	size := r.Intn(20) + 1
 	bytes := make([]byte, size)


### PR DESCRIPTION
The previous checking accidentally re-introduced the cache lookup
during type-check. The type-check needs to be cache-independent, and
should use the supplied attribute descriptor finder & expression, as
that set of expressions are potentially independent of the cached ones.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This fixes the postsubmit test run issue.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
