### PR TITLE
fail on bin/check_license.sh errors

### DIFF
--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -28,7 +28,7 @@ docker run\
 echo 'linters OK'
 
 echo 'Checking licences'
-bin/check_license.sh || true
+bin/check_license.sh
 echo 'licences OK'
 
 echo 'Running buildifier ...'


### PR DESCRIPTION
With the fix of #1671, bin/check_license.sh now succeeds on master.
This PR allows bin/linters.sh to fail with check_license.sh check,
so that this healthy status will continue.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
