### PR TITLE
POC change to support multiple k8s clusters in a service mesh

### DIFF
--- a/pilot/adapter/serviceregistry/aggregate/controller.go
+++ b/pilot/adapter/serviceregistry/aggregate/controller.go
@@ -28,6 +28,19 @@ type Registry struct {
 	model.Controller
 	model.ServiceDiscovery
 	model.ServiceAccounts
+	local bool
+}
+
+// NewRegistry creates a new service registry
+func NewRegistry(regName platform.ServiceRegistry, ctl model.Controller,
+	sd model.ServiceDiscovery, sa model.ServiceAccounts, isLocal bool) Registry {
+	return Registry{
+		Name:             regName,
+		Controller:       ctl,
+		ServiceDiscovery: sd,
+		ServiceAccounts:  sa,
+		local:            isLocal,
+	}
 }
 
 // Controller aggregates data across different registries and monitors for changes
@@ -91,22 +104,66 @@ func (c *Controller) ManagementPorts(addr string) model.PortList {
 	return nil
 }
 
+// NodeIP service
+func (c *Controller) NodeIP(podIP string) string {
+	return ""
+}
+
 // Instances retrieves instances for a service and its ports that match
 // any of the supplied labels. All instances match an empty label list.
 func (c *Controller) Instances(hostname string, ports []string,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {
-	var instances []*model.ServiceInstance
+	instances := make([]*model.ServiceInstance, 0)
 	var errs error
 	for _, r := range c.registries {
 		var err error
-		instances, err = r.Instances(hostname, ports, labels)
+		tmp, err := r.Instances(hostname, ports, labels)
 		if err != nil {
 			errs = multierror.Append(errs, err)
-		} else if len(instances) > 0 {
+		} else if len(tmp) <= 0 {
 			if errs != nil {
 				glog.Warningf("Instances() found match but encountered an error: %v", errs)
 			}
-			return instances, nil
+		} else {
+			// For the purpose of POC:
+			// local cluster: the cluster where this pilot instance is running
+			// other clusters: clusters that are going to join the mesh under this pilot's control.
+			//
+			// The following code adopts the following policy when adding instances from other clusters:
+			//    -- it's from the default namespace
+			//    -- if it has a service type of either LoadBalancer or NodePort, use the NodeIP as endpoint ip
+			//       otherwise, use the podIP as is
+			//
+			// As a result, endpoints that reside in other clusters are added into the service mesh under
+			// this pilot's control.
+
+			// A real implementation would maintain services/endpoints caches for each of
+			// the clusters under this pilot's control. Mesh creation would then follow the mesh policies
+			// established by the mesh admin.
+			//
+			// Note that other clusters can have their own pilot instance running as well if so desired.
+			//
+			// It's possible to have pilot running on its own registry/cluster, thus independent from
+			// all the service clusters. And all the service clusters will be treated by pilot in the same
+			// manner. There will be no local vs other clusters. Service mesh will be created based on mesh
+			// policies created by the mesh admin.
+			if !r.local {
+				for _, inst := range tmp {
+					if inst.Service.Namespace == "default" {
+						if inst.Service.Type == "LoadBalancer" || inst.Service.Type == "NodePort" {
+							inst.Endpoint.Address = r.NodeIP(inst.Endpoint.Address)
+							inst.Endpoint.Port = inst.Endpoint.ServicePort.NodePort
+							inst.Endpoint.ServicePort.Port = inst.Endpoint.ServicePort.NodePort
+							for _, port := range inst.Service.Ports {
+								port.Port = port.NodePort
+							}
+						}
+						instances = append(instances, inst)
+					}
+				}
+			} else {
+				instances = append(instances, tmp...)
+			}
 		}
 	}
 	return instances, errs
@@ -151,7 +208,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 	for _, r := range c.registries {
 		if err := r.AppendServiceHandler(f); err != nil {
 			glog.V(2).Infof("Fail to append service handler to adapter %s", r.Name)
-			return err
+			// return err
 		}
 	}
 	return nil
@@ -162,7 +219,7 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 	for _, r := range c.registries {
 		if err := r.AppendInstanceHandler(f); err != nil {
 			glog.V(2).Infof("Fail to append instance handler to adapter %s", r.Name)
-			return err
+			// return err
 		}
 	}
 	return nil

--- a/pilot/cmd/pilot-discovery/BUILD
+++ b/pilot/cmd/pilot-discovery/BUILD
@@ -26,6 +26,7 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@io_istio_api//:proxy/v1/config",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
     ],
 )
 

