### PR TITLE
Improve our linter story.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,45 +319,36 @@ jobs:
       - store_artifacts:
           path: /go/out/istio-sidecar.deb
 
-  ## CONTAINER BASED LINT. mukai's linter container does not have all
-  # tools. Install linters in istio's ci container.
-  # lint:
-  #   working_directory: /go/src/istio.io/istio
-  #   docker:
-  #     - image: gcr.io/mukai-istio/linter:bbcfb47f85643d4f5a7b1c092280d33ffd214c10
-  #   environment:
-  #     GOPATH: /go
-  #   resource_class: xlarge
-  #   steps:
-  #     - checkout
-  #     - restore_cache:
-  #         keys:
-  #           - dep-cache-{{ checksum "Gopkg.lock" }}
-  #     - run: /go/src/istio.io/istio/bin/check_license.sh
-  #     - run:
-  #         no_output_timeout: 15m
-  #         command: |
-  #           cd /go/src/istio.io/istio
-  #           CGO_ENABLED=0 /usr/local/bin/gometalinter --config=./lintconfig_base.json -s vendor --fast ./...
-
-  ## TODO DISBALE ME and use the container based lint
   lint:
-    <<: *integrationDefaults
+    <<: *defaults
+    environment:
+      KUBECONFIG: /go/src/istio.io/istio/.circleci/config
+    resource_class: xlarge
     steps:
-      - type: shell
-        name: Initialize Working Directory
-        pwd: /
-        command: |
-          sudo mkdir -p /go/src/istio.io/istio
-          sudo chown -R circleci /go
       - checkout
       - restore_cache:
           keys:
             - dep-cache-{{ checksum "Gopkg.lock" }}
-      - run:
-          no_output_timeout: 15m
-          command: |
-            make lint
+      - run: make lint
+
+  ## TODO DISBALE ME and use the container based lint
+  # lint:
+  #   <<: *integrationDefaults
+  #   steps:
+  #     - type: shell
+  #       name: Initialize Working Directory
+  #       pwd: /
+  #       command: |
+  #         sudo mkdir -p /go/src/istio.io/istio
+  #         sudo chown -R circleci /go
+  #     - checkout
+  #     - restore_cache:
+  #         keys:
+  #           - dep-cache-{{ checksum "Gopkg.lock" }}
+  #     - run:
+  #         no_output_timeout: 15m
+  #         command: |
+  #           make lint
 
   docker-push:
     <<: *defaults

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -11,20 +11,16 @@ if [[ -z $SKIP_INIT ]];then
   bin/init.sh
 fi
 
-echo 'Checking licences'
+echo 'Checking licenses'
 bin/check_license.sh
-echo 'licences OK'
+echo 'licenses OK'
 
-echo 'Running linters ....'
+echo 'Installing gometalinter ....'
+go get -u gopkg.in/alecthomas/gometalinter.v2
+gometalinter=gometalinter.v2
+$gometalinter --install
+echo 'Gometalinter installed successfully ....'
 
-#TODO: after the new generation script is in, make sure we generate the exclude
-docker run\
-  -v $(pwd):/go/src/istio.io/istio\
-  -w /go/src/istio.io/istio\
-  gcr.io/mukai-istio/linter:bbcfb47f85643d4f5a7b1c092280d33ffd214c10\
-  --config=./lintconfig_base.json \
-  -s vendor --fast ./...
-
-echo 'linters OK'
-
-
+echo 'Running gometalinter ....'
+$gometalinter --config=./lintconfig_base.json ./...
+echo 'gometalinter OK'

