### PR TITLE
Rename and relocate mixer/test/testenv to pkg/mock

### DIFF
--- a/mixer/cmd/server/cmd/BUILD
+++ b/mixer/cmd/server/cmd/BUILD
@@ -13,7 +13,7 @@ go_library(
     ],
     visibility = [
         "//mixer/cmd:__subpackages__",
-        "//mixer/test/testenv:__subpackages__",
+        "//mixer/pkg/mock:__subpackages__",
     ],
     deps = [
         "//mixer/cmd/shared:go_default_library",

--- a/mixer/pkg/mock/BUILD
+++ b/mixer/pkg/mock/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["testenv.go"],
+    srcs = ["server.go"],
     deps = [
         "//mixer/cmd/server/cmd:go_default_library",
         "//mixer/cmd/shared:go_default_library",
@@ -19,7 +19,7 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["testenv_test.go"],
+    srcs = ["server_test.go"],
     data = [
         "//mixer/testdata",
     ],

--- a/mixer/pkg/mock/server_test.go
+++ b/mixer/pkg/mock/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package testenv
+package mock
 
 import (
 	"flag"
@@ -107,14 +107,14 @@ func TestDenierAdapter(t *testing.T) {
 		ConfigIdentityAttributeDomain: "svc.cluster.local",
 	}
 
-	env, err := NewEnv(&args, template.SupportedTmplInfo, []adapter.InfoFn{denier.GetInfo})
+	env, err := NewServer(&args, template.SupportedTmplInfo, []adapter.InfoFn{denier.GetInfo})
 	if err != nil {
-		t.Fatalf("fail to create testenv: %v", err)
+		t.Fatalf("fail to create mock: %v", err)
 	}
 
 	defer closeHelper(env)
 
-	client, conn, err := env.CreateMixerClient()
+	client, conn, err := env.CreateClient()
 	if err != nil {
 		t.Fatalf("fail to create client connection: %v", err)
 	}

--- a/mixer/test/e2e/BUILD
+++ b/mixer/test/e2e/BUILD
@@ -21,7 +21,7 @@ go_test(
         "//mixer/test/spyAdapter:go_default_library",
         "//mixer/test/template:go_default_library",
         "//mixer/test/template/report:go_default_library",
-        "//mixer/test/testenv:go_default_library",
+        "//mixer/pkg/mock:go_default_library",
         "@io_istio_api//:mixer/v1",
         "@io_istio_api//:mixer/v1/config/descriptor",
     ],

--- a/mixer/test/e2e/e2e_report_test.go
+++ b/mixer/test/e2e/e2e_report_test.go
@@ -23,11 +23,11 @@ import (
 
 	istio_mixer_v1 "istio.io/api/mixer/v1"
 	pb "istio.io/api/mixer/v1/config/descriptor"
+	testEnv "istio.io/istio/mixer/pkg/mock"
 	"istio.io/istio/mixer/pkg/template"
 	spyAdapter "istio.io/istio/mixer/test/spyAdapter"
 	e2eTmpl "istio.io/istio/mixer/test/template"
 	reportTmpl "istio.io/istio/mixer/test/template/report"
-	testEnv "istio.io/istio/mixer/test/testenv"
 )
 
 const (
@@ -163,14 +163,14 @@ func TestReport(t *testing.T) {
 		}
 
 		adapterInfos, spyAdapters := ConstructAdapterInfos(tt.behaviors)
-		env, err := testEnv.NewEnv(&args, e2eTmpl.SupportedTmplInfo, adapterInfos)
+		env, err := testEnv.NewServer(&args, e2eTmpl.SupportedTmplInfo, adapterInfos)
 		if err != nil {
-			t.Fatalf("fail to create testenv: %v", err)
+			t.Fatalf("fail to create mock: %v", err)
 		}
 
 		defer closeHelper(env)
 
-		client, conn, err := env.CreateMixerClient()
+		client, conn, err := env.CreateClient()
 		if err != nil {
 			t.Fatalf("fail to create client connection: %v", err)
 		}

--- a/mixer/testdata/BUILD
+++ b/mixer/testdata/BUILD
@@ -18,5 +18,5 @@ pkg_tar(
 filegroup(
     name = "testdata",
     srcs = glob(["**/*.yml"]) + glob(["**/*.yaml"]),
-    visibility = ["//mixer/test/testenv:__subpackages__"],
+    visibility = ["//mixer/pkg/mock:__subpackages__"],
 )


### PR DESCRIPTION
Mixer contains mixer/pkg/adapter/test/env.go exposing a test.NewEnv method, which was
confusing with mixer/test/testenv's testenv.NewEnv method. The testenv package is now
renamed to 'mock' and the type is now called Server, giving us a nice mock.NewServer
signature instead.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
