### PR TITLE
Added support for multiple TCP protocols in egress rules, including Mongo, rebased.

### DIFF
--- a/pilot/model/egress_rules.go
+++ b/pilot/model/egress_rules.go
@@ -75,7 +75,8 @@ var supportedHTTPProtocols = map[Protocol]bool{
 }
 
 var supportedTCPProtocols = map[Protocol]bool{
-	ProtocolTCP: true,
+	ProtocolTCP:   true,
+	ProtocolMongo: true,
 }
 
 // IsEgressRulesSupportedHTTPProtocol returns true if the protocol is supported

--- a/pilot/model/egress_rules.go
+++ b/pilot/model/egress_rules.go
@@ -24,16 +24,27 @@ import (
 	routing "istio.io/api/routing/v1alpha1"
 )
 
-// RejectConflictingEgressRules rejects rules that have the destination which is equal to
-// the destination of some other rule.
+// RejectConflictingEgressRules rejects conflicting egress rules.
+// The conflicts occur either than two egress rules share the same domain, or when they define
+// different protocols on the same port
+func RejectConflictingEgressRules(rules map[string]*routing.EgressRule) ( // long line split
+	map[string]*routing.EgressRule, error) {
+	rulesWithoutConflictsOnDomain, conflictsOnDomain := rejectConflictingOnDomainEgressRules(rules)
+	rulesWithoutConflicts, conflictsOnPort := rejectConflictingOnPortTCPEgressRules(rulesWithoutConflictsOnDomain)
+	return rulesWithoutConflicts, multierror.Append(conflictsOnDomain, conflictsOnPort).ErrorOrNil()
+}
+
+// rejectConflictingOnDomainEgressRules rejects rules that have the destination which is equal to
+// the destionation of some other rule.
 // According to Envoy's virtual host specification, no virtual hosts can share the same domain.
 // The following code rejects conflicting rules deterministically, by a lexicographical order -
 // a rule with a smaller key lexicographically wins.
 // Here the key of the rule is the key of the Istio configuration objects - see
 // `func (meta *ConfigMeta) Key() string`
