### PR TITLE
Add go native race testing for goroutines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,27 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
+  test:
+    <<: *default
+    environment:
+      KUBECONFIG: /go/src/istio.io/istio/.circleci/config
+    resource_class: xlarge
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dep-cache-{{ checksum "Gopkg.lock" }}
+      - run:
+          command: |
+            mkdir -p /go/out/racetests
+            go get github.com/jstemmer/go-junit-report
+            free
+            trap "go-junit-report </go/out/tests/go-test-report.out > /go/out/tests/go-test-report.xml" EXIT
+            make localTestEnv
+            make pilot-racetest mixer-racetest broker-racetest security-racetest T=-v | tee -a /go/out/racetests/go-racetest-report.out
+      - store_test_results:
+          path: /go/out/racetests
+
   build:
     <<: *defaults
     resource_class: xlarge
@@ -394,6 +415,10 @@ workflows:
           requires:
             - dependencies
             - build
+      - racetest:
+          requires:
+            - dependencies
+            - build
       - e2e-simple:
           requires:
             - test
@@ -442,6 +467,9 @@ workflows:
       - test:
           requires:
             - dependencies
+      - racetest:
+          requires:
+            - dependencies
       - e2e-simple:
           requires:
             - build
@@ -468,6 +496,9 @@ workflows:
           requires:
             - dependencies
       - test:
+          requires:
+            - dependencies
+      - racetest:
           requires:
             - dependencies
       - e2e-pilot:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
-  test:
+  racetest:
     <<: *default
     environment:
       KUBECONFIG: /go/src/istio.io/istio/.circleci/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ jobs:
           path: /go/out/tests
 
   racetest:
-    <<: *default
+    <<: *defaults
     environment:
       KUBECONFIG: /go/src/istio.io/istio/.circleci/config
     resource_class: xlarge

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,31 @@ security-coverage:
 # Run coverage tests
 coverage: pilot-coverage mixer-coverage security-coverage broker-coverage
 
+#-----------------------------------------------------------------------------
+# Target: go test -race
+#-----------------------------------------------------------------------------
+.PHONY: pilot-racetest
+pilot-racetest: pilot-agent
+	go test ${GOTEST_P} ${T} -race ./pilot/...
+
+.PHONY: mixer-racetest
+mixer-racetest: mixs
+	# Some tests use relative path "testdata", must be run from mixer dir
+	(cd mixer; go test ${T} -race ${GOTEST_PARALLEL} ./...)
+
+.PHONY: broker-racetest
+broker-racetest: depend
+	go test ${T} -race ./broker/...
+
+.PHONY: security-racetest
+security-racetest:
+	go test ${T} -race ./security/...
+
+common-racetest:
+	go test ${T} -race ./pkg/...
+
+# Run race tests
+racetest: pilot-racetest mixer-racetest security-racetest broker-racetest common-racetest
 
 #-----------------------------------------------------------------------------
 # Target: precommit

--- a/Makefile
+++ b/Makefile
@@ -278,6 +278,9 @@ coverage: pilot-coverage mixer-coverage security-coverage broker-coverage
 #-----------------------------------------------------------------------------
 # Target: go test -race
 #-----------------------------------------------------------------------------
+
+.PHONY: racetest
+
 .PHONY: pilot-racetest
 pilot-racetest: pilot-agent
 	go test ${GOTEST_P} ${T} -race ./pilot/...


### PR DESCRIPTION
The race testing currently fails in several places.  I'm not sure
if these races are legitimate, or if the implementation of this
make target is missing something mandatory.

Note I ran make kubelink + deployed Kubernetes with kubeadm prior
to testing.