### PR TITLE
Initial pilot api az functionality

### DIFF
--- a/pilot/model/config_test.go
+++ b/pilot/model/config_test.go
@@ -281,35 +281,20 @@ func TestMatchSource(t *testing.T) {
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
-<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "world"},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
-=======
-			svc:       &proxyconfig.IstioService{Name: "world"},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
->>>>>>> initial pilot api az functionality
 			want:      false,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
-<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "hello"},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
-=======
-			svc:       &proxyconfig.IstioService{Name: "hello"},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
->>>>>>> initial pilot api az functionality
 			want:      true,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
-<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "hello", Labels: map[string]string{"version": "v0"}},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
-=======
-			svc:       &proxyconfig.IstioService{Name: "hello", Labels: map[string]string{"version": "v0"}},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
->>>>>>> initial pilot api az functionality
 			want:      true,
 		},
 	}

--- a/pilot/model/config_test.go
+++ b/pilot/model/config_test.go
@@ -281,20 +281,35 @@ func TestMatchSource(t *testing.T) {
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
+<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "world"},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
+=======
+			svc:       &proxyconfig.IstioService{Name: "world"},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+>>>>>>> initial pilot api az functionality
 			want:      false,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
+<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "hello"},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
+=======
+			svc:       &proxyconfig.IstioService{Name: "hello"},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+>>>>>>> initial pilot api az functionality
 			want:      true,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
+<<<<<<< HEAD
 			svc:       &routing.IstioService{Name: "hello", Labels: map[string]string{"version": "v0"}},
 			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)},
+=======
+			svc:       &proxyconfig.IstioService{Name: "hello", Labels: map[string]string{"version": "v0"}},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+>>>>>>> initial pilot api az functionality
 			want:      true,
 		},
 	}
@@ -358,7 +373,7 @@ func (errorStore) Delete(typ, name, namespace string) error {
 
 func TestRouteRules(t *testing.T) {
 	store := model.MakeIstioStore(memory.Make(model.IstioConfigTypes))
-	instance := mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)
+	instance := mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")
 
 	routerule1 := &routing.RouteRule{
 		Match: &routing.MatchCondition{
@@ -396,7 +411,7 @@ func TestRouteRules(t *testing.T) {
 		t.Error("RouteRules() => expected no match for source-matched rules")
 	}
 
-	world := mock.MakeInstance(mock.WorldService, mock.PortHTTP, 0)
+	world := mock.MakeInstance(mock.WorldService, mock.PortHTTP, 0, "")
 	if out := store.RouteRulesByDestination([]*model.ServiceInstance{world}); len(out) != 1 ||
 		!reflect.DeepEqual(routerule1, out[0].Spec) {
 		t.Errorf("RouteRulesByDestination() => got %#v, want %#v", out, routerule1)
@@ -458,7 +473,7 @@ func TestEgressRules(t *testing.T) {
 func TestPolicy(t *testing.T) {
 	store := model.MakeIstioStore(memory.Make(model.IstioConfigTypes))
 	labels := map[string]string{"version": "v1"}
-	instances := []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0)}
+	instances := []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")}
 
 	policy1 := &routing.DestinationPolicy{
 		Source: &routing.IstioService{

--- a/pilot/proxy/envoy/discovery.go
+++ b/pilot/proxy/envoy/discovery.go
@@ -455,9 +455,10 @@ func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response 
 		return
 	}
 	if len(instances) <= 0 {
-		errorResponse(response, http.StatusNotFound, "AvailabilityZone couldn't find a AZ for the given cluster node")
+		errorResponse(response, http.StatusNotFound, "AvailabilityZone couldn't find the given cluster node")
+		return
 	}
-	// All instances are going to have the same addr so will all be in the same AZ
+	// All instances are going to have the same IP addr therefore will all be in the same AZ
 	writeResponse(response, []byte(instances[0].AvailabilityZone))
 }
 

--- a/pilot/proxy/envoy/discovery.go
+++ b/pilot/proxy/envoy/discovery.go
@@ -285,6 +285,14 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 		Param(ws.PathParameter(ServiceCluster, "client proxy service cluster").DataType("string")).
 		Param(ws.PathParameter(ServiceNode, "client proxy service node").DataType("string")))
 
+	// This route retrieves the Availability Zone of the service node requested
+	ws.Route(ws.
+		GET(fmt.Sprintf("/v1/az/{%s}/{%s}", ServiceCluster, ServiceNode)).
+		To(ds.AvailabilityZone).
+		Doc("AZ for service node").
+		Param(ws.PathParameter(ServiceCluster, "client proxy service cluster").DataType("string")).
+		Param(ws.PathParameter(ServiceNode, "client proxy service node").DataType("string")))
+
 	ws.Route(ws.
 		GET("/cache_stats").
 		To(ds.GetCacheStats).
@@ -432,6 +440,25 @@ func (ds *DiscoveryService) parseDiscoveryRequest(request *restful.Request) (pro
 		return role, multierror.Prefix(err, fmt.Sprintf("unexpected %s: ", ServiceNode))
 	}
 	return role, nil
+}
+
+// AvailabilityZone responds to requests for an AZ for the given cluster node
+func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response *restful.Response) {
+	role, err := ds.parseDiscoveryRequest(request)
+	if err != nil {
+		errorResponse(response, http.StatusNotFound, "AvailabilityZone "+err.Error())
+		return
+	}
+	instances, err := ds.HostInstances(map[string]bool{role.IPAddress: true})
+	if err != nil {
+		errorResponse(response, http.StatusNotFound, "AvailabilityZone "+err.Error())
+		return
+	}
+	if len(instances) <= 0 {
+		errorResponse(response, http.StatusNotFound, "AvailabilityZone couldn't find a AZ for the given cluster node")
+	}
+	// All instances are going to have the same addr so will all be in the same AZ
+	writeResponse(response, []byte(instances[0].AvailabilityZone))
 }
 
 // ListClusters responds to CDS requests for all outbound clusters

--- a/pilot/proxy/envoy/discovery_test.go
+++ b/pilot/proxy/envoy/discovery_test.go
@@ -23,8 +23,12 @@ import (
 	"testing"
 
 	restful "github.com/emicklei/go-restful"
+<<<<<<< HEAD
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+=======
+	proxyconfig "istio.io/api/proxy/v1/config"
+>>>>>>> initial pilot api az functionality
 	"istio.io/istio/pilot/adapter/config/memory"
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/proxy"
@@ -814,5 +818,27 @@ func TestDiscoveryCache(t *testing.T) {
 		}
 		got := makeDiscoveryRequest(ds, "GET", "/cache_stats", t)
 		compareResponse(got, c.wantCache, t)
+	}
+}
+
+func TestDiscoveryService_AvailabilityZone(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{
+			name: "golden path returns region/zone",
+			want: "region/zone",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, ds := commonSetup(t)
+			url := fmt.Sprintf("/v1/az/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
+			response := makeDiscoveryRequest(ds, "GET", url, t)
+			if tt.want != string(response) {
+				t.Errorf("wanted %v but received %v", tt.want, string(response))
+			}
+		})
 	}
 }

