### PR TITLE
build: Create empty ~/.kube/config file if missing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ setup: pilot/platform/kube/config
 #-----------------------------------------------------------------------------
 # Target: depend
 #-----------------------------------------------------------------------------
-.PHONY: depend 
+.PHONY: depend
 .PHONY: depend.status depend.ensure depend.graph
 
 depend: depend.ensure
@@ -70,7 +70,7 @@ Gopkg.lock: Gopkg.toml ; $(info $(H) generating) @
 depend.status: Gopkg.lock ; $(info $(H) reporting dependencies status...)
 	$(Q) dep status
 
-# @todo only run if there are changes (e.g., create a checksum file?) 
+# @todo only run if there are changes (e.g., create a checksum file?)
 depend.ensure: Gopkg.lock ; $(info $(H) ensuring dependencies are up to date...)
 	$(Q) dep ensure
 
@@ -145,8 +145,14 @@ push: checkvars
 artifacts: docker
 	@echo 'To be added'
 
-pilot/platform/kube/config:
+pilot/platform/kube/config: ${HOME}/.kube/config
 	ln -fs ~/.kube/config pilot/platform/kube/
+
+${HOME}/.kube/config: ${HOME}/.kube
+	touch $@
+
+${HOME}/.kube:
+	mkdir -p $@
 
 .PHONY: artifacts build checkvars clean docker test setup push
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This change allows the `make build` command to succeed for a user without an existing kubeconfig file, which hopefully makes for a smoother getting started experience. It will not clobber an existing config file if present, but only update its timestamp.

**Which issue this PR fixes**: fixes #1776

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
