### PR TITLE
Update mockapi package name to match new home

### DIFF
--- a/mixer/pkg/mockapi/handler.go
+++ b/mixer/pkg/mockapi/handler.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package mockapi
 
 import (
 	"time"

--- a/mixer/pkg/mockapi/server.go
+++ b/mixer/pkg/mockapi/server.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package test supplies a fake Mixer server for use in testing. It should NOT
+// Package mockapi supplies a fake Mixer server for use in testing. It should NOT
 // be used outside of testing contexts.
-package test // import "istio.io/istio/mixer/test"
+package mockapi // import "istio.io/istio/mixer/pkg/mockapi"
 
 import (
 	"errors"

--- a/mixer/pkg/mockapi/server_test.go
+++ b/mixer/pkg/mockapi/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package mockapi
 
 import (
 	"fmt"


### PR DESCRIPTION
**What this PR does / why we need it**:
The `mockapi` package was created by moving files. During that move, the package statements at the top of the files were not updated to match. This PR fixes that issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note-none
```