### PR TITLE
we no longer need to restrict expression to be non empty string.

### DIFF
--- a/mixer/template/sample/template.gen.go
+++ b/mixer/template/sample/template.gen.go
@@ -53,8 +53,6 @@ var (
 	_ = strings.Reader{}
 )
 
-const emptyQuotes = "\"\""
-
 type (
 	getFn         func(name string) (value interface{}, found bool)
 	namesFn       func() []string
@@ -147,7 +145,7 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -157,7 +155,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -167,7 +165,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -177,7 +175,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -197,7 +195,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -207,7 +205,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -217,7 +215,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.OptionalIP == "" || param.OptionalIP == emptyQuotes {
+					if param.OptionalIP == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"OptionalIP")
 					}
 					if t, e := tEvalFn(param.OptionalIP); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
@@ -227,7 +225,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OptionalIP", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.Email == "" || param.Email == emptyQuotes {
+					if param.Email == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Email")
 					}
 					if t, e := tEvalFn(param.Email); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
@@ -250,7 +248,7 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" || param.Str == emptyQuotes {
+					if param.Str == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
 					}
 					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -273,7 +271,7 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" || param.Str == emptyQuotes {
+					if param.Str == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
 					}
 					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -296,7 +294,7 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -306,7 +304,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -316,7 +314,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -326,7 +324,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -346,7 +344,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -356,7 +354,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -912,7 +910,7 @@ var (
 
 					var err error = nil
 
-					if param.CheckExpression == "" || param.CheckExpression == emptyQuotes {
+					if param.CheckExpression == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"CheckExpression")
 					}
 					if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -954,7 +952,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -971,7 +969,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -981,7 +979,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -991,7 +989,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1001,7 +999,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1021,7 +1019,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -1031,7 +1029,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -1073,7 +1071,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1090,7 +1088,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1471,7 +1469,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1488,7 +1486,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1498,7 +1496,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -1508,7 +1506,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1518,7 +1516,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1538,7 +1536,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -1548,7 +1546,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -1590,7 +1588,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1607,7 +1605,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1945,7 +1943,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1962,7 +1960,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1972,7 +1970,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -1982,7 +1980,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1992,7 +1990,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -2012,7 +2010,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -2022,7 +2020,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -2054,7 +2052,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2071,7 +2069,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2081,7 +2079,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -2091,7 +2089,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -2101,7 +2099,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -2121,7 +2119,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -2131,7 +2129,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -2173,7 +2171,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2190,7 +2188,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2200,7 +2198,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -2210,7 +2208,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -2220,7 +2218,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" || param.IpAddr == emptyQuotes {
+					if param.IpAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
 					}
 					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
@@ -2230,7 +2228,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" || param.DnsName == emptyQuotes {
+					if param.DnsName == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
 					}
 					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
@@ -2240,7 +2238,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" || param.EmailAddr == emptyQuotes {
+					if param.EmailAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
 					}
 					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
