### PR TITLE
Add a new log package.

### DIFF
--- a/mixer/pkg/log/BUILD
+++ b/mixer/pkg/log/BUILD
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "log.go",
+        "options.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_google_grpc//grpclog:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
+        "@org_uber_go_zap//zapgrpc:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = [
+        "log_test.go",
+        "options_test.go",
+    ],
+    library = ":go_default_library",
+)

--- a/mixer/pkg/log/log.go
+++ b/mixer/pkg/log/log.go
@@ -1,0 +1,277 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log provides the canonical logging functionality used by Go-based
+// Istio components.
+//
+// Istio's logging subsystem is built on top of the [Zap](https://godoc.org/go.uber.org/zap) package.
+// High performance scenarios should use the Error, Warn, Info, and Debug methods. Lower perf
+// scenarios can use the more expensive convenience methods such as Debugf and Warnw.
+//
+// The package provides direct integration with the Cobra command-line processor which makes it
+// easy to build programs that use a consistent interface for logging. Here's an example
+// of a simple Cobra-based program using this log package:
+//
+//		func main() {
+//			// get the default logging options
+//			options := log.NewOptions()
+//
+//			rootCmd := &cobra.Command{
+//				Run: func(cmd *cobra.Command, args []string) {
+//
+//					// configure the logging system
+//					if err := log.Configure(options); err != nil {
+//                      // print an error and quit
+//                  }
+//
+//					// output some logs
+//					log.Info("Hello")
+//					log.Sync()
+//				},
+//			}
+//
+//			// add logging-specific flags to the cobra command
+//			options.AttachCobraFlags(rootCmd)
+//			rootCmd.SetArgs(os.Args[1:])
+//			rootCmd.Execute()
+//		}
+//
+// Once configured, this package intercepts the output of the standard golang "log" package as well as anything
+// sent to the global zap logger (zap.L()).
+package log
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zapgrpc"
+	"google.golang.org/grpc/grpclog"
+)
+
+// Global variables against which all our logging occurs.
+var logger *zap.Logger = zap.NewNop()
+var sugar *zap.SugaredLogger = logger.Sugar()
+
+// Configure initializes Istio's logging subsystem.
+//
+// You typically call this once at process startup.
+// Once this call returns, the logging system is ready to accept data.
+func Configure(options *Options) error {
+	return configure(options, func(c *zap.Config) (*zap.Logger, error) { return c.Build() })
+}
+
+type builder func(c *zap.Config) (*zap.Logger, error)
+
+func configure(options *Options, b builder) error {
+	outputLevel, err := options.GetOutputLevel()
+	if err != nil {
+		return err
+	}
+
+	stackTraceLevel, err := options.GetStackTraceLevel()
+	if err != nil {
+		return err
+	}
+
+	if outputLevel == None {
+		// stick with the Nop default
+		logger = zap.NewNop()
+		sugar = logger.Sugar()
+		logger = zap.NewNop()
+		sugar = logger.Sugar()
+		return nil
+	}
+
+	zapConfig := zap.Config{
+		Level:       zap.NewAtomicLevelAt(outputLevel),
+		Development: false,
+
+		Sampling: &zap.SamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+
+		Encoding: "console",
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "time",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			CallerKey:      "caller",
+			MessageKey:     "msg",
+			StacktraceKey:  "stack",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+		},
+
+		OutputPaths:       options.OutputPaths,
+		ErrorOutputPaths:  []string{"stderr"},
+		DisableCaller:     !options.IncludeCallerSourceLocation,
+		DisableStacktrace: stackTraceLevel == None,
+	}
+
+	if options.JSONEncoding {
+		zapConfig.Encoding = "json"
+	}
+
+	l, err := b(&zapConfig)
+	if err != nil {
+		return err
+	}
+
+	logger = l.WithOptions(zap.AddCallerSkip(1), zap.AddStacktrace(stackTraceLevel))
+	sugar = logger.Sugar()
+
+	// capture global zap logging and force it through our logger
+	_ = zap.ReplaceGlobals(l)
+
+	// capture standard golang "log" package output and force it through our logger
+	_ = zap.RedirectStdLog(logger)
+
+	// capture gRPC logging
+	grpclog.SetLogger(zapgrpc.NewLogger(logger.WithOptions(zap.AddCallerSkip(2))))
+
+	return nil
+}
+
+// Debug outputs a message at debug level.
+// This call is a wrapper around [Logger.Debug](https://godoc.org/go.uber.org/zap#Logger.Debug)
+func Debug(msg string, fields ...zapcore.Field) {
+	logger.Debug(msg, fields...)
+}
+
+// Debuga uses fmt.Sprint to construct and log a message at debug level.
+// This call is a wrapper around [Sugaredlogger.Debug](https://godoc.org/go.uber.org/zap#Sugaredlogger.Debug)
+func Debuga(args ...interface{}) {
+	sugar.Debug(args...)
+}
+
+// Debugf uses fmt.Sprintf to construct and log a message at debug level.
+// This call is a wrapper around [Sugaredlogger.Debugf](https://godoc.org/go.uber.org/zap#Sugaredlogger.Debugf)
+func Debugf(template string, args ...interface{}) {
+	sugar.Debugf(template, args...)
+}
+
+// Debugw logs a message at debug level with some additional context.
+// This call is a wrapper around [Sugaredlogger.Debugw](https://godoc.org/go.uber.org/zap#Sugaredlogger.Debugw)
+func Debugw(msg string, keysAndValues ...interface{}) {
+	sugar.Debugw(msg, keysAndValues...)
+}
+
+// DebugEnabled returns whether output of messages at the debug level is currently enabled.
+func DebugEnabled() bool {
+	return logger.Core().Enabled(zap.DebugLevel)
+}
+
+// Error outputs a message at error level.
+// This call is a wrapper around [logger.Error](https://godoc.org/go.uber.org/zap#logger.Error)
+func Error(msg string, fields ...zapcore.Field) {
+	logger.Error(msg, fields...)
+}
+
+// Errora uses fmt.Sprint to construct and log a message at error level.
+// This call is a wrapper around [Sugaredlogger.Error](https://godoc.org/go.uber.org/zap#Sugaredlogger.Error)
+func Errora(args ...interface{}) {
+	sugar.Error(args...)
+}
+
+// Errorf uses fmt.Sprintf to construct and log a message at error level.
+// This call is a wrapper around [Sugaredlogger.Errorf](https://godoc.org/go.uber.org/zap#Sugaredlogger.Errorf)
+func Errorf(template string, args ...interface{}) {
+	sugar.Errorf(template, args...)
+}
+
+// Errorw logs a message at error level with some additional context.
+// This call is a wrapper around [Sugaredlogger.Errorw](https://godoc.org/go.uber.org/zap#Sugaredlogger.Errorw)
+func Errorw(msg string, keysAndValues ...interface{}) {
+	sugar.Errorw(msg, keysAndValues...)
+}
+
+// ErrorEnabled returns whether output of messages at the error level is currently enabled.
+func ErrorEnabled() bool {
+	return logger.Core().Enabled(zap.ErrorLevel)
+}
+
+// Warn outputs a message at warn level.
+// This call is a wrapper around [logger.Warn](https://godoc.org/go.uber.org/zap#logger.Warn)
+func Warn(msg string, fields ...zapcore.Field) {
+	logger.Warn(msg, fields...)
+}
+
+// Warna uses fmt.Sprint to construct and log a message at warn level.
+// This call is a wrapper around [Sugaredlogger.Warn](https://godoc.org/go.uber.org/zap#Sugaredlogger.Warn)
+func Warna(args ...interface{}) {
+	sugar.Warn(args...)
+}
+
+// Warnf uses fmt.Sprintf to construct and log a message at warn level.
+// This call is a wrapper around [Sugaredlogger.Warnf](https://godoc.org/go.uber.org/zap#Sugaredlogger.Warnf)
+func Warnf(template string, args ...interface{}) {
+	sugar.Warnf(template, args...)
+}
+
+// Warnw logs a message at warn level with some additional context.
+// This call is a wrapper around [Sugaredlogger.Warnw](https://godoc.org/go.uber.org/zap#Sugaredlogger.Warnw)
+func Warnw(msg string, keysAndValues ...interface{}) {
+	sugar.Warnw(msg, keysAndValues...)
+}
+
+// WarnEnabled returns whether output of messages at the warn level is currently enabled.
+func WarnEnabled() bool {
+	return logger.Core().Enabled(zap.WarnLevel)
+}
+
+// Info outputs a message at information level.
+// This call is a wrapper around [logger.Info](https://godoc.org/go.uber.org/zap#logger.Info)
+func Info(msg string, fields ...zapcore.Field) {
+	logger.Info(msg, fields...)
+}
+
+// Infoa uses fmt.Sprint to construct and log a message at info level.
+// This call is a wrapper around [Sugaredlogger.Info](https://godoc.org/go.uber.org/zap#Sugaredlogger.Info)
+func Infoa(args ...interface{}) {
+	sugar.Info(args...)
+}
+
+// Infof uses fmt.Sprintf to construct and log a message at info level.
+// This call is a wrapper around [Sugaredlogger.Infof](https://godoc.org/go.uber.org/zap#Sugaredlogger.Infof)
+func Infof(template string, args ...interface{}) {
+	sugar.Infof(template, args...)
+}
+
+// Infow logs a message at info level with some additional context.
+// This call is a wrapper around [Sugaredlogger.Infow](https://godoc.org/go.uber.org/zap#Sugaredlogger.Infow)
+func Infow(msg string, keysAndValues ...interface{}) {
+	sugar.Infow(msg, keysAndValues...)
+}
+
+// InfoEnabled returns whether output of messages at the info level is currently enabled.
+func InfoEnabled() bool {
+	return logger.Core().Enabled(zap.InfoLevel)
+}
+
+// With creates a child logger and adds structured context to it. Fields added
+// to the child don't affect the parent, and vice versa.
+// This call is a wrapper around [logger.With](https://godoc.org/go.uber.org/zap#logger.With)
+func With(fields ...zapcore.Field) *zap.Logger {
+	return logger.With(fields...)
+}
+
+// Sync flushes any buffered log entries.
+// Processes should normally take care to call Sync before exiting.
+// This call is a wrapper around [logger.Sync](https://godoc.org/go.uber.org/zap#logger.Sync)
+func Sync() {
+	logger.Sync()
+}

