### PR TITLE
Fix data races #1945

### DIFF
--- a/pilot/adapter/config/ingress/controller_test.go
+++ b/pilot/adapter/config/ingress/controller_test.go
@@ -16,6 +16,7 @@ package ingress
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -184,8 +185,14 @@ func TestIngressController(t *testing.T) {
 
 	// Append an ingress notification handler that just counts number of notifications
 	stop := make(chan struct{})
+
+	lock := sync.Mutex{}
 	notificationCount := 0
 	ctl.RegisterEventHandler(model.IngressRule.Type, func(config model.Config, ev model.Event) {
+
+		lock.Lock()
+		defer lock.Unlock()
+
 		notificationCount++
 	})
 	go ctl.Run(stop)
@@ -201,6 +208,10 @@ func TestIngressController(t *testing.T) {
 	}
 
 	util.Eventually(func() bool {
+
+		lock.Lock()
+		defer lock.Unlock()
+
 		return notificationCount == expectedRuleCount
 	}, t)
 	if notificationCount != expectedRuleCount {

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -372,8 +372,14 @@ func CheckCacheEvents(store model.ConfigStore, cache model.ConfigStoreCache, nam
 	stop := make(chan struct{})
 	defer close(stop)
 
+	lock := sync.Mutex{}
+
 	added, deleted := 0, 0
 	cache.RegisterEventHandler(model.MockConfig.Type, func(c model.Config, ev model.Event) {
+
+		lock.Lock()
+		defer lock.Unlock()
+
 		switch ev {
 		case model.EventAdd:
 			if deleted != 0 {
@@ -394,7 +400,12 @@ func CheckCacheEvents(store model.ConfigStore, cache model.ConfigStoreCache, nam
 	CheckMapInvariant(store, t, namespace, n)
 
 	log.Infof("Waiting till all events are received")
-	util.Eventually(func() bool { return added == n && deleted == n }, t)
+	util.Eventually(func() bool {
+		lock.Lock()
+		defer lock.Unlock()
+		return added == n && deleted == n
+
+	}, t)
 }
 
 // CheckCacheFreshness validates operational invariants of a cache


### PR DESCRIPTION
This PR attempts to fix the data races highlighted in #1945 

All of the data races fixed here were data races in the tests themselves except for one in the mock. All have been resolved by serialising access to the counters with a mutex.

There is one more data race listed in #1945 (TestSyncer) but that seems to be in the k8s client code rather than in the istio code. The test also looks like more of an integration type test. Any guidance would be appreciated? 