### PR TITLE
Tidy up installing the pre-commit hook

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -152,7 +152,7 @@ passes local tests before being committed.
 
 Run
 ```shell
-user@host:~/GOHOME/src/istio.io/istio$ ./bin/pre-commit
+./bin/pre-commit
 Installing pre-commit hook
 ```
 This hook is invoked every time you commit changes locally.


### PR DESCRIPTION
This PR removes the preamble from the command for consistency with the rest of the instructions.
