### PR TITLE
Log package fixes

### DIFF
--- a/mixer/cmd/mixs/cmd/root.go
+++ b/mixer/cmd/mixs/cmd/root.go
@@ -43,6 +43,13 @@ func GetRootCmd(args []string, info map[string]template.Info, adapters []adapter
 	rootCmd.SetArgs(args)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
+	// hack to make flag.Parsed return true such that glog is happy
+	// about the flags having been parsed
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	/* #nosec */
+	_ = fs.Parse([]string{})
+	flag.CommandLine = fs
+
 	rootCmd.AddCommand(serverCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(crdCmd(info, adapters, printf, fatalf))
 	rootCmd.AddCommand(validatorCmd(info, adapters, printf, fatalf))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -52,6 +52,8 @@
 package log
 
 import (
+	"time"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zapgrpc"
@@ -112,8 +114,11 @@ func configure(options *Options, b builder) error {
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
+
+			EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000Z0700"))
+			},
 		},
 
 		OutputPaths:       options.OutputPaths,


### PR DESCRIPTION
- Force time format output to UTC in order to get consistent output. Fixes #2227.

- Reintroduce the hack to make glog happy in the presence of cobra. This is necessary since even though we don't use glog anymore, we pull in libraries that do (like the k8s client libs). This should fix #2244, since glog was just sending logs to /tmp as it wasn't seeing the --logtostderr command-line option that was being given. 