### PR TITLE
have downloadIstioCandidate.sh ask github for the latest

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -22,12 +22,16 @@ else
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
-  ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases/latest | \
-                  grep tag_name | sed "s/ *\"tag_name\": *\"\(.*\)\",*/\1/")
+  TEMP_FILE="$(mktemp /tmp/istio.latest.XXXX)"
+  curl -L -s -o "$TEMP_FILE" https://api.github.com/repos/istio/istio/releases/latest
+  NAME=istio-$(grep tag_name "$TEMP_FILE" | sed "s/ *\"tag_name\": *\"\(.*\)\",*/\1/")
+  URL=$(grep browser_download_url "$TEMP_FILE" | grep $OSEXT | sed "s/ *\"browser_download_url\": *\"\(.*\)\",*/\1/")
+  rm "$TEMP_FILE"
+else
+  NAME="istio-$ISTIO_VERSION"
+  URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 fi
 
-NAME="istio-$ISTIO_VERSION"
-URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 echo "Downloading $NAME from $URL ..."
 curl -L "$URL" | tar xz
 # TODO: change this so the version is in the tgz/directory name (users trying multiple versions)

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -22,16 +22,12 @@ else
 fi
 
 if [ "x${ISTIO_VERSION}" = "x" ] ; then
-  TEMP_FILE="$(mktemp /tmp/istio.latest.XXXX)"
-  curl -L -s -o "$TEMP_FILE" https://api.github.com/repos/istio/istio/releases/latest
-  NAME=istio-$(grep tag_name "$TEMP_FILE" | sed "s/ *\"tag_name\": *\"\(.*\)\",*/\1/")
-  URL=$(grep browser_download_url "$TEMP_FILE" | grep $OSEXT | sed "s/ *\"browser_download_url\": *\"\(.*\)\",*/\1/")
-  rm "$TEMP_FILE"
-else
-  NAME="istio-$ISTIO_VERSION"
-  URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
+  ISTIO_VERSION=$(curl -L -s https://api.github.com/repos/istio/istio/releases/latest | \
+                  grep tag_name | sed "s/ *\"tag_name\": *\"\(.*\)\",*/\1/")
 fi
 
+NAME="istio-$ISTIO_VERSION"
+URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 echo "Downloading $NAME from $URL ..."
 curl -L "$URL" | tar xz
 # TODO: change this so the version is in the tgz/directory name (users trying multiple versions)

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -6,15 +6,13 @@
 # so it should be pure bourne shell, not bash (and not reference other scripts)
 #
 # The script fetches the latest Istio release candidate and untars it.
-# It's a copy of ../downloadIstio.sh which is for stable releases but lets
+# It's derived from ../downloadIstio.sh which is for stable releases but lets
 # users do curl -L https://git.io/getLatestIstio | ISTIO_VERSION=0.3.6 sh -
 # for instance to change the version fetched.
 
 # This is the latest release candidate (matches ../istio.VERSION after basic
 # sanity checks)
-ISTIO_VERSION=${ISTIO_VERSION:-0.3.0}
 
-NAME="istio-$ISTIO_VERSION"
 OS="$(uname)"
 if [ "x${OS}" = "xDarwin" ] ; then
   OSEXT="osx"
@@ -22,7 +20,18 @@ else
   # TODO we should check more/complain if not likely to work, etc...
   OSEXT="linux"
 fi
-URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
+
+if [ "x${ISTIO_VERSION}" = "x" ] ; then
+  TEMP_FILE="$(mktemp /tmp/istio.latest.XXXX)"
+  curl -L -s -o "$TEMP_FILE" https://api.github.com/repos/istio/istio/releases/latest
+  NAME=istio-$(grep tag_name "$TEMP_FILE" | sed "s/ *\"tag_name\": *\"\(.*\)\",*/\1/")
+  URL=$(grep browser_download_url "$TEMP_FILE" | grep $OSEXT | sed "s/ *\"browser_download_url\": *\"\(.*\)\",*/\1/")
+  rm "$TEMP_FILE"
+else
+  NAME="istio-$ISTIO_VERSION"
+  URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
+fi
+
 echo "Downloading $NAME from $URL ..."
 curl -L "$URL" | tar xz
 # TODO: change this so the version is in the tgz/directory name (users trying multiple versions)


### PR DESCRIPTION
This change allows downloadIstioCandidate.sh to automatically ask github for the latest version.  It seems to work on Mac and Linux and I've preserved the behavior to allow ISTIO_VERSION to override the version.  This file isn't to be confused with ../downloadIstio.sh that's used to grab the latest stable.

The main tradeoff I can think of (besides if I've unknowlying added an inappropriate dependency) is that if we have a release like 0.3.0 and then do a new release for a patch update (e.g., a hypothetical 0.2.15) then github might report that 0.2.15 is the latest.  I'm not sure I have a good solution for this.  Even if I have the script take the max(github-latest, ISTIO_VERSION-in-file) then this won't be ideal either if the version in the script is stale, and my eventual hope/goal would be to get rid of the baked-in version (and the need to update it).

Thoughts on whether this is a worthwhile or achievable goal?

```release-note
NONE
```
