### PR TITLE
Add explanations how to pass test options to integration tests.

### DIFF
--- a/pilot/README.md
+++ b/pilot/README.md
@@ -54,7 +54,7 @@ This will build a docker container for Pilot, the sidecar, and other
 utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
-with the same image hub and tag as the ones you used in the dockerize step. This step will
+with the same image hub and tag as the ones you used in the _dockerize_ step. This step will
 run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the
 command line of `make`, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -54,7 +54,7 @@ This will build a docker container for Pilot, the sidecar, and other
 utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
-with the same image hub and tag as the ones you used in the dockerize stage. This step will
+with the same image hub and tag as the ones you used in the dockerize step. This step will
 run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the
 command line of `make`, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -55,6 +55,8 @@ utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>` 
 with same image tags as the one you used in the dockerize stage. This step will
-run end to end integration tests on Kubernetes.
+run end to end integration tests on Kubernetes. To pass additional flags to [e2e driver](test/integration/driver.go), define TESTOPTS variable in the make
+command line, for example `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
+to run a single e2e test.
 
 Detailed instructions for testing are available [here](doc/testing.md).

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -55,8 +55,10 @@ utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
 with same image tags as the one you used in the dockerize stage. This step will
-run end to end integration tests on Kubernetes. To pass additional flags to [e2e driver](test/integration/driver.go), define TESTOPTS variable in the make
-command line, for example `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
-to run a single e2e test.
+run end to end integration tests on Kubernetes. To provide additioal test options, define TESTOPTS variable in the make
+command line, for example `make e2etest TESTOPTS='-help'` to see all available options.
+
+ Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
+to run a single e2e test by its name.
 
 Detailed instructions for testing are available [here](doc/testing.md).

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -57,8 +57,7 @@ utilities.
 with same image tags as the one you used in the dockerize stage. This step will
 run end to end integration tests on Kubernetes. To provide additioal test options, define TESTOPTS variable in the make
 command line, for example `make e2etest TESTOPTS='-help'` to see all available options.
-
- Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
+Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
 to run a single e2e test by its name.
 
 Detailed instructions for testing are available [here](doc/testing.md).

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -58,6 +58,6 @@ with the same image hub and tag as the ones you used in the _dockerize_ step. Th
 run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the
 command line of `make`, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
-to run a single e2e test by its name.
+to run a single integration test by its name.
 
 Detailed instructions for testing are available [here](doc/testing.md).

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -31,7 +31,7 @@ proxy controllers.
   > integration tests, you need access to a working Kubernetes cluster.
 
 1. *Setup:* Run `make setup`. It installs the required tools and
-[vendorizes](https://golang.org/cmd/go/#hdr-Vendor_Directories) 
+[vendorizes](https://golang.org/cmd/go/#hdr-Vendor_Directories)
 the dependencies.
 
 1. Write code using your favorite IDE. Make sure to format code and run
@@ -49,11 +49,11 @@ the dependencies.
    > NOTE: If you are running on OS X, //proxy/envoy:go_default_test will
    > fail. You can ignore this failure.
 
-1. *Dockerize:* Run `make docker HUB=docker.io/<username> TAG=<sometag>`. 
-This will build a docker container for Pilot, the sidecar, and other 
+1. *Dockerize:* Run `make docker HUB=docker.io/<username> TAG=<sometag>`.
+This will build a docker container for Pilot, the sidecar, and other
 utilities.
 
-1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>` 
+1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
 with same image tags as the one you used in the dockerize stage. This step will
 run end to end integration tests on Kubernetes. To pass additional flags to [e2e driver](test/integration/driver.go), define TESTOPTS variable in the make
 command line, for example `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -55,7 +55,7 @@ utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
 with same image tags as the one you used in the dockerize stage. This step will
-run end to end integration tests on Kubernetes. To provide additioal test options, define TESTOPTS variable in the make
+run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the make
 command line, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
 to run a single e2e test by its name.

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -55,8 +55,8 @@ utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
 with the same image hub and tag as the ones you used in the dockerize stage. This step will
-run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the make
-command line, for example `make e2etest TESTOPTS='-help'` to see all available options.
+run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the
+command line of `make`, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`
 to run a single e2e test by its name.
 

--- a/pilot/README.md
+++ b/pilot/README.md
@@ -54,7 +54,7 @@ This will build a docker container for Pilot, the sidecar, and other
 utilities.
 
 1. *Integration test:* Run `make e2etest HUB=docker.io/<username> TAG=<sometag>`
-with same image tags as the one you used in the dockerize stage. This step will
+with the same image hub and tag as the ones you used in the dockerize stage. This step will
 run end to end integration tests on Kubernetes. To specify additional test options, define TESTOPTS variable in the make
 command line, for example `make e2etest TESTOPTS='-help'` to see all available options.
 Run `make e2etest HUB=docker.io/<username> TAG=<sometag> TESTOPS='-testtype <test name>'`


### PR DESCRIPTION
**What this PR does / why we need it**:
It explains how to pass test options to integration tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```