### PR TITLE
make lint errors more noticeable

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -25,6 +25,26 @@
         "vet",
         "vetshadow"
     ],
+    "severity": {
+        "aligncheck": "error",
+        "deadcode": "error",
+        "errcheck": "error",
+        "gas": "error",
+        "goconst": "error",
+        "gofmt": "error",
+        "goimports": "error",
+        "golint": "error",
+        "ineffassign": "error",
+        "interfacer": "error",
+        "lll": "error",
+        "megacheck": "error",
+        "misspell": "error",
+        "structcheck": "error",
+        "unconvert": "error",
+        "varcheck": "error",
+        "vet": "error",
+        "vetshadow": "error"
+    },
     "exclude": [
         "vendor",
         ".pb.go",

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -136,7 +136,7 @@ echo 'Running Unit Tests'
 time bazel test --test_output=all //...
 
 # run linters in advisory mode
-SKIP_INIT=1 ${ROOT}/bin/linters.sh
+SKIP_INIT=1 ${ROOT}/bin/linters.sh || die "Error: linters.sh failed"
 
 diff=`git diff`
 if [[ -n "$diff" ]]; then


### PR DESCRIPTION
- set "severity" in the config; all lint reports are tagged as
  error.
- use "die", so that failure of linters.sh can be noticed more easily

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2133

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
