### PR TITLE
Undo the gate to do pure `go test`

### DIFF
--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -108,14 +108,14 @@ ln -sf ~/envoy/usr/local/bin/envoy $ROOT/pilot/proxy/envoy/envoy
 cd $ROOT
 
 # go test execution
-time dep ensure -v
+# time dep ensure -v
 
-echo FIXME remove mixer tools exclusion after tests can be run without bazel
-time go test $(go list ./mixer/... | grep -v /tools/codegen)
-time go test ./pilot/...
-time go test ./security/...
-time go test ./broker/...
-rm -rf vendor/
+# echo FIXME remove mixer tools exclusion after tests can be run without bazel
+# time go test $(go list ./mixer/... | grep -v /tools/codegen)
+# time go test ./pilot/...
+# time go test ./security/...
+# time go test ./broker/...
+# rm -rf vendor/
 
 if [ "${CI:-}" == 'bootstrap' ]; then
   # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio


### PR DESCRIPTION
Note this would mean the checked in .gen.go files and the checked in .pb.go files can go out of sync and will not be tested for correctness.

**What this PR does / why we need it**:
Undo the gate to do pure `go test`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
