### PR TITLE
Key circleci cache based on Gopkg.toml/WORKSPACE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run: bin/install-go.sh
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -73,7 +73,7 @@ jobs:
       - run: bin/install-go.sh
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -104,7 +104,7 @@ jobs:
                dep ensure
             fi
       - save_cache:
-          key: dep-cache-{{ checksum "Gopkg.toml" }}
+          key: dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
           paths:
             - /go/src/istio.io/istio/vendor
 
@@ -120,7 +120,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -158,7 +158,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -187,7 +187,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio
@@ -216,7 +216,7 @@ jobs:
           background: true
       - restore_cache:
           keys:
-            - dep-cache-{{ checksum "Gopkg.toml" }}
+            - dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "WORKSPACE" }}
       - run:
           command: |
             cd /go/src/istio.io/istio

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-# dummy line 5 - circli cache is keyed off the checksum of the top level WORKSPACE file -
+# dummy line 6 - circli cache is keyed off the checksum of the top level WORKSPACE file -
 
 workspace(name = "io_istio_istio")
 


### PR DESCRIPTION
Set the circleci cache key to both Gokpkg.toml and WORKSPACE, so that
changes to either will trigger a circleci cache rebuild, and a manual
rebuild without cache will not be needed.

**What this PR does / why we need it**:

Changes in [#1814](https://github.com/istio/istio/pull/1814) resulted in a situation where CircleCI will not rebuild it's dependencies when a change is made to `WORKSPACE`, only `Gopkg.toml`. This condition was discovered as the result of [this test](Remove bazel from circleci integration test) failing as the part of [PR #1737 ](https://github.com/istio/istio/pull/1737).

This change enables the cache to rebuild when updates to `WORKSPACE` are introduced. While this may not be the end goal for package management in Istio, this provides a means to get the CircleCI tests running when needed.

**Special notes for your reviewer**:

I updated the WORKSPACE file also; evidence of the CircleCI cache rebuilding on this PR should indicate it is performing as expected.

**Release note**:
```NONE```
