### PR TITLE
Fix a typo in values.yaml template.

### DIFF
--- a/pilot/cmd/istioctl/gendeployment/helm.go
+++ b/pilot/cmd/istioctl/gendeployment/helm.go
@@ -20,7 +20,7 @@ import (
 )
 
 var valuesTemplate = template.Must(template.New("helm").Parse(
-	`Istio:
+	`istio:
    deploy_base_config: true
    initializer_enabled: {{ .Initializer }}
    mixer_enabled: {{ .Mixer }}

--- a/pilot/cmd/istioctl/gendeployment/testdata/default-values.yaml.golden
+++ b/pilot/cmd/istioctl/gendeployment/testdata/default-values.yaml.golden
@@ -1,4 +1,4 @@
-Istio:
+istio:
    deploy_base_config: true
    initializer_enabled: false
    mixer_enabled: true


### PR DESCRIPTION
Fix a typo: The yaml file generated by gen-deploy cannot be parsed by Helm.