### PR TITLE
make STRINGMAP as a first class type supported in the OutputTemplate

### DIFF
--- a/mixer/template/sample/apa/Apa.proto
+++ b/mixer/template/sample/apa/Apa.proto
@@ -48,6 +48,8 @@ message OutputTemplate {
     istio.mixer.v1.template.EmailAddress email = 10;
 
     istio.mixer.v1.template.IPAddress out_ip = 11;
+
+    map<string, string> out_str_map = 12;
 }
 
 

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -912,6 +912,9 @@ var baseConfig = istio_mixer_v1_config.GlobalConfig{
 				"source.uri": {
 					ValueType: pb.URI,
 				},
+				"source.labels": {
+					ValueType: pb.STRING_MAP,
+				},
 				"source.dns": {
 					ValueType: pb.DNS_NAME,
 				},
@@ -1526,6 +1529,7 @@ attribute_bindings:
   source.string: $out.stringPrimitive
   source.timestamp: $out.timeStamp
   source.duration: $out.duration
+  source.labels: $out.out_str_map
 `,
 			cstrParam:     &istio_mixer_adapter_sample_myapa.InstanceParam{},
 			typeEvalError: nil,
@@ -1692,6 +1696,7 @@ func TestProcessApa(t *testing.T) {
 					"source.myduration":        "$out.duration",
 					"source.email":             "$out.email",
 					"source.ip":                "$out.out_ip",
+					"source.labels":            "$out.out_str_map",
 				},
 			},
 			hdlr: &fakeMyApaHandler{
@@ -1704,6 +1709,7 @@ func TestProcessApa(t *testing.T) {
 					Int64Primitive:  1237,
 					Email:           adapter.EmailAddress("updatedfoo@bar.com"),
 					OutIp:           net.ParseIP("1.2.3.4"),
+					OutStrMap:       map[string]string{"a": "b"},
 				},
 			},
 			wantOutAttrs: map[string]interface{}{
@@ -1715,6 +1721,7 @@ func TestProcessApa(t *testing.T) {
 				"source.mydoublePrimitive": float64(1237),
 				"source.email":             "updatedfoo@bar.com",
 				"source.ip":                []uint8(net.ParseIP("1.2.3.4")),
+				"source.labels":            map[string]string{"a": "b"},
 			},
 			wantInstance: &istio_mixer_adapter_sample_myapa.Instance{
 				Name:                           "foo",

--- a/mixer/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/generator.go
@@ -51,6 +51,7 @@ var primitiveToValueType = map[string]string{
 	"bool":                 fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.BOOL.String(),
 	"int64":                fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.INT64.String(),
 	"float64":              fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DOUBLE.String(),
+	"map[string]string":    fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.STRING_MAP.String(),
 	"net.IP":               fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.IP_ADDRESS.String(),
 	"adapter.URI":          fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.URI.String(),
 	"adapter.DNSName":      fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.DNS_NAME.String(),
@@ -89,7 +90,7 @@ func (g *Generator) Generate(fdsFiles map[string]string) error {
 	tmpl, err := template.New("MixerBootstrap").Funcs(
 		template.FuncMap{
 			"getValueType": func(goType modelgen.TypeInfo) string {
-				return primitiveToValueType[goType.Name]
+				return primitiveToValueType[strings.Replace(goType.Name, " ", "", -1)]
 
 			},
 			"isAliasType": func(goType string) bool {

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -458,6 +458,10 @@ var (
 						"istio_mixer_adapter_sample_myapa.output.uri": {
 							ValueType: istio_mixer_v1_config_descriptor.URI,
 						},
+
+						"istio_mixer_adapter_sample_myapa.output.out_str_map": {
+							ValueType: istio_mixer_v1_config_descriptor.STRING_MAP,
+						},
 					},
 				},
 			},
@@ -876,6 +880,10 @@ var (
 							case "uri":
 
 								return string(out.Uri), true
+
+							case "out_str_map":
+
+								return out.OutStrMap, true
 
 							default:
 								return nil, false

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/ApaTmpl.proto
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/ApaTmpl.proto
@@ -56,6 +56,8 @@ message OutputTemplate {
     istio.mixer.v1.template.EmailAddress email_addr = 13;
 
     istio.mixer.v1.template.Uri uri = 14;
+
+    map<string, string> out_str_map = 15;
 }
 
 


### PR DESCRIPTION
The old PRs for APA template missed out String_map as a possible type of allowed Output field. Such output fields can be directly assigned to a generated attribute in the attribute_binding section of a APA instance config.

**What this PR does / why we need it**:


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
