### PR TITLE
Add Makefile target to generate and clean generated install/ files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,15 @@ lintconfig.gen.json
 # codegen stuff
 bin/protoc-gen-gogoslick*
 bin/protoc-min-version*
+# Install generated files
+install/consul/istio.yaml
+install/eureka/istio.yaml
+install/kubernetes/helm/istio/values.yaml
+install/kubernetes/istio-auth.yaml
+install/kubernetes/istio-ca-plugin-certs.yaml
+install/kubernetes/istio-initializer.yaml
+install/kubernetes/istio-one-namespace-auth.yaml
+install/kubernetes/istio-one-namespace.yaml
+install/kubernetes/istio.yaml
+samples/bookinfo/consul/bookinfo.sidecars.yaml
+samples/bookinfo/eureka/bookinfo.sidecars.yaml

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ coverage: pilot-coverage mixer-coverage security-coverage broker-coverage
 .PHONY: clean
 .PHONY: clean.go
 
-clean: clean.go
+clean: clean.go clean.installgen
 
 clean.go: ; $(info $(H) cleaning...)
 	$(eval GO_CLEAN_FLAGS := -i -r)
@@ -323,7 +323,7 @@ docker.prebuilt:
 	time (cd security/docker && docker build -t ${HUB}/node-agent-test:${TAG} -f Dockerfile.node-agent-test .)
 
 
-push: checkvars
+push: checkvars clean.installgen installgen
 	$(ISTIO_GO)/bin/push $(HUB) $(TAG)
 
 artifacts: docker
@@ -335,7 +335,27 @@ pilot/platform/kube/config:
 kubelink:
 	ln -fs ~/.kube/config pilot/platform/kube/
 
-.PHONY: artifacts build checkvars clean docker test setup push kubelink
+installgen:
+	install/updateVersion.sh -a ${HUB},${TAG}
+
+clean.installgen:
+	rm -f install/consul/istio.yaml
+	rm -f install/eureka/istio.yaml
+	rm -f install/kubernetes/helm/istio/values.yaml
+	rm -f install/kubernetes/istio-auth.yaml
+	rm -f install/kubernetes/istio-ca-plugin-certs.yaml
+	rm -f install/kubernetes/istio-initializer.yaml
+	rm -f install/kubernetes/istio-one-namespace-auth.yaml
+	rm -f install/kubernetes/istio-one-namespace.yaml
+	rm -f install/kubernetes/istio.yaml
+	rm -f pilot/docker/pilot-test-client
+	rm -f pilot/docker/pilot-test-eurekamirror
+	rm -f pilot/docker/pilot-test-server
+	rm -f samples/bookinfo/consul/bookinfo.sidecars.yaml
+	rm -f samples/bookinfo/eureka/bookinfo.sidecars.yaml
+	rm -f security/docker/ca-certificates.tgz
+
+.PHONY: artifacts build checkvars clean docker test setup push kubelink installgen clean.installgen
 
 #-----------------------------------------------------------------------------
 # Target: environment and tools


### PR DESCRIPTION
To checkout Istio, build, push, and run on my own cluster, I think a good workflow would be:
```
HUB=gcr.io/my-project make push
kubectl apply -f install/kubernetes/istio-auth.yaml
```
Right now install/updateVersion.sh needs to be run, which is tricky if you need to figure out what the git hash TAG is. If you are pushing to a registry, it makes sense to go ahead and run this, as you would probably want to deploy the images you pushed.

The files generated from install/updateVersion.sh were removed recently, they should be added to .gitignore. install/updateVersion.sh is not idempotent, so a clean target is added to delete the generated files first.