### PR TITLE
Switch to Istio logging

### DIFF
--- a/broker/pkg/controller/BUILD
+++ b/broker/pkg/controller/BUILD
@@ -10,6 +10,9 @@ go_library(
     deps = [
         "//broker/pkg/model/config:go_default_library",
         "//broker/pkg/model/osb:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/broker/pkg/controller/controller.go
+++ b/broker/pkg/controller/controller.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/broker/pkg/model/config"
 	"istio.io/istio/broker/pkg/model/osb"
+	"istio.io/istio/pkg/log"
 )
 
 // Controller data
@@ -38,9 +40,9 @@ func CreateController(config config.BrokerConfigStore) (*Controller, error) {
 
 // Catalog serves catalog request and generate response.
 func (c *Controller) Catalog(w http.ResponseWriter, _ *http.Request) {
-	glog.Infof("Fetching Service Broker Catalog...")
+	log.Infof("Fetching Service Broker Catalog...")
 	cat := c.catalog()
-	glog.V(2).Infof("Got catalog\n %#v", cat)
+	log.Infof("Got catalog\n %#v", cat)
 	writeResponse(w, http.StatusOK, cat)
 }
 
@@ -48,10 +50,10 @@ func (c *Controller) catalog() *osb.Catalog {
 	jc := new(osb.Catalog)
 	sc := c.ServiceClasses()
 	for k, s := range sc {
-		glog.V(2).Infof("loading service %q", k)
+		log.Infof("loading service %q", k)
 		js := osb.NewService(s)
 		for pk, p := range c.ServicePlansByService(k) {
-			glog.V(2).Infof("loading service plan %q", pk)
+			log.Infof("loading service plan %q", pk)
 			jp := osb.NewServicePlan(p)
 			js.AddPlan(jp)
 		}
@@ -64,14 +66,14 @@ func (c *Controller) catalog() *osb.Catalog {
 func writeResponse(w http.ResponseWriter, code int, object interface{}) {
 	data, err := json.Marshal(object)
 	if err != nil {
-		glog.Errorf("Marsal response data object error %s", err.Error())
+		log.Errorf("Marsal response data object error %s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(code)
 	if _, err = fmt.Fprintf(w, string(data)); err != nil {
-		glog.Errorf("Write response data error %s", err.Error())
+		log.Errorf("Write response data error %s", err.Error())
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/broker/pkg/model/config/BUILD
+++ b/broker/pkg/model/config/BUILD
@@ -11,7 +11,10 @@ go_library(
         "store.go",
     ],
     deps = [
+        "//pkg/log:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+
+        # TODO(nmittler) Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_golang_protobuf//jsonpb:go_default_library",

--- a/broker/pkg/model/config/store.go
+++ b/broker/pkg/model/config/store.go
@@ -17,9 +17,11 @@ package config
 import (
 	"fmt"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	brokerconfig "istio.io/api/broker/v1/config"
+	"istio.io/istio/pkg/log"
 )
 
 // Store describes a set of platform agnostic APIs that must be supported
@@ -146,7 +148,7 @@ func (i brokerConfigStore) ServiceClasses() map[string]*brokerconfig.ServiceClas
 	out := make(map[string]*brokerconfig.ServiceClass)
 	rs, err := i.List(ServiceClass.Type, "")
 	if err != nil {
-		glog.V(2).Infof("ServiceClasses => %v", err)
+		log.Infof("ServiceClasses => %v", err)
 		return out
 	}
 	for _, r := range rs {
@@ -161,7 +163,7 @@ func (i brokerConfigStore) ServicePlans() map[string]*brokerconfig.ServicePlan {
 	out := make(map[string]*brokerconfig.ServicePlan)
 	rs, err := i.List(ServicePlan.Type, "")
 	if err != nil {
-		glog.V(2).Infof("ServicePlans => %v", err)
+		log.Infof("ServicePlans => %v", err)
 		return out
 	}
 	for _, r := range rs {

--- a/broker/pkg/model/osb/BUILD
+++ b/broker/pkg/model/osb/BUILD
@@ -12,6 +12,9 @@ go_library(
         "servicePlan.go",
     ],
     deps = [
+        "//pkg/log:go_default_library",
+
+        // TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_istio_api//broker/v1/config:go_default_library",
     ],

--- a/broker/pkg/model/osb/catalog.go
+++ b/broker/pkg/model/osb/catalog.go
@@ -14,6 +14,7 @@
 
 package osb
 
+// TODO(nmittler): Is this still needed?
 import _ "github.com/golang/glog" // import glog flags
 
 // Catalog defines OSB catalog request data structure.

--- a/broker/pkg/platform/kube/crd/BUILD
+++ b/broker/pkg/platform/kube/crd/BUILD
@@ -13,6 +13,9 @@ go_library(
     deps = [
         "//broker/pkg/model/config:go_default_library",
         "//broker/pkg/testing/mock:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",

--- a/broker/pkg/platform/kube/crd/client.go
+++ b/broker/pkg/platform/kube/crd/client.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -32,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"istio.io/istio/pkg/log"
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic
@@ -91,7 +94,7 @@ func resolveConfig(kubeconfig string) (string, error) {
 
 		// if it's an empty file, switch to in-cluster config
 		if info.Size() == 0 {
-			glog.Info("using in-cluster configuration")
+			log.Info("using in-cluster configuration")
 			return "", nil
 		}
 	}
@@ -192,7 +195,7 @@ func (cl *Client) RegisterResources() error {
 				},
 			},
 		}
-		glog.V(2).Infof("registering CRD %q", rd)
+		log.Infof("registering CRD %q", rd)
 		_, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(rd)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
@@ -212,7 +215,7 @@ func (cl *Client) RegisterResources() error {
 				switch cond.Type {
 				case apiextensionsv1beta1.Established:
 					if cond.Status == apiextensionsv1beta1.ConditionTrue {
-						glog.V(2).Infof("established CRD %q", name)
+						log.Infof("established CRD %q", name)
 						continue descriptor
 					}
 				case apiextensionsv1beta1.NamesAccepted:
@@ -275,13 +278,13 @@ func (cl *Client) Get(typ, name, namespace string) (*config.Entry, bool) {
 		Do().Into(entry)
 
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 		return nil, false
 	}
 
 	out, err := convertObject(schema, entry)
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 		return nil, false
 	}
 	return out, true

--- a/broker/pkg/server/BUILD
+++ b/broker/pkg/server/BUILD
@@ -9,6 +9,9 @@ go_library(
         "//broker/pkg/controller:go_default_library",
         "//broker/pkg/model/config:go_default_library",
         "//broker/pkg/platform/kube/crd:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
     ],

--- a/broker/pkg/server/broker.go
+++ b/broker/pkg/server/broker.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/gorilla/mux"
 
 	"istio.io/istio/broker/pkg/controller"
 	"istio.io/istio/broker/pkg/model/config"
 	"istio.io/istio/broker/pkg/platform/kube/crd"
+	"istio.io/istio/pkg/log"
 )
 
 // Server data
@@ -57,6 +59,6 @@ func (s *Server) Start(port uint16) {
 	http.Handle("/", router)
 
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil); err != nil {
-		glog.Errorf("Unable to start server: %v", err)
+		log.Errorf("Unable to start server: %v", err)
 	}
 }

--- a/broker/pkg/testing/util/BUILD
+++ b/broker/pkg/testing/util/BUILD
@@ -8,6 +8,9 @@ go_library(
         "kubernetes.go",
     ],
     deps = [
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/broker/pkg/version/BUILD
+++ b/broker/pkg/version/BUILD
@@ -4,7 +4,12 @@ go_library(
     name = "go_default_library",
     srcs = ["version.go"],
     visibility = ["//visibility:public"],
-    deps = ["@com_github_golang_glog//:go_default_library"],
+    deps = [
+        "//pkg/log:go_default_library",
+
+        // TODO(nmittler): Remove this
+        "@com_github_golang_glog//:go_default_library",
+    ],
 )
 
 go_test(

--- a/broker/pkg/version/version.go
+++ b/broker/pkg/version/version.go
@@ -19,6 +19,7 @@ package version
 import (
 	"fmt"
 
+	// TODO(nmittler): Is this still needed?
 	_ "github.com/golang/glog" // import glog flags
 )
 

--- a/mixer/adapter/denier/denier.go
+++ b/mixer/adapter/denier/denier.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
-
 	"istio.io/istio/mixer/adapter/denier/config"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/status"

--- a/mixer/adapter/opa/BUILD
+++ b/mixer/adapter/opa/BUILD
@@ -11,6 +11,8 @@ go_library(
         "//mixer/pkg/adapter:go_default_library",
         "//mixer/pkg/status:go_default_library",
         "//mixer/template/authorization:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_open_policy_agent_opa//ast:go_default_library",
         "@com_github_open_policy_agent_opa//rego:go_default_library",

--- a/pilot/adapter/config/crd/BUILD
+++ b/pilot/adapter/config/crd/BUILD
@@ -13,6 +13,9 @@ go_library(
     deps = [
         "//pilot/model:go_default_library",
         "//pilot/platform/kube:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",

--- a/pilot/adapter/config/crd/client.go
+++ b/pilot/adapter/config/crd/client.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -30,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	"istio.io/istio/pkg/log"
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic
@@ -166,7 +169,7 @@ func (cl *Client) RegisterResources() error {
 				},
 			},
 		}
-		glog.V(2).Infof("registering CRD %q", name)
+		log.Infof("registering CRD %q", name)
 		_, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
@@ -186,16 +189,16 @@ func (cl *Client) RegisterResources() error {
 				switch cond.Type {
 				case apiextensionsv1beta1.Established:
 					if cond.Status == apiextensionsv1beta1.ConditionTrue {
-						glog.V(2).Infof("established CRD %q", name)
+						log.Infof("established CRD %q", name)
 						continue descriptor
 					}
 				case apiextensionsv1beta1.NamesAccepted:
 					if cond.Status == apiextensionsv1beta1.ConditionFalse {
-						glog.Warningf("name conflict: %v", cond.Reason)
+						log.Warnf("name conflict: %v", cond.Reason)
 					}
 				}
 			}
-			glog.V(2).Infof("missing status condition for %q", name)
+			log.Infof("missing status condition for %q", name)
 			return false, nil
 		}
 		return true, nil
@@ -248,13 +251,13 @@ func (cl *Client) Get(typ, name, namespace string) (*model.Config, bool) {
 		Do().Into(config)
 
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 		return nil, false
 	}
 
 	out, err := ConvertObject(schema, config, cl.domainSuffix)
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 		return nil, false
 	}
 	return out, true

--- a/pilot/adapter/config/crd/conversion.go
+++ b/pilot/adapter/config/crd/conversion.go
@@ -21,11 +21,13 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // ConvertObject converts an IstioObject k8s-style object to the
@@ -155,7 +157,7 @@ func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
 
 		schema, exists := model.IstioConfigTypes.GetByType(CamelCaseToKabobCase(obj.Kind))
 		if !exists {
-			glog.V(7).Infof("unrecognized type %v", obj.Kind)
+			log.Debugf("unrecognized type %v", obj.Kind)
 			others = append(others, obj)
 			continue
 		}

--- a/pilot/adapter/config/file/BUILD
+++ b/pilot/adapter/config/file/BUILD
@@ -9,6 +9,9 @@ go_library(
     deps = [
         "//pilot/adapter/config/crd:go_default_library",
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/pilot/adapter/config/file/monitor.go
+++ b/pilot/adapter/config/file/monitor.go
@@ -23,10 +23,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/adapter/config/crd"
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -186,7 +188,7 @@ func (m *Monitor) checkAndUpdate() {
 
 func (m *Monitor) createConfig(c *model.Config) {
 	if _, err := m.store.Create(*c); err != nil {
-		glog.Warningf("Failed to create config (%m): %v ", *c, err)
+		log.Warnf("Failed to create config (%m): %v ", *c, err)
 	}
 }
 
@@ -197,13 +199,13 @@ func (m *Monitor) updateConfig(c *model.Config) {
 	}
 
 	if _, err := m.store.Update(*c); err != nil {
-		glog.Warningf("Failed to update config (%m): %v ", *c, err)
+		log.Warnf("Failed to update config (%m): %v ", *c, err)
 	}
 }
 
 func (m *Monitor) deleteConfig(c *model.Config) {
 	if err := m.store.Delete(c.Type, c.Name, c.Namespace); err != nil {
-		glog.Warningf("Failed to delete config (%m): %v ", *c, err)
+		log.Warnf("Failed to delete config (%m): %v ", *c, err)
 	}
 }
 
@@ -218,12 +220,12 @@ func (m *Monitor) readFiles() []*model.Config {
 		}
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
-			glog.Warningf("Failed to read %s: %v", path, err)
+			log.Warnf("Failed to read %s: %v", path, err)
 			return err
 		}
 		configs, err := parseInputs(data)
 		if err != nil {
-			glog.Warningf("Failed to parse %s: %v", path, err)
+			log.Warnf("Failed to parse %s: %v", path, err)
 			return err
 		}
 
@@ -237,7 +239,7 @@ func (m *Monitor) readFiles() []*model.Config {
 		return nil
 	})
 	if err != nil {
-		glog.Warningf("failure during filepath.Walk: %v", err)
+		log.Warnf("failure during filepath.Walk: %v", err)
 	}
 
 	// Sort by the config IDs.

--- a/pilot/adapter/config/ingress/BUILD
+++ b/pilot/adapter/config/ingress/BUILD
@@ -11,6 +11,9 @@ go_library(
     deps = [
         "//pilot/model:go_default_library",
         "//pilot/platform/kube:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
@@ -43,7 +46,7 @@ go_test(
         "//pilot/proxy:go_default_library",
         "//pilot/test/mock:go_default_library",
         "//pilot/test/util:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
+        "//pkg/log:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
         "@io_istio_api//routing/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pilot/adapter/config/ingress/controller.go
+++ b/pilot/adapter/config/ingress/controller.go
@@ -21,7 +21,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +33,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
 )
 
 type controller struct {
@@ -56,7 +58,7 @@ func NewController(client kubernetes.Interface, mesh *meshconfig.MeshConfig,
 	// queue requires a time duration for a retry delay after a handler error
 	queue := kube.NewQueue(1 * time.Second)
 
-	glog.V(2).Infof("Ingress controller watching namespaces %q", options.WatchedNamespace)
+	log.Infof("Ingress controller watching namespaces %q", options.WatchedNamespace)
 	// informer framework from Kubernetes
 	informer := cache.NewSharedIndexInformer(
 		&cache.ListWatch{
@@ -90,7 +92,7 @@ func NewController(client kubernetes.Interface, mesh *meshconfig.MeshConfig,
 			return errors.New("waiting till full synchronization")
 		}
 		if ingress, ok := obj.(*v1beta1.Ingress); ok {
-			glog.V(2).Infof("ingress event %s for %s/%s", event, ingress.Namespace, ingress.Name)
+			log.Infof("ingress event %s for %s/%s", event, ingress.Namespace, ingress.Name)
 		}
 		return nil
 	})

--- a/pilot/adapter/config/ingress/conversion.go
+++ b/pilot/adapter/config/ingress/conversion.go
@@ -19,7 +19,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -28,6 +29,7 @@ import (
 	routing "istio.io/api/routing/v1alpha1"
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
 )
 
 func convertIngress(ingress v1beta1.Ingress, domainSuffix string) []model.Config {
@@ -37,7 +39,7 @@ func convertIngress(ingress v1beta1.Ingress, domainSuffix string) []model.Config
 	if len(ingress.Spec.TLS) > 0 {
 		// TODO(istio/istio/issues/1424): implement SNI
 		if len(ingress.Spec.TLS) > 1 {
-			glog.Warningf("ingress %s requires several TLS secrets but Envoy can only serve one", ingress.Name)
+			log.Warnf("ingress %s requires several TLS secrets but Envoy can only serve one", ingress.Name)
 		}
 		secret := ingress.Spec.TLS[0]
 		tls = fmt.Sprintf("%s.%s", secret.SecretName, ingress.Namespace)
@@ -51,7 +53,7 @@ func convertIngress(ingress v1beta1.Ingress, domainSuffix string) []model.Config
 
 	for i, rule := range ingress.Spec.Rules {
 		if rule.HTTP == nil {
-			glog.Warningf("invalid ingress rule for host %q, no paths defined", rule.Host)
+			log.Warnf("invalid ingress rule for host %q, no paths defined", rule.Host)
 			continue
 		}
 		for j, path := range rule.HTTP.Paths {
@@ -170,7 +172,7 @@ func shouldProcessIngress(mesh *meshconfig.MeshConfig, ingress *v1beta1.Ingress)
 	case meshconfig.MeshConfig_DEFAULT:
 		return !exists || class == mesh.IngressClass
 	default:
-		glog.Warningf("invalid ingress synchronization mode: %v", mesh.IngressControllerMode)
+		log.Warnf("invalid ingress synchronization mode: %v", mesh.IngressControllerMode)
 		return false
 	}
 }

--- a/pilot/adapter/config/ingress/status.go
+++ b/pilot/adapter/config/ingress/status.go
@@ -19,7 +19,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	betaext "k8s.io/api/extensions/v1beta1"
@@ -33,6 +34,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
 )
 
 const ingressElectionID = "istio-ingress-controller-leader"
@@ -81,7 +83,7 @@ func NewStatusSyncer(mesh *meshconfig.MeshConfig,
 	if mesh.IngressService != "" {
 		publishService = fmt.Sprintf("%v/%v", ingressNamespace, mesh.IngressService)
 	}
-	glog.V(2).Infof("ingress status syncer publishService %s", publishService)
+	log.Infof("ingress status syncer publishService %s", publishService)
 	ingressClass, defaultIngressClass := convertIngressControllerMode(mesh.IngressControllerMode, mesh.IngressClass)
 
 	customIngressStatus := func(*betaext.Ingress) []v1.LoadBalancerIngress {

--- a/pilot/adapter/config/ingress/status_test.go
+++ b/pilot/adapter/config/ingress/status_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +30,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/platform/kube"
 	"istio.io/istio/pilot/proxy"
+	"istio.io/istio/pkg/log"
 )
 
 func makeAnnotatedIngress(annotation string) *extensions.Ingress {
@@ -164,7 +166,7 @@ func TestSyncer(t *testing.T) {
 			continue
 		}
 		ips := out.Status.LoadBalancer.Ingress
-		glog.V(2).Info(ips)
+		log.Infoa(ips)
 		if len(ips) > 0 && ips[0].IP == ip {
 			close(stop)
 			break

--- a/pilot/adapter/config/memory/BUILD
+++ b/pilot/adapter/config/memory/BUILD
@@ -10,6 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/pilot/adapter/config/memory/monitor.go
+++ b/pilot/adapter/config/memory/monitor.go
@@ -15,9 +15,11 @@
 package memory
 
 import (
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -89,7 +91,7 @@ func (m *configstoreMonitor) Run(stop <-chan struct{}) {
 
 func (m *configstoreMonitor) processConfigEvent(ce ConfigEvent) {
 	if _, exists := m.handlers[ce.config.Type]; !exists {
-		glog.Warningf("Config Type %s does not exist in config store", ce.config.Type)
+		log.Warnf("Config Type %s does not exist in config store", ce.config.Type)
 		return
 	}
 	m.applyHandlers(ce.config, ce.event)

--- a/pilot/adapter/serviceregistry/aggregate/BUILD
+++ b/pilot/adapter/serviceregistry/aggregate/BUILD
@@ -7,6 +7,9 @@ go_library(
     deps = [
         "//pilot/model:go_default_library",
         "//pilot/platform:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],

--- a/pilot/adapter/serviceregistry/aggregate/controller.go
+++ b/pilot/adapter/serviceregistry/aggregate/controller.go
@@ -15,11 +15,13 @@
 package aggregate
 
 import (
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/platform"
+	"istio.io/istio/pkg/log"
 )
 
 // Registry specifies the collection of service registry related interfaces
@@ -71,7 +73,7 @@ func (c *Controller) GetService(hostname string) (*model.Service, error) {
 			errs = multierror.Append(errs, err)
 		} else if service != nil {
 			if errs != nil {
-				glog.Warningf("GetService() found match but encountered an error: %v", errs)
+				log.Warnf("GetService() found match but encountered an error: %v", errs)
 			}
 			return service, nil
 		}
@@ -104,7 +106,7 @@ func (c *Controller) Instances(hostname string, ports []string,
 			errs = multierror.Append(errs, err)
 		} else if len(instances) > 0 {
 			if errs != nil {
-				glog.Warningf("Instances() found match but encountered an error: %v", errs)
+				log.Warnf("Instances() found match but encountered an error: %v", errs)
 			}
 			return instances, nil
 		}
@@ -127,7 +129,7 @@ func (c *Controller) HostInstances(addrs map[string]bool) ([]*model.ServiceInsta
 
 	if len(out) > 0 {
 		if errs != nil {
-			glog.Warningf("HostInstances() found match but encountered an error: %v", errs)
+			log.Warnf("HostInstances() found match but encountered an error: %v", errs)
 		}
 		return out, nil
 	}
@@ -143,14 +145,14 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	}
 
 	<-stop
-	glog.V(2).Info("Registry Aggregator terminated")
+	log.Info("Registry Aggregator terminated")
 }
 
 // AppendServiceHandler implements a service catalog operation
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
 	for _, r := range c.registries {
 		if err := r.AppendServiceHandler(f); err != nil {
-			glog.V(2).Infof("Fail to append service handler to adapter %s", r.Name)
+			log.Infof("Fail to append service handler to adapter %s", r.Name)
 			return err
 		}
 	}
@@ -161,7 +163,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
 	for _, r := range c.registries {
 		if err := r.AppendInstanceHandler(f); err != nil {
-			glog.V(2).Infof("Fail to append instance handler to adapter %s", r.Name)
+			log.Infof("Fail to append instance handler to adapter %s", r.Name)
 			return err
 		}
 	}

--- a/pilot/cmd/BUILD
+++ b/pilot/cmd/BUILD
@@ -7,6 +7,9 @@ go_library(
     deps = [
         "//pilot/proxy:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/pilot/cmd/istioctl/BUILD
+++ b/pilot/cmd/istioctl/BUILD
@@ -17,7 +17,10 @@ go_library(
         "//pilot/platform/kube:go_default_library",
         "//pilot/platform/kube/inject:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/pilot/cmd/istioctl/inject.go
+++ b/pilot/cmd/istioctl/inject.go
@@ -20,13 +20,15 @@ import (
 	"io"
 	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 
 	"istio.io/istio/pilot/platform/kube"
 	"istio.io/istio/pilot/platform/kube/inject"
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -95,7 +97,7 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 				}
 				defer func() {
 					if err = in.Close(); err != nil {
-						glog.Errorf("Error: close file from %s, %s", inFilename, err)
+						log.Errorf("Error: close file from %s, %s", inFilename, err)
 					}
 				}()
 				reader = in

--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -25,7 +25,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
@@ -41,6 +42,7 @@ import (
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/platform/kube"
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -62,6 +64,8 @@ var (
 
 	// output format (yaml or short)
 	outputFormat string
+
+	loggingOptions = log.NewOptions()
 
 	rootCmd = &cobra.Command{
 		Use:               "istioctl",
@@ -94,6 +98,9 @@ and destination policies.
 			istioctl create -f example-routing.yaml
 			`,
 		RunE: func(c *cobra.Command, args []string) error {
+			if err := log.Configure(loggingOptions); err != nil {
+				return err
+			}
 			if len(args) != 0 {
 				c.Println(c.UsageString())
 				return fmt.Errorf("create takes no arguments")
@@ -514,6 +521,9 @@ func init() {
 	getCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "short",
 		"Output format. One of:yaml|short")
 
+	// Attach the Istio logging options to the command.
+	loggingOptions.AttachCobraFlags(rootCmd)
+
 	cmd.AddFlags(rootCmd)
 
 	rootCmd.AddCommand(postCmd)
@@ -525,8 +535,11 @@ func init() {
 }
 
 func main() {
+	// Needed to avoid "logging before flag.Parse" error with glog.
+	cmd.SupressGlogWarnings()
+
 	if platform != kubePlatform {
-		glog.Warningf("Platform '%s' not supported.", platform)
+		log.Warnf("Platform '%s' not supported.", platform)
 	}
 
 	if err := rootCmd.Execute(); err != nil {
@@ -565,7 +578,7 @@ func readInputs() ([]model.Config, []crd.IstioKind, error) {
 		}
 		defer func() {
 			if err = in.Close(); err != nil {
-				glog.Errorf("Error: close file from %s, %s", file, err)
+				log.Errorf("Error: close file from %s, %s", file, err)
 			}
 		}()
 		reader = in
@@ -599,17 +612,17 @@ func printYamlOutput(configClient *crd.Client, configList []model.Config) {
 	for _, config := range configList {
 		schema, exists := descriptor.GetByType(config.Type)
 		if !exists {
-			glog.Errorf("Unknown kind %q for %v", crd.ResourceName(config.Type), config.Name)
+			log.Errorf("Unknown kind %q for %v", crd.ResourceName(config.Type), config.Name)
 			continue
 		}
 		obj, err := crd.ConvertConfig(schema, config)
 		if err != nil {
-			glog.Errorf("Could not decode %v: %v", config.Name, err)
+			log.Errorf("Could not decode %v: %v", config.Name, err)
 			continue
 		}
 		bytes, err := yaml.Marshal(obj)
 		if err != nil {
-			glog.Errorf("Could not convert %v to YAML: %v", config, err)
+			log.Errorf("Could not convert %v to YAML: %v", config, err)
 			continue
 		}
 		fmt.Print(string(bytes))

--- a/pilot/cmd/istioctl/register.go
+++ b/pilot/cmd/istioctl/register.go
@@ -17,10 +17,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/spf13/cobra"
 
 	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -40,12 +42,12 @@ var (
 				}
 				portsList[i] = p
 			}
-			glog.Infof("Registering for service '%s' ip '%s', ports list %v",
+			log.Infof("Registering for service '%s' ip '%s', ports list %v",
 				svcName, ip, portsList)
 			if svcAcctAnn != "" {
 				annotations = append(annotations, fmt.Sprintf("%s=%s", kube.KubeServiceAccountsOnVMAnnotation, svcAcctAnn))
 			}
-			glog.Infof("%d labels (%v) and %d annotations (%v)",
+			log.Infof("%d labels (%v) and %d annotations (%v)",
 				len(labels), labels, len(annotations), annotations)
 			_, client, err := kube.CreateInterface(kubeconfig)
 			if err != nil {

--- a/pilot/cmd/pilot-agent/BUILD
+++ b/pilot/cmd/pilot-agent/BUILD
@@ -11,6 +11,9 @@ go_library(
         "//pilot/proxy:go_default_library",
         "//pilot/proxy/envoy:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",

--- a/pilot/cmd/pilot-discovery/BUILD
+++ b/pilot/cmd/pilot-discovery/BUILD
@@ -8,6 +8,9 @@ go_library(
     deps = [
         "//pilot/cmd:go_default_library",
         "//pilot/cmd/pilot-discovery/server:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pilot/cmd/pilot-discovery/server/BUILD
+++ b/pilot/cmd/pilot-discovery/server/BUILD
@@ -26,7 +26,10 @@ go_library(
         "//pilot/proxy/envoy:go_default_library",
         "//pilot/test/mock:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
@@ -46,6 +49,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//pilot/proxy/envoy:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )

--- a/pilot/cmd/pilot-discovery/server/monitoring.go
+++ b/pilot/cmd/pilot-discovery/server/monitoring.go
@@ -19,10 +19,12 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
 type monitor struct {
@@ -55,7 +57,7 @@ func startMonitor(port int) (*monitor, error) {
 	mux.Handle(metricsPath, promhttp.Handler())
 	mux.HandleFunc(versionPath, func(out http.ResponseWriter, req *http.Request) {
 		if _, err := out.Write([]byte(version.Line())); err != nil {
-			glog.Errorf("Unable to write version string: %v", err)
+			log.Errorf("Unable to write version string: %v", err)
 		}
 	})
 

--- a/pilot/cmd/sidecar-initializer/BUILD
+++ b/pilot/cmd/sidecar-initializer/BUILD
@@ -9,6 +9,9 @@ go_library(
         "//pilot/platform/kube:go_default_library",
         "//pilot/platform/kube/inject:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/pilot/cmd/sidecar-initializer/main.go
+++ b/pilot/cmd/sidecar-initializer/main.go
@@ -17,7 +17,8 @@ package main
 import (
 	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
@@ -26,26 +27,33 @@ import (
 	"istio.io/istio/pilot/platform/kube"
 	"istio.io/istio/pilot/platform/kube/inject"
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
-func getRootCmd() *cobra.Command {
-	flags := struct {
-		kubeconfig   string
-		meshconfig   string
-		injectConfig string
-		namespace    string
-	}{}
+var (
+	flags = struct {
+		kubeconfig     string
+		meshconfig     string
+		injectConfig   string
+		namespace      string
+		loggingOptions *log.Options
+	}{
+		loggingOptions: log.NewOptions(),
+	}
 
-	rootCmd := &cobra.Command{
+	rootCmd = &cobra.Command{
 		Use:   "sidecar-initializer",
 		Short: "Kubernetes initializer for Istio sidecar",
 		RunE: func(*cobra.Command, []string) error {
+			if err := log.Configure(flags.loggingOptions); err != nil {
+				return err
+			}
 			restConfig, client, err := kube.CreateInterface(flags.kubeconfig)
 			if err != nil {
 				return multierror.Prefix(err, "failed to connect to Kubernetes API.")
 			}
 
-			glog.V(2).Infof("version %s", version.Line())
+			log.Infof("version %s", version.Line())
 
 			config, err := inject.GetInitializerConfig(client, flags.namespace, flags.injectConfig)
 			if err != nil {
@@ -70,7 +78,9 @@ func getRootCmd() *cobra.Command {
 			return nil
 		},
 	}
+)
 
+func init() {
 	rootCmd.PersistentFlags().StringVar(&flags.kubeconfig, "kubeconfig", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
 	rootCmd.PersistentFlags().StringVar(&flags.meshconfig, "meshconfig", "/etc/istio/config/mesh",
@@ -80,13 +90,17 @@ func getRootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&flags.namespace, "namespace", v1.NamespaceDefault, // TODO istio-system?
 		"Namespace of initializer configuration ConfigMap")
 
-	cmd.AddFlags(rootCmd)
+	// Attach the Istio logging options to the command.
+	flags.loggingOptions.AttachCobraFlags(rootCmd)
 
-	return rootCmd
+	cmd.AddFlags(rootCmd)
 }
 
 func main() {
-	if err := getRootCmd().Execute(); err != nil {
+	// Needed to avoid "logging before flag.Parse" error with glog.
+	cmd.SupressGlogWarnings()
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}
 }

--- a/pilot/doc/testing.md
+++ b/pilot/doc/testing.md
@@ -115,5 +115,4 @@ The integration tests use a test mixer server that implements Mixer protocol but
 
 ## Test logging
 
-Istio Pilot uses [glog](https://godoc.org/github.com/golang/glog) library for all its logging. We encourage extensive logging at the appropriate log levels. As a hint to the log level selection, level 10 is the most verbose (Kubernetes will show all its HTTP requests), level 2 is used by default in the integration tests, level 4 turns on extensive logging in the proxy.
-
+Istio Pilot uses the [Istio logging package](https://godoc.org/istio.io/istio/pkg/log) for all its logging. We encourage extensive logging at the appropriate log levels. Refer to [Istio Developer Conventions](../../DEV-CONVENTIONS.md#logging-conventions) for details on logging.

--- a/pilot/platform/cloudfoundry/BUILD
+++ b/pilot/platform/cloudfoundry/BUILD
@@ -11,6 +11,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@in_gopkg_validator_v2//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",

--- a/pilot/platform/cloudfoundry/controller.go
+++ b/pilot/platform/cloudfoundry/controller.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	copilotapi "code.cloudfoundry.org/copilot/api"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"golang.org/x/net/context"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 type serviceHandler func(*model.Service, model.Event)
@@ -75,7 +77,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 		case <-c.Ticker.Chan():
 			backendSets, err := c.Client.Routes(context.Background(), &copilotapi.RoutesRequest{})
 			if err != nil {
-				glog.Warningf("periodic copilot routes poll failed: %s", err)
+				log.Warnf("periodic copilot routes poll failed: %s", err)
 				continue
 			}
 

--- a/pilot/platform/consul/BUILD
+++ b/pilot/platform/consul/BUILD
@@ -10,6 +10,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_consul//api:go_default_library",
     ],

--- a/pilot/platform/consul/controller.go
+++ b/pilot/platform/consul/controller.go
@@ -17,10 +17,12 @@ package consul
 import (
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/hashicorp/consul/api"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // Controller communicates with Consul and monitors for changes
@@ -67,7 +69,7 @@ func (c *Controller) GetService(hostname string) (*model.Service, error) {
 	// Get actual service by name
 	name, err := parseHostname(hostname)
 	if err != nil {
-		glog.V(2).Infof("parseHostname(%s) => error %v", hostname, err)
+		log.Infof("parseHostname(%s) => error %v", hostname, err)
 		return nil, err
 	}
 
@@ -82,7 +84,7 @@ func (c *Controller) GetService(hostname string) (*model.Service, error) {
 func (c *Controller) getServices() (map[string][]string, error) {
 	data, _, err := c.client.Catalog().Services(nil)
 	if err != nil {
-		glog.Warningf("Could not retrieve services from consul: %v", err)
+		log.Warnf("Could not retrieve services from consul: %v", err)
 		return nil, err
 	}
 
@@ -92,7 +94,7 @@ func (c *Controller) getServices() (map[string][]string, error) {
 func (c *Controller) getCatalogService(name string, q *api.QueryOptions) ([]*api.CatalogService, error) {
 	endpoints, _, err := c.client.Catalog().Service(name, "", q)
 	if err != nil {
-		glog.Warningf("Could not retrieve service catalogue from consul: %v", err)
+		log.Warnf("Could not retrieve service catalogue from consul: %v", err)
 		return nil, err
 	}
 
@@ -114,7 +116,7 @@ func (c *Controller) Instances(hostname string, ports []string,
 	// Get actual service by name
 	name, err := parseHostname(hostname)
 	if err != nil {
-		glog.V(2).Infof("parseHostname(%s) => error %v", hostname, err)
+		log.Infof("parseHostname(%s) => error %v", hostname, err)
 		return nil, err
 	}
 

--- a/pilot/platform/consul/conversion.go
+++ b/pilot/platform/consul/conversion.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/hashicorp/consul/api"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -37,7 +39,7 @@ func convertLabels(labels []string) model.Labels {
 		if len(vals) > 1 {
 			out[vals[0]] = vals[1]
 		} else {
-			glog.Warningf("Tag %v ignored since it is not of form key|value", tag)
+			log.Warnf("Tag %v ignored since it is not of form key|value", tag)
 		}
 	}
 	return out
@@ -65,7 +67,7 @@ func convertService(endpoints []*api.CatalogService) *model.Service {
 		port := convertPort(endpoint.ServicePort, endpoint.NodeMeta[protocolTagName])
 
 		if svcPort, exists := ports[port.Port]; exists && svcPort.Protocol != port.Protocol {
-			glog.Warningf("Service %v has two instances on same port %v but different protocols (%v, %v)",
+			log.Warnf("Service %v has two instances on same port %v but different protocols (%v, %v)",
 				name, port.Port, svcPort.Protocol, port.Protocol)
 		} else {
 			ports[port.Port] = port
@@ -141,7 +143,7 @@ func parseHostname(hostname string) (name string, err error) {
 func convertProtocol(name string) model.Protocol {
 	protocol := model.ConvertCaseInsensitiveStringToProtocol(name)
 	if protocol == model.ProtocolUnsupported {
-		glog.Warningf("unsupported protocol value: %s", name)
+		log.Warnf("unsupported protocol value: %s", name)
 		return model.ProtocolTCP
 	}
 	return protocol

--- a/pilot/platform/consul/monitor.go
+++ b/pilot/platform/consul/monitor.go
@@ -19,10 +19,12 @@ import (
 	"sort"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/hashicorp/consul/api"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 type consulServices map[string][]string
@@ -83,7 +85,7 @@ func (m *consulMonitor) run(stop <-chan struct{}) {
 func (m *consulMonitor) updateServiceRecord() {
 	svcs, _, err := m.discovery.Catalog().Services(nil)
 	if err != nil {
-		glog.Warningf("Could not fetch services: %v", err)
+		log.Warnf("Could not fetch services: %v", err)
 		return
 	}
 	newRecord := consulServices(svcs)
@@ -98,7 +100,7 @@ func (m *consulMonitor) updateServiceRecord() {
 		for _, f := range m.serviceHandlers {
 			go func(handler ServiceHandler) {
 				if err := handler(obj, event); err != nil {
-					glog.Warningf("Error executing service handler function: %v", err)
+					log.Warnf("Error executing service handler function: %v", err)
 				}
 			}(f)
 		}
@@ -109,7 +111,7 @@ func (m *consulMonitor) updateServiceRecord() {
 func (m *consulMonitor) updateInstanceRecord() {
 	svcs, _, err := m.discovery.Catalog().Services(nil)
 	if err != nil {
-		glog.Warningf("Could not fetch instances: %v", err)
+		log.Warnf("Could not fetch instances: %v", err)
 		return
 	}
 	for _, tags := range svcs {
@@ -120,7 +122,7 @@ func (m *consulMonitor) updateInstanceRecord() {
 	for name := range svcs {
 		endpoints, _, err := m.discovery.Catalog().Service(name, "", nil)
 		if err != nil {
-			glog.Warningf("Could not retrieve service catalogue from consul: %v", err)
+			log.Warnf("Could not retrieve service catalogue from consul: %v", err)
 			continue
 		}
 		instances = append(instances, endpoints...)
@@ -139,7 +141,7 @@ func (m *consulMonitor) updateInstanceRecord() {
 		for _, f := range m.instanceHandlers {
 			go func(handler InstanceHandler) {
 				if err := handler(obj, event); err != nil {
-					glog.Warningf("Error executing instance handler function: %v", err)
+					log.Warnf("Error executing instance handler function: %v", err)
 				}
 			}(f)
 		}

--- a/pilot/platform/eureka/BUILD
+++ b/pilot/platform/eureka/BUILD
@@ -12,6 +12,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/pilot/platform/eureka/controller.go
+++ b/pilot/platform/eureka/controller.go
@@ -18,9 +18,11 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 type serviceHandler func(*model.Service, model.Event)
@@ -61,7 +63,7 @@ func (c *controller) Run(stop <-chan struct{}) {
 		case <-ticker.C:
 			apps, err := c.client.Applications()
 			if err != nil {
-				glog.Warningf("periodic Eureka poll failed: %v", err)
+				log.Warnf("periodic Eureka poll failed: %v", err)
 				continue
 			}
 			sortApplications(apps)

--- a/pilot/platform/eureka/conversion.go
+++ b/pilot/platform/eureka/conversion.go
@@ -17,9 +17,11 @@ package eureka
 import (
 	"fmt"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // Convert Eureka applications to services. If provided, only convert applications in the hostnames whitelist,
@@ -56,7 +58,7 @@ func convertServices(apps []*application, hostnames map[string]bool) map[string]
 			for _, port := range ports {
 				if servicePort, exists := service.Ports.GetByPort(port.Port); exists {
 					if servicePort.Protocol != protocol {
-						glog.Warningf(
+						log.Warnf(
 							"invalid Eureka config: "+
 								"%s:%d has conflicting protocol definitions %s, %s",
 							instance.Hostname, servicePort.Port,
@@ -127,7 +129,7 @@ func convertProtocol(md metadata) model.Protocol {
 	if md != nil {
 		protocol := model.ConvertCaseInsensitiveStringToProtocol(name)
 		if protocol == model.ProtocolUnsupported {
-			glog.Warningf("unsupported protocol value: %s", name)
+			log.Warnf("unsupported protocol value: %s", name)
 		} else {
 			return protocol
 		}

--- a/pilot/platform/eureka/servicediscovery.go
+++ b/pilot/platform/eureka/servicediscovery.go
@@ -15,9 +15,11 @@
 package eureka
 
 import (
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // NewServiceDiscovery instantiates an implementation of service discovery for Eureka
@@ -35,7 +37,7 @@ type serviceDiscovery struct {
 func (sd *serviceDiscovery) Services() ([]*model.Service, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
-		glog.Warningf("could not list Eureka instances: %v", err)
+		log.Warnf("could not list Eureka instances: %v", err)
 		return nil, err
 	}
 	services := convertServices(apps, nil)
@@ -51,7 +53,7 @@ func (sd *serviceDiscovery) Services() ([]*model.Service, error) {
 func (sd *serviceDiscovery) GetService(hostname string) (*model.Service, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
-		glog.Warningf("could not list Eureka instances: %v", err)
+		log.Warnf("could not list Eureka instances: %v", err)
 		return nil, err
 	}
 
@@ -66,7 +68,7 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 
 	apps, err := sd.client.Applications()
 	if err != nil {
-		glog.Warningf("could not list Eureka instances: %v", err)
+		log.Warnf("could not list Eureka instances: %v", err)
 		return nil, err
 	}
 	portSet := make(map[string]bool)
@@ -94,7 +96,7 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 func (sd *serviceDiscovery) HostInstances(addrs map[string]bool) ([]*model.ServiceInstance, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
-		glog.Warningf("could not list Eureka instances: %v", err)
+		log.Warnf("could not list Eureka instances: %v", err)
 		return nil, err
 	}
 	services := convertServices(apps, nil)

--- a/pilot/platform/kube/BUILD
+++ b/pilot/platform/kube/BUILD
@@ -13,6 +13,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
@@ -53,7 +56,7 @@ go_test(
         "//pilot/model:go_default_library",
         "//pilot/test/util:go_default_library",
         "//tests/k8s:go_default_library",
-        "@com_github_golang_glog//:go_default_library",
+        "//pkg/log:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pilot/platform/kube/admit/BUILD
+++ b/pilot/platform/kube/admit/BUILD
@@ -7,7 +7,10 @@ go_library(
     deps = [
         "//pilot/adapter/config/crd:go_default_library",
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//admission/v1alpha1:go_default_library",
         "@io_k8s_api//admissionregistration/v1alpha1:go_default_library",

--- a/pilot/platform/kube/client.go
+++ b/pilot/platform/kube/client.go
@@ -19,11 +19,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"istio.io/istio/pkg/log"
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic
@@ -45,7 +48,7 @@ func ResolveConfig(kubeconfig string) (string, error) {
 
 		// if it's an empty file, switch to in-cluster config
 		if info.Size() == 0 {
-			glog.Info("using in-cluster configuration")
+			log.Info("using in-cluster configuration")
 			return "", nil
 		}
 	}

--- a/pilot/platform/kube/controller_test.go
+++ b/pilot/platform/kube/controller_test.go
@@ -21,7 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -29,6 +30,7 @@ import (
 
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/k8s"
 )
 
@@ -48,7 +50,7 @@ func eventually(f func() bool, t *testing.T) {
 		if f() {
 			return
 		}
-		glog.Infof("Sleeping %v", interval)
+		log.Infof("Sleeping %v", interval)
 		time.Sleep(interval)
 		interval = 2 * interval
 	}
@@ -88,7 +90,7 @@ func TestServices(t *testing.T) {
 		if clientErr != nil {
 			return false
 		}
-		glog.Info("Services: %#v", out)
+		log.Infof("Services: %#v", out)
 
 		for _, item := range out {
 			if item.Hostname == hostname &&
@@ -136,7 +138,7 @@ func makeService(n, ns string, cl kubernetes.Interface, t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	glog.Infof("Created service %s", n)
+	log.Infof("Created service %s", n)
 }
 
 func TestController_getPodAZ(t *testing.T) {

--- a/pilot/platform/kube/inject/BUILD
+++ b/pilot/platform/kube/inject/BUILD
@@ -12,8 +12,11 @@ go_library(
         "//pilot/platform/kube:go_default_library",
         "//pilot/proxy:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",

--- a/pilot/platform/kube/inject/initializer.go
+++ b/pilot/platform/kube/inject/initializer.go
@@ -18,11 +18,12 @@ import (
 	"encoding/json"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
-	v2alpha1 "k8s.io/api/batch/v2alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/batch/v2alpha1"
+	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
 )
 
 var ignoredNamespaces = []string{
@@ -150,7 +152,7 @@ func NewInitializer(restConfig *rest.Config, config *Config, cl kubernetes.Inter
 			cache.ResourceEventHandlerFuncs{
 				AddFunc: func(obj interface{}) {
 					if err := i.initialize(obj, patcher); err != nil {
-						glog.Error(err.Error())
+						log.Error(err.Error())
 					}
 				},
 			},
@@ -171,7 +173,7 @@ func (i *Initializer) initialize(in interface{}, patcher patcherFunc) error {
 		return err
 	}
 
-	glog.V(2).Infof("ObjectMeta initializer info %v %v/%v policy:%q status:%q %v",
+	log.Infof("ObjectMeta initializer info %v %v/%v policy:%q status:%q %v",
 		gvk, obj.GetNamespace(), obj.GetName(),
 		obj.GetAnnotations()[istioSidecarAnnotationPolicyKey],
 		obj.GetAnnotations()[istioSidecarAnnotationStatusKey],
@@ -226,16 +228,16 @@ func (i *Initializer) initialize(in interface{}, patcher patcherFunc) error {
 
 // Run runs the Initializer controller.
 func (i *Initializer) Run(stopCh <-chan struct{}) {
-	glog.Info("Starting Istio sidecar initializer...")
-	glog.Infof("Initializer name set to: %s", i.config.InitializerName)
-	glog.Infof("Options: %v", spew.Sdump(i.config))
+	log.Info("Starting Istio sidecar initializer...")
+	log.Infof("Initializer name set to: %s", i.config.InitializerName)
+	log.Infof("Options: %v", spew.Sdump(i.config))
 
-	glog.Infof("Supported kinds:")
+	log.Infof("Supported kinds:")
 	for _, kind := range kinds {
 		if gvk, _, err := injectScheme.ObjectKind(kind.obj); err != nil {
-			glog.Warningf("Could not determine object kind: ", err)
+			log.Warnf("Could not determine object kind: ", err)
 		} else {
-			glog.Infof("\t%v/%v %v", gvk.Group, gvk.Version, gvk.Kind)
+			log.Infof("\t%v/%v %v", gvk.Group, gvk.Version, gvk.Kind)
 		}
 	}
 

--- a/pilot/platform/kube/inject/inject.go
+++ b/pilot/platform/kube/inject/inject.go
@@ -29,11 +29,12 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
-	v2alpha1 "k8s.io/api/batch/v2alpha1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/batch/v2alpha1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,6 +45,7 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/proxy"
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
 // per-sidecar policy and status (deployment, job, statefulset, pod, etc)
@@ -299,7 +301,7 @@ IncludeNamespaceSearch:
 
 	status, ok := annotations[istioSidecarAnnotationStatusKey]
 
-	glog.V(2).Infof("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v status:%q required:%v",
+	log.Infof("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v status:%q required:%v",
 		obj.GetNamespace(), obj.GetName(), namespacePolicy, useDefault, inject, status, required)
 
 	if !required {
@@ -314,7 +316,7 @@ IncludeNamespaceSearch:
 func timeString(dur *duration.Duration) string {
 	out, err := ptypes.Duration(dur)
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 	return out.String()
 }
@@ -499,7 +501,7 @@ func intoObject(c *Config, in interface{}) (interface{}, error) {
 	}
 
 	if !injectRequired(c.IncludeNamespaces, ignoredNamespaces, c.ExcludeNamespaces, c.Policy, obj) {
-		glog.V(2).Infof("Skipping %s/%s due to policy check", obj.GetNamespace(), obj.GetName())
+		log.Infof("Skipping %s/%s due to policy check", obj.GetNamespace(), obj.GetName())
 		return out, nil
 	}
 

--- a/pilot/platform/kube/queue.go
+++ b/pilot/platform/kube/queue.go
@@ -18,10 +18,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"k8s.io/client-go/util/flowcontrol"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // Queue of work tickets processed using a rate-limiting loop
@@ -99,7 +101,7 @@ func (q *queueImpl) Run(stop <-chan struct{}) {
 			for {
 				err := item.handler(item.obj, item.event)
 				if err != nil {
-					glog.V(2).Infof("Work item failed (%v), repeating after delay %v", err, q.delay)
+					log.Infof("Work item failed (%v), repeating after delay %v", err, q.delay)
 					time.Sleep(q.delay)
 				} else {
 					break

--- a/pilot/proxy/BUILD
+++ b/pilot/proxy/BUILD
@@ -11,6 +11,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
+        "//pkg/log:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",

--- a/pilot/proxy/context.go
+++ b/pilot/proxy/context.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	multierror "github.com/hashicorp/go-multierror"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 // Environment provides an aggregate environmental API for Pilot
@@ -200,7 +202,7 @@ func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 func ParsePort(addr string) int {
 	port, err := strconv.Atoi(addr[strings.Index(addr, ":")+1:])
 	if err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 
 	return port

--- a/pilot/proxy/envoy/BUILD
+++ b/pilot/proxy/envoy/BUILD
@@ -20,7 +20,10 @@ go_library(
         "//pilot/model:go_default_library",
         "//pilot/proxy:go_default_library",
         "//pilot/tools/version:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_emicklei_go_restful//:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_golang_protobuf//ptypes/duration:go_default_library",

--- a/pilot/proxy/envoy/discovery.go
+++ b/pilot/proxy/envoy/discovery.go
@@ -26,13 +26,15 @@ import (
 	"sync/atomic"
 
 	"github.com/emicklei/go-restful"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/proxy"
 	"istio.io/istio/pilot/tools/version"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -187,7 +189,7 @@ func (c *discoveryCache) updateCachedDiscoveryResponse(key string, resourceCount
 		cacheSizeDelta = float64(len(key) + len(data))
 	} else if entry.data != nil {
 		cacheSizeDelta = float64(len(data) - len(entry.data))
-		glog.Warningf("Overriding cached data for entry %v", key)
+		log.Warnf("Overriding cached data for entry %v", key)
 	}
 	entry.resourceCount = resourceCount
 	entry.data = data
@@ -407,7 +409,7 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 // connections. Content serving is started by this method, but is executed asynchronously. Serving can be cancelled
 // at any time by closing the provided stop channel.
 func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
-	glog.Infof("Starting discovery service at %v", ds.server.Addr)
+	log.Infof("Starting discovery service at %v", ds.server.Addr)
 
 	addr := ds.server.Addr
 	if addr == "" {
@@ -421,7 +423,7 @@ func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
 	go func() {
 		go func() {
 			if err := ds.server.Serve(listener); err != nil {
-				glog.Warning(err)
+				log.Warna(err)
 			}
 		}()
 
@@ -429,7 +431,7 @@ func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
 		<-stop
 		err := ds.server.Close()
 		if err != nil {
-			glog.Warning(err)
+			log.Warna(err)
 		}
 	}()
 
@@ -452,7 +454,7 @@ func (ds *DiscoveryService) GetCacheStats(_ *restful.Request, response *restful.
 		stats[k] = v
 	}
 	if err := response.WriteEntity(discoveryCacheStats{stats}); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }
 
@@ -465,7 +467,7 @@ func (ds *DiscoveryService) ClearCacheStats(_ *restful.Request, _ *restful.Respo
 }
 
 func (ds *DiscoveryService) clearCache() {
-	glog.Infof("Cleared discovery service cache")
+	log.Infof("Cleared discovery service cache")
 	ds.sdsCache.clear()
 	ds.cdsCache.clear()
 	ds.rdsCache.clear()
@@ -524,7 +526,7 @@ func (ds *DiscoveryService) ListAllEndpoints(_ *restful.Request, response *restf
 
 	if err := response.WriteEntity(services); err != nil {
 		incErrors(methodName)
-		glog.Warning(err)
+		log.Warna(err)
 	} else {
 		observeResources(methodName, uint32(len(services)))
 	}
@@ -721,15 +723,15 @@ func observeResources(methodName string, count uint32) {
 
 func errorResponse(methodName string, r *restful.Response, status int, msg string) {
 	incErrors(methodName)
-	glog.Warning(msg)
+	log.Warn(msg)
 	if err := r.WriteErrorString(status, msg); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }
 
 func writeResponse(r *restful.Response, data []byte) {
 	r.WriteHeader(http.StatusOK)
 	if _, err := r.Write(data); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }

--- a/pilot/proxy/envoy/ingress.go
+++ b/pilot/proxy/envoy/ingress.go
@@ -21,12 +21,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	routing "istio.io/api/routing/v1alpha1"
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/proxy"
+	"istio.io/istio/pkg/log"
 )
 
 func buildIngressListeners(mesh *meshconfig.MeshConfig,
@@ -67,7 +69,7 @@ func buildIngressRoutes(mesh *meshconfig.MeshConfig,
 	for _, rule := range rules {
 		routes, tls, err := buildIngressRoute(mesh, instances, rule, discovery, config)
 		if err != nil {
-			glog.Warningf("Error constructing Envoy route from ingress rule: %v", err)
+			log.Warnf("Error constructing Envoy route from ingress rule: %v", err)
 			continue
 		}
 
@@ -79,7 +81,7 @@ func buildIngressRoutes(mesh *meshconfig.MeshConfig,
 				case *routing.StringMatch_Exact:
 					host = match.Exact
 				default:
-					glog.Warningf("Unsupported match type for authority condition %T, falling back to %q", match, host)
+					log.Warnf("Unsupported match type for authority condition %T, falling back to %q", match, host)
 					continue
 				}
 			}
@@ -89,7 +91,7 @@ func buildIngressRoutes(mesh *meshconfig.MeshConfig,
 			if tlsAll == "" {
 				tlsAll = tls
 			} else if tlsAll != tls {
-				glog.Warningf("Multiple secrets detected %s and %s", tls, tlsAll)
+				log.Warnf("Multiple secrets detected %s and %s", tls, tlsAll)
 				if tls < tlsAll {
 					tlsAll = tls
 				}

--- a/pilot/proxy/envoy/mixer.go
+++ b/pilot/proxy/envoy/mixer.go
@@ -22,13 +22,15 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
 	mccpb "istio.io/api/mixer/v1/config/client"
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/proxy"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -223,7 +225,7 @@ func mixerHTTPRouteConfig(role proxy.Node, instances []*model.ServiceInstance, c
 			// scheme, i.e. buildJWKSURIClusterNameAndAddress.
 			for _, jwt := range spec.Jwts {
 				if name, _, _, err := buildJWKSURIClusterNameAndAddress(jwt.JwksUri); err != nil {
-					glog.Warningf("Could not set jwks_uri_envoy and address for jwks_uri %q: %v",
+					log.Warnf("Could not set jwks_uri_envoy and address for jwks_uri %q: %v",
 						jwt.JwksUri, err)
 				} else {
 					jwt.JwksUriEnvoyCluster = name
@@ -233,7 +235,7 @@ func mixerHTTPRouteConfig(role proxy.Node, instances []*model.ServiceInstance, c
 			sc.EndUserAuthnSpec = spec
 			if len(authSpecs) > 1 {
 				// TODO - validation should catch this problem earlier at config time.
-				glog.Warningf("Multiple EndUserAuthenticationPolicySpec found for service %q. Selecting %v",
+				log.Warnf("Multiple EndUserAuthenticationPolicySpec found for service %q. Selecting %v",
 					instance.Service, spec)
 			}
 		}
@@ -242,7 +244,7 @@ func mixerHTTPRouteConfig(role proxy.Node, instances []*model.ServiceInstance, c
 	}
 
 	if v2JSONMap, err := model.ToJSONMap(v2); err != nil {
-		glog.Warningf("Could not encode v2 HTTP mixerclient filter for node %q: %v", role, err)
+		log.Warnf("Could not encode v2 HTTP mixerclient filter for node %q: %v", role, err)
 	} else {
 		filter.V2 = v2JSONMap
 	}
@@ -267,7 +269,7 @@ func mixerTCPConfig(role proxy.Node, check bool, instance *model.ServiceInstance
 		},
 	}
 	if v2JSONMap, err := model.ToJSONMap(v2); err != nil {
-		glog.Warningf("Could not encode v2 TCP mixerclient filter for node %q: %v", role, err)
+		log.Warnf("Could not encode v2 TCP mixerclient filter for node %q: %v", role, err)
 	} else {
 		filter.V2 = v2JSONMap
 
@@ -326,7 +328,7 @@ func buildMixerAuthFilterClusters(config model.IstioConfigStore, mesh *meshconfi
 		for _, policy := range config.EndUserAuthenticationPolicySpecByDestination(instance) {
 			for _, jwt := range policy.Spec.(*mccpb.EndUserAuthenticationPolicySpec).Jwts {
 				if name, address, ssl, err := buildJWKSURIClusterNameAndAddress(jwt.JwksUri); err != nil {
-					glog.Warningf("Could not build envoy cluster and address from jwks_uri %q: %v",
+					log.Warnf("Could not build envoy cluster and address from jwks_uri %q: %v",
 						jwt.JwksUri, err)
 				} else {
 					authClusters[address] = authCluster{name, ssl}

--- a/pilot/proxy/envoy/resources.go
+++ b/pilot/proxy/envoy/resources.go
@@ -19,11 +19,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/duration"
 
 	"istio.io/istio/pilot/model"
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -137,7 +139,7 @@ var ListenersALPNProtocols = []string{"h2", "http/1.1"}
 func convertDuration(d *duration.Duration) time.Duration {
 	dur, err := ptypes.Duration(d)
 	if err != nil {
-		glog.Warningf("error converting duration %#v, using 0: %v", d, err)
+		log.Warnf("error converting duration %#v, using 0: %v", d, err)
 	}
 	return dur
 }

--- a/pilot/proxy/envoy/watcher_test.go
+++ b/pilot/proxy/envoy/watcher_test.go
@@ -229,24 +229,24 @@ func TestEnvoyRun(t *testing.T) {
 	config.ConfigPath = "tmp"
 
 	envoyConfig := buildConfig(config, nil)
-	proxy := envoy{config: config, node: "my-node", extraArgs: []string{"--mode", "validate"}}
+	envoyProxy := envoy{config: config, node: "my-node", extraArgs: []string{"--mode", "validate"}}
 	abortCh := make(chan error, 1)
 
-	if err = proxy.Run(nil, 0, abortCh); err == nil {
+	if err = envoyProxy.Run(nil, 0, abortCh); err == nil {
 		t.Error("expected error on nil config")
 	}
 
-	if err = proxy.Run(envoyConfig, 0, abortCh); err != nil {
+	if err = envoyProxy.Run(envoyConfig, 0, abortCh); err != nil {
 		t.Error(err)
 	}
 
-	proxy.Cleanup(0)
+	envoyProxy.Cleanup(0)
 
 	badConfig := config
 	badConfig.ConfigPath = ""
-	proxy.config = badConfig
+	envoyProxy.config = badConfig
 
-	if err = proxy.Run(envoyConfig, 0, abortCh); err == nil {
+	if err = envoyProxy.Run(envoyConfig, 0, abortCh); err == nil {
 		t.Errorf("expected error on bad config path")
 	}
 }

--- a/pilot/proxy/resolve.go
+++ b/pilot/proxy/resolve.go
@@ -21,7 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
+
+	"istio.io/istio/pkg/log"
 )
 
 // ResolveAddr resolves an authority address to an IP address
@@ -32,8 +35,8 @@ func ResolveAddr(addr string) (string, error) {
 	colon := strings.Index(addr, ":")
 	host := addr[:colon]
 	port := addr[colon:]
-	glog.Infof("Attempting to lookup address: %s", host)
-	defer glog.Infof("Finished lookup of address: %s", host)
+	log.Infof("Attempting to lookup address: %s", host)
+	defer log.Infof("Finished lookup of address: %s", host)
 	// lookup the udp address with a timeout of 15 seconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -42,6 +45,6 @@ func ResolveAddr(addr string) (string, error) {
 		return "", fmt.Errorf("lookup failed for udp address: %v", lookupErr)
 	}
 	resolvedAddr := fmt.Sprintf("%s%s", addrs[0].IP, port)
-	glog.Infof("Addr resolved to: %s", resolvedAddr)
+	log.Infof("Addr resolved to: %s", resolvedAddr)
 	return resolvedAddr, nil
 }

--- a/pilot/test/integration/BUILD
+++ b/pilot/test/integration/BUILD
@@ -25,7 +25,9 @@ go_library(
         "//pilot/platform/kube:go_default_library",
         "//pilot/platform/kube/inject:go_default_library",
         "//pilot/test/util:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_davecgh_go_spew//spew:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_sync//errgroup:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",

--- a/pilot/test/integration/access.go
+++ b/pilot/test/integration/access.go
@@ -19,10 +19,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/platform/kube/inject"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/log"
 )
 
 // envoy access log testing utilities
@@ -56,13 +58,13 @@ func (a *accessLogs) add(app, id, desc string) {
 // check logs against a deployment
 func (a *accessLogs) check(infra *infra) error {
 	if !infra.checkLogs {
-		glog.Info("Log checking is disabled")
+		log.Info("Log checking is disabled")
 		return nil
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	glog.Info("Checking pod logs for request IDs...")
-	glog.V(3).Info(a.logs)
+	log.Info("Checking pod logs for request IDs...")
+	log.Debuga(a.logs)
 
 	funcs := make(map[string]func() status)
 	for app := range a.logs {
@@ -102,7 +104,7 @@ func (a *accessLogs) check(infra *infra) error {
 				for id, want := range counts {
 					got := strings.Count(logs, id)
 					if got < want {
-						glog.Errorf("Got %d for %s in logs of %s, want %d", got, id, pod, want)
+						log.Errorf("Got %d for %s in logs of %s, want %d", got, id, pod, want)
 						return errAgain
 					}
 				}

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -29,7 +29,8 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/golang/sync/errgroup"
 	multierror "github.com/hashicorp/go-multierror"
 	"k8s.io/client-go/kubernetes"
@@ -39,6 +40,7 @@ import (
 	"istio.io/istio/pilot/platform/kube"
 	"istio.io/istio/pilot/platform/kube/inject"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -116,8 +118,11 @@ type test interface {
 
 func main() {
 	flag.Parse()
+	log.Configure(log.NewOptions())
+
 	if params.Tag == "" {
-		glog.Fatal("No docker tag specified")
+		log.Error("No docker tag specified")
+		os.Exit(-1)
 	}
 
 	if verbose {
@@ -134,7 +139,7 @@ func main() {
 	params.PilotCustomConfigFile = pilotConfigFile
 
 	if len(params.Namespace) != 0 && authmode == "both" {
-		glog.Infof("When namespace(=%s) is specified, auth mode(=%s) must be one of enable or disable.",
+		log.Infof("When namespace(=%s) is specified, auth mode(=%s) must be one of enable or disable.",
 			params.Namespace, authmode)
 		return
 	}
@@ -142,7 +147,8 @@ func main() {
 	var err error
 	_, client, err = kube.CreateInterface(kubeconfig)
 	if err != nil {
-		glog.Fatal(err)
+		log.Errora(err)
+		os.Exit(-1)
 	}
 
 	switch authmode {
@@ -153,7 +159,7 @@ func main() {
 	case "both":
 		runTests(params, setAuth(params))
 	default:
-		glog.Infof("Invald auth flag: %s. Please choose from: enable/disable/both.", authmode)
+		log.Infof("Invald auth flag: %s. Please choose from: enable/disable/both.", authmode)
 	}
 }
 
@@ -167,19 +173,24 @@ func setAuth(params infra) infra {
 	return out
 }
 
-func log(header, s string) {
-	glog.Infof("\n\n=================== %s =====================\n%s\n\n", header, s)
+func tlog(header, s string) {
+	log.Infof("\n\n=================== %s =====================\n%s\n\n", header, s)
 }
 
-func logError(header, s string) {
-	glog.Errorf("\n\n=================== %s =====================\n%s\n\n", header, s)
+func tlogError(header, s string) {
+	log.Errorf("\n\n=================== %s =====================\n%s\n\n", header, s)
+}
+
+func tlogFatal(header, s string) {
+	tlogError(header, s)
+	os.Exit(-1)
 }
 
 func runTests(envs ...infra) {
 	var result error
 	for _, istio := range envs {
 		var errs error
-		log("Deploying infrastructure", spew.Sdump(istio))
+		tlog("Deploying infrastructure", spew.Sdump(istio))
 		if err := istio.setup(); err != nil {
 			result = multierror.Append(result, err)
 			continue
@@ -216,18 +227,18 @@ func runTests(envs ...infra) {
 			}
 
 			for i := 0; i < count; i++ {
-				log("Test run", strconv.Itoa(i))
+				tlog("Test run", strconv.Itoa(i))
 				if err := test.setup(); err != nil {
 					errs = multierror.Append(errs, multierror.Prefix(err, test.String()))
 				} else {
-					log("Running test", test.String())
+					tlog("Running test", test.String())
 					if err := test.run(); err != nil {
 						errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("%v run %d", test, i)))
 					} else {
-						log("Success!", test.String())
+						tlog("Success!", test.String())
 					}
 				}
-				log("Tearing down test", test.String())
+				tlog("Tearing down test", test.String())
 				test.teardown()
 			}
 		}
@@ -237,51 +248,50 @@ func runTests(envs ...infra) {
 			for _, pod := range util.GetPods(client, istio.Namespace) {
 				var filename, content string
 				if strings.HasPrefix(pod, "istio-pilot") {
-					log("Discovery log", pod)
+					tlog("Discovery log", pod)
 					filename = "istio-pilot"
 					content = util.FetchLogs(client, pod, istio.IstioNamespace, "discovery")
 				} else if strings.HasPrefix(pod, "istio-mixer") {
-					log("Mixer log", pod)
+					tlog("Mixer log", pod)
 					filename = "istio-mixer"
 					content = util.FetchLogs(client, pod, istio.IstioNamespace, "mixer")
 				} else if strings.HasPrefix(pod, "istio-ingress") {
-					log("Ingress log", pod)
+					tlog("Ingress log", pod)
 					filename = "istio-ingress"
 					content = util.FetchLogs(client, pod, istio.IstioNamespace, inject.ProxyContainerName)
 				} else {
-					log("Proxy log", pod)
+					tlog("Proxy log", pod)
 					filename = pod
 					content = util.FetchLogs(client, pod, istio.Namespace, inject.ProxyContainerName)
 				}
 
 				if len(istio.errorLogsDir) > 0 {
 					if err := ioutil.WriteFile(istio.errorLogsDir+"/"+filename+".txt", []byte(content), 0644); err != nil {
-						glog.Errorf("Failed to save logs to %s:%s. Dumping on stderr\n", filename, err)
-						glog.Info(content)
+						log.Errorf("Failed to save logs to %s:%s. Dumping on stderr\n", filename, err)
+						log.Info(content)
 					}
 				} else {
-					glog.Info(content)
+					log.Info(content)
 				}
 			}
 		}
 
 		// always remove infra even if the tests fail
-		log("Tearing down infrastructure", istio.Name)
+		tlog("Tearing down infrastructure", istio.Name)
 		istio.teardown()
 
 		if errs == nil {
-			log("Passed all tests!", fmt.Sprintf("tests: %v, count: %d", tests, count))
+			tlog("Passed all tests!", fmt.Sprintf("tests: %v, count: %d", tests, count))
 		} else {
-			logError("Failed tests!", errs.Error())
+			tlogError("Failed tests!", errs.Error())
 			result = multierror.Append(result, multierror.Prefix(errs, istio.Name))
 		}
 	}
 
 	if result == nil {
-		log("Passed infrastructure tests!", spew.Sdump(envs))
+		tlog("Passed infrastructure tests!", spew.Sdump(envs))
 	} else {
-		logError("Failed infrastructure tests!", result.Error())
-		os.Exit(1)
+		tlogFatal("Failed infrastructure tests!", result.Error())
 	}
 }
 
@@ -318,7 +328,7 @@ func parallel(fs map[string]func() status) error {
 	repeat := func(name string, f func() status) func() error {
 		return func() error {
 			for n := 0; n < budget; n++ {
-				glog.Infof("%s (attempt %d)", name, n)
+				log.Infof("%s (attempt %d)", name, n)
 				err := f()
 				switch err {
 				case nil:
@@ -354,7 +364,7 @@ func repeat(f func() error, budget int, delay time.Duration) error {
 			return nil
 		}
 		errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("attempt %d", i)))
-		glog.Infof("attempt #%d failed with %v", i, err)
+		log.Infof("attempt #%d failed with %v", i, err)
 		time.Sleep(delay)
 	}
 	return errs

--- a/pilot/test/integration/egress_rules.go
+++ b/pilot/test/integration/egress_rules.go
@@ -21,8 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	"istio.io/istio/pkg/log"
 )
 
 type egressRules struct {
@@ -82,25 +84,25 @@ func (t *egressRules) run() error {
 	}
 	var errs error
 	for _, cs := range cases {
-		log("Checking egressRules test", cs.description)
+		tlog("Checking egressRules test", cs.description)
 		if err := t.applyConfig(cs.config, nil); err != nil {
 			return err
 		}
 
 		if err := repeat(cs.check, 3, time.Second); err != nil {
-			glog.Infof("Failed the test with %v", err)
+			log.Infof("Failed the test with %v", err)
 			errs = multierror.Append(errs, multierror.Prefix(err, cs.description))
 		} else {
-			glog.Info("Success!")
+			log.Info("Success!")
 		}
 	}
 	return errs
 }
 
 func (t *egressRules) teardown() {
-	glog.Info("Cleaning up egress rules...")
+	log.Info("Cleaning up egress rules...")
 	if err := t.deleteAllConfigs(); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }
 

--- a/pilot/test/integration/ingress.go
+++ b/pilot/test/integration/ingress.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pilot/platform"
+	"istio.io/istio/pkg/log"
 )
 
 type ingress struct {
@@ -59,7 +61,7 @@ func (t *ingress) setup() error {
 
 func (t *ingress) run() error {
 	if !t.Ingress {
-		glog.Info("skipping test since ingress is missing")
+		log.Info("skipping test since ingress is missing")
 		return nil
 	}
 	if platform.ServiceRegistry(t.Registry) != platform.KubernetesRegistry {
@@ -105,7 +107,7 @@ func (t *ingress) run() error {
 				} else if len(resp.id) > 0 {
 					if !strings.Contains(resp.body, "X-Forwarded-For") &&
 						!strings.Contains(resp.body, "x-forwarded-for") {
-						glog.Warningf("Missing X-Forwarded-For in the body: %s", resp.body)
+						log.Warnf("Missing X-Forwarded-For in the body: %s", resp.body)
 						return errAgain
 					}
 
@@ -130,7 +132,7 @@ func (t *ingress) checkRouteRule() status {
 	url := fmt.Sprintf("http://%s.%s/c", ingressServiceName, t.IstioNamespace)
 	resp := t.clientRequest("t", url, 100, "")
 	count := counts(resp.version)
-	glog.V(2).Infof("counts: %v", count)
+	log.Infof("counts: %v", count)
 	if count["v1"] >= 95 {
 		return nil
 	}
@@ -155,7 +157,7 @@ func (t *ingress) checkIngressStatus() status {
 			if status.IP == "" && status.Hostname == "" {
 				return errAgain
 			}
-			glog.Infof("Ingress Status IP: %s", status.IP)
+			log.Infof("Ingress Status IP: %s", status.IP)
 		}
 	}
 	return nil
@@ -167,13 +169,13 @@ func (t *ingress) teardown() {
 	}
 	if err := client.Extensions().Ingresses(t.Namespace).
 		DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 	if err := client.CoreV1().Secrets(t.Namespace).
 		Delete(ingressSecretName, &metav1.DeleteOptions{}); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 	if err := t.deleteAllConfigs(); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }

--- a/pilot/test/integration/routing.go
+++ b/pilot/test/integration/routing.go
@@ -23,8 +23,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	"istio.io/istio/pkg/log"
 )
 
 type routing struct {
@@ -127,25 +129,25 @@ func (t *routing) run() error {
 
 	var errs error
 	for _, cs := range cases {
-		log("Checking routing test", cs.description)
+		tlog("Checking routing test", cs.description)
 		if err := t.applyConfig(cs.config, nil); err != nil {
 			return err
 		}
 
 		if err := repeat(cs.check, 3, time.Second); err != nil {
-			glog.Infof("Failed the test with %v", err)
+			log.Infof("Failed the test with %v", err)
 			errs = multierror.Append(errs, multierror.Prefix(err, cs.description))
 		} else {
-			glog.Info("Success!")
+			log.Info("Success!")
 		}
 	}
 	return errs
 }
 
 func (t *routing) teardown() {
-	glog.Info("Cleaning up route rules...")
+	log.Info("Cleaning up route rules...")
 	if err := t.deleteAllConfigs(); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }
 
@@ -161,11 +163,11 @@ func counts(elts []string) map[string]int {
 func (t *routing) verifyRouting(scheme, src, dst, headerKey, headerVal string,
 	samples int, expectedCount map[string]int, operation string) error {
 	url := fmt.Sprintf("%s://%s/%s", scheme, dst, src)
-	glog.Infof("Making %d requests (%s) from %s...\n", samples, url, src)
+	log.Infof("Making %d requests (%s) from %s...\n", samples, url, src)
 
 	resp := t.clientRequest(src, url, samples, fmt.Sprintf("-key %s -val %s", headerKey, headerVal))
 	count := counts(resp.version)
-	glog.Infof("request counts %v", count)
+	log.Infof("request counts %v", count)
 	epsilon := 5
 
 	var errs error
@@ -208,7 +210,7 @@ func (t *routing) verifyDecorator(operation string) error {
 func (t *routing) verifyFaultInjection(src, dst, headerKey, headerVal string,
 	respTime time.Duration, respCode int) error {
 	url := fmt.Sprintf("http://%s/%s", dst, src)
-	glog.Infof("Making 1 request (%s) from %s...\n", url, src)
+	log.Infof("Making 1 request (%s) from %s...\n", url, src)
 
 	start := time.Now()
 	resp := t.clientRequest(src, url, 1, fmt.Sprintf("-key %s -val %s", headerKey, headerVal))
@@ -232,7 +234,7 @@ func (t *routing) verifyFaultInjection(src, dst, headerKey, headerVal string,
 // verifyRedirect verifies if the http redirect was setup properly
 func (t *routing) verifyRedirect(src, dst, targetHost, targetPath, headerKey, headerVal string, respCode int) error {
 	url := fmt.Sprintf("http://%s/%s", dst, src)
-	glog.Infof("Making 1 request (%s) from %s...\n", url, src)
+	log.Infof("Making 1 request (%s) from %s...\n", url, src)
 
 	resp := t.clientRequest(src, url, 1, fmt.Sprintf("-key %s -val %s", headerKey, headerVal))
 	if len(resp.code) == 0 || resp.code[0] != fmt.Sprint(respCode) {

--- a/pilot/test/integration/routingToEgress.go
+++ b/pilot/test/integration/routingToEgress.go
@@ -21,8 +21,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	multierror "github.com/hashicorp/go-multierror"
+	"istio.io/istio/pkg/log"
 )
 
 type routingToEgress struct {
@@ -56,7 +58,7 @@ func (t *routingToEgress) run() error {
 
 	var errs error
 	for _, cs := range cases {
-		log("Checking routing rule to egress rule test", cs.description)
+		tlog("Checking routing rule to egress rule test", cs.description)
 		if err := t.applyConfig(cs.configEgress, nil); err != nil {
 			return err
 		}
@@ -65,24 +67,24 @@ func (t *routingToEgress) run() error {
 		}
 
 		if err := repeat(cs.check, 3, time.Second); err != nil {
-			glog.Infof("Failed the test with %v", err)
+			log.Infof("Failed the test with %v", err)
 			errs = multierror.Append(errs, multierror.Prefix(err, cs.description))
 		} else {
-			glog.Info("Success!")
+			log.Info("Success!")
 		}
 	}
 	return errs
 }
 
 func (t *routingToEgress) teardown() {
-	glog.Info("Cleaning up route rules to egress rules...")
+	log.Info("Cleaning up route rules to egress rules...")
 	if err := t.deleteAllConfigs(); err != nil {
-		glog.Warning(err)
+		log.Warna(err)
 	}
 }
 
 func (t *routingToEgress) verifyFaultInjectionByResponseCode(src, url string, respCode int) error {
-	glog.Infof("Making 1 request (%s) from %s...\n", url, src)
+	log.Infof("Making 1 request (%s) from %s...\n", url, src)
 
 	resp := t.clientRequest(src, url, 1, "")
 

--- a/pilot/test/mock/BUILD
+++ b/pilot/test/mock/BUILD
@@ -12,7 +12,9 @@ go_library(
         "//pilot/model/test:go_default_library",
         "//pilot/proxy:go_default_library",
         "//pilot/test/util:go_default_library",
+        "//pkg/log:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -23,7 +23,8 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
 	mpb "istio.io/api/mixer/v1"
@@ -32,6 +33,7 @@ import (
 	"istio.io/istio/pilot/model"
 	"istio.io/istio/pilot/model/test"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -384,14 +386,14 @@ func CheckCacheEvents(store model.ConfigStore, cache model.ConfigStoreCache, nam
 			}
 			deleted++
 		}
-		glog.Infof("Added %d, deleted %d", added, deleted)
+		log.Infof("Added %d, deleted %d", added, deleted)
 	})
 	go cache.Run(stop)
 
 	// run map invariant sequence
 	CheckMapInvariant(store, t, namespace, n)
 
-	glog.Infof("Waiting till all events are received")
+	log.Infof("Waiting till all events are received")
 	util.Eventually(func() bool { return added == n && deleted == n }, t)
 }
 
@@ -415,7 +417,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 				t.Errorf("Got %#v, %t, expected %#v", elt, exists, o)
 			}
 
-			glog.Infof("Calling Update(%s)", config.Key())
+			log.Infof("Calling Update(%s)", config.Key())
 			revised := Make(namespace, 1)
 			revised.ConfigMeta = elt.ConfigMeta
 			if _, err := cache.Update(revised); err != nil {
@@ -429,7 +431,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 				t.Errorf("Got %#v, %t, expected nonempty", elt, exists)
 			}
 
-			glog.Infof("Calling Delete(%s)", config.Key())
+			log.Infof("Calling Delete(%s)", config.Key())
 			if err := cache.Delete(model.MockConfig.Type, config.Name, config.Namespace); err != nil {
 				t.Error(err)
 			}
@@ -437,7 +439,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 			if len(elts) != 0 {
 				t.Errorf("Got %#v, expected zero elements on Delete event", elts)
 			}
-			glog.Infof("Stopping channel for (%#v)", config.Key)
+			log.Infof("Stopping channel for (%#v)", config.Key)
 			close(stop)
 			doneMu.Lock()
 			done = true
@@ -453,7 +455,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 	}
 
 	// add and remove
-	glog.Infof("Calling Create(%#v)", o)
+	log.Infof("Calling Create(%#v)", o)
 	if _, err := cache.Create(o); err != nil {
 		t.Error(err)
 	}
@@ -497,7 +499,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	// check again in the controller cache
 	util.Eventually(func() bool {
 		os, _ = cache.List(model.MockConfig.Type, namespace)
-		glog.Infof("cache.List => Got %d, expected %d", len(os), 0)
+		log.Infof("cache.List => Got %d, expected %d", len(os), 0)
 		return len(os) == 0
 	}, t)
 
@@ -512,8 +514,8 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	util.Eventually(func() bool {
 		cs, _ := cache.List(model.MockConfig.Type, namespace)
 		os, _ := store.List(model.MockConfig.Type, namespace)
-		glog.Infof("cache.List => Got %d, expected %d", len(cs), n)
-		glog.Infof("store.List => Got %d, expected %d", len(os), n)
+		log.Infof("cache.List => Got %d, expected %d", len(cs), n)
+		log.Infof("store.List => Got %d, expected %d", len(os), n)
 		return len(os) == n && len(cs) == n
 	}, t)
 

--- a/pilot/test/util/BUILD
+++ b/pilot/test/util/BUILD
@@ -9,6 +9,8 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_pmezard_go_difflib//difflib:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -19,10 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/pkg/log"
 )
 
 // Test utilities for kubernetes
@@ -42,7 +45,7 @@ func CreateNamespace(cl kubernetes.Interface) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	glog.Infof("Created namespace %s", ns.Name)
+	log.Infof("Created namespace %s", ns.Name)
 	return ns.Name, nil
 }
 
@@ -50,9 +53,9 @@ func CreateNamespace(cl kubernetes.Interface) (string, error) {
 func DeleteNamespace(cl kubernetes.Interface, ns string) {
 	if ns != "" && ns != "default" {
 		if err := cl.CoreV1().Namespaces().Delete(ns, &meta_v1.DeleteOptions{}); err != nil {
-			glog.Warningf("Error deleting namespace: %v", err)
+			log.Warnf("Error deleting namespace: %v", err)
 		}
-		glog.Infof("Deleted namespace %s", ns)
+		log.Infof("Deleted namespace %s", ns)
 	}
 }
 
@@ -81,12 +84,12 @@ func describeNotReadyPods(items []v1.Pod, kubeconfig, ns string) {
 			cmd := fmt.Sprintf("kubectl describe pods %s --kubeconfig %s -n %s",
 				pod.Name, kubeconfig, ns)
 			output, _ := Shell(cmd)
-			glog.Errorf("%s\n%s", cmd, output)
+			log.Errorf("%s\n%s", cmd, output)
 
 			cmd = fmt.Sprintf("kubectl logs %s -c istio-proxy --kubeconfig %s -n %s",
 				pod.Name, kubeconfig, ns)
 			output, _ = Shell(cmd)
-			glog.Errorf("%s\n%s", cmd, output)
+			log.Errorf("%s\n%s", cmd, output)
 		}
 	}
 }
@@ -98,7 +101,7 @@ func GetAppPods(cl kubernetes.Interface, kubeconfig string, nslist []string) (ma
 	var items []v1.Pod
 
 	for _, ns := range nslist {
-		glog.Infof("Checking all pods are running in namespace %s ...", ns)
+		log.Infof("Checking all pods are running in namespace %s ...", ns)
 
 		for n := 0; ; n++ {
 			list, err := cl.CoreV1().Pods(ns).List(meta_v1.ListOptions{})
@@ -110,13 +113,13 @@ func GetAppPods(cl kubernetes.Interface, kubeconfig string, nslist []string) (ma
 
 			for _, pod := range items {
 				if pod.Status.Phase != "Running" {
-					glog.Infof("Pod %s.%s has status %s", pod.Name, ns, pod.Status.Phase)
+					log.Infof("Pod %s.%s has status %s", pod.Name, ns, pod.Status.Phase)
 					ready = false
 					break
 				} else {
 					for _, container := range pod.Status.ContainerStatuses {
 						if !container.Ready {
-							glog.Infof("Container %s in Pod %s in namespace % s is not ready", container.Name, pod.Name, ns)
+							log.Infof("Container %s in Pod %s in namespace % s is not ready", container.Name, pod.Name, ns)
 							ready = false
 							break
 						}
@@ -150,12 +153,12 @@ func GetAppPods(cl kubernetes.Interface, kubeconfig string, nslist []string) (ma
 
 // FetchLogs for a container in a a pod
 func FetchLogs(cl kubernetes.Interface, name, namespace string, container string) string {
-	glog.V(2).Infof("Fetching log for container %s in %s.%s", container, name, namespace)
+	log.Infof("Fetching log for container %s in %s.%s", container, name, namespace)
 	raw, err := cl.CoreV1().Pods(namespace).
 		GetLogs(name, &v1.PodLogOptions{Container: container}).
 		Do().Raw()
 	if err != nil {
-		glog.Infof("Request error %v", err)
+		log.Infof("Request error %v", err)
 		return ""
 	}
 	return string(raw)
@@ -168,7 +171,7 @@ func Eventually(f func() bool, t *testing.T) {
 		if f() {
 			return
 		}
-		glog.Infof("Sleeping %v", interval)
+		log.Infof("Sleeping %v", interval)
 		time.Sleep(interval)
 		interval = 2 * interval
 	}

--- a/pilot/test/util/shell.go
+++ b/pilot/test/util/shell.go
@@ -20,12 +20,15 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
+
+	"istio.io/istio/pkg/log"
 )
 
 // Run command and stream output
 func Run(command string) error {
-	glog.V(2).Info(command)
+	log.Info(command)
 	parts := strings.Split(command, " ")
 	/* #nosec */
 	c := exec.Command(parts[0], parts[1:]...)
@@ -36,7 +39,7 @@ func Run(command string) error {
 
 // RunInput command and pass input via stdin
 func RunInput(command, input string) error {
-	glog.V(2).Infof("Run %q on input:\n%s", command, input)
+	log.Infof("Run %q on input:\n%s", command, input)
 	parts := strings.Split(command, " ")
 	/* #nosec */
 	c := exec.Command(parts[0], parts[1:]...)
@@ -48,13 +51,13 @@ func RunInput(command, input string) error {
 
 // Shell out a command and aggregate output
 func Shell(command string) (string, error) {
-	glog.V(2).Info(command)
+	log.Info(command)
 	parts := strings.Split(command, " ")
 	/* #nosec */
 	c := exec.Command(parts[0], parts[1:]...)
 	bytes, err := c.CombinedOutput()
 	if err != nil {
-		glog.V(2).Info(string(bytes))
+		log.Info(string(bytes))
 		return "", fmt.Errorf("command %q failed: %q %v", command, string(bytes), err)
 	}
 	return string(bytes), nil

--- a/security/cmd/generate_cert/BUILD
+++ b/security/cmd/generate_cert/BUILD
@@ -5,7 +5,9 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/security/cmd/generate_csr/BUILD
+++ b/security/cmd/generate_csr/BUILD
@@ -5,7 +5,9 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/security/cmd/generate_csr/main.go
+++ b/security/cmd/generate_csr/main.go
@@ -20,9 +20,12 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/ca"
 )
 
@@ -34,15 +37,20 @@ var (
 	keySize = flag.Int("key-size", 2048, "Size of the generated private key")
 )
 
+func fatalf(template string, args ...interface{}) {
+	log.Errorf(template, args)
+	os.Exit(-1)
+}
+
 func saveCreds(csrPem []byte, privPem []byte) {
 	err := ioutil.WriteFile(*outCsr, csrPem, 0644)
 	if err != nil {
-		glog.Fatalf("Could not write output certificate request: %s.", err)
+		fatalf("Could not write output certificate request: %s.", err)
 	}
 
 	err = ioutil.WriteFile(*outPriv, privPem, 0600)
 	if err != nil {
-		glog.Fatalf("Could not write output private key: %s.", err)
+		fatalf("Could not write output private key: %s.", err)
 	}
 }
 
@@ -56,7 +64,7 @@ func main() {
 	})
 
 	if err != nil {
-		glog.Fatalf("Failed to generate CSR: %s.", err)
+		fatalf("Failed to generate CSR: %s.", err)
 	}
 
 	saveCreds(csrPem, privPem)

--- a/security/cmd/istio_ca/BUILD
+++ b/security/cmd/istio_ca/BUILD
@@ -8,6 +8,7 @@ go_library(
     ],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/cmd/istio_ca/version:go_default_library",
         "//security/pkg/cmd:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
@@ -15,6 +16,7 @@ go_library(
         "//security/pkg/registry:go_default_library",
         "//security/pkg/registry/kube:go_default_library",
         "//security/pkg/server/grpc:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_cobra//doc:go_default_library",

--- a/security/cmd/node_agent/BUILD
+++ b/security/cmd/node_agent/BUILD
@@ -5,8 +5,10 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/cmd/node_agent/na:go_default_library",
         "//security/pkg/cmd:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],

--- a/security/cmd/node_agent/na/BUILD
+++ b/security/cmd/node_agent/na/BUILD
@@ -10,11 +10,13 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
         "//security/pkg/platform:go_default_library",
         "//security/pkg/workload:go_default_library",
         "//security/proto:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
@@ -33,12 +35,12 @@ go_test(
     data = glob(["testdata/*"]),
     library = ":go_default_library",
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/platform:go_default_library",
         "//security/pkg/platform/mock:go_default_library",
         "//security/pkg/util/mock:go_default_library",
         "//security/pkg/workload:go_default_library",
         "//security/proto:go_default_library",
-        "@com_github_golang_glog//:go_default_library",        
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",
         "@org_golang_x_net//context:go_default_library",

--- a/security/cmd/node_agent/na/config.go
+++ b/security/cmd/node_agent/na/config.go
@@ -17,6 +17,7 @@ package na
 import (
 	"time"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/platform"
 )
 
@@ -54,12 +55,18 @@ type Config struct {
 
 	// The Configuration for talking to the platform metadata server.
 	PlatformConfig platform.ClientConfig
+
+	// LoggingOptions is the options for Istio logging.
+	LoggingOptions *log.Options
 }
 
-// InitializeConfig initializes Config with default values.
-func InitializeConfig(config *Config) {
-	config.CSRInitialRetrialInterval = defaultCSRInitialRetrialInterval
-	config.CSRMaxRetries = defaultCSRMaxRetries
-	config.CSRGracePeriodPercentage = defaultCSRGracePeriodPercentage
-	config.PlatformConfig = platform.ClientConfig{}
+// NewConfig creates a new Config instance with default values.
+func NewConfig() *Config {
+	return &Config{
+		CSRInitialRetrialInterval: defaultCSRInitialRetrialInterval,
+		CSRMaxRetries:             defaultCSRMaxRetries,
+		CSRGracePeriodPercentage:  defaultCSRGracePeriodPercentage,
+		PlatformConfig:            platform.ClientConfig{},
+		LoggingOptions:            log.NewOptions(),
+	}
 }

--- a/security/cmd/node_agent/na/config_test.go
+++ b/security/cmd/node_agent/na/config_test.go
@@ -19,9 +19,7 @@ import (
 )
 
 func TestInitializeConfig(t *testing.T) {
-	config := Config{}
-
-	InitializeConfig(&config)
+	config := NewConfig()
 
 	if config.CSRInitialRetrialInterval != defaultCSRInitialRetrialInterval {
 		t.Errorf("Unexpected config.CSRInitialRetrialInterval: %v", config.CSRInitialRetrialInterval)

--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -16,9 +16,12 @@ package na
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/platform"
 	"istio.io/istio/security/pkg/workload"
 )
@@ -52,7 +55,8 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 	secretServer, err := workload.NewSecretServer(
 		workload.NewSecretFileServerConfig(cfg.PlatformConfig.OnPremConfig.CertChainFile, cfg.PlatformConfig.OnPremConfig.KeyFile))
 	if err != nil {
-		glog.Fatalf("Workload IO creation error: %v", err)
+		log.Errorf("Workload IO creation error: %v", err)
+		os.Exit(-1)
 	}
 	na.secretServer = secretServer
 	return na, nil

--- a/security/integration/BUILD
+++ b/security/integration/BUILD
@@ -5,10 +5,12 @@ go_library(
     srcs = ["main.go"],
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/integration/utils:go_default_library",
         "//security/pkg/cmd:go_default_library",
         "//security/pkg/pki/ca/controller:go_default_library",
         "//security/pkg/pki/testutil:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/security/integration/utils/BUILD
+++ b/security/integration/utils/BUILD
@@ -7,6 +7,8 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//rbac/v1beta1:go_default_library",

--- a/security/integration/utils/kubernetes.go
+++ b/security/integration/utils/kubernetes.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +28,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // to avoid 'No Auth Provider found for name "gcp"'
 	"k8s.io/client-go/tools/clientcmd"
+
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -62,7 +65,7 @@ func CreateTestNamespace(clientset kubernetes.Interface, prefix string) (string,
 	}
 
 	name := namespace.GetName()
-	glog.Infof("Namespace %v is created", name)
+	log.Infof("Namespace %v is created", name)
 	return name, nil
 }
 
@@ -71,7 +74,7 @@ func DeleteTestNamespace(clientset kubernetes.Interface, namespace string) error
 	if err := clientset.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{GracePeriodSeconds: &immediate}); err != nil {
 		return fmt.Errorf("failed to delete namespace %q (error: %v)", namespace, err)
 	}
-	glog.Infof("Namespace %v is deleted", namespace)
+	log.Infof("Namespace %v is deleted", namespace)
 	return nil
 }
 
@@ -265,7 +268,7 @@ func waitForServiceExternalIPAddress(clientset kubernetes.Interface, namespace s
 		case event := <-events:
 			svc := event.Object.(*v1.Service)
 			if len(svc.Status.LoadBalancer.Ingress) > 0 {
-				glog.Infof("LoadBalancer for %v/%v is ready. IP: %v", namespace, svc.GetName(),
+				log.Infof("LoadBalancer for %v/%v is ready. IP: %v", namespace, svc.GetName(),
 					svc.Status.LoadBalancer.Ingress[0].IP)
 				return nil
 			}
@@ -293,7 +296,7 @@ func waitForPodRunning(clientset kubernetes.Interface, namespace string, uuid st
 		case event := <-events:
 			pod := event.Object.(*v1.Pod)
 			if pod.Status.Phase == v1.PodRunning {
-				glog.Infof("Pod %v/%v is in Running phase", namespace, pod.GetName())
+				log.Infof("Pod %v/%v is in Running phase", namespace, pod.GetName())
 				return nil
 			}
 		case <-time.After(timeToWait - time.Since(startTime)):

--- a/security/pkg/pki/ca/BUILD
+++ b/security/pkg/pki/ca/BUILD
@@ -8,7 +8,9 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -22,11 +22,13 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki"
 )
 
@@ -81,7 +83,7 @@ func NewSelfSignedIstioCA(caCertTTL, certTTL time.Duration, org string, namespac
 		CertTTL: certTTL,
 	}
 	if err != nil {
-		glog.Infof("Failed to get secret (error: %s), will create one", err)
+		log.Infof("Failed to get secret (error: %s), will create one", err)
 
 		now := time.Now()
 		options := CertOptions{
@@ -112,7 +114,7 @@ func NewSelfSignedIstioCA(caCertTTL, certTTL time.Duration, org string, namespac
 		}
 		_, err := core.Secrets(namespace).Create(secret)
 		if err != nil {
-			glog.Errorf("Failed to write secret to CA (error: %s). This CA will not persist when restart.", err)
+			log.Errorf("Failed to write secret to CA (error: %s). This CA will not persist when restart.", err)
 		}
 	} else {
 		// Reuse existing key/cert in secrets.

--- a/security/pkg/pki/ca/controller/BUILD
+++ b/security/pkg/pki/ca/controller/BUILD
@@ -7,8 +7,10 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/security/pkg/platform/BUILD
+++ b/security/pkg/platform/BUILD
@@ -10,11 +10,13 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/credential:go_default_library",
         "//security/pkg/pki:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/ec2metadata:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_fullsailor_pkcs7//:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_google_cloud_go//compute/metadata:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/security/pkg/platform/gcp.go
+++ b/security/pkg/platform/gcp.go
@@ -18,11 +18,13 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"istio.io/istio/pkg/log"
 	cred "istio.io/istio/security/pkg/credential"
 )
 
@@ -76,7 +78,7 @@ func (ci *GcpClientImpl) IsProperPlatform() bool {
 func (ci *GcpClientImpl) GetDialOptions() ([]grpc.DialOption, error) {
 	jwtKey, err := ci.fetcher.FetchToken()
 	if err != nil {
-		glog.Errorf("Failed to get instance from GCE metadata %s, please make sure this binary is running on a GCE VM", err)
+		log.Errorf("Failed to get instance from GCE metadata %s, please make sure this binary is running on a GCE VM", err)
 		return nil, err
 	}
 
@@ -93,7 +95,7 @@ func (ci *GcpClientImpl) GetDialOptions() ([]grpc.DialOption, error) {
 func (ci *GcpClientImpl) GetServiceIdentity() (string, error) {
 	serviceAccount, err := ci.fetcher.FetchServiceAccount()
 	if err != nil {
-		glog.Errorf("Failed to get service account from GCE metadata %v, please make sure this binary is running on a GCE VM", err)
+		log.Errorf("Failed to get service account from GCE metadata %v, please make sure this binary is running on a GCE VM", err)
 		return "", err
 	}
 
@@ -106,7 +108,7 @@ func (ci *GcpClientImpl) GetServiceIdentity() (string, error) {
 func (ci *GcpClientImpl) GetAgentCredential() ([]byte, error) {
 	jwtKey, err := ci.fetcher.FetchToken()
 	if err != nil {
-		glog.Errorf("Failed to get instance from GCE metadata %s, please make sure this binary is running on a GCE VM", err)
+		log.Errorf("Failed to get instance from GCE metadata %s, please make sure this binary is running on a GCE VM", err)
 		return nil, err
 	}
 

--- a/security/pkg/registry/BUILD
+++ b/security/pkg/registry/BUILD
@@ -7,6 +7,8 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
     ],
 )

--- a/security/pkg/registry/registry.go
+++ b/security/pkg/registry/registry.go
@@ -17,7 +17,10 @@ package registry
 import (
 	"sync"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
+
+	"istio.io/istio/pkg/log"
 )
 
 // Registry is the standard interface for identity registry implementation
@@ -46,7 +49,7 @@ func (reg *IdentityRegistry) Check(id1, id2 string) bool {
 	mapped, ok := reg.Map[id1]
 	reg.RUnlock()
 	if !ok || id2 != mapped {
-		glog.Warningf("Identity %q does not exist or is not mapped to %q", id1, id2)
+		log.Warnf("Identity %q does not exist or is not mapped to %q", id1, id2)
 		return false
 	}
 	return true
@@ -58,7 +61,7 @@ func (reg *IdentityRegistry) AddMapping(id1, id2 string) {
 	oldID, ok := reg.Map[id1]
 	reg.RUnlock()
 	if ok {
-		glog.Warningf("Overwriting existing mapping: %q -> %q", id1, oldID)
+		log.Warnf("Overwriting existing mapping: %q -> %q", id1, oldID)
 	}
 	reg.Lock()
 	reg.Map[id1] = id2
@@ -72,7 +75,7 @@ func (reg *IdentityRegistry) DeleteMapping(id1, id2 string) {
 	oldID, ok := reg.Map[id1]
 	reg.RUnlock()
 	if !ok || oldID != id2 {
-		glog.Warningf("Could not delete nonexistent mapping: %q -> %q", id1, id2)
+		log.Warnf("Could not delete nonexistent mapping: %q -> %q", id1, id2)
 		return
 	}
 	reg.Lock()

--- a/security/pkg/server/grpc/BUILD
+++ b/security/pkg/server/grpc/BUILD
@@ -9,11 +9,13 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//security/pkg/pki:go_default_library",
         "//security/pkg/pki/ca:go_default_library",
         "//security/pkg/registry:go_default_library",
         "//security/proto:go_default_library",
         "@com_github_coreos_go_oidc//:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/tests/e2e/framework/BUILD
+++ b/tests/e2e/framework/BUILD
@@ -17,7 +17,10 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//tests/util:go_default_library",
+
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",

--- a/tests/e2e/framework/appManager.go
+++ b/tests/e2e/framework/appManager.go
@@ -18,8 +18,10 @@ import (
 	"flag"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/util"
 )
 
@@ -62,11 +64,11 @@ func (am *AppManager) generateAppYaml(a *App) error {
 	var err error
 	a.AppYaml, err = util.CreateTempfile(am.tmpDir, filepath.Base(a.AppYamlTemplate), yamlSuffix)
 	if err != nil {
-		glog.Errorf("Failed to generate yaml %s: %v", a.AppYamlTemplate, err)
+		log.Errorf("Failed to generate yaml %s: %v", a.AppYamlTemplate, err)
 		return err
 	}
 	if err := util.Fill(a.AppYaml, a.AppYamlTemplate, a.Template); err != nil {
-		glog.Errorf("Failed to generate yaml for template %s", a.AppYamlTemplate)
+		log.Errorf("Failed to generate yaml for template %s", a.AppYamlTemplate)
 		return err
 	}
 	return nil
@@ -81,16 +83,16 @@ func (am *AppManager) deploy(a *App) error {
 		var err error
 		finalYaml, err = util.CreateTempfile(am.tmpDir, kubeInjectPrefix, yamlSuffix)
 		if err != nil {
-			glog.Errorf("CreateTempfile failed %v", err)
+			log.Errorf("CreateTempfile failed %v", err)
 			return err
 		}
 		if err = am.istioctl.KubeInject(a.AppYaml, finalYaml); err != nil {
-			glog.Errorf("KubeInject failed %v", err)
+			log.Errorf("KubeInject failed %v", err)
 			return err
 		}
 	}
 	if err := util.KubeApply(am.namespace, finalYaml); err != nil {
-		glog.Errorf("Kubectl apply %s failed", finalYaml)
+		log.Errorf("Kubectl apply %s failed", finalYaml)
 		return err
 	}
 	return nil
@@ -98,11 +100,11 @@ func (am *AppManager) deploy(a *App) error {
 
 // Setup deploy apps
 func (am *AppManager) Setup() error {
-	glog.Info("Setting up apps")
+	log.Info("Setting up apps")
 	for _, a := range am.Apps {
-		glog.Infof("Setup %v", a)
+		log.Infof("Setup %v", a)
 		if err := am.deploy(a); err != nil {
-			glog.Errorf("error deploying %v: %v", a, err)
+			log.Errorf("error deploying %v: %v", a, err)
 			return err
 		}
 	}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -19,8 +19,10 @@ import (
 	"io/ioutil"
 	"os"
 	"sync"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
-	"github.com/golang/glog"
+	"istio.io/istio/pkg/log"
 )
 
 var (
@@ -58,18 +60,27 @@ type runnable interface {
 	Run() int
 }
 
-// InitGlog sets the logging directory.
+// InitLogging sets the logging directory.
 // Should be called right after flag.Parse().
-func InitGlog() error {
+func InitLogging() error {
+	// Create a temporary directory for any logging files.
 	tmpDir, err := ioutil.TempDir(os.TempDir(), tmpPrefix)
 	if err != nil {
 		return err
 	}
-	f := flag.Lookup("log_dir")
-	if err = f.Value.Set(tmpDir); err != nil {
+
+	// Configure Istio logging to use a file under the temp dir.
+	o := log.NewOptions()
+	tmpLogFile, err := ioutil.TempFile(tmpDir, tmpPrefix)
+	if err != nil {
 		return err
 	}
-	glog.Info("Logging initialized")
+	o.OutputPaths = []string{tmpLogFile.Name()}
+	if err := log.Configure(o); err != nil {
+		return err
+	}
+
+	log.Info("Logging initialized")
 	return nil
 }
 
@@ -79,7 +90,7 @@ func NewCommonConfig(testID string) (*CommonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := newKubeInfo(t.LogsPath, t.RunID)
+	k, err := newKubeInfo(t.TempDir, t.RunID)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +145,7 @@ func (t *testCleanup) popCleanupAction() func() error {
 
 func (t *testCleanup) init() error {
 	// Run setup on all cleanable
-	glog.Info("Starting Initialization")
+	log.Info("Starting Initialization")
 	c := t.popCleanable()
 	for c != nil {
 		err := c.Setup()
@@ -144,25 +155,25 @@ func (t *testCleanup) init() error {
 		}
 		c = t.popCleanable()
 	}
-	glog.Info("Initialization complete")
+	log.Info("Initialization complete")
 	return nil
 }
 
 func (t *testCleanup) cleanup() {
 	if t.skipCleanup {
-		glog.Info("Dev mode (--skip_cleanup), skipping cleanup (removal of namespace/install)")
+		log.Info("Dev mode (--skip_cleanup), skipping cleanup (removal of namespace/install)")
 		return
 	}
 	// Run tear down on all cleanable
-	glog.Info("Starting Cleanup")
+	log.Info("Starting Cleanup")
 	fn := t.popCleanupAction()
 	for fn != nil {
 		if err := fn(); err != nil {
-			glog.Errorf("Failed to cleanup. Error %s", err)
+			log.Errorf("Failed to cleanup. Error %s", err)
 		}
 		fn = t.popCleanupAction()
 	}
-	glog.Info("Cleanup complete")
+	log.Info("Cleanup complete")
 }
 
 // Save test logs to tmp dir
@@ -170,19 +181,19 @@ func (t *testCleanup) cleanup() {
 // Logs are uploaded during test tear down
 func (c *CommonConfig) saveLogs(r int) error {
 	if c.Cleanup.skipCleanup {
-		glog.Info("Dev mode (--skip_cleanup), skipping log fetching")
+		log.Info("Dev mode (--skip_cleanup), skipping log fetching")
 		return nil
 	}
 	if c.Info == nil {
-		glog.Warning("Skipping log saving as Info is not initialized")
+		log.Warn("Skipping log saving as Info is not initialized")
 		return nil
 	}
 	if c.Info.LogBucketPath == "" {
 		return nil
 	}
-	glog.Info("Saving logs")
+	log.Info("Saving logs")
 	if err := c.Info.Update(r); err != nil {
-		glog.Errorf("Could not create status file. Error %s", err)
+		log.Errorf("Could not create status file. Error %s", err)
 		return err
 	}
 	return c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace)
@@ -194,14 +205,14 @@ func (c *CommonConfig) saveLogs(r int) error {
 func (c *CommonConfig) RunTest(m runnable) int {
 	var ret int
 	if err := c.Cleanup.init(); err != nil {
-		glog.Errorf("Failed to complete Init. Error %s", err)
+		log.Errorf("Failed to complete Init. Error %s", err)
 		ret = 1
 	} else {
-		glog.Info("Running test")
+		log.Info("Running test")
 		ret = m.Run()
 	}
 	if err := c.saveLogs(ret); err != nil {
-		glog.Warningf("Log saving incomplete: %v", err)
+		log.Warnf("Log saving incomplete: %v", err)
 	}
 	c.Cleanup.cleanup()
 	return ret

--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -53,7 +53,7 @@ func newCommonConfig(testID string) (*CommonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := newKubeInfo(t.LogsPath, t.RunID)
+	k, err := newKubeInfo(t.TempDir, t.RunID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/e2e/framework/istioctl.go
+++ b/tests/e2e/framework/istioctl.go
@@ -23,8 +23,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/util"
 )
 
@@ -77,9 +79,9 @@ func NewIstioctl(yamlDir, namespace, istioNamespace, proxyHub, proxyTag string) 
 
 // Setup set up istioctl prerequest for tests, port forwarding
 func (i *Istioctl) Setup() error {
-	glog.Info("Setting up istioctl")
+	log.Info("Setting up istioctl")
 	if err := i.Install(); err != nil {
-		glog.Error("Failed to download istioctl")
+		log.Error("Failed to download istioctl")
 		return err
 	}
 	return nil
@@ -87,7 +89,7 @@ func (i *Istioctl) Setup() error {
 
 // Teardown clean up everything created by setup
 func (i *Istioctl) Teardown() error {
-	glog.Info("Cleaning up istioctl")
+	log.Info("Cleaning up istioctl")
 	return nil
 }
 
@@ -103,7 +105,7 @@ func (i *Istioctl) Install() error {
 		}
 		var usr, err = user.Current()
 		if err != nil {
-			glog.Error("Failed to get current user")
+			log.Error("Failed to get current user")
 			return err
 		}
 		homeDir := usr.HomeDir
@@ -119,12 +121,12 @@ func (i *Istioctl) Install() error {
 		}
 
 		if err = util.HTTPDownload(i.binaryPath, i.remotePath+"/istioctl-"+istioctlSuffix); err != nil {
-			glog.Error("Failed to download istioctl")
+			log.Error("Failed to download istioctl")
 			return err
 		}
 		err = os.Chmod(i.binaryPath, 0755) // #nosec
 		if err != nil {
-			glog.Error("Failed to add execute permission to istioctl")
+			log.Error("Failed to add execute permission to istioctl")
 			return err
 		}
 		i.binaryPath = fmt.Sprintf("%s -c %s/.kube/config", i.binaryPath, homeDir)
@@ -137,7 +139,7 @@ func (i *Istioctl) Install() error {
 func (i *Istioctl) run(format string, args ...interface{}) error {
 	format = i.binaryPath + " " + format
 	if _, err := util.Shell(format, args...); err != nil {
-		glog.Errorf("istioctl %s failed", args)
+		log.Errorf("istioctl %s failed", args)
 		return err
 	}
 	return nil

--- a/tests/e2e/tests/bookinfo/BUILD
+++ b/tests/e2e/tests/bookinfo/BUILD
@@ -9,8 +9,10 @@ go_test(
     ],
     tags = ["manual"],
     deps = [
+        "//pkg/log:go_default_library",
         "//tests/e2e/framework:go_default_library",
         "//tests/util:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],

--- a/tests/e2e/tests/mixer/BUILD
+++ b/tests/e2e/tests/mixer/BUILD
@@ -10,8 +10,10 @@ go_test(
     ],
     tags = ["manual"],
     deps = [
+        "//pkg/log:go_default_library",
         "//tests/e2e/framework:go_default_library",
         "//tests/util:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_prometheus_client_golang//api:go_default_library",
         "@com_github_prometheus_client_golang//api/prometheus/v1:go_default_library",

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -29,13 +29,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
 	"istio.io/fortio/fhttp"
 	"istio.io/fortio/periodic"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/e2e/framework"
 	"istio.io/istio/tests/util"
 )
@@ -92,12 +94,12 @@ func (t *testConfig) Setup() (err error) {
 		dest := filepath.Join(t.rulesDir, rule)
 		srcBytes, err = ioutil.ReadFile(src)
 		if err != nil {
-			glog.Errorf("Failed to read original rule file %s", src)
+			log.Errorf("Failed to read original rule file %s", src)
 			return err
 		}
 		err = ioutil.WriteFile(dest, srcBytes, 0600)
 		if err != nil {
-			glog.Errorf("Failed to write into new rule file %s", dest)
+			log.Errorf("Failed to write into new rule file %s", dest)
 			return err
 		}
 	}
@@ -112,7 +114,7 @@ func (t *testConfig) Setup() (err error) {
 	// request, but we want Mixer, etc., to be ready to go when the actual
 	// Tests start.
 	if err = visitProductPage(30*time.Second, 200); err != nil {
-		glog.Infof("initial product page request failed: %v", err)
+		log.Infof("initial product page request failed: %v", err)
 	}
 
 	allowPrometheusSync()
@@ -163,11 +165,11 @@ func dumpK8Env() {
 func podID(labelSelector string) (pod string, err error) {
 	pod, err = util.Shell("kubectl -n %s get pod -l %s -o jsonpath='{.items[0].metadata.name}'", tc.Kube.Namespace, labelSelector)
 	if err != nil {
-		glog.Warningf("could not get %s pod: %v", labelSelector, err)
+		log.Warnf("could not get %s pod: %v", labelSelector, err)
 		return
 	}
 	pod = strings.Trim(pod, "'")
-	glog.Infof("%s pod name: %s", labelSelector, pod)
+	log.Infof("%s pod name: %s", labelSelector, pod)
 	return
 }
 
@@ -176,7 +178,7 @@ func podLogs(labelSelector string, container string) {
 	if err != nil {
 		return
 	}
-	glog.Info("Expect and ignore an error getting crash logs when there are no crash (-p invocation)")
+	log.Info("Expect and ignore an error getting crash logs when there are no crash (-p invocation)")
 	_, _ = util.Shell("kubectl --namespace %s logs %s -c %s --tail=40 -p", tc.Kube.Namespace, pod, container)
 	_, _ = util.Shell("kubectl --namespace %s logs %s -c %s --tail=40", tc.Kube.Namespace, pod, container)
 }
@@ -191,16 +193,16 @@ func (p *promProxy) portForward(labelSelector string, localPort string, remotePo
 	if err != nil {
 		return err
 	}
-	glog.Infof("%s pod name: %s", labelSelector, pod)
+	log.Infof("%s pod name: %s", labelSelector, pod)
 
-	glog.Infof("Setting up %s proxy", labelSelector)
+	log.Infof("Setting up %s proxy", labelSelector)
 	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %s:%s -n %s", strings.Trim(pod, "'"), localPort, remotePort, p.namespace)
-	glog.Info(portFwdCmd)
+	log.Info(portFwdCmd)
 	if p.portFwdProcess, err = util.RunBackground(portFwdCmd); err != nil {
-		glog.Errorf("Failed to port forward: %s", err)
+		log.Errorf("Failed to port forward: %s", err)
 		return err
 	}
-	glog.Infof("running %s port-forward in background, pid = %d", labelSelector, p.portFwdProcess.Pid)
+	log.Infof("running %s port-forward in background, pid = %d", labelSelector, p.portFwdProcess.Pid)
 	return nil
 }
 
@@ -219,18 +221,18 @@ func (p *promProxy) Setup() error {
 }
 
 func (p *promProxy) Teardown() (err error) {
-	glog.Info("Cleaning up mixer proxy")
+	log.Info("Cleaning up mixer proxy")
 	if p.portFwdProcess != nil {
 		err := p.portFwdProcess.Kill()
 		if err != nil {
-			glog.Errorf("Failed to kill port-forward process, pid: %d", p.portFwdProcess.Pid)
+			log.Errorf("Failed to kill port-forward process, pid: %d", p.portFwdProcess.Pid)
 		}
 	}
 	return
 }
 func TestMain(m *testing.M) {
 	flag.Parse()
-	check(framework.InitGlog(), "cannot setup glog")
+	check(framework.InitLogging(), "cannot setup logging")
 	check(setTestConfig(), "could not create TestConfig")
 	tc.Cleanup.RegisterCleanable(tc)
 	os.Exit(tc.RunTest(m))
@@ -276,7 +278,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	}
 	allowPrometheusSync()
 
-	glog.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
 
 	query = fmt.Sprintf("istio_request_count{%s=\"%s\",%s=\"200\"}", destLabel, fqdn("productpage"), responseCodeLabel)
 	t.Logf("prometheus query: %s", query)
@@ -284,7 +286,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	glog.Infof("promvalue := %s", value.String())
+	log.Infof("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {
@@ -317,7 +319,7 @@ func TestTcpMetrics(t *testing.T) {
 	}
 	allowPrometheusSync()
 
-	glog.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
 
 	promAPI, err := promAPI()
 	if err != nil {
@@ -329,7 +331,7 @@ func TestTcpMetrics(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	glog.Infof("promvalue := %s", value.String())
+	log.Infof("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {
@@ -349,7 +351,7 @@ func TestTcpMetrics(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	glog.Infof("promvalue := %s", value.String())
+	log.Infof("promvalue := %s", value.String())
 
 	got, err = vectorValue(value, map[string]string{})
 	if err != nil {
@@ -381,7 +383,7 @@ func TestNewMetrics(t *testing.T) {
 		fatalf(t, "Test app setup failure: %v", err)
 	}
 
-	glog.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
 	allowPrometheusSync()
 	promAPI, err := promAPI()
 	if err != nil {
@@ -393,7 +395,7 @@ func TestNewMetrics(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	glog.Infof("promvalue := %s", value.String())
+	log.Infof("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {
@@ -416,7 +418,7 @@ func TestDenials(t *testing.T) {
 
 	// deny rule will deny all requests to product page unless
 	// ["x-user"] header is set.
-	glog.Infof("Denials: block productpage if x-user header is missing")
+	log.Infof("Denials: block productpage if x-user header is missing")
 	if err := applyMixerRule(denialRule); err != nil {
 		fatalf(t, "could not create required mixer rule: %v", err)
 	}
@@ -430,13 +432,13 @@ func TestDenials(t *testing.T) {
 	time.Sleep(10 * time.Second)
 
 	// Product page should not be accessible anymore.
-	glog.Infof("Denials: ensure productpage is denied access")
+	log.Infof("Denials: ensure productpage is denied access")
 	if err := visitProductPage(productPageTimeout, http.StatusForbidden, &header{"x-user", ""}); err != nil {
 		fatalf(t, "product page was not denied: %v", err)
 	}
 
 	// Product page *should be* accessible with x-user header.
-	glog.Infof("Denials: ensure productpage is accessible for testuser")
+	log.Infof("Denials: ensure productpage is accessible for testuser")
 	if err := visitProductPage(productPageTimeout, http.StatusOK, &header{"x-user", "testuser"}); err != nil {
 		fatalf(t, "product page was not denied: %v", err)
 	}
@@ -517,7 +519,7 @@ func TestRateLimit(t *testing.T) {
 	badReqs := res.RetCodes[http.StatusBadRequest]
 	actualDuration := res.ActualDuration.Seconds() // can be a bit more than requested
 
-	glog.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
 	t.Logf("Fortio Summary: %d reqs (%f rps, %f 200s (%f rps), %d 400s)",
 		totalReqs, res.ActualQPS, succReqs, succReqs/actualDuration, badReqs)
 
@@ -546,7 +548,7 @@ func TestRateLimit(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	glog.Infof("promvalue := %s", value.String())
+	log.Infof("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{responseCodeLabel: "429", "destination_version": "v1"})
 	if err != nil {
@@ -597,12 +599,12 @@ func TestRateLimit(t *testing.T) {
 }
 
 func allowRuleSync() {
-	glog.Info("Sleeping to allow rules to take effect...")
+	log.Info("Sleeping to allow rules to take effect...")
 	time.Sleep(1 * time.Minute)
 }
 
 func allowPrometheusSync() {
-	glog.Info("Sleeping to allow prometheus to record metrics...")
+	log.Info("Sleeping to allow prometheus to record metrics...")
 	time.Sleep(30 * time.Second)
 }
 
@@ -646,13 +648,13 @@ func vectorValue(val model.Value, labels map[string]string) (float64, error) {
 
 // checkProductPageDirect
 func checkProductPageDirect() {
-	glog.Info("checkProductPageDirect")
+	log.Info("checkProductPageDirect")
 	dumpURL("http://localhost:"+productPagePort+"/productpage", false)
 }
 
 // dumpMixerMetrics fetch metrics directly from mixer and dump them
 func dumpMixerMetrics() {
-	glog.Info("dumpMixerMetrics")
+	log.Info("dumpMixerMetrics")
 	dumpURL("http://localhost:"+mixerMetricsPort+"/metrics", true)
 }
 
@@ -661,9 +663,9 @@ func dumpURL(url string, dumpContents bool) {
 		Timeout: 1 * time.Minute,
 	}
 	status, contents, err := get(clnt, url)
-	glog.Infof("%s ==> %d, <%v>", url, status, err)
+	log.Infof("%s ==> %d, <%v>", url, status, err)
 	if dumpContents {
-		glog.Infoln(contents)
+		log.Infof("%v\n", contents)
 	}
 }
 
@@ -684,13 +686,13 @@ func get(clnt *http.Client, url string, headers ...*header) (status int, content
 	}
 	resp, err := clnt.Do(req)
 	if err != nil {
-		glog.Warningf("Error communicating with %s: %v", url, err)
+		log.Warnf("Error communicating with %s: %v", url, err)
 	} else {
-		glog.Infof("Get from %s: %s (%d)", url, resp.Status, resp.StatusCode)
+		log.Infof("Get from %s: %s (%d)", url, resp.Status, resp.StatusCode)
 		var ba []byte
 		ba, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			glog.Warningf("Unable to connect to read from %s: %v", url, err)
+			log.Warnf("Unable to connect to read from %s: %v", url, err)
 			return
 		}
 		contents = string(ba)
@@ -710,11 +712,11 @@ func visitProductPage(timeout time.Duration, wantStatus int, headers ...*header)
 	for {
 		status, _, err := get(clnt, url, headers...)
 		if err != nil {
-			glog.Warningf("Unable to connect to product page: %v", err)
+			log.Warnf("Unable to connect to product page: %v", err)
 		}
 
 		if status == wantStatus {
-			glog.Infof("Got %d response from product page!", wantStatus)
+			log.Infof("Got %d response from product page!", wantStatus)
 			return nil
 		}
 
@@ -767,7 +769,7 @@ func doMixerRule(ruleName string, do kubeDo) error {
 	rule := filepath.Join(tc.rulesDir, ruleName)
 	cb, err := ioutil.ReadFile(rule)
 	if err != nil {
-		glog.Errorf("Cannot read original yaml file %s", rule)
+		log.Errorf("Cannot read original yaml file %s", rule)
 		return err
 	}
 	contents := string(cb)
@@ -814,12 +816,13 @@ func setTestConfig() error {
 
 func check(err error, msg string) {
 	if err != nil {
-		glog.Fatalf("%s. Error %s", msg, err)
+		log.Errorf("%s. Error %s", msg, err)
+		os.Exit(-1)
 	}
 }
 
 func closeResponseBody(r *http.Response) {
 	if err := r.Body.Close(); err != nil {
-		glog.Error(err)
+		log.Errora(err)
 	}
 }

--- a/tests/e2e/tests/simple/BUILD.bazel
+++ b/tests/e2e/tests/simple/BUILD.bazel
@@ -6,8 +6,10 @@ go_test(
     data = [":test_yamls"],
     tags = ["manual"],
     deps = [
+        "//pkg/log:go_default_library",
         "//tests/e2e/framework:go_default_library",
         "//tests/util:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@io_istio_fortio//fhttp:go_default_library",
     ],

--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -12,6 +12,8 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
+        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_google_go_github//github:go_default_library",
         "@com_github_pmezard_go_difflib//difflib:go_default_library",

--- a/tests/util/retry.go
+++ b/tests/util/retry.go
@@ -17,7 +17,10 @@ package util
 import (
 	"time"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
+
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -67,7 +70,7 @@ func (r Retrier) Retry(fn func(retryIndex int) error) (int, error) {
 	var err error
 	var i int
 	if r.Retries <= 0 {
-		glog.Warningf("retries must to be >= 1. Got %d, setting to 1", r.Retries)
+		log.Warnf("retries must to be >= 1. Got %d, setting to 1", r.Retries)
 		r.Retries = 1
 	}
 	for i = 1; i <= r.Retries; i++ {

--- a/tests/util/wrk.go
+++ b/tests/util/wrk.go
@@ -21,7 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	// TODO(nmittler): Remove this
+	_ "github.com/golang/glog"
+
+	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -82,7 +85,7 @@ func (w *Wrk) Install() error {
 		}
 		err = HTTPDownload(w.BinaryPath, *wrkURL)
 		if err != nil {
-			glog.Error("Failed to download wrk")
+			log.Error("Failed to download wrk")
 			return err
 		}
 		err = os.Chmod(w.BinaryPath, 0755) // #nosec
@@ -101,7 +104,7 @@ func (w *Wrk) Install() error {
 func (w *Wrk) Run(format string, args ...interface{}) error {
 	format = w.BinaryPath + " " + format
 	if _, err := Shell(format, args...); err != nil {
-		glog.Errorf("wrk %s failed", args)
+		log.Errorf("wrk %s failed", args)
 		return err
 	}
 	return nil


### PR DESCRIPTION
This completes the transition from the entire Istio code base over
to the new Istio logging library (replacing glog).

The mapping is roughly as follows:

glog.Debug -> log.Debug
glog.Info -> log.Info
glog.Warning -> log.Warn
glog.Error -> log.Error
glog.Fatal -> log.Error + os.Exit(-1)
glog.V(1) -> log.Info
glog.V(2) -> log.Info
glog.V(3+) -> log.Debug
glog.Flush -> log.Sync

Partially addresses #2174

```release-note
None
```
