### PR TITLE
HostIntances now in CloudFoundry Platform Adapter

### DIFF
--- a/pilot/platform/cloudfoundry/servicediscovery.go
+++ b/pilot/platform/cloudfoundry/servicediscovery.go
@@ -71,15 +71,14 @@ func newService(hostname string) *model.Service {
 		Ports: []*model.Port{
 			{
 				Port:     AppPort,
-				Protocol: model.ProtocolTCP,
+				Protocol: model.ProtocolHTTP,
 			},
 		},
 	}
 }
 
 // Instances implements a service catalog operation
-func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
-	tagsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
 	resp, err := sd.Client.Routes(context.Background(), new(copilotapi.RoutesRequest))
 	if err != nil {
 		return nil, fmt.Errorf("getting instances: %s", err)
@@ -104,9 +103,31 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 	return instances, nil
 }
 
-// HostInstances is not currently implemented for Cloud Foundry
+// HostInstances implements a service catalog operation
 func (sd *ServiceDiscovery) HostInstances(addrs map[string]bool) ([]*model.ServiceInstance, error) {
-	return nil, nil
+	resp, err := sd.Client.Routes(context.Background(), new(copilotapi.RoutesRequest))
+	if err != nil {
+		return nil, fmt.Errorf("getting host instances: %s", err)
+	}
+
+	var instances []*model.ServiceInstance
+
+	for hostname, backendSet := range resp.GetBackends() {
+		service := newService(hostname)
+
+		for _, backend := range backendSet.GetBackends() {
+			instances = append(instances, &model.ServiceInstance{
+				Endpoint: model.NetworkEndpoint{
+					Address:     backend.Address,
+					Port:        int(backend.Port),
+					ServicePort: service.Ports[0],
+				},
+				Service: service,
+			})
+		}
+	}
+
+	return instances, nil
 }
 
 // ManagementPorts is not currently implemented for Cloud Foundry

--- a/pilot/platform/cloudfoundry/servicediscovery_test.go
+++ b/pilot/platform/cloudfoundry/servicediscovery_test.go
@@ -92,11 +92,11 @@ func TestServiceDiscovery_Services(t *testing.T) {
 	g.Expect(serviceModels).To(gomega.ConsistOf([]*model.Service{
 		{
 			Hostname: "process-guid-a.cfapps.internal",
-			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolTCP}},
+			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
 		},
 		{
 			Hostname: "process-guid-b.cfapps.internal",
-			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolTCP}},
+			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
 		},
 	}))
 }
@@ -125,7 +125,7 @@ func TestServiceDiscovery_GetService_Success(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(serviceModel).To(gomega.Equal(&model.Service{
 		Hostname: "process-guid-b.cfapps.internal",
-		Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolTCP}},
+		Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
 	}))
 }
 
@@ -167,7 +167,7 @@ func TestServiceDiscovery_Instances_Filtering(t *testing.T) {
 
 	servicePort := &model.Port{
 		Port:     8080,
-		Protocol: model.ProtocolTCP,
+		Protocol: model.ProtocolHTTP,
 	}
 	service := &model.Service{
 		Hostname: "process-guid-a.cfapps.internal",
@@ -217,4 +217,90 @@ func TestServiceDiscovery_Instances_ClientError(t *testing.T) {
 
 	g.Expect(err).To(gomega.MatchError("getting instances: potato"))
 	g.Expect(serviceModel).To(gomega.BeNil())
+}
+
+func TestServiceDiscovery_HostInstances(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	state := newSDTestState()
+
+	state.mockClient.RoutesOutput.Ret0 <- makeSampleClientResponse()
+	state.mockClient.RoutesOutput.Ret1 <- nil
+
+	instances, err := state.serviceDiscovery.HostInstances(map[string]bool{"": false})
+	g.Expect(err).To(gomega.BeNil())
+
+	servicePort := &model.Port{
+		Port:     8080,
+		Protocol: model.ProtocolHTTP,
+	}
+
+	serviceA := &model.Service{
+		Hostname: "process-guid-a.cfapps.internal",
+		Ports:    []*model.Port{servicePort},
+	}
+
+	serviceB := &model.Service{
+		Hostname: "process-guid-b.cfapps.internal",
+		Ports:    []*model.Port{servicePort},
+	}
+
+	g.Expect(instances).To(gomega.ConsistOf([]*model.ServiceInstance{
+		{
+			Endpoint: model.NetworkEndpoint{
+				Address:     "10.10.1.5",
+				Port:        61005,
+				ServicePort: servicePort,
+			},
+			Service: serviceA,
+		},
+		{
+			Endpoint: model.NetworkEndpoint{
+				Address:     "10.0.40.2",
+				Port:        61008,
+				ServicePort: servicePort,
+			},
+			Service: serviceA,
+		},
+		{
+			Endpoint: model.NetworkEndpoint{
+				Address:     "10.0.50.4",
+				Port:        61009,
+				ServicePort: servicePort,
+			},
+			Service: serviceB,
+		},
+		{
+			Endpoint: model.NetworkEndpoint{
+				Address:     "10.0.60.2",
+				Port:        61001,
+				ServicePort: servicePort,
+			},
+			Service: serviceB,
+		},
+	}))
+}
+
+func TestServiceDiscovery_HostInstances_ClientError(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	state := newSDTestState()
+
+	state.mockClient.RoutesOutput.Ret0 <- nil
+	state.mockClient.RoutesOutput.Ret1 <- errors.New("no instances")
+
+	serviceModel, err := state.serviceDiscovery.HostInstances(map[string]bool{"": false})
+
+	g.Expect(err).To(gomega.MatchError("getting host instances: no instances"))
+	g.Expect(serviceModel).To(gomega.BeNil())
+}
+
+func TestServiceDiscovery_HostInstances_NotFound(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	state := newSDTestState()
+
+	state.mockClient.RoutesOutput.Ret0 <- nil
+	state.mockClient.RoutesOutput.Ret1 <- nil
+
+	instances, err := state.serviceDiscovery.HostInstances(map[string]bool{"": false})
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(instances).To(gomega.BeNil())
 }


### PR DESCRIPTION
- HostInstances now returns all instances for all hosts
- Supports clusters and routes endpoints
- Change Port Protocol from TCP to HTTP

Signed-off-by: Charles Hansen <chansen@pivotal.io>