### PR TITLE
Make Istio log levels type safe

### DIFF
--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 
 	mixerpb "istio.io/api/mixer/v1"
@@ -446,6 +445,6 @@ func TestFailingPreproc(t *testing.T) {
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.NewOptions()
-	o.SetOutputLevel(zapcore.DebugLevel)
+	o.SetOutputLevel(log.DebugLevel)
 	_ = log.Configure(o)
 }

--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/pkg/log"
 )
@@ -394,9 +392,9 @@ func TestCopyBag(t *testing.T) {
 	refBag.Set("G6", int64(142))
 	refBag.Set("G7", 142.0)
 
-	copy := CopyBag(refBag)
+	copyBag := CopyBag(refBag)
 
-	if !compareBags(copy, refBag) {
+	if !compareBags(copyBag, refBag) {
 		t.Error("Bags don't match")
 	}
 }
@@ -743,6 +741,6 @@ func TestGlobalWordCount(t *testing.T) {
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.NewOptions()
-	o.SetOutputLevel(zapcore.DebugLevel)
+	o.SetOutputLevel(log.DebugLevel)
 	_ = log.Configure(o)
 }

--- a/mixer/pkg/config/descriptor/descriptor_test.go
+++ b/mixer/pkg/config/descriptor/descriptor_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"go.uber.org/zap/zapcore"
 
 	dpb "istio.io/api/mixer/v1/config/descriptor"
 	pb "istio.io/istio/mixer/pkg/config/proto"
@@ -391,6 +390,6 @@ logs:
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.NewOptions()
-	o.SetOutputLevel(zapcore.DebugLevel)
+	o.SetOutputLevel(log.DebugLevel)
 	_ = log.Configure(o)
 }

