### PR TITLE
Add support for Mapkey caching

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -602,7 +602,7 @@
   branch = "master"
   name = "istio.io/api"
   packages = ["broker/v1/config","mixer/v1","mixer/v1/config/client","mixer/v1/config/descriptor","mixer/v1/template","proxy/v1/config"]
-  revision = "24661875c20416edbd4e79a7d22bbabb6c794896"
+  revision = "80e750910cd1a63367153b30e2a047973b68e5f0"
 
 [[projects]]
   branch = "master"

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -9,7 +9,8 @@ source $SCRIPTPATH/use_bazel_go.sh
 ROOTDIR=$SCRIPTPATH/..
 cd $ROOTDIR
 
-PKGS="."
+PKGS=${PKGS:-"."}
+
 GO_FILES=$(find ${PKGS} -type f -name '*.go' ! -name '*.gen.go' ! -name '*.pb.go' ! -name '*mock*.go')
 
 UX=$(uname)

--- a/mixer/cmd/client/cmd/check.go
+++ b/mixer/cmd/client/cmd/check.go
@@ -109,6 +109,7 @@ func check(rootArgs *rootArgs, printf, fatalf shared.FormatFn, quotas map[string
 			printf("Check RPC completed successfully. Check status was %s", decodeStatus(response.Precondition.Status))
 			printf("  Valid use count: %v, valid duration: %v", response.Precondition.ValidUseCount, response.Precondition.ValidDuration)
 			dumpAttributes(printf, fatalf, &response.Precondition.Attributes)
+			dumpReferencedAttributes(printf, fatalf, &response.Precondition.ReferencedAttributes)
 			dumpQuotas(printf, response.Quotas)
 		} else {
 			printf("Check RPC failed with: %s", decodeError(err))

--- a/mixer/cmd/client/cmd/util.go
+++ b/mixer/cmd/client/cmd/util.go
@@ -273,3 +273,30 @@ func dumpAttributes(printf, fatalf shared.FormatFn, attrs *mixerpb.CompressedAtt
 	_ = tw.Flush()
 	printf("%s", buf.String())
 }
+
+func dumpReferencedAttributes(printf, fatalf shared.FormatFn, attrs *mixerpb.ReferencedAttributes) {
+	vals := make([]string, 0, len(attrs.AttributeMatches))
+	for _, at := range attrs.AttributeMatches {
+		out := attrs.Words[-1*at.Name-1]
+		if at.MapKey != 0 {
+			out += "::" + attrs.Words[-1*at.MapKey-1]
+		}
+		out += " " + at.Condition.String()
+		vals = append(vals, out)
+	}
+
+	sort.Strings(vals)
+
+	buf := bytes.Buffer{}
+	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	fmt.Fprint(tw, "  Referenced Attributes\n")
+
+	for _, v := range vals {
+		fmt.Fprintf(tw, "  %s\n", v)
+	}
+
+	_ = tw.Flush()
+	printf("%s", buf.String())
+
+}

--- a/mixer/istio_api.bzl
+++ b/mixer/istio_api.bzl
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-ISTIO_API_SHA = "24661875c20416edbd4e79a7d22bbabb6c794896"
+ISTIO_API_SHA = "80e750910cd1a63367153b30e2a047973b68e5f0"
 
 def go_istio_api_repositories(use_local=False):
     if use_local:

--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -498,7 +498,7 @@ func compareAttributeValues(v1, v2 interface{}) (bool, error) {
 			}
 		}
 
-	case StringMap:  // compare entries
+	case StringMap:
 		return reflect.DeepEqual(t1.entries, v2), nil
 
 	case map[string]string:

--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -498,16 +498,11 @@ func compareAttributeValues(v1, v2 interface{}) (bool, error) {
 			}
 		}
 
+	case StringMap:  // compare entries
+		return reflect.DeepEqual(t1.entries, v2), nil
+
 	case map[string]string:
-		t2, ok := v2.(map[string]string)
-		if result = ok && len(t1) == len(t2); result {
-			for k, v := range t1 {
-				if v != t2[k] {
-					result = false
-					break
-				}
-			}
-		}
+		return reflect.DeepEqual(t1, v2), nil
 
 	default:
 		return false, fmt.Errorf("unsupported attribute value type: %T", v1)

