### PR TITLE
Allow "make push" to work without pushing to the "istio-artifacts" GCS bucket.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ endif
 # Discover if user has dep installed -- prefer that
 DEP := $(shell which dep || echo "${ISTIO_BIN}/dep" )
 
+# Set Google Storage bucket if not set
+GS_BUCKET ?= istio-artifacts
+export GS_BUCKET
+
 #-----------------------------------------------------------------------------
 # Output control
 #-----------------------------------------------------------------------------
@@ -113,7 +117,7 @@ ${DEP}:
 
 Gopkg.lock: Gopkg.toml | ${DEP} ; $(info $(H) generating) @
 	$(Q) ${DEP} ensure -update
-	
+
 depend.status: Gopkg.lock
 	$(Q) ${DEP} status > vendor/dep.txt
 	$(Q) ${DEP} status -dot > vendor/dep.dot
@@ -481,7 +485,7 @@ $(foreach TGT,$(DOCKER_TARGETS),$(eval DOCKER_TAR_TARGETS+=tar.$(TGT)))
 docker.save: $(DOCKER_TAR_TARGETS)
 
 push: checkvars clean.installgen installgen
-	$(ISTIO_GO)/bin/push $(HUB) $(TAG)
+	$(ISTIO_GO)/bin/push $(HUB) $(TAG) $(GS_BUCKET)
 
 artifacts: docker
 	@echo 'To be added'
@@ -595,4 +599,3 @@ ${OUT}/istio-sidecar.deb: ${ISTIO_BIN}/envoy ${ISTIO_BIN}/pilot-agent ${ISTIO_BI
 # Target: e2e tests
 #-----------------------------------------------------------------------------
 include tests/istio.mk
-

--- a/bin/push
+++ b/bin/push
@@ -2,6 +2,9 @@
 set -exu
 HUB=${1:?"1st arg hub is required"}
 TAG=${2:?"2nd arg tag is required"}
+if [[ -z "${GS_BUCKET:-}" ]]; then
+    GS_BUCKET=${3:-"istio-artifacts"}
+fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -23,9 +26,9 @@ pilot/bin/push-docker -hub ${HUB} -tag ${TAG} &
 mixer/bin/push-docker -hub ${HUB} -tag ${TAG} &
 security/bin/push-docker -hub ${HUB} -tag ${TAG} &
 
-# Permit $HUB overrides to suppress errors during push
+# Only try to upload if HUB starts with gcr.io
 if [[ "${HUB}" =~ ^gcr\.io ]]; then
-    pilot/bin/upload-istioctl -p "gs://istio-artifacts/pilot/${TAG}/artifacts/istioctl" &
+    pilot/bin/upload-istioctl -p "gs://${GS_BUCKET}/pilot/${TAG}/artifacts/istioctl" &
 fi
 
 FAIL=0


### PR DESCRIPTION
A new environment variable GS_BUCKET allows "make push" to push to the
specified bucket. Makefile and bin/push observe this
varibale. bin/push also can take a third argument. The default
behavour of bin/push only attempting an upload if HUB begins with
gcr.io is preserved.