### PR TITLE
Remove using redis proxy for redis protocol

### DIFF
--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -435,6 +435,12 @@ func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int, protocol m
 		},
 	}
 
+	// Use Envoy's TCP proxy for TCP and Redis protocols. Currently, Envoy does not support CDS clusters
+	// for Redis proxy. Once Envoy supports CDS clusters, remove the following lines
+	if protocol == model.ProtocolRedis {
+		protocol = model.ProtocolTCP
+	}
+
 	switch protocol {
 	case model.ProtocolMongo:
 		// TODO: add a watcher for /var/lib/istio/mongo/certs

--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
@@ -452,10 +453,35 @@ func buildTCPListener(tcpConfig *TCPRouteConfig, ip string, port int, protocol m
 				baseTCPProxy,
 			},
 		}
+	case model.ProtocolRedis:
+		// Redis filter requires the cluster name to be specified
+		// as part of the filter. We extract the cluster from the
+		// TCPRoute. Since TCPRoute has only one route, we take the
+		// cluster from the first route. The moment this route array
+		// has multiple routes, we need a fallback. For the moment,
+		// fallback to base TCP.
+
+		// Unlike Mongo, Redis is a standalone filter, that is not
+		// stacked on top of tcp_proxy
+		if len(tcpConfig.Routes) == 1 {
+			return &Listener{
+				Name:    fmt.Sprintf("redis_%s_%d", ip, port),
+				Address: fmt.Sprintf("tcp://%s:%d", ip, port),
+				Filters: []*NetworkFilter{{
+					Type: both,
+					Name: RedisProxyFilter,
+					Config: &RedisProxyFilterConfig{
+						ClusterName: tcpConfig.Routes[0].Cluster,
+						StatPrefix:  "redis",
+						ConnPool: &RedisConnPool{
+							OperationTimeoutMS: int64(RedisDefaultOpTimeout / time.Millisecond),
+						},
+					},
+				}},
+			}
+		}
 	}
 
