### PR TITLE
more unique version names

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -62,7 +62,7 @@ elif [[ -n ${ISTIO_VERSION} ]]; then
   VERSION="${ISTIO_VERSION}"
 fi
 
-# used by pilot/istioctl version package
+# used by pilot/istioctl/security version package
 echo buildAppVersion    "${VERSION}"
 echo buildGitRevision   "${BUILD_GIT_REVISION}"
 echo buildGitBranch     "${BRANCH}"
@@ -72,10 +72,3 @@ echo buildHost          "$(hostname -f)"
 # used by mixer/broker version package
 echo "buildVersion ${VERSION}"
 echo "buildStatus ${tree_status}"
-
-# used by security version package
-echo host "$(hostname -f)"
-echo gitBranch "${BRANCH}"
-echo gitRevision "${BUILD_GIT_REVISION}"
-echo user "$(whoami)"
-echo version "${VERSION}"

--- a/security/cmd/istio_ca/version/version.go
+++ b/security/cmd/istio_ca/version/version.go
@@ -22,11 +22,11 @@ import (
 )
 
 var (
-	host        string
-	gitBranch   string
-	gitRevision string
-	user        string
-	version     string
+	buildHost        string
+	buildGitBranch   string
+	buildGitRevision string
+	buildUser        string
+	buildAppVersion  string
 
 	// this is used for testing command output
 	printFunc = fmt.Printf
@@ -40,7 +40,7 @@ GitRevision: %v
 GitBranch: %v
 User: %v@%v
 Golang version: %v
-`, version, gitRevision, gitBranch, user, host, runtime.Version())
+`, buildAppVersion, buildGitRevision, buildGitBranch, buildUser, buildHost, runtime.Version())
 		},
 		Use:   "version",
 		Short: "Display version information",

--- a/security/cmd/istio_ca/version/version_test.go
+++ b/security/cmd/istio_ca/version/version_test.go
@@ -22,15 +22,15 @@ import (
 )
 
 func TestVersionCommand(t *testing.T) {
-	host = "test-host"
-	gitBranch = "test-git-branch"
-	gitRevision = "test-git-revision"
-	user = "test-user"
-	version = "test-version"
+	buildHost = "test-host"
+	buildGitBranch = "test-git-branch"
+	buildGitRevision = "test-git-revision"
+	buildUser = "test-user"
+	buildAppVersion = "test-version"
 
 	expectedOutput := fmt.Sprintf(
 		"Version: %v\nGitRevision: %v\nGitBranch: %v\nUser: %v@%v\nGolang version: %v\n",
-		version, gitRevision, gitBranch, user, host, runtime.Version())
+		buildAppVersion, buildGitRevision, buildGitBranch, buildUser, buildHost, runtime.Version())
 
 	var buffer bytes.Buffer
 	printFunc = func(format string, a ...interface{}) (int, error) {


### PR DESCRIPTION
This PR brings to release-0.3 the additional changes that were made on master to address some failures in the pre-submit tests.

The generic -X parameters like "version", "host", "user" that are used by security apparently break other components so this change makes the names more unique by switching security to use the names already defined by pilot that have a "build" prefix in the name.

```release-note
NONE
```
