### PR TITLE
enable initializer by default for e2e pilot test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ integrationDefaults: &integrationDefaults
     CHANGE_MINIKUBE_NONE_USER: true
     HUB: docker.io/dnerepo
     TAG: dontpush
-    GOPATH: /go      
+    GOPATH: /go
 
 jobs:
   pilot-integration-auth:
@@ -22,7 +22,7 @@ jobs:
         pwd: /
         command: |
           sudo mkdir -p /go/src/istio.io/istio
-          sudo chown -R circleci /go 
+          sudo chown -R circleci /go
       - checkout
       - run: curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run: curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
@@ -42,7 +42,7 @@ jobs:
       - run: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until sudo kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       - run: sudo -E kubectl cluster-info
       - run: make setup
-      - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=enable -errorlogsdir=/home/circleci/logs
+      - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=enable -errorlogsdir=/home/circleci/logs -use-initializer
       - store_artifacts:
           path: /home/circleci/logs
 
@@ -54,7 +54,7 @@ jobs:
         pwd: /
         command: |
           sudo mkdir -p /go/src/istio.io/istio
-          sudo chown -R circleci /go 
+          sudo chown -R circleci /go
       - checkout
       - run: curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run: curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
@@ -74,7 +74,7 @@ jobs:
       - run: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until sudo kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       - run: sudo -E kubectl cluster-info
       - run: make setup
-      - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=disable -errorlogsdir=/home/circleci/logs
+      - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=disable -errorlogsdir=/home/circleci/logs -use-initializer
       - store_artifacts:
           path: /home/circleci/logs
 
@@ -98,7 +98,7 @@ jobs:
 
   unittest-pilot:
     <<: *defaults
-    resource_class: xlarge  
+    resource_class: xlarge
     steps:
       - checkout
       - run: mkdir -p /tmp/coverage
@@ -153,7 +153,7 @@ jobs:
 
   unittest-security:
     <<: *defaults
-    resource_class: xlarge  
+    resource_class: xlarge
     steps:
       - checkout
       - run: mkdir -p /tmp/coverage
@@ -176,7 +176,7 @@ jobs:
 
   unittest-broker:
     <<: *defaults
-    resource_class: xlarge  
+    resource_class: xlarge
     steps:
       - checkout
       - run: mkdir -p /tmp/coverage

--- a/prow/istio-pilot-e2e.sh
+++ b/prow/istio-pilot-e2e.sh
@@ -51,4 +51,4 @@ create_cluster 'e2e-pilot'
 
 ln -sf "${HOME}/.kube/config" ${ROOT}/pilot/platform/kube/config
 HUB="gcr.io/istio-testing"
-make -C "${ROOT}/pilot" e2etest HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=false"
+make -C "${ROOT}/pilot" e2etest HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=false --use-initializer"


### PR DESCRIPTION
We can enable the cluster-wide initializer in e2e tests now that tests are run in dedicated clusters.