### PR TITLE
Use standard_types in templates (allow ipaddress, dns, uri, email in template).

### DIFF
--- a/mixer/adapter/svcctrl/template/svcctrlreport/template.proto
+++ b/mixer/adapter/svcctrl/template/svcctrlreport/template.proto
@@ -16,8 +16,7 @@ syntax = "proto3";
 
 package svcctrlReport;
 
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 
@@ -56,13 +55,13 @@ message Template {
     string api_service = 4;
     string api_key = 5;
 
-    google.protobuf.Timestamp request_time = 6;
+    istio.mixer.v1.template.TimeStamp request_time = 6;
     string request_method = 7;
     string request_path = 8;
     int64 request_bytes = 9;
 
-    google.protobuf.Timestamp response_time = 10;
+    istio.mixer.v1.template.TimeStamp response_time = 10;
     int64 response_code = 11;
     int64 response_bytes = 12;
-    google.protobuf.Duration response_latency = 13;
+    istio.mixer.v1.template.Duration response_latency = 13;
 }

--- a/mixer/doc/templates.md
+++ b/mixer/doc/templates.md
@@ -101,23 +101,38 @@ name should follow the normal protobuf naming convention of snake_case.
 
 ## Supported field types
 
-Templates currently only support a subset of the full protobuf type system. Fields in a template can
-be one of the following types:
+Templates currently only support a subset of the full protobuf type system. Following types can be used for fields in a
+template. Below table also shows the corresponding Golang type delivered to the adapters:
 
