### PR TITLE
Specify ServiceAccount for Grafana

### DIFF
--- a/install/kubernetes/templates/addons/grafana.yaml.tmpl
+++ b/install/kubernetes/templates/addons/grafana.yaml.tmpl
@@ -26,6 +26,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      serviceAccountName: grafana
       containers:
       - name: grafana
         image: {MIXER_HUB}/grafana:{MIXER_TAG}
@@ -49,4 +50,9 @@ spec:
       volumes:
       - name: grafana-data
         emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana
 ---


### PR DESCRIPTION
This is useful to facilitate deployment on Openshift where the scc can be given to anyuid for the specific
ServiceAccounts, instead of having to give it to the default ServiceAccount.
  