### PR TITLE
Add istioctl deregister feature

### DIFF
--- a/pilot/cmd/istioctl/BUILD
+++ b/pilot/cmd/istioctl/BUILD
@@ -8,20 +8,17 @@ go_library(
         "main.go",
         "mixer.go",
         "register.go",
+        "deregister.go",
     ],
     visibility = ["//visibility:private"],
     deps = [
         "//pilot/adapter/config/crd:go_default_library",
         "//pilot/cmd:go_default_library",
-        "//pilot/cmd/istioctl/gendeployment:go_default_library",
         "//pilot/model:go_default_library",
         "//pilot/platform/kube:go_default_library",
         "//pilot/platform/kube/inject:go_default_library",
         "//pilot/tools/version:go_default_library",
-        "//pkg/log:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
-
-        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
@@ -33,7 +30,6 @@ go_library(
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
         "@io_k8s_client_go//tools/clientcmd/api:go_default_library",
-        "@io_k8s_client_go//util/homedir:go_default_library",
     ],
 )
 

--- a/pilot/cmd/istioctl/deregister.go
+++ b/pilot/cmd/istioctl/deregister.go
@@ -1,0 +1,52 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/pilot/platform/kube"
+)
+
+var (
+	deregisterCmd = &cobra.Command{
+		Use:   "deregister <svcname> <ip>",
+		Short: "De-registers a service instance",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			svcName := args[0]
+			ip := args[1]
+			glog.Infof("De-registering for service '%s' ip '%s'",
+				svcName, ip)
+			if svcAcctAnn != "" {
+				annotations = append(annotations, fmt.Sprintf("%s=%s", kube.KubeServiceAccountsOnVMAnnotation, svcAcctAnn))
+			}
+			_, client, err := kube.CreateInterface(kubeconfig)
+			if err != nil {
+				return err
+			}
+			return kube.DeRegisterEndpoint(client, namespace, svcName, ip)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deregisterCmd)
+	deregisterCmd.PersistentFlags().StringVarP(&svcAcctAnn, "serviceaccount", "s",
+		"default", "Service account to link to the service")
+}

--- a/pilot/platform/kube/BUILD
+++ b/pilot/platform/kube/BUILD
@@ -9,13 +9,11 @@ go_library(
         "conversion.go",
         "queue.go",
         "register.go",
+        "deregister.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//pilot/model:go_default_library",
-        "//pkg/log:go_default_library",
-
-        # TODO(nmittler): Remove this
         "@com_github_golang_glog//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
@@ -49,14 +47,14 @@ go_test(
         "conversion_test.go",
         "queue_test.go",
         "register_test.go",
+        "deregister_test.go",
     ],
     data = [":kubeconfig"] + glob(["testdata/*"]),
     library = ":go_default_library",
     deps = [
         "//pilot/model:go_default_library",
         "//pilot/test/util:go_default_library",
-        "//tests/k8s:go_default_library",
-        "//pkg/log:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
         "@io_istio_api//mesh/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pilot/platform/kube/deregister.go
+++ b/pilot/platform/kube/deregister.go
@@ -1,0 +1,99 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// VerifyEndpoint verifies if the provided IP to deregister has already
+// been registered.
+func VerifyEndpoint(eps *v1.Endpoints, ip string) bool {
+	var match bool
+	subsetLen := len(eps.Subsets)
+	/*
+		1. Check if this is the only entry; if this is the only entry
+		   then delete the entry and should return an empty subset.
+		2. Check if service endpoint is part of only one subset. If so
+		   wipe off the empty subset and return non-empty subsets.
+		3. Check if service endpoint is part of multiple subset. If so
+		   wipe off the empty subset and coalease non-empty subsets.
+	*/
+	for i, ss := range eps.Subsets {
+		for j, ipaddr := range ss.Addresses {
+			if strings.Compare(ipaddr.IP, ip) == 0 {
+				/*
+					If the IP address match then remove that
+					specific IP address.
+				*/
+				match = true
+				if j < len(ss.Addresses) {
+					ss.Addresses = append(ss.Addresses[:j], ss.Addresses[j+1:]...)
+				} else {
+					ss.Addresses = ss.Addresses[:j]
+				}
+			}
+		}
+		if len(ss.Addresses) == 0 {
+			if len(eps.Subsets) < subsetLen {
+				eps.Subsets = append(eps.Subsets[:len(eps.Subsets)], eps.Subsets[len(eps.Subsets)+1:]...)
+			} else {
+				eps.Subsets = append(eps.Subsets[:i], eps.Subsets[i+1:]...)
+			}
+		} else {
+			if len(eps.Subsets) < subsetLen {
+				eps.Subsets[len(eps.Subsets)-1].Addresses = ss.Addresses
+			} else {
+				eps.Subsets[i].Addresses = ss.Addresses
+			}
+		}
+	}
+	return match
+}
+
+// DeRegisterEndpoint registers the endpoint (and the service if it
+// already exists). It creates or updates as needed.
+func DeRegisterEndpoint(client kubernetes.Interface, namespace string, svcName string,
+	ip string) error {
+	getOpt := meta_v1.GetOptions{IncludeUninitialized: true}
+	var match bool
+	eps, err := client.CoreV1().Endpoints(namespace).Get(svcName, getOpt)
+	if err != nil {
+		glog.Error("Endpoint not found for service ", svcName)
+		return err
+	}
+	match = VerifyEndpoint(eps, ip)
+	if match == false {
+		/*
+			If the service endpoint has not been registered
+			before, report proper error message.
+		*/
+		glog.Error("Please make sure the endpoint is registered! Register endpoint using istioctl register")
+		return err
+	}
+	eps, err = client.CoreV1().Endpoints(namespace).Update(eps)
+	if err != nil {
+		glog.Error("Update failed with: ", err)
+		return err
+	}
+	glog.Error("Endpoint updated %v", eps)
+	glog.Error("Deregistered service successfully")
+	return nil
+}

--- a/pilot/platform/kube/deregister_test.go
+++ b/pilot/platform/kube/deregister_test.go
@@ -1,0 +1,117 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+// Test if the provided IP to deregister has already
+// been registered.
+func TestVerifyEndpoint(t *testing.T) {
+	var match bool
+	var tests = []struct {
+		input1   *v1.Endpoints
+		input2   string
+		expected bool
+	}{
+		{&v1.Endpoints{}, "10.128.0.17", false},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.18", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			false,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+					{
+						[]v1.EndpointAddress{{"10.128.0.20", "", nil, nil}, {"10.128.0.21", "", nil, nil}, {"10.128.0.22", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3308", 3308, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.22",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+					{
+						[]v1.EndpointAddress{{"10.128.0.20", "", nil, nil}, {"10.128.0.21", "", nil, nil}, {"10.128.0.22", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3308", 3308, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.23",
+			false,
+		},
+	}
+	for _, tst := range tests {
+		match = VerifyEndpoint(tst.input1, tst.input2)
+		if tst.expected == match {
+			t.Errorf("Matched")
+		} else {
+			t.Errorf("Not Matched")
+		}
+	}
+}


### PR DESCRIPTION
This commit adds the istioctl deregister feature. At present only
istioctl register is available. Deregister will deregister the
endpoint registered as part of the registration option. It takes
into consideration

1. No endpoint registered and deregister is issued.
2. Only one endpoint registered and same is inputed to deregister.
3. Multiple endpoints are registered and one of them is asked to
deregister.