### PR TITLE
Add check of go version to top-level Makefile and avoid unnecessary launching of apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ export CGO_ENABLE=0
 # OUT is the directory where dist artifacts and temp files will be created.
 OUT=${GO_TOP}/out
 
+# It's more concise to use GO?=$(shell which go)
+# but the following approach uses a more efficient "simply expanded" :=
+# variable instead of a "recursively expanded" =
 ifeq ($(origin GO), undefined)
   GO:=$(shell which go)
   ifeq ($(GO),)
@@ -61,9 +64,9 @@ export ISTIO_BIN=${GO_TOP}/bin
 # if you change this value then also update the echo statement in the section that follows
 GO_VERSION_REQUIRED=109
 
-# using a sentinel file so this check is only performed once.  Performance is being
-# favored over the unlikely situation that go gets downgraded to an older version
-check_go_version: | ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
+# using a sentinel file so this check is only performed once per version.  Performance is
+# being favored over the unlikely situation that go gets downgraded to an older version
+check-go-version: | ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
 ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
 # sed parses out the x.y version (of what may be x.y or x.y.z) and outputs "x y".
 # awk takes the two separate variables and combines them as a single value x*100+y (e.g., 1.9 is 109).
@@ -157,7 +160,7 @@ pre-commit: fmt lint
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
 # Will also check vendor, based on Gopkg.lock
-init: ${DEP}
+init: check-go-version ${DEP}
 	@(DEP=${DEP} bin/init.sh)
 
 # init.sh downloads envoy

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
 	@if test $(shell go version | sed "s/[a-z| ]*\([0-9]*\)\.\([0-9]*\).*/\1 \2/" | \
                    awk '{print $$1*100+$$2}') -lt $(GO_VERSION_REQUIRED); \
 		then echo -n "go version 1.9+ required, found: "; go version; exit 1; fi
+	@mkdir -p ${ISTIO_BIN}
 	@touch ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
 
 hub = ""

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -33,8 +33,6 @@ export GOPATH=${GOPATH:-$GO_TOP}
 # Normally set by Makefile
 export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 
-$ROOT/bin/verify_go_version.sh
-
 # Ensure expected GOPATH setup
 if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        echo "Istio not found in GOPATH/src/istio.io/"


### PR DESCRIPTION
In an earlier change I was asked to move the version check of go from mixer's Makefile to the top-level makefile.  I added the check, but also make it cache the result via a sentinel file so this doesn't add overhead on every invocation of make.

I also added in support to check when go isn't found at all.  As part of this I noticed how make was trying to launch go and other apps due to $(shell) being used to initialize some variables.  I tried to address these by making them simple command statements that get invoked by the shell via $().  I didn't think of a good solution not launching git to init TAG, and that variable seems more likely to be used (and less expensive to call) than others so I left it alone.

I tested that the targets I touched still seem to work on Linux.  For Mac I mostly just tested that the go version check works there too.  I'm going to put a hold on this since it's not vital and I don't want to risk it getting in the way of a RC for a monthly release.