### PR TITLE
change the behavior of copying autogen files.

### DIFF
--- a/bin/bazel_to_go.py
+++ b/bin/bazel_to_go.py
@@ -165,7 +165,6 @@ def bazel_to_vendor(WKSPC):
 
         makelink(target, linksrc)
         print "Vendored", linksrc, '-->', target
-    regenerate_files.regenerate(WKSPC, genfiles)
 
 def get_external_links(external):
     return [file for file in os.listdir(external) if os.path.isdir(os.path.join(external, file))]

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -17,6 +17,8 @@ if [[ -z $SKIP_INIT ]];then
   bin/init.sh
 fi
 
+bin/regenerate_files.py --lintconfig_only
+
 echo 'Running linters .... in advisory mode'
 docker run\
   -v $(bazel info output_base):$(bazel info output_base)\

--- a/bin/regenerate_files.py
+++ b/bin/regenerate_files.py
@@ -9,6 +9,12 @@ import re
 import bazel_util
 
 def should_copy(src, dest):
+    '''
+    check if dest should be overwritten by src.
+
+    Basically this means src is different from dest, but has some heuristics to ignore
+    non significant changes for .pb.go files.
+    '''
     if not os.path.exists(dest):
         return True
     p = subprocess.Popen(['diff', '-u', src, dest], stdout=subprocess.PIPE)
@@ -48,45 +54,65 @@ def should_copy(src, dest):
         has_diff = (stdout != '')
     return has_diff
 
+def node_to_path(node):
+    '''
+    get the filepath name from bazel node name (query result).
+
+    The node name is in format of //path/to/directory:filename.
+    '''
+    return re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', node)
+
+def replace_extension(path, new_ext):
+    '''replace the file extension of path to the new one.'''
+    return os.path.splitext(path)[0] + new_ext
+
 def get_generated_files(WKSPC, genfiles):
+    '''get the files automatically generated for building istio.'''
     lst = []
+
+    # bazel query for go_proto_library, like //pilot/test/grpcecho.
     proto_libraries = 'kind("go_proto_library", "//...")'
+
+    # bazel query for proto_compiles. This is also used internally by gogoslick_proto_library
+    # and mixer_proto_library. attr("langs", "go") filter is necessary, since some proto_compile
+    # rules are for descriptors.
     proto_compiles = 'attr("langs", "go", kind("proto_compile", "//..."))'
+
+    # bazel query for genrules. This is used for .gen.go files for mixer templates, but also
+    # used by others like pilot/adapter/config/crd.
     genrules = 'attr("outs", ".go", kind("genrule", "//..."))'
+
+    # First regenerate those codegens.
     bazel_util.bazel_build(bazel_util.bazel_query('+'.join([proto_libraries, proto_compiles, genrules])))
 
+    # Second, get the list of generated files (like .pb.go files) from those build targets.
+    # This can be done through labels() extraction and filtering of suffix of bazel query.
     for proto in bazel_util.bazel_query('filter("\.proto$", labels("srcs", %s))' % proto_libraries):
-        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
-        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        pbgo = replace_extension(node_to_path(proto), '.pb.go')
         lst.append((os.path.join(genfiles, pbgo), os.path.join(WKSPC, pbgo)))
     for proto in bazel_util.bazel_query('filter("\.proto$", labels("protos", %s))' % proto_compiles):
-        proto = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', proto)
-        pbgo = proto[:len(proto)-len('.proto')] + '.pb.go'
+        pbgo = replace_extension(node_to_path(proto), '.pb.go')
         src = os.path.join(genfiles, pbgo)
         lst.append((src, os.path.join(WKSPC, pbgo)))
     for genout in bazel_util.bazel_query('filter("\.go$", labels("outs", %s))' % genrules):
-        genout = re.sub(r'//(.*):([^/]*)', '\\g<1>/\\g<2>', genout)
+        genout = node_to_path(genout)
         lst.append((os.path.join(genfiles, genout), os.path.join(WKSPC, genout)))
     return lst
 
-def regenerate(WKSPC, genfiles):
-    generated_files = get_generated_files(WKSPC, genfiles)
-    bazel_util.bazel_build(['@io_istio_api//mixer/v1/config:config_fixed'])
-    generated_files.append((genfiles + "/external/io_istio_api/mixer/v1/config/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go"))
-
-    # generate manifest of generated files
-    manifest = sorted([src[len(genfiles)+1:] for (src, _) in generated_files])
-    with open(WKSPC+"/generated_files", "wt") as fl:
-      print >>fl, "#List of generated files that are checked in"
-      for mm in manifest:
-        print >>fl, mm
-
-    # generate gometalinter config file which excludes generated files
+def generate_linters_conf(WKSPC, manifest):
+    '''generates gometalinter config file which excludes generated files'''
     with open(os.path.join(WKSPC, "lintconfig_base.json")) as fin:
         conf = json.load(fin)
     conf['exclude'].extend(manifest)
     with open(os.path.join(WKSPC, "lintconfig.gen.json"), "wt") as fout:
         json.dump(conf, fout, sort_keys=True, indent=4, separators=(',', ': '))
