### PR TITLE
Touch pilot/platform/kube/config instead of symlinking.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - run: go build -i ./pilot/test/integration
       - run: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until sudo kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       - run: sudo -E kubectl cluster-info
-      - run: make setup
+      - run: make kubelink
       - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=enable -errorlogsdir=/home/circleci/logs -use-initializer
       - store_artifacts:
           path: /home/circleci/logs
@@ -85,7 +85,7 @@ jobs:
       - run: go build -i ./pilot/test/integration
       - run: JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until sudo kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       - run: sudo -E kubectl cluster-info
-      - run: make setup
+      - run: make kubelink
       - run: ./integration --logtostderr -hub $HUB -tag $TAG -mixer=false -auth=disable -errorlogsdir=/home/circleci/logs -use-initializer
       - store_artifacts:
           path: /home/circleci/logs

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,12 @@ artifacts: docker
 	@echo 'To be added'
 
 pilot/platform/kube/config:
+	touch $@
+
+kubelink:
 	ln -fs ~/.kube/config pilot/platform/kube/
 
-.PHONY: artifacts build checkvars clean docker test setup push
+.PHONY: artifacts build checkvars clean docker test setup push kubelink
 
 #-----------------------------------------------------------------------------
 # Target: environment and tools


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the build for a user with no existing `~/.kube/config` file, but places the burden on developers to set up proper symlink if they need it for testing.

For convenience, another make target is added to create the symlink: `kubelink`. If developers want to create the symlink instead of creating an empty file, they can run:

    $ make kubelink
    $ make build

or

    $ make kubelink build

or just create the symlink manually.

This is an alternate approach to https://github.com/istio/istio/pull/1950 based on PR feedback.

**Which issue this PR fixes**: fixes #1776

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
