### PR TITLE
Fix linter errors.

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -28,7 +28,6 @@
     "exclude": [
         "vendor",
         "mixer/adapter/svcctrl",
-        "^security",
         ".pb.go",
         "mixer/pkg/config/proto/combined.go",
         ".*.gen.go",

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -168,12 +168,12 @@ func createCA(core corev1.SecretsGetter) ca.CertificateAuthority {
 		glog.Info("Use self-signed certificate as the CA certificate")
 
 		// TODO(wattli): Refactor this and combine it with NewIstioCA().
-		ca, err := ca.NewSelfSignedIstioCA(opts.caCertTTL, opts.certTTL, opts.selfSignedCAOrg,
+		istioCA, err := ca.NewSelfSignedIstioCA(opts.caCertTTL, opts.certTTL, opts.selfSignedCAOrg,
 			opts.istioCaStorageNamespace, core)
 		if err != nil {
 			glog.Fatalf("Failed to create a self-signed Istio CA (error: %v)", err)
 		}
-		return ca
+		return istioCA
 	}
 
 	var certChainBytes []byte
@@ -188,11 +188,11 @@ func createCA(core corev1.SecretsGetter) ca.CertificateAuthority {
 		RootCertBytes:    readFile(opts.rootCertFile),
 	}
 
-	ca, err := ca.NewIstioCA(caOpts)
+	istioCA, err := ca.NewIstioCA(caOpts)
 	if err != nil {
 		glog.Errorf("Failed to create an Istio CA (error: %v)", err)
 	}
-	return ca
+	return istioCA
 }
 
 func generateConfig() *rest.Config {

--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -32,7 +32,7 @@ type NodeAgent interface {
 // NewNodeAgent is constructor for Node agent based on the provided Environment variable.
 func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 	if cfg == nil {
-		return nil, fmt.Errorf("Nil configuration passed")
+		return nil, fmt.Errorf("nil configuration passed")
 	}
 	na := &nodeAgentInternal{
 		config:   cfg,

--- a/security/cmd/node_agent/na/nafactory_test.go
+++ b/security/cmd/node_agent/na/nafactory_test.go
@@ -26,7 +26,7 @@ func TestNewNodeAgent(t *testing.T) {
 	}{
 		"null config test": {
 			config:      nil,
-			expectedErr: "Nil configuration passed",
+			expectedErr: "nil configuration passed",
 		},
 		"onprem env test": {
 			config: &Config{

--- a/security/cmd/node_agent/na/nodeagent.go
+++ b/security/cmd/node_agent/na/nodeagent.go
@@ -49,7 +49,7 @@ func (c *cAGrpcClientImpl) SendCSR(req *pb.Request, pc platform.Client, cfg *Con
 	}
 	conn, err := grpc.Dial(cfg.IstioCAAddress, dialOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to dial %s: %s", cfg.IstioCAAddress, err)
+		return nil, fmt.Errorf("failed to dial %s: %s", cfg.IstioCAAddress, err)
 	}
 	defer func() {
 		if closeErr := conn.Close(); closeErr != nil {

--- a/security/cmd/node_agent/na/nodeagent.go
+++ b/security/cmd/node_agent/na/nodeagent.go
@@ -41,7 +41,7 @@ type cAGrpcClientImpl struct {
 // SendCSR sends CSR to CA through GRPC.
 func (c *cAGrpcClientImpl) SendCSR(req *pb.Request, pc platform.Client, cfg *Config) (*pb.Response, error) {
 	if cfg.IstioCAAddress == "" {
-		return nil, fmt.Errorf("Istio CA address is empty")
+		return nil, fmt.Errorf("istio CA address is empty")
 	}
 	dialOptions, err := pc.GetDialOptions()
 	if err != nil {

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -268,7 +268,7 @@ func TestSendCSRAgainstLocalInstance(t *testing.T) {
 			pc:       mockpc.FakeClient{[]grpc.DialOption{}, "", "service1", "", []byte{}, "", true},
 			res:      defaultServerResponse,
 			cAClient: &cAGrpcClientImpl{},
-			expectedErr: fmt.Sprintf("Failed to dial %s: grpc: no transport security set "+
+			expectedErr: fmt.Sprintf("failed to dial %s: grpc: no transport security set "+
 				"(use grpc.WithInsecure() explicitly or set credentials)", lis.Addr().String()),
 		},
 		"Error from GetDialOptions": {

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -246,7 +246,7 @@ func TestSendCSRAgainstLocalInstance(t *testing.T) {
 			}, "", "service1", "", []byte{}, "", true},
 			res:         defaultServerResponse,
 			cAClient:    &cAGrpcClientImpl{},
-			expectedErr: "Istio CA address is empty",
+			expectedErr: "istio CA address is empty",
 		},
 		"IstioCAAddress is incorrect": {
 			config: &Config{

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -164,15 +164,15 @@ func runSelfSignedCATests() error {
 
 	// Delete the secret.
 	do := &metav1.DeleteOptions{}
-	if errors := opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); errors != nil {
-		return errors
+	if delErr := opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); delErr != nil {
+		return delErr
 	}
 	glog.Info(`Secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
-	if _, errors := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
-		secretWaitTime); errors != nil {
-		return errors
+	if _, creErr := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
+		secretWaitTime); creErr != nil {
+		return creErr
 	}
 	glog.Info(`Secret "istio.default" is correctly re-created`)
 

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -164,15 +164,15 @@ func runSelfSignedCATests() error {
 
 	// Delete the secret.
 	do := &metav1.DeleteOptions{}
-	if delErr := opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); delErr != nil {
-		return delErr
+	if err = opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); err != nil {
+		return err
 	}
 	glog.Info(`Secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
-	if _, creErr := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
-		secretWaitTime); creErr != nil {
-		return creErr
+	if _, err := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
+		secretWaitTime); err != nil {
+		return err
 	}
 	glog.Info(`Secret "istio.default" is correctly re-created`)
 

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -63,8 +63,8 @@ type options struct {
 	clientset      kubernetes.Interface
 	kubeconfig     string
 	namespace      string
-	org_root_cert  string
-	org_cert_chain string
+	orgRootCert    string
+	orgCertChain   string
 }
 
 func init() {
@@ -73,8 +73,8 @@ func init() {
 	flags.StringVar(&opts.containerImage, "image", "", "Name of Istio CA image")
 	flags.StringVar(&opts.containerTag, "tag", "", "Tag for Istio CA image")
 	flags.StringVarP(&opts.kubeconfig, "kube-config", "k", "~/.kube/config", "path to kubeconfig file")
-	flags.StringVar(&opts.org_root_cert, "root-cert", "", "Path to the original root ceritificate")
-	flags.StringVar(&opts.org_cert_chain, "cert-chain", "", "Path to the original certificate chain")
+	flags.StringVar(&opts.orgRootCert, "root-cert", "", "Path to the original root ceritificate")
+	flags.StringVar(&opts.orgCertChain, "cert-chain", "", "Path to the original workload certificate chain")
 
 	cmd.InitializeFlags(rootCmd)
 }
@@ -82,60 +82,60 @@ func init() {
 func main() {
 	// HACKHACK: let `flag.Parsed()` return true to prevent glog from emitting errors
 	flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
-	if err := flag.CommandLine.Parse([]string{}); err != nil {
-		glog.Fatal(err)
+	if errors := flag.CommandLine.Parse([]string{}); errors != nil {
+		glog.Fatal(errors)
 	}
 
-	if err := rootCmd.Execute(); err != nil {
+	if errors := rootCmd.Execute(); errors != nil {
 		if opts.clientset != nil && len(opts.namespace) > 0 {
-			err = utils.DeleteTestNamespace(opts.clientset, opts.namespace)
-			if err != nil {
-				glog.Errorf("Failed to delete namespace %v : %v", opts.namespace, err)
+			errors = utils.DeleteTestNamespace(opts.clientset, opts.namespace)
+			if errors != nil {
+				glog.Errorf("Failed to delete namespace %v : %v", opts.namespace, errors)
 			}
 		}
-		glog.Fatal(err)
+		glog.Fatal(errors)
 	}
 }
 
 func runTests(cmd *cobra.Command, args []string) error {
-	err := runSelfSignedCATests()
-	if err != nil {
-		return err
+	errors := runSelfSignedCATests()
+	if errors != nil {
+		return errors
 	}
 
-	err = runCAForNodeAgentTests()
-	if err != nil {
-		return err
+	errors = runCAForNodeAgentTests()
+	if errors != nil {
+		return errors
 	}
 
 	return nil
 }
 
 func initializeIntegrationTest(cmd *cobra.Command, args []string) error {
-	clientset, err := utils.CreateClientset(opts.kubeconfig)
-	if err != nil {
-		return err
+	clientset, errors := utils.CreateClientset(opts.kubeconfig)
+	if errors != nil {
+		return errors
 	}
 	opts.clientset = clientset
 
-	namespace, err := utils.CreateTestNamespace(opts.clientset, integrationTestNamespacePrefix)
-	if err != nil {
-		return err
+	namespace, errors := utils.CreateTestNamespace(opts.clientset, integrationTestNamespacePrefix)
+	if errors != nil {
+		return errors
 	}
 	opts.namespace = namespace
 
 	// Create Role
-	err = utils.CreateRole(opts.clientset, opts.namespace)
-	if err != nil {
+	errors = utils.CreateIstioCARole(opts.clientset, opts.namespace)
+	if errors != nil {
 		utils.DeleteTestNamespace(opts.clientset, opts.namespace)
-		return fmt.Errorf("failed to create a role (error: %v)", err)
+		return fmt.Errorf("failed to create a role (error: %v)", errors)
 	}
 
 	// Create RoleBinding
-	err = utils.CreateRoleBinding(opts.clientset, opts.namespace)
-	if err != nil {
+	errors = utils.CreateIstioCARoleBinding(opts.clientset, opts.namespace)
+	if errors != nil {
 		utils.DeleteTestNamespace(opts.clientset, opts.namespace)
-		return fmt.Errorf("failed to create a rolebinding (error: %v)", err)
+		return fmt.Errorf("failed to create a rolebinding (error: %v)", errors)
 	}
 
 	return nil
@@ -143,45 +143,43 @@ func initializeIntegrationTest(cmd *cobra.Command, args []string) error {
 
 func runSelfSignedCATests() error {
 	// Create Istio CA with self signed certificates
-	self_signed_ca_pod, err := utils.CreatePod(opts.clientset, opts.namespace,
+	selfSignedCaPod, errors := utils.CreatePod(opts.clientset, opts.namespace,
 		fmt.Sprintf("%v/istio-ca:%v", opts.containerHub, opts.containerTag), "istio-ca-self")
-	if err != nil {
-		return fmt.Errorf("failed to deploy Istio CA (error: %v)", err)
+	if errors != nil {
+		return fmt.Errorf("failed to deploy Istio CA (error: %v)", errors)
 	}
-	glog.Infof("Succesfully created Istio CA pod(%v) with the self-signed-ca option",
-		self_signed_ca_pod.GetName())
+	glog.Infof("Successfully created Istio CA pod(%v) with the self-signed-ca option",
+		selfSignedCaPod.GetName())
 
 	// Test the existence of istio.default secret.
-	if s, err := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
-		secretWaitTime); err != nil {
-		return err
-	} else {
-		glog.Info(`Secret "istio.default" is correctly created`)
-
-		expectedID := fmt.Sprintf("spiffe://cluster.local/ns/%s/sa/default", s.GetNamespace())
-		examineSecret(s, expectedID)
+	secret, errors := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
+		secretWaitTime);
+	if errors != nil {
+		return errors
 	}
+	glog.Info(`Secret "istio.default" is correctly created`)
+
+	expectedID := fmt.Sprintf("spiffe://cluster.local/ns/%secret/sa/default", secret.GetNamespace())
+	examineSecret(secret, expectedID)
 
 	// Delete the secret.
 	do := &metav1.DeleteOptions{}
-	if err := opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); err != nil {
-		return err
-	} else {
-		glog.Info(`Secret "istio.default" has been deleted`)
+	if errors := opts.clientset.CoreV1().Secrets(opts.namespace).Delete("istio.default", do); errors != nil {
+		return errors
 	}
+	glog.Info(`Secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
-	if _, err := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
-		secretWaitTime); err != nil {
-		return err
-	} else {
-		glog.Info(`Secret "istio.default" is correctly re-created`)
+	if _, errors := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
+		secretWaitTime); errors != nil {
+		return errors
 	}
+	glog.Info(`Secret "istio.default" is correctly re-created`)
 
 	// Delete pods
-	err = utils.DeletePod(opts.clientset, opts.namespace, self_signed_ca_pod.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to delete Istio CA (error: %v)", err)
+	errors = utils.DeletePod(opts.clientset, opts.namespace, selfSignedCaPod.GetName())
+	if errors != nil {
+		return fmt.Errorf("failed to delete Istio CA (error: %v)", errors)
 	}
 
 	return nil
@@ -189,69 +187,68 @@ func runSelfSignedCATests() error {
 
 func runCAForNodeAgentTests() error {
 	// Create a Istio CA and Service with generated certificates
-	ca_pod, err := utils.CreatePod(opts.clientset, opts.namespace,
+	caPod, errors := utils.CreatePod(opts.clientset, opts.namespace,
 		fmt.Sprintf("%v/istio-ca-test:%v", opts.containerHub, opts.containerTag),
 		"istio-ca-cert")
-	if err != nil {
-		return fmt.Errorf("failed to deploy Istio CA (error: %v)", err)
+	if errors != nil {
+		return fmt.Errorf("failed to deploy Istio CA (error: %v)", errors)
 	}
 
 	// Create the istio-ca service for NodeAgent pod
-	ca_service, err := utils.CreateService(opts.clientset, opts.namespace, "istio-ca", 8060,
-		v1.ServiceTypeClusterIP, ca_pod)
-	if err != nil {
-		return fmt.Errorf("failed to deploy Istio CA (error: %v)", err)
+	caService, errors := utils.CreateService(opts.clientset, opts.namespace, "istio-ca", 8060,
+		v1.ServiceTypeClusterIP, caPod)
+	if errors != nil {
+		return fmt.Errorf("failed to deploy Istio CA (error: %v)", errors)
 	}
 
 	// Create the NodeAgent pod
-	na_pod, err := utils.CreatePod(opts.clientset, opts.namespace,
+	naPod, errors := utils.CreatePod(opts.clientset, opts.namespace,
 		fmt.Sprintf("%v/node-agent-test:%v", opts.containerHub, opts.containerTag),
 		"node-agent-cert")
-	if err != nil {
-		return fmt.Errorf("failed to deploy NodeAgent pod (error: %v)", err)
+	if errors != nil {
+		return fmt.Errorf("failed to deploy NodeAgent pod (error: %v)", errors)
 	}
 
 	// Create the service for NodeAgent pod
-	na_service, err := utils.CreateService(opts.clientset, opts.namespace, "node-agent", 8080,
-		v1.ServiceTypeLoadBalancer, na_pod)
-	if err != nil {
-		return fmt.Errorf("failed to deploy Istio CA (error: %v)", err)
+	naService, errors := utils.CreateService(opts.clientset, opts.namespace, "node-agent", 8080,
+		v1.ServiceTypeLoadBalancer, naPod)
+	if errors != nil {
+		return fmt.Errorf("failed to deploy Istio CA (error: %v)", errors)
 	}
 
 	// Test certificates of NodeAgent were updated and valid
-	_, err = opts.clientset.CoreV1().Services(opts.namespace).Get("node-agent", metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get the external IP adddress of node-agent service: %v", err)
+	_, errors = opts.clientset.CoreV1().Services(opts.namespace).Get("node-agent", metav1.GetOptions{})
+	if errors != nil {
+		return fmt.Errorf("failed to get the external IP adddress of node-agent service: %v", errors)
 	}
 
-	err = waitForNodeAgentCertificateUpdate(fmt.Sprintf("http://%v:%v",
-		na_service.Status.LoadBalancer.Ingress[0].IP, 8080))
-	if err != nil {
-		return fmt.Errorf("failed to check certificate update node-agent (err: %v)", err)
-	} else {
-		glog.Info("Certificate of NodeAgent was updated and verified successfully")
+	errors = waitForNodeAgentCertificateUpdate(fmt.Sprintf("http://%v:%v",
+		naService.Status.LoadBalancer.Ingress[0].IP, 8080))
+	if errors != nil {
+		return fmt.Errorf("failed to check certificate update node-agent (errors: %v)", errors)
 	}
+	glog.Info("Certificate of NodeAgent was updated and verified successfully")
 
 	// Delete created services
-	err = utils.DeleteService(opts.clientset, opts.namespace, ca_service.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to delete CA service: %v (error: %v)", ca_service.GetName(), err)
+	errors = utils.DeleteService(opts.clientset, opts.namespace, caService.GetName())
+	if errors != nil {
+		return fmt.Errorf("failed to delete CA service: %v (error: %v)", caService.GetName(), errors)
 	}
 
-	err = utils.DeleteService(opts.clientset, opts.namespace, na_service.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to delete NodeAgent service: %v (error: %v)", na_service.GetName(), err)
+	errors = utils.DeleteService(opts.clientset, opts.namespace, naService.GetName())
+	if errors != nil {
+		return fmt.Errorf("failed to delete NodeAgent service: %v (error: %v)", naService.GetName(), errors)
 	}
 
 	// Delete created pods
-	err = utils.DeletePod(opts.clientset, opts.namespace, ca_pod.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to delete CA pod: %v (error: %v)", ca_pod.GetName(), err)
+	errors = utils.DeletePod(opts.clientset, opts.namespace, caPod.GetName())
+	if errors != nil {
+		return fmt.Errorf("failed to delete CA pod: %v (error: %v)", caPod.GetName(), errors)
 	}
 
-	err = utils.DeletePod(opts.clientset, opts.namespace, na_pod.GetName())
-	if err != nil {
-		return fmt.Errorf("failed to delete NodeAgent pod: %v (error: %v)", na_pod.GetName(), err)
+	errors = utils.DeletePod(opts.clientset, opts.namespace, naPod.GetName())
+	if errors != nil {
+		return fmt.Errorf("failed to delete NodeAgent pod: %v (error: %v)", naPod.GetName(), errors)
 	}
 
 	return nil
@@ -266,7 +263,7 @@ func cleanUpIntegrationTest(cmd *cobra.Command, args []string) error {
 // * Key, certificate and CA root are correctly saved in the data section;
 func examineSecret(secret *v1.Secret, expectedID string) error {
 	if secret.Type != controller.IstioSecretType {
-		return fmt.Errorf(`Unexpected value for the "type" annotation: expecting %v but got %v`,
+		return fmt.Errorf(`unexpected value for the "type" annotation: expecting %v but got %v`,
 			controller.IstioSecretType, secret.Type)
 	}
 
@@ -284,30 +281,30 @@ func examineSecret(secret *v1.Secret, expectedID string) error {
 		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		IsCA:        false,
 	}
-	if err := testutil.VerifyCertificate(key, cert, root, expectedID, verifyFields); err != nil {
-		return fmt.Errorf("Certificate verification failed: %v", err)
+	if errors := testutil.VerifyCertificate(key, cert, root, expectedID, verifyFields); errors != nil {
+		return fmt.Errorf("certificate verification failed: %v", errors)
 	}
 
 	return nil
 }
 
 func readFile(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return "", err
+	data, errors := ioutil.ReadFile(path)
+	if errors != nil {
+		return "", errors
 	}
 	return string(data), nil
 }
 
-func readUri(uri string) (string, error) {
-	resp, err := http.Get(uri)
-	if err != nil {
-		return "", err
+func readURI(uri string) (string, error) {
+	resp, errors := http.Get(uri)
+	if errors != nil {
+		return "", errors
 	}
 	defer resp.Body.Close()
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
+	bodyBytes, errors := ioutil.ReadAll(resp.Body)
+	if errors != nil {
 		return "", nil
 	}
 
@@ -315,49 +312,49 @@ func readUri(uri string) (string, error) {
 }
 
 func waitForNodeAgentCertificateUpdate(appurl string) error {
-	max_retry := certValidateRetry
+	maxRetry := certValidateRetry
 	term := certValidationInterval
 
-	org_root_cert, err := readFile(opts.org_root_cert)
-	if err != nil {
-		return fmt.Errorf("Unable to read original root certificate: %v", opts.org_root_cert)
+	orgRootCert, errors := readFile(opts.orgRootCert)
+	if errors != nil {
+		return fmt.Errorf("unable to read original root certificate: %v", opts.orgRootCert)
 	}
 
-	org_cert_chain, err := readFile(opts.org_cert_chain)
-	if err != nil {
-		return fmt.Errorf("Unable to read original certificate chain: %v", opts.org_cert_chain)
+	orgCertChain, errors := readFile(opts.orgCertChain)
+	if errors != nil {
+		return fmt.Errorf("unable to read original certificate chain: %v", opts.orgCertChain)
 	}
 
-	for i := 0; i < max_retry; i++ {
+	for i := 0; i < maxRetry; i++ {
 		if i > 0 {
 			glog.Infof("Retry checking certificate update and validation in %v seconds", term)
 			time.Sleep(time.Duration(term) * time.Second)
 			term = term * 2
 		}
 
-		certPEM, err := readUri(fmt.Sprintf("%v/cert", appurl))
-		if err != nil {
-			glog.Errorf("Failed to read the certificate of NodeAgent: %v", err)
+		certPEM, errors := readURI(fmt.Sprintf("%v/cert", appurl))
+		if errors != nil {
+			glog.Errorf("Failed to read the certificate of NodeAgent: %v", errors)
 			continue
 		}
 
-		rootPEM, err := readUri(fmt.Sprintf("%v/root", appurl))
-		if err != nil {
-			glog.Errorf("Failed to read the root certificate of NodeAgent: %v", err)
+		rootPEM, errors := readURI(fmt.Sprintf("%v/root", appurl))
+		if errors != nil {
+			glog.Errorf("Failed to read the root certificate of NodeAgent: %v", errors)
 			continue
 		}
 
-		if org_root_cert != rootPEM {
-			return fmt.Errorf("Invalid root certificate was downloaded")
+		if orgRootCert != rootPEM {
+			return fmt.Errorf("invalid root certificate was downloaded")
 		}
 
-		if org_cert_chain == certPEM {
+		if orgCertChain == certPEM {
 			glog.Error("Certificate chain was not updated yet")
 			continue
 		}
 
 		roots := x509.NewCertPool()
-		ok := roots.AppendCertsFromPEM([]byte(org_root_cert))
+		ok := roots.AppendCertsFromPEM([]byte(orgRootCert))
 		if !ok {
 			return fmt.Errorf("failed to parse root certificate")
 		}
@@ -365,24 +362,23 @@ func waitForNodeAgentCertificateUpdate(appurl string) error {
 		block, _ := pem.Decode([]byte(certPEM))
 		if block == nil {
 			return fmt.Errorf("failed to parse certificate PEM")
-			continue
 		}
 
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return fmt.Errorf("failed to parse certificate: %v", err)
+		cert, errors := x509.ParseCertificate(block.Bytes)
+		if errors != nil {
+			return fmt.Errorf("failed to parse certificate: %v", errors)
 		}
 
 		opts := x509.VerifyOptions{
 			Roots: roots,
 		}
 
-		if _, err := cert.Verify(opts); err != nil {
-			return fmt.Errorf("failed to verify certificate: %v", err)
+		if _, errors := cert.Verify(opts); errors != nil {
+			return fmt.Errorf("failed to verify certificate: %v", errors)
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("Failed to check certificate update and validate after %v retry", max_retry)
+	return fmt.Errorf("failed to check certificate update and validate after %v retry", maxRetry)
 }

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -170,7 +170,7 @@ func runSelfSignedCATests() error {
 	glog.Info(`Secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
-	if _, err := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
+	if _, err = utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
 		secretWaitTime); err != nil {
 		return err
 	}

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -153,7 +153,7 @@ func runSelfSignedCATests() error {
 
 	// Test the existence of istio.default secret.
 	secret, errors := utils.WaitForSecretExist(opts.clientset, opts.namespace, "istio.default",
-		secretWaitTime);
+		secretWaitTime)
 	if errors != nil {
 		return errors
 	}

--- a/security/integration/utils/kubernetes.go
+++ b/security/integration/utils/kubernetes.go
@@ -141,7 +141,7 @@ func CreatePod(clientset kubernetes.Interface, namespace string, image string, n
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"podUuid":      podUuid,
+				"podUuid":   podUuid,
 				"pod-group": fmt.Sprintf("%v-pod-group", name),
 			},
 			Name: name,

--- a/security/integration/utils/kubernetes.go
+++ b/security/integration/utils/kubernetes.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// CreateClientset creates a new Clientset for the given kubeconfig.
 func CreateClientset(kubeconfig string) (*kubernetes.Clientset, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -44,6 +45,7 @@ func CreateClientset(kubeconfig string) (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
+// CreateTestNamespace creates a namespace for test. Returns name of the namespace on success, and error if there is any.
 func CreateTestNamespace(clientset kubernetes.Interface, prefix string) (string, error) {
 	template := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -60,6 +62,7 @@ func CreateTestNamespace(clientset kubernetes.Interface, prefix string) (string,
 	return name, nil
 }
 
+// DeleteTestNamespace deletes a namespace for test.
 func DeleteTestNamespace(clientset kubernetes.Interface, namespace string) error {
 	if err := clientset.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("failed to delete namespace %q (error: %v)", namespace, err)
@@ -68,6 +71,7 @@ func DeleteTestNamespace(clientset kubernetes.Interface, namespace string) error
 	return nil
 }
 
+// CreateService creates a service object and returns a pointer pointing to this object on success.
 func CreateService(clientset kubernetes.Interface, namespace string, name string, port int32,
 	serviceType v1.ServiceType, pod *v1.Pod) (*v1.Service, error) {
 	uuid := string(uuid.NewUUID())
@@ -103,12 +107,14 @@ func CreateService(clientset kubernetes.Interface, namespace string, name string
 	return clientset.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 }
 
+// DeleteService deletes a service.
 func DeleteService(clientset kubernetes.Interface, namespace string, name string) error {
 	return clientset.CoreV1().Services(namespace).Delete(name, &metav1.DeleteOptions{})
 }
 
+// CreatePod creates a pod object and returns a pointer pointing to this object on success.
 func CreatePod(clientset kubernetes.Interface, namespace string, image string, name string) (*v1.Pod, error) {
-	uuid := string(uuid.NewUUID())
+	podUuid := string(uuid.NewUUID())
 
 	env := []v1.EnvVar{
 		{
@@ -135,7 +141,7 @@ func CreatePod(clientset kubernetes.Interface, namespace string, image string, n
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"uuid":      uuid,
+				"podUuid":      podUuid,
 				"pod-group": fmt.Sprintf("%v-pod-group", name),
 			},
 			Name: name,
@@ -143,23 +149,25 @@ func CreatePod(clientset kubernetes.Interface, namespace string, image string, n
 		Spec: spec,
 	}
 
-	pod, err := clientset.CoreV1().Pods(namespace).Create(pod)
+	_, err := clientset.CoreV1().Pods(namespace).Create(pod)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := waitForPodRunning(clientset, namespace, uuid, 60*time.Second); err != nil {
+	if err := waitForPodRunning(clientset, namespace, podUuid, 60*time.Second); err != nil {
 		return nil, err
 	}
 
 	return clientset.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 }
 
+// DeletePod deletes a pod.
 func DeletePod(clientset kubernetes.Interface, namespace string, name string) error {
 	return clientset.CoreV1().Pods(namespace).Delete(name, &metav1.DeleteOptions{})
 }
 
-func CreateRole(clientset kubernetes.Interface, namespace string) error {
+// CreateIstioCARole creates a role object named "istio-ca-role".
+func CreateIstioCARole(clientset kubernetes.Interface, namespace string) error {
 	role := rbac.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
@@ -187,7 +195,8 @@ func CreateRole(clientset kubernetes.Interface, namespace string) error {
 	return nil
 }
 
-func CreateRoleBinding(clientset kubernetes.Interface, namespace string) error {
+// CreateIstioCARoleBinding binds role "istio-ca-role" to default service account.
+func CreateIstioCARoleBinding(clientset kubernetes.Interface, namespace string) error {
 	rolebinding := rbac.RoleBinding{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1beta1",
@@ -272,6 +281,8 @@ func waitForPodRunning(clientset kubernetes.Interface, namespace string, uuid st
 	}
 }
 
+// WaitForSecretExist takes name of a secret and watches the secret. Returns the requested secret
+// if it exists, or error on timeouts.
 func WaitForSecretExist(clientset kubernetes.Interface, namespace string, secretName string,
 	timeToWait time.Duration) (*v1.Secret, error) {
 	watch, err := clientset.CoreV1().Secrets(namespace).Watch(metav1.ListOptions{})

--- a/security/integration/utils/kubernetes.go
+++ b/security/integration/utils/kubernetes.go
@@ -114,7 +114,7 @@ func DeleteService(clientset kubernetes.Interface, namespace string, name string
 
 // CreatePod creates a pod object and returns a pointer pointing to this object on success.
 func CreatePod(clientset kubernetes.Interface, namespace string, image string, name string) (*v1.Pod, error) {
-	podUuid := string(uuid.NewUUID())
+	podUUID := string(uuid.NewUUID())
 
 	env := []v1.EnvVar{
 		{
@@ -141,7 +141,7 @@ func CreatePod(clientset kubernetes.Interface, namespace string, image string, n
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
-				"podUuid":   podUuid,
+				"podUUID":   podUUID,
 				"pod-group": fmt.Sprintf("%v-pod-group", name),
 			},
 			Name: name,
@@ -154,7 +154,7 @@ func CreatePod(clientset kubernetes.Interface, namespace string, image string, n
 		return nil, err
 	}
 
-	if err := waitForPodRunning(clientset, namespace, podUuid, 60*time.Second); err != nil {
+	if err := waitForPodRunning(clientset, namespace, podUUID, 60*time.Second); err != nil {
 		return nil, err
 	}
 

--- a/security/pkg/credential/token.go
+++ b/security/pkg/credential/token.go
@@ -42,7 +42,7 @@ func (fetcher *GcpTokenFetcher) FetchToken() (string, error) {
 	return metadata.Get(fetcher.getTokenURI())
 }
 
-// FetchToken fetches the GCE VM identity jwt token from its metadata server.
+// FetchServiceAccount fetches the GCE VM identity jwt token from its metadata server.
 // Note: this function only works in a GCE VM environment.
 func (fetcher *GcpTokenFetcher) FetchServiceAccount() (string, error) {
 	return metadata.Get("instance/service-accounts/default/email")

--- a/security/pkg/platform/aws_test.go
+++ b/security/pkg/platform/aws_test.go
@@ -165,7 +165,7 @@ func TestAwsGetServiceIdentity(t *testing.T) {
 			client: ec2metadata.New(unit.Session, &aws.Config{Endpoint: aws.String(server.URL + "/latest")}),
 		}
 
-		serviceIdentity, err := awsc.GetServiceIdentity()
+		serviceIdentity, _ := awsc.GetServiceIdentity()
 		if serviceIdentity != c.expectedServiceIdentity {
 			t.Errorf("%s: Wrong Service Identity. Expected %v, Actual %v", id,
 				string(c.expectedServiceIdentity), string(serviceIdentity))

--- a/security/pkg/platform/aws_test.go
+++ b/security/pkg/platform/aws_test.go
@@ -165,8 +165,10 @@ func TestAwsGetServiceIdentity(t *testing.T) {
 			client: ec2metadata.New(unit.Session, &aws.Config{Endpoint: aws.String(server.URL + "/latest")}),
 		}
 
-		serviceIdentity, _ := awsc.GetServiceIdentity()
-		if serviceIdentity != c.expectedServiceIdentity {
+		serviceIdentity, err := awsc.GetServiceIdentity()
+		if err != nil {
+			t.Fatalf("%s: Unexpected Error: %v", id, err)
+		} else if serviceIdentity != c.expectedServiceIdentity {
 			t.Errorf("%s: Wrong Service Identity. Expected %v, Actual %v", id,
 				string(c.expectedServiceIdentity), string(serviceIdentity))
 		}

--- a/security/pkg/server/grpc/authorizer.go
+++ b/security/pkg/server/grpc/authorizer.go
@@ -22,11 +22,11 @@ type authorizer interface {
 	authorize(requester *caller, requestedIds []string) error
 }
 
-// sameIdAuthorizer approves a request if the requested identities matches the
+// sameIDAuthorizer approves a request if the requested identities matches the
 // identities of the requester.
-type sameIdAuthorizer struct{}
+type sameIDAuthorizer struct{}
 
-func (authZ *sameIdAuthorizer) authorize(requester *caller, requestedIDs []string) error {
+func (authZ *sameIDAuthorizer) authorize(requester *caller, requestedIDs []string) error {
 	if requester.authSource == authSourceIDToken {
 		// TODO: currently the "sub" claim of an ID token returned by GCP
 		// metadata server contains obfuscated ID, so we cannot do
@@ -41,7 +41,7 @@ func (authZ *sameIdAuthorizer) authorize(requester *caller, requestedIDs []strin
 
 	for _, requestedID := range requestedIDs {
 		if _, exists := idMap[requestedID]; !exists {
-			return fmt.Errorf("The requested identity (%q) does not match the caller's identities", requestedID)
+			return fmt.Errorf("the requested identity (%q) does not match the caller's identities", requestedID)
 		}
 	}
 

--- a/security/pkg/server/grpc/authorizer_test.go
+++ b/security/pkg/server/grpc/authorizer_test.go
@@ -30,13 +30,13 @@ func TestAuthroizer(t *testing.T) {
 			callerIDs:    []string{"id1", "id2"},
 		},
 		"Unauthorized": {
-			expectedErr:  "The requested identity (\"id3\") does not match the caller's identities",
+			expectedErr:  "the requested identity (\"id3\") does not match the caller's identities",
 			requestedIDs: []string{"id3"},
 			callerIDs:    []string{"id1", "id2"},
 		},
 	}
 
-	authz := &sameIdAuthorizer{}
+	authz := &sameIDAuthorizer{}
 	for id, tc := range testCases {
 		err := authz.authorize(&caller{authSourceClientCertificate, tc.callerIDs}, tc.requestedIDs)
 		if len(tc.expectedErr) > 0 {

--- a/security/pkg/server/grpc/server.go
+++ b/security/pkg/server/grpc/server.go
@@ -129,7 +129,7 @@ func New(ca ca.CertificateAuthority, hostname string, port int) *Server {
 
 	return &Server{
 		authenticators: authenticators,
-		authorizer:     &sameIdAuthorizer{},
+		authorizer:     &sameIDAuthorizer{},
 		ca:             ca,
 		hostname:       hostname,
 		port:           port,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1446

**Special notes for your reviewer**:
The following linter errors are reported by linters.sh, and are fixed in this PR.
security/integration/main.go:151:13:warning: "Succesfully" is a misspelling of "Successfully" (misspell)
security/integration/main.go:368::error: unreachable code (vet)
security/cmd/istio_ca/main.go:171::warning: declaration of "ca" shadows declaration at security/cmd/istio_ca/main.go:32 (vetshadow)
security/cmd/istio_ca/main.go:191::warning: declaration of "ca" shadows declaration at security/cmd/istio_ca/main.go:32 (vetshadow)
security/integration/main.go:155::warning: declaration of "err" shadows declaration at security/integration/main.go:146 (vetshadow)
security/integration/main.go:167::warning: declaration of "err" shadows declaration at security/integration/main.go:146 (vetshadow)
security/integration/main.go:174::warning: declaration of "err" shadows declaration at security/integration/main.go:146 (vetshadow)
security/integration/utils/kubernetes.go:111::warning: declaration of "uuid" shadows declaration at security/integration/utils/kubernetes.go:26 (vetshadow)
security/integration/utils/kubernetes.go:146:2:warning: ineffectual assignment to pod (ineffassign)
security/pkg/platform/aws_test.go:168:20:warning: ineffectual assignment to err (ineffassign)
security/cmd/node_agent/na/nafactory.go:35:26:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/cmd/node_agent/na/nodeagent.go:44:26:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/cmd/node_agent/na/nodeagent.go:52:26:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:66:2:warning: don't use underscores in Go names; struct field org_root_cert should be orgRootCert (golint)
security/integration/main.go:67:2:warning: don't use underscores in Go names; struct field org_cert_chain should be orgCertChain (golint)
security/integration/main.go:146:2:warning: don't use underscores in Go names; var self_signed_ca_pod should be selfSignedCaPod (golint)
security/integration/main.go:158:9:warning: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (golint)
security/integration/main.go:169:9:warning: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (golint)
security/integration/main.go:177:9:warning: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (golint)
security/integration/main.go:192:2:warning: don't use underscores in Go names; var ca_pod should be caPod (golint)
security/integration/main.go:200:2:warning: don't use underscores in Go names; var ca_service should be caService (golint)
security/integration/main.go:207:2:warning: don't use underscores in Go names; var na_pod should be naPod (golint)
security/integration/main.go:215:2:warning: don't use underscores in Go names; var na_service should be naService (golint)
security/integration/main.go:231:9:warning: if block ends with a return statement, so drop this else and outdent its block (golint)
security/integration/main.go:269:21:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:288:21:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:302:6:warning: func readUri should be readURI (golint)
security/integration/main.go:318:2:warning: don't use underscores in Go names; var max_retry should be maxRetry (golint)
security/integration/main.go:321:2:warning: don't use underscores in Go names; var org_root_cert should be orgRootCert (golint)
security/integration/main.go:323:21:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:326:2:warning: don't use underscores in Go names; var org_cert_chain should be orgCertChain (golint)
security/integration/main.go:328:21:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:351:22:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/main.go:387:20:warning: error strings should not be capitalized or end with punctuation or a newline (golint)
security/integration/utils/kubernetes.go:32:1:warning: exported function CreateClientset should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:47:1:warning: exported function CreateTestNamespace should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:63:1:warning: exported function DeleteTestNamespace should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:71:1:warning: exported function CreateService should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:106:1:warning: exported function DeleteService should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:110:1:warning: exported function CreatePod should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:158:1:warning: exported function DeletePod should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:162:1:warning: exported function CreateRole should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:190:1:warning: exported function CreateRoleBinding should have comment or be unexported (golint)
security/integration/utils/kubernetes.go:275:1:warning: exported function WaitForSecretExist should have comment or be unexported (golint)
security/pkg/credential/token.go:45:1:warning: comment on exported method GcpTokenFetcher.FetchServiceAccount should be of the form "FetchServiceAccount ..." (golint)
security/pkg/server/grpc/authorizer.go:27:6:warning: type sameIdAuthorizer should be sameIDAuthorizer (golint)
security/pkg/server/grpc/authorizer.go:44:22:warning: error strings should not be capitalized or end with punctuation or a newline (golint)

**Release note**:

```Fix linter errors.
```
