### PR TITLE
Add short-circuiting support to LAND.

### DIFF
--- a/mixer/pkg/il/compiler/compiler.go
+++ b/mixer/pkg/il/compiler/compiler.go
@@ -371,11 +371,26 @@ func (g *generator) generateLor(f *expr.Function, depth int) {
 }
 
 func (g *generator) generateLand(f *expr.Function, depth int) {
-	for _, a := range f.Args {
+	// Short circuit jump point for arguments that evaluate to false.
+	lfalse := g.builder.AllocateLabel()
+
+	// Label for the end of the and block.
+	lend := g.builder.AllocateLabel()
+
+	for i, a := range f.Args {
 		g.generate(a, depth+1, nmNone, "")
+		if i < len(f.Args)-1 {
+			// if this is not the last argument, check and jump to the false label.
+			g.builder.Jz(lfalse)
+		} else {
+			g.builder.Jmp(lend)
+		}
 	}
 
-	g.builder.And()
+	g.builder.SetLabelPos(lfalse)
+	g.builder.APushBool(false)
+
+	g.builder.SetLabelPos(lend)
 }
 
 func (g *generator) generateIndex(f *expr.Function, depth int, mode nilMode, valueJmpLabel string) {

--- a/mixer/pkg/il/interpreter/interpreterBenchmark_test.go
+++ b/mixer/pkg/il/interpreter/interpreterBenchmark_test.go
@@ -21,6 +21,14 @@ import (
 	"istio.io/istio/mixer/pkg/il/text"
 )
 
+// 1/10/2018
+//BenchmarkInterpreter/ExprBench/ok_1st-8         	10000000	       136 ns/op	       0 B/op	       0 allocs/op
+//BenchmarkInterpreter/ExprBench/ok_2nd-8         	 5000000	       236 ns/op	      16 B/op	       1 allocs/op
+//BenchmarkInterpreter/ExprBench/not_found-8      	 5000000	       241 ns/op	      16 B/op	       1 allocs/op
+//BenchmarkInterpreter/true_&&_false-8            	10000000	       120 ns/op	       0 B/op	       0 allocs/op
+//BenchmarkInterpreter/true_&&_true-8             	10000000	       118 ns/op	       0 B/op	       0 allocs/op
+//BenchmarkInterpreter/false_&&_false-8           	20000000	       117 ns/op	       0 B/op	       0 allocs/op
+
 // 12/6/2017
 //BenchmarkIL/ExprBench/ok_1st-8         	10000000	       135 ns/op	       0 B/op	       0 allocs/op
 //BenchmarkIL/ExprBench/ok_2nd-8         	 5000000	       238 ns/op	      16 B/op	       1 allocs/op

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -266,6 +266,19 @@ end`,
 			"a": int64(20),
 			"b": int64(10),
 		},
+		IL: `
+ fn eval() bool
+  resolve_i "x"
+  aeq_i 20
+  jz L0
+  resolve_i "y"
+  aeq_i 10
+  jmp L1
+L0:
+  apush_b false
+L1:
+  ret
+end`,
 		Err:    "lookup failed: 'x'",
 		AstErr: "unresolved attribute",
 		conf:   TestConfigs["Expr/Eval"],
@@ -673,32 +686,105 @@ end`,
 		IL: `
 fn eval() bool
   apush_b false
+  jz L0
   apush_b true
-  and
+  jmp L1
+L0:
+  apush_b false
+L1:
   ret
 end`,
 	},
 	{
-		E:    `true && false`,
+		E:     `true && false`,
+		Bench: true,
+		Type:  descriptor.BOOL,
+		R:     false,
+		IL: `
+fn eval() bool
+  apush_b true
+  jz L0
+  apush_b false
+  jmp L1
+L0:
+  apush_b false
+L1:
+  ret
+end`,
+	},
+	{
+		E:     `true && true`,
+		Bench: true,
+		Type:  descriptor.BOOL,
+		R:     true,
+		IL: `
+fn eval() bool
+  apush_b true
+  jz L0
+  apush_b true
+  jmp L1
+L0:
+  apush_b false
+L1:
+  ret
+end `,
+	},
+	{
+		E:     `false && false`,
+		Bench: true,
+		Type:  descriptor.BOOL,
+		R:     false,
+		IL: `
+fn eval() bool
+  apush_b false
+  jz L0
+  apush_b false
+  jmp L1
+L0:
+  apush_b false
+L1:
+  ret
+end`,
+	},
+	{
+		E:    `false && false && false`,
 		Type: descriptor.BOOL,
 		R:    false,
-		IL: `
- fn eval() bool
-  apush_b true
-  apush_b false
-  and
-  ret
-end`,
 	},
 	{
-		E:    `true && true`,
+		E:    `false && false && true`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `false && true && false`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `true && false && false`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `true && true && false`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `true && false && true`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `false && true && true`,
+		Type: descriptor.BOOL,
+		R:    false,
+	},
+	{
+		E:    `true && true && true`,
 		Type: descriptor.BOOL,
 		R:    true,
-	},
-	{
-		E:    `false && false`,
-		Type: descriptor.BOOL,
-		R:    false,
 	},
 	{
 		E:    "b1 && b2",


### PR DESCRIPTION
This adds short-circuiting support to the emitted AND IL code.