### PR TITLE
Fixes for consul and eureka istio.io tasks

### DIFF
--- a/samples/bookinfo/consul/bookinfo.sidecars.yaml
+++ b/samples/bookinfo/consul/bookinfo.sidecars.yaml
@@ -34,7 +34,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   ratings-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -52,7 +52,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   productpage-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -70,7 +70,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -88,7 +88,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v2-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -106,7 +106,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v3-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -124,4 +124,4 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Consul --serviceCluster reviews-v3 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Consul --serviceCluster reviews-v3 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"

--- a/samples/bookinfo/consul/cleanup.sh
+++ b/samples/bookinfo/consul/cleanup.sh
@@ -36,6 +36,7 @@ done
 export OUTPUT=$(mktemp)
 echo "Application cleanup may take up to one minute"
 docker-compose -f $SCRIPTDIR/bookinfo.yaml down > ${OUTPUT} 2>&1
+docker-compose -f $SCRIPTDIR/bookinfo.sidecar.yaml down > ${OUTPUT} 2>&1
 ret=$?
 function cleanup() {
   rm -f ${OUTPUT}

--- a/samples/bookinfo/eureka/bookinfo.sidecars.yaml
+++ b/samples/bookinfo/eureka/bookinfo.sidecars.yaml
@@ -34,7 +34,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   ratings-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -52,7 +52,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   productpage-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -70,7 +70,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v1-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -88,7 +88,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v2-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -106,7 +106,7 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v3-init:
     image: gcr.io/istio-testing/proxy_init:3101ea9d82a5f83b699c2d3245b371a19fa6bef4
     cap_add:
@@ -124,4 +124,4 @@ services:
       - su
       - istio-proxy
       - -c
-      - "/usr/local/bin/pilot-agent proxy -v 2 --serviceregistry Eureka --serviceCluster reviews-v3 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
+      - "/usr/local/bin/pilot-agent proxy -v 2 --discoveryAddress istio-pilot:8080 --serviceregistry Eureka --serviceCluster reviews-v3 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"

--- a/samples/bookinfo/eureka/cleanup.sh
+++ b/samples/bookinfo/eureka/cleanup.sh
@@ -36,6 +36,7 @@ done
 export OUTPUT=$(mktemp)
 echo "Application cleanup may take up to one minute"
 docker-compose -f $SCRIPTDIR/bookinfo.yaml down > ${OUTPUT} 2>&1
+docker-compose -f $SCRIPTDIR/bookinfo.sidecar.yaml down > ${OUTPUT} 2>&1
 ret=$?
 function cleanup() {
   rm -f ${OUTPUT}


### PR DESCRIPTION
**What this PR does / why we need it**:
default discovery istio-pilot:<port> was changed from 8080 to 15003, broke consul and eureka docker-compose yamls

**Which issue this PR fixes**: fixes #2080 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed issue with Pilot port in Consul and Eureka samples.
```