--- a/mixer/pkg/perf/server.go
+++ b/mixer/pkg/perf/server.go
@@ -20,8 +20,6 @@ import (
 	"path"
 	"time"
 
-	"go.uber.org/zap"
-
 	"istio.io/istio/mixer/pkg/adapter"
 	testEnv "istio.io/istio/mixer/pkg/server"
 	"istio.io/istio/mixer/pkg/template"
@@ -98,13 +96,13 @@ func initializeArgs(settings *Settings, setup *Setup) (*testEnv.Args, error) {
 		setup.Config.EnableLog = true
 
 		o := log.NewOptions()
-		o.SetOutputLevel(zap.DebugLevel)
+		o.SetOutputLevel(log.DebugLevel)
 		args.LoggingOptions = o
 	}
 
 	if !setup.Config.EnableLog {
 		o := log.NewOptions()
-		o.SetOutputLevel(log.None)
+		o.SetOutputLevel(log.NoneLevel)
 		args.LoggingOptions = o
 	}
 

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,27 @@
+reviewers:
+  - geeknoid
+  - andraxylia
+  - costinm
+  - Douglas-reid
+  - ldemailly
+  - rshriram
+  - sebastienvas
+  - mandarjog
+  - frankbu
+  - linsun
+  - kyessenov
+  - hklai
+  - wattli
+approvers:
+  - geeknoid
+  - andraxylia
+  - costinm
+  - Douglas-reid
+  - ldemailly
+  - rshriram
+  - mandarjog
+  - frankbu
+  - linsun
+  - kyessenov
+  - hklai
+  - wattli

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -59,6 +59,17 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
+// none is used to disable logging output as well as to disable stack tracing.
+const none zapcore.Level = 100
+
+var levelToZap = map[Level]zapcore.Level{
+	DebugLevel: zapcore.DebugLevel,
+	InfoLevel:  zapcore.InfoLevel,
+	WarnLevel:  zapcore.WarnLevel,
+	ErrorLevel: zapcore.ErrorLevel,
+	NoneLevel:  none,
+}
+
 // Configure initializes Istio's logging subsystem.
 //
 // You typically call this once at process startup.
@@ -76,7 +87,7 @@ func Configure(options *Options) error {
 		return err
 	}
 
-	if outputLevel == None || ((len(options.OutputPaths) == 0) && options.RotateOutputPath == "") {
+	if outputLevel == NoneLevel || ((len(options.OutputPaths) == 0) && options.RotateOutputPath == "") {
 		// stick with the Nop default
 		logger = zap.NewNop()
 		sugar = logger.Sugar()
@@ -143,16 +154,16 @@ func Configure(options *Options) error {
 		opts = append(opts, zap.AddCaller())
 	}
 
-	if stackTraceLevel != None {
-		opts = append(opts, zap.AddStacktrace(stackTraceLevel))
+	if stackTraceLevel != NoneLevel {
+		opts = append(opts, zap.AddStacktrace(levelToZap[stackTraceLevel]))
 	}
 
 	l := zap.New(
-		zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(outputLevel)),
+		zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(levelToZap[outputLevel])),
 		opts...,
 	)
 
-	logger = l.WithOptions(zap.AddCallerSkip(1), zap.AddStacktrace(stackTraceLevel))
+	logger = l.WithOptions(zap.AddCallerSkip(1), zap.AddStacktrace(levelToZap[stackTraceLevel]))
 	sugar = logger.Sugar()
 
 	// capture global zap logging and force it through our logger

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -22,8 +22,8 @@ import (
 )
 
 // Global variables against which all our logging occurs.
-var logger *zap.Logger = zap.NewNop()
-var sugar *zap.SugaredLogger = logger.Sugar()
+var logger = zap.NewNop()
+var sugar = logger.Sugar()
 
 func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 	t = t.UTC()

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -96,47 +96,47 @@ func TestBasic(t *testing.T) {
 		pat        string
 		json       bool
 		caller     bool
-		stackLevel zapcore.Level
+		stackLevel Level
 	}{
-		{func() { Debug("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
-		{func() { Debugf("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
-		{func() { Debugw("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
-		{func() { Debuga("Hello") }, timePattern + "\tdebug\tHello", false, false, None},
+		{func() { Debug("Hello") }, timePattern + "\tdebug\tHello", false, false, NoneLevel},
+		{func() { Debugf("Hello") }, timePattern + "\tdebug\tHello", false, false, NoneLevel},
+		{func() { Debugw("Hello") }, timePattern + "\tdebug\tHello", false, false, NoneLevel},
+		{func() { Debuga("Hello") }, timePattern + "\tdebug\tHello", false, false, NoneLevel},
 
-		{func() { Info("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
-		{func() { Infof("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
-		{func() { Infow("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
-		{func() { Infoa("Hello") }, timePattern + "\tinfo\tHello", false, false, None},
+		{func() { Info("Hello") }, timePattern + "\tinfo\tHello", false, false, NoneLevel},
+		{func() { Infof("Hello") }, timePattern + "\tinfo\tHello", false, false, NoneLevel},
+		{func() { Infow("Hello") }, timePattern + "\tinfo\tHello", false, false, NoneLevel},
+		{func() { Infoa("Hello") }, timePattern + "\tinfo\tHello", false, false, NoneLevel},
 
-		{func() { Warn("Hello") }, timePattern + "\twarn\tHello", false, false, None},
-		{func() { Warnf("Hello") }, timePattern + "\twarn\tHello", false, false, None},
-		{func() { Warnw("Hello") }, timePattern + "\twarn\tHello", false, false, None},
-		{func() { Warna("Hello") }, timePattern + "\twarn\tHello", false, false, None},
+		{func() { Warn("Hello") }, timePattern + "\twarn\tHello", false, false, NoneLevel},
+		{func() { Warnf("Hello") }, timePattern + "\twarn\tHello", false, false, NoneLevel},
+		{func() { Warnw("Hello") }, timePattern + "\twarn\tHello", false, false, NoneLevel},
+		{func() { Warna("Hello") }, timePattern + "\twarn\tHello", false, false, NoneLevel},
 
-		{func() { Error("Hello") }, timePattern + "\terror\tHello", false, false, None},
-		{func() { Errorf("Hello") }, timePattern + "\terror\tHello", false, false, None},
-		{func() { Errorw("Hello") }, timePattern + "\terror\tHello", false, false, None},
-		{func() { Errora("Hello") }, timePattern + "\terror\tHello", false, false, None},
+		{func() { Error("Hello") }, timePattern + "\terror\tHello", false, false, NoneLevel},
+		{func() { Errorf("Hello") }, timePattern + "\terror\tHello", false, false, NoneLevel},
+		{func() { Errorw("Hello") }, timePattern + "\terror\tHello", false, false, NoneLevel},
+		{func() { Errora("Hello") }, timePattern + "\terror\tHello", false, false, NoneLevel},
 
 		{func() {
 			l := With(zap.String("key", "value"))
 			l.Debug("Hello")
-		}, timePattern + "\tdebug\tHello\t{\"key\": \"value\"}", false, false, None},
+		}, timePattern + "\tdebug\tHello\t{\"key\": \"value\"}", false, false, NoneLevel},
 
-		{func() { Debug("Hello") }, timePattern + "\tdebug\tlog/log_test.go:.*\tHello", false, true, None},
+		{func() { Debug("Hello") }, timePattern + "\tdebug\tlog/log_test.go:.*\tHello", false, true, NoneLevel},
 
 		{func() { Debug("Hello") }, "{\"level\":\"debug\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
 			"\"stack\":\".*\"}",
-			true, true, zapcore.DebugLevel},
+			true, true, DebugLevel},
 		{func() { Info("Hello") }, "{\"level\":\"info\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
 			"\"stack\":\".*\"}",
-			true, true, zapcore.DebugLevel},
+			true, true, DebugLevel},
 		{func() { Warn("Hello") }, "{\"level\":\"warn\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
 			"\"stack\":\".*\"}",
-			true, true, zapcore.DebugLevel},
+			true, true, DebugLevel},
 		{func() { Error("Hello") }, "{\"level\":\"error\",\"time\":\"" + timePattern + "\",\"caller\":\"log/log_test.go:.*\",\"msg\":\"Hello\"," +
 			"\"stack\":\".*\"}",
-			true, true, zapcore.DebugLevel},
+			true, true, DebugLevel},
 	}
 
 	for i, c := range cases {
@@ -147,7 +147,7 @@ func TestBasic(t *testing.T) {
 				o.JSONEncoding = c.json
 				o.IncludeCallerSourceLocation = c.caller
 
-				_ = o.SetOutputLevel(zapcore.DebugLevel)
+				_ = o.SetOutputLevel(DebugLevel)
 				_ = o.SetStackTraceLevel(c.stackLevel)
 				if err := Configure(o); err != nil {
 					t.Errorf("Got err '%v', expecting success", err)
@@ -175,17 +175,17 @@ func TestBasic(t *testing.T) {
 
 func TestEnabled(t *testing.T) {
 	cases := []struct {
-		level        zapcore.Level
+		level        Level
 		debugEnabled bool
 		infoEnabled  bool
 		warnEnabled  bool
 		errorEnabled bool
 	}{
-		{zapcore.DebugLevel, true, true, true, true},
-		{zapcore.InfoLevel, false, true, true, true},
-		{zapcore.WarnLevel, false, false, true, true},
-		{zapcore.ErrorLevel, false, false, false, true},
-		{None, false, false, false, false},
+		{DebugLevel, true, true, true, true},
+		{InfoLevel, false, true, true, true},
+		{WarnLevel, false, false, true, true},
+		{ErrorLevel, false, false, false, true},
+		{NoneLevel, false, false, false, false},
 	}
 
 	for i, c := range cases {

--- a/pkg/log/options_test.go
+++ b/pkg/log/options_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestOpts(t *testing.T) {
@@ -32,8 +31,8 @@ func TestOpts(t *testing.T) {
 		{"--log_as_json", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			JSONEncoding:       true,
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
@@ -43,8 +42,8 @@ func TestOpts(t *testing.T) {
 		{"--log_target stdout --log_target stderr", Options{
 			OutputPaths:        []string{"stdout", "stderr"},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -53,8 +52,8 @@ func TestOpts(t *testing.T) {
 		{"--log_callers", Options{
 			OutputPaths:                 []string{defaultOutputPath},
 			ErrorOutputPaths:            []string{defaultErrorOutputPath},
-			outputLevel:                 levelToString[defaultOutputLevel],
-			stackTraceLevel:             levelToString[defaultStackTraceLevel],
+			outputLevel:                 string(defaultOutputLevel),
+			stackTraceLevel:             string(defaultStackTraceLevel),
 			IncludeCallerSourceLocation: true,
 			RotationMaxAge:              defaultRotationMaxAge,
 			RotationMaxSize:             defaultRotationMaxSize,
@@ -64,8 +63,8 @@ func TestOpts(t *testing.T) {
 		{"--log_stacktrace_level debug", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[zapcore.DebugLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(DebugLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -74,8 +73,8 @@ func TestOpts(t *testing.T) {
 		{"--log_stacktrace_level info", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[zapcore.InfoLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(InfoLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -84,8 +83,8 @@ func TestOpts(t *testing.T) {
 		{"--log_stacktrace_level warn", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[zapcore.WarnLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(WarnLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -94,8 +93,8 @@ func TestOpts(t *testing.T) {
 		{"--log_stacktrace_level error", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[zapcore.ErrorLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(ErrorLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -104,8 +103,8 @@ func TestOpts(t *testing.T) {
 		{"--log_stacktrace_level none", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[None],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(NoneLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -114,8 +113,8 @@ func TestOpts(t *testing.T) {
 		{"--log_output_level debug", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[zapcore.DebugLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(DebugLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -124,8 +123,8 @@ func TestOpts(t *testing.T) {
 		{"--log_output_level info", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[zapcore.InfoLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(InfoLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -134,8 +133,8 @@ func TestOpts(t *testing.T) {
 		{"--log_output_level warn", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[zapcore.WarnLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(WarnLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -144,8 +143,8 @@ func TestOpts(t *testing.T) {
 		{"--log_output_level error", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[zapcore.ErrorLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(ErrorLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -154,8 +153,8 @@ func TestOpts(t *testing.T) {
 		{"--log_output_level none", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[None],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(NoneLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -164,8 +163,8 @@ func TestOpts(t *testing.T) {
 		{"--log_rotate foobar", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotateOutputPath:   "foobar",
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
@@ -175,8 +174,8 @@ func TestOpts(t *testing.T) {
 		{"--log_rotate_max_age 1234", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     1234,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -185,8 +184,8 @@ func TestOpts(t *testing.T) {
 		{"--log_rotate_max_size 1234", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    1234,
 			RotationMaxBackups: defaultRotationMaxBackups,
@@ -195,8 +194,8 @@ func TestOpts(t *testing.T) {
 		{"--log_rotate_max_backups 1234", Options{
 			OutputPaths:        []string{defaultOutputPath},
 			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevel:        levelToString[defaultOutputLevel],
-			stackTraceLevel:    levelToString[defaultStackTraceLevel],
+			outputLevel:        string(defaultOutputLevel),
+			stackTraceLevel:    string(defaultStackTraceLevel),
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: 1234,
@@ -223,65 +222,43 @@ func TestOpts(t *testing.T) {
 
 func TestLevel(t *testing.T) {
 	cases := []struct {
-		inputLevel  zapcore.Level
-		outputLevel zapcore.Level
-		fail        bool
+		outputLevel     Level
+		stackTraceLevel Level
+		fail            bool
 	}{
-		{zapcore.DebugLevel, zapcore.DebugLevel, false},
-		{zapcore.InfoLevel, zapcore.InfoLevel, false},
-		{zapcore.WarnLevel, zapcore.WarnLevel, false},
-		{zapcore.ErrorLevel, zapcore.ErrorLevel, false},
-		{None, None, false},
+		{DebugLevel, InfoLevel, false},
+		{InfoLevel, WarnLevel, false},
+		{WarnLevel, ErrorLevel, false},
+		{ErrorLevel, NoneLevel, false},
+		{NoneLevel, DebugLevel, false},
+		{"bad", "bad", true},
 	}
 
 	for i, c := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			o := NewOptions()
 
-			err := o.SetOutputLevel(c.inputLevel)
-			if c.fail && err == nil {
-				t.Errorf("Got success, expecting failure")
-			} else if !c.fail && err != nil {
-				t.Errorf("Got failure '%v', expecting success", err)
-			}
+			oldLevel, _ := o.GetOutputLevel()
+			err := o.SetOutputLevel(c.outputLevel)
+			newLevel, _ := o.GetOutputLevel()
 
-			var l zapcore.Level
-			l, err = o.GetOutputLevel()
-			if err != nil {
-				t.Errorf("Got failure %v, expecting success", err)
-			}
+			checkSetLevel(t, oldLevel, c.outputLevel, newLevel, err, c.fail)
 
-			if c.outputLevel != l {
-				t.Errorf("Got %v, expecting %v", l, c.outputLevel)
-			}
+			oldLevel, _ = o.GetStackTraceLevel()
+			err = o.SetStackTraceLevel(c.stackTraceLevel)
+			newLevel, _ = o.GetStackTraceLevel()
 
-			err = o.SetStackTraceLevel(c.inputLevel)
-			if c.fail && err == nil {
-				t.Errorf("Got success, expecting failure")
-			} else if !c.fail && err != nil {
-				t.Errorf("Got failure '%v', expecting success", err)
-			}
-
-			l, err = o.GetStackTraceLevel()
-			if err != nil {
-				t.Errorf("Got failure %v, expecting success", err)
-			}
-
-			if c.outputLevel != l {
-				t.Errorf("Got %v, expecting %v", l, c.outputLevel)
-			}
+			checkSetLevel(t, oldLevel, c.stackTraceLevel, newLevel, err, c.fail)
 		})
 	}
 
+	// Now test setting the underlying field directly. This simulates what would
+	// happen if an invalid CLI flag was provided.
 	o := NewOptions()
 	o.outputLevel = "foobar"
 	_, err := o.GetOutputLevel()
 	if err == nil {
 		t.Errorf("Got nil, expecting error")
-	}
-
-	if err = o.SetOutputLevel(127); err == nil {
-		t.Errorf("Got success, expecting error")
 	}
 
 	o = NewOptions()
@@ -290,8 +267,24 @@ func TestLevel(t *testing.T) {
 	if err == nil {
 		t.Errorf("Got nil, expecting error")
 	}
+}
 
-	if err = o.SetStackTraceLevel(127); err == nil {
-		t.Errorf("Got success, expecting error")
+func checkSetLevel(t *testing.T, oldLevel Level, requestedLevel Level, newLevel Level, err error, expectError bool) {
+	if expectError { // Expecting Error
+		if err == nil {
+			t.Errorf("Got success, expecting failure")
+		}
+
+		if newLevel != oldLevel {
+			t.Errorf("Got %v, expecting %v", newLevel, oldLevel)
+		}
+	} else { // Expecting success
+		if err != nil {
+			t.Errorf("Got failure '%v', expecting success", err)
+		}
+
+		if newLevel != requestedLevel {
+			t.Errorf("Got %v, expecting %v", newLevel, requestedLevel)
+		}
 	}
 }


### PR DESCRIPTION
Added a new OutputLogLevel enumeration and changed accessor methods for the levels to use the enum.