### PR TITLE
add service controller for identity registry support

### DIFF
--- a/security/cmd/istio_ca/BUILD
+++ b/security/cmd/istio_ca/BUILD
@@ -16,6 +16,7 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_cobra//doc:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",

--- a/security/pkg/pki/ca/controller/BUILD
+++ b/security/pkg/pki/ca/controller/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["secret.go"],
+    srcs = [
+        "secret.go",
+        "service.go",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//security/pkg/pki:go_default_library",
@@ -22,7 +25,10 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["secret_test.go"],
+    srcs = [
+        "secret_test.go",
+        "service_test.go",
+    ],
     library = ":go_default_library",
     deps = [
         "//security/pkg/pki/ca:go_default_library",

--- a/security/pkg/pki/ca/controller/secret.go
+++ b/security/pkg/pki/ca/controller/secret.go
@@ -113,7 +113,7 @@ func NewSecretController(ca ca.CertificateAuthority, core corev1.CoreV1Interface
 	return c
 }
 
-// Run starts the SecretController until stopCh is closed.
+// Run starts the SecretController until a value is sent to stopCh.
 func (sc *SecretController) Run(stopCh chan struct{}) {
 	go sc.scrtController.Run(stopCh)
 	go sc.saController.Run(stopCh)

--- a/security/pkg/pki/ca/controller/service.go
+++ b/security/pkg/pki/ca/controller/service.go
@@ -25,7 +25,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// ServiceController moniters the service definition changes
+// ServiceController monitors the service definition changes in a namespace.
+// Callback functions are called whenever there is a new service, a service deleted,
+// or a service updated.
 type ServiceController struct {
 	core corev1.CoreV1Interface
 

--- a/security/pkg/pki/ca/controller/service.go
+++ b/security/pkg/pki/ca/controller/service.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ServiceController moniters the service definition changes
+type ServiceController struct {
+	core corev1.CoreV1Interface
+
+	// controller for service objects
+	controller cache.Controller
+
+	// handlers for service events
+	addFunc    func(*v1.Service)
+	deleteFunc func(*v1.Service)
+	updateFunc func(*v1.Service, *v1.Service)
+}
+
+// NewServiceController returns a new ServiceController
+func NewServiceController(core corev1.CoreV1Interface, namespace string,
+	addFunc, deleteFunc func(*v1.Service),
+	updateFunc func(*v1.Service, *v1.Service)) *ServiceController {
+	c := &ServiceController{
+		core:       core,
+		addFunc:    addFunc,
+		deleteFunc: deleteFunc,
+		updateFunc: updateFunc,
+	}
+
+	LW := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return core.Services(namespace).List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return core.Services(namespace).Watch(options)
+		},
+	}
+
+	handler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.serviceAdded,
+		DeleteFunc: c.serviceDeleted,
+		UpdateFunc: c.serviceUpdated,
+	}
+	_, c.controller = cache.NewInformer(LW, &v1.Service{}, time.Minute, handler)
+	return c
+}
+
+// Run starts the ServiceController until a value is sent to stopCh.
+// It should only be called once.
+func (c *ServiceController) Run(stopCh chan struct{}) {
+	go c.controller.Run(stopCh)
+}
+
+func (c *ServiceController) serviceAdded(obj interface{}) {
+	c.addFunc(obj.(*v1.Service))
+}
+
+func (c *ServiceController) serviceDeleted(obj interface{}) {
+	c.deleteFunc(obj.(*v1.Service))
+}
+
+func (c *ServiceController) serviceUpdated(oldObj, newObj interface{}) {
+	c.updateFunc(oldObj.(*v1.Service), newObj.(*v1.Service))
+}

--- a/security/pkg/pki/ca/controller/service_test.go
+++ b/security/pkg/pki/ca/controller/service_test.go
@@ -1,0 +1,118 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type reg struct {
+	sync.Mutex
+	m map[string]bool
+}
+
+var (
+	r = &reg{
+		m: make(map[string]bool),
+	}
+)
+
+func (r *reg) simpleAdd(svc *v1.Service) {
+	r.Lock()
+	r.m[svc.ObjectMeta.Name] = true
+	r.Unlock()
+}
+
+func (r *reg) simpleDelete(svc *v1.Service) {
+	r.Lock()
+	delete(r.m, svc.ObjectMeta.Name)
+	r.Unlock()
+}
+
+func (r *reg) simpleUpdate(oldSvc, newSvc *v1.Service) {
+	r.Lock()
+	delete(r.m, oldSvc.ObjectMeta.Name)
+	r.m[newSvc.ObjectMeta.Name] = true
+	r.Unlock()
+}
+
+func createService(name, namespace string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+type servicePair struct {
+	oldSvc *v1.Service
+	newSvc *v1.Service
+}
+
+func TestServiceController(t *testing.T) {
+	namespace := "test-ns"
+	testCases := map[string]struct {
+		toAdd            *v1.Service
+		toDelete         *v1.Service
+		toUpdate         *servicePair
+		expectedServices map[string]bool
+	}{
+		"add a serivce": {
+			toAdd:            createService("test-svc", namespace),
+			expectedServices: map[string]bool{"test-svc": true},
+		},
+		"add and update a service": {
+			toAdd: createService("test-svc1", namespace),
+			toUpdate: &servicePair{
+				oldSvc: createService("test-svc1", namespace),
+				newSvc: createService("test-svc2", namespace),
+			},
+			expectedServices: map[string]bool{"test-svc2": true},
+		},
+		"add and delete a service": {
+			toAdd:            createService("test-svc", namespace),
+			toDelete:         createService("test-svc", namespace),
+			expectedServices: map[string]bool{},
+		},
+	}
+
+	client := fake.NewSimpleClientset()
+	controller := NewServiceController(client.CoreV1(), namespace, r.simpleAdd, r.simpleDelete, r.simpleUpdate)
+	for id, c := range testCases {
+		r.m = make(map[string]bool)
+
+		if c.toAdd != nil {
+			controller.serviceAdded(c.toAdd)
+		}
+		if c.toDelete != nil {
+			controller.serviceDeleted(c.toDelete)
+
+		}
+		if c.toUpdate != nil {
+			controller.serviceUpdated(c.toUpdate.oldSvc, c.toUpdate.newSvc)
+		}
+
+		if !reflect.DeepEqual(r.m, c.expectedServices) {
+			t.Errorf("%s: service names don't match. Expected %v, Actual %v", id, c.expectedServices, r.m)
+		}
+	}
+}

--- a/security/pkg/pki/ca/controller/service_test.go
+++ b/security/pkg/pki/ca/controller/service_test.go
@@ -105,7 +105,6 @@ func TestServiceController(t *testing.T) {
 		}
 		if c.toDelete != nil {
 			controller.serviceDeleted(c.toDelete)
-
 		}
 		if c.toUpdate != nil {
 			controller.serviceUpdated(c.toUpdate.oldSvc, c.toUpdate.newSvc)


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a service controller, that is similar to secret controller and listens for events related to Service objects. Therefore another goroutine is started in CA which does nothing currently. `service_test.go` demonstrates how a very simple registry should work with the controller.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/istio/old_auth_repo/issues/293

**Special notes for your reviewer**:
I also removed unreachable code at the end of `main()`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