--- a/pilot/proxy/envoy/discovery_test.go
+++ b/pilot/proxy/envoy/discovery_test.go
@@ -827,14 +827,14 @@ func TestDiscoveryService_AvailabilityZone(t *testing.T) {
 		{
 			name: "golden path returns region/zone",
 			hostInstances: []*model.ServiceInstance{
-				&model.ServiceInstance{AvailabilityZone: "region/zone"},
+				{AvailabilityZone: "region/zone"},
 			},
 			want: "region/zone",
 		},
 		{
 			name: "when no AZ return blank",
 			hostInstances: []*model.ServiceInstance{
-				&model.ServiceInstance{},
+				{},
 			},
 			want: "",
 		},

--- a/pilot/test/mock/service.go
+++ b/pilot/test/mock/service.go
@@ -147,7 +147,7 @@ func MakeExternalHTTPSService(hostname, external string, address string) *model.
 }
 
 // MakeInstance creates a mock instance, version enumerates endpoints
-func MakeInstance(service *model.Service, port *model.Port, version int) *model.ServiceInstance {
+func MakeInstance(service *model.Service, port *model.Port, version int, az string) *model.ServiceInstance {
 	if service.External() {
 		return nil
 	}
@@ -164,8 +164,9 @@ func MakeInstance(service *model.Service, port *model.Port, version int) *model.
 			Port:        target,
 			ServicePort: port,
 		},
-		Service: service,
-		Labels:  map[string]string{"version": fmt.Sprintf("v%d", version)},
+		Service:          service,
+		Labels:           map[string]string{"version": fmt.Sprintf("v%d", version)},
+		AvailabilityZone: az,
 	}
 }
 
@@ -238,7 +239,7 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 		if port, ok := service.Ports.Get(name); ok {
 			for v := 0; v < sd.versions; v++ {
 				if labels.HasSubsetOf(map[string]string{"version": fmt.Sprintf("v%d", v)}) {
-					out = append(out, MakeInstance(service, port, v))
+					out = append(out, MakeInstance(service, port, v, ""))
 				}
 			}
 		}
@@ -257,7 +258,7 @@ func (sd *ServiceDiscovery) HostInstances(addrs map[string]bool) ([]*model.Servi
 			for v := 0; v < sd.versions; v++ {
 				if addrs[MakeIP(service, v)] {
 					for _, port := range service.Ports {
-						out = append(out, MakeInstance(service, port, v))
+						out = append(out, MakeInstance(service, port, v, "region/zone"))
 					}
 				}
 			}

--- a/pilot/test/mock/service.go
+++ b/pilot/test/mock/service.go
@@ -186,6 +186,7 @@ func MakeIP(service *model.Service, version int) string {
 type ServiceDiscovery struct {
 	services           map[string]*model.Service
 	versions           int
+	WantHostInstances  []*model.ServiceInstance
 	ServicesError      error
 	GetServiceError    error
 	InstancesError     error
@@ -252,13 +253,16 @@ func (sd *ServiceDiscovery) HostInstances(addrs map[string]bool) ([]*model.Servi
 	if sd.HostInstancesError != nil {
 		return nil, sd.HostInstancesError
 	}
+	if sd.WantHostInstances != nil {
+		return sd.WantHostInstances, nil
+	}
 	out := make([]*model.ServiceInstance, 0)
 	for _, service := range sd.services {
 		if !service.External() {
 			for v := 0; v < sd.versions; v++ {
 				if addrs[MakeIP(service, v)] {
 					for _, port := range service.Ports {
-						out = append(out, MakeInstance(service, port, v, "region/zone"))
+						out = append(out, MakeInstance(service, port, v, ""))
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**: A new API path for pilot, az. It is needed to allow proxy agent to set the availability zone of a proxy using the --availabilityZone flag

**Which issue this PR fixes**: 
Continues on from: https://github.com/istio/old_pilot_repo/pull/1230
Working towards: #1473 

**Special notes for your reviewer**: This is a quick and dirty PR to get feedback on the API path and general approach. The PR that allows Proxy Agent to consume this endpoint will come later.

**Release note**:
```
Add /v1/az/{ServiceCluster}/{ServiceNode} endpoint to pilot API for retrieving AZ for a given ServiceNode
```
