### PR TITLE
Avoid logging tokens during github operations

### DIFF
--- a/release/start_gcb_build.sh
+++ b/release/start_gcb_build.sh
@@ -92,10 +92,10 @@ cat << EOF > ${SUBS_FILE}
   "substitutions": {
     "_VER_STRING": "${VER_STRING}",
     "_MFEST_URL": "${REPO}",
-    "_MFEST_FILE\": "${REPO_FILE}",
-    "_MFEST_VER\": "${REPO_FILE_VER}",
-    "_GCS_PATH\": "${GCS_PATH}",
-    "_GCR_PATH\": "${GCR_PATH}"
+    "_MFEST_FILE": "${REPO_FILE}",
+    "_MFEST_VER": "${REPO_FILE_VER}",
+    "_GCS_PATH": "${GCS_PATH}",
+    "_GCR_PATH": "${GCR_PATH}"
   }
 EOF
 

--- a/release/start_gcb_build.sh
+++ b/release/start_gcb_build.sh
@@ -88,14 +88,16 @@ if [[ -z "${SVC_ACCT}"  ]]; then
 fi
 
 # generate the substitutions file
-echo "  \"substitutions\": {
-    \"_VER_STRING\": \"${VER_STRING}\",
-    \"_MFEST_URL\": \"${REPO}\",
-    \"_MFEST_FILE\": \"${REPO_FILE}\",
-    \"_MFEST_VER\": \"${REPO_FILE_VER}\",
-    \"_GCS_PATH\": \"${GCS_PATH}\",
-    \"_GCR_PATH\": \"${GCR_PATH}\"
-  }" > "${SUBS_FILE}"
+cat << EOF > ${SUBS_FILE}
+  "substitutions": {
+    "_VER_STRING": "${VER_STRING}",
+    "_MFEST_URL": "${REPO}",
+    "_MFEST_FILE\": "${REPO_FILE}",
+    "_MFEST_VER\": "${REPO_FILE_VER}",
+    "_GCS_PATH\": "${GCS_PATH}",
+    "_GCR_PATH\": "${GCR_PATH}"
+  }
+EOF
 
 run_build "${REPO}" "${REPO_FILE}" "${REPO_FILE_VER}" "cloud_build.template.json" \
   "${SUBS_FILE}" "${PROJECT_ID}" "${SVC_ACCT}" "${KEY_FILE_PATH}" "${WAIT_FOR_RESULT}"

--- a/release/start_gcb_publish.sh
+++ b/release/start_gcb_publish.sh
@@ -113,19 +113,22 @@ if [[ -z "${SVC_ACCT}"  ]]; then
   SVC_ACCT="${DEFAULT_SVC_ACCT}"
 fi
 
-echo "  \"substitutions\": {
-    \"_VER_STRING\": \"${VER_STRING}\",
-    \"_MFEST_URL\": \"${REPO}\",
-    \"_MFEST_FILE\": \"${REPO_FILE}\",
-    \"_MFEST_VER\": \"${REPO_FILE_VER}\",
-    \"_GCS_SOURCE\": \"${GCS_SRC}\",
-    \"_GCR_DST\": \"${GCR_DST}\",
-    \"_GCS_DST\": \"${GCS_DST}\",
-    \"_DOCKER_DST\": \"${DOCKER_DST}\",
-    \"_GCS_SECRET\": \"${GCS_GITHUB_SECRET}\",
-    \"_ORG\": \"${REL_ORG}\",
-    \"_REPO\": \"${REL_REPO}\",
-  }" >> "${SUBS_FILE}"
+# generate the substitutions file
+cat << EOF > ${SUBS_FILE}
+  "substitutions": {
+    "_VER_STRING": "${VER_STRING}",
+    "_MFEST_URL": "${REPO}",
+    "_MFEST_FILE": "${REPO_FILE}",
+    "_MFEST_VER": "${REPO_FILE_VER}",
+    "_GCS_SOURCE": "${GCS_SRC}",
+    "_GCR_DST": "${GCR_DST}",
+    "_GCS_DST": "${GCS_DST}",
+    "_DOCKER_DST": "${DOCKER_DST}",
+    "_GCS_SECRET": "${GCS_GITHUB_SECRET}",
+    "_ORG": "${REL_ORG}",
+    "_REPO": "${REL_REPO}"
+  }
+EOF
 
 run_build "${REPO}" "${REPO_FILE}" "${REPO_FILE_VER}" "cloud_publish.template.json" \
   "${SUBS_FILE}" "${PROJECT_ID}" "${SVC_ACCT}" "${KEY_FILE_PATH}" "${WAIT_FOR_RESULT}"

--- a/release/start_gcb_tag.sh
+++ b/release/start_gcb_tag.sh
@@ -105,17 +105,19 @@ if [[ -z "${SVC_ACCT}"  ]]; then
 fi
 
 # generate the substitutions file
-echo "  \"substitutions\": {
-    \"_VER_STRING\": \"${VER_STRING}\",
-    \"_MFEST_URL\": \"${REPO}\",
-    \"_MFEST_FILE\": \"${REPO_FILE}\",
-    \"_MFEST_VER\": \"${REPO_FILE_VER}\",
-    \"_GCS_SOURCE\": \"${GCS_SRC}\",
-    \"_GCS_SECRET\": \"${GCS_GITHUB_SECRET}\",
-    \"_ORG\": \"${REL_ORG}\",
-    \"_USER_EMAIL\": \"${USER_EMAIL}\",
-    \"_USER_NAME\": \"${USER_NAME}\",
-  }" >> "${SUBS_FILE}"
+cat << EOF > ${SUBS_FILE}
+  substitutions": {
+    "_VER_STRING": "${VER_STRING}",
+    "_MFEST_URL": "${REPO}",
+    "_MFEST_FILE": "${REPO_FILE}",
+    "_MFEST_VER": "${REPO_FILE_VER}",
+    "_GCS_SOURCE": "${GCS_SRC}",
+    "_GCS_SECRET": "${GCS_GITHUB_SECRET}",
+    "_ORG": "${REL_ORG}",
+    "_USER_EMAIL": "${USER_EMAIL}",
+    "_USER_NAME": "${USER_NAME}"
+  }
+EOF
 
 run_build "${REPO}" "${REPO_FILE}" "${REPO_FILE_VER}" "cloud_tag.template.json" \
   "${SUBS_FILE}" "${PROJECT_ID}" "${SVC_ACCT}" "${KEY_FILE_PATH}" "${WAIT_FOR_RESULT}"

--- a/release/start_gcb_tag.sh
+++ b/release/start_gcb_tag.sh
@@ -106,7 +106,7 @@ fi
 
 # generate the substitutions file
 cat << EOF > ${SUBS_FILE}
-  substitutions": {
+  "substitutions": {
     "_VER_STRING": "${VER_STRING}",
     "_MFEST_URL": "${REPO}",
     "_MFEST_FILE": "${REPO_FILE}",


### PR DESCRIPTION
In my initial change for tagging and publishing there's an issue where a github token can be logged (from using -x with bash).  Bash outputs the post-expansion version of each command, so my initial attempts at solutions weren't successful.  I'm now resorting to disabling the logging of the curl calls that use a static token.

I also changed a few multi-line "echo > file" instances to "cat << EOF > file" to improve readability.

I tested this change by performing a build/tag/publish in my project and confirmed that the token was no longer logged.

```release-note
NONE
```