--- a/mixer/pkg/attribute/protoBag.go
+++ b/mixer/pkg/attribute/protoBag.go
@@ -28,7 +28,7 @@ import (
 // TODO: consider implementing a pool of proto bags
 
 type attributeRef struct {
-	Name string
+	Name   string
 	MapKey string
 }
 
@@ -76,7 +76,7 @@ type StringMap struct {
 }
 
 // Get returns a stringmap value and records access
-func (s StringMap) Get(key string)  (string, bool){
+func (s StringMap) Get(key string) (string, bool) {
 	cond := mixerpb.ABSENCE
 	str, found := s.entries[key]
 
@@ -121,7 +121,7 @@ func (pb *ProtoBag) GetReferencedAttributes(globalDict map[string]int32, globalW
 	for k, v := range pb.referencedAttrs {
 		output.AttributeMatches[i] = mixerpb.ReferencedAttributes_AttributeMatch{
 			Name:      ds.assignDictIndex(k.Name),
-			MapKey: ds.assignDictIndex(k.MapKey),
+			MapKey:    ds.assignDictIndex(k.MapKey),
 			Condition: v,
 		}
 		i++
@@ -193,7 +193,7 @@ func (pb *ProtoBag) internalGet(name string, index int32) (interface{}, bool) {
 		pb.convertedStringMaps[index] = m
 		pb.stringMapMutex.Unlock()
 
-		return StringMap{name: name, entries:m, pb: pb}, true
+		return StringMap{name: name, entries: m, pb: pb}, true
 	}
 
 	value, ok = pb.proto.Int64S[index]

--- a/mixer/pkg/config/crd/BUILD
+++ b/mixer/pkg/config/crd/BUILD
@@ -42,8 +42,8 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//pilot/platform/kube/admit/testcerts:go_default_library", # for testing cert data
         "//mixer/pkg/config/store:go_default_library",
+        "//pilot/platform/kube/admit/testcerts:go_default_library",  # for testing cert data
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/mixer/pkg/il/compiler/compiler_test.go
+++ b/mixer/pkg/il/compiler/compiler_test.go
@@ -76,10 +76,10 @@ func TestCompile(t *testing.T) {
 			if input == nil {
 				input = map[string]interface{}{}
 			}
-			b := ilt.FakeBag{Attrs: input}
+			b := ilt.NewFakeBag(input)
 
 			i := interpreter.New(result.Program, runtime.Externs)
-			v, err := i.Eval("eval", &b)
+			v, err := i.Eval("eval", b)
 			if err != nil {
 				if test.Err != err.Error() {
 					tt.Fatalf("expected error not found: E:'%v', A:'%v'", test.Err, err)

--- a/mixer/pkg/il/evaluator/evaluator_test.go
+++ b/mixer/pkg/il/evaluator/evaluator_test.go
@@ -53,7 +53,7 @@ func testWithILEvaluator(test ilt.TestInfo, t *testing.T) {
 	}
 
 	evaluator := initEvaluator(t, *config)
-	bag := &ilt.FakeBag{Attrs: test.I}
+	bag := ilt.NewFakeBag(test.I)
 
 	r, err := evaluator.Eval(test.E, bag)
 	if test.Err != "" || test.CompileErr != "" {
@@ -160,11 +160,11 @@ func TestConcurrent(t *testing.T) {
 
 	for i := 0; i < maxNum; i++ {
 		v := randString(6)
-		bags = append(bags, &ilt.FakeBag{
-			Attrs: map[string]interface{}{
+		bags = append(bags, ilt.NewFakeBag(
+			map[string]interface{}{
 				"attr": v,
 			},
-		})
+		))
 	}
 
 	expression := fmt.Sprintf("attr == \"%s\"", randString(16))
@@ -349,7 +349,7 @@ func initBag(attrValue interface{}) attribute.Bag {
 	attrs := make(map[string]interface{})
 	attrs["attr"] = attrValue
 
-	return &ilt.FakeBag{Attrs: attrs}
+	return ilt.NewFakeBag(attrs)
 }
 
 func initEvaluator(t *testing.T, config pb.GlobalConfig) *IL {

--- a/mixer/pkg/il/interpreter/extern.go
+++ b/mixer/pkg/il/interpreter/extern.go
@@ -121,8 +121,14 @@ func ilType(t reflect.Type) il.Type {
 		case "Time":
 			return il.Interface
 		}
+	case reflect.Interface:
+		switch t.Name() {
+		case "StringMap":
+			return il.Interface
+		}
 	}
 
+	panic("Unmapped go type: "+t.Name()+" "+t.String()+" kind:"+t.Kind().String())
 	return il.Unknown
 }
 

--- a/mixer/pkg/il/interpreter/interpreterBenchmark_test.go
+++ b/mixer/pkg/il/interpreter/interpreterBenchmark_test.go
@@ -124,7 +124,7 @@ func BenchmarkIL(b *testing.B) {
 			b.Fatal("function not found: 'eval'")
 		}
 
-		bg := &ilt.FakeBag{Attrs: bt.attrs}
+		bg := ilt.NewFakeBag(bt.attrs)
 
 		in := New(p, map[string]Extern{})
 

--- a/mixer/pkg/il/interpreter/interpreterRun.go
+++ b/mixer/pkg/il/interpreter/interpreterRun.go
@@ -15,10 +15,6 @@ import (
 	"istio.io/istio/mixer/pkg/il"
 )
 
-type stringMap interface {
-	Get(key string) (value string, found bool)
-}
-
 func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Result, error) {
 
 	var registers [registerCount]uint32
@@ -908,7 +904,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if tFound {
 				t3 = strings.GetID(tStr)
 				opstack[sp] = t3
@@ -931,7 +927,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tErr = fmt.Errorf("member lookup failed: '%v'", strings.GetString(t1))
 				goto RETURN_ERR
@@ -952,7 +948,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}
@@ -973,7 +969,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tErr = fmt.Errorf("member lookup failed: '%v'", strings.GetString(t1))
 				goto RETURN_ERR
@@ -995,7 +991,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}

--- a/mixer/pkg/il/interpreter/interpreterRun.go
+++ b/mixer/pkg/il/interpreter/interpreterRun.go
@@ -15,6 +15,10 @@ import (
 	"istio.io/istio/mixer/pkg/il"
 )
 
+type stringMap interface {
+	Get(key string) (value string, found bool)
+}
+
 func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Result, error) {
 
 	var registers [registerCount]uint32
@@ -904,7 +908,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if tFound {
 				t3 = strings.GetID(tStr)
 				opstack[sp] = t3
@@ -927,7 +931,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tErr = fmt.Errorf("member lookup failed: '%v'", strings.GetString(t1))
 				goto RETURN_ERR
@@ -948,7 +952,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}
@@ -969,7 +973,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tErr = fmt.Errorf("member lookup failed: '%v'", strings.GetString(t1))
 				goto RETURN_ERR
@@ -991,7 +995,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				goto INVALID_HEAP_ACCESS
 			}
 			tVal = heap[t2]
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -24,6 +24,11 @@ import (
 	"istio.io/istio/mixer/pkg/il"
 )
 
+type stringMap interface {
+    // Get returns a stringmap value.
+    Get(key string) (value string, found bool)
+}
+
 #define ERR(...) tErr = errors.New(__VA_ARGS__); goto RETURN_ERR;
 #define ERRF(...) tErr = fmt.Errorf(__VA_ARGS__); goto RETURN_ERR;
 
@@ -700,7 +705,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).(tStr)
 			if tFound {
 				t3 = strings.GetID(tStr)
 				STACK_PUSH2(t3, 1)
@@ -713,7 +718,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -725,7 +730,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).(tStr)
 			if !tFound {
 				tStr = ""
 			}
@@ -738,7 +743,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -751,7 +756,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(map[string]string)[tStr]
+			tStr, tFound = tVal.(stringMap).(tStr)
 			if !tFound {
 				tStr = ""
 			}

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -24,11 +24,6 @@ import (
 	"istio.io/istio/mixer/pkg/il"
 )
 
-type stringMap interface {
-    // Get returns a stringmap value.
-    Get(key string) (value string, found bool)
-}
-
 #define ERR(...) tErr = errors.New(__VA_ARGS__); goto RETURN_ERR;
 #define ERRF(...) tErr = fmt.Errorf(__VA_ARGS__); goto RETURN_ERR;
 
@@ -705,7 +700,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if tFound {
 				t3 = strings.GetID(tStr)
 				STACK_PUSH2(t3, 1)
@@ -718,7 +713,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -730,7 +725,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}
@@ -743,7 +738,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -756,7 +751,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).Get(tStr)
+			tStr, tFound = tVal.(il.StringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -705,7 +705,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).(tStr)
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if tFound {
 				t3 = strings.GetID(tStr)
 				STACK_PUSH2(t3, 1)
@@ -718,7 +718,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).(tStr)
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -730,7 +730,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_POP2(t1, t2)
 			tStr = strings.GetString(t1)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).(tStr)
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}
@@ -743,7 +743,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).(tStr)
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
@@ -756,7 +756,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tStr = strings.GetString(t1)
 			STACK_POP(t2)
 			GET_HEAP_VALUE(t2, tVal)
-			tStr, tFound = tVal.(stringMap).(tStr)
+			tStr, tFound = tVal.(stringMap).Get(tStr)
 			if !tFound {
 				tStr = ""
 			}

--- a/mixer/pkg/il/interpreter/interpreter_test.go
+++ b/mixer/pkg/il/interpreter/interpreter_test.go
@@ -55,7 +55,7 @@ func TestInterpreter_EvalFnID(t *testing.T) {
 
 	i := New(p, map[string]Extern{})
 	fnID := p.Functions.IDOf("main")
-	r, e := i.EvalFnID(fnID, &ilt.FakeBag{})
+	r, e := i.EvalFnID(fnID, ilt.NewFakeBag(nil))
 
 	if e != nil {
 		t.Fatal(e)
@@ -74,7 +74,7 @@ func TestInterpreter_Eval_FunctionNotFound(t *testing.T) {
 	`)
 
 	i := New(p, map[string]Extern{})
-	_, e := i.Eval("foo", &ilt.FakeBag{})
+	_, e := i.Eval("foo", ilt.NewFakeBag(nil))
 	if e == nil {
 		t.Fatal("expected error during Eval()")
 	}
@@ -1681,8 +1681,8 @@ func TestInterpreter_Eval(t *testing.T) {
 		`,
 			expected: "c",
 			externs: map[string]Extern{
-				"ext": ExternFromFn("ext", func() map[string]string {
-					return map[string]string{"b": "c"}
+				"ext": ExternFromFn("ext", func() il.StringMap {
+					return ilt.NewStringMap("", map[string]string{"b": "c"})
 				}),
 			},
 		},
@@ -1837,8 +1837,9 @@ func TestInterpreter_Eval(t *testing.T) {
 				},
 			},
 			externs: map[string]Extern{
-				"ext": ExternFromFn("ext", func(r map[string]string) string {
-					return r["b"]
+				"ext": ExternFromFn("ext", func(r il.StringMap) string {
+					v, _ := r.Get("b")
+					return v
 				}),
 			},
 		},
@@ -2059,8 +2060,9 @@ end`,
 		}
 
 		test.code = code
+		name := n
 		t.Run(n, func(tt *testing.T) {
-			runTestCode(tt, test)
+			runTestCode(name, tt, test)
 		})
 	}
 }
@@ -2225,8 +2227,9 @@ end
 	for n, test := range tests {
 		test.code = fmt.Sprintf(template, test.code)
 		test.err = "stack underflow"
+		name := n
 		t.Run(n, func(tt *testing.T) {
-			runTestCode(tt, test)
+			runTestCode(name, tt, test)
 		})
 	}
 }
@@ -2247,7 +2250,7 @@ fn main() %s
 end`, ty),
 		}
 
-		t.Run("StackUnderflow_Ret_"+ty, func(tt *testing.T) { runTestCode(tt, tst) })
+		t.Run("StackUnderflow_Ret_"+ty, func(tt *testing.T) { runTestCode("StackUnderflow_Ret_"+ty, tt, tst) })
 	}
 }
 
@@ -2339,9 +2342,9 @@ end
 	for n, test := range tests {
 		test.err = "stack overflow"
 		test.code = fmt.Sprintf(template, test.code)
-
+		name := n
 		t.Run(n, func(tt *testing.T) {
-			runTestCode(tt, test)
+			runTestCode(name, tt, test)
 		})
 	}
 }
@@ -2378,13 +2381,14 @@ end
 				"b": "c",
 			},
 		}
