### PR TITLE
stop race errors of mixer/pkg/tracing

### DIFF
--- a/mixer/pkg/tracing/tracing.go
+++ b/mixer/pkg/tracing/tracing.go
@@ -94,6 +94,11 @@ func newJaegerTracer(opts tracingOpts) (opentracing.Tracer, io.Closer, error) {
 		reporters = append(reporters, rep)
 	}
 	if len(opts.jaegerURL) > 0 {
+		if len(reporters) > 0 {
+			// zipkin and jaeger reporters can't safely exist at the same time.
+			// Proceed with warning message.
+			glog.Warning("Both zipkin and jaeger URLs are specified, but their reporters can cause race condition. See https://github.com/istio/istio/issues/1943")
+		}
 		reporters = append(reporters, newJaegerReporter(opts.jaegerURL))
 	}
 	if opts.logger != nil {

--- a/mixer/pkg/tracing/tracing_test.go
+++ b/mixer/pkg/tracing/tracing_test.go
@@ -51,7 +51,11 @@ func TestNewTracer(t *testing.T) {
 		{"with logging", []Option{loggingOpt}, false, false, true},
 		{"with jaeger", []Option{jaegerOpt}, true, false, false},
 		{"with zipkin", []Option{zipkinOpt}, false, true, false},
-		{"with jaeger and zipkin", []Option{jaegerOpt, zipkinOpt}, true, true, false},
+		{"with jaeger and logging", []Option{jaegerOpt, loggingOpt}, true, false, true},
+		{"with zipkin and logging", []Option{zipkinOpt, loggingOpt}, false, true, true},
+		// jaeger and zipkin can't co-exist safely; they touch the same span without
+		// locking, which causes race errors.
+		// {"with jaeger and zipkin", []Option{jaegerOpt, zipkinOpt}, true, true, false},
 	}
 
 	for _, v := range cases {


### PR DESCRIPTION
updates #1943. It seems jaeger reporter and zipkin reporter
doesn't care the case that other reporters exist at the same time,
so it touches the same span without locking, which is considered
as an error by the race detector.

For the time being, let's stop doing such test case, and also
it's better to put some warning message for this fact.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
