### PR TITLE
Allow pilot to start w/o kubernetes cluster

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -240,7 +240,7 @@ var (
 				return fmt.Errorf("failed to create discovery service: %v", err)
 			}
 
-			if flags.configStore == kubernetesConfigStore && registered[platform.KubernetesRegistry] {
+			if flags.configStore == kubernetesConfigStore {
 
 				// Set up configuration validation admission
 				// controller. Fill in remaining admission controller


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allows pilot to start with inmemory config store
- This work is required to introduce CloudFoundry adapter

[#151465998]

Signed-off-by: Nino Kodabande <nkodabande@suse.com>

This PR allows pilot to start without kubernetes, this is done through allowing pilot to start with an in-memory config store. This work is a first step to introduce Cloudfoundry platform adapter.

**Release note**:
```release-note
Allows pilot to start with in-memory configStore. 
```