### PR TITLE
Only update /vendor lock file when it has changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,12 +94,14 @@ depend: init
 
 depend.ensure: init
 
+vendor/Gopkg.lock: Gopkg.lock
+	cp Gopkg.lock vendor/Gopkg.lock
+
 # Target to update the Gopkg.lock with latest versions.
 # Should be run when adding any new dependency and periodically.
 depend.update: ${GOPATH}/bin/dep; $(info $(H) ensuring dependencies are up to date...)
 	dep ensure
 	dep ensure -update
-	cp Gopkg.lock vendor/Gopkg.lock
 
 ${GOPATH}/bin/dep:
 	go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
The /vendor directory was being modified with a new copy of
Gopkg.lock on every make command.  Instead, only write it when
the local copy has changed.

This removes unnecessary building  during "make test".