### PR TITLE
Fix bug where tab was used instead of whitespace

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -88,7 +88,7 @@ resources:
           gcloud container clusters get-credentials {{ properties['gkeClusterName'] }} --zone {{ properties['zone'] }}
           kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
           git clone https://github.com/istio/istio.git
-	  cd istio
+          cd istio
           git checkout tags/{{ properties['installIstioRelease'] }}
 
           {% if  properties['enableMutualTLS'] %}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in the deployment-manager scripts. In PR #1861 I responded to comments to switch two lines around and accidently introduced a tab instead of spaces; this causes the template to fail after it's deployed.

**Special notes for your reviewer**:

This is *only* a whitespace change; nothing else was modified.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
