### PR TITLE
Add quota rule for mixer client.

### DIFF
--- a/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
+++ b/samples/bookinfo/kube/mixer-rule-deny-serviceaccount.yaml
@@ -18,7 +18,7 @@ kind: rule
 metadata:
   name: denyproductpage
 spec:
-  match: destination.labels["app"] == "details" && source.user == "spiffe://cluster.local/ns/default/sa/bookinfo-productpage"
+  match: destination.labels["app"] == "details" && source.user == "cluster.local/ns/default/sa/bookinfo-productpage"
   actions:
   - handler: denyproductpagehandler.denier
     instances: [ denyproductpagerequest.checknothing ]

--- a/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
@@ -49,3 +49,28 @@ spec:
   - handler: handler.memquota
     instances:
     - requestcount.quota
+---
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpec
+metadata:
+  creationTimestamp: null
+  name: request-count
+  namespace: istio-system
+spec:
+  rules:
+  - quotas:
+    - charge: 1
+      quota: RequestCount
+---
+apiVersion: config.istio.io/v1alpha2
+kind: QuotaSpecBinding
+metadata:
+  creationTimestamp: null
+  name: request-count
+  namespace: istio-system
+spec:
+  quotaSpecs:
+  - name: request-count
+  services:
+  - service: ratings
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix mixer E2E tests:
1) Pilot is hardcoded "RequestCount" quota.  This PR https://github.com/istio/proxy/pull/722 removed it
need to add quota to mixer client config
2) origin.user has removed spiff prefix in this PR https://github.com/istio/proxy/pull/719

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
