### PR TITLE
remove make gazelle instruction

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -313,14 +313,6 @@ make lint
 bin/linters.sh -s HEAD^
 ```
 
-### Source file dependencies
-
-You can keep track of dependencies between sources using:
-
-```shell
-make gazelle
-```
-
 ### Race detection tests
 
 You can run the test suite using the Go race detection tools using:


### PR DESCRIPTION
to avoid confusion as it doesn't work and seems to be bazel related during quick googling.

bash-3.2$ make gazelle
make: *** No rule to make target `gazelle'.  Stop.
bash-3.2$