### PR TITLE
Updates bazel max supported version to 0.9.0

### DIFF
--- a/check_bazel_version.bzl
+++ b/check_bazel_version.bzl
@@ -14,7 +14,7 @@ def _parse_bazel_version(bazel_version):
 
 # acceptable min_version <= version <= max_version
 def check_version():
-    check_bazel_version("0.5.4", "0.8.99")
+    check_bazel_version("0.5.4", "0.9.99")
 
 # acceptable min_version <= version <= max_version
 def check_bazel_version(min_version, max_version):


### PR DESCRIPTION
Fixes Issue: https://github.com/istio/istio/issues/2264

With this PR, istio builds using bazel 0.9.0:
```
$ make build
<SNIP>
bazel  build  //...
...........
INFO: Analysed 455 targets (748 packages loaded).
INFO: Found 455 targets...
INFO: Elapsed time: 406.458s, Critical Path: 53.54s
INFO: Build completed successfully, 1873 total actions
```