### PR TITLE
Move AZ look up post start up to set correct value

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -17,8 +17,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -116,24 +114,6 @@ var (
 				}
 			}
 
-			// Get AZ for proxy
-			azResp, err := http.Get(fmt.Sprintf("http://%v/v1/az/%v/%v", discoveryAddress, serviceCluster, role.ServiceNode()))
-			if err != nil {
-				log.Infof("Error retrieving availability zone from pilot: %v", err)
-			} else {
-				body, err := ioutil.ReadAll(azResp.Body)
-				if err != nil {
-					log.Infof("Error reading availability zone response from pilot: %v", err)
-				}
-				if azResp.StatusCode != http.StatusOK {
-					log.Infof("Received %q status from pilot when retrieving availability zone: %v", azResp.StatusCode, string(body))
-				} else {
-					availabilityZone = string(body)
-					log.Infof("Proxy availability zone: %v", availabilityZone)
-				}
-
-			}
-
 			log.Infof("Proxy role: %#v", role)
 
 			proxyConfig := meshconfig.ProxyConfig{}
@@ -143,7 +123,6 @@ var (
 			proxyConfig.ConfigPath = configPath
 			proxyConfig.BinaryPath = binaryPath
 			proxyConfig.ServiceCluster = serviceCluster
-			proxyConfig.AvailabilityZone = availabilityZone
 			proxyConfig.DrainDuration = ptypes.DurationProto(drainDuration)
 			proxyConfig.ParentShutdownDuration = ptypes.DurationProto(parentShutdownDuration)
 			proxyConfig.DiscoveryAddress = discoveryAddress

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -119,6 +119,7 @@ var (
 			proxyConfig := meshconfig.ProxyConfig{}
 
 			// set all flags
+			proxyConfig.AvailabilityZone = availabilityZone
 			proxyConfig.CustomConfigFile = customConfigFile
 			proxyConfig.ConfigPath = configPath
 			proxyConfig.BinaryPath = binaryPath

--- a/pilot/proxy/envoy/watcher_test.go
+++ b/pilot/proxy/envoy/watcher_test.go
@@ -20,6 +20,9 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path"
 	"reflect"
@@ -27,6 +30,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	_ "github.com/golang/glog"
 	"github.com/howeyc/fsnotify"
 
 	"istio.io/istio/pilot/proxy"
@@ -69,6 +75,109 @@ func TestRunReload(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Errorf("The callback is not called within time limit " + time.Now().String())
 		cancel()
+	}
+}
+
+type pilotStubHandler struct {
+	sync.Mutex
+	States []pilotStubState
+}
+
+type pilotStubState struct {
+	StatusCode int
+	Response   string
+}
+
+func (p *pilotStubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.Lock()
+	w.WriteHeader(p.States[0].StatusCode)
+	w.Write([]byte(p.States[0].Response))
+	p.States = p.States[1:]
+	p.Unlock()
+}
+
+func Test_watcher_retrieveAZ(t *testing.T) {
+	tests := []struct {
+		name        string
+		az          string
+		wantReload  bool
+		wantAZ      string
+		pilotStates []pilotStubState
+	}{
+		{
+			name:       "retrieves an AZ and calls for a reload",
+			wantReload: true,
+			wantAZ:     "az1",
+			pilotStates: []pilotStubState{
+				{StatusCode: 200, Response: "az1"},
+			},
+		},
+		{
+			name:       "retries if it receives an error",
+			wantReload: true,
+			wantAZ:     "az1",
+			pilotStates: []pilotStubState{
+				{StatusCode: 301, Response: ""},
+				{StatusCode: 200, Response: "az1"},
+			},
+		},
+		{
+			name:       "retries if it receives non 200 status from pilot",
+			wantReload: true,
+			wantAZ:     "az1",
+			pilotStates: []pilotStubState{
+				{StatusCode: 500, Response: ""},
+				{StatusCode: 200, Response: "az1"},
+			},
+		},
+		{
+			name:       "do nothing if az is set",
+			az:         "az1",
+			wantAZ:     "az1",
+			wantReload: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := make(chan bool)
+			agent := TestAgent{
+				schedule: func(_ interface{}) {
+					called <- true
+				},
+			}
+			node := proxy.Node{
+				Type:      proxy.Ingress,
+				ID:        "id",
+				Domain:    "domain",
+				IPAddress: "ip",
+			}
+			config := proxy.DefaultProxyConfig()
+			config.AvailabilityZone = tt.az
+			pilotStub := httptest.NewServer(
+				&pilotStubHandler{States: tt.pilotStates},
+			)
+			stubURL, _ := url.Parse(pilotStub.URL)
+			config.DiscoveryAddress = stubURL.Host
+			w := NewWatcher(config, agent, node, nil, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			go w.(*watcher).retrieveAZ(ctx, 0)
+
+			select {
+			case <-called:
+				if !tt.wantReload {
+					t.Errorf("Unexpected reload called")
+				}
+				assert.Equal(t, tt.wantAZ, w.(*watcher).config.AvailabilityZone)
+				cancel()
+			case <-time.After(time.Second):
+				if tt.wantReload {
+					t.Errorf("The callback is not called within time limit " + time.Now().String())
+				}
+				cancel()
+			}
+
+		})
 	}
 }
 


### PR DESCRIPTION
What this PR does / why we need it: Moves AZ look up post start up as pod doesn't have node set on start up.

Which issue this PR fixes: #2353
Release note:
```
Move setting of proxy availability zone post start up
```