### PR TITLE
Remove the sidecast of Evaluator to VocabularyChangeListener in pkg/runtime.

### DIFF
--- a/mixer/cmd/server/cmd/server.go
+++ b/mixer/cmd/server/cmd/server.go
@@ -255,7 +255,7 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	// Old and new runtime maintain their own evaluators with
 	// configs and attribute vocabularies.
 	var ilEvalForLegacy *evaluator.IL
-	var eval expr.Evaluator
+	var eval *evaluator.IL
 	var evalForLegacy expr.Evaluator
 	eval, err = evaluator.NewILEvaluator(expressionEvalCacheSize, sa.stringTablePurgeLimit)
 	if err != nil {
@@ -280,7 +280,7 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	if err != nil {
 		fatalf("Failed to connect to the configuration server. %v", err)
 	}
-	dispatcher, err = mixerRuntime.New(eval, evaluator.NewTypeChecker(), gp, adapterGP,
+	dispatcher, err = mixerRuntime.New(eval, evaluator.NewTypeChecker(), eval, gp, adapterGP,
 		sa.configIdentityAttribute, sa.configDefaultNamespace,
 		store2, adapterMap, info,
 	)

--- a/mixer/pkg/runtime/controller_test.go
+++ b/mixer/pkg/runtime/controller_test.go
@@ -49,7 +49,7 @@ func TestControllerEmpty(t *testing.T) {
 		evaluator:              nil,
 		typeChecker:            nil,
 		configState:            make(map[store.Key]*store.Resource),
-		dispatcher:             d,
+		resolverChangeListener: d,
 		resolver:               &resolver{}, // get an empty resolver
 		identityAttribute:      DefaultIdentityAttribute,
 		defaultConfigNamespace: DefaultConfigNamespace,
@@ -210,7 +210,7 @@ func TestController_workflow(t *testing.T) {
 		evaluator:              nil,
 		typeChecker:            nil,
 		configState:            configState,
-		dispatcher:             d,
+		resolverChangeListener: d,
 		resolver:               res, // get an empty resolver
 		identityAttribute:      DefaultIdentityAttribute,
 		defaultConfigNamespace: DefaultConfigNamespace,

--- a/mixer/pkg/runtime/init.go
+++ b/mixer/pkg/runtime/init.go
@@ -34,13 +34,13 @@ import (
 // New creates a new runtime Dispatcher
 // Create a new controller and a dispatcher.
 // Returns a ready to use dispatcher.
-func New(eval expr.Evaluator, typeChecker expr.TypeChecker, gp *pool.GoroutinePool, handlerPool *pool.GoroutinePool,
-	identityAttribute string, defaultConfigNamespace string,
-	s store.Store2, adapterInfo map[string]*adapter.Info,
-	templateInfo map[string]template.Info) (Dispatcher, error) {
+func New(eval expr.Evaluator, typeChecker expr.TypeChecker, v VocabularyChangeListener, gp *pool.GoroutinePool,
+	handlerPool *pool.GoroutinePool, identityAttribute string, defaultConfigNamespace string, s store.Store2,
+	adapterInfo map[string]*adapter.Info, templateInfo map[string]template.Info) (Dispatcher, error) {
+
 	// controller will set Resolver before the dispatcher is used.
 	d := newDispatcher(eval, nil, gp, identityAttribute)
-	err := startController(s, adapterInfo, templateInfo, eval, typeChecker, d,
+	err := startController(s, adapterInfo, templateInfo, eval, typeChecker, v, d,
 		identityAttribute, defaultConfigNamespace, handlerPool)
 
 	return d, err
@@ -87,7 +87,7 @@ func KindMap(adapterInfo map[string]*adapter.Info,
 // startController creates a controller from the given params.
 func startController(s store.Store2, adapterInfo map[string]*adapter.Info,
 	templateInfo map[string]template.Info, eval expr.Evaluator, checker expr.TypeChecker,
-	dispatcher ResolverChangeListener,
+	vocabularyChangeListener VocabularyChangeListener, resolverChangeListener ResolverChangeListener,
 	identityAttribute string, defaultConfigNamespace string, handlerPool *pool.GoroutinePool) error {
 
 	data, watchChan, err := startWatch(s, adapterInfo, templateInfo)
@@ -96,18 +96,19 @@ func startController(s store.Store2, adapterInfo map[string]*adapter.Info,
 	}
 
 	c := &Controller{
-		adapterInfo:            adapterInfo,
-		templateInfo:           templateInfo,
-		evaluator:              eval,
-		typeChecker:            checker,
-		configState:            data,
-		dispatcher:             dispatcher,
-		resolver:               &resolver{}, // get an empty resolver
-		identityAttribute:      identityAttribute,
-		defaultConfigNamespace: defaultConfigNamespace,
-		handlerGoRoutinePool:   handlerPool,
-		table:                  make(map[string]*HandlerEntry),
-		createHandlerFactory:   newHandlerFactory,
+		adapterInfo:              adapterInfo,
+		templateInfo:             templateInfo,
+		evaluator:                eval,
+		typeChecker:              checker,
+		configState:              data,
+		resolverChangeListener:   resolverChangeListener,
+		vocabularyChangeListener: vocabularyChangeListener,
+		resolver:                 &resolver{}, // get an empty resolver
+		identityAttribute:        identityAttribute,
+		defaultConfigNamespace:   defaultConfigNamespace,
+		handlerGoRoutinePool:     handlerPool,
+		table:                    make(map[string]*HandlerEntry),
+		createHandlerFactory:     newHandlerFactory,
 	}
 
 	c.publishSnapShot()


### PR DESCRIPTION
**What this PR does / why we need it**:
The runtime code makes assumptions about the Evaluator and does a side-cast to VocabularyChangeListener. This is brittle, as it stops us from freely changing the listener pathway and couples components in a hard-to-discover way.

+ Also, changes the name of a field from dispatcher to -> *Listener to make its type more clear.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
