### PR TITLE
fix regeneration in bazel_to_go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ vendor
 *.descriptor_set
 # vi backups
 *.bak
+# python artifacts
+*.pyc
 # Vm setup generated files
 cluster.env
 kubedns

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -126,6 +126,19 @@ def makelink(target, linksrc):
 def bazel_info(name):
     return subprocess.check_output(["bazel", "info", name]).strip()
 
+def bazel_query(q):
+    p = subprocess.Popen(['bazel', 'query', q], stdout=subprocess.PIPE)
+    (stdout, _) = p.communicate()
+    return [l for l in stdout.split('\n') if l]
+
+def bazel_build(targets):
+    p = subprocess.Popen(['xargs', 'bazel', 'build'], stdin=subprocess.PIPE)
+    (_, stderr) = p.communicate('\n'.join(targets))
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=p.returncode,
+            cmd=['bazel', 'build'] + targets,
+            output=stderr)
 
 def bazel_to_vendor(WKSPC):
     WKSPC = bazel_info("workspace")
@@ -171,11 +184,12 @@ def bazel_to_vendor(WKSPC):
         makelink(target, linksrc)
         print "Vendored", linksrc, '-->', target
 
-    protolst = protos(WKSPC, genfiles, genfiles_external)
-    protolst.append((genfiles + "/external/io_istio_api/mixer/v1/config/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go"))
+    generated_files = get_generated_files(WKSPC, genfiles)
+    bazel_build(['@io_istio_api//mixer/v1/config:config_fixed'])
+    generated_files.append((genfiles + "/external/io_istio_api/mixer/v1/config/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go"))
 
     # generate manifest of generated files
-    manifest = sorted([l[0][len(genfiles)+1:] for l in protolst])
+    manifest = sorted([src[len(genfiles)+1:] for (src, _) in generated_files])
     with open(WKSPC+"/generated_files", "wt") as fl:
       print >>fl, "#List of generated files that are checked in"
       for mm in manifest:
@@ -189,7 +203,7 @@ def bazel_to_vendor(WKSPC):
         json.dump(conf, fout, sort_keys=True, indent=4, separators=(',', ': '))
 
 
-    for (src, dest) in protolst:
+    for (src, dest) in generated_files:
         try:
             if should_copy(src, dest):
                 shutil.copyfile(src, dest)
@@ -246,16 +260,25 @@ def should_copy(src, dest):
         has_diff = (stdout != '')
     return has_diff
 
-def protos(WKSPC, genfiles, genfiles_external):
+def get_generated_files(WKSPC, genfiles):
     lst = []
-    for directory, dirnames, filenames in os.walk(genfiles):
-        if directory.startswith(genfiles_external):
-            continue
-        for file in filenames:
-            if file.endswith(".go"):
-                src = os.path.join(directory, file)
-                dest = os.path.join(WKSPC, os.path.relpath(src, genfiles))
-                lst.append((src, dest))
+    proto_libraries = 'kind("go_proto_library", "//...")'
+    proto_compiles = 'attr("langs", "go", kind("proto_compile", "//..."))'
+    genrules = 'attr("outs", ".go", kind("genrule", "//..."))'
+    bazel_build(bazel_query('+'.join([proto_libraries, proto_compiles, genrules])))
+
+    for proto in bazel_query('filter("\.proto$", labels("srcs", %s))' % proto_libraries):
+        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
+        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        lst.append((os.path.join(genfiles, pbgo), os.path.join(WKSPC, pbgo)))
+    for proto in bazel_query('filter("\.proto$", labels("protos", %s))' % proto_compiles):
+        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
+        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        src = os.path.join(genfiles, pbgo)
+        lst.append((src, os.path.join(WKSPC, pbgo)))
+    for genout in bazel_query('filter("\.go$", labels("outs", %s))' % genrules):
+        genout = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', genout)
+        lst.append((os.path.join(genfiles, genout), os.path.join(WKSPC, genout)))
     return lst
 
 

--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -171,7 +171,7 @@ def get_external_links(external):
     return [file for file in os.listdir(external) if os.path.isdir(os.path.join(external, file))]
 
 def main(args):
-    WKSPC = os.getcwd()
+    WKSPC = bazel_util.bazel_info('workspace')
     if len(args) > 0:
         WKSPC = args[0]
 

--- a/bin/bazel_util.py
+++ b/bin/bazel_util.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# utility functions to invoke bazel.
+
+import subprocess
+
+def bazel_info(name):
+    return subprocess.check_output(["bazel", "info", name]).strip()
+
+def bazel_query(q):
+    p = subprocess.Popen(['bazel', 'query', q], stdout=subprocess.PIPE)
+    (stdout, _) = p.communicate()
+    return [l for l in stdout.split('\n') if l]
+
+def bazel_build(targets):
+    p = subprocess.Popen(['xargs', 'bazel', 'build'], stdin=subprocess.PIPE)
+    (_, stderr) = p.communicate('\n'.join(targets))
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode=p.returncode,
+            cmd=['bazel', 'build'] + targets,
+            output=stderr)

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -35,7 +35,7 @@ if [ $BRANCH_NAME != '(no branch)' ]; then
     cd $ROOT
 
     echo "updating autogen files..."
-    bin/bazel_to_go.py
+    bin/regenerate_files.py
 
     echo "formatting..."
     bin/fmt.sh

