### PR TITLE
Makefile: explicit go binary as GOBIN is reserved

### DIFF
--- a/security/Makefile
+++ b/security/Makefile
@@ -1,5 +1,5 @@
-GOBIN ?= go
-GO_MINOR_VERSION = $(shell $(GOBIN) version | cut -d . -f 2)
+GOBINARY ?= go
+GO_MINOR_VERSION = $(shell $(GOBINARY) version | cut -d . -f 2)
 
 VERSION_MODULE = istio.io/istio/security/cmd/istio_ca/version
 


### PR DESCRIPTION
Follow-up on
https://github.com/istio/istio/pull/2470#issuecomment-356110214

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>

cc @rkpagadala 