### PR TITLE
Add generated file to linter exclude

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -47,16 +47,16 @@
     },
     "exclude": [
         "vendor",
-	"../vendor",
+	    "../vendor",
         ".pb.go",
-	"mock_*",
+	    "mock_*",
         "mixer/adapter/doc.go",
         "mixer/pkg/config/proto/combined.go",
         ".*.gen.go",
-	"mixer/template/doc.go",
-	"mixer/template/sample/doc.go",
-	"mixer/test/spyAdapter/template/doc.go",
-        "should have a package comment",
+        "mixer/template/doc.go",
+        "mixer/template/sample/doc.go",
+        "mixer/test/spyAdapter/template/doc.go",
+        "mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go",
         "genfiles"
     ]
 }

--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -57,6 +57,7 @@
         "mixer/template/sample/doc.go",
         "mixer/test/spyAdapter/template/doc.go",
         "mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go",
+        "should have a package comment",
         "genfiles"
     ]
 }

--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -47,9 +47,9 @@
     },
     "exclude": [
         "vendor",
-	    "../vendor",
+        "../vendor",
         ".pb.go",
-	    "mock_*",
+        "mock_*",
         "mixer/adapter/doc.go",
         "mixer/pkg/config/proto/combined.go",
         ".*.gen.go",


### PR DESCRIPTION
Also replaces random tabs with spaces (which the rest of the file uses).
  