--- a/mixer/pkg/log/log_test.go
+++ b/mixer/pkg/log/log_test.go
@@ -1,0 +1,233 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc/grpclog"
+)
+
+func TestBasic(t *testing.T) {
+	cases := []struct {
+		f          func()
+		pat        string
+		json       bool
+		caller     bool
+		stackLevel zapcore.Level
+	}{
+		{func() { Debug("Hello") }, ".*Z\tdebug\tHello", false, false, None},
+		{func() { Debugf("Hello") }, ".*Z\tdebug\tHello", false, false, None},
+		{func() { Debugw("Hello") }, ".*Z\tdebug\tHello", false, false, None},
+		{func() { Debuga("Hello") }, ".*Z\tdebug\tHello", false, false, None},
+
+		{func() { Info("Hello") }, ".*Z\tinfo\tHello", false, false, None},
+		{func() { Infof("Hello") }, ".*Z\tinfo\tHello", false, false, None},
+		{func() { Infow("Hello") }, ".*Z\tinfo\tHello", false, false, None},
+		{func() { Infoa("Hello") }, ".*Z\tinfo\tHello", false, false, None},
+
+		{func() { Warn("Hello") }, ".*Z\twarn\tHello", false, false, None},
+		{func() { Warnf("Hello") }, ".*Z\twarn\tHello", false, false, None},
+		{func() { Warnw("Hello") }, ".*Z\twarn\tHello", false, false, None},
+		{func() { Warna("Hello") }, ".*Z\twarn\tHello", false, false, None},
+
+		{func() { Error("Hello") }, ".*Z\terror\tHello", false, false, None},
+		{func() { Errorf("Hello") }, ".*Z\terror\tHello", false, false, None},
+		{func() { Errorw("Hello") }, ".*Z\terror\tHello", false, false, None},
+		{func() { Errora("Hello") }, ".*Z\terror\tHello", false, false, None},
+
+		{func() {
+			l := With(zap.String("key", "value"))
+			l.Debug("Hello")
+		}, ".*Z\tdebug\tHello\t{\"key\": \"value\"}", false, false, None},
+
+		{func() { Debug("Hello") }, ".*Z\tdebug\tlog/log_test.go:.*\tHello", false, true, None},
+
+		{func() { Debug("Hello") }, "{\"level\":\"debug\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+			true, true, zapcore.DebugLevel},
+		{func() { Info("Hello") }, "{\"level\":\"info\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+			true, true, zapcore.DebugLevel},
+		{func() { Warn("Hello") }, "{\"level\":\"warn\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+			true, true, zapcore.DebugLevel},
+		{func() { Error("Hello") }, "{\"level\":\"error\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+			true, true, zapcore.DebugLevel},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			lines, err := captureStdout(func() {
+				o := NewOptions()
+
+				o.JSONEncoding = c.json
+				o.IncludeCallerSourceLocation = c.caller
+
+				_ = o.SetOutputLevel(zapcore.DebugLevel)
+				_ = o.SetStackTraceLevel(c.stackLevel)
+				if err := Configure(o); err != nil {
+					t.Errorf("Got err '%v', expecting success", err)
+				}
+
+				c.f()
+				Sync()
+			})
+
+			if err != nil {
+				t.Errorf("Got error '%v', expected success", err)
+			}
+
+			if match, _ := regexp.MatchString(c.pat, lines[0]); !match {
+				t.Errorf("Got '%v', expected a match with '%v'", lines[0], c.pat)
+			}
+		})
+	}
+
+	// sadly, only testing whether we crash or not...
+	l := With(zap.String("Key", "Value"))
+	l.Debug("Hello")
+	l.Sync()
+}
+
+func TestEnabled(t *testing.T) {
+	cases := []struct {
+		level        zapcore.Level
+		debugEnabled bool
+		infoEnabled  bool
+		warnEnabled  bool
+		errorEnabled bool
+	}{
+		{zapcore.DebugLevel, true, true, true, true},
+		{zapcore.InfoLevel, false, true, true, true},
+		{zapcore.WarnLevel, false, false, true, true},
+		{zapcore.ErrorLevel, false, false, false, true},
+		{None, false, false, false, false},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			o := NewOptions()
+			_ = o.SetOutputLevel(c.level)
+			_ = Configure(o)
+
+			if c.debugEnabled != DebugEnabled() {
+				t.Errorf("Got %v, expecting %v", DebugEnabled(), c.debugEnabled)
+			}
+
+			if c.infoEnabled != InfoEnabled() {
+				t.Errorf("Got %v, expecting %v", InfoEnabled(), c.infoEnabled)
+			}
+
+			if c.warnEnabled != WarnEnabled() {
+				t.Errorf("Got %v, expecting %v", WarnEnabled(), c.warnEnabled)
+			}
+
+			if c.errorEnabled != ErrorEnabled() {
+				t.Errorf("Got %v, expecting %v", ErrorEnabled(), c.errorEnabled)
+			}
+		})
+	}
+}
+
+func TestOddballs(t *testing.T) {
+	o := NewOptions()
+	_ = Configure(o)
+
+	o = NewOptions()
+	o.outputLevel = "foobar"
+	err := Configure(o)
+	if err == nil {
+		t.Errorf("Got success, expected failure")
+	}
+
+	o = NewOptions()
+	o.stackTraceLevel = "foobar"
+	err = Configure(o)
+	if err == nil {
+		t.Errorf("Got success, expected failure")
+	}
+
+	o = NewOptions()
+	err = configure(o, func(c *zap.Config) (*zap.Logger, error) { return nil, errors.New("BAD") })
+	if err == nil {
+		t.Errorf("Got success, expecting error")
+	}
+}
+
+func TestCapture(t *testing.T) {
+	lines, _ := captureStdout(func() {
+		o := NewOptions()
+		o.IncludeCallerSourceLocation = true
+		_ = Configure(o)
+
+		// output to the plain golang "log" package
+		log.Println("Hello")
+
+		// output to the gRPC logging package
+		grpclog.Info("There")
+
+		// output directly to zap
+		zap.L().Info("Goodbye")
+	})
+
+	patterns := []string{
+		".*Z\tinfo\tlog/log_test.go:.*\tHello",
+		".*Z\tinfo\tlog/log_test.go:.*\tThere",
+		".*Z\tinfo\tlog/log_test.go:.*\tGoodbye",
+	}
+
+	for i, pat := range patterns {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			match, _ := regexp.MatchString(pat, lines[i])
+			if !match {
+				t.Errorf("Got '%s', expecting to match '%s'", lines[i], pat)
+			}
+		})
+	}
+}
+
+// Runs the given function while capturing everything sent to stdout
+func captureStdout(f func()) ([]string, error) {
+	tf, err := ioutil.TempFile("", "log_test")
+	if err != nil {
+		return nil, err
+	}
+
+	old := os.Stdout
+	os.Stdout = tf
+
+	f()
+
+	os.Stdout = old
+	path := tf.Name()
+	tf.Sync()
+	tf.Close()
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = os.Remove(path)
+
+	return strings.Split(string(content), "\n"), nil
+}

