### PR TITLE
[pilot] Move metrics/version to separate port

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -89,6 +89,8 @@ func init() {
 
 	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.Port, "port", 8080,
 		"Discovery service port")
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.MonitoringPort, "monitoringPort", 9093,
+		"HTTP port to use for the exposing pilot self-monitoring information")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.DiscoveryOptions.EnableProfiling, "profile", true,
 		"Enable profiling via web interface host:port/debug/pprof")
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.DiscoveryOptions.EnableCaching, "discovery_cache", true,

--- a/pilot/cmd/pilot-discovery/server/BUILD
+++ b/pilot/cmd/pilot-discovery/server/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "monitoring.go",
         "server.go",
     ],
     visibility = ["//visibility:public"],
@@ -29,6 +30,8 @@ go_library(
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@org_cloudfoundry_code_copilot//:go_default_library",

--- a/pilot/cmd/pilot-discovery/server/monitoring.go
+++ b/pilot/cmd/pilot-discovery/server/monitoring.go
@@ -19,10 +19,9 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"istio.io/istio/mixer/pkg/version"
-	"istio.io/istio/pkg/log"
+	"istio.io/istio/pilot/tools/version"
 )
 
 type monitor struct {
@@ -35,7 +34,7 @@ const (
 	versionPath = "/version"
 )
 
-func startMonitor(port uint16) (*monitor, error) {
+func startMonitor(port int) (*monitor, error) {
 	m := &monitor{
 		shutdown: make(chan struct{}),
 	}
@@ -48,14 +47,14 @@ func startMonitor(port uint16) (*monitor, error) {
 	}
 
 	// NOTE: this is a temporary solution to provide bare-bones debug functionality
-	// for mixer. a full design / implementation of self-monitoring and reporting
+	// for pilot. a full design / implementation of self-monitoring and reporting
 	// is coming. that design will include proper coverage of statusz/healthz type
-	// functionality, in addition to how mixer reports its own metrics.
+	// functionality, in addition to how pilot reports its own metrics.
 	mux := http.NewServeMux()
 	mux.Handle(metricsPath, promhttp.Handler())
 	mux.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {
-		if _, err := out.Write([]byte(version.Info.String())); err != nil {
-			log.Errorf("Unable to write version string: %v", err)
+		if _, err := out.Write([]byte(version.Line())); err != nil {
+			glog.Errorf("Unable to write version string: %v", err)
 		}
 	})
 

--- a/pilot/proxy/envoy/BUILD
+++ b/pilot/proxy/envoy/BUILD
@@ -27,7 +27,6 @@ go_library(
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_howeyc_fsnotify//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
         "@io_istio_api//mixer/v1:go_default_library",
         "@io_istio_api//mixer/v1/config/client:go_default_library",

--- a/pilot/proxy/envoy/discovery.go
+++ b/pilot/proxy/envoy/discovery.go
@@ -29,17 +29,12 @@ import (
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/proxy"
 	"istio.io/istio/pilot/tools/version"
 )
 
 const (
-	metricsPath = "/metrics"
-	versionPath = "/version"
-
 	metricsNamespace     = "pilot"
 	metricsSubsystem     = "discovery"
 	metricLabelCacheName = "cache_name"
@@ -280,6 +275,7 @@ const (
 // service instance.
 type DiscoveryServiceOptions struct {
 	Port            int
+	MonitoringPort  int
 	EnableProfiling bool
 	EnableCaching   bool
 }
@@ -403,17 +399,6 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 		Doc("Clear discovery service cache stats"))
 
 	container.Add(ws)
-
-	// NOTE: this is a temporary solution to provide bare-bones debug functionality
-	// for pilot. a full design / implementation of self-monitoring and reporting
-	// is coming. that design will include proper coverage of statusz/healthz type
-	// functionality, in addition to how pilot reports its own metrics.
-	container.Handle(metricsPath, promhttp.Handler())
-	container.Handle(versionPath, http.HandlerFunc(func(out http.ResponseWriter, req *http.Request) {
-		if _, err := out.Write([]byte(version.Line())); err != nil {
-			glog.Errorf("Unable to write version string: %v", err)
-		}
-	}))
 }
 
 // Start starts the Pilot discovery service on the port specified in DiscoveryServiceOptions. If Port == 0, a


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes pilot monitoring more consistent with what is currently done in mixer, using a separate monitoring port with the same default value (9093). Also separates monitoring out from the discovery service and moves it to the server bootstrapping logic.

**Which issue this PR fixes**
fixes #2104

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
