### PR TITLE
del git checkout on removed lintconfig.json to fix release build

### DIFF
--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -119,7 +119,6 @@ rm -rf vendor/k8s.io/*/vendor
 # it's easier to ask git to restore files than add
 # an option to bazel_to_go to not touch them
 git checkout generated_files
-git checkout lintconfig.json
 
 pushd pilot
 ./bin/upload-istioctl -r -o "${OUTPUT_PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The cloud-build script runs "git checkout" twice to undo changes that bin/bazel-to-go.py makes to source files (these changes cause "-dirty" to be added to the version that istioctl reports).  One of these files is now deleted so the build breaks.  This change removes the "git checkout" call for the deleted file.  I verified that the build is successful with this change and that "-dirty" still is not reported in the version.

```release-note
NONE
```
