### PR TITLE
Look up and set the availability zone of a proxy using the --availabilityZone envoy flag

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -104,6 +106,19 @@ var (
 				} else {
 					role.Domain = ""
 				}
+			}
+
+			// Get AZ for proxy
+			azResp, err := http.Get(fmt.Sprintf("http://%v/v1/az/%v/%v", discoveryAddress, serviceCluster, role.ServiceNode()))
+			if err != nil {
+				glog.V(2).Infof("Error retrieving availability zone from pilot: %v", err)
+			} else {
+				body, err := ioutil.ReadAll(azResp.Body)
+				if err != nil {
+					glog.V(2).Infof("Error reading availability zone response from pilot: %v", err)
+				}
+				availabilityZone = string(body)
+				glog.V(2).Infof("Proxy availability zone: %v", availabilityZone)
 			}
 
 			glog.V(2).Infof("Proxy role: %#v", role)


### PR DESCRIPTION
**What this PR does / why we need it**: It is needed to allow proxy agent to set the availability zone of a proxy using the --availabilityZone flag

**Which issue this PR fixes**: 
Continues on from: https://github.com/istio/old_pilot_repo/pull/1230 and https://github.com/istio/istio/pull/1815
Working towards: #1473 

**Special notes for your reviewer**: This needs testing but would like some advice on how to go about it!

**Release note**:
```
Look up and set the availability zone of a proxy using the --availabilityZone envoy flag
```

cc @rshriram 