--- a/pilot/model/service.go
+++ b/pilot/model/service.go
@@ -55,6 +55,9 @@ type Service struct {
 	// external service instances as a service inside the cluster.
 	ExternalName string `json:"external"`
 
+	// ExternalIPs
+	ExternalIPs []string `json:"addresses,omitempty"`
+
 	// ServiceAccounts specifies the service accounts that run the service.
 	ServiceAccounts []string `json:"serviceaccounts,omitempty"`
 
@@ -74,6 +77,9 @@ type Port struct {
 	// map to the corresponding port numbers for the instances behind the
 	// service. See NetworkEndpoint definition below.
 	Port int `json:"port"`
+
+	// NodePort
+	NodePort int `json:"port"`
 
 	// Protocol to be used for the port.
 	Protocol Protocol `json:"protocol,omitempty"`
@@ -234,6 +240,9 @@ type ServiceDiscovery interface {
 
 	// HostInstances lists service instances for a given set of IPv4 addresses.
 	HostInstances(addrs map[string]bool) ([]*ServiceInstance, error)
+
+	// NodeIP lists node ips in a given cluster
+	NodeIP(podIP string) string
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.
 	// These management ports are typically used by the platform for out of band management

--- a/pilot/platform/eureka/servicediscovery.go
+++ b/pilot/platform/eureka/servicediscovery.go
@@ -31,6 +31,11 @@ type serviceDiscovery struct {
 	client Client
 }
 
+// NodeIP return node IPs in a given cluster
+func (sd *serviceDiscovery) NodeIP(podIP string) string {
+	return ""
+}
+
 // Services implements a service catalog operation
 func (sd *serviceDiscovery) Services() ([]*model.Service, error) {
 	apps, err := sd.client.Applications()

--- a/pilot/platform/kube/conversion.go
+++ b/pilot/platform/kube/conversion.go
@@ -78,6 +78,7 @@ func convertPort(port v1.ServicePort, obj meta_v1.ObjectMeta) *model.Port {
 	return &model.Port{
 		Name:                 port.Name,
 		Port:                 int(port.Port),
+		NodePort:             int(port.NodePort),
 		Protocol:             ConvertProtocol(port.Name, port.Protocol),
 		AuthenticationPolicy: extractAuthenticationPolicy(port, obj),
 	}
@@ -91,6 +92,12 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 
 	if svc.Spec.Type == v1.ServiceTypeExternalName && svc.Spec.ExternalName != "" {
 		external = svc.Spec.ExternalName
+	}
+
+	var extIPs []string
+	if len(svc.Spec.ExternalIPs) > 0 {
+		extIPs = make([]string, len(svc.Spec.ExternalIPs))
+		copy(extIPs, svc.Spec.ExternalIPs)
 	}
 
 	ports := make([]*model.Port, 0, len(svc.Spec.Ports))
@@ -116,10 +123,14 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 	sort.Sort(sort.StringSlice(serviceaccounts))
 
 	return &model.Service{
+		Name:                  svc.ObjectMeta.Name,
+		Namespace:             svc.ObjectMeta.Namespace,
+		Type:                  string(svc.Spec.Type),
 		Hostname:              serviceHostname(svc.Name, svc.Namespace, domainSuffix),
 		Ports:                 ports,
 		Address:               addr,
 		ExternalName:          external,
+		ExternalIPs:           extIPs,
 		ServiceAccounts:       serviceaccounts,
 		LoadBalancingDisabled: loadBalancingDisabled,
 	}

--- a/pilot/test/mock/service.go
+++ b/pilot/test/mock/service.go
@@ -212,6 +212,11 @@ func (sd *ServiceDiscovery) GetService(hostname string) (*model.Service, error) 
 	return val, sd.GetServiceError
 }
 
+// NodeIP implements discovery interface
+func (sd *ServiceDiscovery) NodeIP(podIP string) string {
+	return ""
+}
+
 // Instances implements discovery interface
 func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a POC (and therefore not for merge) to demonstrate the support of multiple k8s clusters in a service mesh.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I've added comments in the code where the change is made to explain the basic ideas involved in this POC.

The original POC was made to work based on the the old repo structure (0.2.9). The current change in this PR is a port to the new repo and I haven't had time to compile and test it yet. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```