### PR TITLE
pass templates/adapters info to the server

### DIFF
--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -28,12 +28,15 @@ import (
 
 func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, printf, fatalf shared.FormatFn) *cobra.Command {
 	sa := server.NewArgs()
+	sa.Templates = info
+	sa.Adapters = adapters
+	sa.LegacyAdapters = legacyAdapters
 
 	serverCmd := cobra.Command{
 		Use:   "server",
 		Short: "Starts Mixer as a server",
 		Run: func(cmd *cobra.Command, args []string) {
-			runServer(sa, info, adapters, legacyAdapters, printf, fatalf)
+			runServer(sa, printf, fatalf)
 		},
 	}
 
@@ -95,7 +98,7 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, legacyA
 	return &serverCmd
 }
 
-func runServer(sa *server.Args, info map[string]template.Info, adapters []adapter.InfoFn, legacyAdapters []adapter.RegisterFn, printf, fatalf shared.FormatFn) {
+func runServer(sa *server.Args, printf, fatalf shared.FormatFn) {
 	printf("Mixer started with\n%s", sa)
 
 	s, err := server.New(sa)


### PR DESCRIPTION
It seems PR #1911 accidentally removes the connection between
the server and those info. E2E tests start failing because of
this.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
