### PR TITLE
Replace the logging time formatter with a much faster version.

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -115,10 +115,7 @@ func configure(options *Options, b builder) error {
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 			EncodeDuration: zapcore.StringDurationEncoder,
-
-			EncodeTime: func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-				enc.AppendString(t.UTC().Format("2006-01-02T15:04:05.000Z0700"))
-			},
+			EncodeTime:     formatDate,
 		},
 
 		OutputPaths:       options.OutputPaths,
@@ -149,6 +146,45 @@ func configure(options *Options, b builder) error {
 	grpclog.SetLogger(zapgrpc.NewLogger(logger.WithOptions(zap.AddCallerSkip(2))))
 
 	return nil
+}
+
+func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	t = t.UTC()
+	year, month, day := t.Date()
+	hour, minute, second := t.Clock()
+	micros := t.Nanosecond() / 1000
+
+	buf := make([]byte, 27)
+
+	buf[0] = (byte(year/1000) % 10) + '0'
+	buf[1] = (byte(year/100) % 10) + '0'
+	buf[2] = (byte(year/10) % 10) + '0'
+	buf[3] = (byte(year) % 10) + '0'
+	buf[4] = '-'
+	buf[5] = (byte(month) / 10) + '0'
+	buf[6] = (byte(month) % 10) + '0'
+	buf[7] = '-'
+	buf[8] = (byte(day) / 10) + '0'
+	buf[9] = (byte(day) % 10) + '0'
+	buf[10] = 'T'
+	buf[11] = (byte(hour) / 10) + '0'
+	buf[12] = (byte(hour) % 10) + '0'
+	buf[13] = ':'
+	buf[14] = (byte(minute) / 10) + '0'
+	buf[15] = (byte(minute) % 10) + '0'
+	buf[16] = ':'
+	buf[17] = (byte(second) / 10) + '0'
+	buf[18] = (byte(second) % 10) + '0'
+	buf[19] = '.'
+	buf[20] = (byte(micros/100000) % 10) + '0'
+	buf[21] = (byte(micros/10000) % 10) + '0'
+	buf[22] = (byte(micros/1000) % 10) + '0'
+	buf[23] = (byte(micros/100) % 10) + '0'
+	buf[24] = (byte(micros/10) % 10) + '0'
+	buf[25] = (byte(micros) % 10) + '0'
+	buf[26] = 'Z'
+
+	enc.AppendString(string(buf))
 }
 
 // Debug outputs a message at debug level.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -29,6 +29,8 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
+const timePattern = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9][0-9][0-9][0-9]Z"
+
 func TestBasic(t *testing.T) {
 	cases := []struct {
 		f          func()
@@ -37,40 +39,44 @@ func TestBasic(t *testing.T) {
 		caller     bool
 		stackLevel zapcore.Level
 	}{
-		{func() { Debug("Hello") }, ".*Z\tdebug\tHello", false, false, None},
-		{func() { Debugf("Hello") }, ".*Z\tdebug\tHello", false, false, None},
-		{func() { Debugw("Hello") }, ".*Z\tdebug\tHello", false, false, None},
-		{func() { Debuga("Hello") }, ".*Z\tdebug\tHello", false, false, None},
+		{func() { Debug("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
+		{func() { Debugf("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
+		{func() { Debugw("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
+		{func() { Debuga("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
 
-		{func() { Info("Hello") }, ".*Z\tinfo\tHello", false, false, None},
-		{func() { Infof("Hello") }, ".*Z\tinfo\tHello", false, false, None},
-		{func() { Infow("Hello") }, ".*Z\tinfo\tHello", false, false, None},
-		{func() { Infoa("Hello") }, ".*Z\tinfo\tHello", false, false, None},
+		{func() { Info("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
+		{func() { Infof("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
+		{func() { Infow("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
+		{func() { Infoa("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
 
-		{func() { Warn("Hello") }, ".*Z\twarn\tHello", false, false, None},
-		{func() { Warnf("Hello") }, ".*Z\twarn\tHello", false, false, None},
-		{func() { Warnw("Hello") }, ".*Z\twarn\tHello", false, false, None},
-		{func() { Warna("Hello") }, ".*Z\twarn\tHello", false, false, None},
+		{func() { Warn("Hello") }, timePattern + "\twarn\tHello", false, false, None},
+		{func() { Warnf("Hello") }, timePattern + "\twarn\tHello", false, false, None},
+		{func() { Warnw("Hello") }, timePattern + "\twarn\tHello", false, false, None},
+		{func() { Warna("Hello") }, timePattern + "\twarn\tHello", false, false, None},
 
-		{func() { Error("Hello") }, ".*Z\terror\tHello", false, false, None},
-		{func() { Errorf("Hello") }, ".*Z\terror\tHello", false, false, None},
-		{func() { Errorw("Hello") }, ".*Z\terror\tHello", false, false, None},
-		{func() { Errora("Hello") }, ".*Z\terror\tHello", false, false, None},
+		{func() { Error("Hello") }, timePattern + "\terror\tHello", false, false, None},
+		{func() { Errorf("Hello") }, timePattern + "\terror\tHello", false, false, None},
+		{func() { Errorw("Hello") }, timePattern + "\terror\tHello", false, false, None},
+		{func() { Errora("Hello") }, timePattern + "\terror\tHello", false, false, None},
 
 		{func() {
 			l := With(zap.String("key", "value"))
 			l.Debug("Hello")
-		}, ".*Z\tdebug\tHello\t{\"key\": \"value\"}", false, false, None},
+		}, timePattern + "\tdebug\tHello\t{\"key\": \"value\"}", false, false, None},
 
-		{func() { Debug("Hello") }, ".*Z\tdebug\tlog/log_test.go:.*\tHello", false, true, None},
+		{func() { Debug("Hello") }, timePattern + "\tdebug\tlog/log_test.go:.*\tHello", false, true, None},
 
-		{func() { Debug("Hello") }, "{\"level\":\"debug\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+		{func() { Debug("Hello") }, "{\"level\":\"debug\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
+			"\"stack\":\".*\"}",
 			true, true, zapcore.DebugLevel},
-		{func() { Info("Hello") }, "{\"level\":\"info\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+		{func() { Info("Hello") }, "{\"level\":\"info\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
+			"\"stack\":\".*\"}",
 			true, true, zapcore.DebugLevel},
-		{func() { Warn("Hello") }, "{\"level\":\"warn\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+		{func() { Warn("Hello") }, "{\"level\":\"warn\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
+			"\"stack\":\".*\"}",
 			true, true, zapcore.DebugLevel},
-		{func() { Error("Hello") }, "{\"level\":\"error\",\"time\":\".*T.*Z\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\",\"stack\":\".*\"}",
+		{func() { Error("Hello") }, "{\"level\":\"error\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
+			"\"stack\":\".*\"}",
 			true, true, zapcore.DebugLevel},
 	}
 
@@ -190,9 +196,9 @@ func TestCapture(t *testing.T) {
 	})
 
 	patterns := []string{
-		".*Z\tinfo\tlog/log_test.go:.*\tHello",
-		".*Z\tinfo\tlog/log_test.go:.*\tThere",
-		".*Z\tinfo\tlog/log_test.go:.*\tGoodbye",
+		timePattern + "\tinfo\tlog/log_test.go:.*\tHello",
+		timePattern + "\tinfo\tlog/log_test.go:.*\tThere",
+		timePattern + "\tinfo\tlog/log_test.go:.*\tGoodbye",
 	}
 
 	for i, pat := range patterns {


### PR DESCRIPTION
Execution time went from ~340ns to ~85ns. We also now log to microsecond precision instead of merely milliseconds.