@@ -2250,7 +2248,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" || param.Uri == emptyQuotes {
+					if param.Uri == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
 					}
 					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -516,41 +516,11 @@ dimensions:
   source: source.string
   target: source.string
 `,
-			cstrParam:     &sample_report.InstanceParam{},
-			typeEvalError: nil,
-			wantErr:       "expression for field 'StringPrimitive' cannot be empty",
-			willPanic:     false,
-		},
-
-		{
-			name: "EmptyStringSubMsg",
-			instYamlCfg: `
-value: source.int64
-int64Primitive: source.int64
-boolPrimitive: source.bool
-doublePrimitive: source.double
-stringPrimitive: source.string
-timeStamp: source.timestamp
-duration: source.duration
-dimensions:
-  source: source.string
-  target: source.string
-res1:
-  value: source.int64
-  int64Primitive: source.int64
-  boolPrimitive: source.bool
-  doublePrimitive: source.double
-  stringPrimitive: '""'
-  timeStamp: source.timestamp
-  duration: source.duration
-  dimensions:
-    source: source.string
-    target: source.string
-`,
-			cstrParam:     &sample_report.InstanceParam{},
-			typeEvalError: nil,
-			wantErr:       "expression for field 'Res1.StringPrimitive' cannot be empty",
-			willPanic:     false,
+			cstrParam: &sample_report.InstanceParam{},
+			wantType: &sample_report.Type{
+				Value:      pb.INT64,
+				Dimensions: map[string]pb.ValueType{"source": pb.STRING, "target": pb.STRING},
+			},
 		},
 		{
 			name:        "NotValidInstanceParam",

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -63,8 +63,6 @@ var (
 	_ = strings.Reader{}
 )
 
-const emptyQuotes = "\"\""
-
 type (
 	getFn         func(name string) (value interface{}, found bool)
 	namesFn       func() []string
@@ -144,7 +142,7 @@ var (
 
 					var err error = nil
 
-					if param.ApiVersion == "" || param.ApiVersion == emptyQuotes {
+					if param.ApiVersion == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiVersion")
 					}
 					if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -154,7 +152,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiOperation == "" || param.ApiOperation == emptyQuotes {
+					if param.ApiOperation == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiOperation")
 					}
 					if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -164,7 +162,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiProtocol == "" || param.ApiProtocol == emptyQuotes {
+					if param.ApiProtocol == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiProtocol")
 					}
 					if t, e := tEvalFn(param.ApiProtocol); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -174,7 +172,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiProtocol", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiService == "" || param.ApiService == emptyQuotes {
+					if param.ApiService == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiService")
 					}
 					if t, e := tEvalFn(param.ApiService); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -184,7 +182,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiService", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiKey == "" || param.ApiKey == emptyQuotes {
+					if param.ApiKey == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiKey")
 					}
 					if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -194,7 +192,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestTime == "" || param.RequestTime == emptyQuotes {
+					if param.RequestTime == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestTime")
 					}
 					if t, e := tEvalFn(param.RequestTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -204,7 +202,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.RequestMethod == "" || param.RequestMethod == emptyQuotes {
+					if param.RequestMethod == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestMethod")
 					}
 					if t, e := tEvalFn(param.RequestMethod); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -214,7 +212,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestMethod", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestPath == "" || param.RequestPath == emptyQuotes {
+					if param.RequestPath == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestPath")
 					}
 					if t, e := tEvalFn(param.RequestPath); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -224,7 +222,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestPath", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestBytes == "" || param.RequestBytes == emptyQuotes {
+					if param.RequestBytes == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestBytes")
 					}
 					if t, e := tEvalFn(param.RequestBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -234,7 +232,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestBytes", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseTime == "" || param.ResponseTime == emptyQuotes {
+					if param.ResponseTime == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseTime")
 					}
 					if t, e := tEvalFn(param.ResponseTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -244,7 +242,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.ResponseCode == "" || param.ResponseCode == emptyQuotes {
+					if param.ResponseCode == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseCode")
 					}
 					if t, e := tEvalFn(param.ResponseCode); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -254,7 +252,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseCode", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseBytes == "" || param.ResponseBytes == emptyQuotes {
+					if param.ResponseBytes == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseBytes")
 					}
 					if t, e := tEvalFn(param.ResponseBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -264,7 +262,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseBytes", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseLatency == "" || param.ResponseLatency == emptyQuotes {
+					if param.ResponseLatency == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseLatency")
 					}
 					if t, e := tEvalFn(param.ResponseLatency); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -497,7 +495,7 @@ var (
 
 					var err error = nil
 
-					if param.Api == "" || param.Api == emptyQuotes {
+					if param.Api == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Api")
 					}
 					if t, e := tEvalFn(param.Api); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -507,7 +505,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Api", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiVersion == "" || param.ApiVersion == emptyQuotes {
+					if param.ApiVersion == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiVersion")
 					}
 					if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -517,7 +515,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiOperation == "" || param.ApiOperation == emptyQuotes {
+					if param.ApiOperation == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiOperation")
 					}
 					if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -527,7 +525,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiKey == "" || param.ApiKey == emptyQuotes {
+					if param.ApiKey == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiKey")
 					}
 					if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -537,7 +535,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Timestamp == "" || param.Timestamp == emptyQuotes {
+					if param.Timestamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Timestamp")
 					}
 					if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -777,7 +775,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if t, e := tEvalFn(param.Value); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -897,7 +895,7 @@ var (
 						}
 					}
 
-					if param.Timestamp == "" || param.Timestamp == emptyQuotes {
+					if param.Timestamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Timestamp")
 					}
 					if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -907,7 +905,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Timestamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Severity == "" || param.Severity == emptyQuotes {
+					if param.Severity == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Severity")
 					}
 					if t, e := tEvalFn(param.Severity); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -917,7 +915,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Severity", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.MonitoredResourceType == "" || param.MonitoredResourceType == emptyQuotes {
+					if param.MonitoredResourceType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"MonitoredResourceType")
 					}
 					if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1080,7 +1078,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1097,7 +1095,7 @@ var (
 						}
 					}
 
-					if param.MonitoredResourceType == "" || param.MonitoredResourceType == emptyQuotes {
+					if param.MonitoredResourceType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"MonitoredResourceType")
 					}
 					if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1452,7 +1450,7 @@ var (
 
 					var err error = nil
 
-					if param.TraceId == "" || param.TraceId == emptyQuotes {
+					if param.TraceId == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TraceId")
 					}
 					if t, e := tEvalFn(param.TraceId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1462,7 +1460,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TraceId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.SpanId == "" || param.SpanId == emptyQuotes {
+					if param.SpanId == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SpanId")
 					}
 					if t, e := tEvalFn(param.SpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1472,7 +1470,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ParentSpanId == "" || param.ParentSpanId == emptyQuotes {
+					if param.ParentSpanId == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ParentSpanId")
 					}
 					if t, e := tEvalFn(param.ParentSpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1482,7 +1480,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ParentSpanId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.SpanName == "" || param.SpanName == emptyQuotes {
+					if param.SpanName == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SpanName")
 					}
 					if t, e := tEvalFn(param.SpanName); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1492,7 +1490,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanName", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.StartTime == "" || param.StartTime == emptyQuotes {
+					if param.StartTime == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StartTime")
 					}
 					if t, e := tEvalFn(param.StartTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -1502,7 +1500,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StartTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.EndTime == "" || param.EndTime == emptyQuotes {
+					if param.EndTime == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EndTime")
 					}
 					if t, e := tEvalFn(param.EndTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {

--- a/mixer/test/spyAdapter/template/template.gen.go
+++ b/mixer/test/spyAdapter/template/template.gen.go
@@ -47,8 +47,6 @@ var (
 	_ = strings.Reader{}
 )
 
-const emptyQuotes = "\"\""
-
 type (
 	getFn         func(name string) (value interface{}, found bool)
 	namesFn       func() []string
@@ -126,7 +124,7 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -136,7 +134,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -146,7 +144,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -156,7 +154,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -397,7 +395,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -63,9 +63,6 @@ var (
 	_ = strings.Reader{}
 )
 
-
-const emptyQuotes = "\"\""
-
 type (
 	getFn         func(name string) (value interface{}, found bool)
 	namesFn       func() []string
@@ -190,7 +187,7 @@ var (
 									}
 								}
 							{{else}}
-								if param.{{.GoName}} == "" || param.{{.GoName}} == emptyQuotes {
+								if param.{{.GoName}} == "" {
 									return nil, fmt.Errorf("expression for field '%s' cannot be empty", path + "{{.GoName}}")
 								}
 								if infrdType.{{.GoName}}, err = tEvalFn(param.{{.GoName}}); err != nil {
@@ -211,7 +208,7 @@ var (
 								}
 							}
 						{{else}}
-							if param.{{.GoName}} == "" || param.{{.GoName}} == emptyQuotes {
+							if param.{{.GoName}} == "" {
 								return nil, fmt.Errorf("expression for field '%s' cannot be empty", path + "{{.GoName}}")
 							}
 							if t, e := tEvalFn(param.{{.GoName}}); e != nil || t != {{getValueType .GoType}} {

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/AllTemplates.go.golden
@@ -55,8 +55,6 @@ var (
 	_ = strings.Reader{}
 )
 
-const emptyQuotes = "\"\""
-
 type (
 	getFn         func(name string) (value interface{}, found bool)
 	namesFn       func() []string
@@ -149,7 +147,7 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -159,7 +157,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -169,7 +167,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -179,7 +177,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -199,7 +197,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -209,7 +207,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -219,7 +217,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" || param.IpAddr == emptyQuotes {
+					if param.IpAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
 					}
 					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
@@ -229,7 +227,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" || param.DnsName == emptyQuotes {
+					if param.DnsName == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
 					}
 					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
@@ -239,7 +237,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" || param.EmailAddr == emptyQuotes {
+					if param.EmailAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
 					}
 					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
@@ -249,7 +247,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" || param.Uri == emptyQuotes {
+					if param.Uri == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
 					}
 					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
@@ -272,7 +270,7 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" || param.Str == emptyQuotes {
+					if param.Str == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
 					}
 					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -295,7 +293,7 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" || param.Str == emptyQuotes {
+					if param.Str == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
 					}
 					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -318,7 +316,7 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -328,7 +326,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -338,7 +336,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -348,7 +346,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -368,7 +366,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -378,7 +376,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -970,7 +968,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -987,7 +985,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -997,7 +995,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -1007,7 +1005,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1017,7 +1015,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1027,7 +1025,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.AnotherValueType == "" || param.AnotherValueType == emptyQuotes {
+					if param.AnotherValueType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
 					}
 					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
@@ -1044,7 +1042,7 @@ var (
 						}
 					}
 
-					if param.CheckExpression == "" || param.CheckExpression == emptyQuotes {
+					if param.CheckExpression == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"CheckExpression")
 					}
 					if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1076,7 +1074,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1093,7 +1091,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1103,7 +1101,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -1113,7 +1111,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1123,7 +1121,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1143,7 +1141,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -1153,7 +1151,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -1195,7 +1193,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1212,7 +1210,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1222,7 +1220,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -1232,7 +1230,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -1242,7 +1240,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" || param.IpAddr == emptyQuotes {
+					if param.IpAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
 					}
 					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
@@ -1252,7 +1250,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" || param.DnsName == emptyQuotes {
+					if param.DnsName == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
 					}
 					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
@@ -1262,7 +1260,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" || param.EmailAddr == emptyQuotes {
+					if param.EmailAddr == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
 					}
 					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
@@ -1272,7 +1270,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" || param.Uri == emptyQuotes {
+					if param.Uri == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
 					}
 					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
@@ -1731,7 +1729,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -1748,7 +1746,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -1758,7 +1756,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -1768,7 +1766,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -1778,7 +1776,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -1788,7 +1786,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.AnotherValueType == "" || param.AnotherValueType == emptyQuotes {
+					if param.AnotherValueType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
 					}
 					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
@@ -1992,7 +1990,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2009,7 +2007,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2019,7 +2017,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -2029,7 +2027,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -2039,7 +2037,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -2049,7 +2047,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.AnotherValueType == "" || param.AnotherValueType == emptyQuotes {
+					if param.AnotherValueType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
 					}
 					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
@@ -2066,7 +2064,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -2076,7 +2074,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -2108,7 +2106,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2125,7 +2123,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2135,7 +2133,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -2145,7 +2143,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -2155,7 +2153,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -2175,7 +2173,7 @@ var (
 						}
 					}
 
-					if param.TimeStamp == "" || param.TimeStamp == emptyQuotes {
+					if param.TimeStamp == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
 					}
 					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
@@ -2185,7 +2183,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" || param.Duration == emptyQuotes {
+					if param.Duration == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
 					}
 					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
@@ -2227,7 +2225,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2244,7 +2242,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2656,7 +2654,7 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" || param.Value == emptyQuotes {
+					if param.Value == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
 					}
 					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
@@ -2673,7 +2671,7 @@ var (
 						}
 					}
 
-					if param.Int64Primitive == "" || param.Int64Primitive == emptyQuotes {
+					if param.Int64Primitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
 					}
 					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
@@ -2683,7 +2681,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" || param.BoolPrimitive == emptyQuotes {
+					if param.BoolPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
 					}
 					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
@@ -2693,7 +2691,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" || param.DoublePrimitive == emptyQuotes {
+					if param.DoublePrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
 					}
 					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
@@ -2703,7 +2701,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" || param.StringPrimitive == emptyQuotes {
+					if param.StringPrimitive == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
 					}
 					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
@@ -2713,7 +2711,7 @@ var (
 						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.AnotherValueType == "" || param.AnotherValueType == emptyQuotes {
+					if param.AnotherValueType == "" {
 						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
 					}
 					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {


### PR DESCRIPTION
After [Oz's fix that solve](https://github.com/istio/istio/pull/1322) the old issue of Mixer panic on empty expression,
we can waive of the constraint that requires expression to be non empty strings.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
