### PR TITLE
Bug fix - redirect route rule to egress and additional tests to pilot's integration test

### DIFF
--- a/pilot/proxy/envoy/config_test.go
+++ b/pilot/proxy/envoy/config_test.go
@@ -298,6 +298,11 @@ var (
 		file: "testdata/redirect-route-v1alpha2.yaml.golden",
 	}
 
+	redirectRouteToEgressRule = fileConfig{
+		meta: model.ConfigMeta{Type: model.RouteRule.Type, Name: "redirect-to-egress"},
+		file: "testdata/redirect-route-to-egress.yaml.golden",
+	}
+
 	rewriteRouteRule = fileConfig{
 		meta: model.ConfigMeta{Type: model.RouteRule.Type, Name: "rewrite"},
 		file: "testdata/rewrite-route.yaml.golden",

--- a/pilot/proxy/envoy/discovery_test.go
+++ b/pilot/proxy/envoy/discovery_test.go
@@ -496,6 +496,16 @@ func TestRouteDiscoveryRedirect(t *testing.T) {
 	}
 }
 
+func TestRouteToEgressDiscoveryRedirect(t *testing.T) {
+	_, registry, ds := commonSetup(t)
+	addConfig(registry, egressRule, t)
+	addConfig(registry, redirectRouteToEgressRule, t)
+
+	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/rds-redirect-egress.json", t)
+}
+
 func TestRouteDiscoveryRewrite(t *testing.T) {
 	for _, rewriteConfig := range []fileConfig{rewriteRouteRule, rewriteRouteRuleV2} {
 		_, registry, ds := commonSetup(t)

--- a/pilot/proxy/envoy/testdata/rds-redirect-egress.json.golden
+++ b/pilot/proxy/envoy/testdata/rds-redirect-egress.json.golden
@@ -1,0 +1,84 @@
+{
+  "virtual_hosts": [
+   {
+    "name": "*.google.com:80",
+    "domains": [
+     "*.google.com",
+     "*.google.com:80"
+    ],
+    "routes": [
+     {
+      "path": "/path",
+      "path_redirect": "/new/path",
+      "host_redirect": "foo.bar.com",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "redirect-to-egress"
+      }
+     },
+     {
+      "prefix": "/",
+      "cluster": "out.*.google.com|external-HTTP-80",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   },
+   {
+    "name": "hello.default.svc.cluster.local|http",
+    "domains": [
+     "hello:80",
+     "hello",
+     "hello.default:80",
+     "hello.default",
+     "hello.default.svc:80",
+     "hello.default.svc",
+     "hello.default.svc.cluster:80",
+     "hello.default.svc.cluster",
+     "hello.default.svc.cluster.local:80",
+     "hello.default.svc.cluster.local",
+     "10.1.0.0:80",
+     "10.1.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.hello.default.svc.cluster.local|http",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http",
+    "domains": [
+     "world:80",
+     "world",
+     "world.default:80",
+     "world.default",
+     "world.default.svc:80",
+     "world.default.svc",
+     "world.default.svc.cluster:80",
+     "world.default.svc.cluster",
+     "world.default.svc.cluster.local:80",
+     "world.default.svc.cluster.local",
+     "10.2.0.0:80",
+     "10.2.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.world.default.svc.cluster.local|http",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   }
+  ]
+ }

--- a/pilot/proxy/envoy/testdata/redirect-route-to-egress.yaml.golden
+++ b/pilot/proxy/envoy/testdata/redirect-route-to-egress.yaml.golden
@@ -1,0 +1,11 @@
+destination:
+  service: "*.google.com"
+match:
+  request:
+    headers:
+      uri:
+        exact: /path
+redirect:
+  uri: "/new/path"
+  authority: "foo.bar.com"
+

--- a/pilot/test/integration/egress_rules.go
+++ b/pilot/test/integration/egress_rules.go
@@ -110,6 +110,10 @@ func (t *egressRules) run() error {
 		} else {
 			log.Info("Success!")
 		}
+
+		if err := t.deleteConfig(cs.config, nil); err != nil {
+			return err
+		}
 	}
 	return errs
 }

--- a/pilot/test/integration/infra.go
+++ b/pilot/test/integration/infra.go
@@ -463,8 +463,8 @@ func (infra *infra) applyConfig(inFile string, data map[string]string) error {
 	return nil
 }
 
-func (infra *infra) deleteConfig(inFile string) error {
-	config, err := fill(inFile, nil)
+func (infra *infra) deleteConfig(inFile string, data map[string]string) error {
+	config, err := fill(inFile, data)
 	if err != nil {
 		return err
 	}

--- a/pilot/test/integration/infra.go
+++ b/pilot/test/integration/infra.go
@@ -483,10 +483,6 @@ func (infra *infra) deleteConfig(inFile string, data map[string]string) error {
 			return err
 		}
 	}
-
-	sleepTime := time.Second * 3
-	log.Infof("Sleeping %v for the config to propagate", sleepTime)
-	time.Sleep(sleepTime)
 	return nil
 }
 

--- a/pilot/test/integration/testdata/egress-rule-wildcard-httpbin.yaml.tmpl
+++ b/pilot/test/integration/testdata/egress-rule-wildcard-httpbin.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: config.istio.io/v1alpha2
 kind: EgressRule
 metadata:
-  name: httpbin
+  name: httpbin-wildcard
 spec:
   destination:
       service: "*.httpbin.org"

--- a/pilot/test/integration/testdata/rule-fault-injection-to-egress.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-fault-injection-to-egress.yaml.tmpl
@@ -1,10 +1,10 @@
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
 metadata:
-  name: httpbin-fault-rule
+  name: fault-injection-to-egress-rule
 spec:
   destination:
-    service: "httpbin.org"
+    service: "{{.service}}"
   httpFault:
     abort:
       httpStatus: 418

--- a/pilot/test/integration/testdata/rule-redirect-to-egress.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-redirect-to-egress.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: redirect-route-to-egress
+spec:
+  destination:
+    service: "{{.service}}"
+  match:
+    request:
+      headers:
+        uri:
+          exact: {{.from}}
+  redirect:
+    uri: {{.to}}
+    authority: {{.authority}}

--- a/pilot/test/integration/testdata/rule-rewrite-to-egress.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-rewrite-to-egress.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: rewrite-route-to-egress
+spec:
+  destination:
+    service: "{{.service}}"
+  match:
+    request:
+      headers:
+        uri:
+          exact: {{.from}}
+  rewrite:
+    uri: {{.to}}
+    authority: {{.authority}}


### PR DESCRIPTION
The bug is that when configuring a redirect route rule to egress there is a redundant 'cluster' key in envoy's routes config.

Additional tests to the e2e test:
- Redirect route rule to egress
- Rewrite route rule to egress
- Fault injection to egress traffic configured with wildcard