### PR TITLE
Remove the -p flag for pilot test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ jobs:
             free
             trap "go-junit-report </go/out/tests/go-test-report.out > /go/out/tests/go-test-report.xml" EXIT
             make localTestEnv
-            make pilot-test mixer-test broker-test security-test T=-v | tee -a /go/out/tests/go-test-report.out
+            make pilot-test mixer-test broker-test security-test common-test T="-v -p 1" | tee -a /go/out/tests/go-test-report.out
       - store_test_results:
           path: /go/out/tests
 
@@ -293,7 +293,7 @@ jobs:
             free
             trap "go-junit-report </go/out/tests/go-test-report.out > /go/out/tests/go-test-report.xml" EXIT
             make localTestEnv
-            make pilot-racetest mixer-racetest broker-racetest security-racetest T=-v | tee -a /go/out/racetests/go-racetest-report.out
+            make pilot-racetest mixer-racetest broker-racetest security-racetest T="-v -p 1" | tee -a /go/out/racetests/go-racetest-report.out
       - store_test_results:
           path: /go/out/racetests
 

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,6 @@ pilot: ${ISTIO_BIN}/pilot-discovery
 .PHONY: go-test localTestEnv test-bins
 
 GOTEST_PARALLEL ?= '-test.parallel=4'
-GOTEST_P ?= -p 1
 GOSTATIC = -ldflags '-extldflags "-static"'
 
 PILOT_TEST_BINS:=${ISTIO_BIN}/pilot-test-server ${ISTIO_BIN}/pilot-test-client ${ISTIO_BIN}/pilot-test-eurekamirror
@@ -240,11 +239,9 @@ test-bins: $(PILOT_TEST_BINS)
 localTestEnv: test-bins
 	bin/testEnvLocalK8S.sh ensure
 
-# Temp. disable parallel test - flaky consul test.
-# https://github.com/istio/istio/issues/2318
 .PHONY: pilot-test
 pilot-test: pilot-agent
-	go test ${GOTEST_P} ${T} ./pilot/...
+	go test ${T} ./pilot/...
 
 .PHONY: mixer-test
 mixer-test: mixs
@@ -298,7 +295,7 @@ coverage: pilot-coverage mixer-coverage security-coverage broker-coverage
 
 .PHONY: pilot-racetest
 pilot-racetest: pilot-agent
-	go test ${GOTEST_P} ${T} -race ./pilot/...
+	go test ${T} -race ./pilot/...
 
 .PHONY: mixer-racetest
 mixer-racetest: mixs


### PR DESCRIPTION
I found that https://github.com/istio/istio/issues/2318 was the
reason why, but actually -p flag doesn't deal with the reported
problem.

The -p flag specifies the number of processes `go test` runs
simultaneously, while the test flakiness seems happening purely
within a single process, and no other running processes seems not
to interfere the reported test case. The error would be affected
by the goroutine scheduling, but this flag is unrelated.

On the other hand, removing this flag accelerate the test time
since `go test` can run more tests at the same time.