### PR TITLE
re-add kubeconfig to the create_release_archive script.  Required for…

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -105,7 +105,7 @@ function create_windows_archive() {
 
 pushd "${OUTPUT_PATH}"
 ${CP} istio.VERSION LICENSE README.md "${COMMON_FILES_DIR}"/
-find samples install -type f \( -name "*.yaml" -o -name "cleanup*" -o -name "*.md" \) \
+find samples install -type f \( -name "*.yaml" -o -name "cleanup*" -o -name "*.md" -o -name "kubeconfig" \) \
   -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 find install/tools -type f -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 popd


### PR DESCRIPTION
… consul and Eurkea demos

**What this PR does / why we need it**:
`kubeconfig` was not added to the `find` and so the kubeconfig file in install/consul and install/eureka is not getting added to the release.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Issue #1995 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