-- `string`
-- `int64`
-- `double`
-- `bool`
-- `google.protobuf.Timestamp`
-- `google.protobuf.Duration`
-- `istio.mixer.v1.config.descriptor.ValueType`
-- `map<string, string>`
-- `map<string, int64>`
-- `map<string, double>`
-- `map<string, bool>`
-- `map<string, google.protobuf.Timestamp>`
-- `map<string, google.protobuf.Duration>`
-- `map<string, istio.mixer.v1.config.descriptor.ValueType>`
+Template field type | Golang type
+--- | ---
+`string` | `string`
+`int64` | `int64`
+`double` | `float64`
+`bool` | `bool`
+`istio.mixer.v1.template.TimeStamp` | `time.Time`
+`istio.mixer.v1.template.Duration` | `time.Duration`
+`istio.mixer.v1.template.IPAddress` | `net.IP`
+`istio.mixer.v1.template.DNSName` | `adapter.DNSName`
+`istio.mixer.v1.config.descriptor.ValueType` | `interface{}`
+`map<string, string>` | `map[string]string`
+`map<string, int64>` | `map[string]int64`
+`map<string, double>` | `map[string]float64`
+`map<string, bool>` | `map[string]bool`
+`map<string, istio.mixer.v1.template.TimeStamp>` | `map[string]time.Time`
+`map<string, istio.mixer.v1.template.Duration>` | `map[string]time.Duration`
+`map<string, istio.mixer.v1.template.IPAddress>` | `map[string]net.IP`
+`map<string, istio.mixer.v1.template.DNSName>` | `map[string]adapter.DNSName`
+`map<string, istio.mixer.v1.config.descriptor.ValueType>` | `map[string]interface{}`
+
+There is currently no support for nested messages, enums, `oneof`, and `repeated`.
+
+The type `istio.mixer.v1.config.descriptor.ValueType` has a special meaning. Use of this type
+tells Mixer that the associated value can be any of the supported attribute
+types which are defined by the [ValueType](https://github.com/istio/api/blob/master/mixer/v1/config/descriptor/value_type.proto)
+enum. The specific type that will be used at runtime depends on the configuration the operator writes.
+Adapters are told what these types are at [configuration time](./adapters.md##adapter-lifecycle) so they can prepare
+themselves accordingly.
 
 There is currently no support for nested messages, enums, `oneof`, and `repeated`.
 

--- a/mixer/pkg/adapter/BUILD
+++ b/mixer/pkg/adapter/BUILD
@@ -22,6 +22,7 @@ go_library(
         "registrar.go",
         "requestData.go",
         "result.go",
+        "standardTypes.go",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/mixer/pkg/adapter/labels.go
+++ b/mixer/pkg/adapter/labels.go
@@ -24,10 +24,10 @@ const (
 	Float64
 	Bool
 	Time
-	Duration
-	IPAddress
-	EmailAddress
-	URI
-	DNSName
+	DurationLegacy
+	IPAddressLegacy
+	EmailAddressLegacy
+	URILegacy
+	DNSNameLegacy
 	StringMap
 )

--- a/mixer/pkg/adapter/standardTypes.go
+++ b/mixer/pkg/adapter/standardTypes.go
@@ -1,0 +1,30 @@
+// Copyright 2016 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+// Strong Go types for template-specific instance fields that are sent to the adapters.
+type (
+	// Associated with template field type istio.mixer.v1.template.DNSName
+	DNSName string
+	// Associated with template field type istio.mixer.v1.template.EmailAddress
+	EmailAddress string
+	// Associated with template field type istio.mixer.v1.template.Uri
+	Uri string
+
+	// For other types in "istio.mixer.v1.template", we use well known Go types. For example:
+	// istio.mixer.v1.template.Duration -> time.Duration
+	// istio.mixer.v1.template.TimeStamp -> time.time
+	// istio.mixer.v1.template.IPAddress -> net.IP
+)

--- a/mixer/pkg/adapter/standardTypes.go
+++ b/mixer/pkg/adapter/standardTypes.go
@@ -16,12 +16,12 @@ package adapter
 
 // Strong Go types for template-specific instance fields that are sent to the adapters.
 type (
-	// Associated with template field type istio.mixer.v1.template.DNSName
+	// DNSName is associated with template field type istio.mixer.v1.template.DNSName
 	DNSName string
-	// Associated with template field type istio.mixer.v1.template.EmailAddress
+	// EmailAddress is associated with template field type istio.mixer.v1.template.EmailAddress
 	EmailAddress string
-	// Associated with template field type istio.mixer.v1.template.Uri
-	Uri string
+	// URI is associated with template field type istio.mixer.v1.template.Uri
+	URI string
 
 	// For other types in "istio.mixer.v1.template", we use well known Go types. For example:
 	// istio.mixer.v1.template.Duration -> time.Duration

--- a/mixer/pkg/aspect/descriptors.go
+++ b/mixer/pkg/aspect/descriptors.go
@@ -35,15 +35,15 @@ func valueTypeToLabelType(pbt dpb.ValueType) (adapter.LabelType, error) {
 	case dpb.TIMESTAMP:
 		return adapter.Time, nil
 	case dpb.DNS_NAME:
-		return adapter.DNSName, nil
+		return adapter.DNSNameLegacy, nil
 	case dpb.DURATION:
-		return adapter.Duration, nil
+		return adapter.DurationLegacy, nil
 	case dpb.EMAIL_ADDRESS:
-		return adapter.EmailAddress, nil
+		return adapter.EmailAddressLegacy, nil
 	case dpb.IP_ADDRESS:
-		return adapter.IPAddress, nil
+		return adapter.IPAddressLegacy, nil
 	case dpb.URI:
-		return adapter.URI, nil
+		return adapter.URILegacy, nil
 	case dpb.STRING_MAP:
 		return adapter.StringMap, nil
 	default:

--- a/mixer/pkg/aspect/descriptors_test.go
+++ b/mixer/pkg/aspect/descriptors_test.go
@@ -35,11 +35,11 @@ func TestFromPbType(t *testing.T) {
 		{dpb.DOUBLE, adapter.Float64, ""},
 		{dpb.BOOL, adapter.Bool, ""},
 		{dpb.TIMESTAMP, adapter.Time, ""},
-		{dpb.IP_ADDRESS, adapter.IPAddress, ""},
-		{dpb.EMAIL_ADDRESS, adapter.EmailAddress, ""},
-		{dpb.URI, adapter.URI, ""},
-		{dpb.DNS_NAME, adapter.DNSName, ""},
-		{dpb.DURATION, adapter.Duration, ""},
+		{dpb.IP_ADDRESS, adapter.IPAddressLegacy, ""},
+		{dpb.EMAIL_ADDRESS, adapter.EmailAddressLegacy, ""},
+		{dpb.URI, adapter.URILegacy, ""},
+		{dpb.DNS_NAME, adapter.DNSNameLegacy, ""},
+		{dpb.DURATION, adapter.DurationLegacy, ""},
 		{dpb.STRING_MAP, adapter.StringMap, ""},
 	}
 	for idx, c := range cases {

--- a/mixer/pkg/il/compiler/compiler.go
+++ b/mixer/pkg/il/compiler/compiler.go
@@ -114,6 +114,12 @@ func (g *generator) toIlType(t dpb.ValueType) il.Type {
 		return il.Interface
 	case dpb.IP_ADDRESS:
 		return il.Interface
+	case dpb.EMAIL_ADDRESS:
+		return il.Interface
+	case dpb.DNS_NAME:
+		return il.Interface
+	case dpb.URI:
+		return il.Interface
 	case dpb.TIMESTAMP:
 		return il.Interface
 	default:

--- a/mixer/template/apikey/template.proto
+++ b/mixer/template/apikey/template.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package apiKey;
 
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 import "mixer/v1/template/extensions.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
@@ -52,5 +52,5 @@ message Template {
     string api_key = 4;
 
     // Timestamp of API call.
-    google.protobuf.Timestamp timestamp = 5;
+    istio.mixer.v1.template.TimeStamp timestamp = 5;
 }

--- a/mixer/template/logentry/template.proto
+++ b/mixer/template/logentry/template.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package logEntry;
 
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
 
@@ -56,7 +56,7 @@ message Template {
     map<string, istio.mixer.v1.config.descriptor.ValueType> variables = 1;
 
     // Timestamp is the time value for the log entry
-    google.protobuf.Timestamp timestamp = 2;
+    istio.mixer.v1.template.TimeStamp timestamp = 2;
 
     // Severity indicates the importance of the log entry.
     string severity = 3;

--- a/mixer/template/sample/apa/Apa.proto
+++ b/mixer/template/sample/apa/Apa.proto
@@ -3,8 +3,7 @@ syntax = "proto3";
 package istio.mixer.adapter.sample.myApa;
 
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR;
 
@@ -21,15 +20,15 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 
     map<string, Resource3> res3_map = 8;
 
-    repeated bytes optionalIP = 9;
+    istio.mixer.v1.template.IPAddress optionalIP = 9;
 
-    string optionalString = 10;
+    istio.mixer.v1.template.EmailAddress email = 10;
 }
 
 message OutputTemplate {
@@ -42,9 +41,13 @@ message OutputTemplate {
 
     string stringPrimitive = 4;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
+
+    istio.mixer.v1.template.EmailAddress email = 10;
+
+    istio.mixer.v1.template.IPAddress out_ip = 11;
 }
 
 
@@ -73,7 +76,7 @@ message Resource3 {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }

--- a/mixer/template/sample/check/CheckTesterTemplate.proto
+++ b/mixer/template/sample/check/CheckTesterTemplate.proto
@@ -4,8 +4,7 @@ package istio.mixer.adapter.sample.check;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
@@ -29,9 +28,9 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res2 res2 = 11;
 

--- a/mixer/template/sample/quota/QuotaTesterTemplate.proto
+++ b/mixer/template/sample/quota/QuotaTesterTemplate.proto
@@ -4,8 +4,7 @@ package istio.mixer.adapter.sample.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
@@ -29,9 +28,9 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res2 res2 = 11;
 

--- a/mixer/template/sample/report/ReportTesterTemplate.proto
+++ b/mixer/template/sample/report/ReportTesterTemplate.proto
@@ -4,8 +4,7 @@ package istio.mixer.adapter.sample.report;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
@@ -23,9 +22,9 @@ message Template {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res1 res1 = 11;
 }
@@ -44,9 +43,9 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res2 res2 = 11;
 
@@ -58,4 +57,16 @@ message Res2 {
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
 
     int64 int64Primitive = 3;
+
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
+
+    istio.mixer.v1.template.Duration duration = 10;
+
+    istio.mixer.v1.template.IPAddress ip_addr = 11;
+
+    istio.mixer.v1.template.DNSName dns_name = 12;
+
+    istio.mixer.v1.template.EmailAddress email_addr = 13;
+
+    istio.mixer.v1.template.Uri uri = 14;
 }

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -1065,7 +1065,7 @@ func TestProcessReport(t *testing.T) {
 							EmailAddr:      adapter.EmailAddress("myEMAIL"),
 							IpAddr:         net.ParseIP("0.0.0.0"),
 							TimeStamp:      time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
-							Uri:            adapter.Uri("myURI"),
+							Uri:            adapter.URI("myURI"),
 						},
 						Res2Map: map[string]*sample_report.Res2{
 							"foo": {
@@ -1077,7 +1077,7 @@ func TestProcessReport(t *testing.T) {
 								EmailAddr:      adapter.EmailAddress("myEMAIL"),
 								IpAddr:         net.ParseIP("0.0.0.0"),
 								TimeStamp:      time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
-								Uri:            adapter.Uri("myURI"),
+								Uri:            adapter.URI("myURI"),
 							},
 						},
 					},

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -325,6 +325,11 @@ func getExprEvalFunc(err error) func(string) (pb.ValueType, error) {
 		if strings.HasSuffix(expr, "timestamp") {
 			retType = pb.TIMESTAMP
 		}
+
+		if retType == pb.VALUE_TYPE_UNSPECIFIED {
+			tc := evaluator.NewTypeChecker()
+			retType, _ = tc.EvalType(expr, createAttributeDescriptorFinder(nil))
+		}
 		return retType, err
 	}
 }
@@ -375,6 +380,15 @@ res1:
   stringPrimitive: source.string
   timeStamp: source.timestamp
   duration: source.duration
+  Res2:
+    value: source.int64
+    int64Primitive: source.int64
+    dns_name: source.dns
+    duration: source.duration
+    email_addr: source.email
+    ip_addr: 'ip("0.0.0.0")'
+    timeStamp: source.timestamp
+    uri: source.uri
   dimensions:
     source: source.string
     target: source.string
@@ -389,7 +403,11 @@ res1:
 				Res1: &sample_report.Res1Type{
 					Value:      pb.INT64,
 					Dimensions: map[string]pb.ValueType{"source": pb.STRING, "target": pb.STRING},
-					Res2Map:    map[string]*sample_report.Res2Type{},
+					Res2: &sample_report.Res2Type{
+						Value:      pb.INT64,
+						Dimensions: map[string]pb.ValueType{},
+					},
+					Res2Map: map[string]*sample_report.Res2Type{},
 				},
 			},
 		},
@@ -840,6 +858,9 @@ func (e *fakeExpr) Eval(mapExpression string, attrs attribute.Bag) (interface{},
 	if strings.HasSuffix(expr2, "duration") {
 		return 10 * time.Second, nil
 	}
+	if strings.HasSuffix(expr2, "source.email") {
+		return "foo@bar.com", nil
+	}
 	if strings.HasSuffix(expr2, "timestamp") {
 		return time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC), nil
 	}
@@ -884,6 +905,15 @@ var baseConfig = istio_mixer_v1_config.GlobalConfig{
 				},
 				"source.ip": {
 					ValueType: pb.IP_ADDRESS,
+				},
+				"source.email": {
+					ValueType: pb.EMAIL_ADDRESS,
+				},
+				"source.uri": {
+					ValueType: pb.URI,
+				},
+				"source.dns": {
+					ValueType: pb.DNS_NAME,
 				},
 			},
 		},
@@ -969,12 +999,24 @@ func TestProcessReport(t *testing.T) {
 							Value:          "1",
 							Dimensions:     map[string]string{"s": "2"},
 							Int64Primitive: "54362",
+							DnsName:        `"myDNS"`,
+							Duration:       "request.duration",
+							EmailAddr:      `"myEMAIL"`,
+							IpAddr:         `ip("0.0.0.0")`,
+							TimeStamp:      "request.timestamp",
+							Uri:            `"myURI"`,
 						},
 						Res2Map: map[string]*sample_report.Res2InstanceParam{
 							"foo": {
 								Value:          "1",
 								Dimensions:     map[string]string{"s": "2"},
 								Int64Primitive: "54362",
+								DnsName:        `"myDNS"`,
+								Duration:       "request.duration",
+								EmailAddr:      `"myEMAIL"`,
+								IpAddr:         `ip("0.0.0.0")`,
+								TimeStamp:      "request.timestamp",
+								Uri:            `"myURI"`,
 							},
 						},
 					},
@@ -1018,12 +1060,24 @@ func TestProcessReport(t *testing.T) {
 							Value:          int64(1),
 							Dimensions:     map[string]interface{}{"s": int64(2)},
 							Int64Primitive: 54362,
+							DnsName:        adapter.DNSName("myDNS"),
+							Duration:       10 * time.Second,
+							EmailAddr:      adapter.EmailAddress("myEMAIL"),
+							IpAddr:         net.ParseIP("0.0.0.0"),
+							TimeStamp:      time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+							Uri:            adapter.Uri("myURI"),
 						},
 						Res2Map: map[string]*sample_report.Res2{
 							"foo": {
 								Value:          int64(1),
 								Dimensions:     map[string]interface{}{"s": int64(2)},
 								Int64Primitive: 54362,
+								DnsName:        adapter.DNSName("myDNS"),
+								Duration:       10 * time.Second,
+								EmailAddr:      adapter.EmailAddress("myEMAIL"),
+								IpAddr:         net.ParseIP("0.0.0.0"),
+								TimeStamp:      time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+								Uri:            adapter.Uri("myURI"),
 							},
 						},
 					},
@@ -1459,7 +1513,7 @@ boolPrimitive: source.bool
 doublePrimitive: source.double
 stringPrimitive: source.string
 optionalIP: 'ip("0.0.0.0")'
-optionalString: '"unknown"'
+email: source.email
 dimensionsFixedInt64ValueDType:
  d1: source.int64
  d1: source.int64
@@ -1610,14 +1664,14 @@ func TestProcessApa(t *testing.T) {
 			name:     "Valid",
 			instName: "foo",
 			instParam: &istio_mixer_adapter_sample_myapa.InstanceParam{
-				BoolPrimitive:                  "true",
-				DoublePrimitive:                "1.2",
-				Int64Primitive:                 "54362",
-				StringPrimitive:                `"mystring"`,
-				TimeStamp:                      "request.timestamp",
-				Duration:                       "request.duration",
-				OptionalIP:                     `ip("0.0.0.0")`,
-				OptionalString:                 `""`,
+				BoolPrimitive:   "true",
+				DoublePrimitive: "1.2",
+				Int64Primitive:  "54362",
+				StringPrimitive: `"mystring"`,
+				TimeStamp:       "request.timestamp",
+				Duration:        "request.duration",
+				OptionalIP:      `ip("0.0.0.0")`,
+				Email:           "source.email",
 				DimensionsFixedInt64ValueDType: map[string]string{"a": "1"},
 				Res3Map: map[string]*istio_mixer_adapter_sample_myapa.Resource3InstanceParam{
 					"source2": {
@@ -1636,6 +1690,8 @@ func TestProcessApa(t *testing.T) {
 					"source.mystring":          "$out.stringPrimitive",
 					"source.mytimeStamp":       "$out.timeStamp",
 					"source.myduration":        "$out.duration",
+					"source.email":             "$out.email",
+					"source.ip":                "$out.out_ip",
 				},
 			},
 			hdlr: &fakeMyApaHandler{
@@ -1643,18 +1699,22 @@ func TestProcessApa(t *testing.T) {
 					BoolPrimitive:   true,
 					DoublePrimitive: 1237,
 					StringPrimitive: "1237",
-					TimeStamp:       time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+					TimeStamp:       time.Date(2019, time.January, 01, 0, 0, 0, 0, time.UTC),
 					Duration:        10 * time.Second,
 					Int64Primitive:  1237,
+					Email:           adapter.EmailAddress("updatedfoo@bar.com"),
+					OutIp:           net.ParseIP("1.2.3.4"),
 				},
 			},
 			wantOutAttrs: map[string]interface{}{
 				"source.mystring":          "1237",
-				"source.mytimeStamp":       time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+				"source.mytimeStamp":       time.Date(2019, time.January, 01, 0, 0, 0, 0, time.UTC),
 				"source.myduration":        10 * time.Second,
 				"source.myint64Primitive":  int64(1237),
 				"source.myboolPrimitive":   true,
 				"source.mydoublePrimitive": float64(1237),
+				"source.email":             "updatedfoo@bar.com",
+				"source.ip":                []uint8(net.ParseIP("1.2.3.4")),
 			},
 			wantInstance: &istio_mixer_adapter_sample_myapa.Instance{
 				Name:                           "foo",
@@ -1666,7 +1726,7 @@ func TestProcessApa(t *testing.T) {
 				Duration:                       10 * time.Second,
 				DimensionsFixedInt64ValueDType: map[string]int64{"a": int64(1)},
 				OptionalIP:                     net.ParseIP("0.0.0.0"),
-				OptionalString:                 "",
+				Email:                          "foo@bar.com",
 				Res3Map: map[string]*istio_mixer_adapter_sample_myapa.Resource3{
 					"source2": {
 						BoolPrimitive:                  true,
@@ -1700,7 +1760,7 @@ func TestProcessApa(t *testing.T) {
 				Duration:                       "request.duration",
 				DimensionsFixedInt64ValueDType: map[string]string{"a": "1"},
 				OptionalIP:                     `ip("0.0.0.0")`,
-				OptionalString:                 `""`,
+				Email:                          "source.email",
 				Res3Map: map[string]*istio_mixer_adapter_sample_myapa.Resource3InstanceParam{
 					"source2": {
 						BoolPrimitive:   "true",
@@ -1754,7 +1814,7 @@ func TestProcessApa(t *testing.T) {
 						"return attrs = %v want %v", spew.Sdump(returnAttr), spew.Sdump(tst.wantOutAttrs))
 				}
 				for k, v := range tst.wantOutAttrs {
-					if x, _ := returnAttr.Get(k); x != v {
+					if x, _ := returnAttr.Get(k); !reflect.DeepEqual(x, v) {
 						t.Errorf("Apa handler "+
 							"return attattrs = %v want %v", spew.Sdump(returnAttr), spew.Sdump(tst.wantOutAttrs))
 					}

--- a/mixer/template/tracespan/tracespan.proto
+++ b/mixer/template/tracespan/tracespan.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package traceSpan;
 
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
 
@@ -88,12 +88,12 @@ message Template {
     // The start time of the span.
     //
     // Required.
-    google.protobuf.Timestamp start_time = 5;
+    istio.mixer.v1.template.TimeStamp start_time = 5;
 
     // The end time of the span.
     //
     // Required.
-    google.protobuf.Timestamp end_time = 6;
+    istio.mixer.v1.template.TimeStamp end_time = 6;
 
     // Span tags are a set of <key, value> pairs that provide metadata for the
     // entire span. The values can be specified in the form of expressions.

--- a/mixer/testdata/BUILD
+++ b/mixer/testdata/BUILD
@@ -20,6 +20,6 @@ filegroup(
     srcs = glob(["**/*.yml"]) + glob(["**/*.yaml"]),
     visibility = [
         "//mixer/pkg/mock:__subpackages__",
-        "//tests/integration/component/mixer:__subpackages__"
+        "//tests/integration/component/mixer:__subpackages__",
     ],
 )

--- a/mixer/tools/codegen/generate.bzl
+++ b/mixer/tools/codegen/generate.bzl
@@ -16,6 +16,7 @@ MIXER_INPUTS = [
 MIXER_IMPORT_MAP = {
     "mixer/v1/config/descriptor/value_type.proto": "istio.io/api/mixer/v1/config/descriptor",
     "mixer/v1/template/extensions.proto": "istio.io/api/mixer/v1/template",
+    "mixer/v1/template/standard_types.proto": "istio.io/api/mixer/v1/template",
 }
 
 # TODO: develop better approach to import management.

--- a/mixer/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/generator.go
@@ -52,7 +52,7 @@ var primitiveToValueType = map[string]string{
 	"int64":                fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.INT64.String(),
 	"float64":              fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DOUBLE.String(),
 	"net.IP":               fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.IP_ADDRESS.String(),
-	"adapter.Uri":          fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.URI.String(),
+	"adapter.URI":          fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.URI.String(),
 	"adapter.DNSName":      fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DNS_NAME.String(),
 	"adapter.EmailAddress": fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.EMAIL_ADDRESS.String(),
 
@@ -63,7 +63,7 @@ var primitiveToValueType = map[string]string{
 var aliasTypes = map[string]string{
 	"adapter.DNSName":      "string",
 	"adapter.EmailAddress": "string",
-	"adapter.Uri":          "string",
+	"adapter.URI":          "string",
 	"net.IP":               "[]uint8",
 }
 

--- a/mixer/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/generator.go
@@ -47,16 +47,24 @@ const (
 
 // TODO share the code between this generator and the interfacegen code generator.
 var primitiveToValueType = map[string]string{
-	"string":  fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.STRING.String(),
-	"bool":    fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.BOOL.String(),
-	"int64":   fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.INT64.String(),
-	"float64": fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DOUBLE.String(),
-	// TODO: currently IP_ADDRESS is byte[], but reverse might not be true. This code assumes []byte is
-	// IP_ADDRESS, which is a temporary hack since there is currently no way to express IP_ADDRESS inside templates
-	// yet.
-	"[]byte":        fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.IP_ADDRESS.String(),
+	"string":               fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.STRING.String(),
+	"bool":                 fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.BOOL.String(),
+	"int64":                fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.INT64.String(),
+	"float64":              fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DOUBLE.String(),
+	"net.IP":               fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.IP_ADDRESS.String(),
+	"adapter.Uri":          fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.URI.String(),
+	"adapter.DNSName":      fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DNS_NAME.String(),
+	"adapter.EmailAddress": fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.EMAIL_ADDRESS.String(),
+
 	"time.Duration": fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DURATION.String(),
 	"time.Time":     fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.TIMESTAMP.String(),
+}
+
+var aliasTypes = map[string]string{
+	"adapter.DNSName":      "string",
+	"adapter.EmailAddress": "string",
+	"adapter.Uri":          "string",
+	"net.IP":               "[]uint8",
 }
 
 func containsValueTypeOrResMsg(ti modelgen.TypeInfo) bool {
@@ -83,6 +91,13 @@ func (g *Generator) Generate(fdsFiles map[string]string) error {
 			"getValueType": func(goType modelgen.TypeInfo) string {
 				return primitiveToValueType[goType.Name]
 
+			},
+			"isAliasType": func(goType string) bool {
+				_, found := aliasTypes[goType]
+				return found
+			},
+			"getAliasType": func(goType string) string {
+				return aliasTypes[goType]
 			},
 			"containsValueTypeOrResMsg": containsValueTypeOrResMsg,
 			"reportTypeUsed": func(ti modelgen.TypeInfo) string {

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -356,12 +356,20 @@ var (
 								{{.GoName}}: func(m map[string]interface{}) map[string]{{.GoType.MapValue.Name}} {
 									res := make(map[string]{{.GoType.MapValue.Name}}, len(m))
 									for k, v := range m {
+										{{if isAliasType .GoType.MapValue.Name}}
+										res[k] = {{.GoType.MapValue.Name}}(v.({{getAliasType .GoType.MapValue.Name}}))
+										{{else}}
 										res[k] = v.({{.GoType.MapValue.Name}})
+										{{end}}
 									}
 									return res
 								}({{.GoName}}),
 							{{else}}
+								{{if isAliasType .GoType.Name}}
+								{{.GoName}}: {{.GoType.Name}}({{.GoName}}.({{getAliasType .GoType.Name}})),{{reportTypeUsed .GoType}}
+								{{else}}
 								{{.GoName}}: {{.GoName}}.({{.GoType.Name}}),{{reportTypeUsed .GoType}}
+								{{end}}
 							{{end}}
 						{{end}}
 					{{end}}
@@ -409,7 +417,11 @@ var (
 								switch field {
 									{{range .OutputTemplateMessage.Fields}}
 									case "{{.ProtoName}}":
+										{{if isAliasType .GoType.Name}}
+										return {{getAliasType .GoType.Name}}(out.{{.GoName}}), true
+										{{else}}
 										return out.{{.GoName}}, true
+										{{end}}
 									{{end}}
 									default:
 									return nil, false

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -630,7 +630,7 @@ var (
 
 						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
 
-						Uri: adapter.Uri(Uri.(string)),
+						Uri: adapter.URI(Uri.(string)),
 					}, nil
 				}
 
@@ -1670,7 +1670,7 @@ var (
 
 						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
 
-						Uri: adapter.Uri(Uri.(string)),
+						Uri: adapter.URI(Uri.(string)),
 					}, nil
 				}
 

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -219,6 +219,46 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
+					if param.IpAddr == "" || param.IpAddr == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
+					}
+					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
+					}
+
+					if param.DnsName == "" || param.DnsName == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
+					}
+					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
+					}
+
+					if param.EmailAddr == "" || param.EmailAddr == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
+					}
+					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
+					}
+
+					if param.Uri == "" || param.Uri == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
+					}
+					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
+					}
+
 					return nil, err
 
 				}
@@ -402,6 +442,22 @@ var (
 						"istio_mixer_adapter_sample_myapa.output.duration": {
 							ValueType: istio_mixer_v1_config_descriptor.DURATION,
 						},
+
+						"istio_mixer_adapter_sample_myapa.output.ip_addr": {
+							ValueType: istio_mixer_v1_config_descriptor.IP_ADDRESS,
+						},
+
+						"istio_mixer_adapter_sample_myapa.output.dns_name": {
+							ValueType: istio_mixer_v1_config_descriptor.DNS_NAME,
+						},
+
+						"istio_mixer_adapter_sample_myapa.output.email_addr": {
+							ValueType: istio_mixer_v1_config_descriptor.EMAIL_ADDRESS,
+						},
+
+						"istio_mixer_adapter_sample_myapa.output.uri": {
+							ValueType: istio_mixer_v1_config_descriptor.URI,
+						},
 					},
 				},
 			},
@@ -507,6 +563,38 @@ var (
 						return nil, errors.New(msg)
 					}
 
+					IpAddr, err := mapper.Eval(param.IpAddr, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"IpAddr", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					DnsName, err := mapper.Eval(param.DnsName, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DnsName", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					EmailAddr, err := mapper.Eval(param.EmailAddr, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EmailAddr", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					Uri, err := mapper.Eval(param.Uri, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Uri", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Instance{
 
@@ -523,7 +611,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),
@@ -533,6 +623,14 @@ var (
 						Duration: Duration.(time.Duration),
 
 						Res3Map: Res3Map,
+
+						IpAddr: net.IP(IpAddr.([]uint8)),
+
+						DnsName: adapter.DNSName(DnsName.(string)),
+
+						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
+
+						Uri: adapter.Uri(Uri.(string)),
 					}, nil
 				}
 
@@ -708,7 +806,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),
@@ -738,22 +838,44 @@ var (
 							switch field {
 
 							case "int64Primitive":
+
 								return out.Int64Primitive, true
 
 							case "boolPrimitive":
+
 								return out.BoolPrimitive, true
 
 							case "doublePrimitive":
+
 								return out.DoublePrimitive, true
 
 							case "stringPrimitive":
+
 								return out.StringPrimitive, true
 
 							case "timeStamp":
+
 								return out.TimeStamp, true
 
 							case "duration":
+
 								return out.Duration, true
+
+							case "ip_addr":
+
+								return []uint8(out.IpAddr), true
+
+							case "dns_name":
+
+								return string(out.DnsName), true
+
+							case "email_addr":
+
+								return string(out.EmailAddr), true
+
+							case "uri":
+
+								return string(out.Uri), true
 
 							default:
 								return nil, false
@@ -1088,6 +1210,66 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
+					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
+					}
+					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
+					}
+
+					if param.Duration == "" || param.Duration == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
+					}
+					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
+					}
+
+					if param.IpAddr == "" || param.IpAddr == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
+					}
+					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
+					}
+
+					if param.DnsName == "" || param.DnsName == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
+					}
+					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
+					}
+
+					if param.EmailAddr == "" || param.EmailAddr == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
+					}
+					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
+					}
+
+					if param.Uri == "" || param.Uri == emptyQuotes {
+						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
+					}
+					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
+						if e != nil {
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+						}
+						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
+					}
+
 					return infrdType, err
 
 				}