--- a/mixer/pkg/log/options.go
+++ b/mixer/pkg/log/options.go
@@ -1,0 +1,141 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	// None is used to disable logging output as well as to disable stack tracing.
+	None zapcore.Level = 100
+)
+
+// Options defines the set of options supported by Istio's component logging package.
+type Options struct {
+	// OutputPaths is a list of file system paths to write the log data to.
+	// The special values stdout and stderr can be used to output to the
+	// standard I/O streams.
+	OutputPaths []string
+
+	// JSONEncoding controls whether the log is formatted as JSON.
+	JSONEncoding bool
+
+	// IncludeCallerSourceLocation determines whether log messages include the source location of the caller.
+	IncludeCallerSourceLocation bool
+
+	stackTraceLevel string
+	outputLevel     string
+}
+
+var levelToString = map[zapcore.Level]string{
+	zapcore.DebugLevel: "debug",
+	zapcore.InfoLevel:  "info",
+	zapcore.WarnLevel:  "warn",
+	zapcore.ErrorLevel: "error",
+	None:               "none",
+}
+
+var stringToLevel = map[string]zapcore.Level{
+	"debug": zapcore.DebugLevel,
+	"info":  zapcore.InfoLevel,
+	"warn":  zapcore.WarnLevel,
+	"error": zapcore.ErrorLevel,
+	"none":  None,
+}
+
+// NewOptions returns a new set of options, initialized to the defaults
+func NewOptions() *Options {
+	return &Options{
+		OutputPaths:     []string{"stdout"},
+		outputLevel:     "info",
+		stackTraceLevel: "none",
+	}
+}
+
+// SetOutputLevel sets the minimum log output level.
+//
+// The level can be one of zapcore.DebugLevel, zapcore.InfoLevel,
+// zapcore.WarnLevel, zapcore.ErrorLevel, or None. The default is
+// zapcore.InfoLevel.
+func (o *Options) SetOutputLevel(level zapcore.Level) error {
+	s, ok := levelToString[level]
+	if !ok {
+		return fmt.Errorf("unknown output level: %v", level)
+	}
+
+	o.outputLevel = s
+	return nil
+}
+
+// GetOutputLevel returns the minimum log output level.
+func (o *Options) GetOutputLevel() (zapcore.Level, error) {
+	l, ok := stringToLevel[o.outputLevel]
+	if !ok {
+		return 0, fmt.Errorf("unknown output level: %s", o.outputLevel)
+	}
+
+	return l, nil
+}
+
+// SetStackTraceLevel sets the minimum stack trace capture level.
+//
+// The level can be one of zapcore.DebugLevel, zapcore.InfoLevel,
+// zapcore.WarnLevel, zapcore.ErrorLevel, or None. The default is
+// None.
+func (o *Options) SetStackTraceLevel(level zapcore.Level) error {
+	s, ok := levelToString[level]
+	if !ok {
+		return fmt.Errorf("unknown stack trace level: %v", level)
+	}
+
+	o.stackTraceLevel = s
+	return nil
+}
+
+// GetStackTraceLevel returns the current stack trace level.
+func (o *Options) GetStackTraceLevel() (zapcore.Level, error) {
+	l, ok := stringToLevel[o.stackTraceLevel]
+	if !ok {
+		return 0, fmt.Errorf("unknown stack trace level: %s", o.stackTraceLevel)
+	}
+
+	return l, nil
+}
+
+// AttachCobraFlags attaches a set of Cobra flags to the given Cobra command.
+//
+// Cobra is the command-line processor that Istio uses. This command attaches
+// the necessary set of flags to expose a CLI to let the user control all
+// logging options.
+func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringArrayVar(&o.OutputPaths, "log_target", o.OutputPaths,
+		"The set of paths where to output the log. This can be any path as well as the special values stdout and stderr")
+
+	cmd.PersistentFlags().BoolVar(&o.JSONEncoding, "log_as_json", o.JSONEncoding,
+		"Whether to format output as JSON or in plain console-friendly format")
+
+	cmd.PersistentFlags().StringVar(&o.outputLevel, "log_output_level", o.outputLevel,
+		"The minimum logging level of messages to output, can be one of debug, info, warning, error, or none")
+
+	cmd.PersistentFlags().BoolVar(&o.IncludeCallerSourceLocation, "log_callers", o.IncludeCallerSourceLocation,
+		"Include caller information, useful for debugging")
+
+	cmd.PersistentFlags().StringVar(&o.stackTraceLevel, "log_stacktrace_level", o.stackTraceLevel,
+		"The minimum logging level at which stack traces are captured, can be one of debug, info, warning, error, or none")
+}

