### PR TITLE
Fix linter errors in bootstrapTemplate.go.

### DIFF
--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -16,6 +16,7 @@ package template
 
 // InterfaceTemplate defines the template used to generate the adapter
 // interfaces for Mixer for a given aspect.
+// nolint:lll
 var InterfaceTemplate = `// Copyright 2017 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adding nolint to the file, as breaking up the template doesn't seem to be 
the right thing to do here.
  