+
+def copy_autogen_files(WKSPC, genfiles, generated_files, manifest):
+    '''copies auto-generated files from bazel-genfiles directory'''
+    with open(WKSPC+"/generated_files", "wt") as fl:
+      print >>fl, "#List of generated files that are checked in"
+      for mm in manifest:
+        print >>fl, mm
 
     for (src, dest) in generated_files:
         try:
@@ -95,13 +121,26 @@ def regenerate(WKSPC, genfiles):
         except Exception as ex:
             print src, dest, ex
 
-def main(args):
-    WKSPC = bazel_util.bazel_info('workspace')
-    if len(args) > 0:
-        WKSPC = args[0]
-    regenerate(WKSPC, bazel_util.bazel_info("bazel-genfiles"))
+def regenerate(WKSPC, genfiles, regenerate_autogen_files=True):
+    generated_files = get_generated_files(WKSPC, genfiles)
+    bazel_util.bazel_build(['@io_istio_api//mixer/v1/config:config_fixed'])
+    generated_files.append((genfiles + "/external/io_istio_api/mixer/v1/config/fixed_cfg.pb.go", WKSPC + "/mixer/pkg/config/proto/fixed_cfg.pb.go"))
+    manifest = sorted([src[len(genfiles)+1:] for (src, _) in generated_files])
+
+    generate_linters_conf(WKSPC, manifest)
+    if regenerate_autogen_files:
+        copy_autogen_files(WKSPC, genfiles, generated_files, manifest)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lintconfig_only', action='store_true')
+    parser.add_argument('WKSPC', nargs='?', default=bazel_util.bazel_info('workspace'))
+    args = parser.parse_args()
+    regenerate(args.WKSPC, bazel_util.bazel_info("bazel-genfiles"), regenerate_autogen_files=not args.lintconfig_only)
 
 
 if __name__ == "__main__":
     import sys
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main())

--- a/generated_files
+++ b/generated_files
@@ -47,9 +47,6 @@ mixer/template/tracespan/go_default_library_tmpl.pb.go
 mixer/test/spyAdapter/template/report/go_default_library_handler.gen.go
 mixer/test/spyAdapter/template/report/go_default_library_tmpl.pb.go
 mixer/test/spyAdapter/template/template.gen.go
-mixer/test/template/report/go_default_library_handler.gen.go
-mixer/test/template/report/go_default_library_tmpl.pb.go
-mixer/test/template/template.gen.go
 mixer/tools/codegen/pkg/bootstrapgen/testdata/check_handler.gen.go
 mixer/tools/codegen/pkg/bootstrapgen/testdata/check_tmpl.pb.go
 mixer/tools/codegen/pkg/bootstrapgen/testdata/quota_handler.gen.go

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -129,7 +129,7 @@ fi
 # Build
 ${ROOT}/bin/init.sh
 
-#run_or_die_on_change ./bin/fmt.sh
+run_or_die_on_change ./bin/fmt.sh
 
 # bazel test execution
 echo 'Running Unit Tests'
@@ -142,10 +142,7 @@ diff=`git diff`
 if [[ -n "$diff" ]]; then
   echo "Some uncommitted changes are found. Maybe miss committing some generated files? Here's the diff"
   echo $diff
-  # Do not fail for the changes for now; presubmit bot may share the bazel-genfiles, and that will cause
-  # unrelated failure here randomly. See https://github.com/istio/istio/issues/1689 for the details.
-  # TODO: fix the problem and fail here again.
-  # exit -1
+  exit -1
 fi
 
 HUB="gcr.io/istio-testing"


### PR DESCRIPTION
This changes the behavior to copy autogen files from bazel-genfiles
to the repository location.
- bazel_to_go (and init) does not copy them anymore at all
- direct invocation of bin/regenerate_files.py copies those files.
  this will be invoked from pre-commit hook.
- bin/linters.sh will regen lintconfig.gen.json, but does not do
  anything else.
- as the result, prow/istio-presubmit.sh does not copy those
  autogen files.

This will effectively fix the problem we're seeing so far:
- copying of autogen files from unrelated PR never happens again,
  since presubmit bot does not do this anymore.
- linters.sh should pass normal cases, since those autogen files
  are already committed into the repository.
- if a PR changes some .proto files but forgot to copy them in
  the PR: this should cause lint errors, since other part of
  go files want to refer the generated files but linters will see
  only the checked-in copies.

There's some little chance this can't prevent forgetting copies
of autogen files. For example, when a PR changes only comments
in the .proto files, this will not cause any lint errors even
if the PR author forgets to copy the generated files. I think
this is not a big deal.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
