### PR TITLE
Make initializer deploy

### DIFF
--- a/install/kubernetes/templates/istio-initializer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-initializer.yaml.tmpl
@@ -53,7 +53,6 @@ spec:
           image: {PILOT_HUB}/sidecar_initializer:{PILOT_TAG}
           imagePullPolicy: IfNotPresent
           args:
-            - --port=8083
             - --namespace={ISTIO_NAMESPACE}
             - -v=2
           volumeMounts:


### PR DESCRIPTION
The initializer rejects the --port config option. This is a recent
change. I did test bookinfo as well as the addons with this change
although I don't understand the nature of the removal of --port
from the sidecar initializer.  The reviewer should take care to
verify that change was correct, or this solution is correct.