### PR TITLE
Move mixer client integration tests from istio/proxy  repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,11 +260,15 @@ security-test:
 	go test ${T} ./security/pkg/...
 	go test ${T} ./security/cmd/...
 
+.PHONY: mixer-client-test
+mixer-client-test:
+	mixer/test/client/run_test.sh
+
 common-test:
 	go test ${T} ./pkg/...
 
 # Run coverage tests
-go-test: pilot-test mixer-test security-test broker-test common-test
+go-test: pilot-test mixer-test security-test broker-test common-test mixer-client-test
 
 #-----------------------------------------------------------------------------
 # Target: Code coverage ( go )

--- a/Makefile
+++ b/Makefile
@@ -260,15 +260,11 @@ security-test:
 	go test ${T} ./security/pkg/...
 	go test ${T} ./security/cmd/...
 
-.PHONY: mixer-client-test
-mixer-client-test:
-	mixer/test/client/run_test.sh
-
 common-test:
 	go test ${T} ./pkg/...
 
 # Run coverage tests
-go-test: pilot-test mixer-test security-test broker-test common-test mixer-client-test
+go-test: pilot-test mixer-test security-test broker-test common-test
 
 #-----------------------------------------------------------------------------
 # Target: Code coverage ( go )

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -55,14 +55,9 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     curl -Lo - https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
     cp usr/local/bin/envoy $ISTIO_GO/vendor/envoy-$PROXYVERSION
     popd
-fi
 
-if [ ! -f $GO_TOP/bin/envoy ] ; then
     mkdir -p $GO_TOP/bin
     cp $ISTIO_GO/vendor/envoy-$PROXYVERSION $GO_TOP/bin/envoy
-fi
 
-if [ ! -f ${ROOT}/pilot/proxy/envoy/envoy ] ; then
     ln -sf $GO_TOP/bin/envoy ${ROOT}/pilot/proxy/envoy
 fi
