### PR TITLE
istioctl: Specify the name of the entity to be deleted

### DIFF
--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -399,6 +399,7 @@ and destination policies.
 					err = otherClient.Delete().
 						Namespace(config.Namespace).
 						Resource(resource.Name).
+						Name(config.Name).
 						Do().
 						Error()
 					if err != nil {


### PR DESCRIPTION
Weirdly no names are specified, so this will remove all entities
of a kind under the same namespace unexpectedly.

fixes #2032

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2032

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
bug fix on deleting mixer config with istioctl
```
