### PR TITLE
add to Makefile verification that there is no vendor directory in top-level directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,14 @@ checkvars:
 	@if test -z "$(TAG)"; then echo "TAG missing"; exit 1; fi
 	@if test -z "$(HUB)"; then echo "HUB missing"; exit 1; fi
 
-setup: pilot/platform/kube/config
+verify.preconditions:
+	@if [ -d "vendor" ]; then echo "You have directory 'vendor' in the top-level directory, please remove it."\
+	" Otherwise it will confuse Bazel." ; exit 1; fi
+
+.PHONY: verify.preconditions
+
+setup: pilot/platform/kube/config verify.preconditions
+
 
 #-----------------------------------------------------------------------------
 # Target: depend


### PR DESCRIPTION
otherwise it will confuse Bazel

**What this PR does / why we need it**:
To prevent confusing users will failing Bazel.

Here is the user's question https://groups.google.com/d/msg/istio-users/7uZHtVew-a8/XpVYuEQsCgAJ

Bazel fails with the following errors:
```
ERROR: error loading package 'vendor/k8s.io/apimachinery/pkg/util/sets': Extension file not found. Unable to load package for '@io_kubernetes_build//defs:go.bzl': The repository could not be resolved.
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```