### PR TITLE
dep ensure on cache miss in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run: bin/install-go.sh
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -73,7 +73,7 @@ jobs:
       - run: bin/install-go.sh
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -104,7 +104,7 @@ jobs:
                dep ensure
             fi
       - save_cache:
-          key: dep-cache-{{ checksum "Gopkg.lock" }}
+          key: dep-cache-{{ checksum "Gopkg.toml" }}
           paths:
             - /go/src/istio.io/istio/vendor
 
@@ -120,7 +120,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -158,7 +158,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -187,7 +187,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -216,7 +216,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.lock" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}
       - run:
           command: |
             cd /go/src/istio.io/istio

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,12 @@ jobs:
       - restore_cache:
           keys:
             - dep-cache-{{ checksum "Gopkg.lock" }}
+      - run:
+          command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
       - run: cd pilot; bin/gocompile-and-push-images.sh -hub $HUB -tag $TAG -build-only
       - run: mkdir /home/circleci/logs
       - run: go build -i ./pilot/test/integration
@@ -68,6 +74,12 @@ jobs:
       - restore_cache:
           keys:
             - dep-cache-{{ checksum "Gopkg.lock" }}
+      - run:
+          command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
       - run: cd pilot; bin/gocompile-and-push-images.sh -hub $HUB -tag $TAG -build-only
       - run: mkdir /home/circleci/logs
       - run: go build -i ./pilot/test/integration
@@ -111,6 +123,12 @@ jobs:
             - dep-cache-{{ checksum "Gopkg.lock" }}
       - run:
           command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
+      - run:
+          command: |
             mkdir ~/.kube
             cp /go/src/istio.io/istio/.circleci/config ~/.kube/config
             ln -s ~/.kube/config /go/src/istio.io/istio/pilot/platform/kube/config
@@ -143,6 +161,12 @@ jobs:
             - dep-cache-{{ checksum "Gopkg.lock" }}
       - run:
           command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
+      - run:
+          command: |
             mkdir ~/.kube
             cp /go/src/istio.io/istio/.circleci/config ~/.kube/config
             ln -s ~/.kube/config /go/src/istio.io/istio/pilot/platform/kube/config
@@ -166,6 +190,12 @@ jobs:
             - dep-cache-{{ checksum "Gopkg.lock" }}
       - run:
           command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
+      - run:
+          command: |
             mkdir ~/.kube
             cp /go/src/istio.io/istio/.circleci/config ~/.kube/config
             ln -s ~/.kube/config /go/src/istio.io/istio/pilot/platform/kube/config
@@ -187,6 +217,12 @@ jobs:
       - restore_cache:
           keys:
             - dep-cache-{{ checksum "Gopkg.lock" }}
+      - run:
+          command: |
+            cd /go/src/istio.io/istio
+            if [ ! -d vendor ]; then
+               dep ensure
+            fi
       - run:
           command: |
             mkdir ~/.kube

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -540,16 +540,14 @@
   revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [[projects]]
-  branch = "master"
   name = "istio.io/api"
   packages = ["broker/v1/config","mixer/v1","mixer/v1/config/client","mixer/v1/config/descriptor","mixer/v1/template","proxy/v1/config"]
-  revision = "80e750910cd1a63367153b30e2a047973b68e5f0"
+  revision = "9f333d0643ba30f18dbc43bc08e0604e9371fe76"
 
 [[projects]]
-  branch = "master"
   name = "istio.io/fortio"
   packages = ["fhttp","log","periodic","stats"]
-  revision = "352aab8335fe279251e986d7168fd6d53f09faa3"
+  revision = "6684bc54abfa793ee4beffe8b2a5b9ec83c782e3"
 
 [[projects]]
   name = "k8s.io/api"
@@ -584,6 +582,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7e463f6a8f1c4d2515ecd17ee57d34627be7f05f7e7d4634536b4a0ddc9f5c94"
+  inputs-digest = "97b03a1286969e211bcfa9771f8581b25a773e5079838aa952d204643b4b4750"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,10 +67,12 @@
  name = "github.com/apache/thrift"
  version = ">=0.9.3, <0.11.0"
 
+### DO NOT PIN these repos to master. It will result in inconsistent builds in circleci
+### as we cache dep ensure.
 [[constraint]]
   name = "istio.io/api"
-  branch = "master"
+  revision = "9f333d0643ba30f18dbc43bc08e0604e9371fe76"
 
 [[constraint]]
   name = "istio.io/fortio"
-  branch = "master"
+  revision = "6684bc54abfa793ee4beffe8b2a5b9ec83c782e3"


### PR DESCRIPTION
Pin Istio/api and istio/fortio to particular SHAs in Gopkg.toml. Otherwise, builds in circleci will continue using old cached version of Gopkg.lock, which will prevent people from updating istio/api and applying the updates here. 