### PR TITLE
Add in consul datacenter (AvailabilityZone) support

### DIFF
--- a/pilot/cmd/pilot-discovery/server/server.go
+++ b/pilot/cmd/pilot-discovery/server/server.go
@@ -431,8 +431,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		case ConsulRegistry:
 			log.Infof("Consul url: %v", args.Service.Consul.ServerURL)
 			conctl, conerr := consul.NewController(
-				// TODO: Remove this hardcoding!
-				args.Service.Consul.ServerURL, "dc1", 2*time.Second)
+				args.Service.Consul.ServerURL, 2*time.Second)
 			if conerr != nil {
 				return fmt.Errorf("failed to create Consul controller: %v", conerr)
 			}

--- a/pilot/platform/consul/controller.go
+++ b/pilot/platform/consul/controller.go
@@ -27,21 +27,19 @@ import (
 
 // Controller communicates with Consul and monitors for changes
 type Controller struct {
-	client     *api.Client
-	dataCenter string
-	monitor    Monitor
+	client  *api.Client
+	monitor Monitor
 }
 
 // NewController creates a new Consul controller
-func NewController(addr, datacenter string, interval time.Duration) (*Controller, error) {
+func NewController(addr string, interval time.Duration) (*Controller, error) {
 	conf := api.DefaultConfig()
 	conf.Address = addr
 
 	client, err := api.NewClient(conf)
 	return &Controller{
-		monitor:    NewConsulMonitor(client, interval),
-		client:     client,
-		dataCenter: datacenter,
+		monitor: NewConsulMonitor(client, interval),
+		client:  client,
 	}, err
 }
 

--- a/pilot/platform/consul/controller_test.go
+++ b/pilot/platform/consul/controller_test.go
@@ -130,7 +130,7 @@ func newServer() *mockServer {
 func TestInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestInstances(t *testing.T) {
 func TestInstancesBadHostname(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestInstancesBadHostname(t *testing.T) {
 
 func TestInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		ts.Server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -227,7 +227,7 @@ func TestInstancesError(t *testing.T) {
 func TestGetService(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -248,7 +248,7 @@ func TestGetService(t *testing.T) {
 
 func TestGetServiceError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		ts.Server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -267,7 +267,7 @@ func TestGetServiceError(t *testing.T) {
 func TestGetServiceBadHostname(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -284,7 +284,7 @@ func TestGetServiceBadHostname(t *testing.T) {
 func TestGetServiceNoInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestGetServiceNoInstances(t *testing.T) {
 func TestServices(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -333,7 +333,7 @@ func TestServices(t *testing.T) {
 
 func TestServicesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		ts.Server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)
@@ -352,7 +352,7 @@ func TestServicesError(t *testing.T) {
 func TestHostInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
@@ -373,7 +373,7 @@ func TestHostInstances(t *testing.T) {
 
 func TestHostInstancesError(t *testing.T) {
 	ts := newServer()
-	controller, err := NewController(ts.Server.URL, "datacenter", 3*time.Second)
+	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
 		ts.Server.Close()
 		t.Errorf("could not create Consul Controller: %v", err)

--- a/pilot/platform/consul/conversion.go
+++ b/pilot/platform/consul/conversion.go
@@ -110,7 +110,7 @@ func convertInstance(instance *api.CatalogService) *model.ServiceInstance {
 			Port:        instance.ServicePort,
 			ServicePort: port,
 		},
-
+		AvailabilityZone: instance.Datacenter,
 		Service: &model.Service{
 			Hostname: serviceHostname(instance.ServiceName),
 			Address:  instance.ServiceAddress,

--- a/pilot/platform/consul/conversion_test.go
+++ b/pilot/platform/consul/conversion_test.go
@@ -79,6 +79,7 @@ func TestConvertInstance(t *testing.T) {
 	tagVal1 := "v1"
 	tagKey2 := "zone"
 	tagVal2 := "prod"
+	dc := "dc1"
 	consulServiceInst := api.CatalogService{
 		Node:        "istio-node",
 		Address:     "172.19.0.5",
@@ -90,6 +91,7 @@ func TestConvertInstance(t *testing.T) {
 		},
 		ServiceAddress: ip,
 		ServicePort:    port,
+		Datacenter:     dc,
 		NodeMeta:       map[string]string{protocolTagName: protocol},
 	}
 
@@ -105,6 +107,10 @@ func TestConvertInstance(t *testing.T) {
 
 	if out.Endpoint.ServicePort.Port != port {
 		t.Errorf("convertInstance() => %v, want %v", out.Endpoint.ServicePort.Port, port)
+	}
+
+	if out.AvailabilityZone != dc {
+		t.Errorf("convertInstance() => %v, want %v", out.AvailabilityZone, dc)
 	}
 
 	if out.Endpoint.Address != ip {


### PR DESCRIPTION
What this PR does / why we need it: Currently we only support AZ routing for kube based service registries. This enables it for consul.

Which issue this PR fixes:
Continues on from: istio/old_pilot_repo#1230, #2054 and #1815
Working towards: #1473

Release note:

Enable consul intra-datacenter routing with AvailabilityZone