--- a/bin/regenerate_files.py
+++ b/bin/regenerate_files.py
@@ -96,7 +96,7 @@ def regenerate(WKSPC, genfiles):
             print src, dest, ex
 
 def main(args):
-    WKSPC = os.getcwd()
+    WKSPC = bazel_util.bazel_info('workspace')
     if len(args) > 0:
         WKSPC = args[0]
     regenerate(WKSPC, bazel_util.bazel_info("bazel-genfiles"))

--- a/bin/regenerate_files.py
+++ b/bin/regenerate_files.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+import json
+import os
+import shutil
+import subprocess
+import re
+
+import bazel_util
+
+def should_copy(src, dest):
+    if not os.path.exists(dest):
+        return True
+    p = subprocess.Popen(['diff', '-u', src, dest], stdout=subprocess.PIPE)
+    (stdout, _) = p.communicate()
+    if src.endswith('.pb.go'):
+        # there might be diffs for 'source:' lines and others.
+        has_diff = False
+        linecount = 0
+        for l in stdout.split('\n'):
+            linecount += 1
+            if not l:
+                continue
+            if linecount < 3:
+                # first two lines are headers, skipping
+                continue
+            if l.startswith('@@ '):
+                # header for a diff chunk
+                continue
+            if l.startswith(' '):
+                # part of non-changes
+                continue
+            if re.search(r'genfiles/.*\.proto\b', l):
+                # ignoring the proto file path -- the exact file path can be different,
+                # depending on the platform.
+                continue
+            if re.search(r'// \d+ bytes of a gzipped FileDescriptorProto', l):
+                # header comment for descriptor bytes data. It can be different if the file path
+                # is different.
+                continue
+            if re.match(r'^.\s*(0x[0-9a-f][0-9a-f],\s*)+$', l):
+                # file descriptor bytes data. It can be different if the file path is different.
+                continue
+            # Other changes would be meaningful changes.
+            has_diff = True
+            break
+    else:
+        has_diff = (stdout != '')
+    return has_diff
+
+def get_generated_files(WKSPC, genfiles):
+    lst = []
+    proto_libraries = 'kind("go_proto_library", "//...")'
+    proto_compiles = 'attr("langs", "go", kind("proto_compile", "//..."))'
+    genrules = 'attr("outs", ".go", kind("genrule", "//..."))'
+    bazel_util.bazel_build(bazel_util.bazel_query('+'.join([proto_libraries, proto_compiles, genrules])))
+
+    for proto in bazel_util.bazel_query('filter("\.proto$", labels("srcs", %s))' % proto_libraries):
+        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
+        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        lst.append((os.path.join(genfiles, pbgo), os.path.join(WKSPC, pbgo)))
+    for proto in bazel_util.bazel_query('filter("\.proto$", labels("protos", %s))' % proto_compiles):
+        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
+        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        src = os.path.join(genfiles, pbgo)
+        lst.append((src, os.path.join(WKSPC, pbgo)))
+    for genout in bazel_util.bazel_query('filter("\.go$", labels("outs", %s))' % genrules):
+        genout = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', genout)
+        lst.append((os.path.join(genfiles, genout), os.path.join(WKSPC, genout)))
+    return lst
+
+def regenerate(WKSPC, genfiles):
+    generated_files = get_generated_files(WKSPC, genfiles)
+    bazel_util.bazel_build(['@io_istio_api//mixer/v1/config:config_fixed'])
+    generated_files.append((genfiles + "/external/io_istio_api/mixer/v1/config/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go"))
+
+    # generate manifest of generated files
+    manifest = sorted([src[len(genfiles)+1:] for (src, _) in generated_files])
+    with open(WKSPC+"/generated_files", "wt") as fl:
+      print >>fl, "#List of generated files that are checked in"
+      for mm in manifest:
+        print >>fl, mm
+
+    # generate gometalinter config file which excludes generated files
+    with open(os.path.join(WKSPC, "lintconfig_base.json")) as fin:
+        conf = json.load(fin)
+    conf['exclude'].extend(manifest)
+    with open(os.path.join(WKSPC, "lintconfig.gen.json"), "wt") as fout:
+        json.dump(conf, fout, sort_keys=True, indent=4, separators=(',', ': '))
+
+    for (src, dest) in generated_files:
+        try:
+            if should_copy(src, dest):
+                shutil.copyfile(src, dest)
+        except Exception as ex:
+            print src, dest, ex
+
+def main(args):
+    WKSPC = os.getcwd()
+    if len(args) > 0:
+        WKSPC = args[0]
+    regenerate(WKSPC, bazel_util.bazel_info("bazel-genfiles"))
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main(sys.argv[1:]))

--- a/mixer/adapter/svcctrl/svcctrl.go
+++ b/mixer/adapter/svcctrl/svcctrl.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	pbtypes "github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/mixer/adapter/svcctrl/config"
 	"istio.io/istio/mixer/adapter/svcctrl/template/svcctrlreport"


### PR DESCRIPTION
**What this PR does / why we need it**:

bazel_to_go currently scans `bazel-genfiles` directory for the generated files, but this doesn't work for
presubmit bot, since it shares the build cache among runs (i.e. some generated files in a presubmit run
may appear in another run of a totally unrelated PR).

This PR changes this situation:
- use `bazel query` to list up the files which should be generated in the current workspace.
- run `bazel build`, so it can find the source files regardless of the current build status.
- split the copying of the regenerated files into another file -- and pre-commit does the regeneration only.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1515

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
