### PR TITLE
update (/revert) issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,4 +1,7 @@
 <!--
-Please see https://istio.io/troubleshooting for potential workarounds.
+Please see https://istio.io/troubleshooting/ and if you are a user of Istio, please file issues in
+https://github.com/istio/issues/issues instead of here
+
+Only confirmed, triaged and labelled issues should be filled here.
 Please add the correct labels and epics (and priority and milestones if you have that information)
 -->

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,7 +1,7 @@
 <!--
-Please see https://istio.io/troubleshooting/ and if you are a user of Istio, please file issues in
-https://github.com/istio/issues/issues instead of here
+Please see https://istio.io/help and if you are a user of Istio, please file issues in
+https://github.com/istio/issues/issues instead of here.
 
-Only confirmed, triaged and labelled issues should be filled here.
+Only confirmed, triaged and labelled issues should be filed here.
 Please add the correct labels and epics (and priority and milestones if you have that information)
 -->


### PR DESCRIPTION
There has been a slew of un-labeled and user-support type of issues filled directly against istio/istio

We should stick to triaging in istio/issues before promoting dev reviewed 'real' issues with labels etc