### PR TITLE
Add prom/statsd-exporter image version tag

### DIFF
--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -57,7 +57,7 @@ spec:
       serviceAccountName: istio-mixer-service-account
       containers:
       - name: statsd-to-prometheus
-        image: prom/statsd-exporter
+        image: prom/statsd-exporter:v0.5.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9102


### PR DESCRIPTION
**What this PR does / why we need it**:
The statsd to prometheus exporter image in istio.yaml does not include a version tag:
```
      containers:
      - name: statsd-to-prometheus
        image: prom/statsd-exporter
        imagePullPolicy: IfNotPresent
```
We need to pick a specific version of the `prom/statsd-exporter` so that the version used
by a particular Istio release will be fixed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
