### PR TITLE
Removes sidecar initializer port leftovers from PR #2209

### DIFF
--- a/install/kubernetes/templates/istio-initializer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-initializer.yaml.tmpl
@@ -53,7 +53,6 @@ spec:
           image: {PILOT_HUB}/sidecar_initializer:{PILOT_TAG}
           imagePullPolicy: IfNotPresent
           args:
-            - --port=8083
             - --namespace={ISTIO_NAMESPACE}
             - -v=2
           volumeMounts:

--- a/pilot/cmd/sidecar-initializer/main.go
+++ b/pilot/cmd/sidecar-initializer/main.go
@@ -34,7 +34,6 @@ func getRootCmd() *cobra.Command {
 		meshconfig   string
 		injectConfig string
 		namespace    string
-		port         int
 	}{}
 
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
PR https://github.com/istio/istio/pull/2209 removed the http injection endpoint from the sidecar initializer. In doing so, the --port flag was removed. However, the flags struct still contained a port field and the sidecar initializer kube deployment template continued to specify the `--port` flag causing the initializer pod to fail starting-up.

Fixes Issue: https://github.com/istio/issues/issues/141