### PR TITLE
Refactor pkg/server tracing args and expose dispatcher for testing.

### DIFF
--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -95,6 +95,11 @@ type Args struct {
 	LoggingOptions *log.Options
 }
 
+// EnableTracing detects whether tracing should be enabled by introspecting tracing related argument values.
+func (a *Args) EnableTracing() bool {
+	return len(a.ZipkinURL) > 0 || len(a.JaegerURL) > 0 || a.LogTraceSpans
+}
+
 // NewArgs allocates an Args struct initialized with Mixer's default configuration.
 func NewArgs() *Args {
 	return &Args{

--- a/mixer/pkg/server/args_test.go
+++ b/mixer/pkg/server/args_test.go
@@ -50,3 +50,29 @@ func TestString(t *testing.T) {
 	s := a.String()
 	t.Log(s)
 }
+
+func TestEnableTracing(t *testing.T) {
+	a := NewArgs()
+
+	if a.EnableTracing() {
+		t.Fatal("default arg values should not have enabled tracing")
+	}
+
+	a = NewArgs()
+	a.LogTraceSpans = true
+	if !a.EnableTracing() {
+		t.Fatal("logTraceSpans should have trigged tracing")
+	}
+
+	a = NewArgs()
+	a.ZipkinURL = "http://foo.bar.com"
+	if !a.EnableTracing() {
+		t.Fatal("zipkinURL should have trigged tracing")
+	}
+
+	a = NewArgs()
+	a.JaegerURL = "http://foo.bar.com"
+	if !a.EnableTracing() {
+		t.Fatal("jaegerURL should have trigged tracing")
+	}
+}

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -118,6 +118,11 @@ func TestBasic(t *testing.T) {
 		t.Fatalf("Unable to create server: %v", err)
 	}
 
+	d := s.GetDispatcherForTesting()
+	if d != s.dispatcherForTesting {
+		t.Fatalf("returned dispatcher is incorrect")
+	}
+
 	err = s.Close()
 	if err != nil {
 		t.Errorf("Got error during Close: %v", err)
@@ -172,6 +177,7 @@ func TestErrors(t *testing.T) {
 	a.MonitoringPort = 0
 	a.GlobalConfig = globalCfg
 	a.ServiceConfig = serviceCfg
+	a.LogTraceSpans = true
 
 	for i := 0; i < 20; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -208,7 +214,7 @@ func TestErrors(t *testing.T) {
 				return
 			}
 
-			s, err := new(a, pt)
+			s, err := newServer(a, pt)
 			if s != nil || err == nil {
 				t.Errorf("Got success, expecting error")
 			}

--- a/mixer/pkg/server/tracing.go
+++ b/mixer/pkg/server/tracing.go
@@ -36,26 +36,24 @@ func startTracer(zipkinURL string, jaegerURL string, logTraceSpans bool) (*mixer
 	var err error
 	var interceptor grpc.UnaryServerInterceptor
 
-	if len(zipkinURL) > 0 || len(jaegerURL) > 0 || logTraceSpans {
-		opts := make([]tracing.Option, 0, 3)
-		if len(zipkinURL) > 0 {
-			opts = append(opts, tracing.WithZipkinCollector(zipkinURL))
-		}
-		if len(jaegerURL) > 0 {
-			opts = append(opts, tracing.WithJaegerHTTPCollector(jaegerURL))
-		}
-		if logTraceSpans {
-			opts = append(opts, tracing.WithLogger())
-		}
-		tracer, closer, err = tracing.NewTracer("istio-mixer", opts...)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not create tracer: %v", err)
-		}
-
-		// NOTE: global side effect!
-		ot.SetGlobalTracer(tracer)
-		interceptor = otgrpc.OpenTracingServerInterceptor(tracer)
+	opts := make([]tracing.Option, 0, 3)
+	if len(zipkinURL) > 0 {
+		opts = append(opts, tracing.WithZipkinCollector(zipkinURL))
 	}
+	if len(jaegerURL) > 0 {
+		opts = append(opts, tracing.WithJaegerHTTPCollector(jaegerURL))
+	}
+	if logTraceSpans {
+		opts = append(opts, tracing.WithLogger())
+	}
+	tracer, closer, err = tracing.NewTracer("istio-mixer", opts...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not create tracer: %v", err)
+	}
+
+	// NOTE: global side effect!
+	ot.SetGlobalTracer(tracer)
+	interceptor = otgrpc.OpenTracingServerInterceptor(tracer)
 
 	return &mixerTracer{
 		closer: closer,


### PR DESCRIPTION
Two changes to pkg/server:
- Adding an aggregate EnableTracing() method to check whether tracing should be enabled or not. This way, we can conditionally log trace spans (which will come in a later PR).
- Expose runtime.Dispatcher for testing purposes. This helps when writing perf tests that directly target runtime.Dispatcher interface.