### PR TITLE
fix bookinfo route of test delay

### DIFF
--- a/samples/bookinfo/kube/route-rule-ratings-test-delay.yaml
+++ b/samples/bookinfo/kube/route-rule-ratings-test-delay.yaml
@@ -13,7 +13,7 @@ spec:
           regex: "^(.*?;)?(user=jason)(;.*)?$"
   route:
   - labels:
-      version: v1
+      version: v2
   httpFault:
     delay:
       percent: 100


### PR DESCRIPTION
samples/bookinfo application is never access to rating in v1.
Thus, route-rule-ratings-test-delay in bookinfo is failed by access route is v1.
This patch will fix route from v1 to v2.