### PR TITLE
Fix #2389 add missing jinja files to install folder

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -106,7 +106,13 @@ function create_windows_archive() {
 
 pushd "${OUTPUT_PATH}"
 ${CP} istio.VERSION LICENSE README.md "${COMMON_FILES_DIR}"/
-find samples install -type f \( -name "*.yaml" -o -name "cleanup*" -o -name "*.md" -o -name "kubeconfig" \) \
+find samples install -type f \( \
+  -name "*.yaml" \
+  -o -name "cleanup*" \
+  -o -name "*.md" \
+  -o -name "kubeconfig" \
+  -o -name "*.jinja*" \
+  \) \
   -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 find install/tools -type f -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 popd


### PR DESCRIPTION
This includes all the files but `BUILD` files in `install` folder when creating the release packages.