### PR TITLE
Avoid using StringTable for runtime data.

### DIFF
--- a/mixer/cmd/server/cmd/server.go
+++ b/mixer/cmd/server/cmd/server.go
@@ -82,7 +82,6 @@ type serverArgs struct {
 	configFetchIntervalSec        uint
 	configIdentityAttribute       string
 	configIdentityAttributeDomain string
-	stringTablePurgeLimit         int
 
 	// @deprecated
 	serviceConfigFile string
@@ -115,7 +114,6 @@ func (sa *serverArgs) String() string {
 	b.WriteString(fmt.Sprint("configFetchIntervalSec: ", s.configFetchIntervalSec, "\n"))
 	b.WriteString(fmt.Sprint("configIdentityAttribute: ", s.configIdentityAttribute, "\n"))
 	b.WriteString(fmt.Sprint("configIdentityAttributeDomain: ", s.configIdentityAttributeDomain, "\n"))
-	b.WriteString(fmt.Sprint("stringTablePurgeLimit: ", s.stringTablePurgeLimit, "\n"))
 	return b.String()
 }
 
@@ -206,7 +204,6 @@ func serverCmd(info map[string]template.Info, adapters []adptr.InfoFn, legacyAda
 		fatalf("unable to hide: %v", err)
 	}
 
-	serverCmd.PersistentFlags().IntVar(&sa.stringTablePurgeLimit, "stringTablePurgeLimit", 1024, "Upper limit for String table size to purge at.")
 	// serviceConfig and gobalConfig are for compatibility only
 	serverCmd.PersistentFlags().StringVarP(&sa.serviceConfigFile, "serviceConfigFile", "", "", "Combined Service Config")
 	serverCmd.PersistentFlags().StringVarP(&sa.globalConfigFile, "globalConfigFile", "", "", "Global Config")
@@ -257,11 +254,11 @@ func setupServer(sa *serverArgs, info map[string]template.Info, adapters []adptr
 	var ilEvalForLegacy *evaluator.IL
 	var eval *evaluator.IL
 	var evalForLegacy expr.Evaluator
-	eval, err = evaluator.NewILEvaluator(expressionEvalCacheSize, sa.stringTablePurgeLimit)
+	eval, err = evaluator.NewILEvaluator(expressionEvalCacheSize)
 	if err != nil {
 		fatalf("Failed to create IL expression evaluator with cache size %d: %v", expressionEvalCacheSize, err)
 	}
-	ilEvalForLegacy, err = evaluator.NewILEvaluator(expressionEvalCacheSize, sa.stringTablePurgeLimit)
+	ilEvalForLegacy, err = evaluator.NewILEvaluator(expressionEvalCacheSize)
 	if err != nil {
 		fatalf("Failed to create IL expression evaluator with cache size %d: %v", expressionEvalCacheSize, err)
 	}

--- a/mixer/pkg/il/builder.go
+++ b/mixer/pkg/il/builder.go
@@ -293,5 +293,5 @@ func (f *Builder) op2(op Opcode, p1 uint32, p2 uint32) {
 }
 
 func (f *Builder) id(s string) uint32 {
-	return f.strings.GetID(s)
+	return f.strings.Add(s)
 }

--- a/mixer/pkg/il/evaluator/evaluator_test.go
+++ b/mixer/pkg/il/evaluator/evaluator_test.go
@@ -30,8 +30,6 @@ import (
 	ilt "istio.io/istio/mixer/pkg/il/testing"
 )
 
-const maxStringTableSizeForPurge int = 1024
-
 func TestExpressions(t *testing.T) {
 	for _, test := range ilt.TestData {
 		if test.E == "" {
@@ -260,29 +258,6 @@ func TestConfigChange(t *testing.T) {
 	}
 }
 
-func Test_StringTableSizeBasedEviction(t *testing.T) {
-	src := rand.NewSource(time.Now().UnixNano())
-	rnd := rand.New(src)
-	e := initEvaluator(t, configString)
-
-	expr := `attr == "boo"`
-
-	for i := 0; i < maxStringTableSizeForPurge*10; i++ {
-		bag := initBag(generateRandomStr(rnd))
-		_, err := e.Eval(expr, bag)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		entry, err := e.getAttrContext().getOrCreateCacheEntry(expr, e.functions)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if entry.interpreter.StringTableSize() > maxStringTableSizeForPurge {
-			t.Fatalf("%d > %d", entry.interpreter.StringTableSize(), maxStringTableSizeForPurge)
-		}
-	}
-}
-
 func Test_Stress(t *testing.T) {
 	src := rand.NewSource(time.Now().UnixNano())
 	rnd := rand.New(src)
@@ -316,7 +291,7 @@ func Test_Stress(t *testing.T) {
 }
 
 func Test_TypeChecker_Uninitialized(t *testing.T) {
-	e, err := NewILEvaluator(10, maxStringTableSizeForPurge)
+	e, err := NewILEvaluator(10)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}
@@ -358,7 +333,7 @@ func initBag(attrValue interface{}) attribute.Bag {
 }
 
 func initEvaluator(t *testing.T, config pb.GlobalConfig) *IL {
-	e, err := NewILEvaluator(10, maxStringTableSizeForPurge)
+	e, err := NewILEvaluator(10)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/mixer/pkg/il/function_test.go
+++ b/mixer/pkg/il/function_test.go
@@ -39,7 +39,7 @@ func TestNames(t *testing.T) {
 	}
 
 	f.add(&Function{
-		ID:         s.GetID("foo"),
+		ID:         s.Add("foo"),
 		ReturnType: Void,
 	})
 
@@ -62,7 +62,7 @@ func TestGet(t *testing.T) {
 	}
 
 	foo := &Function{
-		ID:         s.GetID("foo"),
+		ID:         s.Add("foo"),
 		ReturnType: Void,
 	}
 	f.add(foo)
@@ -87,7 +87,7 @@ func TestGetByID(t *testing.T) {
 	}
 
 	foo := &Function{
-		ID:         s.GetID("foo"),
+		ID:         s.Add("foo"),
 		ReturnType: Void,
 	}
 	f.add(foo)
@@ -110,7 +110,7 @@ func TestIDOf(t *testing.T) {
 	}
 
 	foo := &Function{
-		ID:         s.GetID("foo"),
+		ID:         s.Add("foo"),
 		ReturnType: Void,
 	}
 	f.add(foo)

--- a/mixer/pkg/il/interpreter/extern.go
+++ b/mixer/pkg/il/interpreter/extern.go
@@ -150,7 +150,7 @@ func (e Extern) invoke(s *il.StringTable, heap []interface{}, hp *uint32, stack 
 
 		switch e.paramTypes[i] {
 		case il.String:
-			str := s.GetString(stack[ap])
+			str := heap[stack[ap]].(string)
 			ins[i] = reflect.ValueOf(str)
 
 		case il.Bool:
@@ -209,8 +209,9 @@ func (e Extern) invoke(s *il.StringTable, heap []interface{}, hp *uint32, stack 
 	switch e.returnType {
 	case il.String:
 		str := rv.String()
-		id := s.GetID(str)
-		return id, 0, nil
+		heap[*hp] = str
+		*hp++
+		return *hp - 1, 0, nil
 
 	case il.Bool:
 		if rv.Bool() {

--- a/mixer/pkg/il/interpreter/interpreter.go
+++ b/mixer/pkg/il/interpreter/interpreter.go
@@ -78,11 +78,6 @@ func (i *Interpreter) EvalFnID(fnID uint32, bag attribute.Bag) (Result, error) {
 	return i.run(fn, bag, false)
 }
 
-// StringTableSize returns the number of entries in the StringTable.
-func (i *Interpreter) StringTableSize() int {
-	return i.program.Strings().Size()
-}
-
 func newIntr(p *il.Program, es map[string]Extern, s *Stepper) *Interpreter {
 	i := Interpreter{
 		program: p,

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -87,6 +87,10 @@ import (
   HEAP_ACCESS_GUARD(index) \
   target = heap[index];
 
+#define GET_HEAP_VALUE_STRING(index, target) \
+  HEAP_ACCESS_GUARD(index) \
+  target = heap[index].(string);
+
 #define NEW_HEAP_VALUE(value, target) \
   HEAP_OVERFLOW_GUARD \
   target = hp; \
@@ -127,6 +131,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 	var tf64 float64
 	var tVal interface{}
 	var tStr string
+	var tStr2 string
 	var tDur time.Duration
 	var tBool bool
 	var tFound bool
@@ -215,7 +220,12 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			LOAD_OP_CODE(t1)
 			STACK_POP2(REGISTER(t1), REGISTER(t1+1))
 
-		case il.ALoadS, il.ALoadB:
+        case il.ALoadS:
+			LOAD_OP_CODE(t1)
+			NEW_HEAP_VALUE(strings.GetString(t1), t2)
+			REGISTER(t1) = t2
+
+		case il.ALoadB:
 			LOAD_OP_CODE(t1)
 			LOAD_OP_CODE(REGISTER(t1))
 
@@ -233,7 +243,13 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_OVERFLOW_GUARD(1)
 			STACK_PUSH2(REGISTER(t1+1), REGISTER(t1))
 
-		case il.APushS, il.APushB:
+		case il.APushS:
+			LOAD_OP_CODE(t1)
+			STACK_OVERFLOW_GUARD(1)
+			NEW_HEAP_VALUE(strings.GetString(t1), t2)
+			STACK_PUSH(t2)
+
+		case il.APushB:
 			LOAD_OP_CODE(t1)
 			STACK_OVERFLOW_GUARD(1)
 			STACK_PUSH(t1)
@@ -243,7 +259,19 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			STACK_OVERFLOW_GUARD(2)
 			STACK_PUSH2(t2, t1)
 
-		case il.EqS, il.EqB:
+		case il.EqS:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+            GET_HEAP_VALUE_STRING(t1, tStr)
+            GET_HEAP_VALUE_STRING(t2, tStr2)
+
+			if tStr == tStr2 {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.EqB:
 			STACK_UNDERFLOW_GUARD(2)
 			STACK_POP2(t1, t2)
 			if t1 == t2 {
@@ -262,7 +290,18 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				STACK_PUSH(0)
 			}
 
-		case il.AEqS, il.AEqB:
+		case il.AEqS:
+			LOAD_OP_CODE(t1)
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t2)
+            GET_HEAP_VALUE_STRING(t2, tStr)
+			if strings.GetString(t1) == tStr {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.AEqB:
 			LOAD_OP_CODE(t1)
 			STACK_UNDERFLOW_GUARD(1)
 			STACK_POP(t2)
@@ -360,7 +399,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if !tFound {
 				ERRF("error converting value to string: '%v'", tVal)
 			}
-			STACK_PUSH(strings.GetID(tStr))
+            NEW_HEAP_VALUE(tStr, t2)
+            STACK_PUSH(t2)
 
 		case il.ResolveB:
 			STACK_OVERFLOW_GUARD(1)
@@ -437,7 +477,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				if !tFound {
 					ERRF("error converting value to string: '%v'", tVal)
 				}
-				STACK_PUSH(strings.GetID(tStr))
+                NEW_HEAP_VALUE(tStr, t2)
+                STACK_PUSH(t2)
 				STACK_PUSH(1)
 			}
 
@@ -660,7 +701,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				case il.String:
 					STACK_UNDERFLOW_GUARD(1)
 					STACK_PEEK(r.v1)
-					r.vs = strings.GetString(r.v1)
+					GET_HEAP_VALUE_STRING(r.v1, r.vs)
 
 				case il.Interface:
 					STACK_UNDERFLOW_GUARD(1)
@@ -698,12 +739,12 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 		case il.TLookup:
 			STACK_UNDERFLOW_GUARD(2)
 			STACK_POP2(t1, t2)
-			tStr = strings.GetString(t1)
+			GET_HEAP_VALUE_STRING(t1, tStr)
 			GET_HEAP_VALUE(t2, tVal)
 			tStr, tFound = il.MapGet(tVal, tStr)
 			if tFound {
-				t3 = strings.GetID(tStr)
-				STACK_PUSH2(t3, 1)
+                NEW_HEAP_VALUE(tStr, t3)
+                STACK_PUSH2(t3, 1)
 			} else {
 				STACK_PUSH(0)
 			}
@@ -711,25 +752,26 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 		case il.Lookup:
 			STACK_UNDERFLOW_GUARD(2)
 			STACK_POP2(t1, t2)
-			tStr = strings.GetString(t1)
+			GET_HEAP_VALUE_STRING(t1, tStr)
 			GET_HEAP_VALUE(t2, tVal)
 			tStr, tFound = il.MapGet(tVal, tStr)
 			if !tFound {
-				ERRF("member lookup failed: '%v'", strings.GetString(t1))
+    			GET_HEAP_VALUE_STRING(t1, tStr)
+				ERRF("member lookup failed: '%v'", tStr)
 			}
-			t3 = strings.GetID(tStr)
+			NEW_HEAP_VALUE(tStr, t3)
 			STACK_PUSH(t3)
 
 		case il.NLookup:
 			STACK_UNDERFLOW_GUARD(2)
 			STACK_POP2(t1, t2)
-			tStr = strings.GetString(t1)
+			GET_HEAP_VALUE_STRING(t1, tStr)
 			GET_HEAP_VALUE(t2, tVal)
 			tStr, tFound = il.MapGet(tVal, tStr)
 			if !tFound {
 				tStr = ""
 			}
-			t3 = strings.GetID(tStr)
+			NEW_HEAP_VALUE(tStr, t3)
 			STACK_PUSH(t3)
 
 		case il.ALookup:
@@ -742,7 +784,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if !tFound {
 				ERRF("member lookup failed: '%v'", strings.GetString(t1))
 			}
-			t3 = strings.GetID(tStr)
+			NEW_HEAP_VALUE(tStr, t3)
 			STACK_PUSH(t3)
 
 		case il.ANLookup:
@@ -755,7 +797,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if !tFound {
 				tStr = ""
 			}
-			t3 = strings.GetID(tStr)
+			NEW_HEAP_VALUE(tStr, t3)
 			STACK_PUSH(t3)
 
 		default:

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -220,7 +220,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			LOAD_OP_CODE(t1)
 			STACK_POP2(REGISTER(t1), REGISTER(t1+1))
 
-        case il.ALoadS:
+		case il.ALoadS:
 			LOAD_OP_CODE(t1)
 			NEW_HEAP_VALUE(strings.GetString(t1), t2)
 			REGISTER(t1) = t2
@@ -262,8 +262,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 		case il.EqS:
 			STACK_UNDERFLOW_GUARD(2)
 			STACK_POP2(t1, t2)
-            GET_HEAP_VALUE_STRING(t1, tStr)
-            GET_HEAP_VALUE_STRING(t2, tStr2)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr2)
 
 			if tStr == tStr2 {
 				STACK_PUSH(1)
@@ -294,7 +294,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			LOAD_OP_CODE(t1)
 			STACK_UNDERFLOW_GUARD(1)
 			STACK_POP(t2)
-            GET_HEAP_VALUE_STRING(t2, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr)
 			if strings.GetString(t1) == tStr {
 				STACK_PUSH(1)
 			} else {
@@ -399,8 +399,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if !tFound {
 				ERRF("error converting value to string: '%v'", tVal)
 			}
-            NEW_HEAP_VALUE(tStr, t2)
-            STACK_PUSH(t2)
+			NEW_HEAP_VALUE(tStr, t2)
+			STACK_PUSH(t2)
 
 		case il.ResolveB:
 			STACK_OVERFLOW_GUARD(1)
@@ -477,8 +477,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 				if !tFound {
 					ERRF("error converting value to string: '%v'", tVal)
 				}
-                NEW_HEAP_VALUE(tStr, t2)
-                STACK_PUSH(t2)
+				NEW_HEAP_VALUE(tStr, t2)
+				STACK_PUSH(t2)
 				STACK_PUSH(1)
 			}
 
@@ -743,8 +743,8 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			GET_HEAP_VALUE(t2, tVal)
 			tStr, tFound = il.MapGet(tVal, tStr)
 			if tFound {
-                NEW_HEAP_VALUE(tStr, t3)
-                STACK_PUSH2(t3, 1)
+				NEW_HEAP_VALUE(tStr, t3)
+				STACK_PUSH2(t3, 1)
 			} else {
 				STACK_PUSH(0)
 			}

--- a/mixer/pkg/il/interpreter/interpreter_test.go
+++ b/mixer/pkg/il/interpreter/interpreter_test.go
@@ -84,20 +84,6 @@ func TestInterpreter_Eval_FunctionNotFound(t *testing.T) {
 	}
 }
 
-func TestInterpreter_StringTableSize(t *testing.T) {
-	p, _ := text.ReadText(`
-	fn main() bool
-		apush_b false
-		ret
-	end
-	`)
-
-	i := New(p, map[string]Extern{})
-	if i.StringTableSize() != p.Strings().Size() {
-		t.Fatalf("Size mismatch: %d != %d", i.StringTableSize(), p.Strings().Size())
-	}
-}
-
 func TestInterpreter_Eval(t *testing.T) {
 	duration20ms, _ := time.ParseDuration("20ms")
 

--- a/mixer/pkg/il/opcode.go
+++ b/mixer/pkg/il/opcode.go
@@ -675,7 +675,7 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// and pushes the result back into stack. The operation follows Go's integer addition
 	// semantics.
 	AAddI: {name: "AAddI", keyword: "aadd_i", args: []OpcodeArg{
-		// Value to add
+		// Value to Add
 		OpcodeArgInt,
 	}},
 
@@ -683,7 +683,7 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// and pushes the result back into stack. The operation follows Go's double addition
 	// semantics.
 	AAddD: {name: "AAddD", keyword: "aadd_d", args: []OpcodeArg{
-		// Value to add
+		// Value to Add
 		OpcodeArgDouble,
 	}},
 

--- a/mixer/pkg/il/opcode.go
+++ b/mixer/pkg/il/opcode.go
@@ -675,7 +675,7 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// and pushes the result back into stack. The operation follows Go's integer addition
 	// semantics.
 	AAddI: {name: "AAddI", keyword: "aadd_i", args: []OpcodeArg{
-		// Value to Add
+		// Value to add
 		OpcodeArgInt,
 	}},
 
@@ -683,7 +683,7 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 	// and pushes the result back into stack. The operation follows Go's double addition
 	// semantics.
 	AAddD: {name: "AAddD", keyword: "aadd_d", args: []OpcodeArg{
-		// Value to Add
+		// Value to add
 		OpcodeArgDouble,
 	}},
 

--- a/mixer/pkg/il/program.go
+++ b/mixer/pkg/il/program.go
@@ -93,7 +93,7 @@ func NewProgram() *Program {
 // need to be supplied to the interpreter separately.
 func (p *Program) AddExternDef(name string, parameters []Type, returnType Type) {
 	f := Function{
-		ID:         p.strings.GetID(name),
+		ID:         p.strings.Add(name),
 		Length:     0,
 		Address:    0,
 		Parameters: parameters,
@@ -132,7 +132,7 @@ func (p *Program) AddFunction(name string, parameters []Type, returnType Type, b
 	}
 
 	f := &Function{
-		ID:         p.strings.GetID(name),
+		ID:         p.strings.Add(name),
 		Length:     l,
 		Address:    start,
 		Parameters: parameters,

--- a/mixer/pkg/il/strings_test.go
+++ b/mixer/pkg/il/strings_test.go
@@ -38,7 +38,7 @@ func TestNewStringTable(t *testing.T) {
 func TestGetID(t *testing.T) {
 	s := newStringTable()
 
-	i := s.GetID("foo")
+	i := s.Add("foo")
 	if s.nextID != i+1 {
 		t.Fatal()
 	}
@@ -51,7 +51,7 @@ func TestGetID(t *testing.T) {
 		t.Fatal()
 	}
 
-	i2 := s.GetID("foo")
+	i2 := s.Add("foo")
 	if i != i2 {
 		t.Fatal()
 	}
@@ -70,7 +70,7 @@ func TestTryGetID(t *testing.T) {
 		t.Fatal()
 	}
 
-	i = s.GetID("foo")
+	i = s.Add("foo")
 	if i != s.TryGetID("foo") {
 		t.Fatal()
 	}
@@ -87,7 +87,7 @@ func TestGetString(t *testing.T) {
 		t.Fatal()
 	}
 
-	i := s.GetID("foo")
+	i := s.Add("foo")
 	if s.GetString(i) != "foo" {
 		t.Fatal()
 	}
@@ -100,7 +100,7 @@ func TestExpansion(t *testing.T) {
 
 	for i := 1; i < allocSize*10+1; i++ {
 		str := fmt.Sprintf("str-%d", i)
-		id := s.GetID(str)
+		id := s.Add(str)
 		strMap[id] = str
 	}
 
@@ -111,7 +111,7 @@ func TestExpansion(t *testing.T) {
 			t.Fatal()
 		}
 
-		actualID := s.GetID(str)
+		actualID := s.Add(str)
 		if actualID != id {
 			t.Fatal()
 		}
@@ -121,7 +121,7 @@ func TestExpansion(t *testing.T) {
 func TestSize(t *testing.T) {
 	s := newStringTable()
 
-	_ = s.GetID("AAA")
+	_ = s.Add("AAA")
 
 	if s.Size() != int(s.nextID) {
 		t.Fatalf("Size mismatch")

--- a/mixer/pkg/il/text/read.go
+++ b/mixer/pkg/il/text/read.go
@@ -209,7 +209,7 @@ Loop:
 					p.failUnexpectedInput()
 					goto FAILED
 				}
-				id := p.program.Strings().GetID(i)
+				id := p.program.Strings().Add(i)
 				body = append(body, id)
 
 			case il.OpcodeArgFunction:
@@ -218,7 +218,7 @@ Loop:
 					p.failUnexpectedInput()
 					goto FAILED
 				}
-				id := p.program.Strings().GetID(i)
+				id := p.program.Strings().Add(i)
 				body = append(body, id)
 
 			case il.OpcodeArgInt:

--- a/mixer/pkg/il/text/write_test.go
+++ b/mixer/pkg/il/text/write_test.go
@@ -105,7 +105,7 @@ end
 
 func TestWriteStringArg(t *testing.T) {
 	p := il.NewProgram()
-	id := p.Strings().GetID("foo")
+	id := p.Strings().Add("foo")
 	err := p.AddFunction("main", []il.Type{}, il.Bool, []uint32{
 		uint32(il.ResolveS),
 		uint32(id),
@@ -170,7 +170,7 @@ func TestWriteFunctionArg(t *testing.T) {
 	}
 	err = p.AddFunction("caller", []il.Type{}, il.Bool, []uint32{
 		uint32(il.Call),
-		p.Strings().GetID("callee"),
+		p.Strings().Add("callee"),
 		uint32(il.Ret),
 	})
 	if err != nil {

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -843,7 +843,7 @@ func (e *fakeExpr) Eval(mapExpression string, attrs attribute.Bag) (interface{},
 	if strings.HasSuffix(expr2, "timestamp") {
 		return time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC), nil
 	}
-	ev, _ := evaluator.NewILEvaluator(1024, 1024)
+	ev, _ := evaluator.NewILEvaluator(1024)
 	ev.ChangeVocabulary(createAttributeDescriptorFinder(e.extraAttrManifest))
 	return ev.Eval(expr2, attrs)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes an issue in the evaluator that causes runtime strings to be captured in the strings table. With this fix:
- The strings are stored in heap, similar to other interface{} objects.
- The comparisons are performed using regular string comparison.
- The size-based expression cache eviction algorithm (& its parameter) is removed.
- Renamed the method on StringTable from GetID => Add for clarity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #1369
**Special notes for your reviewer**:
This will most likely conflict with the pkg/server change. I'll wait until that one lands, before checking this in.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
