### PR TITLE
Fix servicegraph /dotviz.

### DIFF
--- a/mixer/example/servicegraph/Makefile
+++ b/mixer/example/servicegraph/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -rf docker/viz
 	rm -f docker/servicegraph
 
-docker: docker/viz docker/servicegraph 
+docker: docker/viz docker/servicegraph
 	cd docker && docker build -t servicegraph -f Dockerfile .
 	cd docker && docker build -t servicegraph_debug -f Dockerfile.debug .
 

--- a/mixer/example/servicegraph/docker/Dockerfile
+++ b/mixer/example/servicegraph/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM scratch
 
 WORKDIR /tmp/
-ADD servicegraph /usr/local/bin/
-ADD viz /tmp/js/
+COPY servicegraph /usr/local/bin/
+COPY viz /tmp/js/viz/
 
 EXPOSE 8088
 ENTRYPOINT ["/usr/local/bin/servicegraph", "--assetDir=/tmp"]

--- a/mixer/example/servicegraph/docker/Dockerfile.debug
+++ b/mixer/example/servicegraph/docker/Dockerfile.debug
@@ -1,8 +1,8 @@
 FROM gcr.io/istio-testing/ubuntu_xenial_debug:3f57ae2aceef79e4000fb07ec850bbf4bce811e6f81dc8cfd970e16cdf33e622
 
 WORKDIR /tmp/
-ADD servicegraph /usr/local/bin/
-ADD viz /tmp/js/
+COPY servicegraph /usr/local/bin/
+COPY viz /tmp/js/viz/
 
 EXPOSE 8088
-ENTRYPOINT ["/usr/local/bin/servicegraph", "--assetDir=/tmp"]
+CMD ["/usr/local/bin/servicegraph", "--assetDir=/tmp"]


### PR DESCRIPTION
The new servicegraph Dockerfiles were not putting the visualization js
in the correct spot in the image. Updated the Dockerfiles with best
practices.