### PR TITLE
Fix dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           command: |
             cd /go/src/istio.io/istio
             if [ ! -d vendor ]; then
-               dep ensure
+               dep ensure -vendor-only
             fi
       - save_cache:
           key: dep-cache-{{ checksum "Gopkg.toml" }}-{{ checksum "Gopkg.lock" }}


### PR DESCRIPTION
Vendor-only is required so the lock file doesn't change.