--- a/mixer/pkg/log/options_test.go
+++ b/mixer/pkg/log/options_test.go
@@ -1,0 +1,228 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestOpts(t *testing.T) {
+	cases := []struct {
+		cmdLine string
+		result  Options
+	}{
+		{"--log_as_json", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                true,
+		}},
+
+		{"--log_target stdout --log_target stderr", Options{
+			OutputPaths:                 []string{"stdout", "stderr"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_callers", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: true,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_stacktrace_level debug", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "debug",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_stacktrace_level info", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "info",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_stacktrace_level warn", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "warn",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_stacktrace_level error", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "error",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_stacktrace_level none", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_output_level debug", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "debug",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_output_level info", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "info",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_output_level warn", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "warn",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_output_level error", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "error",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+
+		{"--log_output_level none", Options{
+			OutputPaths:                 []string{"stdout"},
+			outputLevel:                 "none",
+			stackTraceLevel:             "none",
+			IncludeCallerSourceLocation: false,
+			JSONEncoding:                false,
+		}},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			o := NewOptions()
+			cmd := &cobra.Command{}
+			o.AttachCobraFlags(cmd)
+			cmd.SetArgs(strings.Split(c.cmdLine, " "))
+
+			if err := cmd.Execute(); err != nil {
+				t.Errorf("Got %v, expecting success", err)
+			}
+
+			if !reflect.DeepEqual(c.result, *o) {
+				t.Errorf("Got %v, expected %v", *o, c.result)
+			}
+		})
+	}
+}
+
+func TestLevel(t *testing.T) {
+	cases := []struct {
+		inputLevel  zapcore.Level
+		outputLevel zapcore.Level
+		fail        bool
+	}{
+		{zapcore.DebugLevel, zapcore.DebugLevel, false},
+		{zapcore.InfoLevel, zapcore.InfoLevel, false},
+		{zapcore.WarnLevel, zapcore.WarnLevel, false},
+		{zapcore.ErrorLevel, zapcore.ErrorLevel, false},
+		{None, None, false},
+	}
+
+	for i, c := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			o := NewOptions()
+
+			err := o.SetOutputLevel(c.inputLevel)
+			if c.fail && err == nil {
+				t.Errorf("Got success, expecting failure")
+			} else if !c.fail && err != nil {
+				t.Errorf("Got failure '%v', expecting success", err)
+			}
+
+			var l zapcore.Level
+			l, err = o.GetOutputLevel()
+			if err != nil {
+				t.Errorf("Got failure %v, expecting success", err)
+			}
+
+			if c.outputLevel != l {
+				t.Errorf("Got %v, expecting %v", l, c.outputLevel)
+			}
+
+			err = o.SetStackTraceLevel(c.inputLevel)
+			if c.fail && err == nil {
+				t.Errorf("Got success, expecting failure")
+			} else if !c.fail && err != nil {
+				t.Errorf("Got failure '%v', expecting success", err)
+			}
+
+			l, err = o.GetStackTraceLevel()
+			if err != nil {
+				t.Errorf("Got failure %v, expecting success", err)
+			}
+
+			if c.outputLevel != l {
+				t.Errorf("Got %v, expecting %v", l, c.outputLevel)
+			}
+		})
+	}
+
+	o := NewOptions()
+	o.outputLevel = "foobar"
+	_, err := o.GetOutputLevel()
+	if err == nil {
+		t.Errorf("Got nil, expecting error")
+	}
+
+	if err = o.SetOutputLevel(127); err == nil {
+		t.Errorf("Got success, expecting error")
+	}
+
+	o = NewOptions()
+	o.stackTraceLevel = "foobar"
+	_, err = o.GetStackTraceLevel()
+	if err == nil {
+		t.Errorf("Got nil, expecting error")
+	}
+
+	if err = o.SetStackTraceLevel(127); err == nil {
+		t.Errorf("Got success, expecting error")
+	}
+}


### PR DESCRIPTION
This is preliminary PR to present a new logging package intended to be
used by all Go components in Istio. This is being introduced in the Mixer
first, I'll make this project-wide as a separate step. This is intended to completely
replace glog within Istio.

This PR contains no tests as I wanted to validate the approach first. I won't submit this
PR until I have 100% test coverage.

This log package is a wrapper around the zap logger. It exposes a radically simplified API
relative to zap which is intended to ensure maximum consistency across Istio. As we discover use cases, we can extend the API bit by bit to expose more of zap's underlying functionality.

Comments appreciated.