### PR TITLE
Make 0.4.0 available in template and default to 0.3.0

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja.schema
+++ b/install/gcp/deployment_manager/istio-cluster.jinja.schema
@@ -43,10 +43,11 @@ properties:
   installIstioRelease:
     type: string
     description: Install Istio Release version.
-    default: 0.2.12
+    default: 0.3.0
     enum:
       - 0.2.12
       - 0.3.0
+      - 0.4.0
 
   enableBookInfoSample:
     type: boolean

--- a/install/gcp/deployment_manager/istio-cluster.yaml
+++ b/install/gcp/deployment_manager/istio-cluster.yaml
@@ -17,4 +17,4 @@ resources:
     enableZipkin: true
     enableServiceGraph: true
     enableBookInfoSample: true
-    installIstioRelease: 0.2.12
+    installIstioRelease: 0.3.0


### PR DESCRIPTION
Now that 0.4.0 is available, allow it as a selectable option in the Cloud Launcher api (and default to 0.3.0).

/cc @salrashid123