### PR TITLE
Add istioctl deregister feature

### DIFF
--- a/pilot/cmd/istioctl/BUILD
+++ b/pilot/cmd/istioctl/BUILD
@@ -8,6 +8,7 @@ go_library(
         "main.go",
         "mixer.go",
         "register.go",
+        "deregister.go",
     ],
     visibility = ["//visibility:private"],
     deps = [

--- a/pilot/cmd/istioctl/deregister.go
+++ b/pilot/cmd/istioctl/deregister.go
@@ -1,0 +1,45 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/pilot/platform/kube"
+	"istio.io/istio/pkg/log"
+)
+
+var (
+	deregisterCmd = &cobra.Command{
+		Use:   "deregister <svcname> <ip>",
+		Short: "De-registers a service instance",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(c *cobra.Command, args []string) error {
+			svcName := args[0]
+			ip := args[1]
+			log.Infof("De-registering for service '%s' ip '%s'",
+				svcName, ip)
+			_, client, err := kube.CreateInterface(kubeconfig)
+			if err != nil {
+				return err
+			}
+			return kube.DeRegisterEndpoint(client, namespace, svcName, ip)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(deregisterCmd)
+}

--- a/pilot/platform/kube/BUILD
+++ b/pilot/platform/kube/BUILD
@@ -9,6 +9,7 @@ go_library(
         "conversion.go",
         "queue.go",
         "register.go",
+        "deregister.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -49,6 +50,7 @@ go_test(
         "conversion_test.go",
         "queue_test.go",
         "register_test.go",
+        "deregister_test.go",
     ],
     data = [":kubeconfig"] + glob(["testdata/*"]),
     library = ":go_default_library",

--- a/pilot/platform/kube/deregister.go
+++ b/pilot/platform/kube/deregister.go
@@ -1,0 +1,92 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"strings"
+
+	"k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"istio.io/istio/pkg/log"
+)
+
+// removeIPFromEndpoint verifies if the provided IP to deregister
+// has already been registered.
+func removeIPFromEndpoint(eps *v1.Endpoints, ip string) bool {
+	var match bool
+	/*
+		1. Check if this is the only entry; if this is the only entry
+		   then delete the entry and should return an empty subset.
+		2. Check if service endpoint is part of only one subset. If so
+		   wipe off the empty subset and return non-empty subsets.
+		3. Check if service endpoint is part of multiple subset. If so
+		   wipe off the empty subset and coalease non-empty subsets.
+	*/
+	for i := 0; i < len(eps.Subsets); {
+		ss := eps.Subsets[i]
+		for j := 0; j < len(ss.Addresses); {
+			ipaddr := ss.Addresses[j]
+			if strings.Compare(ipaddr.IP, ip) == 0 {
+				/*
+					If the IP address match then remove that
+					specific IP address.
+				*/
+				match = true
+				ss.Addresses = append(ss.Addresses[:j], ss.Addresses[j+1:]...)
+			} else {
+				j++
+			}
+		}
+		if len(ss.Addresses) == 0 {
+			eps.Subsets = append(eps.Subsets[:i], eps.Subsets[i+1:]...)
+		} else {
+			eps.Subsets[i].Addresses = ss.Addresses
+			i++
+		}
+	}
+	return match
+}
+
+// DeRegisterEndpoint registers the endpoint (and the service if it
+// already exists). It creates or updates as needed.
+func DeRegisterEndpoint(client kubernetes.Interface, namespace string, svcName string,
+	ip string) error {
+	getOpt := meta_v1.GetOptions{IncludeUninitialized: true}
+	var match bool
+	eps, err := client.CoreV1().Endpoints(namespace).Get(svcName, getOpt)
+	if err != nil {
+		log.Errora("Endpoint not found for service ", svcName)
+		return err
+	}
+	match = removeIPFromEndpoint(eps, ip)
+	if !match {
+		/*
+			If the service endpoint has not been registered
+			before, report proper error message.
+		*/
+		log.Errora("Could not find ip %s in svc %s endpoints", ip, svcName)
+		return err
+	}
+	eps, err = client.CoreV1().Endpoints(namespace).Update(eps)
+	if err != nil {
+		log.Errora("Update failed with: ", err)
+		return err
+	}
+	log.Infof("Endpoint updated %v", eps)
+	log.Infof("Deregistered service successfully")
+	return nil
+}

--- a/pilot/platform/kube/deregister_test.go
+++ b/pilot/platform/kube/deregister_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+
+	"istio.io/istio/pkg/log"
+)
+
+// TestRemoveIPFromEndpoint if the provided IP to deregister has already
+// been registered.
+func TestRemoveIPFromEndpoint(t *testing.T) {
+	var match bool
+	var tests = []struct {
+		input1   *v1.Endpoints
+		input2   string
+		expected bool
+	}{
+		{&v1.Endpoints{}, "10.128.0.17", false},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.18", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			false,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.17",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+					{
+						[]v1.EndpointAddress{{"10.128.0.20", "", nil, nil}, {"10.128.0.21", "", nil, nil}, {"10.128.0.22", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3308", 3308, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.22",
+			true,
+		},
+		{
+			&v1.Endpoints{
+				Subsets: []v1.EndpointSubset{
+					{
+						[]v1.EndpointAddress{{"10.128.0.17", "", nil, nil}, {"10.128.0.18", "", nil, nil}, {"10.128.0.19", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3309", 3309, "TCP"}},
+					},
+					{
+						[]v1.EndpointAddress{{"10.128.0.20", "", nil, nil}, {"10.128.0.21", "", nil, nil}, {"10.128.0.22", "", nil, nil}},
+						[]v1.EndpointAddress{{"", "", nil, nil}},
+						[]v1.EndpointPort{{"3308", 3308, "TCP"}},
+					},
+				},
+			},
+			"10.128.0.23",
+			false,
+		},
+	}
+	for _, tst := range tests {
+		match = removeIPFromEndpoint(tst.input1, tst.input2)
+		if tst.expected != match {
+			t.Errorf("Expected %t got %t", tst.expected, match)
+		}
+		if !match {
+			log.Infof("Ip %s does not exist in Endpoint %v", tst.input2, tst.input1)
+		} else {
+			log.Infof("Ip %s exist in Endpoint %v", tst.input2, tst.input1)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds the istioctl deregister feature. At present only
istioctl register is available. Deregister will deregister the
endpoint registered as part of the registration option. It takes
into consideration

No endpoint registered and deregister is issued.
Only one endpoint registered and same is inputed to deregister.
Multiple endpoints are registered and one of them is asked to
deregister.