### PR TITLE
Fix bug where az was set for non-200 responses from Pilot

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -125,8 +125,13 @@ var (
 				if err != nil {
 					log.Infof("Error reading availability zone response from pilot: %v", err)
 				}
-				availabilityZone = string(body)
-				log.Infof("Proxy availability zone: %v", availabilityZone)
+				if azResp.StatusCode != http.StatusOK {
+					log.Infof("Received %q status from pilot when retrieving availability zone: %v", azResp.StatusCode, string(body))
+				} else {
+					availabilityZone = string(body)
+					log.Infof("Proxy availability zone: %v", availabilityZone)
+				}
+
 			}
 
 			log.Infof("Proxy role: %#v", role)


### PR DESCRIPTION
What this PR does / why we need it: Fixes a bug in pilot whereby if the agent receives a non-200 response code from Pilot it will set the AZ to be the error message.

Which issue this PR fixes: #2353 (Fixes one of the two issues seen)


Release note:
```
Fix bug where az was set for non-200 responses from Pilot
```

  