### PR TITLE
fix bazel_to_go.py for setting up vendor directory

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1077,11 +1077,6 @@ git_repository(
 )
 
 ## auth deps
-go_repository(
-    name = "com_github_aws_aws-sdk-go",
-    importpath = "github.com/aws/aws-sdk-go",
-    tag = "v1.12.5",
-)
 
 go_repository(
     name = "com_github_go_ini_ini",

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -31,10 +31,6 @@ def keywords(stmt):
     u = urlparse(path)
     return u.netloc + u.path, kw["name"]
 
-pathmap = {
-    "github.com/istio/api": "istio.io/api"
-}
-
 known_repos = {
         "org_golang_google": "google.golang.org",
         "com_github": "github.com",
@@ -86,8 +82,8 @@ class WORKSPACE(object):
 def process(fl, external, genfiles, vendor):
     src = subprocess.Popen("bazel query 'kind(\"go_repository|new_git.*_repository\", \"//external:*\")' --output=build", shell=True, stdout=subprocess.PIPE).stdout.read()
     tree = ast.parse(src, fl)
-    lst = []
     wksp = WORKSPACE(external, genfiles, vendor)
+    lst = [wksp.go_repository('io_istio_api', 'istio.io/api')]
 
     for stmt in ast.walk(tree):
         stmttype = type(stmt)
@@ -100,7 +96,6 @@ def process(fl, external, genfiles, vendor):
             path, name = keywords(stmt)
             if path.endswith(".git"):
                 path = path[:-4]
-            path = pathmap.get(path, path)
             tup = fn(name, path)
             lst.append(tup)
 
@@ -165,9 +160,6 @@ def bazel_to_vendor(WKSPC):
         link = repos(ext_target)
         if not link:
             # print "Could not resolve", ext_target
-            continue
-        if link in pathmap:
-            # skip remapped deps
             continue
         linksrc = os.path.join(vendor, link)
 

--- a/mixer/pkg/attribute/list.gen.go
+++ b/mixer/pkg/attribute/list.gen.go
@@ -188,5 +188,6 @@ var (
 		"request.auth.principal",
 		"request.auth.audiences",
 		"request.auth.presenter",
+		"request.api_key",
 	}
 )

--- a/mixer/template/metric/go_default_library_handler.gen.go
+++ b/mixer/template/metric/go_default_library_handler.gen.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/istio/mixer/pkg/adapter"
 )
 
-// TemplateName is the fully qualified name of the template
+// Fully qualified name of the template
 const TemplateName = "metric"
 
 // Instance is constructed by Mixer for the 'metric' template.


### PR DESCRIPTION
- aws/aws-go-sdk in WORKSPACE: the same repository is already
  referred above, with a different name. This entry is just
  redundant, and confuses bazel_to_go.py script, so removed.
- istio.io/api: this repository seems not in as a standard
  go_repository() declarations, manually added to bazel_to_go.

additionally, some mixer/ files are changed due to a run of
bazel_to_go.py itself, synchronization of the generated files.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
