### PR TITLE
Add comprehensive function support to the IL code generator. 

### DIFF
--- a/mixer/pkg/il/compiler/compiler.go
+++ b/mixer/pkg/il/compiler/compiler.go
@@ -208,19 +208,11 @@ func (g *generator) generateFunction(f *expr.Function, depth int, mode nilMode, 
 		g.generateIndex(f, depth, mode, valueJmpLabel)
 	case "OR":
 		g.generateOr(f, depth, mode, valueJmpLabel)
-	case "ip":
-		g.generate(f.Args[0], depth+1, nmNone, "")
-		g.builder.Call("ip")
-	case "timestamp":
-		g.generate(f.Args[0], depth+1, nmNone, "")
-		g.builder.Call("timestamp")
-	case "match":
-		g.generate(f.Args[0], depth+1, nmNone, "")
-		g.generate(f.Args[1], depth+1, nmNone, "")
-		g.builder.Call("match")
 	default:
-		// TODO: generalize "ip" and "match" case to iterate over Args and append Call
-		g.internalError("function not yet implemented: %s", f.Name)
+		for _, arg := range f.Args {
+			g.generate(arg, depth, nmNone, "")
+		}
+		g.builder.Call(f.Name)
 	}
 }
 

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -1463,6 +1463,20 @@ end`,
 		CompileErr: "EQ($ai, true) arg 2 (true) typeError got BOOL, expected INT64",
 		AstErr:     "unresolved attribute ai",
 	},
+
+	{
+		E:  `"foo" | "bar"`,
+		IL: `
+fn eval() string
+  apush_s "foo"
+  jmp L0
+  apush_s "bar"
+L0:
+  ret
+end
+		`,
+		R: "foo",
+	},
 }
 
 // TestInfo is a structure that contains detailed test information. Depending

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -1477,6 +1477,85 @@ end
 		`,
 		R: "foo",
 	},
+
+	{
+		E:  `ip("1.2.3.4")`,
+		IL: `
+fn eval() interface
+  apush_s "1.2.3.4"
+  call ip
+  ret
+end
+		`,
+		R: []uint8(net.ParseIP("1.2.3.4")),
+	},
+
+	{
+		E:  `ip(as)`,
+		I: map[string]interface{} {
+			"as": "1.2.3.4",
+		},
+		IL: `
+fn eval() interface
+  resolve_s "as"
+  call ip
+  ret
+end
+		`,
+		R: []uint8(net.ParseIP("1.2.3.4")),
+	},
+
+	{
+		E:  `ip("1.2.3.4" | "5.6.7.8")`,
+		IL: `
+fn eval() interface
+  apush_s "1.2.3.4"
+  jmp L0
+  apush_s "5.6.7.8"
+L0:
+  call ip
+  ret
+end
+		`,
+		R: []uint8(net.ParseIP("1.2.3.4")),
+	},
+
+	{
+		E:  `ip(as | "5.6.7.8")`,
+		IL: `
+fn eval() interface
+  tresolve_s "as"
+  jnz L0
+  apush_s "5.6.7.8"
+L0:
+  call ip
+  ret
+end
+`,
+		R: []uint8(net.ParseIP("5.6.7.8")),
+	},
+
+	{
+		E:  `ip(as | bs)`,
+		I: map[string]interface{} {
+			"bs": "1.2.3.4",
+		},
+		R: []uint8(net.ParseIP("1.2.3.4")),
+	},
+
+	{
+		E:  `ip(as | bs)`,
+		Err: "lookup failed: 'bs'",
+	},
+
+	{
+		E:  `ip(ar["foo"])`,
+		IL: ``,
+		I: map[string]interface{} {
+			"ar": map[string]string{ "foo": "1.2.3.4" },
+		},
+		R: []uint8(net.ParseIP("1.2.3.4")),
+	},
 }
 
 // TestInfo is a structure that contains detailed test information. Depending


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation of IL code generator hard-wires function names and signatures. This PR makes the generator generic, and makes it use the type-information for generating IL.

Also, it fixes a code-generator bug for the "|" operator, where the LHS is a constant. (The bug is, the constant would be evaluated, but the generated call would still fall-through to the next expression in line).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
