### PR TITLE
Enable linter for svcctrl adapter

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -27,7 +27,6 @@
     ],
     "exclude": [
         "vendor",
-        "mixer/adapter/svcctrl",
         ".pb.go",
         "mixer/pkg/config/proto/combined.go",
         ".*.gen.go",


### PR DESCRIPTION
**What this PR does / why we need it**

Re-enable linter since issues in /mixer/adapter/svcctrl are fixed.

