### PR TITLE
Resolve two problems with depend target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ depend.status: Gopkg.lock ; $(info $(H) reporting dependencies status...)
 # @todo only run if there are changes (e.g., create a checksum file?) 
 # Update the vendor dir, pulling latest compatible dependencies from the
 # defined branches.
-depend.ensure: Gopkg.lock ${GOPATH}/bin/dep; $(info $(H) ensuring dependencies are up to date...)
+depend.ensure: ${GOPATH}/bin/dep; $(info $(H) ensuring dependencies are up to date...)
 	$(Q) dep ensure
 
 depend.graph: Gopkg.lock ; $(info $(H) visualizing dependency graph...)


### PR DESCRIPTION
In the depend target, if dep isn't already installed, the Makefile
always fails  because the ordering of the dep installation and
the usage of dep are in the wrong order.

In the depend target, there is no need to have depend.ensure depend
on Gopkg.lock as it fails on the first run of a clean system (-update
won't work if there is no existing lock file), and depend.ensure always
runs dep ensure.