### PR TITLE
Get golint working & speed up each invocation of make by a second

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ export GOARCH ?= amd64
 
 
 # @todo allow user to run for a single $PKG only?
-PACKAGES := $(shell GOPATH=$(GOPATH) $(GO) list ./...)
+PACKAGES_CMD := GOPATH=$(GOPATH) $(GO) list ./...
 GO_EXCLUDE := /vendor/|.pb.go|.gen.go
-GO_FILES := $(shell find . -name '*.go' | grep -v -E '$(GO_EXCLUDE)')
+GO_FILES_CMD := find . -name '*.go' | grep -v -E '$(GO_EXCLUDE)'
 
 # Environment for tests, the directory containing istio and deps binaries.
 # Typically same as GOPATH/bin, so tests work seemlessly with IDEs.
@@ -159,20 +159,20 @@ fmt: format.gofmt format.goimports # backward compatible with ./bin/fmt.sh
 check: check.vet check.lint
 
 format.gofmt: ; $(info $(H) formatting files with go fmt...)
-	$(Q) gofmt -s -w $(GO_FILES)
+	$(Q) gofmt -s -w $$($(GO_FILES_CMD))
 
 format.goimports: ; $(info $(H) formatting files with goimports...)
-	$(Q) goimports -w -local istio.io $(GO_FILES)
+	$(Q) goimports -w -local istio.io $$($(GO_FILES_CMD))
 
 # @todo fail on vet errors? Currently uses `true` to avoid aborting on failure
 check.vet: ; $(info $(H) running go vet on packages...)
-	$(Q) $(GO) vet $(PACKAGES) || true
+	$(Q) $(GO) vet $$($(PACKAGES_CMD)) || true
 
 # @todo fail on lint errors? Currently uses `true` to avoid aborting on failure
 # @todo remove _test and mock_ from ignore list and fix the errors?
 check.lint: | ${GOLINT} ; $(info $(H) running golint on packages...)
 	$(eval LINT_EXCLUDE := $(GO_EXCLUDE)|_test.go|mock_)
-	$(Q) for p in $(PACKAGES); do \
+	$(Q) for p in $$($(PACKAGES_CMD)); do \
 		${GOLINT} $$p | grep -v -E '$(LINT_EXCLUDE)' ; \
 	done || true;
 


### PR DESCRIPTION
In the continuous build the "running golint on packages..." is followed by a long sequence of:

/bin/bash: line 1: golint: command not found

So, this change does something akin to dep and has make download golint when needed and specify a full path when executing golint.

The next issue is that golint complains about not finding libraries.  Essentially passing "./..." to "go list" causes it to output absolute paths that are prefixed with an underscore.  Setting GOPATH when calling "go list" resolves this.  I'm aware that the istio docs prescribe that people set this in advance but the core build already makes an attempt to cope without this in order to make the build more turnkey and self-sufficient.

With this change golint complains about 3 dozen items, though they all seemed cosmetic in nature (vs causing an issue in runtime behavior) so I punted on fixing them.

I also added in a change from my go version check change that avoids shelling out to run various apps (including a "find") on each invocation of make that seems to take about 1.2 seconds on my system.