### PR TITLE
Fix #2150 istioctl create -f samples/bookinfo/kube/route-rule-all-v1.yaml

### DIFF
--- a/samples/bookinfo/kube/route-rule-all-v1.yaml
+++ b/samples/bookinfo/kube/route-rule-all-v1.yaml
@@ -20,6 +20,7 @@ spec:
     name: productpage
   match:
     source:
+      service: productpage
       labels:
         istio: ingress
   precedence: 2
@@ -39,6 +40,7 @@ spec:
     name: productpage
   match:
     source:
+      service: productpage
       labels:
         istio: ingress
     request:
@@ -59,6 +61,7 @@ spec:
     name: productpage
   match:
     source:
+      service: productpage
       labels:
         istio: ingress
     request:
@@ -79,6 +82,7 @@ spec:
     name: productpage
   match:
     source:
+      service: productpage
       labels:
         istio: ingress
     request:
@@ -99,6 +103,7 @@ spec:
     name: productpage
   match:
     source:
+      service: productpage
       labels:
         istio: ingress
     request:


### PR DESCRIPTION
….yaml

**What this PR does / why we need it**:

fix the sample that can not run.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #2150

**Special notes for your reviewer**:

it may be caused by the validation.

https://github.com/istio/istio/blob/d1c939b5d6a23c496e0c1a9a1a02419b3837c93d/pilot/model/validation.go#L256
```
func ValidateIstioService(svc *routing.IstioService) (errs error) {
	if svc.Name == "" && svc.Service == "" {
		errs = multierror.Append(errs, errors.New("name or service is mandatory for a service reference"))
	}
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