-	// Use Envoy's TCP proxy for TCP and Redis protocols. Currently, Envoy does not support CDS clusters
-	// for Redis proxy.
 	return &Listener{
 		Name:    fmt.Sprintf("tcp_%s_%d", ip, port),
 		Address: fmt.Sprintf("tcp://%s:%d", ip, port),

--- a/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
@@ -30,17 +30,20 @@
    },
    {
     "address": "tcp://0.0.0.0:110",
-    "name": "redis_0.0.0.0_110",
+    "name": "tcp_0.0.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis"
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router-auth.json.golden
@@ -30,20 +30,17 @@
    },
    {
     "address": "tcp://0.0.0.0:110",
-    "name": "tcp_0.0.0.0_110",
+    "name": "redis_0.0.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis"
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-router.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router.json.golden
@@ -30,17 +30,20 @@
    },
    {
     "address": "tcp://0.0.0.0:110",
-    "name": "redis_0.0.0.0_110",
+    "name": "tcp_0.0.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis"
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-router.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-router.json.golden
@@ -30,20 +30,17 @@
    },
    {
     "address": "tcp://0.0.0.0:110",
-    "name": "tcp_0.0.0.0_110",
+    "name": "redis_0.0.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis"
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
@@ -404,17 +404,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -681,7 +687,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -709,14 +715,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -927,17 +939,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-auth.json.golden
@@ -404,23 +404,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -687,7 +681,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -715,20 +709,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -939,23 +927,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
@@ -204,17 +204,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -357,17 +363,23 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -510,17 +522,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-nomixer.json.golden
@@ -204,23 +204,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -363,23 +357,17 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -522,23 +510,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-auth.json.golden
@@ -337,17 +337,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -614,7 +620,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -642,14 +648,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -860,17 +872,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-auth.json.golden
@@ -337,23 +337,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -620,7 +614,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -648,20 +642,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -872,23 +860,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
@@ -187,17 +187,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -340,17 +346,23 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -493,17 +505,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
@@ -187,23 +187,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -346,23 +340,17 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -505,23 +493,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp.json.golden
@@ -337,17 +337,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -596,7 +602,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -624,14 +630,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -830,17 +842,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule-tcp.json.golden
@@ -337,23 +337,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -602,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -630,20 +624,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -842,23 +830,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
@@ -404,17 +404,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -663,7 +669,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -691,14 +697,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -897,17 +909,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-egress-rule.json.golden
@@ -404,23 +404,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -669,7 +663,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -697,20 +691,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -909,23 +897,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -377,17 +377,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -654,7 +660,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -682,14 +688,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -900,17 +912,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault-auth.json.golden
@@ -377,23 +377,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -660,7 +654,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -688,20 +682,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -912,23 +900,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
@@ -227,17 +227,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -380,17 +386,23 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -533,17 +545,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault-nomixer.json.golden
@@ -227,23 +227,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -386,23 +380,17 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -545,23 +533,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -377,17 +377,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -636,7 +642,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -664,14 +670,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -870,17 +882,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-fault.json.golden
@@ -377,23 +377,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -642,7 +636,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -670,20 +664,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -882,23 +870,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -812,17 +824,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optin.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -824,23 +812,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -830,17 +842,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth-optout.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -842,23 +830,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -836,17 +848,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-auth.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -848,23 +836,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
@@ -163,17 +163,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -316,17 +322,23 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -469,17 +481,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none-nomixer.json.golden
@@ -163,23 +163,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -322,23 +316,17 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -481,23 +469,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -806,17 +818,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-none.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -818,23 +806,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -836,17 +848,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted-auth.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -848,23 +836,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
@@ -163,17 +163,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -316,17 +322,23 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -469,17 +481,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted-nomixer.json.golden
@@ -163,23 +163,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -322,23 +316,17 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -481,23 +469,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -806,17 +818,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v0-weighted.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -818,23 +806,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
@@ -404,17 +404,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -681,7 +687,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -709,14 +715,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -927,17 +939,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-auth.json.golden
@@ -404,23 +404,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -687,7 +681,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -715,20 +709,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -939,23 +927,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
@@ -204,17 +204,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -357,17 +363,23 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -510,17 +522,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-nomixer.json.golden
@@ -204,23 +204,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -363,23 +357,17 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -522,23 +510,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-auth.json.golden
@@ -337,17 +337,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -614,7 +620,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -642,14 +648,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -860,17 +872,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-auth.json.golden
@@ -337,23 +337,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -620,7 +614,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -648,20 +642,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -872,23 +860,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
@@ -187,17 +187,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -340,17 +346,23 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -493,17 +505,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
@@ -187,23 +187,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -346,23 +340,17 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -505,23 +493,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp.json.golden
@@ -337,17 +337,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -596,7 +602,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -624,14 +630,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -830,17 +842,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule-tcp.json.golden
@@ -337,23 +337,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -602,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -630,20 +624,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -842,23 +830,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
@@ -404,17 +404,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -663,7 +669,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -691,14 +697,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -897,17 +909,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-egress-rule.json.golden
@@ -404,23 +404,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -669,7 +663,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -697,20 +691,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -909,23 +897,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -836,17 +848,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault-auth.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -848,23 +836,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
@@ -163,17 +163,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -316,17 +322,23 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -469,17 +481,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault-nomixer.json.golden
@@ -163,23 +163,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -322,23 +316,17 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -481,23 +469,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -806,17 +818,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-fault.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -818,23 +806,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -836,17 +848,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none-auth.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -848,23 +836,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
@@ -163,17 +163,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -316,17 +322,23 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -469,17 +481,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none-nomixer.json.golden
@@ -163,23 +163,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -322,23 +316,17 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -481,23 +469,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -806,17 +818,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-none.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -818,23 +806,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -590,7 +596,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -618,14 +624,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -836,17 +848,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted-auth.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -596,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -624,20 +618,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -848,23 +836,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
@@ -163,17 +163,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -316,17 +322,23 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -469,17 +481,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted-nomixer.json.golden
@@ -163,23 +163,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -322,23 +316,17 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -481,23 +469,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -572,7 +578,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "redis_10.1.1.1_1110",
+    "name": "tcp_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -600,14 +606,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.1/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -806,17 +818,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-v1-weighted.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -578,7 +572,7 @@
    },
    {
     "address": "tcp://10.1.1.1:1110",
-    "name": "tcp_10.1.1.1_1110",
+    "name": "redis_10.1.1.1_1110",
     "filters": [
      {
       "type": "both",
@@ -606,20 +600,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.1/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -818,23 +806,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-websocket.json.golden
@@ -313,17 +313,23 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "redis_10.1.0.0_110",
+    "name": "tcp_10.1.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.hello.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -584,7 +590,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "redis_10.1.1.0_1110",
+    "name": "tcp_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -612,14 +618,20 @@
       }
      },
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "in.1110",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],
@@ -830,17 +842,23 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "redis_10.2.0.0_110",
+    "name": "tcp_10.2.0.0_110",
     "filters": [
      {
-      "type": "both",
-      "name": "redis_proxy",
+      "type": "read",
+      "name": "tcp_proxy",
       "config": {
-       "cluster_name": "out.world.default.svc.cluster.local|redis",
-       "conn_pool": {
-        "op_timeout_ms": 30000
-       },
-       "stat_prefix": "redis"
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
       }
      }
     ],

