### PR TITLE
BUILD FIX Restore previous version of init.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ pre-commit: fmt lint
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
 # Will also check vendor, based on Gopkg.lock
-init:
-	@bin/init.sh
+init: ${DEP}
+	@(DEP=${DEP} bin/init.sh)
 
 # init.sh downloads envoy
 ${ISTIO_BIN}/envoy: init

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -21,15 +21,7 @@ if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
-DEP=$(which dep || echo "${GO_TOP}/bin/dep" )
-echo "using dep: ${DEP}"
-
-if [ ${DEP} == "${GO_TOP}/bin/dep" ]; then
-    unset GOOS && go get -u github.com/golang/dep/cmd/dep
-fi
-
-
-# Download dependencies
+# Download dependencies if needed
 if [ ! -d vendor/github.com ]; then
     ${DEP} ensure -vendor-only
 	cp Gopkg.lock vendor/Gopkg.lock

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -24,7 +24,7 @@ if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
-DEP=${DEP:-$(shell which dep || echo "${ISTIO_BIN}/dep" )}
+DEP=${DEP:-$(which dep || echo "${ISTIO_BIN}/dep" )}
 
 # Download dependencies if needed
 if [ ! -d vendor/github.com ]; then

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -24,13 +24,15 @@ if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
+DEP=${DEP:-$(shell which dep || echo "${ISTIO_BIN}/dep" )}
+
 # Download dependencies if needed
 if [ ! -d vendor/github.com ]; then
     ${DEP} ensure -vendor-only
-	cp Gopkg.lock vendor/Gopkg.lock
+	  cp Gopkg.lock vendor/Gopkg.lock
 elif [ ! -f vendor/Gopkg.lock ]; then
     ${DEP} ensure -vendor-only
-	cp Gopkg.lock vendor/Gopkg.lock
+	  cp Gopkg.lock vendor/Gopkg.lock
 else
     diff Gopkg.lock vendor/Gopkg.lock > /dev/null || \
             ( ${DEP} ensure -vendor-only ; \

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -29,16 +29,16 @@ DEP=${DEP:-$(which dep || echo "${ISTIO_BIN}/dep" )}
 # Just in case init.sh is called directly, not from Makefile which has a dependency to dep
 if [ ! -f ${DEP} ]; then
     DEP=${ISTIO_BIN}/dep
-  	unset GOOS && go get -u github.com/golang/dep/cmd/dep
+    unset GOOS && go get -u github.com/golang/dep/cmd/dep
 fi
 
 # Download dependencies if needed
 if [ ! -d vendor/github.com ]; then
     ${DEP} ensure -vendor-only
-	  cp Gopkg.lock vendor/Gopkg.lock
+    cp Gopkg.lock vendor/Gopkg.lock
 elif [ ! -f vendor/Gopkg.lock ]; then
     ${DEP} ensure -vendor-only
-	  cp Gopkg.lock vendor/Gopkg.lock
+    cp Gopkg.lock vendor/Gopkg.lock
 else
     diff Gopkg.lock vendor/Gopkg.lock > /dev/null || \
             ( ${DEP} ensure -vendor-only ; \
@@ -58,7 +58,7 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     # New version of envoy downloaded. Save it to cache, and clean any old version.
     curl -Lo - https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
     cp usr/local/bin/envoy $ISTIO_GO/vendor/envoy-$PROXYVERSION
-    rm -f ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy
+    rm -f ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy/envoy
     popd
 fi
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -58,7 +58,7 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     # New version of envoy downloaded. Save it to cache, and clean any old version.
     curl -Lo - https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
     cp usr/local/bin/envoy $ISTIO_GO/vendor/envoy-$PROXYVERSION
-    rm ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy
+    rm -f ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy
     popd
 fi
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -55,9 +55,14 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     curl -Lo - https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
     cp usr/local/bin/envoy $ISTIO_GO/vendor/envoy-$PROXYVERSION
     popd
+fi
 
+if [ ! -f $GO_TOP/bin/envoy ] ; then
     mkdir -p $GO_TOP/bin
     cp $ISTIO_GO/vendor/envoy-$PROXYVERSION $GO_TOP/bin/envoy
+fi
 
+if [ ! -f ${ROOT}/pilot/proxy/envoy/envoy ] ; then
     ln -sf $GO_TOP/bin/envoy ${ROOT}/pilot/proxy/envoy
 fi
+

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -26,6 +26,12 @@ fi
 
 DEP=${DEP:-$(which dep || echo "${ISTIO_BIN}/dep" )}
 
+# Just in case init.sh is called directly, not from Makefile which has a dependency to dep
+if [ ! -f ${DEP} ]; then
+    DEP=${ISTIO_BIN}/dep
+  	unset GOOS && go get -u github.com/golang/dep/cmd/dep
+fi
+
 # Download dependencies if needed
 if [ ! -d vendor/github.com ]; then
     ${DEP} ensure -vendor-only

--- a/tools/deb/istio-ca.sh
+++ b/tools/deb/istio-ca.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# Script to configure and start the Istio sidecar.
+
+set -e
+
+# Load optional config variables
+ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
+if [[ -r ${ISTIO_SIDECAR_CONFIG} ]]; then
+  . $ISTIO_SIDECAR_CONFIG
+fi
+
+# Set defaults
+ISTIO_BIN_BASE=${ISTIO_BIN_BASE:-/usr/local/bin}
+ISTIO_LOG_DIR=${ISTIO_LOG_DIR:-/var/log/istio}
+ISTIO_CFG=${ISTIO_CFG:-/var/lib/istio}
+
+# Default kube config for istio components
+# TODO: use different configs, with different service accounts, for ca/pilot/mixer
+KUBECONFIG=${ISTIO_CFG}/kube.config
+
+# TODO: use separate user for ca
+if [ $(id -u) = "0" ] ; then
+    exec su -s /bin/bash -c "${ISTIO_BIN_BASE}/istio_ca --self-signed-ca --kube-config ${KUBECONFIG} 2> ${ISTIO_LOG_DIR}/istio_ca.err.log > ${ISTIO_LOG_DIR}/istio_ca.log" istio-proxy
+else
+    ${ISTIO_BIN_BASE}/istio_ca --self-signed-ca --kube-config ${KUBECONFIG}
+fi


### PR DESCRIPTION
Envoy is downloaded into the vendor directory, with the full version included - vendor is cached between build steps and between builds, so we avoid downloading envoy on each job. 

Init creates a copy in bin (will probably move in future), and also adds it to the pilot directory until the 
pilot tests that depend on that location are updated. 