### PR TITLE
Make az look up less chatty and give up after a specified retry

### DIFF
--- a/pilot/proxy/envoy/watcher.go
+++ b/pilot/proxy/envoy/watcher.go
@@ -122,14 +122,14 @@ func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration, retries i
 		time.Sleep(delay)
 		resp, err := http.Get(fmt.Sprintf("http://%v/v1/az/%v/%v", w.config.DiscoveryAddress, w.config.ServiceCluster, w.role.ServiceNode()))
 		if err != nil {
-			log.Debugf("Unable to retrieve availability zone from pilot: %v", err)
+			log.Infof("Unable to retrieve availability zone from pilot: %v", err)
 		} else {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				log.Debugf("Unable to read availability zone response from pilot: %v", err)
+				log.Infof("Unable to read availability zone response from pilot: %v", err)
 			}
 			if resp.StatusCode != http.StatusOK {
-				log.Debugf("Received %v status from pilot when retrieving availability zone: %v", resp.StatusCode, string(body))
+				log.Infof("Received %v status from pilot when retrieving availability zone: %v", resp.StatusCode, string(body))
 			} else {
 				w.config.AvailabilityZone = string(body)
 				log.Infof("Proxy availability zone: %v", w.config.AvailabilityZone)
@@ -139,6 +139,7 @@ func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration, retries i
 		}
 		attempts++
 	}
+	log.Info("Availability zone not set, proxy will default to not using zone aware routing. To manually override use the --availabilityZone flag.")
 }
 
 type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent,

--- a/pilot/proxy/envoy/watcher.go
+++ b/pilot/proxy/envoy/watcher.go
@@ -75,8 +75,12 @@ func NewWatcher(config meshconfig.ProxyConfig, agent proxy.Agent, role model.Nod
 	}
 }
 
-// defaultMinDelay is the minimum amount of time between delivery of two successive events via updateFunc.
-const defaultMinDelay = 10 * time.Second
+const (
+	// defaultMinDelay is the minimum amount of time between delivery of two successive events via updateFunc.
+	defaultMinDelay = 10 * time.Second
+	azRetryInterval = time.Second * 30
+	azRetryAttempts = 10
+)
 
 func (w *watcher) Run(ctx context.Context) {
 	// agent consumes notifications from the controller
@@ -92,7 +96,7 @@ func (w *watcher) Run(ctx context.Context) {
 	}
 
 	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.Reload)
-	go w.retrieveAZ(ctx, time.Duration(time.Second*10), 10)
+	go w.retrieveAZ(ctx, azRetryInterval, azRetryAttempts)
 
 	<-ctx.Done()
 }

--- a/pilot/proxy/envoy/watcher_test.go
+++ b/pilot/proxy/envoy/watcher_test.go
@@ -99,6 +99,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 	tests := []struct {
 		name        string
 		az          string
+		retries     int
 		wantReload  bool
 		wantAZ      string
 		pilotStates []pilotStubState
@@ -107,6 +108,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 			name:       "retrieves an AZ and calls for a reload",
 			wantReload: true,
 			wantAZ:     "az1",
+			retries:    5,
 			pilotStates: []pilotStubState{
 				{StatusCode: 200, Response: "az1"},
 			},
@@ -115,6 +117,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 			name:       "retries if it receives an error",
 			wantReload: true,
 			wantAZ:     "az1",
+			retries:    5,
 			pilotStates: []pilotStubState{
 				{StatusCode: 301, Response: ""},
 				{StatusCode: 200, Response: "az1"},
@@ -124,6 +127,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 			name:       "retries if it receives non 200 status from pilot",
 			wantReload: true,
 			wantAZ:     "az1",
+			retries:    5,
 			pilotStates: []pilotStubState{
 				{StatusCode: 500, Response: ""},
 				{StatusCode: 200, Response: "az1"},
@@ -133,6 +137,18 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 			name:       "do nothing if az is set",
 			az:         "az1",
 			wantAZ:     "az1",
+			retries:    5,
+			wantReload: false,
+		},
+		{
+			name:    "give up after retry count is reached",
+			retries: 2,
+			pilotStates: []pilotStubState{
+				{StatusCode: 500, Response: ""},
+				{StatusCode: 500, Response: ""},
+				{StatusCode: 500, Response: ""},
+				{StatusCode: 200, Response: "az1"},
+			},
 			wantReload: false,
 		},
 	}
@@ -160,7 +176,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 			w := NewWatcher(config, agent, node, nil, nil)
 			ctx, cancel := context.WithCancel(context.Background())
 
-			go w.(*watcher).retrieveAZ(ctx, 0)
+			go w.(*watcher).retrieveAZ(ctx, 0, tt.retries)
 
 			select {
 			case <-called:

--- a/pilot/proxy/envoy/watcher_test.go
+++ b/pilot/proxy/envoy/watcher_test.go
@@ -34,6 +34,7 @@ import (
 
 	_ "github.com/golang/glog"
 	"github.com/howeyc/fsnotify"
+
 	"istio.io/istio/pilot/model"
 )
 

--- a/pilot/test/integration/routing.go
+++ b/pilot/test/integration/routing.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/pkg/log"
 )
 


### PR DESCRIPTION
What this PR does / why we need it: Is causing confusion when debugging tests.

Release note:
```
Make az look up logs less ambiguous and give up on look up after a specified number of retries.
```