--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -1,15 +1,15 @@
 {
     "concurrency": 4,
     "enableGC": true,
+    "vendor": true,
     "vendoredLinters": true,
     "deadline": "600s",
-    "minConfidence": 0,
+    "minConfidence": 0.0,
     "lineLength": 160,
+    "tests": true,
     "enable": [
-        "aligncheck",
         "deadcode",
         "errcheck",
-        "gas",
         "goconst",
         "gofmt",
         "goimports",
@@ -17,6 +17,7 @@
         "ineffassign",
         "interfacer",
         "lll",
+        "maligned",
         "megacheck",
         "misspell",
         "structcheck",
@@ -26,10 +27,8 @@
         "vetshadow"
     ],
     "severity": {
-        "aligncheck": "warn",
         "deadcode": "error",
         "errcheck": "error",
-        "gas": "error",
         "goconst": "error",
         "gofmt": "error",
         "goimports": "error",
@@ -37,6 +36,7 @@
         "ineffassign": "error",
         "interfacer": "error",
         "lll": "error",
+        "maligned": "error",
         "megacheck": "error",
         "misspell": "error",
         "structcheck": "error",
@@ -46,16 +46,14 @@
         "vetshadow": "error"
     },
     "exclude": [
-        "vendor",
-	"../vendor",
         ".pb.go",
-	"mock_*",
+        "mock_*",
         "mixer/adapter/doc.go",
         "mixer/pkg/config/proto/combined.go",
         ".*.gen.go",
-	"mixer/template/doc.go",
-	"mixer/template/sample/doc.go",
-	"mixer/test/spyAdapter/template/doc.go",
+        "mixer/template/doc.go",
+        "mixer/template/sample/doc.go",
+        "mixer/test/spyAdapter/template/doc.go",
         "should have a package comment",
         "genfiles"
     ]

--- a/mixer/adapter/circonus/circonus.go
+++ b/mixer/adapter/circonus/circonus.go
@@ -205,7 +205,7 @@ func GetInfo() adapter.Info {
 // logToEnvLogger converts CGM log package writes to env.Logger()
 func (b logToEnvLogger) Write(msg []byte) (int, error) {
 	if bytes.HasPrefix(msg, []byte("[ERROR]")) {
-		b.env.Logger().Errorf(string(msg))
+		_ = b.env.Logger().Errorf(string(msg))
 	} else if bytes.HasPrefix(msg, []byte("[WARN]")) {
 		b.env.Logger().Warningf(string(msg))
 	} else if bytes.HasPrefix(msg, []byte("[DEBUG]")) {

--- a/mixer/adapter/opa/opa.go
+++ b/mixer/adapter/opa/opa.go
@@ -122,7 +122,7 @@ func (b *builder) Validate() (ce *adapter.ConfigErrors) {
 func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handler, error) {
 	if len(b.configErrors) >= 0 {
 		for _, err := range b.configErrors {
-			env.Logger().Errorf("%v", err)
+			_ = env.Logger().Errorf("%v", err)
 		}
 	}
 

--- a/mixer/adapter/opa/opa_integration_test.go
+++ b/mixer/adapter/opa/opa_integration_test.go
@@ -176,8 +176,10 @@ spec:
 `
 )
 
-//https://github.com/istio/istio/issues/2300
-func xTestServer(t *testing.T) {
+func TestServer(t *testing.T) {
+	//https://github.com/istio/istio/issues/2300
+	t.SkipNow()
+
 	args := server.NewArgs()
 
 	args.APIPort = 0

--- a/mixer/adapter/opa/opa_test.go
+++ b/mixer/adapter/opa/opa_test.go
@@ -24,7 +24,6 @@ import (
 
 	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 	"istio.io/istio/mixer/adapter/opa/config"
-	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/adapter/test"
 	"istio.io/istio/mixer/template/authorization"
 )
@@ -95,14 +94,15 @@ func TestConvertSubjectObjectToMap(t *testing.T) {
 
 	for id, c := range cases {
 		actual := convertSubjectObjectToMap(&c.subject)
-		if reflect.DeepEqual(c.expected, actual) == false {
+		if !reflect.DeepEqual(c.expected, actual) {
 			t.Errorf("%v: expected: %v, received: %v", id, c.expected, actual)
 		}
 	}
 }
 
+/*
 //https://github.com/istio/istio/issues/2300
-func xTestValidateError(t *testing.T) {
+func TestValidateError(t *testing.T) {
 	cases := map[string]struct {
 		cfg      adapter.Config
 		expected []string
@@ -165,6 +165,7 @@ func xTestValidateError(t *testing.T) {
 		}
 	}
 }
+*/
 
 func TestSinglePolicy(t *testing.T) {
 	info := GetInfo()
@@ -242,8 +243,9 @@ func TestSinglePolicy(t *testing.T) {
 	}
 }
 
+/*
 //https://github.com/istio/istio/issues/2300
-func xTestMultiplePolicy(t *testing.T) {
+func TestMultiplePolicy(t *testing.T) {
 	info := GetInfo()
 
 	if !contains(info.SupportedTemplates, authorization.TemplateName) {
@@ -397,6 +399,7 @@ func xTestMultiplePolicy(t *testing.T) {
 		}
 	}
 }
+*/
 
 func TestFailOpenClose(t *testing.T) {
 	cases := []struct {

--- a/mixer/adapter/prometheus/prometheus.go
+++ b/mixer/adapter/prometheus/prometheus.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/gogo/protobuf/proto"
 	"istio.io/istio/mixer/adapter/prometheus/config"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/template/metric"
@@ -341,7 +342,7 @@ func promLabels(l map[string]interface{}) prometheus.Labels {
 	return labels
 }
 
-func computeSha(m *config.Params_MetricInfo, log adapter.Logger) [sha1.Size]byte {
+func computeSha(m proto.Marshaler, log adapter.Logger) [sha1.Size]byte {
 	ba, err := m.Marshal()
 	if err != nil {
 		log.Warningf("Unable to encode %v", err)

--- a/mixer/adapter/servicecontrol/checkprocessor.go
+++ b/mixer/adapter/servicecontrol/checkprocessor.go
@@ -107,7 +107,7 @@ func (c *checkImpl) doCheck(consumerID, operationName string, timestamp time.Tim
 
 	if c.env.Logger().VerbosityLevel(logDebug) {
 		if requestDetail, err := toFormattedJSON(request); err == nil {
-			c.env.Logger().Infof("request: %v", string(requestDetail))
+			c.env.Logger().Infof("request: %v", requestDetail)
 		}
 	}
 
@@ -118,7 +118,7 @@ func (c *checkImpl) doCheck(consumerID, operationName string, timestamp time.Tim
 
 	if c.env.Logger().VerbosityLevel(logDebug) {
 		if responseDetail, err := toFormattedJSON(response); err == nil {
-			c.env.Logger().Infof("response: %v", string(responseDetail))
+			c.env.Logger().Infof("response: %v", responseDetail)
 		}
 	}
 

--- a/mixer/adapter/servicecontrol/handler.go
+++ b/mixer/adapter/servicecontrol/handler.go
@@ -143,7 +143,8 @@ func (h *handler) Close() error {
 	h.lock.Lock()
 	defer h.lock.Lock()
 	for _, svcProc := range h.svcProcMap {
-		svcProc.Close()
+		// TODO: handle Close errors
+		_ = svcProc.Close()
 	}
 	return nil
 }

--- a/mixer/adapter/servicecontrol/quotaprocessor.go
+++ b/mixer/adapter/servicecontrol/quotaprocessor.go
@@ -182,21 +182,21 @@ func (p *quotaImpl) ProcessQuota(ctx context.Context,
 
 	if p.env.Logger().VerbosityLevel(logDebug) {
 		if requestDetail, err := toFormattedJSON(request); err == nil {
-			p.env.Logger().Infof("Quota request :%v", string(requestDetail))
+			p.env.Logger().Infof("Quota request :%v", requestDetail)
 		}
 	}
 
 	response, err := p.client.AllocateQuota(
 		p.serviceSetting.GoogleServiceName, request)
 	if err != nil {
-		p.env.Logger().Errorf("allocate quota failed: %v", err)
+		err = p.env.Logger().Errorf("allocate quota failed: %v", err)
 		return createQuotaResult(status.WithError(err),
 			quotaDuration, 0), err
 	}
 
 	if p.env.Logger().VerbosityLevel(logDebug) {
 		if responseDetail, err := toFormattedJSON(response); err == nil {
-			p.env.Logger().Infof("response :%v", string(responseDetail))
+			p.env.Logger().Infof("response :%v", responseDetail)
 		}
 	}
 

--- a/mixer/adapter/servicecontrol/reportprocessor.go
+++ b/mixer/adapter/servicecontrol/reportprocessor.go
@@ -66,7 +66,7 @@ func (r *reportImpl) scheduleReport(op *sc.Operation) {
 
 		response, err := r.client.Report(r.serviceConfig.GoogleServiceName, request)
 		if err != nil || response.ReportErrors != nil {
-			logger.Errorf("fail to send report: %v", err)
+			_ = logger.Errorf("fail to send report: %v", err)
 		}
 
 		if logger.VerbosityLevel(logDebug) {

--- a/mixer/adapter/servicecontrol/reportprocessor_test.go
+++ b/mixer/adapter/servicecontrol/reportprocessor_test.go
@@ -87,7 +87,9 @@ func TestReport(t *testing.T) {
 			HTTPStatusCode: 200,
 		},
 	})
-	test.processor.ProcessReport(context.Background(), []*servicecontrolreport.Instance{test.inst})
+	if err := test.processor.ProcessReport(context.Background(), []*servicecontrolreport.Instance{test.inst}); err != nil {
+		t.Errorf("Expecting success, got %v", err)
+	}
 	<-test.env.GetDoneChan()
 	if test.client.reportRequest == nil {
 		t.Error("report request failed")

--- a/mixer/adapter/servicecontrol/servicecontrol.go
+++ b/mixer/adapter/servicecontrol/servicecontrol.go
@@ -103,7 +103,7 @@ func validateRuntimeConfig(config *config.RuntimeConfig) *multierror.Error {
 
 func validateGcpServiceSetting(settings []*config.GcpServiceSetting) *multierror.Error {
 	var result *multierror.Error
-	if settings == nil || len(settings) == 0 {
+	if len(settings) == 0 {
 		result = multierror.Append(result, errors.New("settings is nil or empty"))
 		return result
 	}

--- a/mixer/adapter/servicecontrol/testhelper.go
+++ b/mixer/adapter/servicecontrol/testhelper.go
@@ -30,7 +30,6 @@ type mockSvcctrlClient struct {
 	reportResponse        *sc.ReportResponse
 	allocateQuotaRequest  *sc.AllocateQuotaRequest
 	allocateQuotaResponse *sc.AllocateQuotaResponse
-	done                  chan struct{}
 }
 
 func (c *mockSvcctrlClient) Check(serviceName string, request *sc.CheckRequest) (*sc.CheckResponse, error) {

--- a/mixer/adapter/servicecontrol/utils.go
+++ b/mixer/adapter/servicecontrol/utils.go
@@ -151,5 +151,5 @@ func toFormattedJSON(marshaller json.Marshaler) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(out.Bytes()), err
+	return out.String(), err
 }

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -28,7 +28,7 @@ func ToOpts(cfg *config.Params) (opts []gapiopts.ClientOption) {
 	case *config.Params_ApiKey:
 		opts = append(opts, gapiopts.WithAPIKey(cfg.GetApiKey()))
 	case *config.Params_ServiceAccountPath:
-		opts = append(opts, gapiopts.WithServiceAccountFile(cfg.GetServiceAccountPath()))
+		opts = append(opts, gapiopts.WithCredentialsFile(cfg.GetServiceAccountPath()))
 	case *config.Params_AppCredentials:
 		// When using default app credentials the SDK handles everything for us.
 	}

--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -35,13 +35,13 @@ func TestToOpts(t *testing.T) {
 		{"app creds", &config.Params{Creds: &config.Params_AppCredentials{}}, []gapiopts.ClientOption{}},
 		{"service account",
 			&config.Params{Creds: &config.Params_ServiceAccountPath{}},
-			[]gapiopts.ClientOption{gapiopts.WithServiceAccountFile("")}},
+			[]gapiopts.ClientOption{gapiopts.WithCredentialsFile("")}},
 		{"endpoint",
 			&config.Params{Endpoint: "foo.bar"},
 			[]gapiopts.ClientOption{gapiopts.WithEndpoint("")}},
 		{"endpoint + svc account",
 			&config.Params{Endpoint: "foo.bar", Creds: &config.Params_ServiceAccountPath{}},
-			[]gapiopts.ClientOption{gapiopts.WithEndpoint(""), gapiopts.WithServiceAccountFile("")}},
+			[]gapiopts.ClientOption{gapiopts.WithEndpoint(""), gapiopts.WithCredentialsFile("")}},
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {

--- a/mixer/adapter/stdio/stdio_test.go
+++ b/mixer/adapter/stdio/stdio_test.go
@@ -720,8 +720,8 @@ func captureStdout(f func()) ([]string, error) {
 
 	os.Stdout = old
 	path := tf.Name()
-	tf.Sync()
-	tf.Close()
+	_ = tf.Sync()
+	_ = tf.Close()
 
 	content, err := ioutil.ReadFile(path)
 	_ = os.Remove(path)

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -55,9 +55,6 @@ type rootArgs struct {
 	// mixerAddress is the full address (including port) of a mixer instance to call.
 	mixerAddress string
 
-	// enableTracing controls whether client-side traces are generated for calls to Mixer.
-	enableTracing bool
-
 	// # times to repeat the operation
 	repeat int
 

--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -40,8 +40,6 @@ type reportCallback func(ctx context.Context, requestBag attribute.Bag) error
 type quotaCallback func(ctx context.Context, requestBag attribute.Bag,
 	qma *runtime.QuotaMethodArgs) (*adapter.QuotaResult, error)
 
-type preprocCallbackLegacy func(requestBag attribute.Bag, responseBag *attribute.MutableBag) rpc.Status
-
 type testState struct {
 	client     mixerpb.MixerClient
 	connection *grpc.ClientConn
@@ -85,7 +83,7 @@ func (ts *testState) createGRPCServer() (string, error) {
 
 func (ts *testState) deleteGRPCServer() {
 	ts.gs.GracefulStop()
-	ts.gp.Close()
+	_ = ts.gp.Close()
 }
 
 func (ts *testState) createAPIClient(dial string) error {
@@ -445,6 +443,6 @@ func TestFailingPreproc(t *testing.T) {
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.NewOptions()
-	o.SetOutputLevel(log.DebugLevel)
+	_ = o.SetOutputLevel(log.DebugLevel)
 	_ = log.Configure(o)
 }

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip" // register the gzip compressor
 
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -40,24 +41,15 @@ type benchState struct {
 	delayOnClose bool
 }
 
-func (bs *benchState) createGRPCServer(grpcCompression bool) (string, error) {
+func (bs *benchState) createGRPCServer() (string, error) {
 	// get the network stuff setup
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
 		return "", err
 	}
 
-	var grpcOptions []grpc.ServerOption
-	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(256))
-	grpcOptions = append(grpcOptions, grpc.MaxMsgSize(1024*1024))
-
-	if grpcCompression {
-		grpcOptions = append(grpcOptions, grpc.RPCCompressor(grpc.NewGZIPCompressor()))
-		grpcOptions = append(grpcOptions, grpc.RPCDecompressor(grpc.NewGZIPDecompressor()))
-	}
-
 	// get everything wired up
-	bs.gs = grpc.NewServer(grpcOptions...)
+	bs.gs = grpc.NewServer(grpc.MaxConcurrentStreams(256), grpc.MaxMsgSize(1024*1024))
 
 	bs.gp = pool.NewGoroutinePool(32, false)
 	bs.gp.AddWorkers(32)
@@ -75,20 +67,12 @@ func (bs *benchState) createGRPCServer(grpcCompression bool) (string, error) {
 
 func (bs *benchState) deleteGRPCServer() {
 	bs.gs.GracefulStop()
-	bs.gp.Close()
+	_ = bs.gp.Close()
 }
 
-func (bs *benchState) createAPIClient(dial string, grpcCompression bool) error {
-	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithInsecure())
-
-	if grpcCompression {
-		opts = append(opts, grpc.WithCompressor(grpc.NewGZIPCompressor()))
-		opts = append(opts, grpc.WithDecompressor(grpc.NewGZIPDecompressor()))
-	}
-
+func (bs *benchState) createAPIClient(dial string) error {
 	var err error
-	if bs.connection, err = grpc.Dial(dial, opts...); err != nil {
+	if bs.connection, err = grpc.Dial(dial, grpc.WithInsecure()); err != nil {
 		return err
 	}
 
@@ -110,14 +94,14 @@ func (bs *benchState) deleteAPIClient() {
 	bs.connection = nil
 }
 
-func prepBenchState(grpcCompression bool) (*benchState, error) {
+func prepBenchState() (*benchState, error) {
 	bs := &benchState{}
-	dial, err := bs.createGRPCServer(grpcCompression)
+	dial, err := bs.createGRPCServer()
 	if err != nil {
 		return nil, err
 	}
 
-	if err = bs.createAPIClient(dial, grpcCompression); err != nil {
+	if err = bs.createAPIClient(dial); err != nil {
 		bs.deleteGRPCServer()
 		return nil, err
 	}
@@ -172,7 +156,7 @@ func BenchmarkAPI_Unary_NoGlobalDict_Compress(b *testing.B) {
 }
 
 func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
-	bs, err := prepBenchState(grpcCompression)
+	bs, err := prepBenchState()
 	if err != nil {
 		b.Fatalf("unable to prep test state %v", err)
 	}
@@ -191,6 +175,11 @@ func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
 	gp := pool.NewGoroutinePool(32, false)
 	gp.AddWorkers(32)
 
+	var opts []grpc.CallOption
+	if grpcCompression {
+		opts = append(opts, grpc.UseCompressor("gzip"))
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		uuid[4] = byte(i)
@@ -206,7 +195,7 @@ func unaryBench(b *testing.B, grpcCompression, useGlobalDict bool) {
 
 		wg.Add(1)
 		gp.ScheduleWork(func(_ interface{}) {
-			if _, err := bs.client.Check(context.Background(), request); err != nil {
+			if _, err := bs.client.Check(context.Background(), request, opts...); err != nil {
 				b.Errorf("Check2 failed with %v", err)
 			}
 			wg.Done()

--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -741,6 +741,6 @@ func TestGlobalWordCount(t *testing.T) {
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.NewOptions()
-	o.SetOutputLevel(log.DebugLevel)
+	_ = o.SetOutputLevel(log.DebugLevel)
 	_ = log.Configure(o)
 }

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -2282,9 +2282,6 @@ type TestInfo struct {
 	// tracking checks will be skipped.
 	Referenced []string
 
-	// Type is the expected of the expression upon successful compilation.
-	Type descriptor.ValueType
-
 	// Err contains the expected error message of a failed evaluation.
 	Err string
 
@@ -2303,6 +2300,9 @@ type TestInfo struct {
 
 	// Externs holds any additional externs that should be used during evaluation.
 	Externs map[string]interface{}
+
+	// Type is the expected type of the expression upon successful compilation.
+	Type descriptor.ValueType
 
 	// SkipAst indicates that AST based evaluator should not be used for this test.
 	SkipAst bool

--- a/mixer/pkg/perf/run.go
+++ b/mixer/pkg/perf/run.go
@@ -90,7 +90,9 @@ func run(b benchmark, setup *Setup, settings *Settings, coprocess bool) {
 		b.fatalf("controller initialization failed: '%v'", err)
 		return
 	}
-	defer controller.close()
+	defer func() {
+		_ = controller.close()
+	}()
 
 	if coprocess {
 		var exeName string
@@ -139,7 +141,7 @@ func run(b benchmark, setup *Setup, settings *Settings, coprocess bool) {
 
 	// Even though we have a deferred close for controller, do it explicitly before leaving control to perform
 	// graceful close of clients during teardown.
-	controller.close()
+	_ = controller.close()
 }
 
 func runDispatcherOnly(b benchmark, setup *Setup, settings *Settings) {
@@ -154,7 +156,9 @@ func runDispatcherOnly(b benchmark, setup *Setup, settings *Settings) {
 		b.fatalf("error creating Mixer server: '%s'", err.Error())
 		return
 	}
-	defer s.Close()
+	defer func() {
+		_ = s.Close()
+	}()
 
 	dispatcher := s.Dispatcher()
 

--- a/mixer/pkg/perf/server.go
+++ b/mixer/pkg/perf/server.go
@@ -96,13 +96,13 @@ func initializeArgs(settings *Settings, setup *Setup) (*testEnv.Args, error) {
 		setup.Config.EnableLog = true
 
 		o := log.NewOptions()
-		o.SetOutputLevel(log.DebugLevel)
+		_ = o.SetOutputLevel(log.DebugLevel)
 		args.LoggingOptions = o
 	}
 
 	if !setup.Config.EnableLog {
 		o := log.NewOptions()
-		o.SetOutputLevel(log.NoneLevel)
+		_ = o.SetOutputLevel(log.NoneLevel)
 		args.LoggingOptions = o
 	}
 
@@ -113,9 +113,9 @@ func (s *server) shutdown() {
 	if s != nil {
 		if err := s.s.Close(); err != nil {
 			log.Error(err.Error())
-			log.Sync()
+			_ = log.Sync()
 		}
-		s = nil
+		s.s = nil
 	}
 }
 

--- a/mixer/pkg/pool/goroutine_test.go
+++ b/mixer/pkg/pool/goroutine_test.go
@@ -51,6 +51,6 @@ func TestWorkerPool(t *testing.T) {
 		}
 
 		// make sure the pool can be shutdown cleanly
-		gp.Close()
+		_ = gp.Close()
 	}
 }

--- a/mixer/pkg/runtime/dispatcher_test.go
+++ b/mixer/pkg/runtime/dispatcher_test.go
@@ -104,7 +104,7 @@ func TestReport(t *testing.T) {
 			}
 		})
 	}
-	gp.Close()
+	_ = gp.Close()
 }
 
 func TestCheck(t *testing.T) {
@@ -157,7 +157,7 @@ func TestCheck(t *testing.T) {
 			}
 		})
 	}
-	gp.Close()
+	_ = gp.Close()
 }
 
 func TestQuota(t *testing.T) {
@@ -216,7 +216,7 @@ func TestQuota(t *testing.T) {
 		})
 	}
 
-	gp.Close()
+	_ = gp.Close()
 }
 
 func TestPreprocess(t *testing.T) {
@@ -241,7 +241,7 @@ func TestPreprocess(t *testing.T) {
 		{name: "errFromTmpl", tn: tname, callErr: err1},
 		{name: "resolverErr", tn: tname, callErr: err1, resolveErr: true},
 	} {
-		t.Run(fmt.Sprintf("%s", s.name), func(t *testing.T) {
+		t.Run(s.name, func(t *testing.T) {
 			fp := &fakeProc{
 				err:              s.callErr,
 				mutableBagResult: s.aBag,

--- a/mixer/pkg/runtime/env_test.go
+++ b/mixer/pkg/runtime/env_test.go
@@ -30,7 +30,7 @@ func TestEnv(t *testing.T) {
 
 		// set up the ambient logger so newEnv picks it up
 		o := log.NewOptions()
-		log.Configure(o)
+		_ = log.Configure(o)
 
 		env := newEnv("Foo", gp)
 		log := env.Logger()
@@ -71,6 +71,6 @@ func TestEnv(t *testing.T) {
 		// hack to give time for the panic to 'take hold' if it doesn't get recovered properly
 		time.Sleep(200 * time.Millisecond)
 
-		gp.Close()
+		_ = gp.Close()
 	}
 }

--- a/mixer/pkg/runtime2/config/config_test.go
+++ b/mixer/pkg/runtime2/config/config_test.go
@@ -1356,9 +1356,9 @@ Attributes:
 	},
 }
 
-var noTemplates = make(map[string]*template.Info, 0)
+var noTemplates = make(map[string]*template.Info)
 
-var noAdapters = make(map[string]*adapter.Info, 0)
+var noAdapters = make(map[string]*adapter.Info)
 
 var stdAdapters = map[string]*adapter.Info{
 	"adapter1": {
@@ -1407,8 +1407,8 @@ func TestConfigs(t *testing.T) {
 
 	// enable debug logging and run again to ensure debug logging won't cause a crash.
 	o := log.NewOptions()
-	o.SetOutputLevel(log.DebugLevel)
-	log.Configure(o)
+	_ = o.SetOutputLevel(log.DebugLevel)
+	_ = log.Configure(o)
 	runTests(t)
 }
 

--- a/mixer/pkg/runtime2/config/ephemeral.go
+++ b/mixer/pkg/runtime2/config/ephemeral.go
@@ -53,7 +53,7 @@ func NewEphemeral(
 
 		nextID: 0,
 
-		entries: make(map[store.Key]*store.Resource, 0),
+		entries: make(map[store.Key]*store.Resource),
 
 		cachedAttributes: nil,
 	}

--- a/mixer/pkg/runtime2/handler/env_test.go
+++ b/mixer/pkg/runtime2/handler/env_test.go
@@ -30,7 +30,7 @@ func TestEnv(t *testing.T) {
 
 		// set up the ambient logger so newEnv picks it up
 		o := log.NewOptions()
-		log.Configure(o)
+		_ = log.Configure(o)
 
 		env := NewEnv(0, "Foo", gp)
 		log := env.Logger()
@@ -81,6 +81,6 @@ func TestEnv(t *testing.T) {
 		// hack to give time for the panic to 'take hold' if it doesn't get recovered properly
 		time.Sleep(200 * time.Millisecond)
 
-		gp.Close()
+		_ = gp.Close()
 	}
 }

--- a/mixer/pkg/runtime2/handler/factory.go
+++ b/mixer/pkg/runtime2/handler/factory.go
@@ -149,7 +149,7 @@ func (f *factory) buildHandler(
 	for tmplName := range inferredTypes {
 		types = inferredTypes[tmplName]
 		// ti should be there for a valid configuration.
-		ti, _ = f.snapshot.Templates[tmplName]
+		ti = f.snapshot.Templates[tmplName]
 		if ti.SetType != nil { // for case like APA template that does not have SetType
 			ti.SetType(types, builder)
 		}

--- a/mixer/pkg/runtime2/testing/data/adapters.go
+++ b/mixer/pkg/runtime2/testing/data/adapters.go
@@ -91,6 +91,8 @@ var _ adapter.Env = &FakeEnv{}
 
 // FakeHandlerBuilder is a fake of HandlerBuilder.
 type FakeHandlerBuilder struct {
+	Handler                       *FakeHandler
+	PanicData                     interface{}
 	PanicAtSetAdapterConfig       bool
 	ErrorAtBuild                  bool
 	PanicAtBuild                  bool
@@ -98,9 +100,7 @@ type FakeHandlerBuilder struct {
 	PanicAtValidate               bool
 	HandlerErrorOnClose           bool
 	HandlerPanicOnClose           bool
-	Handler                       *FakeHandler
 	HandlerDoesNotSupportTemplate bool
-	PanicData                     interface{}
 }
 
 // SetAdapterConfig is an implementation of HandlerBuilder.SetAdapterConfig.
@@ -118,7 +118,7 @@ func (f *FakeHandlerBuilder) Validate() *adapter.ConfigErrors {
 
 	if f.ErrorAtValidate {
 		errs := &adapter.ConfigErrors{}
-		errs.Append("field", fmt.Errorf("some validation error"))
+		errs = errs.Append("field", fmt.Errorf("some validation error"))
 		return errs
 	}
 	return nil

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -49,15 +49,6 @@ type Args struct {
 	// Maximum number of entries in the expression cache
 	ExpressionEvalCacheSize int
 
-	// Port to use for Mixer's gRPC API
-	APIPort uint16
-
-	// Port to use for exposing mixer self-monitoring information
-	MonitoringPort uint16
-
-	// If true, each request to Mixer will be executed in a single go routine (useful for debugging)
-	SingleThreaded bool
-
 	// URL of the config store. Use k8s://path_to_kubeconfig or fs:// for file system. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 	ConfigStoreURL string
 
@@ -80,14 +71,23 @@ type Args struct {
 	// Supplies a string to use for global configuration, overrides ConfigStoreURL
 	GlobalConfig string
 
-	// Enables gRPC-level tracing
-	EnableGRPCTracing bool
-
 	// The logging options to use
 	LoggingOptions *log.Options
 
 	// The tracing options to use
 	TracingOptions *tracing.Options
+
+	// Port to use for Mixer's gRPC API
+	APIPort uint16
+
+	// Port to use for exposing mixer self-monitoring information
+	MonitoringPort uint16
+
+	// Enables gRPC-level tracing
+	EnableGRPCTracing bool
+
+	// If true, each request to Mixer will be executed in a single go routine (useful for debugging)
+	SingleThreaded bool
 }
 
 // NewArgs allocates an Args struct initialized with Mixer's default configuration.

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -226,7 +226,7 @@ func (s *Server) Wait() error {
 func (s *Server) Close() error {
 	if s.shutdown != nil {
 		s.server.GracefulStop()
-		s.Wait()
+		_ = s.Wait()
 	}
 
 	if s.listener != nil {
@@ -254,7 +254,7 @@ func (s *Server) Close() error {
 	}
 
 	// final attempt to purge buffered logs
-	log.Sync()
+	_ = log.Sync()
 
 	return nil
 }

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -78,7 +78,6 @@ type fakeMyApaHandler struct {
 	adapter.Handler
 	retOutput     *istio_mixer_adapter_sample_myapa.Output
 	retError      error
-	cnfgCallInput interface{}
 	procCallInput interface{}
 }
 

--- a/mixer/test/e2e/util_test.go
+++ b/mixer/test/e2e/util_test.go
@@ -110,7 +110,6 @@ func interfaceMap(m interface{}) map[interface{}]interface{} {
 	return ret
 }
 
-// nolint: deadcode
 type testData struct {
 	name      string
 	cfg       string
@@ -120,7 +119,6 @@ type testData struct {
 	validate  func(t *testing.T, err error, sypAdpts []*spyAdapter.Adapter)
 }
 
-// nolint: deadcode
 func closeHelper(c io.Closer) {
 	err := c.Close()
 	if err != nil {
@@ -128,7 +126,6 @@ func closeHelper(c io.Closer) {
 	}
 }
 
-// nolint: deadcode
 func getAttrBag(attrs map[string]interface{}, identityAttr, identityAttrDomain string) istio_mixer_v1.CompressedAttributes {
 	requestBag := attribute.GetMutableBag(nil)
 	requestBag.Set(identityAttr, identityAttrDomain)

--- a/mixer/test/perf/common_test.go
+++ b/mixer/test/perf/common_test.go
@@ -231,21 +231,6 @@ spec:
     - i1.reportnothing.istio-system
 `
 
-// r4UsingH1AndI2Conditional is a simple conditional rule that calls into the noop adapter with checknothing template.
-var r4UsingH1AndI2Conditional = `
-apiVersion: "config.istio.io/v1alpha2"
-kind: rule
-metadata:
-  name: r3-h1-i2-conditional
-  namespace: istio-system
-spec:
-  match: attr.int64 == 42
-  actions:
-  - handler: h1.noop
-    instances:
-    - i2.checknothing.istio-system
-`
-
 var r5UsingH1AndI3 = `
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule

--- a/mixer/test/spyAdapter/spyadapter.go
+++ b/mixer/test/spyAdapter/spyadapter.go
@@ -46,7 +46,7 @@ type (
 	}
 
 	// AdapterBehavior defines the behavior of the Adapter
-	// nolint: aligncheck
+	// nolint: maligned
 	AdapterBehavior struct {
 		Name    string
 		Builder BuilderBehavior
@@ -54,7 +54,7 @@ type (
 	}
 
 	// HandlerBehavior defines the behavior of the Handler
-	// nolint: aligncheck
+	// nolint: maligned
 	HandlerBehavior struct {
 		HandleSampleReportErr   error
 		HandleSampleReportPanic bool
@@ -68,7 +68,7 @@ type (
 	}
 
 	// BuilderBehavior defines the behavior of the Builder
-	// nolint: aligncheck
+	// nolint: maligned
 	BuilderBehavior struct {
 		SetSampleReportTypesPanic bool
 
@@ -81,7 +81,7 @@ type (
 		BuildPanic bool
 	}
 
-	// nolint: aligncheck
+	// nolint: maligned
 	builder struct {
 		behavior        BuilderBehavior
 		handlerBehavior HandlerBehavior

--- a/pilot/adapter/config/aggregate/config_test.go
+++ b/pilot/adapter/config/aggregate/config_test.go
@@ -52,7 +52,7 @@ func makeCache(t *testing.T) (model.ConfigStore, model.ConfigStoreCache) {
 	}
 	ctl, err := aggregate.MakeCache([]model.ConfigStoreCache{mockStoreCache, istioStoreCache})
 	if err != nil {
-		t.Fatal("unexpected error %v", err)
+		t.Fatalf("unexpected error %v", err)
 	}
 	return store, ctl
 }

--- a/pilot/adapter/config/file/monitor_test.go
+++ b/pilot/adapter/config/file/monitor_test.go
@@ -107,7 +107,7 @@ func (e *env) teardown() {
 	close(e.stop)
 
 	// Remove the temp dir.
-	os.RemoveAll(e.fsroot)
+	_ = os.RemoveAll(e.fsroot)
 }
 
 func (e *env) watchFor(eventType model.Event) event {
@@ -233,7 +233,7 @@ func TestUpdate(t *testing.T) {
 
 	// Overwrite the original file with the updated.
 	updateFilePath := "testdata/cb-policy.yaml.update"
-	copyFile(updateFilePath, path.Join(e.fsroot, "cb-policy.yaml"))
+	_ = copyFile(updateFilePath, path.Join(e.fsroot, "cb-policy.yaml"))
 
 	// Get the configuration that we expect to be deleted
 	expectedCfgs, err := parseFile(updateFilePath)

--- a/pilot/cmd/cmd.go
+++ b/pilot/cmd/cmd.go
@@ -81,5 +81,5 @@ func WaitSignal(stop chan struct{}) {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	<-sigs
 	close(stop)
-	log.Sync()
+	_ = log.Sync()
 }

--- a/pilot/cmd/istioctl/gendeployment/cmd.go
+++ b/pilot/cmd/istioctl/gendeployment/cmd.go
@@ -117,15 +117,7 @@ func getValues(path string, i *installation) (string, error) {
 }
 
 type installation struct {
-	Mixer       bool
-	Pilot       bool
-	CA          bool
-	Ingress     bool
-	Initializer bool
-
 	Namespace string
-	Debug     bool
-	NodePort  uint16
 
 	// todo: support hub per component
 	Hub      string // hub to pull images from
@@ -136,6 +128,15 @@ type installation struct {
 
 	HyperkubeHub string
 	HyperkubeTag string
+
+	NodePort uint16
+	Debug    bool
+
+	Mixer       bool
+	Pilot       bool
+	CA          bool
+	Ingress     bool
+	Initializer bool
 }
 
 func defaultInstall() *installation {

--- a/pilot/cmd/istioctl/gendeployment/yaml.go
+++ b/pilot/cmd/istioctl/gendeployment/yaml.go
@@ -53,7 +53,7 @@ func yamlFromInstallation(values, namespace, helmChartDirectory string) (string,
 
 	out := &bytes.Buffer{}
 	for name, data := range files {
-		if len(strings.TrimSpace(string(data))) == 0 {
+		if len(strings.TrimSpace(data)) == 0 {
 			continue
 		}
 		if _, err = fmt.Fprintf(out, "---\n# Source: %q\n", name); err != nil {

--- a/pilot/cmd/pilot-discovery/server/server_test.go
+++ b/pilot/cmd/pilot-discovery/server/server_test.go
@@ -85,7 +85,7 @@ func (e *env) teardown() {
 	close(e.stop)
 
 	// Remove the temp dir.
-	os.RemoveAll(e.fsRoot)
+	_ = os.RemoveAll(e.fsRoot)
 }
 
 func createTempDir() string {

--- a/pilot/platform/cloudfoundry/config_test.go
+++ b/pilot/platform/cloudfoundry/config_test.go
@@ -43,7 +43,7 @@ type testState struct {
 
 func (s *testState) cleanup() {
 	s.creds.CleanupTempFiles()
-	os.RemoveAll(s.configFilePath)
+	_ = os.RemoveAll(s.configFilePath)
 }
 
 func newTestState() *testState {
@@ -151,8 +151,8 @@ func TestConfig_TLSClient_Connects(t *testing.T) {
 	msgs := make(chan string)
 	go func() {
 		for {
-			conn, err := serverListener.Accept()
-			if err != nil {
+			conn, err2 := serverListener.Accept()
+			if err2 != nil {
 				return
 			}
 			b := make([]byte, 6)
@@ -200,15 +200,15 @@ func TestConfig_TLSClient_HasSecureParameters(t *testing.T) {
 
 	rawSubjectData := string(tlsConfig.RootCAs.Subjects()[0])
 	if !strings.Contains(rawSubjectData, "serverCA") {
-		t.Errorf("expected to find substring %q in root CAs subject data")
+		t.Errorf("expected to find substring 'serverCA' in root CAs subject data")
 	}
 }
 
 func TestConfig_TLSClient_Errors(t *testing.T) {
 	// checking that we get useful errors when the config is broken in various ways
 	breakageTypes := map[string]func(path string){
-		"remove":       func(path string) { os.Remove(path) },
-		"writeBadData": func(path string) { ioutil.WriteFile(path, []byte("bad-data"), 0600) },
+		"remove":       func(path string) { _ = os.Remove(path) },
+		"writeBadData": func(path string) { _ = ioutil.WriteFile(path, []byte("bad-data"), 0600) },
 	}
 
 	testCases := []struct {

--- a/pilot/platform/cloudfoundry/controller_test.go
+++ b/pilot/platform/cloudfoundry/controller_test.go
@@ -71,10 +71,10 @@ func TestController_Caching(t *testing.T) {
 	ih1, ih2 := new(fakeInstanceHandler), new(fakeInstanceHandler)
 	sh1, sh2 := new(fakeServiceHandler), new(fakeServiceHandler)
 
-	controller.AppendInstanceHandler(ih1.Do)
-	controller.AppendInstanceHandler(ih2.Do)
-	controller.AppendServiceHandler(sh1.Do)
-	controller.AppendServiceHandler(sh2.Do)
+	_ = controller.AppendInstanceHandler(ih1.Do)
+	_ = controller.AppendInstanceHandler(ih2.Do)
+	_ = controller.AppendServiceHandler(sh1.Do)
+	_ = controller.AppendServiceHandler(sh2.Do)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -160,8 +160,8 @@ func TestController_ClientErrors(t *testing.T) {
 	ih1 := new(fakeInstanceHandler)
 	sh1 := new(fakeServiceHandler)
 
-	controller.AppendInstanceHandler(ih1.Do)
-	controller.AppendServiceHandler(sh1.Do)
+	_ = controller.AppendInstanceHandler(ih1.Do)
+	_ = controller.AppendServiceHandler(sh1.Do)
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pilot/platform/consul/monitor_test.go
+++ b/pilot/platform/consul/monitor_test.go
@@ -29,8 +29,10 @@ const (
 	notifyThreshold = resync * 10
 )
 
-// https://github.com/istio/istio/issues/2318
-func xTestController(t *testing.T) {
+func TestController(t *testing.T) {
+	// https://github.com/istio/istio/issues/2318
+	t.SkipNow()
+
 	ts := newServer()
 	defer ts.Server.Close()
 	conf := api.DefaultConfig()

--- a/pilot/platform/eureka/client.go
+++ b/pilot/platform/eureka/client.go
@@ -28,7 +28,7 @@ type application struct {
 	Instances []*instance `json:"instance"`
 }
 
-type instance struct { // nolint: aligncheck
+type instance struct { // nolint: maligned
 	Hostname   string `json:"hostName"`
 	IPAddress  string `json:"ipAddr"`
 	Status     string `json:"status"`

--- a/pilot/platform/kube/controller_test.go
+++ b/pilot/platform/kube/controller_test.go
@@ -111,7 +111,7 @@ func TestServices(t *testing.T) {
 }
 
 func makeService(n, ns string, cl kubernetes.Interface, t *testing.T) {
-	_, err := cl.Core().Services(ns).Create(&v1.Service{
+	_, err := cl.CoreV1().Services(ns).Create(&v1.Service{
 		ObjectMeta: meta_v1.ObjectMeta{Name: n},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{

--- a/pilot/platform/kube/inject/inject_test.go
+++ b/pilot/platform/kube/inject/inject_test.go
@@ -52,9 +52,6 @@ const unitTestTag = "unittest"
 // and the other .injected "want" YAMLs
 const unitTestHub = "docker.io/istio"
 
-// Default unit test DebugMode parameter
-const unitTestDebugMode = true
-
 func TestIntoResourceFile(t *testing.T) {
 	cases := []struct {
 		enableAuth      bool

--- a/pilot/platform/kube/register.go
+++ b/pilot/platform/kube/register.go
@@ -121,7 +121,7 @@ func addLabelsAndAnnotations(obj *meta_v1.ObjectMeta, labels []string, annotatio
 func RegisterEndpoint(client kubernetes.Interface, namespace string, svcName string,
 	ip string, portsList []NamedPort, labels []string, annotations []string) error {
 	getOpt := meta_v1.GetOptions{IncludeUninitialized: true}
-	_, err := client.Core().Services(namespace).Get(svcName, getOpt)
+	_, err := client.CoreV1().Services(namespace).Get(svcName, getOpt)
 	if err != nil {
 		log.Warnf("Got '%v' looking up svc '%s' in namespace '%s', attempting to create it", err, svcName, namespace)
 		svc := v1.Service{}

--- a/pilot/proxy/envoy/watcher.go
+++ b/pilot/proxy/envoy/watcher.go
@@ -92,7 +92,7 @@ func (w *watcher) Run(ctx context.Context) {
 	}
 
 	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.Reload)
-	go w.retrieveAZ(ctx, time.Duration(time.Second*10))
+	go w.retrieveAZ(ctx, time.Second*10)
 
 	<-ctx.Done()
 }
@@ -130,7 +130,7 @@ func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration) {
 				log.Infof("Proxy availability zone: %v", w.config.AvailabilityZone)
 				w.Reload()
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 	}
 }

--- a/pilot/proxy/envoy/watcher_test.go
+++ b/pilot/proxy/envoy/watcher_test.go
@@ -90,7 +90,7 @@ type pilotStubState struct {
 func (p *pilotStubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.Lock()
 	w.WriteHeader(p.States[0].StatusCode)
-	w.Write([]byte(p.States[0].Response))
+	_, _ = w.Write([]byte(p.States[0].Response))
 	p.States = p.States[1:]
 	p.Unlock()
 }

--- a/pilot/test/eurekamirror/eurekamirror.go
+++ b/pilot/test/eurekamirror/eurekamirror.go
@@ -65,7 +65,7 @@ type registerInstance struct {
 	Instance instance `json:"instance"`
 }
 
-type instance struct { // nolint: aligncheck
+type instance struct { // nolint: maligned
 	ID         string   `json:"instanceId,omitempty"`
 	Hostname   string   `json:"hostName"`
 	App        string   `json:"app"`

--- a/pilot/test/integration/auth_exclusion.go
+++ b/pilot/test/integration/auth_exclusion.go
@@ -35,10 +35,7 @@ func (r *authExclusion) setup() error {
 func (r *authExclusion) teardown() {}
 
 func (r *authExclusion) run() error {
-	if err := r.makeRequests(); err != nil {
-		return err
-	}
-	return nil
+	return r.makeRequests()
 }
 
 // makeRequests executes requests in pods and collects request ids per pod to check against access logs

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -116,7 +116,7 @@ type test interface {
 
 func main() {
 	flag.Parse()
-	log.Configure(log.NewOptions())
+	_ = log.Configure(log.NewOptions())
 
 	if params.Tag == "" {
 		log.Error("No docker tag specified")

--- a/pilot/test/integration/infra.go
+++ b/pilot/test/integration/infra.go
@@ -48,7 +48,7 @@ const (
 	ingressSecretName = "istio-ingress-certs"
 )
 
-type infra struct { // nolint: aligncheck
+type infra struct { // nolint: maligned
 	Name string
 
 	// docker tags
@@ -115,7 +115,7 @@ func (infra *infra) setup() error {
 		}
 		infra.namespaceCreated = true
 	} else {
-		if _, err := client.Core().Namespaces().Get(infra.Namespace, meta_v1.GetOptions{}); err != nil {
+		if _, err := client.CoreV1().Namespaces().Get(infra.Namespace, meta_v1.GetOptions{}); err != nil {
 			return err
 		}
 	}
@@ -127,7 +127,7 @@ func (infra *infra) setup() error {
 		}
 		infra.istioNamespaceCreated = true
 	} else {
-		if _, err := client.Core().Namespaces().Get(infra.IstioNamespace, meta_v1.GetOptions{}); err != nil {
+		if _, err := client.CoreV1().Namespaces().Get(infra.IstioNamespace, meta_v1.GetOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pilot/test/integration/ingress.go
+++ b/pilot/test/integration/ingress.go
@@ -141,7 +141,7 @@ func (t *ingress) checkRouteRule() status {
 
 // ensure that IPs/hostnames are in the ingress statuses
 func (t *ingress) checkIngressStatus() status {
-	ings, err := client.Extensions().Ingresses(t.Namespace).List(metav1.ListOptions{})
+	ings, err := client.ExtensionsV1beta1().Ingresses(t.Namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (t *ingress) teardown() {
 	if !t.Ingress {
 		return
 	}
-	if err := client.Extensions().Ingresses(t.Namespace).
+	if err := client.ExtensionsV1beta1().Ingresses(t.Namespace).
 		DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{}); err != nil {
 		log.Warna(err)
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -190,6 +190,6 @@ func With(fields ...zapcore.Field) *zap.Logger {
 // Sync flushes any buffered log entries.
 // Processes should normally take care to call Sync before exiting.
 // This call is a wrapper around [logger.Sync](https://godoc.org/go.uber.org/zap#logger.Sync)
-func Sync() {
-	logger.Sync()
+func Sync() error {
+	return logger.Sync()
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -170,7 +170,7 @@ func TestBasic(t *testing.T) {
 	// sadly, only testing whether we crash or not...
 	l := With(zap.String("Key", "Value"))
 	l.Debug("Hello")
-	l.Sync()
+	_ = l.Sync()
 }
 
 func TestEnabled(t *testing.T) {
@@ -353,8 +353,8 @@ func captureStdout(f func()) ([]string, error) {
 
 	os.Stdout = old
 	path := tf.Name()
-	tf.Sync()
-	tf.Close()
+	_ = tf.Sync()
+	_ = tf.Close()
 
 	content, err := ioutil.ReadFile(path)
 	_ = os.Remove(path)

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -137,11 +137,12 @@ func (h holder) Close() error {
 		ot.SetGlobalTracer(ot.NoopTracer{})
 	}
 
+	var err error
 	if h.closer != nil {
-		h.closer.Close()
+		err = h.closer.Close()
 	}
 
-	return nil
+	return err
 }
 
 type spanLogger struct{}

--- a/pkg/tracing/config_test.go
+++ b/pkg/tracing/config_test.go
@@ -29,11 +29,6 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-var (
-	testUser = "test"
-	testPass = "pass"
-)
-
 func TestConfigure(t *testing.T) {
 	srv := &testServer{}
 	zipkinServer := httptest.NewServer(handler(srv.receiveZipkin))
@@ -76,10 +71,10 @@ func TestConfigure(t *testing.T) {
 				span.Finish()
 
 				// force a flush of spans to endpoints
-				closer.Close()
+				_ = closer.Close()
 
 				// force the log to flush
-				log.Sync()
+				_ = log.Sync()
 			})
 
 			if err != nil {
@@ -186,8 +181,8 @@ func captureStdout(f func()) ([]string, error) {
 
 	os.Stdout = old
 	path := tf.Name()
-	tf.Sync()
-	tf.Close()
+	_ = tf.Sync()
+	_ = tf.Close()
 
 	content, err := ioutil.ReadFile(path)
 	_ = os.Remove(path)

--- a/security/integration/main.go
+++ b/security/integration/main.go
@@ -139,14 +139,14 @@ func initializeIntegrationTest(cmd *cobra.Command, args []string) error {
 	// Create Role
 	err = utils.CreateIstioCARole(opts.clientset, opts.namespace)
 	if err != nil {
-		utils.DeleteTestNamespace(opts.clientset, opts.namespace)
+		_ = utils.DeleteTestNamespace(opts.clientset, opts.namespace)
 		return fmt.Errorf("failed to create a role (error: %v)", err)
 	}
 
 	// Create RoleBinding
 	err = utils.CreateIstioCARoleBinding(opts.clientset, opts.namespace)
 	if err != nil {
-		utils.DeleteTestNamespace(opts.clientset, opts.namespace)
+		_ = utils.DeleteTestNamespace(opts.clientset, opts.namespace)
 		return fmt.Errorf("failed to create a rolebinding (error: %v)", err)
 	}
 
@@ -376,7 +376,9 @@ func readURI(uri string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/security/integration/utils/kubernetes.go
+++ b/security/integration/utils/kubernetes.go
@@ -59,7 +59,7 @@ func CreateTestNamespace(clientset kubernetes.Interface, prefix string) (string,
 			GenerateName: prefix,
 		},
 	}
-	namespace, err := clientset.Core().Namespaces().Create(template)
+	namespace, err := clientset.CoreV1().Namespaces().Create(template)
 	if err != nil {
 		return "", fmt.Errorf("failed to create a namespace (error: %v)", err)
 	}
@@ -242,11 +242,8 @@ func CreateIstioCARoleBinding(clientset kubernetes.Interface, namespace string) 
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
-	if _, err := clientset.RbacV1beta1().RoleBindings(namespace).Create(&rolebinding); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := clientset.RbacV1beta1().RoleBindings(namespace).Create(&rolebinding)
+	return err
 }
 
 func waitForServiceExternalIPAddress(clientset kubernetes.Interface, namespace string, uuid string,

--- a/security/pkg/platform/gcp_test.go
+++ b/security/pkg/platform/gcp_test.go
@@ -224,9 +224,8 @@ func TestGcpGetRequestMetadata(t *testing.T) {
 
 func TestGcpRequireTransportSecurity(t *testing.T) {
 	testCases := map[string]struct {
-		token       string
-		expectedErr string
-		expected    bool
+		token    string
+		expected bool
 	}{
 		"Expected true": {
 			expected: true,

--- a/security/pkg/registry/kube/serviceaccount.go
+++ b/security/pkg/registry/kube/serviceaccount.go
@@ -110,7 +110,7 @@ func (c *ServiceAccountController) serviceAccountUpdated(oldObj, newObj interfac
 	if oldSa.GetName() != newSa.GetName() || oldSa.GetNamespace() != newSa.GetNamespace() {
 		oldID := getSpiffeID(oldSa)
 		newID := getSpiffeID(newSa)
-		c.reg.DeleteMapping(oldID, oldID)
-		c.reg.AddMapping(newID, newID)
+		_ = c.reg.DeleteMapping(oldID, oldID)
+		_ = c.reg.AddMapping(newID, newID)
 	}
 }

--- a/security/pkg/server/grpc/authorizer_test.go
+++ b/security/pkg/server/grpc/authorizer_test.go
@@ -90,7 +90,7 @@ func TestRegistryAuthorizerWithJWT(t *testing.T) {
 				authz := &registryAuthorizor{&registry.IdentityRegistry{
 					Map: map[string]string{"id": "id"},
 				}}
-				authz.authorize(idRequestor, requestedIDs)
+				_ = authz.authorize(idRequestor, requestedIDs)
 				return authz
 			}(),
 		},

--- a/security/pkg/server/grpc/server_test.go
+++ b/security/pkg/server/grpc/server_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	"google.golang.org/grpc/status"
 	"istio.io/istio/security/pkg/pki/ca"
 	pb "istio.io/istio/security/proto"
 )
@@ -61,10 +61,9 @@ func (ca *mockCA) GetRootCertificate() []byte {
 }
 
 type mockAuthenticator struct {
-	authenticated bool
-	authSource    authSource
-	identities    []string
-	errMsg        string
+	authSource authSource
+	identities []string
+	errMsg     string
 }
 
 func (authn *mockAuthenticator) authenticate(ctx context.Context) (*caller, error) {
@@ -142,9 +141,11 @@ func TestSign(t *testing.T) {
 		}
 		request := &pb.Request{CsrPem: []byte(c.csr)}
 
-		response, err := server.HandleCSR(nil, request)
-		if c.code != grpc.Code(err) {
-			t.Errorf("Case %s: expecting code to be (%d) but got (%d)", id, c.code, grpc.Code(err))
+		response, err := server.HandleCSR(context.Background(), request)
+		s, _ := status.FromError(err)
+		code := s.Code()
+		if c.code != code {
+			t.Errorf("Case %s: expecting code to be (%d) but got (%d)", id, c.code, code)
 		} else if c.code == codes.OK && !bytes.Equal(response.SignedCertChain, []byte(c.cert)) {
 			t.Errorf("Case %s: expecting cert to be (%s) but got (%s)", id, c.cert, response.SignedCertChain)
 		}

--- a/security/tests/integration/kubernetes_utils.go
+++ b/security/tests/integration/kubernetes_utils.go
@@ -73,14 +73,14 @@ func createTestNamespace(clientset kubernetes.Interface, prefix string) (string,
 	// Create Role
 	err = createIstioCARole(clientset, namespace.GetName())
 	if err != nil {
-		deleteTestNamespace(clientset, namespace.GetName())
+		_ = deleteTestNamespace(clientset, namespace.GetName())
 		return "", fmt.Errorf("failed to create a role (error: %v)", err)
 	}
 
 	// Create RoleBinding
 	err = createIstioCARoleBinding(clientset, namespace.GetName())
 	if err != nil {
-		deleteTestNamespace(clientset, namespace.GetName())
+		_ = deleteTestNamespace(clientset, namespace.GetName())
 		return "", fmt.Errorf("failed to create a rolebinding (error: %v)", err)
 	}
 
@@ -233,11 +233,8 @@ func createIstioCARoleBinding(clientset kubernetes.Interface, namespace string) 
 			APIGroup: "rbac.authorization.k8s.io",
 		},
 	}
-	if _, err := clientset.RbacV1beta1().RoleBindings(namespace).Create(&rolebinding); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := clientset.RbacV1beta1().RoleBindings(namespace).Create(&rolebinding)
+	return err
 }
 
 func waitForServiceExternalIPAddress(clientset kubernetes.Interface, namespace string, uuid string,

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -54,7 +54,6 @@ var (
 	authEnable      = flag.Bool("auth_enable", false, "Enable auth")
 	localCluster    = flag.Bool("use_local_cluster", false, "Whether the cluster is local or not")
 	skipSetup       = flag.Bool("skip_setup", false, "Skip namespace creation and istio cluster setup")
-	skipDelete      = flag.Bool("skip_delete", false, "Skip namespace deletion, for ephemeral machines and to debug after test")
 	initializerFile = flag.String("initializer_file", istioInitializerFile, "Initializer yaml file")
 	clusterWide     = flag.Bool("cluster_wide", false, "Run cluster wide tests")
 

--- a/tests/e2e/framework/rawVM.go
+++ b/tests/e2e/framework/rawVM.go
@@ -135,10 +135,8 @@ func (vm *GCPRawVM) Teardown() error {
 			return err
 		}
 	}
-	if _, err := u.Shell(vm.baseCommand("delete")); err != nil {
-		return err
-	}
-	return nil
+	_, err := u.Shell(vm.baseCommand("delete"))
+	return err
 }
 
 // Setup initialize the VM

--- a/tests/e2e/framework/testInfo.go
+++ b/tests/e2e/framework/testInfo.go
@@ -272,7 +272,7 @@ func (t testInfo) uploadDir() error {
 func (t testInfo) Teardown() error {
 	if t.Bucket != "" {
 		log.Info("Uploading logs remotely")
-		log.Sync()
+		_ = log.Sync()
 		return t.uploadDir()
 	}
 	return nil

--- a/tests/integration/example/environment/appOnlyEnv/app_only_env.go
+++ b/tests/integration/example/environment/appOnlyEnv/app_only_env.go
@@ -63,6 +63,6 @@ func (appOnlyEnv *AppOnlyEnv) GetComponents() []framework.Component {
 // Remove the local temp dir. Can be manually overrided if necessary.
 func (appOnlyEnv *AppOnlyEnv) Cleanup() (err error) {
 	log.Printf("Cleaning up %s", appOnlyEnv.EnvID)
-	os.RemoveAll(appOnlyEnv.TmpDir)
+	_ = os.RemoveAll(appOnlyEnv.TmpDir)
 	return
 }

--- a/tests/integration/example/environment/mixerEnvoyEnv/mixer_envoy_env.go
+++ b/tests/integration/example/environment/mixerEnvoyEnv/mixer_envoy_env.go
@@ -71,7 +71,7 @@ func (mixerEnvoyEnv *MixerEnvoyEnv) GetComponents() []framework.Component {
 // Remove the local temp dir. Can be manually overrided if necessary.
 func (mixerEnvoyEnv *MixerEnvoyEnv) Cleanup() (err error) {
 	log.Printf("Cleaning up %s", mixerEnvoyEnv.EnvID)
-	os.RemoveAll(mixerEnvoyEnv.TmpDir)
-	os.RemoveAll(mixerEnvoyEnv.configDir)
+	_ = os.RemoveAll(mixerEnvoyEnv.TmpDir)
+	_ = os.RemoveAll(mixerEnvoyEnv.configDir)
 	return
 }

--- a/tests/integration/example/tests/sample1/sample1_test.go
+++ b/tests/integration/example/tests/sample1/sample1_test.go
@@ -63,7 +63,7 @@ func TestSample1(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
+	_, _ = buf.ReadFrom(resp.Body)
 	bodyReceived := buf.String()
 	if bodyReceived != testID {
 		t.Fatalf("Echo server, [%s] sent, [%s] received", testID, bodyReceived)

--- a/tests/integration/framework/testEnvManager.go
+++ b/tests/integration/framework/testEnvManager.go
@@ -90,7 +90,7 @@ func (envManager *TestEnvManager) TearDown() {
 			log.Printf("Failed to cleanup %s: %s", comp.GetName(), err)
 		}
 	}
-	envManager.TestEnv.Cleanup()
+	_ = envManager.TestEnv.Cleanup()
 }
 
 // WaitUntilReady checks and waits until the whole environment is ready

--- a/tests/util/processUtils.go
+++ b/tests/util/processUtils.go
@@ -36,7 +36,7 @@ func IsProcessRunning(p *os.Process) (bool, error) {
 
 // IsProcessRunningInt check if a process of the given pid(int) is running
 func IsProcessRunningInt(pid int) (bool, error) {
-	process, err := os.FindProcess(int(pid))
+	process, err := os.FindProcess(pid)
 	if err != nil {
 		return false, fmt.Errorf("failed to find process %d: %v (check os.FindProcess)", pid, err)
 	}


### PR DESCRIPTION
- Stop setting the --fast option since that disables a bunch of linters

- Enable the --tests option so linters work on tests

- Stop using a docker image so that gometalinter runs a lot faster and runs
to completion on a Mac.

- Fix a whole bunch of warnings throughout the source tree.

There remain a few issues reported by the 'gas' and 'megacheck' linters which I've
explicitly excluded. I'll file separate issues to get those addressed.