### PR TITLE
Add namespace for quota refe in mixer ratelimit test.

### DIFF
--- a/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
@@ -71,6 +71,7 @@ metadata:
 spec:
   quotaSpecs:
   - name: request-count
+    namespace: istio-system
   services:
   - service: ratings
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Added namespace in the quota spec for mixer ratelimit test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
