### PR TITLE
Fault injection should use abort instead of timeout (#1279)

### DIFF
--- a/samples/bookinfo/kube/route-rule-ratings-test-abort.yaml
+++ b/samples/bookinfo/kube/route-rule-ratings-test-abort.yaml
@@ -1,0 +1,20 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: ratings-test-abort
+spec:
+  destination:
+    name: ratings
+  precedence: 2
+  match:
+    request:
+      headers:
+        cookie:
+          regex: "^(.*?;)?(user=jason)(;.*)?$"
+  route:
+  - labels:
+      version: v1
+  httpFault:
+    abort:
+      percent: 100
+      httpStatus: 500 


### PR DESCRIPTION
This commit introduces a new fault injection file that simulates
HTTP abort in addition to the HTTP timeout exampls. The documentation
will be updated to add this as an fault injection example.

**What this PR does / why we need it**:
Adds a fault injection example using HTTP abort in addition to the HTTP timeout example

**Which issue this PR fixes**: fixes #1279 

**Special notes for your reviewer**:
Documentation will be updated to use this example.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Added fault injection example using HTTP abort.
```