+		name := n
 		t.Run(n, func(tt *testing.T) {
-			runTestCode(tt, test)
+			runTestCode(name, tt, test)
 		})
 	}
 }
 
-func runTestCode(t *testing.T, test test) {
+func runTestCode(name string, t *testing.T, test test) {
 	p := il.NewProgram()
 	err := text.MergeText(test.code, p)
 	if err != nil {
@@ -2396,7 +2400,7 @@ func runTestCode(t *testing.T, test test) {
 func runTestProgram(t *testing.T, p *il.Program, test test) {
 	s := NewStepper(p, test.externs)
 
-	bag := &ilt.FakeBag{Attrs: test.input}
+	bag := ilt.NewFakeBag(test.input)
 	for err := s.Begin("main", bag); !s.Done(); s.Step() {
 		if err != nil {
 			t.Fatal(s.Error())

--- a/mixer/pkg/il/testing/BUILD
+++ b/mixer/pkg/il/testing/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//mixer/pkg/attribute:go_default_library",
         "//mixer/pkg/config/proto:go_default_library",
         "//mixer/pkg/expr:go_default_library",
+        "//mixer/pkg/il:go_default_library",
         "@io_istio_api//mixer/v1/config/descriptor:descriptor",
     ],
 )

--- a/mixer/pkg/il/testing/fakebag.go
+++ b/mixer/pkg/il/testing/fakebag.go
@@ -14,28 +14,57 @@
 
 package ilt
 
-import "istio.io/istio/mixer/pkg/attribute"
+import (
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/il"
+)
 
-// FakeBag is a fake implementation of the Bag for testing purposes.
-type FakeBag struct {
+func NewFakeBag(attrs map[string]interface{}) attribute.Bag {
+	for k, v := range attrs {
+		if sm, ok := v.(map[string]string); ok {
+			attrs[k] = NewStringMap(k, sm)
+		}
+	}
+	return &fakeBag{Attrs: attrs}
+}
+
+// fakeBag is a fake implementation of the Bag for testing purposes.
+type fakeBag struct {
 	Attrs map[string]interface{}
 }
 
-var _ attribute.Bag = (*FakeBag)(nil)
+var _ attribute.Bag = (*fakeBag)(nil)
 
 // Get returns an attribute value.
-func (b *FakeBag) Get(name string) (interface{}, bool) {
+func (b *fakeBag) Get(name string) (interface{}, bool) {
 	c, found := b.Attrs[name]
 	return c, found
 }
 
 // Names return the names of all the attributes known to this bag.
-func (b *FakeBag) Names() []string {
+func (b *fakeBag) Names() []string {
 	return []string{}
 }
 
 // Done indicates the bag can be reclaimed.
-func (b *FakeBag) Done() {}
+func (b *fakeBag) Done() {}
 
 // DebugString is needed to implement the Bag interface.
-func (b *FakeBag) DebugString() string { return "" }
+func (b *fakeBag) DebugString() string { return "" }
+
+func NewStringMap(name string, entries map[string]string) il.StringMap {
+	return stringMap{Name: name, Entries: entries}
+}
+
+type stringMap struct {
+	// Name of the stringmap  -- request.headers
+	Name string
+	// Entries in the stringmap
+	Entries map[string]string
+}
+
+// Get returns a stringmap value and records access
+func (s stringMap) Get(key string) (string, bool) {
+	str, found := s.Entries[key]
+	return str, found
+}

--- a/mixer/pkg/il/types.go
+++ b/mixer/pkg/il/types.go
@@ -73,3 +73,8 @@ func GetType(name string) (Type, bool) {
 	t, f := typesByName[name]
 	return t, f
 }
+
+//
+type StringMap interface {
+	Get(key string) (value string, found bool)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Protobag reference counts StringMap separately.
2. IL uses StringMap interface to fetch subkeys instead of using map[string]string
3. mixc prints out referenced attributes in the output. 


**Release note**:

```release-note
Mixer protocol supports sub key level caching for stringmap attributes. This enables efficient caching based on request headers.
```