@@ -1238,7 +1420,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),
@@ -1369,7 +1553,9 @@ var (
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(Int64Map),
@@ -1417,6 +1603,54 @@ var (
 						return nil, errors.New(msg)
 					}
 
+					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					Duration, err := mapper.Eval(param.Duration, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					IpAddr, err := mapper.Eval(param.IpAddr, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"IpAddr", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					DnsName, err := mapper.Eval(param.DnsName, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DnsName", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					EmailAddr, err := mapper.Eval(param.EmailAddr, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EmailAddr", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
+					Uri, err := mapper.Eval(param.Uri, attrs)
+
+					if err != nil {
+						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Uri", instName, err)
+						glog.Error(msg)
+						return nil, errors.New(msg)
+					}
+
 					_ = param
 					return &istio_mixer_template_list.Res2{
 
@@ -1425,6 +1659,18 @@ var (
 						Dimensions: Dimensions,
 
 						Int64Primitive: Int64Primitive.(int64),
+
+						TimeStamp: TimeStamp.(time.Time),
+
+						Duration: Duration.(time.Duration),
+
+						IpAddr: net.IP(IpAddr.([]uint8)),
+
+						DnsName: adapter.DNSName(DnsName.(string)),
+
+						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
+
+						Uri: adapter.Uri(Uri.(string)),
 					}, nil
 				}
 
@@ -1671,7 +1917,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),
@@ -2151,7 +2399,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),
@@ -2284,7 +2534,9 @@ var (
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(Int64Map),
@@ -2589,7 +2841,9 @@ var (
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
 							for k, v := range m {
+
 								res[k] = v.(int64)
+
 							}
 							return res
 						}(DimensionsFixedInt64ValueDType),

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/ApaTmpl.proto
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/ApaTmpl.proto
@@ -3,8 +3,7 @@ syntax = "proto3";
 package istio.mixer.adapter.sample.myApa;
 
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR;
 
@@ -21,11 +20,19 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 
     map<string, Resource3> res3_map = 8;
+
+    istio.mixer.v1.template.IPAddress ip_addr = 11;
+
+    istio.mixer.v1.template.DNSName dns_name = 12;
+
+    istio.mixer.v1.template.EmailAddress email_addr = 13;
+
+    istio.mixer.v1.template.Uri uri = 14;
 }
 
 message OutputTemplate {
@@ -38,9 +45,17 @@ message OutputTemplate {
 
     string stringPrimitive = 4;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
+
+    istio.mixer.v1.template.IPAddress ip_addr = 11;
+
+    istio.mixer.v1.template.DNSName dns_name = 12;
+
+    istio.mixer.v1.template.EmailAddress email_addr = 13;
+
+    istio.mixer.v1.template.Uri uri = 14;
 }
 
 
@@ -69,7 +84,7 @@ message Resource3 {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/CheckTmpl.proto
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/CheckTmpl.proto
@@ -4,8 +4,7 @@ package istio.mixer.template.list;
 
 import "mixer/v1/template/extensions.proto";
 import "mixer/v1/config/descriptor/value_type.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
@@ -46,9 +45,9 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res2 res2 = 11;
 
@@ -60,4 +59,16 @@ message Res2 {
     map<string, istio.mixer.v1.config.descriptor.ValueType> dimensions = 2;
 
     int64 int64Primitive = 3;
+
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
+
+    istio.mixer.v1.template.Duration duration = 10;
+
+    istio.mixer.v1.template.IPAddress ip_addr = 11;
+
+    istio.mixer.v1.template.DNSName dns_name = 12;
+
+    istio.mixer.v1.template.EmailAddress email_addr = 13;
+
+    istio.mixer.v1.template.Uri uri = 14;
 }

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/QuotaTemplate.proto
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/QuotaTemplate.proto
@@ -31,7 +31,7 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
     google.protobuf.Duration duration = 10;
 

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/Report1Tmpl.proto
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/Report1Tmpl.proto
@@ -6,8 +6,7 @@ package istio.mixer.template.log;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
@@ -30,9 +29,9 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 8;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res1 res1 = 11;
 }
@@ -51,9 +50,9 @@ message Res1 {
 
     map<string, int64> int64Map = 7;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
     Res2 res2 = 11;
 

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ApaTmpl.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ApaTmpl.proto
@@ -9,8 +9,7 @@ Additional overview of what myapa is etc..
 package istio.mixer.adapter.MyApa;
 
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR;
 
@@ -27,9 +26,9 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 
     map<string, Resource3> res3_map = 8;
 }
@@ -44,9 +43,9 @@ message OutputTemplate {
 
     string stringPrimitive = 4;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }
 
 
@@ -75,7 +74,7 @@ message Resource3 {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/CheckTmpl.proto
@@ -4,8 +4,7 @@ package foo.bar.mylistChecker;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_CHECK;
 
@@ -26,7 +25,7 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 8;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 }

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/QuotaTmpl.proto
@@ -4,8 +4,7 @@ package istio.mixer.adapter.quota;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_QUOTA;
 
@@ -26,7 +25,7 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 8;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 }

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
@@ -18,6 +18,7 @@ package istio_mixer_adapter_metricentry
 
 import (
 	"context"
+	"net"
 	"time"
 
 	"istio.io/istio/mixer/pkg/adapter"
@@ -60,6 +61,14 @@ type Instance struct {
 	TimeStamp time.Time
 
 	Duration time.Duration
+
+	IpAddr net.IP
+
+	DnsName adapter.DNSName
+
+	EmailAddr adapter.EmailAddress
+
+	Uri adapter.Uri
 
 	Res3List []*Resource3
 

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.go.golden
@@ -68,7 +68,7 @@ type Instance struct {
 
 	EmailAddr adapter.EmailAddress
 
-	Uri adapter.Uri
+	Uri adapter.URI
 
 	Res3List []*Resource3
 

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.golden.proto
@@ -39,9 +39,9 @@ message Type {
   
   istio.mixer.v1.config.descriptor.ValueType anotherValueType = 7;
   
-  repeated Resource3Type res3_list = 11;
+  repeated Resource3Type res3_list = 15;
   
-  map<string, Resource3Type> res3_map = 12;
+  map<string, Resource3Type> res3_map = 16;
 }
 
 
@@ -100,9 +100,17 @@ message InstanceParam {
   
   string duration = 10;
   
-  repeated Resource3InstanceParam res3_list = 11;
+  string ip_addr = 11;
   
-  map<string, Resource3InstanceParam> res3_map = 12;
+  string dns_name = 12;
+  
+  string email_addr = 13;
+  
+  string uri = 14;
+  
+  repeated Resource3InstanceParam res3_list = 15;
+  
+  map<string, Resource3InstanceParam> res3_map = 16;
   
   
 }

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/ReportTmpl.proto
@@ -10,8 +10,7 @@ package istio.mixer.adapter.metricEntry;
 
 import "mixer/v1/config/descriptor/value_type.proto";
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_REPORT;
 
@@ -36,12 +35,20 @@ message Template {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 8;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 
-    repeated Resource3 res3_list = 11;
-    map<string, istio.mixer.adapter.metricEntry.Resource3> res3_map = 12;
+    istio.mixer.v1.template.IPAddress ip_addr = 11;
+
+    istio.mixer.v1.template.DNSName dns_name = 12;
+
+    istio.mixer.v1.template.EmailAddress email_addr = 13;
+
+    istio.mixer.v1.template.Uri uri = 14;
+
+    repeated Resource3 res3_list = 15;
+    map<string, istio.mixer.adapter.metricEntry.Resource3> res3_map = 16;
 }
 
 message Resource1 {
@@ -76,9 +83,9 @@ message Resource3 {
 
     map<string, int64> dimensionsFixedInt64ValueDType = 8;
 
-    google.protobuf.Timestamp timeStamp = 9;
+    istio.mixer.v1.template.TimeStamp timeStamp = 9;
 
-    google.protobuf.Duration duration = 10;
+    istio.mixer.v1.template.Duration duration = 10;
 }
 
 // Tests

--- a/mixer/tools/codegen/pkg/modelgen/model.go
+++ b/mixer/tools/codegen/pkg/modelgen/model.go
@@ -31,22 +31,30 @@ const fullProtoNameOfValueTypeEnum = "istio.mixer.v1.config.descriptor.ValueType
 type typeMetadata struct {
 	goName   string
 	goImport string
-
-	protoImport string
 }
 
 // Hardcoded proto->go type mapping along with imports for the
 // generated code.
 var customMessageTypeMetadata = map[string]typeMetadata{
-	".google.protobuf.Timestamp": {
-		goName:      "time.Time",
-		goImport:    "time",
-		protoImport: "google/protobuf/timestamp.proto",
+	".istio.mixer.v1.template.Duration": {
+		goName:   "time.Duration",
+		goImport: "time",
 	},
-	".google.protobuf.Duration": {
-		goName:      "time.Duration",
-		goImport:    "time",
-		protoImport: "google/protobuf/duration.proto",
+	".istio.mixer.v1.template.TimeStamp": {
+		goName:   "time.Time",
+		goImport: "time",
+	},
+	".istio.mixer.v1.template.IPAddress": {
+		goName: "net.IP",
+	},
+	".istio.mixer.v1.template.DNSName": {
+		goName: "adapter.DNSName",
+	},
+	".istio.mixer.v1.template.EmailAddress": {
+		goName: "adapter.EmailAddress",
+	},
+	".istio.mixer.v1.template.Uri": {
+		goName: "adapter.Uri",
 	},
 }
 
@@ -174,7 +182,7 @@ func (m *Model) fillModel(templateProto *FileDescriptor, resourceProtos []*FileD
 			)
 
 			isPrimitiveValueType := func(typ TypeInfo) bool {
-				if typ.IsValueType || typ.IsResourceMessage || (typ.IsRepeated && typ.Name != "[]byte") || (typ.IsMap && typ.MapValue.Name != "string") {
+				if typ.IsValueType || typ.IsResourceMessage || typ.IsRepeated || (typ.IsMap && typ.MapValue.Name != "string") {
 					return false
 				}
 				return true
@@ -406,8 +414,6 @@ func getTypeNameRec(g *FileDescriptorSetParser, field *descriptor.FieldDescripto
 		return TypeInfo{Name: "double"}, TypeInfo{Name: sFLOAT64}, nil
 	case descriptor.FieldDescriptorProto_TYPE_BOOL:
 		return TypeInfo{Name: "bool"}, TypeInfo{Name: sBOOL}, nil
-	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		return TypeInfo{Name: "bytes"}, TypeInfo{Name: "byte"}, nil
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:
 		if valueTypeAllowed && field.GetTypeName()[1:] == fullProtoNameOfValueTypeEnum {
 			desc := g.ObjectNamed(field.GetTypeName())
@@ -415,7 +421,7 @@ func getTypeNameRec(g *FileDescriptorSetParser, field *descriptor.FieldDescripto
 		}
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		if v, ok := customMessageTypeMetadata[field.GetTypeName()]; ok {
-			return TypeInfo{Name: field.GetTypeName()[1:], Import: v.protoImport},
+			return TypeInfo{Name: field.GetTypeName()[1:]},
 				TypeInfo{Name: v.goName, Import: v.goImport},
 				nil
 		}

--- a/mixer/tools/codegen/pkg/modelgen/model.go
+++ b/mixer/tools/codegen/pkg/modelgen/model.go
@@ -54,7 +54,7 @@ var customMessageTypeMetadata = map[string]typeMetadata{
 		goName: "adapter.EmailAddress",
 	},
 	".istio.mixer.v1.template.Uri": {
-		goName: "adapter.Uri",
+		goName: "adapter.URI",
 	},
 }
 

--- a/mixer/tools/codegen/pkg/modelgen/testdata/SimpleApaTemplate.proto
+++ b/mixer/tools/codegen/pkg/modelgen/testdata/SimpleApaTemplate.proto
@@ -9,8 +9,7 @@ Additional overview of what myapa is etc..
 package istio.mixer.adapter.MyApa;
 
 import "mixer/v1/template/extensions.proto";
-import "google/protobuf/duration.proto";
-import "google/protobuf/timestamp.proto";
+import "mixer/v1/template/standard_types.proto";
 
 option (istio.mixer.v1.template.template_variety) = TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR;
 
@@ -27,9 +26,9 @@ message Template {
 
     map<string, string> dimensions = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }
 
 /* my outputtemplate
@@ -46,7 +45,7 @@ message OutputTemplate {
 
     map<string, string> dimensions = 5;
 
-    google.protobuf.Timestamp timeStamp = 6;
+    istio.mixer.v1.template.TimeStamp timeStamp = 6;
 
-    google.protobuf.Duration duration = 7;
+    istio.mixer.v1.template.Duration duration = 7;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains following changes.
* use standard_types inside templates
* **Reviewer (@geeknoid ) attention needed** : define type alias inside [pkg/adapter/standardTypes.go](https://github.com/istio/istio/compare/master...guptasu:useStdTypes2?expand=1#diff-860ef0498af3d10e39aa299b862610fd). Adapters will get the aliased type instead of string for IP_ADDRESS, EMAIL, URI and DNS_NAME
* **Reviewer  (@ozevren PTAL) attention needed** : Support the above 4 types (IP_ADDRESS, URI and DNS_NAME) inside the [il/compiler/compiler.go](https://github.com/istio/istio/compare/master...guptasu:useStdTypes2?expand=1#diff-a01154c5769eedb368257f22e2829267)
* **Reviewer attention needed**: Due to type aliasing there is type assertion and conversion inside the generated code. PTAL https://github.com/istio/istio/compare/master...guptasu:useStdTypes2?expand=1#diff-aecbd97d3bcb64dd8d2a900a893b3e39

**Other Changes**
* Remove the original hack that was using `[]byte` for IP_ADDRESS
* stop supporting google.protobuf.Timestamp and google.protobuf.Duration in all existing Templates.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
