### PR TITLE
Fix rate limit fortio timeout on mixer_test side

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -501,11 +501,8 @@ func TestRateLimit(t *testing.T) {
 			Duration:   1 * time.Minute,
 			NumThreads: 8,
 		},
-		HTTPOptions: fhttp.HTTPOptions{
-			URL: url,
-		},
 	}
-
+	opts.Init(url)
 	// productpage should still return 200s when ratings is rate-limited.
 	res, err := fhttp.RunHTTPTest(&opts)
 	if err != nil {


### PR DESCRIPTION
Default timeout wasn’t initialized

(There is also another more complete fix in 
https://github.com/istio/fortio/pull/84
)