### PR TITLE
Use latest 'stable' istio and 'getLatestIstio' script when installing

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -80,16 +80,15 @@ resources:
       items:
       - key: startup-script
         value: |
-          #!/bin/bash
+          #!/bin/bash -x
           apt-get update && apt-get install -y git curl kubectl
           export HOME=/root
           gcloud components update -q
           gcloud components install beta -q
           gcloud container clusters get-credentials {{ properties['gkeClusterName'] }} --zone {{ properties['zone'] }}
           kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
-          git clone https://github.com/istio/istio.git
-	  cd istio
-          git checkout tags/{{ properties['installIstioRelease'] }}
+          curl -L https://raw.githubusercontent.com/istio/istio/master/release/downloadIstioCandidate.sh | ISTIO_VERSION={{ properties['installIstioRelease'] }} sh -
+          cd istio-{{ properties['installIstioRelease'] }}
 
           {% if  properties['enableMutualTLS'] %}
             kubectl apply -f install/kubernetes/istio-auth.yaml

--- a/install/gcp/deployment_manager/istio-cluster.jinja.display
+++ b/install/gcp/deployment_manager/istio-cluster.jinja.display
@@ -1,7 +1,7 @@
 metadataVersion: v1test
 
 description:
-  title: Istio on GKE with Deployment Manager
+  title: Istio on GKE
   version: 0.0.1
   url: 'https://istio.io/'
   tagline: Running Istio on GKE

--- a/install/gcp/deployment_manager/istio-cluster.jinja.schema
+++ b/install/gcp/deployment_manager/istio-cluster.jinja.schema
@@ -46,6 +46,7 @@ properties:
     default: 0.2.12
     enum:
       - 0.2.12
+      - 0.3.0
 
   enableBookInfoSample:
     type: boolean

--- a/install/gcp/deployment_manager/istio-cluster.yaml
+++ b/install/gcp/deployment_manager/istio-cluster.yaml
@@ -17,4 +17,4 @@ resources:
     enableZipkin: true
     enableServiceGraph: true
     enableBookInfoSample: true
-    installIstioRelease: 0.3.0
+    installIstioRelease: 0.2.12


### PR DESCRIPTION
**What this PR does / why we need it**:
Istio 0.3.0 was released, but is not currently the 'stable' version (according to `downloadIstioCandidate.sh`). This change moves the default back to 0.2.12, and also uses the recommended method of installation rather than attempting to clone the repo.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Small changes to startup-script. Should have no impact on any e2e tests (as it's not covered in any way).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```

/cc @salrashid123 @costinm 