### PR TITLE
remove /TMP workdir workaround

### DIFF
--- a/mixer/docker/Dockerfile
+++ b/mixer/docker/Dockerfile
@@ -2,8 +2,6 @@ FROM scratch
 
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
-# All containers need a /tmp directory
-WORKDIR /tmp/
 ADD mixs /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/mixs", "server"]

--- a/mixer/docker/Dockerfile.debug
+++ b/mixer/docker/Dockerfile.debug
@@ -2,7 +2,7 @@ FROM gcr.io/istio-testing/ubuntu_xenial_debug:3f57ae2aceef79e4000fb07ec850bbf4bc
 
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
-WORKDIR /tmp/
 ADD mixs /usr/local/bin/
+
 ENTRYPOINT ["/usr/local/bin/mixs", "server"]
 CMD ["--configStoreURL=fs:///etc/opt/mixer/configroot","--configStore2URL=k8s://","--logtostderr","--v=2"]

--- a/security/docker/Dockerfile.istio-ca
+++ b/security/docker/Dockerfile.istio-ca
@@ -2,8 +2,6 @@ FROM scratch
 
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
-# All containers need a /tmp directory
-WORKDIR /tmp/
 ADD istio_ca /usr/local/bin/istio_ca
 
 ENTRYPOINT [ "/usr/local/bin/istio_ca", "--self-signed-ca" ]

--- a/security/docker/Dockerfile.istio-ca
+++ b/security/docker/Dockerfile.istio-ca
@@ -2,6 +2,8 @@ FROM scratch
 
 # obtained from debian ca-certs deb using fetch_cacerts.sh
 ADD ca-certificates.tgz /
+# All containers need a /tmp directory
+WORKDIR /tmp/
 ADD istio_ca /usr/local/bin/istio_ca
 
 ENTRYPOINT [ "/usr/local/bin/istio_ca", "--self-signed-ca" ]


### PR DESCRIPTION
Mixer no longer needs to write to /tmp.

/tmp WORKDIR workaround is removed from docker files.