### PR TITLE
Make linking the kubeconfig idempotent.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ artifacts: docker
 	@echo 'To be added'
 
 pilot/platform/kube/config:
-	ln -s ~/.kube/config pilot/platform/kube/
+	ln -fs ~/.kube/config pilot/platform/kube/
 
 .PHONY: artifacts build checkvars clean docker test setup push
 


### PR DESCRIPTION
Previously there were situations where we needed to manually unlink the config, e.g., after build errors.

```release-note
NONE
```