-

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -1,0 +1,212 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	mccpb "istio.io/api/mixer/v1/config/client"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+const (
+	JWT_ISSUER  = "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
+	JWT_CLUSTER = "service1"
+)
+
+//
+// How to generate a long live token:
+// * git clone https://github.com/cloudendpoints/esp
+// * modify file: bazel-esp/external/grpc_git/src/core/lib/security/credentials/jwt/json_token.c
+//     remove the lines using grpc_max_auth_token_lifetime()
+// * modify src/api_manager/auth/lib/auth_token.cc
+//     change TOKEN_LIFETIME = 3600000000
+// * bazel build //src/tools:all
+// * client/custom/gen-auth-token.sh -s src/nginx/t/matching-client-secret.json
+//
+const longLiveToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImIzMzE5YTE0NzUxNGRmN2VlNWU0YmNkZWU1MTM1MGNjODkwY2M4OWUifQ==.eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==.HKWpc8zLw7NAzlgPphHpQ6fWh7k1cJ0XM7B_9YqcOQYLe8UA9KvOC_4D6cNw7HCaEv8UQufA4d8ErDn5PI3mPxn6m8pciJbcqblXmNN8jCJUSH2OHZsWDdzipHPrt5kxz9onx39m9Zdb_xXAffHREVDXO6eMzNte8ZihZwmZauIT9fbL8BbD74_D5tQvswdjUNAQuTdK6-pBXOH1Qf7fE3V92ESVqUmqM05FkTBfDZw6CGKj47W8ecs0QiLyERth8opCTLsRi5QN1xEPggTpfH_YBZTtsuIybVjiw9UAizWE-ziFWx2qlt9JPEArjvroMfNmJz4gTenbKNuXBMJOQg=="
+
+const checkAttributes = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.auth.audiences": "bookstore-esp-echo.cloudendpointsapis.com",
+  "request.auth.principal": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+  "request.auth.claims": {
+     "iss": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+     "aud": "bookstore-esp-echo.cloudendpointsapis.com",
+     "sub": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
+  }
+}
+`
+
+const reportAttributes = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "sec-istio-auth-userinfo": "eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.auth.audiences": "bookstore-esp-echo.cloudendpointsapis.com",
+  "request.auth.principal": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+  "request.auth.claims": {
+     "iss": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+     "aud": "bookstore-esp-echo.cloudendpointsapis.com",
+     "sub": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain; charset=utf-8",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+const FailedReportAttributes = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "authorization": "Bearer invalidtoken",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 14,
+  "response.duration": "*",
+  "response.code": 401,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "14",
+     ":status": "401",
+     "server": "envoy"
+  }
+}
+`
+
+func TestJWTAuth(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	// pubkey server is the same as backend server.
+	// Empty audiences.
+	env.AddJwtAuth(s.V2().HttpServerConf, &mccpb.JWT{
+		Issuer:              JWT_ISSUER,
+		JwksUri:             fmt.Sprintf("http://localhost:%d/pubkey", env.BackendPort),
+		JwksUriEnvoyCluster: JWT_CLUSTER,
+	})
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	tag := "Good-Token"
+	headers := map[string]string{}
+	headers["Authorization"] = fmt.Sprintf("Bearer %v", longLiveToken)
+	code, _, err := env.HTTPGetWithHeaders(url, headers)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 200 {
+		t.Errorf("Status code 200 is expected, got %d.", code)
+	}
+	s.VerifyCheck(tag, checkAttributes)
+	s.VerifyReport(tag, reportAttributes)
+
+	tag = "Invalid-Token"
+	headers["Authorization"] = fmt.Sprintf("Bearer invalidtoken")
+	code, _, err = env.HTTPGetWithHeaders(url, headers)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	s.VerifyReport(tag, FailedReportAttributes)
+}

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -195,7 +195,7 @@ func TestJWTAuth(t *testing.T) {
 	s := env.NewTestSetupV2(env.JWTAuthTest, t)
 	// pubkey server is the same as backend server.
 	// Empty audiences.
-	env.AddJwtAuth(s.V2().HttpServerConf, &mccpb.JWT{
+	env.AddJwtAuth(s.V2().HTTPServerConf, &mccpb.JWT{
 		Issuer:              JwtIssuer,
 		JwksUri:             fmt.Sprintf("http://localhost:%d/pubkey", s.Ports().BackendPort),
 		JwksUriEnvoyCluster: JwtCluster,

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	JWT_ISSUER  = "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
-	JWT_CLUSTER = "service1"
+	JwtIssuer  = "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
+	JwtCluster = "service1"
 )
 
 //
@@ -37,7 +37,17 @@ const (
 // * bazel build //src/tools:all
 // * client/custom/gen-auth-token.sh -s src/nginx/t/matching-client-secret.json
 //
-const longLiveToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImIzMzE5YTE0NzUxNGRmN2VlNWU0YmNkZWU1MTM1MGNjODkwY2M4OWUifQ==.eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==.HKWpc8zLw7NAzlgPphHpQ6fWh7k1cJ0XM7B_9YqcOQYLe8UA9KvOC_4D6cNw7HCaEv8UQufA4d8ErDn5PI3mPxn6m8pciJbcqblXmNN8jCJUSH2OHZsWDdzipHPrt5kxz9onx39m9Zdb_xXAffHREVDXO6eMzNte8ZihZwmZauIT9fbL8BbD74_D5tQvswdjUNAQuTdK6-pBXOH1Qf7fE3V92ESVqUmqM05FkTBfDZw6CGKj47W8ecs0QiLyERth8opCTLsRi5QN1xEPggTpfH_YBZTtsuIybVjiw9UAizWE-ziFWx2qlt9JPEArjvroMfNmJz4gTenbKNuXBMJOQg=="
+const longLiveToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImIzMzE5YTE0Nz" +
+	"UxNGRmN2VlNWU0YmNkZWU1MTM1MGNjODkwY2M4OWUifQ==.eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9h" +
+	"Yml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20" +
+	"iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZW" +
+	"xvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlb" +
+	"mRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==.HKWpc8z" +
+	"Lw7NAzlgPphHpQ6fWh7k1cJ0XM7B_9YqcOQYLe8UA9KvOC_4D6cNw7HCaEv8UQufA4d8ErDn5PI3mPx" +
+	"n6m8pciJbcqblXmNN8jCJUSH2OHZsWDdzipHPrt5kxz9onx39m9Zdb_xXAffHREVDXO6eMzNte8ZihZ" +
+	"wmZauIT9fbL8BbD74_D5tQvswdjUNAQuTdK6-pBXOH1Qf7fE3V92ESVqUmqM05FkTBfDZw6CGKj47W8" +
+	"ecs0QiLyERth8opCTLsRi5QN1xEPggTpfH_YBZTtsuIybVjiw9UAizWE-ziFWx2qlt9JPEArjvroMfN" +
+	"mJz4gTenbKNuXBMJOQg=="
 
 const checkAttributes = `
 {
@@ -68,7 +78,10 @@ const checkAttributes = `
      "x-request-id": "*"
   },
   "request.auth.audiences": "bookstore-esp-echo.cloudendpointsapis.com",
-  "request.auth.principal": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+  "request.auth.principal": "` +
+	"628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/628645" +
+	"741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com" +
+	`",
   "request.auth.claims": {
      "iss": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
      "aud": "bookstore-esp-echo.cloudendpointsapis.com",
@@ -101,13 +114,21 @@ const reportAttributes = `
      ":method": "GET",
      ":path": "/echo",
      ":authority": "*",
-     "sec-istio-auth-userinfo": "eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==",
+     "sec-istio-auth-userinfo": "` +
+	"eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLm" +
+	"dzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4" +
+	"bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG" +
+	"8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==" +
+	`",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
   },
   "request.auth.audiences": "bookstore-esp-echo.cloudendpointsapis.com",
-  "request.auth.principal": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+  "request.auth.principal": "` +
+	"628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com/6286457418" +
+	"81-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com" +
+	`",
   "request.auth.claims": {
      "iss": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
      "aud": "bookstore-esp-echo.cloudendpointsapis.com",
@@ -175,9 +196,9 @@ func TestJWTAuth(t *testing.T) {
 	// pubkey server is the same as backend server.
 	// Empty audiences.
 	env.AddJwtAuth(s.V2().HttpServerConf, &mccpb.JWT{
-		Issuer:              JWT_ISSUER,
+		Issuer:              JwtIssuer,
 		JwksUri:             fmt.Sprintf("http://localhost:%d/pubkey", s.Ports().BackendPort),
-		JwksUriEnvoyCluster: JWT_CLUSTER,
+		JwksUriEnvoyCluster: JwtCluster,
 	})
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -45,7 +45,7 @@ const checkAttributes = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -62,7 +62,7 @@ const checkAttributes = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -83,7 +83,7 @@ const reportAttributes = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -100,7 +100,7 @@ const reportAttributes = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "sec-istio-auth-userinfo": "eyJpc3MiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJzdWIiOiI2Mjg2NDU3NDE4ODEtbm9hYml1MjNmNWE4bThvdmQ4dWN2Njk4bGo3OHZ2MGxAZGV2ZWxvcGVyLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJhdWQiOiJib29rc3RvcmUtZXNwLWVjaG8uY2xvdWRlbmRwb2ludHNhcGlzLmNvbSIsImlhdCI6MTUxMjc1NDIwNSwiZXhwIjo1MTEyNzU0MjA1fQ==",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
@@ -134,7 +134,7 @@ const FailedReportAttributes = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -149,7 +149,7 @@ const FailedReportAttributes = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "authorization": "Bearer invalidtoken",
      "x-istio-attributes": "-",
@@ -171,12 +171,12 @@ const FailedReportAttributes = `
 `
 
 func TestJWTAuth(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.JWTAuthTest, t)
 	// pubkey server is the same as backend server.
 	// Empty audiences.
 	env.AddJwtAuth(s.V2().HttpServerConf, &mccpb.JWT{
 		Issuer:              JWT_ISSUER,
-		JwksUri:             fmt.Sprintf("http://localhost:%d/pubkey", env.BackendPort),
+		JwksUri:             fmt.Sprintf("http://localhost:%d/pubkey", s.Ports().BackendPort),
 		JwksUriEnvoyCluster: JWT_CLUSTER,
 	})
 	if err := s.SetUp(); err != nil {
@@ -184,7 +184,7 @@ func TestJWTAuth(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	tag := "Good-Token"
 	headers := map[string]string{}

--- a/mixer/test/client/check_cache/check_cache_test.go
+++ b/mixer/test/client/check_cache/check_cache_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check_cache
+package checkCache
 
 import (
 	"fmt"

--- a/mixer/test/client/check_cache/check_cache_test.go
+++ b/mixer/test/client/check_cache/check_cache_test.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_cache
+
+import (
+	"fmt"
+	"testing"
+
+	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+func TestCheckCache(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Need to override mixer test server Referenced field in the check response.
+	// Its default is all fields in the request which could not be used fo test check cache.
+	output := mixerpb.ReferencedAttributes{
+		AttributeMatches: make([]mixerpb.ReferencedAttributes_AttributeMatch, 1),
+	}
+	output.AttributeMatches[0] = mixerpb.ReferencedAttributes_AttributeMatch{
+		// Assume "target.name" is in the request attributes, and it is used for Check.
+		Name:      10,
+		Condition: mixerpb.EXACT,
+	}
+	s.SetMixerCheckReferenced(&output)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+	for i := 0; i < 10; i++ {
+		if _, _, err := env.HTTPGet(url); err != nil {
+			t.Errorf("Failed in request %s: %v", tag, err)
+		}
+		// Only the first check is called.
+		s.VerifyCheckCount(tag, 1)
+	}
+}

--- a/mixer/test/client/check_cache/check_cache_test.go
+++ b/mixer/test/client/check_cache/check_cache_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 func TestCheckCache(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.CheckCacheTest, t)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Need to override mixer test server Referenced field in the check response.
 	// Its default is all fields in the request which could not be used fo test check cache.

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check_report
+package checkReport
 
 import (
 	"fmt"

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -28,7 +28,7 @@ const checkAttributesOkGet = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -45,7 +45,7 @@ const checkAttributesOkGet = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -60,7 +60,7 @@ const reportAttributesOkGet = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -77,7 +77,7 @@ const reportAttributesOkGet = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -104,7 +104,7 @@ const checkAttributesOkPost = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -121,7 +121,7 @@ const checkAttributesOkPost = `
   "request.headers": {
      ":method": "POST",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -136,7 +136,7 @@ const reportAttributesOkPost = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -153,7 +153,7 @@ const reportAttributesOkPost = `
   "request.headers": {
      ":method": "POST",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -174,13 +174,13 @@ const reportAttributesOkPost = `
 `
 
 func TestCheckReportAttributes(t *testing.T) {
-	s := env.NewTestSetup(t, env.BasicConfig)
+	s := env.NewTestSetup(env.CheckReportAttributesTest, t, env.BasicConfig)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Issues a GET echo request with 0 size body
 	tag := "OKGetV1"

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -1,0 +1,218 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_report
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good GET request
+const checkAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  }
+}
+`
+
+// Report attributes from a good GET request
+const reportAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain; charset=utf-8",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+// Check attributes from a good POST request
+const checkAttributesOkPost = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "POST",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "POST",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  }
+}
+`
+
+// Report attributes from a good POST request
+const reportAttributesOkPost = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "POST",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "POST",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 12,
+  "response.time": "*",
+  "response.size": 12,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "12",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+func TestCheckReportAttributes(t *testing.T) {
+	s := env.NewTestSetup(t, env.BasicConfig)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGetV1"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkGet)
+	s.VerifyReport(tag, reportAttributesOkGet)
+
+	// Issues a POST request.
+	tag = "OKPostV1"
+	if _, _, err := env.HTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesOkPost)
+
+	s.SetV2Conf()
+	s.ReStartEnvoy()
+
+	tag = "OKGet"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkGet)
+	s.VerifyReport(tag, reportAttributesOkGet)
+
+	// Issues a POST request.
+	tag = "OKPost"
+	if _, _, err := env.HTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesOkPost)
+}

--- a/mixer/test/client/check_report_disable/check_report_disable_test.go
+++ b/mixer/test/client/check_report_disable/check_report_disable_test.go
@@ -32,6 +32,7 @@ const reportOnlyFlags = `
 
 func TestCheckReportDisable(t *testing.T) {
 	s := env.NewTestSetup(
+		env.CheckReportDisableTest,
 		t,
 		env.BasicConfig+","+env.DisableCheckCache+","+env.DisableReportBatch)
 	if err := s.SetUp(); err != nil {
@@ -39,7 +40,7 @@ func TestCheckReportDisable(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	tag := "Both Check and Report v1"
 	if _, _, err := env.HTTPGet(url); err != nil {

--- a/mixer/test/client/check_report_disable/check_report_disable_test.go
+++ b/mixer/test/client/check_report_disable/check_report_disable_test.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check_report_disable
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+const checkOnlyFlags = `
+                   "mixer_check": "on",
+`
+
+const reportOnlyFlags = `
+                   "mixer_report": "on",
+`
+
+func TestCheckReportDisable(t *testing.T) {
+	s := env.NewTestSetup(
+		t,
+		env.BasicConfig+","+env.DisableCheckCache+","+env.DisableReportBatch)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	tag := "Both Check and Report v1"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Even report batch is disabled, but it is better to wait
+	// since sending batch is after request is completed.
+	time.Sleep(1 * time.Second)
+	// Send both check and report
+	s.VerifyCheckCount(tag, 1)
+	s.VerifyReportCount(tag, 1)
+
+	// stop and start a new envoy config
+	s.SetFlags(checkOnlyFlags)
+	s.ReStartEnvoy()
+
+	tag = "Check Only v1"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Wait for Report
+	time.Sleep(1 * time.Second)
+	// Only send check, not report.
+	s.VerifyCheckCount(tag, 2)
+	s.VerifyReportCount(tag, 1)
+
+	// stop and start a new envoy config
+	s.SetFlags(reportOnlyFlags)
+	s.ReStartEnvoy()
+
+	// wait for 2 second to wait for envoy to come up
+	tag = "Report Only v1"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Wait for Report
+	time.Sleep(1 * time.Second)
+	// Only send report, not check.
+	s.VerifyCheckCount(tag, 2)
+	s.VerifyReportCount(tag, 2)
+
+	//
+	// Use V2 config
+	//
+
+	s.SetV2Conf()
+	// Disable all cache.
+	env.DisableClientCache(s.V2().HttpServerConf, true, true, true)
+	s.ReStartEnvoy()
+
+	tag = "Both Check and Report"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Even report batch is disabled, but it is better to wait
+	// since sending batch is after request is completed.
+	time.Sleep(1 * time.Second)
+	// Send both check and report
+	s.VerifyCheckCount(tag, 3)
+	s.VerifyReportCount(tag, 3)
+
+	// stop and start a new envoy config
+	// Check enabled, Report disabled
+	env.DisableHttpCheckReport(s.V2().HttpServerConf, false, true)
+	s.ReStartEnvoy()
+
+	tag = "Check Only"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Wait for Report
+	time.Sleep(1 * time.Second)
+	// Only send check, not report.
+	s.VerifyCheckCount(tag, 4)
+	s.VerifyReportCount(tag, 3)
+
+	// Check disabled, Report enabled
+	env.DisableHttpCheckReport(s.V2().HttpServerConf, true, false)
+	s.ReStartEnvoy()
+
+	tag = "Report Only"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Wait for Report
+	time.Sleep(1 * time.Second)
+	// Only send report, not check.
+	s.VerifyCheckCount(tag, 4)
+	s.VerifyReportCount(tag, 4)
+}

--- a/mixer/test/client/check_report_disable/check_report_disable_test.go
+++ b/mixer/test/client/check_report_disable/check_report_disable_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check_report_disable
+package checkReportDisable
 
 import (
 	"fmt"

--- a/mixer/test/client/check_report_disable/check_report_disable_test.go
+++ b/mixer/test/client/check_report_disable/check_report_disable_test.go
@@ -88,7 +88,7 @@ func TestCheckReportDisable(t *testing.T) {
 
 	s.SetV2Conf()
 	// Disable all cache.
-	env.DisableClientCache(s.V2().HttpServerConf, true, true, true)
+	env.DisableClientCache(s.V2().HTTPServerConf, true, true, true)
 	s.ReStartEnvoy()
 
 	tag = "Both Check and Report"
@@ -104,7 +104,7 @@ func TestCheckReportDisable(t *testing.T) {
 
 	// stop and start a new envoy config
 	// Check enabled, Report disabled
-	env.DisableHttpCheckReport(s.V2().HttpServerConf, false, true)
+	env.DisableHTTPCheckReport(s.V2().HTTPServerConf, false, true)
 	s.ReStartEnvoy()
 
 	tag = "Check Only"
@@ -118,7 +118,7 @@ func TestCheckReportDisable(t *testing.T) {
 	s.VerifyReportCount(tag, 3)
 
 	// Check disabled, Report enabled
-	env.DisableHttpCheckReport(s.V2().HttpServerConf, true, false)
+	env.DisableHTTPCheckReport(s.V2().HTTPServerConf, true, false)
 	s.ReStartEnvoy()
 
 	tag = "Report Only"

--- a/mixer/test/client/disable_check_cache/disable_check_cache_test.go
+++ b/mixer/test/client/disable_check_cache/disable_check_cache_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disable_check_cache
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+func TestDisableCheckCache(t *testing.T) {
+	s := env.NewTestSetup(
+		t,
+		env.BasicConfig+","+env.DisableCheckCache)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet v1"
+	for i := 0; i < 10; i++ {
+		if _, _, err := env.HTTPGet(url); err != nil {
+			t.Errorf("Failed in request %s: %v", tag, err)
+		}
+	}
+	// Check is called 10 time.
+	s.VerifyCheckCount(tag, 10)
+
+	//
+	// Use V2 config
+	//
+
+	s.SetV2Conf()
+	// Disable check cache.
+	env.DisableClientCache(s.V2().HttpServerConf, true, false, false)
+	s.ReStartEnvoy()
+
+	tag = "OKGet"
+	for i := 0; i < 10; i++ {
+		if _, _, err := env.HTTPGet(url); err != nil {
+			t.Errorf("Failed in request %s: %v", tag, err)
+		}
+	}
+	// Check is called 10 time.
+	s.VerifyCheckCount(tag, 20)
+}

--- a/mixer/test/client/disable_check_cache/disable_check_cache_test.go
+++ b/mixer/test/client/disable_check_cache/disable_check_cache_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package disable_check_cache
+package disableCheckCache
 
 import (
 	"fmt"

--- a/mixer/test/client/disable_check_cache/disable_check_cache_test.go
+++ b/mixer/test/client/disable_check_cache/disable_check_cache_test.go
@@ -49,7 +49,7 @@ func TestDisableCheckCache(t *testing.T) {
 
 	s.SetV2Conf()
 	// Disable check cache.
-	env.DisableClientCache(s.V2().HttpServerConf, true, false, false)
+	env.DisableClientCache(s.V2().HTTPServerConf, true, false, false)
 	s.ReStartEnvoy()
 
 	tag = "OKGet"

--- a/mixer/test/client/disable_check_cache/disable_check_cache_test.go
+++ b/mixer/test/client/disable_check_cache/disable_check_cache_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestDisableCheckCache(t *testing.T) {
 	s := env.NewTestSetup(
+		env.DisableCheckCacheTest,
 		t,
 		env.BasicConfig+","+env.DisableCheckCache)
 	if err := s.SetUp(); err != nil {
@@ -30,7 +31,7 @@ func TestDisableCheckCache(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Issues a GET echo request with 0 size body
 	tag := "OKGet v1"

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -1,0 +1,91 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disable_tcp_check_calls
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good POST request
+const checkAttributesOkPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222"
+}
+`
+
+// Report attributes from a good POST request
+const reportAttributesOkPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": 28080,
+  "connection.received.bytes": 178,
+  "connection.received.bytes_total": 178,
+  "connection.sent.bytes": 133,
+  "connection.sent.bytes_total": 133,
+  "connection.duration": "*"
+}
+`
+
+func TestDisableTcpCheckCalls(t *testing.T) {
+	s := env.NewTestSetup(
+		t,
+		env.BasicConfig+","+env.DisableTcpCheckCalls)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.TcpProxyPort)
+
+	// Issues a POST request.
+	tag := "OKPost v1"
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheckCount(tag, 0)
+	s.VerifyReport(tag, reportAttributesOkPost)
+
+	//
+	// Use V2 config
+	//
+
+	s.SetV2Conf()
+	// Disable Check
+	env.DisableTcpCheckReport(s.V2().TcpServerConf, true, false)
+	s.ReStartEnvoy()
+
+	tag = "OKPost"
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheckCount(tag, 0)
+	s.VerifyReport(tag, reportAttributesOkPost)
+}

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package disableTcpCheckCalls
+package disableTCPCheckCalls
 
 import (
 	"fmt"
@@ -54,17 +54,17 @@ const reportAttributesOkPost = `
 }
 `
 
-func TestDisableTcpCheckCalls(t *testing.T) {
+func TestDisableTCPCheckCalls(t *testing.T) {
 	s := env.NewTestSetup(
-		env.DisableTcpCheckCallsTest,
+		env.DisableTCPCheckCallsTest,
 		t,
-		env.BasicConfig+","+env.DisableTcpCheckCalls)
+		env.BasicConfig+","+env.DisableTCPCheckCalls)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TcpProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TCPProxyPort)
 
 	// Issues a POST request.
 	tag := "OKPost v1"
@@ -80,7 +80,7 @@ func TestDisableTcpCheckCalls(t *testing.T) {
 
 	s.SetV2Conf()
 	// Disable Check
-	env.DisableTcpCheckReport(s.V2().TcpServerConf, true, false)
+	env.DisableTCPCheckReport(s.V2().TCPServerConf, true, false)
 	s.ReStartEnvoy()
 
 	tag = "OKPost"

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package disable_tcp_check_calls
+package disableTcpCheckCalls
 
 import (
 	"fmt"

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -45,7 +45,7 @@ const reportAttributesOkPost = `
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "destination.ip": "[127 0 0 1]",
-  "destination.port": 28080,
+  "destination.port": "*",
   "connection.received.bytes": 178,
   "connection.received.bytes_total": 178,
   "connection.sent.bytes": 133,
@@ -56,6 +56,7 @@ const reportAttributesOkPost = `
 
 func TestDisableTcpCheckCalls(t *testing.T) {
 	s := env.NewTestSetup(
+		env.DisableTcpCheckCallsTest,
 		t,
 		env.BasicConfig+","+env.DisableTcpCheckCalls)
 	if err := s.SetUp(); err != nil {
@@ -63,7 +64,7 @@ func TestDisableTcpCheckCalls(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.TcpProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TcpProxyPort)
 
 	// Issues a POST request.
 	tag := "OKPost v1"

--- a/mixer/test/client/env/attributes.go
+++ b/mixer/test/client/env/attributes.go
@@ -154,7 +154,7 @@ func Verify(b *attribute.MutableBag, json_results string) error {
 
 	if len(all_keys) > 0 {
 		var s string
-		for k, _ := range all_keys {
+		for k := range all_keys {
 			s += k + ", "
 		}
 		return fmt.Errorf("Following attributes are not expected: %s", s)

--- a/mixer/test/client/env/attributes.go
+++ b/mixer/test/client/env/attributes.go
@@ -1,0 +1,163 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"istio.io/istio/mixer/pkg/attribute"
+)
+
+func verifyRawStringMap(actual map[string]string, expected map[string]interface{}) error {
+	for k, v := range expected {
+		vstring := v.(string)
+		// "-" make sure the key does not exist.
+		if vstring == "-" {
+			if _, ok := actual[k]; ok {
+				return fmt.Errorf("key %+v is NOT expected", k)
+			}
+		} else {
+			if val, ok := actual[k]; ok {
+				// "*" only check key exist
+				if val != vstring && vstring != "*" {
+					return fmt.Errorf("key %+v value doesn't match. Actual %+v, expected %+v",
+						k, val, vstring)
+				}
+			} else {
+				return fmt.Errorf("key %+v is expected", k)
+			}
+		}
+	}
+	return nil
+}
+
+// TODO: remove duplicated code by change StringMap object to expose the whole map
+func verifyObjStringMap(actual attribute.StringMap, expected map[string]interface{}) error {
+	for k, v := range expected {
+		vstring := v.(string)
+		// "-" make sure the key does not exist.
+		if vstring == "-" {
+			if _, ok := actual.Get(k); ok {
+				return fmt.Errorf("key %+v is NOT expected", k)
+			}
+		} else {
+			if val, ok := actual.Get(k); ok {
+				// "*" only check key exist
+				if val != vstring && vstring != "*" {
+					return fmt.Errorf("key %+v value doesn't match. Actual %+v, expected %+v",
+						k, val, vstring)
+				}
+			} else {
+				return fmt.Errorf("key %+v is expected", k)
+			}
+		}
+	}
+	return nil
+}
+
+// Attributes verification rules:
+//
+// 1) If value is *,  key must exist, but value is not checked.
+// 1) If value is -,  key must NOT exist.
+// 3) At top level attributes, not inside StringMap, all keys must
+//    be listed. Extra keys are NOT allowed
+// 3) Inside StringMap, not need to list all keys. Extra keys are allowed
+//
+// Attributes provided from envoy config
+// * source.id and source.namespace are forwarded from client proxy
+// * target.id and target.namespace are from server proxy
+//
+// HTTP header "x-istio-attributes" is used to forward attributes between
+// proxy. It should be removed before calling mixer and backend.
+//
+func Verify(b *attribute.MutableBag, json_results string) error {
+	var r map[string]interface{}
+	if err := json.Unmarshal([]byte(json_results), &r); err != nil {
+		return fmt.Errorf("unable to decode json %v", err)
+	}
+
+	all_keys := make(map[string]bool)
+	for _, k := range b.Names() {
+		all_keys[k] = true
+	}
+
+	for k, v := range r {
+		switch vv := v.(type) {
+		case string:
+			// "*" means only checking key.
+			if vv == "*" {
+				if _, ok := b.Get(k); !ok {
+					return fmt.Errorf("attribute %+v is expected", k)
+				}
+			} else {
+				if val, ok := b.Get(k); ok {
+					val_string := fmt.Sprintf("%v", val)
+					if val_string != v.(string) {
+						return fmt.Errorf("attribute %+v value doesn't match. Actual %+v, expected %+v",
+							k, val_string, v.(string))
+					}
+				} else {
+					return fmt.Errorf("attribute %+v is expected", k)
+				}
+			}
+		case float64:
+			// Json converts all integers to float64,
+			// Our tests only verify size related attributes which are int64 type
+			if val, ok := b.Get(k); ok {
+				vint64 := int64(vv)
+				if val.(int64) != vint64 {
+					return fmt.Errorf("attribute %+v value doesn't match. Actual %+v, expected %+v",
+						k, val.(int64), vint64)
+				}
+			} else {
+				return fmt.Errorf("attribute %+v is expected", k)
+			}
+		case map[string]interface{}:
+			if val, ok := b.Get(k); ok {
+				var err error
+				switch val.(type) {
+				case attribute.StringMap:
+					err = verifyObjStringMap(val.(attribute.StringMap), v.(map[string]interface{}))
+				case map[string]string:
+					err = verifyRawStringMap(val.(map[string]string), v.(map[string]interface{}))
+				default:
+					return fmt.Errorf("StringMap attribute %+v is of a type %+v that I don't know how to handle ",
+						k, reflect.TypeOf(val))
+				}
+				if err != nil {
+					return fmt.Errorf("attribute %+v StringMap doesn't match: %+v", k, err)
+				}
+			} else {
+				return fmt.Errorf("attribute %+v is expected", k)
+			}
+		default:
+			return fmt.Errorf("attribute %+v is of a type %+v that I don't know how to handle ",
+				k, reflect.TypeOf(v))
+		}
+		delete(all_keys, k)
+
+	}
+
+	if len(all_keys) > 0 {
+		var s string
+		for k, _ := range all_keys {
+			s += k + ", "
+		}
+		return fmt.Errorf("Following attributes are not expected: %s", s)
+	}
+	return nil
+}

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -1,0 +1,83 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Envoy struct {
+	cmd *exec.Cmd
+}
+
+// Run command and return the merged output from stderr and stdout, error code
+func Run(name string, args ...string) (s string, err error) {
+	log.Println(">", name, strings.Join(args, " "))
+	c := exec.Command(name, args...)
+	bytes, err := c.CombinedOutput()
+	s = string(bytes)
+	for _, line := range strings.Split(s, "\n") {
+		log.Println(line)
+	}
+	if err != nil {
+		log.Println(err)
+	}
+	return
+}
+
+func NewEnvoy(conf, flags string, stress, faultInject bool, v2 *V2Conf) (*Envoy, error) {
+	bin_path := "envoy"
+	log.Printf("Envoy binary: %v\n", bin_path)
+
+	conf_path := "/tmp/envoy.conf"
+	log.Printf("Envoy config: in %v\n%v\n", conf_path, conf)
+	if err := CreateEnvoyConf(conf_path, conf, flags, stress, faultInject, v2); err != nil {
+		return nil, err
+	}
+
+	var cmd *exec.Cmd
+	if stress {
+		cmd = exec.Command(bin_path, "-c", conf_path, "--concurrency", "10")
+	} else {
+		cmd = exec.Command(bin_path, "-c", conf_path, "-l", "debug", "--concurrency", "1")
+	}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	return &Envoy{
+		cmd: cmd,
+	}, nil
+}
+
+func (s *Envoy) Start() error {
+	err := s.cmd.Start()
+	if err == nil {
+		url := fmt.Sprintf("http://localhost:%v/server_info", AdminPort)
+		WaitForHttpServer(url)
+		WaitForPort(ClientProxyPort)
+		WaitForPort(ServerProxyPort)
+	}
+	return err
+}
+
+func (s *Envoy) Stop() error {
+	log.Printf("Kill Envoy ...\n")
+	err := s.cmd.Process.Kill()
+	log.Printf("Kill Envoy ... Done\n")
+	return err
+}

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -20,28 +20,12 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 )
 
 // Envoy stores data for Envoy process
 type Envoy struct {
 	cmd   *exec.Cmd
 	ports *Ports
-}
-
-// Run command and return the merged output from stderr and stdout, error code
-func Run(name string, args ...string) (s string, err error) {
-	log.Println(">", name, strings.Join(args, " "))
-	c := exec.Command(name, args...)
-	bytes, err := c.CombinedOutput()
-	s = string(bytes)
-	for _, line := range strings.Split(s, "\n") {
-		log.Println(line)
-	}
-	if err != nil {
-		log.Println(err)
-	}
-	return
 }
 
 // NewEnvoy creates a new Envoy struct.
@@ -61,6 +45,7 @@ func NewEnvoy(conf, flags string, stress, faultInject bool, v2 *V2Conf, ports *P
 		args = append(args, "-l", "debug", "--concurrency", "1")
 	}
 
+	/* #nosec */
 	cmd := exec.Command(envoyPath, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -75,7 +60,7 @@ func (s *Envoy) Start() error {
 	err := s.cmd.Start()
 	if err == nil {
 		url := fmt.Sprintf("http://localhost:%v/server_info", s.ports.AdminPort)
-		WaitForHttpServer(url)
+		WaitForHTTPServer(url)
 		WaitForPort(s.ports.ClientProxyPort)
 		WaitForPort(s.ports.ServerProxyPort)
 	}

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 )
 
+// Envoy stores data for Envoy process
 type Envoy struct {
 	cmd   *exec.Cmd
 	ports *Ports
@@ -43,23 +44,24 @@ func Run(name string, args ...string) (s string, err error) {
 	return
 }
 
+// NewEnvoy creates a new Envoy struct.
 func NewEnvoy(conf, flags string, stress, faultInject bool, v2 *V2Conf, ports *Ports) (*Envoy, error) {
 	// Asssume test environment has copied latest envoy to $HOME/go/bin in bin/init.sh
-	envoy_path := "envoy"
-	conf_path := fmt.Sprintf("/tmp/config.conf.%v", ports.AdminPort)
-	log.Printf("Envoy config: in %v\n%v\n", conf_path, conf)
-	if err := CreateEnvoyConf(conf_path, conf, flags, stress, faultInject, v2, ports); err != nil {
+	envoyPath := "envoy"
+	confPath := fmt.Sprintf("/tmp/config.conf.%v", ports.AdminPort)
+	log.Printf("Envoy config: in %v\n%v\n", confPath, conf)
+	if err := CreateEnvoyConf(confPath, conf, flags, stress, faultInject, v2, ports); err != nil {
 		return nil, err
 	}
 
-	args := []string{"-c", conf_path, "--base-id", strconv.Itoa(int(ports.AdminPort))}
+	args := []string{"-c", confPath, "--base-id", strconv.Itoa(int(ports.AdminPort))}
 	if stress {
 		args = append(args, "--concurrency", "10")
 	} else {
 		args = append(args, "-l", "debug", "--concurrency", "1")
 	}
 
-	cmd := exec.Command(envoy_path, args...)
+	cmd := exec.Command(envoyPath, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return &Envoy{
@@ -68,6 +70,7 @@ func NewEnvoy(conf, flags string, stress, faultInject bool, v2 *V2Conf, ports *P
 	}, nil
 }
 
+// Start starts the envoy process
 func (s *Envoy) Start() error {
 	err := s.cmd.Start()
 	if err == nil {
@@ -79,6 +82,7 @@ func (s *Envoy) Start() error {
 	return err
 }
 
+// Stop stops the envoy process
 func (s *Envoy) Stop() error {
 	log.Printf("Kill Envoy ...\n")
 	err := s.cmd.Process.Kill()

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -24,22 +24,11 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-const (
-	// These ports should match with used envoy.conf
-	// Default is using one in this folder.
-	ServerProxyPort = 29090
-	ClientProxyPort = 27070
-	TcpProxyPort    = 26060
-	MixerPort       = 29091
-	BackendPort     = 28080
-	AdminPort       = 29001
-)
-
 type ConfParam struct {
-	ClientPort      int
-	ServerPort      int
-	TcpProxyPort    int
-	AdminPort       int
+	ClientPort      uint16
+	ServerPort      uint16
+	TcpProxyPort    uint16
+	AdminPort       uint16
 	MixerServer     string
 	Backend         string
 	ClientConfig    string
@@ -66,7 +55,7 @@ const QuotaConfig = `
 `
 
 // A quota cache is on by default
-const quotaCacheConfig = `
+const QuotaCacheConfig = `
                   "quota_name": "RequestCount"
 `
 
@@ -81,7 +70,7 @@ const DisableCheckCache = `
 `
 
 // A config to disable quota cache
-const disableQuotaCache = `
+const DisableQuotaCache = `
                   "disable_quota_cache": true
 `
 
@@ -326,21 +315,21 @@ func (c *ConfParam) write(path string) error {
 	return tmpl.Execute(f, *c)
 }
 
-func getConf() ConfParam {
+func getConf(ports *Ports) ConfParam {
 	return ConfParam{
-		ClientPort:   ClientProxyPort,
-		ServerPort:   ServerProxyPort,
-		TcpProxyPort: TcpProxyPort,
-		AdminPort:    AdminPort,
-		MixerServer:  fmt.Sprintf("localhost:%d", MixerPort),
-		Backend:      fmt.Sprintf("localhost:%d", BackendPort),
+		ClientPort:   ports.ClientProxyPort,
+		ServerPort:   ports.ServerProxyPort,
+		TcpProxyPort: ports.TcpProxyPort,
+		AdminPort:    ports.AdminPort,
+		MixerServer:  fmt.Sprintf("localhost:%d", ports.MixerPort),
+		Backend:      fmt.Sprintf("localhost:%d", ports.BackendPort),
 		ClientConfig: defaultClientMixerConfig,
 		AccessLog:    "/dev/stdout",
 	}
 }
 
-func CreateEnvoyConf(path, conf, flags string, stress, faultInject bool, v2 *V2Conf) error {
-	c := getConf()
+func CreateEnvoyConf(path, conf, flags string, stress, faultInject bool, v2 *V2Conf, ports *Ports) error {
+	c := getConf(ports)
 	c.ServerConfig = conf
 	c.TcpServerConfig = conf
 	c.MixerRouteFlags = defaultMixerRouteFlags

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -1,0 +1,374 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package env
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+)
+
+const (
+	// These ports should match with used envoy.conf
+	// Default is using one in this folder.
+	ServerProxyPort = 29090
+	ClientProxyPort = 27070
+	TcpProxyPort    = 26060
+	MixerPort       = 29091
+	BackendPort     = 28080
+	AdminPort       = 29001
+)
+
+type ConfParam struct {
+	ClientPort      int
+	ServerPort      int
+	TcpProxyPort    int
+	AdminPort       int
+	MixerServer     string
+	Backend         string
+	ClientConfig    string
+	ServerConfig    string
+	TcpServerConfig string
+	AccessLog       string
+	MixerRouteFlags string
+	FaultFilter     string
+}
+
+// A basic config
+const BasicConfig = `
+                  "mixer_attributes": {
+		      "mesh1.ip": "1.1.1.1",
+                      "target.uid": "POD222",
+                      "target.namespace": "XYZ222"
+                  }
+`
+
+// A quota config without cache
+const QuotaConfig = `
+                  "quota_name": "RequestCount",
+                  "quota_amount": "5"
+`
+
+// A quota cache is on by default
+const quotaCacheConfig = `
+                  "quota_name": "RequestCount"
+`
+
+// A config to disable all check calls for Tcp proxy
+const DisableTcpCheckCalls = `
+                  "disable_tcp_check_calls": true
+`
+
+// A config to disable check cache
+const DisableCheckCache = `
+                  "disable_check_cache": true
+`
+
+// A config to disable quota cache
+const disableQuotaCache = `
+                  "disable_quota_cache": true
+`
+
+// A config to disable report batch
+const DisableReportBatch = `
+                  "disable_report_batch": true
+`
+
+// A config with network fail close policy
+const NetworkFailClose = `
+                  "network_fail_policy": "close"
+`
+
+// The default client proxy mixer config
+const defaultClientMixerConfig = `
+                   "forward_attributes": {
+		      "mesh3.ip": "1::8",
+                      "source.uid": "POD11",
+                      "source.namespace": "XYZ11"
+                   }
+`
+
+const defaultMixerRouteFlags = `
+                   "mixer_control": "on",
+`
+
+const allAbortFaultFilter = `
+               {
+                   "type": "decoder",
+                   "name": "fault",
+                   "config": {
+                       "abort": {
+                           "abort_percent": 100,
+                           "http_status": 503
+                       }
+                   }
+               },
+`
+
+// The envoy config template
+const envoyConfTempl = `
+{
+  "listeners": [
+    {
+      "address": "tcp://0.0.0.0:{{.ServerPort}}",
+      "bind_to_port": true,
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],
+                  "routes": [
+                    {
+                      "timeout_ms": 0,
+                      "prefix": "/",
+                      "cluster": "service1",
+                      "opaque_config": {
+{{.MixerRouteFlags}}
+                        "mixer_forward": "off",
+			"mixer_attributes.mesh2.ip": "::ffff:204.152.189.116",
+                        "mixer_attributes.target.user": "target-user",
+                        "mixer_attributes.target.name": "target-name"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "access_log": [
+              {
+                "path": "{{.AccessLog}}"
+              }
+            ],
+            "filters": [
+{{.FaultFilter}}
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+{{.ServerConfig}}
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "address": "tcp://0.0.0.0:{{.ClientPort}}",
+      "bind_to_port": true,
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],
+                  "routes": [
+                    {
+                      "timeout_ms": 0,
+                      "prefix": "/",
+                      "cluster": "service2",
+                      "opaque_config": {
+                        "mixer_forward_attributes.source.user": "source-user",
+                        "mixer_forward_attributes.source.name": "source-name"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "access_log": [
+              {
+                "path": "{{.AccessLog}}"
+              }
+            ],
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+{{.ClientConfig}}
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "address": "tcp://0.0.0.0:{{.TcpProxyPort}}",
+      "bind_to_port": true,
+      "filters": [
+        {
+          "type": "both",
+          "name": "mixer",
+          "config": {
+{{.TcpServerConfig}}
+          }
+        },
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
+                {
+                  "cluster": "service1"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "access_log_path": "/dev/stdout",
+    "address": "tcp://0.0.0.0:{{.AdminPort}}"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "service1",
+        "connect_timeout_ms": 5000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://{{.Backend}}"
+          }
+        ]
+      },
+      {
+        "name": "service2",
+        "connect_timeout_ms": 5000,
+        "type": "strict_dns",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://localhost:{{.ServerPort}}"
+          }
+        ]
+      },
+      {
+        "name": "mixer_server",
+        "connect_timeout_ms": 5000,
+        "type": "strict_dns",
+	"circuit_breakers": {
+           "default": {
+	      "max_pending_requests": 10000,
+	      "max_requests": 10000
+            }
+	},
+        "lb_type": "round_robin",
+        "features": "http2",
+        "hosts": [
+          {
+            "url": "tcp://{{.MixerServer}}"
+          }
+        ]
+      }
+    ]
+  }
+}
+`
+
+func (c *ConfParam) write(path string) error {
+	tmpl, err := template.New("test").Parse(envoyConfTempl)
+	if err != nil {
+		return fmt.Errorf("Failed to parse config template: %v", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("Failed to create file %v: %v", path, err)
+	}
+	defer f.Close()
+	return tmpl.Execute(f, *c)
+}
+
+func getConf() ConfParam {
+	return ConfParam{
+		ClientPort:   ClientProxyPort,
+		ServerPort:   ServerProxyPort,
+		TcpProxyPort: TcpProxyPort,
+		AdminPort:    AdminPort,
+		MixerServer:  fmt.Sprintf("localhost:%d", MixerPort),
+		Backend:      fmt.Sprintf("localhost:%d", BackendPort),
+		ClientConfig: defaultClientMixerConfig,
+		AccessLog:    "/dev/stdout",
+	}
+}
+
+func CreateEnvoyConf(path, conf, flags string, stress, faultInject bool, v2 *V2Conf) error {
+	c := getConf()
+	c.ServerConfig = conf
+	c.TcpServerConfig = conf
+	c.MixerRouteFlags = defaultMixerRouteFlags
+	if flags != "" {
+		c.MixerRouteFlags = flags
+	}
+	if stress {
+		c.AccessLog = "/dev/null"
+	}
+	if faultInject {
+		c.FaultFilter = allAbortFaultFilter
+	}
+
+	if v2 != nil {
+		c.ServerConfig = getV2Config(v2.HttpServerConf)
+		c.ClientConfig = getV2Config(v2.HttpClientConf)
+		c.TcpServerConfig = getV2Config(v2.TcpServerConf)
+	}
+	return c.write(path)
+}
+
+func getV2Config(v2 proto.Message) string {
+	m := jsonpb.Marshaler{
+		Indent: "  ",
+	}
+	str, err := m.MarshalToString(v2)
+	if err != nil {
+		return ""
+	}
+	return "\"v2\": " + str
+}

--- a/mixer/test/client/env/http_client.go
+++ b/mixer/test/client/env/http_client.go
@@ -133,7 +133,7 @@ func WaitForHttpServer(url string) {
 	log.Println("Give up the wait, continue the test...")
 }
 
-func WaitForPort(port int) {
+func WaitForPort(port uint16) {
 	server_port := fmt.Sprintf("localhost:%v", port)
 	for i := 0; i < maxAttempts; i++ {
 		log.Println("Pinging port: ", server_port)

--- a/mixer/test/client/env/http_client.go
+++ b/mixer/test/client/env/http_client.go
@@ -1,0 +1,149 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// HTTP client time out in second.
+const HttpTimeOut = 5
+
+// Maximum number of ping the server to wait.
+const maxAttempts = 30
+
+// Issue fast request, only care about network error.
+// Don't care about server response.
+func HTTPFastGet(url string) (err error) {
+	client := &http.Client{}
+	client.Timeout = time.Duration(HttpTimeOut * time.Second)
+	_, err = client.Get(url)
+	return err
+}
+
+func HTTPGet(url string) (code int, resp_body string, err error) {
+	log.Println("HTTP GET", url)
+	client := &http.Client{}
+	client.Timeout = time.Duration(HttpTimeOut * time.Second)
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp_body = string(body)
+	code = resp.StatusCode
+	log.Println(resp_body)
+	return code, resp_body, nil
+}
+
+func HTTPPost(url string, content_type string, req_body string) (code int, resp_body string, err error) {
+	log.Println("HTTP POST", url)
+	client := &http.Client{}
+	client.Timeout = time.Duration(HttpTimeOut * time.Second)
+	resp, err := client.Post(url, content_type, strings.NewReader(req_body))
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp_body = string(body)
+	code = resp.StatusCode
+	log.Println(resp_body)
+	return code, resp_body, nil
+}
+
+func ShortLiveHTTPPost(url string, content_type string, req_body string) (code int, resp_body string, err error) {
+	log.Println("Short live HTTP POST", url)
+	tr := &http.Transport{
+		DisableKeepAlives: true,
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Post(url, content_type, strings.NewReader(req_body))
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp_body = string(body)
+	code = resp.StatusCode
+	log.Println(resp_body)
+	return code, resp_body, nil
+}
+
+func HTTPGetWithHeaders(l string, headers map[string]string) (code int, resp_body string, err error) {
+	log.Println("HTTP GET with headers: ", l)
+	client := &http.Client{}
+	client.Timeout = time.Duration(HttpTimeOut * time.Second)
+	req := http.Request{}
+
+	req.Header = map[string][]string{}
+	for k, v := range headers {
+		req.Header[k] = []string{v}
+	}
+	req.Method = http.MethodGet
+	req.URL, _ = url.Parse(l)
+
+	resp, err := client.Do(&req)
+	if err != nil {
+		log.Println(err)
+		return 0, "", err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp_body = string(body)
+	code = resp.StatusCode
+	log.Println(resp_body)
+	return code, resp_body, nil
+}
+
+func WaitForHttpServer(url string) {
+	for i := 0; i < maxAttempts; i++ {
+		log.Println("Pinging URL: ", url)
+		code, _, err := HTTPGet(url)
+		if err == nil && code == http.StatusOK {
+			log.Println("Server is up and running...")
+			return
+		}
+		log.Println("Will wait a second and try again.")
+		time.Sleep(time.Second)
+	}
+	log.Println("Give up the wait, continue the test...")
+}
+
+func WaitForPort(port int) {
+	server_port := fmt.Sprintf("localhost:%v", port)
+	for i := 0; i < maxAttempts; i++ {
+		log.Println("Pinging port: ", server_port)
+		_, err := net.Dial("tcp", server_port)
+		if err == nil {
+			log.Println("The port is up and running...")
+			return
+		}
+		log.Println("Wait a second and try again.")
+		time.Sleep(time.Second)
+	}
+	log.Println("Give up the wait, continue the test...")
+}

--- a/mixer/test/client/env/http_server.go
+++ b/mixer/test/client/env/http_server.go
@@ -35,7 +35,13 @@ const PubKey = `
             "e": "AQAB",
             "kid": "62a93512c9ee4c7f8067b5a216dade2763d32a47",
             "kty": "RSA",
-            "n": "0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw",
+            "n": "` +
+	"0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6" +
+	"s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3" +
+	"Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORX" +
+	"Q6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11Ho" +
+	"lzZmTQpRoLV8ZoHbHEaTfqX_aYahIw" +
+	`",
             "use": "sig"
         },
         {
@@ -43,7 +49,13 @@ const PubKey = `
             "e": "AQAB",
             "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e",
             "kty": "RSA",
-            "n": "qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q",
+            "n": "` +
+	"qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16w" +
+	"E-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdag" +
+	"B8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDS" +
+	"wMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2" +
+	"Mn_oA8jBuI8YKwBqYkZCN1I95Q" +
+	`",
             "use": "sig"
         }
     ]

--- a/mixer/test/client/env/http_server.go
+++ b/mixer/test/client/env/http_server.go
@@ -1,0 +1,114 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+)
+
+const (
+	FailHeader = "x-istio-backend-fail"
+	FailBody   = "Bad request from backend."
+)
+
+const PubKey = `
+{
+    "keys": [
+        {
+            "alg": "RS256",
+            "e": "AQAB",
+            "kid": "62a93512c9ee4c7f8067b5a216dade2763d32a47",
+            "kty": "RSA",
+            "n": "0YWnm_eplO9BFtXszMRQNL5UtZ8HJdTH2jK7vjs4XdLkPW7YBkkm_2xNgcaVpkW0VT2l4mU3KftR-6s3Oa5Rnz5BrWEUkCTVVolR7VYksfqIB2I_x5yZHdOiomMTcm3DheUUCgbJRv5OKRnNqszA4xHn3tA3Ry8VO3X7BgKZYAUh9fyZTFLlkeAh0-bLK5zvqCmKW5QgDIXSxUTJxPjZCgfx1vmAfGqaJb-nvmrORXQ6L284c73DUL7mnt6wj3H6tVqPKA27j56N0TB1Hfx4ja6Slr8S4EB3F1luYhATa1PKUSH8mYDW11HolzZmTQpRoLV8ZoHbHEaTfqX_aYahIw",
+            "use": "sig"
+        },
+        {
+            "alg": "RS256",
+            "e": "AQAB",
+            "kid": "b3319a147514df7ee5e4bcdee51350cc890cc89e",
+            "kty": "RSA",
+            "n": "qDi7Tx4DhNvPQsl1ofxxc2ePQFcs-L0mXYo6TGS64CY_2WmOtvYlcLNZjhuddZVV2X88m0MfwaSA16wE-RiKM9hqo5EY8BPXj57CMiYAyiHuQPp1yayjMgoE1P2jvp4eqF-BTillGJt5W5RuXti9uqfMtCQdagB8EC3MNRuU_KdeLgBy3lS3oo4LOYd-74kRBVZbk2wnmmb7IhP9OoLc1-7-9qU1uhpDxmE6JwBau0mDSwMnYDS4G_ML17dC-ZDtLd1i24STUw39KH0pcSdfFbL2NtEZdNeam1DDdk0iUtJSPZliUHJBI_pj8M-2Mn_oA8jBuI8YKwBqYkZCN1I95Q",
+            "use": "sig"
+        }
+    ]
+}
+`
+
+type HttpServer struct {
+	port uint16
+	lis  net.Listener
+}
+
+func pubkey_handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "%v", PubKey)
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Fail if there is such header.
+	if r.Header.Get(FailHeader) != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(FailBody))
+		return
+	}
+
+	// echo back the Content-Type and Content-Length in the response
+	for _, k := range []string{"Content-Type", "Content-Length"} {
+		if v := r.Header.Get(k); v != "" {
+			w.Header().Set(k, v)
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(body)
+}
+
+func NewHttpServer(port uint16) (*HttpServer, error) {
+	log.Printf("Http server listening on port %v\n", port)
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatal(err)
+		return nil, err
+	}
+	return &HttpServer{
+		port: port,
+		lis:  lis,
+	}, nil
+}
+
+func (s *HttpServer) Start() {
+	go func() {
+		http.HandleFunc("/", handler)
+		http.HandleFunc("/pubkey", pubkey_handler)
+		http.Serve(s.lis, nil)
+	}()
+
+	url := fmt.Sprintf("http://localhost:%v/echo", s.port)
+	WaitForHttpServer(url)
+}
+
+func (s *HttpServer) Stop() {
+	log.Printf("Close HTTP server\n")
+	s.lis.Close()
+	log.Printf("Close HTTP server -- Done\n")
+}

--- a/mixer/test/client/env/mixer_server.go
+++ b/mixer/test/client/env/mixer_server.go
@@ -1,0 +1,145 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+
+	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/mockapi"
+)
+
+type Handler struct {
+	stress   bool
+	ch       chan *attribute.MutableBag
+	count    int
+	r_status rpc.Status
+}
+
+func newHandler(stress bool) *Handler {
+	h := &Handler{
+		stress:   stress,
+		count:    0,
+		r_status: rpc.Status{},
+	}
+	if !stress {
+		h.ch = make(chan *attribute.MutableBag, 100) // Allow maximum 100 requests
+	}
+	return h
+}
+
+func (h *Handler) run(bag attribute.Bag) rpc.Status {
+	if !h.stress {
+		h.ch <- attribute.CopyBag(bag)
+	}
+	h.count++
+	return h.r_status
+}
+
+type MixerServer struct {
+	mockapi.AttributesHandler
+
+	lis net.Listener
+	gs  *grpc.Server
+
+	check  *Handler
+	report *Handler
+	quota  *Handler
+
+	qma          mockapi.QuotaArgs
+	quota_amount int64
+	quota_limit  int64
+
+	check_referenced *mixerpb.ReferencedAttributes
+	quota_referenced *mixerpb.ReferencedAttributes
+}
+
+func (ts *MixerServer) Check(bag attribute.Bag, output *attribute.MutableBag) (mockapi.CheckResponse, rpc.Status) {
+	result := mockapi.CheckResponse{
+		ValidDuration: mockapi.DefaultValidDuration,
+		ValidUseCount: mockapi.DefaultValidUseCount,
+		Referenced:    ts.check_referenced,
+	}
+	return result, ts.check.run(bag)
+}
+
+func (ts *MixerServer) Report(bag attribute.Bag) rpc.Status {
+	return ts.report.run(bag)
+}
+
+func (ts *MixerServer) Quota(bag attribute.Bag, qma mockapi.QuotaArgs) (mockapi.QuotaResponse, rpc.Status) {
+	ts.qma = qma
+	status := ts.quota.run(bag)
+	qmr := mockapi.QuotaResponse{}
+	if status.Code == 0 {
+		if ts.quota_limit == 0 {
+			qmr.Amount = qma.Amount
+		} else {
+			if ts.quota_amount < ts.quota_limit {
+				delta := ts.quota_limit - ts.quota_amount
+				if delta > qma.Amount {
+					qmr.Amount = qma.Amount
+				} else {
+					qmr.Amount = delta
+				}
+			}
+			ts.quota_amount += qmr.Amount
+		}
+		qmr.Expiration = time.Minute
+	}
+	qmr.Referenced = ts.quota_referenced
+	return qmr, status
+}
+
+func NewMixerServer(port uint16, stress bool) (*MixerServer, error) {
+	log.Printf("Mixer server listening on port %v\n", port)
+	s := &MixerServer{
+		check:  newHandler(stress),
+		report: newHandler(stress),
+		quota:  newHandler(stress),
+		qma:    mockapi.QuotaArgs{},
+	}
+
+	var err error
+	s.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+		return nil, err
+	}
+
+	attrSrv := mockapi.NewAttributesServer(s)
+	s.gs = mockapi.NewMixerServer(attrSrv)
+	return s, nil
+}
+
+func (s *MixerServer) Start() {
+	go func() {
+		_ = s.gs.Serve(s.lis)
+		log.Printf("Mixer server exited\n")
+	}()
+}
+
+func (s *MixerServer) Stop() {
+	log.Printf("Stop Mixer server\n")
+	s.gs.Stop()
+	log.Printf("Stop Mixer server  -- Done\n")
+}

--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+// Dynamic port allocation scheme
+// In order to run the tests in parallel. Each test should use unique ports
+// Each test has a unique test_name, its ports will be allocated based on that name
+
+// All tests should be listed here to get their test ids
+const (
+	CheckCacheTest uint16 = iota
+	CheckReportAttributesTest
+	CheckReportDisableTest
+	DisableCheckCacheTest
+	DisableTcpCheckCallsTest
+	FailedRequestTest
+	FaultInjectTest
+	JWTAuthTest
+	MixerInternalFailTest
+	NetworkFailureTest
+	ReportBatchTest
+	StressEnvoyTest
+	TcpMixerFilterTest
+	QuotaCacheTest
+	QuotaCallTest
+)
+
+const (
+	PortBase uint16 = 29000
+	PortStep uint16 = 10
+)
+
+type Ports struct {
+	ClientProxyPort uint16
+	ServerProxyPort uint16
+	TcpProxyPort    uint16
+	MixerPort       uint16
+	BackendPort     uint16
+	AdminPort       uint16
+}
+
+func NewPorts(name uint16) *Ports {
+	base := PortBase + name*PortStep
+	return &Ports{
+		ClientProxyPort: base,
+		ServerProxyPort: base + 1,
+		TcpProxyPort:    base + 2,
+		MixerPort:       base + 3,
+		BackendPort:     base + 4,
+		AdminPort:       base + 5,
+	}
+}

--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -24,7 +24,7 @@ const (
 	CheckReportAttributesTest
 	CheckReportDisableTest
 	DisableCheckCacheTest
-	DisableTcpCheckCallsTest
+	DisableTCPCheckCallsTest
 	FailedRequestTest
 	FaultInjectTest
 	JWTAuthTest
@@ -32,31 +32,33 @@ const (
 	NetworkFailureTest
 	ReportBatchTest
 	StressEnvoyTest
-	TcpMixerFilterTest
+	TCPMixerFilterTest
 	QuotaCacheTest
 	QuotaCallTest
 )
 
 const (
-	PortBase uint16 = 29000
-	PortStep uint16 = 10
+	portBase uint16 = 29000
+	portStep uint16 = 10
 )
 
+// Ports stores all used ports
 type Ports struct {
 	ClientProxyPort uint16
 	ServerProxyPort uint16
-	TcpProxyPort    uint16
+	TCPProxyPort    uint16
 	MixerPort       uint16
 	BackendPort     uint16
 	AdminPort       uint16
 }
 
+// NewPorts allocate all ports based on test id.
 func NewPorts(name uint16) *Ports {
-	base := PortBase + name*PortStep
+	base := portBase + name*portStep
 	return &Ports{
 		ClientProxyPort: base,
 		ServerProxyPort: base + 1,
-		TcpProxyPort:    base + 2,
+		TCPProxyPort:    base + 2,
 		MixerPort:       base + 3,
 		BackendPort:     base + 4,
 		AdminPort:       base + 5,

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -1,0 +1,209 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"log"
+	"testing"
+
+	mixerpb "istio.io/api/mixer/v1"
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+)
+
+type TestSetup struct {
+	t           *testing.T
+	conf        string
+	flags       string
+	stress      bool
+	faultInject bool
+	noMixer     bool
+	v2          *V2Conf
+
+	envoy   *Envoy
+	mixer   *MixerServer
+	backend *HttpServer
+}
+
+func NewTestSetup(t *testing.T, conf string) *TestSetup {
+	return &TestSetup{
+		t:    t,
+		conf: conf,
+	}
+}
+
+func NewTestSetupV2(t *testing.T) *TestSetup {
+	return &TestSetup{
+		t:  t,
+		v2: GetDefaultV2Conf(),
+	}
+}
+
+func (s *TestSetup) SetConf(conf string) {
+	s.conf = conf
+}
+
+func (s *TestSetup) SetV2Conf() {
+	s.v2 = GetDefaultV2Conf()
+}
+
+func (s *TestSetup) V2() *V2Conf {
+	return s.v2
+}
+
+func (s *TestSetup) SetMixerCheckReferenced(ref *mixerpb.ReferencedAttributes) {
+	s.mixer.check_referenced = ref
+}
+
+func (s *TestSetup) SetMixerQuotaReferenced(ref *mixerpb.ReferencedAttributes) {
+	s.mixer.quota_referenced = ref
+}
+
+func (s *TestSetup) SetMixerCheckStatus(status rpc.Status) {
+	s.mixer.check.r_status = status
+}
+
+func (s *TestSetup) SetMixerQuotaStatus(status rpc.Status) {
+	s.mixer.quota.r_status = status
+}
+
+func (s *TestSetup) SetMixerQuotaLimit(limit int64) {
+	s.mixer.quota_limit = limit
+}
+
+func (s *TestSetup) GetMixerQuotaCount() int {
+	return s.mixer.quota.count
+}
+
+func (s *TestSetup) SetFlags(flags string) {
+	s.flags = flags
+}
+
+func (s *TestSetup) SetStress(stress bool) {
+	s.stress = stress
+}
+
+func (s *TestSetup) SetNoMixer(no bool) {
+	s.noMixer = no
+}
+
+func (s *TestSetup) SetFaultInject(f bool) {
+	s.faultInject = f
+}
+
+func (s *TestSetup) SetUp() error {
+	var err error
+	s.envoy, err = NewEnvoy(s.conf, s.flags, s.stress, s.faultInject, s.v2)
+	if err != nil {
+		log.Printf("unable to create Envoy %v", err)
+	} else {
+		s.envoy.Start()
+	}
+
+	if !s.noMixer {
+		s.mixer, err = NewMixerServer(MixerPort, s.stress)
+		if err != nil {
+			log.Printf("unable to create mixer server %v", err)
+		} else {
+			s.mixer.Start()
+		}
+	}
+
+	s.backend, err = NewHttpServer(BackendPort)
+	if err != nil {
+		log.Printf("unable to create HTTP server %v", err)
+	} else {
+		s.backend.Start()
+	}
+	return err
+}
+
+func (s *TestSetup) TearDown() {
+	s.envoy.Stop()
+	if s.mixer != nil {
+		s.mixer.Stop()
+	}
+	s.backend.Stop()
+}
+
+func (s *TestSetup) ReStartEnvoy() {
+	s.envoy.Stop()
+	var err error
+	s.envoy, err = NewEnvoy(s.conf, s.flags, s.stress, s.faultInject, s.v2)
+	if err != nil {
+		s.t.Errorf("unable to re-start Envoy %v", err)
+	} else {
+		s.envoy.Start()
+	}
+}
+
+func (s *TestSetup) VerifyCheckCount(tag string, expected int) {
+	if s.mixer.check.count != expected {
+		s.t.Fatalf("%s check count doesn't match: %v\n, expected: %+v",
+			tag, s.mixer.check.count, expected)
+	}
+}
+
+func (s *TestSetup) VerifyReportCount(tag string, expected int) {
+	if s.mixer.report.count != expected {
+		s.t.Fatalf("%s report count doesn't match: %v\n, expected: %+v",
+			tag, s.mixer.report.count, expected)
+	}
+}
+
+func (s *TestSetup) VerifyCheck(tag string, result string) {
+	bag := <-s.mixer.check.ch
+	if err := Verify(bag, result); err != nil {
+		s.t.Fatalf("Failed to verify %s check: %v\n, Attributes: %+v",
+			tag, err, bag)
+	}
+}
+
+func (s *TestSetup) VerifyReport(tag string, result string) {
+	bag := <-s.mixer.report.ch
+	if err := Verify(bag, result); err != nil {
+		s.t.Fatalf("Failed to verify %s report: %v\n, Attributes: %+v",
+			tag, err, bag)
+	}
+}
+
+func (s *TestSetup) VerifyQuota(tag string, name string, amount int64) {
+	_ = <-s.mixer.quota.ch
+	if s.mixer.qma.Quota != name {
+		s.t.Fatalf("Failed to verify %s quota name: %v, expected: %v\n",
+			tag, s.mixer.qma.Quota, name)
+	}
+	if s.mixer.qma.Amount != amount {
+		s.t.Fatalf("Failed to verify %s quota amount: %v, expected: %v\n",
+			tag, s.mixer.qma.Amount, amount)
+	}
+}
+
+func (s *TestSetup) DrainMixerAllChannels() {
+	go func() {
+		for true {
+			_ = <-s.mixer.check.ch
+		}
+	}()
+	go func() {
+		for true {
+			_ = <-s.mixer.report.ch
+		}
+	}()
+	go func() {
+		for true {
+			_ = <-s.mixer.quota.ch
+		}
+	}()
+}

--- a/mixer/test/client/env/v2_config.go
+++ b/mixer/test/client/env/v2_config.go
@@ -1,0 +1,154 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package env
+
+import (
+	mpb "istio.io/api/mixer/v1"
+	mccpb "istio.io/api/mixer/v1/config/client"
+)
+
+var (
+	MeshIp1 = []byte{1, 1, 1, 1}
+	MeshIp2 = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 204, 152, 189, 116}
+	MeshIp3 = []byte{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}
+)
+
+type V2Conf struct {
+	HttpServerConf *mccpb.HttpClientConfig
+	HttpClientConf *mccpb.HttpClientConfig
+	TcpServerConf  *mccpb.TcpClientConfig
+}
+
+func GetDefaultV2Conf() *V2Conf {
+	return &V2Conf{
+		HttpServerConf: GetDefaultHttpServerConf(),
+		HttpClientConf: GetDefaultHttpClientConf(),
+		TcpServerConf:  GetDefaultTcpServerConf(),
+	}
+}
+
+func GetDefaultHttpServerConf() *mccpb.HttpClientConfig {
+	v2 := &mccpb.HttpClientConfig{
+		MixerAttributes: &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{
+				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp1}},
+				"target.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD222"}},
+				"target.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ222"}},
+			},
+		},
+		ServiceConfigs: map[string]*mccpb.ServiceConfig{},
+	}
+	service := ":default"
+	v2.DefaultDestinationService = service
+	v2.ServiceConfigs[service] = &mccpb.ServiceConfig{
+		MixerAttributes: &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{
+				"mesh2.ip":    {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp2}},
+				"target.user": {Value: &mpb.Attributes_AttributeValue_StringValue{"target-user"}},
+				"target.name": {Value: &mpb.Attributes_AttributeValue_StringValue{"target-name"}},
+			},
+		},
+		// TODO per-service HttpApiApsec, QuotaSpec
+	}
+
+	return v2
+}
+
+func GetDefaultHttpClientConf() *mccpb.HttpClientConfig {
+	v2 := &mccpb.HttpClientConfig{
+		ForwardAttributes: &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{
+				"mesh3.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp3}},
+				"source.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD11"}},
+				"source.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ11"}},
+			},
+		},
+		ServiceConfigs: map[string]*mccpb.ServiceConfig{},
+	}
+	return v2
+}
+
+func GetDefaultTcpServerConf() *mccpb.TcpClientConfig {
+	v2 := &mccpb.TcpClientConfig{
+		MixerAttributes: &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{
+				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp1}},
+				"target.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD222"}},
+				"target.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ222"}},
+			},
+		},
+	}
+	return v2
+}
+
+func SetNetworPolicy(v2 *mccpb.HttpClientConfig, open bool) {
+	if v2.Transport == nil {
+		v2.Transport = &mccpb.TransportConfig{}
+	}
+	if open {
+		v2.Transport.NetworkFailPolicy = mccpb.FAIL_OPEN
+	} else {
+		v2.Transport.NetworkFailPolicy = mccpb.FAIL_CLOSE
+	}
+}
+
+func DisableClientCache(v2 *mccpb.HttpClientConfig, check_cache, quota_cache, report_batch bool) {
+	if v2.Transport == nil {
+		v2.Transport = &mccpb.TransportConfig{}
+	}
+	v2.Transport.DisableCheckCache = check_cache
+	v2.Transport.DisableQuotaCache = quota_cache
+	v2.Transport.DisableReportBatch = report_batch
+}
+
+func DisableHttpCheckReport(v2 *mccpb.HttpClientConfig, disable_check, disable_report bool) {
+	for _, s := range v2.ServiceConfigs {
+		s.DisableCheckCalls = disable_check
+		s.DisableReportCalls = disable_report
+	}
+}
+
+func AddHttpQuota(v2 *mccpb.HttpClientConfig, quota string, charge int64) {
+	q := &mccpb.QuotaSpec{
+		Rules: make([]*mccpb.QuotaRule, 1),
+	}
+	q.Rules[0] = &mccpb.QuotaRule{
+		Quotas: make([]*mccpb.Quota, 1),
+	}
+	q.Rules[0].Quotas[0] = &mccpb.Quota{
+		Quota:  quota,
+		Charge: charge,
+	}
+
+	for _, s := range v2.ServiceConfigs {
+		s.QuotaSpec = make([]*mccpb.QuotaSpec, 1)
+		s.QuotaSpec[0] = q
+	}
+}
+
+func DisableTcpCheckReport(v2 *mccpb.TcpClientConfig, disable_check, disable_report bool) {
+	v2.DisableCheckCalls = disable_check
+	v2.DisableReportCalls = disable_report
+}
+
+func AddJwtAuth(v2 *mccpb.HttpClientConfig, jwt *mccpb.JWT) {
+	for _, s := range v2.ServiceConfigs {
+		if s.EndUserAuthnSpec == nil {
+			s.EndUserAuthnSpec = &mccpb.EndUserAuthenticationPolicySpec{}
+		}
+		s.EndUserAuthnSpec.Jwts = append(s.EndUserAuthnSpec.Jwts, jwt)
+	}
+}

--- a/mixer/test/client/env/v2_config.go
+++ b/mixer/test/client/env/v2_config.go
@@ -21,30 +21,33 @@ import (
 )
 
 var (
-	MeshIp1 = []byte{1, 1, 1, 1}
-	MeshIp2 = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 204, 152, 189, 116}
-	MeshIp3 = []byte{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}
+	meshIP1 = []byte{1, 1, 1, 1}
+	meshIP2 = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 204, 152, 189, 116}
+	meshIP3 = []byte{0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}
 )
 
+// V2Conf stores v2 config.
 type V2Conf struct {
-	HttpServerConf *mccpb.HttpClientConfig
-	HttpClientConf *mccpb.HttpClientConfig
-	TcpServerConf  *mccpb.TcpClientConfig
+	HTTPServerConf *mccpb.HttpClientConfig
+	HTTPClientConf *mccpb.HttpClientConfig
+	TCPServerConf  *mccpb.TcpClientConfig
 }
 
+// GetDefaultV2Conf get V2 config
 func GetDefaultV2Conf() *V2Conf {
 	return &V2Conf{
-		HttpServerConf: GetDefaultHttpServerConf(),
-		HttpClientConf: GetDefaultHttpClientConf(),
-		TcpServerConf:  GetDefaultTcpServerConf(),
+		HTTPServerConf: GetDefaultHTTPServerConf(),
+		HTTPClientConf: GetDefaultHTTPClientConf(),
+		TCPServerConf:  GetDefaultTCPServerConf(),
 	}
 }
 
-func GetDefaultHttpServerConf() *mccpb.HttpClientConfig {
+// GetDefaultHTTPServerConf get default HTTP server config
+func GetDefaultHTTPServerConf() *mccpb.HttpClientConfig {
 	v2 := &mccpb.HttpClientConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp1}},
+				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{meshIP1}},
 				"target.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD222"}},
 				"target.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ222"}},
 			},
@@ -56,22 +59,23 @@ func GetDefaultHttpServerConf() *mccpb.HttpClientConfig {
 	v2.ServiceConfigs[service] = &mccpb.ServiceConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"mesh2.ip":    {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp2}},
+				"mesh2.ip":    {Value: &mpb.Attributes_AttributeValue_BytesValue{meshIP2}},
 				"target.user": {Value: &mpb.Attributes_AttributeValue_StringValue{"target-user"}},
 				"target.name": {Value: &mpb.Attributes_AttributeValue_StringValue{"target-name"}},
 			},
 		},
-		// TODO per-service HttpApiApsec, QuotaSpec
+		// TODO per-service HTTPApiApsec, QuotaSpec
 	}
 
 	return v2
 }
 
-func GetDefaultHttpClientConf() *mccpb.HttpClientConfig {
+// GetDefaultHTTPClientConf get default HTTP client config
+func GetDefaultHTTPClientConf() *mccpb.HttpClientConfig {
 	v2 := &mccpb.HttpClientConfig{
 		ForwardAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"mesh3.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp3}},
+				"mesh3.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{meshIP3}},
 				"source.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD11"}},
 				"source.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ11"}},
 			},
@@ -81,11 +85,12 @@ func GetDefaultHttpClientConf() *mccpb.HttpClientConfig {
 	return v2
 }
 
-func GetDefaultTcpServerConf() *mccpb.TcpClientConfig {
+// GetDefaultTCPServerConf get default TCP server config
+func GetDefaultTCPServerConf() *mccpb.TcpClientConfig {
 	v2 := &mccpb.TcpClientConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{MeshIp1}},
+				"mesh1.ip":         {Value: &mpb.Attributes_AttributeValue_BytesValue{meshIP1}},
 				"target.uid":       {Value: &mpb.Attributes_AttributeValue_StringValue{"POD222"}},
 				"target.namespace": {Value: &mpb.Attributes_AttributeValue_StringValue{"XYZ222"}},
 			},
@@ -94,6 +99,7 @@ func GetDefaultTcpServerConf() *mccpb.TcpClientConfig {
 	return v2
 }
 
+// SetNetworPolicy set network policy
 func SetNetworPolicy(v2 *mccpb.HttpClientConfig, open bool) {
 	if v2.Transport == nil {
 		v2.Transport = &mccpb.TransportConfig{}
@@ -105,23 +111,26 @@ func SetNetworPolicy(v2 *mccpb.HttpClientConfig, open bool) {
 	}
 }
 
-func DisableClientCache(v2 *mccpb.HttpClientConfig, check_cache, quota_cache, report_batch bool) {
+// DisableClientCache disable client cache
+func DisableClientCache(v2 *mccpb.HttpClientConfig, checkCache, quotaCache, reportBatch bool) {
 	if v2.Transport == nil {
 		v2.Transport = &mccpb.TransportConfig{}
 	}
-	v2.Transport.DisableCheckCache = check_cache
-	v2.Transport.DisableQuotaCache = quota_cache
-	v2.Transport.DisableReportBatch = report_batch
+	v2.Transport.DisableCheckCache = checkCache
+	v2.Transport.DisableQuotaCache = quotaCache
+	v2.Transport.DisableReportBatch = reportBatch
 }
 
-func DisableHttpCheckReport(v2 *mccpb.HttpClientConfig, disable_check, disable_report bool) {
+// DisableHTTPCheckReport disable HTTP check report
+func DisableHTTPCheckReport(v2 *mccpb.HttpClientConfig, disableCheck, disableReport bool) {
 	for _, s := range v2.ServiceConfigs {
-		s.DisableCheckCalls = disable_check
-		s.DisableReportCalls = disable_report
+		s.DisableCheckCalls = disableCheck
+		s.DisableReportCalls = disableReport
 	}
 }
 
-func AddHttpQuota(v2 *mccpb.HttpClientConfig, quota string, charge int64) {
+// AddHTTPQuota add HTTP quota config
+func AddHTTPQuota(v2 *mccpb.HttpClientConfig, quota string, charge int64) {
 	q := &mccpb.QuotaSpec{
 		Rules: make([]*mccpb.QuotaRule, 1),
 	}
@@ -139,11 +148,13 @@ func AddHttpQuota(v2 *mccpb.HttpClientConfig, quota string, charge int64) {
 	}
 }
 
-func DisableTcpCheckReport(v2 *mccpb.TcpClientConfig, disable_check, disable_report bool) {
-	v2.DisableCheckCalls = disable_check
-	v2.DisableReportCalls = disable_report
+// DisableTCPCheckReport disable TCP check report.
+func DisableTCPCheckReport(v2 *mccpb.TcpClientConfig, disableCheck, disableReport bool) {
+	v2.DisableCheckCalls = disableCheck
+	v2.DisableReportCalls = disableReport
 }
 
+// AddJwtAuth add JWT auth.
 func AddJwtAuth(v2 *mccpb.HttpClientConfig, jwt *mccpb.JWT) {
 	for _, s := range v2.ServiceConfigs {
 		if s.EndUserAuthnSpec == nil {

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package failed_request
+package failedRequest
 
 import (
 	"fmt"
@@ -161,7 +161,7 @@ func TestFailedRequest(t *testing.T) {
 		Code:    int32(rpc.UNAUTHENTICATED),
 		Message: mixerAuthFailMessage,
 	})
-	code, resp_body, err := env.HTTPGet(url)
+	code, respBody, err := env.HTTPGet(url)
 	// Make sure to restore r_status for next request.
 	s.SetMixerCheckStatus(rpc.Status{})
 	if err != nil {
@@ -170,8 +170,8 @@ func TestFailedRequest(t *testing.T) {
 	if code != 401 {
 		t.Errorf("Status code 401 is expected, got %d.", code)
 	}
-	if resp_body != "UNAUTHENTICATED:"+mixerAuthFailMessage {
-		t.Errorf("Error response body is not expected, got: '%s'.", resp_body)
+	if respBody != "UNAUTHENTICATED:"+mixerAuthFailMessage {
+		t.Errorf("Error response body is not expected, got: '%s'.", respBody)
 	}
 	s.VerifyCheck(tag, checkAttributesMixerFail)
 	s.VerifyReport(tag, reportAttributesMixerFail)
@@ -180,15 +180,15 @@ func TestFailedRequest(t *testing.T) {
 	tag = "BackendFail"
 	headers := map[string]string{}
 	headers[env.FailHeader] = "Yes"
-	code, resp_body, err = env.HTTPGetWithHeaders(url, headers)
+	code, respBody, err = env.HTTPGetWithHeaders(url, headers)
 	if err != nil {
 		t.Errorf("Failed in request %s: %v", tag, err)
 	}
 	if code != 400 {
 		t.Errorf("Status code 400 is expected, got %d.", code)
 	}
-	if resp_body != env.FailBody {
-		t.Errorf("Error response body is not expected, got '%s'.", resp_body)
+	if respBody != env.FailBody {
+		t.Errorf("Error response body is not expected, got '%s'.", respBody)
 	}
 	// Same Check attributes as the first one.
 	s.VerifyCheck(tag, checkAttributesMixerFail)

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -33,7 +33,7 @@ const checkAttributesMixerFail = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -50,7 +50,7 @@ const checkAttributesMixerFail = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -67,7 +67,7 @@ const reportAttributesMixerFail = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -84,7 +84,7 @@ const reportAttributesMixerFail = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -110,7 +110,7 @@ const reportAttributesBackendFail = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -127,7 +127,7 @@ const reportAttributesBackendFail = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -148,13 +148,13 @@ const reportAttributesBackendFail = `
 `
 
 func TestFailedRequest(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.FailedRequestTest, t)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	tag := "MixerFail"
 	s.SetMixerCheckStatus(rpc.Status{

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -93,6 +93,7 @@ const reportAttributesMixerFail = `
   "response.time": "*",
   "response.size": 41,
   "response.duration": "*",
+  "response.code": 401,
   "response.headers": {
      "date": "*",
      "content-type": "text/plain",

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -1,0 +1,196 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failed_request
+
+import (
+	"fmt"
+	"testing"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+const (
+	mixerAuthFailMessage = "Unauthenticated by mixer."
+)
+
+// Check attributes from a fail GET request from mixer
+const checkAttributesMixerFail = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  }
+}
+`
+
+// Report attributes from a fail GET request from mixer
+const reportAttributesMixerFail = `
+{
+  "check.error_code": 16,
+  "check.error_message": "UNAUTHENTICATED:Unauthenticated by mixer.",
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 41,
+  "response.duration": "*",
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "41",
+     ":status": "401",
+     "server": "envoy"
+  }
+}
+`
+
+// Report attributes from a fail GET request from backend
+const reportAttributesBackendFail = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 25,
+  "response.duration": "*",
+  "response.code": 400,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain; charset=utf-8",
+     "content-length": "25",
+     ":status": "400",
+     "server": "envoy"
+  }
+}
+`
+
+func TestFailedRequest(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	tag := "MixerFail"
+	s.SetMixerCheckStatus(rpc.Status{
+		Code:    int32(rpc.UNAUTHENTICATED),
+		Message: mixerAuthFailMessage,
+	})
+	code, resp_body, err := env.HTTPGet(url)
+	// Make sure to restore r_status for next request.
+	s.SetMixerCheckStatus(rpc.Status{})
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp_body != "UNAUTHENTICATED:"+mixerAuthFailMessage {
+		t.Errorf("Error response body is not expected, got: '%s'.", resp_body)
+	}
+	s.VerifyCheck(tag, checkAttributesMixerFail)
+	s.VerifyReport(tag, reportAttributesMixerFail)
+
+	// Issues a failed request caused by backend
+	tag = "BackendFail"
+	headers := map[string]string{}
+	headers[env.FailHeader] = "Yes"
+	code, resp_body, err = env.HTTPGetWithHeaders(url, headers)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 400 {
+		t.Errorf("Status code 400 is expected, got %d.", code)
+	}
+	if resp_body != env.FailBody {
+		t.Errorf("Error response body is not expected, got '%s'.", resp_body)
+	}
+	// Same Check attributes as the first one.
+	s.VerifyCheck(tag, checkAttributesMixerFail)
+	s.VerifyReport(tag, reportAttributesBackendFail)
+}

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -28,7 +28,7 @@ const reportAttributes = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -43,7 +43,7 @@ const reportAttributes = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -64,7 +64,7 @@ const reportAttributes = `
 `
 
 func TestFaultInject(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.FaultInjectTest, t)
 	s.SetFaultInject(true)
 
 	if err := s.SetUp(); err != nil {
@@ -72,7 +72,7 @@ func TestFaultInject(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	tag := "FaultInject"
 	code, _, err := env.HTTPGet(url)

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fault_inject
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Report attributes from a fault inject GET request
+const reportAttributes = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 18,
+  "response.duration": "*",
+  "response.code": 503,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "18",
+     ":status": "503",
+     "server": "envoy"
+  }
+}
+`
+
+func TestFaultInject(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	s.SetFaultInject(true)
+
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	tag := "FaultInject"
+	code, _, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 503 {
+		t.Errorf("Status code 503 is expected, got %d.", code)
+	}
+	// Fault filter is before Mixer, Check is not called.
+	s.VerifyReport(tag, reportAttributes)
+}

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fault_inject
+package faultInject
 
 import (
 	"fmt"

--- a/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
+++ b/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mixer_internal_fail
+package mixerInternalFail
 
 import (
 	"fmt"

--- a/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
+++ b/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
@@ -75,7 +75,7 @@ func TestMixerInternalFail(t *testing.T) {
 	}
 
 	// Set to fail_close
-	env.SetNetworPolicy(s.V2().HttpServerConf, false)
+	env.SetNetworPolicy(s.V2().HTTPServerConf, false)
 	s.ReStartEnvoy()
 
 	tag = "Fail-Close"

--- a/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
+++ b/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
@@ -1,0 +1,91 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixer_internal_fail
+
+import (
+	"fmt"
+	"testing"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Mixer server returns INTERNAL failure.
+func TestMixerInternalFail(t *testing.T) {
+	s := env.NewTestSetup(t, env.BasicConfig)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ServerProxyPort)
+
+	// Mixer to return INTERNAL error.
+	s.SetMixerCheckStatus(rpc.Status{
+		Code: int32(rpc.INTERNAL),
+	})
+
+	tag := "Fail-Open-v1"
+	code, _, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Since fail_open policy by default, expect 200.
+	if code != 200 {
+		t.Errorf("Status code 200 is expected, got %d.", code)
+	}
+
+	s.SetConf(env.BasicConfig + "," + env.NetworkFailClose)
+	s.ReStartEnvoy()
+
+	tag = "Fail-Close-V1"
+	// Use fail close policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Since fail_close policy, expect 500.
+	if code != 500 {
+		t.Errorf("Status code 500 is expected, got %d.", code)
+	}
+
+	s.SetV2Conf()
+	s.ReStartEnvoy()
+
+	tag = "Fail-Open"
+	// Default is fail open policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 200 {
+		t.Errorf("Status code 200 is expected, got %d.", code)
+	}
+
+	// Set to fail_close
+	env.SetNetworPolicy(s.V2().HttpServerConf, false)
+	s.ReStartEnvoy()
+
+	tag = "Fail-Close"
+	// Use fail close policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Since fail_close policy, expect 500.
+	if code != 500 {
+		t.Errorf("Status code 500 is expected, got %d.", code)
+	}
+}

--- a/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
+++ b/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
@@ -24,13 +24,13 @@ import (
 
 // Mixer server returns INTERNAL failure.
 func TestMixerInternalFail(t *testing.T) {
-	s := env.NewTestSetup(t, env.BasicConfig)
+	s := env.NewTestSetup(env.MixerInternalFailTest, t, env.BasicConfig)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ServerProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ServerProxyPort)
 
 	// Mixer to return INTERNAL error.
 	s.SetMixerCheckStatus(rpc.Status{

--- a/mixer/test/client/network_policy/network_policy_test.go
+++ b/mixer/test/client/network_policy/network_policy_test.go
@@ -23,14 +23,14 @@ import (
 
 // Mixer server not running.
 func TestNetworkFailure(t *testing.T) {
-	s := env.NewTestSetup(t, env.BasicConfig)
+	s := env.NewTestSetup(env.NetworkFailureTest, t, env.BasicConfig)
 	s.SetNoMixer(true)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ServerProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ServerProxyPort)
 
 	tag := "Fail-Open-V1"
 	// Default is fail open policy.

--- a/mixer/test/client/network_policy/network_policy_test.go
+++ b/mixer/test/client/network_policy/network_policy_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package network_policy
+package networkPolicy
 
 import (
 	"fmt"

--- a/mixer/test/client/network_policy/network_policy_test.go
+++ b/mixer/test/client/network_policy/network_policy_test.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network_policy
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Mixer server not running.
+func TestNetworkFailure(t *testing.T) {
+	s := env.NewTestSetup(t, env.BasicConfig)
+	s.SetNoMixer(true)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ServerProxyPort)
+
+	tag := "Fail-Open-V1"
+	// Default is fail open policy.
+	code, _, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 200 {
+		t.Errorf("Status code 200 is expected, got %d.", code)
+	}
+
+	s.SetConf(env.BasicConfig + "," + env.NetworkFailClose)
+	s.ReStartEnvoy()
+
+	tag = "Fail-Close-V1"
+	// Use fail close policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 503 {
+		t.Errorf("Status code 503 is expected, got %d.", code)
+	}
+
+	s.SetV2Conf()
+	s.ReStartEnvoy()
+
+	tag = "Fail-Open"
+	// Default is fail open policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 200 {
+		t.Errorf("Status code 200 is expected, got %d.", code)
+	}
+
+	// Set to fail_close
+	env.SetNetworPolicy(s.V2().HttpServerConf, false)
+	s.ReStartEnvoy()
+
+	tag = "Fail-Close"
+	// Use fail close policy.
+	code, _, err = env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 503 {
+		t.Errorf("Status code 503 is expected, got %d.", code)
+	}
+}

--- a/mixer/test/client/network_policy/network_policy_test.go
+++ b/mixer/test/client/network_policy/network_policy_test.go
@@ -69,7 +69,7 @@ func TestNetworkFailure(t *testing.T) {
 	}
 
 	// Set to fail_close
-	env.SetNetworPolicy(s.V2().HttpServerConf, false)
+	env.SetNetworPolicy(s.V2().HTTPServerConf, false)
 	s.ReStartEnvoy()
 
 	tag = "Fail-Close"

--- a/mixer/test/client/quota/quota_test.go
+++ b/mixer/test/client/quota/quota_test.go
@@ -28,6 +28,7 @@ const (
 
 func TestQuotaCall(t *testing.T) {
 	s := env.NewTestSetup(
+		env.QuotaCallTest,
 		t,
 		env.BasicConfig+","+env.QuotaConfig)
 	if err := s.SetUp(); err != nil {
@@ -35,7 +36,7 @@ func TestQuotaCall(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Issues a GET echo request with 0 size body
 	tag := "OKGet v1"

--- a/mixer/test/client/quota/quota_test.go
+++ b/mixer/test/client/quota/quota_test.go
@@ -71,7 +71,7 @@ func TestQuotaCall(t *testing.T) {
 
 	s.SetV2Conf()
 	// Add v2 quota config for all requests.
-	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 5)
+	env.AddHTTPQuota(s.V2().HTTPServerConf, "RequestCount", 5)
 	s.ReStartEnvoy()
 
 	// Issues a GET echo request with 0 size body

--- a/mixer/test/client/quota/quota_test.go
+++ b/mixer/test/client/quota/quota_test.go
@@ -51,7 +51,7 @@ func TestQuotaCall(t *testing.T) {
 		Code:    int32(rpc.RESOURCE_EXHAUSTED),
 		Message: mixerQuotaFailMessage,
 	})
-	code, resp_body, err := env.HTTPPost(url, "text/plain", "Hello World!")
+	code, respBody, err := env.HTTPPost(url, "text/plain", "Hello World!")
 	// Make sure to restore r_status for next request.
 	s.SetMixerQuotaStatus(rpc.Status{})
 	if err != nil {
@@ -60,7 +60,7 @@ func TestQuotaCall(t *testing.T) {
 	if code != 429 {
 		t.Errorf("Status code 429 is expected.")
 	}
-	if resp_body != "RESOURCE_EXHAUSTED:"+mixerQuotaFailMessage {
+	if respBody != "RESOURCE_EXHAUSTED:"+mixerQuotaFailMessage {
 		t.Errorf("Error response body is not expected.")
 	}
 	s.VerifyQuota(tag, "RequestCount", 5)

--- a/mixer/test/client/quota/quota_test.go
+++ b/mixer/test/client/quota/quota_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"fmt"
+	"testing"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+const (
+	mixerQuotaFailMessage = "Quota is exhausted for: RequestCount"
+)
+
+func TestQuotaCall(t *testing.T) {
+	s := env.NewTestSetup(
+		t,
+		env.BasicConfig+","+env.QuotaConfig)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet v1"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyQuota(tag, "RequestCount", 5)
+
+	// Issues a failed POST request caused by Mixer Quota
+	tag = "QuotaFail v1"
+	s.SetMixerQuotaStatus(rpc.Status{
+		Code:    int32(rpc.RESOURCE_EXHAUSTED),
+		Message: mixerQuotaFailMessage,
+	})
+	code, resp_body, err := env.HTTPPost(url, "text/plain", "Hello World!")
+	// Make sure to restore r_status for next request.
+	s.SetMixerQuotaStatus(rpc.Status{})
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	if code != 429 {
+		t.Errorf("Status code 429 is expected.")
+	}
+	if resp_body != "RESOURCE_EXHAUSTED:"+mixerQuotaFailMessage {
+		t.Errorf("Error response body is not expected.")
+	}
+	s.VerifyQuota(tag, "RequestCount", 5)
+
+	//
+	// Use V2 config
+	//
+
+	s.SetV2Conf()
+	// Add v2 quota config for all requests.
+	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 5)
+	s.ReStartEnvoy()
+
+	// Issues a GET echo request with 0 size body
+	tag = "OKGet"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyQuota(tag, "RequestCount", 5)
+}

--- a/mixer/test/client/quota_cache/quota_cache_test.go
+++ b/mixer/test/client/quota_cache/quota_cache_test.go
@@ -23,14 +23,14 @@ import (
 
 func TestQuotaCache(t *testing.T) {
 	// Only check cache is enabled, quota cache is enabled.
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.QuotaCacheTest, t)
 	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 1)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Need to override mixer test server Referenced field in the check response.
 	// Its default is all fields in the request which could not be used fo test check cache.

--- a/mixer/test/client/quota_cache/quota_cache_test.go
+++ b/mixer/test/client/quota_cache/quota_cache_test.go
@@ -1,0 +1,72 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota_cache
+
+import (
+	"fmt"
+	mixerpb "istio.io/api/mixer/v1"
+	"istio.io/istio/mixer/test/client/env"
+	"testing"
+)
+
+func TestQuotaCache(t *testing.T) {
+	// Only check cache is enabled, quota cache is enabled.
+	s := env.NewTestSetupV2(t)
+	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Need to override mixer test server Referenced field in the check response.
+	// Its default is all fields in the request which could not be used fo test check cache.
+	output := mixerpb.ReferencedAttributes{
+		AttributeMatches: make([]mixerpb.ReferencedAttributes_AttributeMatch, 1),
+	}
+	output.AttributeMatches[0] = mixerpb.ReferencedAttributes_AttributeMatch{
+		// Assume "target.name" is in the request attributes, and it is used for Check.
+		Name:      10,
+		Condition: mixerpb.EXACT,
+	}
+	s.SetMixerCheckReferenced(&output)
+	s.SetMixerQuotaReferenced(&output)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+	s.SetMixerQuotaLimit(10)
+	reject := 0
+	ok := 0
+	for i := 0; i < 20; i++ {
+		code, _, err := env.HTTPGet(url)
+		if err != nil {
+			t.Errorf("Failed in request %s: %v", tag, err)
+		}
+		if code == 200 {
+			ok++
+		} else if code == 429 {
+			reject++
+		}
+	}
+	if ok != 10 || reject != 10 {
+		t.Fatalf("Unexpected quota ok count %v, reject count %v", ok, reject)
+	}
+	// Less than 5 time of Quota is called.
+	if s.GetMixerQuotaCount() >= 5 {
+		t.Fatalf("%s quota called count %v should not be more than 5",
+			tag, s.GetMixerQuotaCount())
+	}
+}

--- a/mixer/test/client/quota_cache/quota_cache_test.go
+++ b/mixer/test/client/quota_cache/quota_cache_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package quota_cache
+package quotaCache
 
 import (
 	"fmt"

--- a/mixer/test/client/quota_cache/quota_cache_test.go
+++ b/mixer/test/client/quota_cache/quota_cache_test.go
@@ -16,15 +16,16 @@ package quotaCache
 
 import (
 	"fmt"
+	"testing"
+
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/test/client/env"
-	"testing"
 )
 
 func TestQuotaCache(t *testing.T) {
 	// Only check cache is enabled, quota cache is enabled.
 	s := env.NewTestSetupV2(env.QuotaCacheTest, t)
-	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 1)
+	env.AddHTTPQuota(s.V2().HTTPServerConf, "RequestCount", 1)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package report_batch
+package reportBatch
 
 import (
 	"fmt"

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -28,7 +28,7 @@ const reportAttributesOkGet = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -45,7 +45,7 @@ const reportAttributesOkGet = `
   "request.headers": {
      ":method": "GET",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -72,7 +72,7 @@ const reportAttributesOkPost1 = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -89,7 +89,7 @@ const reportAttributesOkPost1 = `
   "request.headers": {
      ":method": "POST",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -116,7 +116,7 @@ const reportAttributesOkPost2 = `
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
-  "request.host": "localhost:27070",
+  "request.host": "*",
   "request.path": "/echo",
   "request.time": "*",
   "request.useragent": "Go-http-client/1.1",
@@ -133,7 +133,7 @@ const reportAttributesOkPost2 = `
   "request.headers": {
      ":method": "POST",
      ":path": "/echo",
-     ":authority": "localhost:27070",
+     ":authority": "*",
      "x-forwarded-proto": "http",
      "x-istio-attributes": "-",
      "x-request-id": "*"
@@ -154,13 +154,13 @@ const reportAttributesOkPost2 = `
 `
 
 func TestReportBatch(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.ReportBatchTest, t)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	// Issues a GET echo request with 0 size body
 	tag := "OKGet"

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -1,0 +1,184 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package report_batch
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Report attributes from a good GET request
+const reportAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain; charset=utf-8",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+// Report attributes from a good POST request
+const reportAttributesOkPost1 = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "POST",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "POST",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 12,
+  "response.time": "*",
+  "response.size": 12,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "12",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+// Report attributes from a good POST request
+const reportAttributesOkPost2 = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "localhost:27070",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "POST",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "request.headers": {
+     ":method": "POST",
+     ":path": "/echo",
+     ":authority": "localhost:27070",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 18,
+  "response.time": "*",
+  "response.size": 18,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-type": "text/plain",
+     "content-length": "18",
+     ":status": "200",
+     "server": "envoy"
+  }
+}
+`
+
+func TestReportBatch(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+	if _, _, err := env.HTTPGet(url); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Issues a POST request.
+	tag = "OKPost1"
+	if _, _, err := env.HTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Issues a POST request again.
+	tag = "OKPost2"
+	if _, _, err := env.HTTPPost(url, "text/plain", "Hello World Again!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	tag = "Batch"
+	s.VerifyReport(tag, reportAttributesOkGet)
+	s.VerifyReport(tag, reportAttributesOkPost1)
+	s.VerifyReport(tag, reportAttributesOkPost2)
+}

--- a/mixer/test/client/run_test.sh
+++ b/mixer/test/client/run_test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Run all tests in the sub-folders
-# Somehow it fails to run as "go test ./..."
-# Mock mixer server failed to bind its listening port.
-
-for f in $(find $(dirname $0) -name *_test.go); do echo "go test $f"; go test $f;  done

--- a/mixer/test/client/run_test.sh
+++ b/mixer/test/client/run_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Run all tests in the sub-folders
+# Somehow it fails to run as "go test ./..."
+# Mock mixer server failed to bind its listening port.
+
+for f in $(find $(dirname $0) -name *_test.go); do echo "go test $f"; go test $f;  done

--- a/mixer/test/client/stress/stress_test.go
+++ b/mixer/test/client/stress/stress_test.go
@@ -26,11 +26,11 @@ import (
 
 const (
 	concurrent         = 10
-	duration_in_second = 15
+	duration_in_second = 10
 )
 
 func TestStressEnvoy(t *testing.T) {
-	s := env.NewTestSetupV2(t)
+	s := env.NewTestSetupV2(env.StressEnvoyTest, t)
 	s.SetStress(true)
 
 	// Not cache, enable quota
@@ -41,7 +41,7 @@ func TestStressEnvoy(t *testing.T) {
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
 	var count uint64 = 0
 	for k := 0; k < concurrent; k++ {

--- a/mixer/test/client/stress/stress_test.go
+++ b/mixer/test/client/stress/stress_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stress
+
+import (
+	"fmt"
+	"log"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+const (
+	concurrent         = 10
+	duration_in_second = 15
+)
+
+func TestStressEnvoy(t *testing.T) {
+	s := env.NewTestSetupV2(t)
+	s.SetStress(true)
+
+	// Not cache, enable quota
+	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 1)
+	env.DisableClientCache(s.V2().HttpServerConf, true, true, true)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.ClientProxyPort)
+
+	var count uint64 = 0
+	for k := 0; k < concurrent; k++ {
+		go func() {
+			for true {
+				if err := env.HTTPFastGet(url); err != nil {
+					t.Errorf("Failed in request: %v", err)
+				}
+				atomic.AddUint64(&count, 1)
+			}
+		}()
+	}
+	time.Sleep(time.Second * time.Duration(duration_in_second))
+	countFinal := atomic.LoadUint64(&count)
+	log.Printf("Total: %v, concurrent: %v, duration: %v seconds, qps: %v\n",
+		countFinal, concurrent, duration_in_second, countFinal/duration_in_second)
+}

--- a/mixer/test/client/stress/stress_test.go
+++ b/mixer/test/client/stress/stress_test.go
@@ -34,8 +34,8 @@ func TestStressEnvoy(t *testing.T) {
 	s.SetStress(true)
 
 	// Not cache, enable quota
-	env.AddHttpQuota(s.V2().HttpServerConf, "RequestCount", 1)
-	env.DisableClientCache(s.V2().HttpServerConf, true, true, true)
+	env.AddHTTPQuota(s.V2().HTTPServerConf, "RequestCount", 1)
+	env.DisableClientCache(s.V2().HTTPServerConf, true, true, true)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}

--- a/mixer/test/client/stress/stress_test.go
+++ b/mixer/test/client/stress/stress_test.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	concurrent         = 10
-	duration_in_second = 10
+	concurrent       = 10
+	durationInSecond = 10
 )
 
 func TestStressEnvoy(t *testing.T) {
@@ -43,7 +43,7 @@ func TestStressEnvoy(t *testing.T) {
 
 	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
 
-	var count uint64 = 0
+	var count uint64
 	for k := 0; k < concurrent; k++ {
 		go func() {
 			for true {
@@ -54,8 +54,8 @@ func TestStressEnvoy(t *testing.T) {
 			}
 		}()
 	}
-	time.Sleep(time.Second * time.Duration(duration_in_second))
+	time.Sleep(time.Second * time.Duration(durationInSecond))
 	countFinal := atomic.LoadUint64(&count)
 	log.Printf("Total: %v, concurrent: %v, duration: %v seconds, qps: %v\n",
-		countFinal, concurrent, duration_in_second, countFinal/duration_in_second)
+		countFinal, concurrent, durationInSecond, countFinal/durationInSecond)
 }

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -1,0 +1,133 @@
+// Copyright 2017 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp_filter
+
+import (
+	"fmt"
+	"testing"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good POST request
+const checkAttributesOkPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222"
+}
+`
+
+// Report attributes from a good POST request
+const reportAttributesOkPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": 28080,
+  "connection.received.bytes": 178,
+  "connection.received.bytes_total": 178,
+  "connection.sent.bytes": 133,
+  "connection.sent.bytes_total": 133,
+  "connection.duration": "*"
+}
+`
+
+// Report attributes from a failed POST request
+const reportAttributesFailPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.received.bytes": 0,
+  "connection.received.bytes_total": 0,
+  "connection.sent.bytes": 0,
+  "connection.sent.bytes_total": 0,
+  "connection.duration": "*",
+  "check.error_code": 16,
+  "check.error_message": "UNAUTHENTICATED"
+}
+`
+
+func TestTcpMixerFilter(t *testing.T) {
+	s := env.NewTestSetup(t, env.BasicConfig)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", env.TcpProxyPort)
+
+	// Issues a POST request.
+	tag := "OKPost v1"
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesOkPost)
+
+	tag = "MixerFail v1"
+	s.SetMixerCheckStatus(rpc.Status{
+		Code: int32(rpc.UNAUTHENTICATED),
+	})
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err == nil {
+		t.Errorf("Expect request to fail %s: %v", tag)
+	}
+	// Reset to a positive one
+	s.SetMixerCheckStatus(rpc.Status{})
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesFailPost)
+
+	//
+	// Use V2 config
+	//
+
+	s.SetV2Conf()
+	s.ReStartEnvoy()
+
+	// Issues a POST request.
+	tag = "OKPost"
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesOkPost)
+
+	tag = "MixerFail"
+	s.SetMixerCheckStatus(rpc.Status{
+		Code: int32(rpc.UNAUTHENTICATED),
+	})
+	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err == nil {
+		t.Errorf("Expect request to fail %s: %v", tag)
+	}
+	// Reset to a positive one
+	s.SetMixerCheckStatus(rpc.Status{})
+	s.VerifyCheck(tag, checkAttributesOkPost)
+	s.VerifyReport(tag, reportAttributesFailPost)
+}

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -46,7 +46,7 @@ const reportAttributesOkPost = `
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "destination.ip": "[127 0 0 1]",
-  "destination.port": 28080,
+  "destination.port": "*",
   "connection.received.bytes": 178,
   "connection.received.bytes_total": 178,
   "connection.sent.bytes": 133,
@@ -76,13 +76,13 @@ const reportAttributesFailPost = `
 `
 
 func TestTcpMixerFilter(t *testing.T) {
-	s := env.NewTestSetup(t, env.BasicConfig)
+	s := env.NewTestSetup(env.TcpMixerFilterTest, t, env.BasicConfig)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", env.TcpProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TcpProxyPort)
 
 	// Issues a POST request.
 	tag := "OKPost v1"

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tcp_filter
+package tcpFilter
 
 import (
 	"fmt"
@@ -97,7 +97,7 @@ func TestTcpMixerFilter(t *testing.T) {
 		Code: int32(rpc.UNAUTHENTICATED),
 	})
 	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err == nil {
-		t.Errorf("Expect request to fail %s: %v", tag)
+		t.Errorf("Expect request to fail %s: %v", tag, err)
 	}
 	// Reset to a positive one
 	s.SetMixerCheckStatus(rpc.Status{})
@@ -124,7 +124,7 @@ func TestTcpMixerFilter(t *testing.T) {
 		Code: int32(rpc.UNAUTHENTICATED),
 	})
 	if _, _, err := env.ShortLiveHTTPPost(url, "text/plain", "Hello World!"); err == nil {
-		t.Errorf("Expect request to fail %s: %v", tag)
+		t.Errorf("The request is expected to fail %s, but it did not.", tag)
 	}
 	// Reset to a positive one
 	s.SetMixerCheckStatus(rpc.Status{})

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -75,14 +75,14 @@ const reportAttributesFailPost = `
 }
 `
 
-func TestTcpMixerFilter(t *testing.T) {
-	s := env.NewTestSetup(env.TcpMixerFilterTest, t, env.BasicConfig)
+func TestTCPMixerFilter(t *testing.T) {
+	s := env.NewTestSetup(env.TCPMixerFilterTest, t, env.BasicConfig)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
 	defer s.TearDown()
 
-	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TcpProxyPort)
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().TCPProxyPort)
 
 	// Issues a POST request.
 	tag := "OKPost v1"


### PR DESCRIPTION
So that istio/proxy repo doesn't have to deal with golang.  It will be a pure c++ repo.

Added a script to run it sequentially.
