### PR TITLE
Add max_retries to circuit breaker configuration

### DIFF
--- a/pilot/proxy/envoy/policy.go
+++ b/pilot/proxy/envoy/policy.go
@@ -99,7 +99,9 @@ func applyClusterPolicy(cluster *Cluster,
 		if cbconfig.HttpMaxPendingRequests > 0 {
 			cluster.CircuitBreaker.Default.MaxPendingRequests = int(cbconfig.HttpMaxPendingRequests)
 		}
-		//TODO: need to add max_retries as well. Currently it defaults to 3
+		if cbconfig.HttpMaxRetries > 0 {
+			cluster.CircuitBreaker.Default.MaxRetries = int(cbconfig.HttpMaxRetries)
+		}
 
 		cluster.OutlierDetection = &OutlierDetection{}
 

--- a/pilot/proxy/envoy/testdata/cb-policy.yaml.golden
+++ b/pilot/proxy/envoy/testdata/cb-policy.yaml.golden
@@ -16,5 +16,6 @@ circuitBreaker:
     httpConsecutiveErrors: 10
     httpDetectionInterval: 30s
     httpMaxEjectionPercent: 100
+    httpMaxRetries: 10
 loadBalancing:
   name: RANDOM

--- a/pilot/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/pilot/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -195,7 +195,8 @@
      "default": {
       "max_connections": 100,
       "max_pending_requests": 100,
-      "max_requests": 100
+      "max_requests": 100,
+      "max_retries": 10
      }
     },
     "outlier_detection": {
@@ -223,7 +224,8 @@
      "default": {
       "max_connections": 100,
       "max_pending_requests": 100,
-      "max_requests": 100
+      "max_requests": 100,
+      "max_retries": 10
      }
     },
     "outlier_detection": {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds the possibility to use the httpMaxRetries config attribute in the DestinationPolicy yaml file. It allows configuring the max number of outgoing retries in a circuit breaker scenario.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
