### PR TITLE
fix versioning

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -5,9 +5,9 @@
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
-
+#
 #       http://www.apache.org/licenses/LICENSE-2.0
-
+#
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,17 +42,40 @@ else
     BRANCH=unknown
 fi
 
+# Check for local changes
+git diff-index --quiet HEAD --
+if [[ $? == 0 ]];
+then
+  tree_status="Clean"
+else
+  tree_status="Modified"
+fi
+
+# XXX This needs to be updated to accomodate tags added after building, rather than prior to builds
 RELEASE_TAG=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' --exact-match 2> /dev/null || echo "")
 
+# security wanted VERSION='unknown'
 VERSION="${BUILD_GIT_REVISION}"
 if [[ -n "${RELEASE_TAG}" ]]; then
   VERSION="${RELEASE_TAG}"
 elif [[ -n ${ISTIO_VERSION} ]]; then
-  VERSION="${ISTIO_VERSION}-${BUILD_GIT_REVISION}"
+  VERSION="${ISTIO_VERSION}"
 fi
 
+# used by pilot/istioctl version package
 echo buildAppVersion    "${VERSION}"
 echo buildGitRevision   "${BUILD_GIT_REVISION}"
 echo buildGitBranch     "${BRANCH}"
 echo buildUser          "$(whoami)"
 echo buildHost          "$(hostname -f)"
+
+# used by mixer/broker version package
+echo "buildVersion ${VERSION}"
+echo "buildStatus ${tree_status}"
+
+# used by security version package
+echo host "$(hostname -f)"
+echo gitBranch "${BRANCH}"
+echo gitRevision "${BUILD_GIT_REVISION}"
+echo user "$(whoami)"
+echo version "${VERSION}"

--- a/pilot/bin/upload-istioctl
+++ b/pilot/bin/upload-istioctl
@@ -61,7 +61,7 @@ if [[ ${RELEASE} == true ]]; then
   while read line; do
     read SYMBOL VALUE < <(echo $line)
     LDFLAGS=${LDFLAGS}" -X istio.io/istio/pilot/tools/version.${SYMBOL}=${VALUE}"
-  done < <(./bin/get_workspace_status)
+  done < <(../bin/get_workspace_status)
 
   GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" istio.io/istio/pilot/cmd/istioctl
   mv istioctl "${BIN_DIR}/istioctl-osx"

--- a/pilot/cmd/istioctl/BUILD
+++ b/pilot/cmd/istioctl/BUILD
@@ -35,6 +35,6 @@ go_library(
 go_binary(
     name = "istioctl",
     library = ":go_default_library",
-    linkstamp = "istio.io/pilot/tools/version",
+    linkstamp = "istio.io/istio/pilot/tools/version",
     visibility = ["//visibility:public"],
 )

--- a/pilot/cmd/pilot-agent/BUILD
+++ b/pilot/cmd/pilot-agent/BUILD
@@ -22,6 +22,6 @@ go_library(
 go_binary(
     name = "pilot-agent",
     library = ":go_default_library",
-    linkstamp = "istio.io/pilot/tools/version",
+    linkstamp = "istio.io/istio/pilot/tools/version",
     visibility = ["//visibility:public"],
 )

--- a/pilot/cmd/pilot-discovery/BUILD
+++ b/pilot/cmd/pilot-discovery/BUILD
@@ -32,6 +32,6 @@ go_library(
 go_binary(
     name = "pilot-discovery",
     library = ":go_default_library",
-    linkstamp = "istio.io/pilot/tools/version",
+    linkstamp = "istio.io/istio/pilot/tools/version",
     visibility = ["//visibility:public"],
 )

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,0 +1,11 @@
+# This is so we understand failures better
+build --verbose_failures
+test --test_output=errors
+test --test_size_filters=-large,-enormous
+
+# gogo output_filter is required by Mixer (why?)
+build --workspace_status_command=./bin/get_workspace_status --action_env=ISTIO_VERSION --output_filter=^gogo
+build --sandbox_tmpfs_path=/dev/shm
+
+# disable race detection until //pilot/adapter/config/... is fixed
+# test --features=race


### PR DESCRIPTION
Bazel only wants to look at tools/bazel.rc, but monorepo didn't move the indvidual repo's files to istio/tools/bazel.rc (which also requires unifying the differences in the files). Additionally, the linkstamp references weren't updated to the new library paths used in post-monorepo.

Without this change the version info in "istioctl version" was empty (besides go verison), and after this change the version info is populated.

I also removed files that were only used by cloud builder in 0.2. I thought these were already deleted to either I overlooked them or someone added them back.

```release-note
NONE
```