-func RejectConflictingEgressRules(egressRules map[string]*routing.EgressRule) ( // long line split
+func rejectConflictingOnDomainEgressRules(egressRules map[string]*routing.EgressRule) ( // long line split
 	map[string]*routing.EgressRule, error) {
 	filteredEgressRules := make(map[string]*routing.EgressRule)
+
 	var errs error
 
 	var keys []string
@@ -129,4 +140,57 @@ func egressRulesSupportedProtocols() string {
 		separator = ","
 	}
 	return httpSupportedProtocols + separator + tcpSupportedProtocols
+}
+
+// rejectConflictingOnPortTCPEgressRules rejects rules that have conflicting protocols on the same port
+// E.g. Mongo and TCP, or TCP and HTTP. In the current implementation of egress rules support,
+// conflicts between TCP protocols and other TCP or HTTP protocols are not allowed.
+// The following code rejects conflicting rules deterministically, by a lexicographical order -
+// a rule with a smaller key lexicographically wins.
+// Here the key of the rule is the key of the Istio configuration objects - see
+// `func (meta *ConfigMeta) Key() string`
+func rejectConflictingOnPortTCPEgressRules(egressRules map[string]*routing.EgressRule) ( // long line split
+	map[string]*routing.EgressRule, error) {
+	filteredEgressRules := make(map[string]*routing.EgressRule)
+	var errs error
+
+	var keys []string
+
+	// the key here is the key of the Istio configuration objects - see
+	// `func (meta *ConfigMeta) Key() string`
+	for key := range egressRules {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	protocolsPerPort := make(map[int]Protocol)
+	rulesByPort := make(map[int][]string)
+
+	for _, egressRuleKey := range keys {
+		egressRule := egressRules[egressRuleKey]
+		isRuleConflicting := false
+		for _, port := range egressRule.Ports {
+			protocol := ConvertCaseInsensitiveStringToProtocol(port.Protocol)
+			if IsEgressRulesSupportedHTTPProtocol(protocol) {
+				// we treat all the http protocols the same here, since there is no collision
+				// between HTTP protocols in the current implementation
+				protocol = ProtocolHTTP
+			}
+			intPort := int(port.Port)
+			if protocolUntilNow, ok := protocolsPerPort[intPort]; ok && protocolUntilNow != protocol {
+				errs = multierror.Append(errs, fmt.Errorf("rule %s is rejected since it conflicts "+
+					"rules %v on port %d, protocol %s vs. protocol %s",
+					egressRuleKey, rulesByPort[intPort], intPort, protocol, protocolUntilNow))
+				isRuleConflicting = true
+				break
+			}
+			protocolsPerPort[intPort] = protocol
+			rulesByPort[intPort] = append(rulesByPort[intPort], egressRuleKey)
+		}
+		if !isRuleConflicting {
+			filteredEgressRules[egressRuleKey] = egressRule
+		}
+	}
+
+	return filteredEgressRules, errs
 }

--- a/pilot/model/egress_rules.go
+++ b/pilot/model/egress_rules.go
@@ -54,7 +54,7 @@ func RejectConflictingEgressRules(egressRules map[string]*routing.EgressRule) ( 
 		keyOfAnEgressRuleWithTheSameDomain, conflictingRule := domains[domain]
 		if conflictingRule {
 			errs = multierror.Append(errs,
-				fmt.Errorf("rule %q conflicts with rule %q on domain "+
+				fmt.Errorf("rule %s conflicts with rule %s on domain "+
 					"%s, is rejected", egressRuleKey,
 					keyOfAnEgressRuleWithTheSameDomain, domain))
 			continue

--- a/pilot/model/egress_rules_test.go
+++ b/pilot/model/egress_rules_test.go
@@ -175,6 +175,112 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 				},
 			},
 			valid: false},
+		{name: "no conflicts on port",
+			in: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+				"rule2": {
+					Destination: &routing.IstioService{
+						Service: "10.10.10.11",
+					},
+
+					Ports: []*routing.EgressRule_Port{
+						{Port: 80, Protocol: "http2"},
+						{Port: 1000, Protocol: "tcp"},
+					},
+				},
+			},
+			out: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+				"rule2": {
+					Destination: &routing.IstioService{
+						Service: "10.10.10.11",
+					},
+
+					Ports: []*routing.EgressRule_Port{
+						{Port: 80, Protocol: "http2"},
+						{Port: 1000, Protocol: "tcp"},
+					},
+				},
+			},
+			valid: true},
+		{name: "conflicts on port between tcp protocols",
+			in: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+				"rule2": {
+					Destination: &routing.IstioService{
+						Service: "10.10.10.11",
+					},
+
+					Ports: []*routing.EgressRule_Port{
+						{Port: 80, Protocol: "http2"},
+						{Port: 1000, Protocol: "mongo"},
+					},
+				},
+			},
+			out: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+			},
+			valid: false},
+		{name: "conflicts on port between http protocols",
+			in: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+				"rule2": {
+					Destination: &routing.IstioService{
+						Service: "10.10.10.11",
+					},
+
+					Ports: []*routing.EgressRule_Port{
+						{Port: 80, Protocol: "mongo"},
+						{Port: 1000, Protocol: "tcp"},
+					},
+				},
+			},
+			out: map[string]*routing.EgressRule{"rule1": {
+				Destination: &routing.IstioService{
+					Service: "10.10.10.10",
+				},
+				Ports: []*routing.EgressRule_Port{
+					{Port: 80, Protocol: "http"},
+					{Port: 1000, Protocol: "tcp"},
+				},
+			},
+			},
+			valid: false},
 	}
 
 	for _, c := range cases {

--- a/pilot/model/egress_rules_test.go
+++ b/pilot/model/egress_rules_test.go
@@ -180,12 +180,12 @@ func TestRejectConflictingEgressRules(t *testing.T) {
 	for _, c := range cases {
 		got, errs := model.RejectConflictingEgressRules(c.in)
 		if (errs == nil) != c.valid {
-			t.Errorf("RejectConflictingEgressRules failed on %s: got valid=%v but wanted valid=%v",
-				c.name, errs == nil, c.valid)
+			t.Errorf("RejectConflictingEgressRules failed on %s: got valid=%v but wanted valid=%v, errs=%v",
+				c.name, errs == nil, c.valid, errs)
 		}
 		if !reflect.DeepEqual(got, c.out) {
-			t.Errorf("RejectConflictingEgressRules failed on %s: got=%v but wanted %v: %v",
-				c.name, got, c.in)
+			t.Errorf("RejectConflictingEgressRules failed on %s: got=%v but wanted %v, errs= %v",
+				c.name, got, c.in, errs)
 		}
 	}
 }

--- a/pilot/model/validation.go
+++ b/pilot/model/validation.go
@@ -883,7 +883,7 @@ func ValidateEgressRule(msg proto.Message) error {
 		}
 
 		if cidrDestinationService &&
-			!IsEgressRulesSupportedTCPProtocol(Protocol(strings.ToUpper(port.Protocol))) {
+			!IsEgressRulesSupportedTCPProtocol(ConvertCaseInsensitiveStringToProtocol(port.Protocol)) {
 			errs = multierror.Append(errs, fmt.Errorf("Only the following protocols can be defined for "+
 				"CIDR destination service notation: %s. "+
 				"This rule - port: %d protocol: %s destination.service: %s",
@@ -970,7 +970,7 @@ func ValidateEgressRulePort(port *routing.EgressRule_Port) error {
 		return err
 	}
 
-	if !IsEgressRulesSupportedProtocol(Protocol(strings.ToUpper(port.Protocol))) {
+	if !IsEgressRulesSupportedProtocol(ConvertCaseInsensitiveStringToProtocol(port.Protocol)) {
 		return fmt.Errorf("egress rule support is available only for the following protocols: %s",
 			egressRulesSupportedProtocols())
 	}

--- a/pilot/model/validation_test.go
+++ b/pilot/model/validation_test.go
@@ -1146,6 +1146,7 @@ func TestValidateEgressRulePort(t *testing.T) {
 		{Port: 1, Protocol: "http"}:     true,
 		{Port: 2, Protocol: "https"}:    true,
 		{Port: 80, Protocol: "tcp"}:     true,
+		{Port: 1000, Protocol: "mongo"}: true,
 		{Port: 80, Protocol: "udp"}:     false,
 		{Port: 0, Protocol: "http"}:     false,
 		{Port: 65536, Protocol: "http"}: false,

--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -883,8 +883,7 @@ func buildEgressHTTPRoutes(mesh *meshconfig.MeshConfig, node proxy.Node,
 	for _, rule := range egressRules {
 		for _, port := range rule.Ports {
 			protocol := model.ConvertCaseInsensitiveStringToProtocol(port.Protocol)
-			if protocol != model.ProtocolHTTP && protocol != model.ProtocolHTTPS &&
-				protocol != model.ProtocolHTTP2 && protocol != model.ProtocolGRPC {
+			if !model.IsEgressRulesSupportedHTTPProtocol(protocol) {
 				continue
 			}
 			intPort := int(port.Port)

--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -923,7 +923,7 @@ func buildEgressTCPListeners(mesh *meshconfig.MeshConfig, node proxy.Node,
 
 	for _, rule := range egressRules {
 		for _, port := range rule.Ports {
-			protocol := model.Protocol(strings.ToUpper(port.Protocol))
+			protocol := model.ConvertCaseInsensitiveStringToProtocol(port.Protocol)
 			if !model.IsEgressRulesSupportedTCPProtocol(protocol) {
 				continue
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for multiple TCP protocols, with Mongo protocol being the first one to be added after TCP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1476

**Special notes for your reviewer**:
This is a rebased PR of #1892.

This PR enables multiple TCP protocols, with Mongo being the first case. Redis will be added in a separate PR, after I test it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Added support for Mongo protocol in egress rules
```