--- a/pilot/proxy/envoy/testdata/lds-websocket.json.golden
+++ b/pilot/proxy/envoy/testdata/lds-websocket.json.golden
@@ -313,23 +313,17 @@
    },
    {
     "address": "tcp://10.1.0.0:110",
-    "name": "tcp_10.1.0.0_110",
+    "name": "redis_10.1.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.hello.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.1.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.hello.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -590,7 +584,7 @@
    },
    {
     "address": "tcp://10.1.1.0:1110",
-    "name": "tcp_10.1.1.0_1110",
+    "name": "redis_10.1.1.0_1110",
     "filters": [
      {
       "type": "both",
@@ -618,20 +612,14 @@
       }
      },
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "in.1110",
-          "destination_ip_list": [
-           "10.1.1.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "in.1110",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],
@@ -842,23 +830,17 @@
    },
    {
     "address": "tcp://10.2.0.0:110",
-    "name": "tcp_10.2.0.0_110",
+    "name": "redis_10.2.0.0_110",
     "filters": [
      {
-      "type": "read",
-      "name": "tcp_proxy",
+      "type": "both",
+      "name": "redis_proxy",
       "config": {
-       "stat_prefix": "tcp",
-       "route_config": {
-        "routes": [
-         {
-          "cluster": "out.world.default.svc.cluster.local|redis",
-          "destination_ip_list": [
-           "10.2.0.0/32"
-          ]
-         }
-        ]
-       }
+       "cluster_name": "out.world.default.svc.cluster.local|redis",
+       "conn_pool": {
+        "op_timeout_ms": 30000
+       },
+       "stat_prefix": "redis"
       }
      }
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, envoy does not support CDS clusters for redis proxy. Redis services become unaccessible on Istio when redis proxy is used.

The code in envoy that produces an error when CDS cluster is used for redis proxy:
https://github.com/envoyproxy/envoy/blob/8fee0f11f1d06abb1dae820a388ffe6d785274c0/source/common/redis/proxy_filter.cc#L21

calls
https://github.com/envoyproxy/envoy/blob/6b2823da5006e92bc4b365e9e8804a4f6a2eba37/source/common/config/utility.cc#L47

where an exception is thrown, resulting in listener on the port and the cluster not being added.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1763

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```