### PR TITLE
Support bazel 0.8.x

### DIFF
--- a/mixer/adapter_author_deps.bzl
+++ b/mixer/adapter_author_deps.bzl
@@ -4,7 +4,7 @@ def mixer_adapter_repositories():
 
     native.git_repository(
         name = "org_pubref_rules_protobuf",
-        commit = "ff3b7e7963daa7cb3b42f8936bc11eda4b960926",  # Oct 03, 2017 (Updating External Import Paths)
+        commit = "563b674a2ce6650d459732932ea2bc98c9c9a9bf",  # Nov 28, 2017 (bazel 0.8.0 support)
         remote = "https://github.com/pubref/rules_protobuf",
     )
 

--- a/mixer/check_bazel_version.bzl
+++ b/mixer/check_bazel_version.bzl
@@ -14,7 +14,7 @@ def _parse_bazel_version(bazel_version):
 
 # acceptable min_version <= version <= max_version
 def check_version():
-    check_bazel_version("0.5.4", "0.7.99")
+    check_bazel_version("0.5.4", "0.8.99")
 
 # acceptable min_version <= version <= max_version
 def check_bazel_version(min_version, max_version):


### PR DESCRIPTION
rules_protobuf needs the update for 0.8 support.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1868

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
