### PR TITLE
Add function parameter support to mixer/pkg/pool.GoRoutinePool

### DIFF
--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -205,7 +205,7 @@ func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
 		}
 
 		wg.Add(1)
-		gp.ScheduleWork(func() {
+		gp.ScheduleWorkNoParam(func() {
 			if _, err := bs.client.Check(context.Background(), request); err != nil {
 				b.Errorf("Check2 failed with %v", err)
 			}

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -205,12 +205,12 @@ func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
 		}
 
 		wg.Add(1)
-		gp.ScheduleWorkNoParam(func() {
+		gp.ScheduleWork(func(_ interface{}) {
 			if _, err := bs.client.Check(context.Background(), request); err != nil {
 				b.Errorf("Check2 failed with %v", err)
 			}
 			wg.Done()
-		})
+		}, nil)
 	}
 
 	// wait for all the async work to be done

--- a/mixer/pkg/pool/goroutine.go
+++ b/mixer/pkg/pool/goroutine.go
@@ -56,23 +56,15 @@ func (gp *GoroutinePool) Close() error {
 
 // ScheduleWork registers the given function to be executed at some point. The given param will
 // be supplied to the function during execution.
+//
+// By making use of the supplied parameter, it is possible to avoid allocation costs when scheduling the
+// work function. The caller needs to make sure that function fn only depends on external data through the
+// passed in param interface{} and nothing else.
 func (gp *GoroutinePool) ScheduleWork(fn WorkFunc, param interface{}) {
 	if gp.singleThreaded {
 		fn(param)
 	} else {
 		gp.queue <- work{fn: fn, param: param}
-	}
-}
-
-// ScheduleWorkNoParam registers the given function to be executed at some point.
-// Prefer ScheduleWork instead, if possible. By passing the parameter on the side, it is possible to avoid
-// extra allocations. However, using this method almost always guarantees allocation due to the inherent
-// need of a closure for any meaningful work.
-func (gp *GoroutinePool) ScheduleWorkNoParam(fn func()) {
-	if gp.singleThreaded {
-		fn()
-	} else {
-		gp.queue <- work{fn: runParameterlessFn, param: fn}
 	}
 }
 

--- a/mixer/pkg/pool/goroutine_test.go
+++ b/mixer/pkg/pool/goroutine_test.go
@@ -19,31 +19,6 @@ import (
 	"testing"
 )
 
-func TestWorkerPoolWithNoParam(t *testing.T) {
-	const numWorkers = 123
-	const numWorkItems = 456
-
-	for i := 0; i < 2; i++ {
-		gp := NewGoroutinePool(128, i == 0)
-		gp.AddWorkers(numWorkers)
-
-		wg := &sync.WaitGroup{}
-		wg.Add(numWorkItems)
-
-		for i := 0; i < numWorkItems; i++ {
-			gp.ScheduleWorkNoParam(func() {
-				wg.Done()
-			})
-		}
-
-		// wait for all the functions to have run
-		wg.Wait()
-
-		// make sure the pool can be shutdown cleanly
-		gp.Close()
-	}
-}
-
 func TestWorkerPool(t *testing.T) {
 	const numWorkers = 123
 	const numWorkItems = 456

--- a/mixer/pkg/pool/goroutine_test.go
+++ b/mixer/pkg/pool/goroutine_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestWorkerPool(t *testing.T) {
+func TestWorkerPoolWithNoParam(t *testing.T) {
 	const numWorkers = 123
 	const numWorkItems = 456
 
@@ -31,7 +31,7 @@ func TestWorkerPool(t *testing.T) {
 		wg.Add(numWorkItems)
 
 		for i := 0; i < numWorkItems; i++ {
-			gp.ScheduleWork(func() {
+			gp.ScheduleWorkNoParam(func() {
 				wg.Done()
 			})
 		}
@@ -44,7 +44,7 @@ func TestWorkerPool(t *testing.T) {
 	}
 }
 
-func TestWorkerPoolWithParam(t *testing.T) {
+func TestWorkerPool(t *testing.T) {
 	const numWorkers = 123
 	const numWorkItems = 456
 
@@ -59,7 +59,7 @@ func TestWorkerPoolWithParam(t *testing.T) {
 
 		for i := 0; i < numWorkItems; i++ {
 			passedParam := i // capture the parameter on stack to avoid closing on the loop variable.
-			gp.ScheduleWorkWithParam(func(param interface{}) {
+			gp.ScheduleWork(func(param interface{}) {
 				paramI := param.(int)
 				if paramI != passedParam {
 					parameterMismatch = true

--- a/mixer/pkg/runtime/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher.go
@@ -404,7 +404,7 @@ func safeDispatch(ctx context.Context, do dispatchFn, op string) (res *result) {
 func (m *dispatcher) runAsync(ctx context.Context, callinfo *Action, results chan *result, do dispatchFn) {
 	log.Debugf("runAsync %v", *callinfo)
 
-	m.gp.ScheduleWorkNoParam(func() {
+	m.gp.ScheduleWork(func(_ interface{}) {
 		// tracing
 		op := callinfo.processor.Name + ":" + callinfo.handlerName + "(" + callinfo.adapterName + ")"
 		span, ctx := opentracing.StartSpanFromContext(ctx, op)
@@ -442,5 +442,5 @@ func (m *dispatcher) runAsync(ctx context.Context, callinfo *Action, results cha
 
 		results <- out
 		span.Finish()
-	})
+	}, nil)
 }

--- a/mixer/pkg/runtime/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher.go
@@ -404,7 +404,7 @@ func safeDispatch(ctx context.Context, do dispatchFn, op string) (res *result) {
 func (m *dispatcher) runAsync(ctx context.Context, callinfo *Action, results chan *result, do dispatchFn) {
 	log.Debugf("runAsync %v", *callinfo)
 
-	m.gp.ScheduleWork(func() {
+	m.gp.ScheduleWorkNoParam(func() {
 		// tracing
 		op := callinfo.processor.Name + ":" + callinfo.handlerName + "(" + callinfo.adapterName + ")"
 		span, ctx := opentracing.StartSpanFromContext(ctx, op)

--- a/mixer/pkg/runtime/env.go
+++ b/mixer/pkg/runtime/env.go
@@ -36,7 +36,7 @@ func (e env) Logger() adapter.Logger {
 }
 
 func (e env) ScheduleWork(fn adapter.WorkFunc) {
-	e.gp.ScheduleWorkNoParam(func() {
+	e.gp.ScheduleWork(func(_ interface{}) {
 		defer func() {
 			if r := recover(); r != nil {
 				_ = e.Logger().Errorf("Adapter worker failed: %v", r) // nolint: gas
@@ -49,7 +49,7 @@ func (e env) ScheduleWork(fn adapter.WorkFunc) {
 		}()
 
 		fn()
-	})
+	}, nil)
 }
 
 func (e env) ScheduleDaemon(fn adapter.DaemonFunc) {

--- a/mixer/pkg/runtime/env.go
+++ b/mixer/pkg/runtime/env.go
@@ -36,7 +36,7 @@ func (e env) Logger() adapter.Logger {
 }
 
 func (e env) ScheduleWork(fn adapter.WorkFunc) {
-	e.gp.ScheduleWork(func() {
+	e.gp.ScheduleWorkNoParam(func() {
 		defer func() {
 			if r := recover(); r != nil {
 				_ = e.Logger().Errorf("Adapter worker failed: %v", r) // nolint: gas


### PR DESCRIPTION
The current model of scheduling func(){} types causes the caller to
(almost) always create closure over the state that the function needs
to operate on.

This PR introduces the ability to schedule functions that takes
parameters and also the ability to pass those parameters on the side.