### PR TITLE
fix continuous builds

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -58,6 +58,7 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
 fi
 
 if [ ! -f $GO_TOP/bin/envoy ] ; then
+    mkdir -p $GO_TOP/bin
     cp $ISTIO_GO/vendor/envoy-$PROXYVERSION $GO_TOP/bin/envoy
 fi
 


### PR DESCRIPTION
If a person has dep installed on the system then init.sh no longer tries to grab its own copy of dep.  This step is what created the $GO_TOP/bin directory, so if this step is bypassed then the later step to copy envoy into bin fails.

When CI tries to do a "make build" this essentially does a "make init", which in turn tries to run "bin/init.sh" and fails on this issue.

This script seems to have other issues about assuming what the pwd is but I'll look into that later.