### PR TITLE
Revert servicecontrol adapter BUILD change from PR 1987

### DIFF
--- a/mixer/adapter/servicecontrol/BUILD
+++ b/mixer/adapter/servicecontrol/BUILD
@@ -14,7 +14,6 @@ go_library(
         "reportbuilder.go",
         "reportprocessor.go",
         "servicecontrol.go",
-        "testhelper.go",
         "utils.go",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
**What this PR does / why we need it**:
Test code shouldn't be compiled into prod code. This reverts change from https://github.com/istio/istio/pull/1987. It appeared it was an accident. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
