### PR TITLE
add pilot end-to-end test for routing rules to outboud traffic

### DIFF
--- a/pilot/test/integration/BUILD
+++ b/pilot/test/integration/BUILD
@@ -13,6 +13,7 @@ go_library(
         "infra.go",
         "ingress.go",
         "routing.go",
+        "routingToEgress.go",
         "tcp.go",
         "zipkin.go",
     ],

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -204,6 +204,7 @@ func runTests(envs ...infra) {
 			&ingress{infra: &istio},
 			&egressRules{infra: &istio},
 			&routing{infra: &istio},
+			&routingToEgress{infra: &istio},
 			&zipkin{infra: &istio},
 			&authExclusion{infra: &istio},
 		}

--- a/pilot/test/integration/routingToEgress.go
+++ b/pilot/test/integration/routingToEgress.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Routing tests
+// Tests of routing rules to outbound traffic defined by egress rules
 
 package main
 

--- a/pilot/test/integration/routingToEgress.go
+++ b/pilot/test/integration/routingToEgress.go
@@ -1,0 +1,100 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Routing tests
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+	multierror "github.com/hashicorp/go-multierror"
+)
+
+type routingToEgress struct {
+	*infra
+}
+
+func (t *routingToEgress) String() string {
+	return "routing-rules-to-egress"
+}
+
+func (t *routingToEgress) setup() error {
+	return nil
+}
+
+func (t *routingToEgress) run() error {
+	cases := []struct {
+		description   string
+		configEgress  string
+		configRouting string
+		check         func() error
+	}{
+		{
+			description:   "inject a http fault in traffic to httpbin.org",
+			configEgress:  "egress-rule-httpbin.yaml.tmpl",
+			configRouting: "rule-fault-injection-httpbin.yaml.tmpl",
+			check: func() error {
+				return t.verifyFaultInjectionByResponseCode("a", "http://httpbin.org", 418)
+			},
+		},
+	}
+
+	var errs error
+	for _, cs := range cases {
+		log("Checking routing rule to egress rule test", cs.description)
+		if err := t.applyConfig(cs.configEgress, nil); err != nil {
+			return err
+		}
+		if err := t.applyConfig(cs.configRouting, nil); err != nil {
+			return err
+		}
+
+		if err := repeat(cs.check, 3, time.Second); err != nil {
+			glog.Infof("Failed the test with %v", err)
+			errs = multierror.Append(errs, multierror.Prefix(err, cs.description))
+		} else {
+			glog.Info("Success!")
+		}
+	}
+	return errs
+}
+
+func (t *routingToEgress) teardown() {
+	glog.Info("Cleaning up route rules to egress rules...")
+	if err := t.deleteAllConfigs(); err != nil {
+		glog.Warning(err)
+	}
+}
+
+func (t *routingToEgress) verifyFaultInjectionByResponseCode(src, url string, respCode int) error {
+	glog.Infof("Making 1 request (%s) from %s...\n", url, src)
+
+	resp := t.clientRequest(src, url, 1, "")
+
+	statusCode := ""
+	if len(resp.code) > 0 {
+		statusCode = resp.code[0]
+	}
+
+	if strconv.Itoa(respCode) != statusCode {
+		return fmt.Errorf("fault injection verification failed: "+
+			"status code %s, "+
+			"expected status code %d", statusCode, respCode)
+	}
+	return nil
+}

--- a/pilot/test/integration/testdata/rule-fault-injection-httpbin.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-fault-injection-httpbin.yaml.tmpl
@@ -1,0 +1,11 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: httpbin-fault-rule
+spec:
+  destination:
+    service: "httpbin.org"
+  httpFault:
+    abort:
+      httpStatus: 418
+      percent: 100


### PR DESCRIPTION
**What this PR does / why we need it**:
add pilot end-to-end test for routing rules to outboud traffic defined by egress rules

**Special notes for your reviewer**:
This PR adds the first test of routing rules to egress rules:
fault injection to httpbin.org
more tests to follow...

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
