### PR TITLE
disable CGO and eliminate release build's use of upload-istioctl

### DIFF
--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -36,11 +36,10 @@ BUILDINFO=${BUILDINFO:-""}
 STATIC=${STATIC:-1}
 LDFLAGS="-extldflags -static"
 GOBUILDFLAGS=${GOBUILDFLAGS:-""}
+export CGO_ENABLED=0
 
 if [[ "${STATIC}" !=  "1" ]];then
     LDFLAGS=""
-else
-    export CGO_ENABLED=0
 fi
 
 # gather buildinfo if not already provided

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -44,9 +44,11 @@ fi
 DEP=${DEP:-$(which dep || echo "${ISTIO_BIN}/dep" )}
 
 # Just in case init.sh is called directly, not from Makefile which has a dependency to dep
+# If CGO_ENABLED=0 then go get tries to install in system directories.
+# If -pkgdir <dir> is also used then various additional .a files are present.
 if [ ! -f ${DEP} ]; then
     DEP=${ISTIO_BIN}/dep
-    unset GOOS && go get -u github.com/golang/dep/cmd/dep
+    unset GOOS && CGO_ENABLED=1 go get -u github.com/golang/dep/cmd/dep
 fi
 
 # Download dependencies if needed

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -88,11 +88,12 @@ fi
 
 pushd pilot
 mkdir -p "${OUTPUT_PATH}/istioctl"
-# make istioctl just outputs to pilot/cmd/istioctl
-ISTIO_DOCKER_HUB=${REL_DOCKER_HUB}  ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl"
+ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} make istioctl-all
+cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl
 if [[ -n "${TEST_DOCKER_HUB}" ]]; then
-   mkdir -p "${OUTPUT_PATH}/istioctl-stage"
-   ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl-stage"
+  mkdir -p "${OUTPUT_PATH}/istioctl-stage"
+  ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} make istioctl-all
+  cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl-stage
 fi
 popd
 

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -86,7 +86,6 @@ if [ "${BUILD_DEBIAN}" == "true" ]; then
   cp ${GOPATH}/out/istio-sidecar.deb ${OUTPUT_PATH}/deb
 fi
 
-pushd pilot
 mkdir -p "${OUTPUT_PATH}/istioctl"
 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} make istioctl-all
 cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl
@@ -95,7 +94,6 @@ if [[ -n "${TEST_DOCKER_HUB}" ]]; then
   ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} make istioctl-all
   cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl-stage
 fi
-popd
 
 if [ "${BUILD_DOCKER}" == "true" ]; then
   VERBOSE=1 VERSION=$ISTIO_VERSION ISTIO_DOCKER_HUB=$REL_DOCKER_HUB TAG=$ISTIO_VERSION make docker.save

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -87,11 +87,11 @@ if [ "${BUILD_DEBIAN}" == "true" ]; then
 fi
 
 mkdir -p "${OUTPUT_PATH}/istioctl"
-ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} make istioctl-all
+VERBOSE=1 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make istioctl-all
 cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl
 if [[ -n "${TEST_DOCKER_HUB}" ]]; then
   mkdir -p "${OUTPUT_PATH}/istioctl-stage"
-  ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} make istioctl-all
+  VERBOSE=1 ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make istioctl-all
   cp ${GOPATH}/out/istioctl-* ${OUTPUT_PATH}/istioctl-stage
 fi
 


### PR DESCRIPTION
The main point of this change was to eliminate the release build's use of the upload-istioctl script so that the build is now mostly just invoking targets against make (TBD if I'll later add an uber target so the build just needs to invoke make once ["make release-build"]).

I basically added a "istioctl-all" that will build istioctl-linux, istioctl-osx, istioctl-win.exe.

I tried to preserve the upload-istioctl's attempt to make non-static binaries, though I honestly don't know the motivation for this (assuming I'm interpreting "static" properly, which I take to mean a monolithic executable that doesn't attempt to pull in other libraries from the system).  In any case, "ldd" seems to think that go always creates a static binary on Linux (I didn't check Mac or Windows).

On my Linux dev system the cross-compile to Windows ran okay but Mac ran into problems (the docker image used for release builds doesn't hit this issue) :

\# net
/usr/lib/google-golang/src/net/cgo_bsd.go:15:72: could not determine kind of name for C.AI_MASK
\# os/user
/usr/lib/google-golang/src/os/user/getgrouplist_darwin.go: In function ‘mygetgrouplist’:
/usr/lib/google-golang/src/os/user/getgrouplist_darwin.go:14:11: warning: implicit declaration of function ‘getgrouplist’ [-Wimplicit-function-declaration]
  int rv = getgrouplist(user, (int) group, buf, ngroups);
           ^~~~~~~~~~~~

The problem goes away if I set CGO_ENABLED=0.  While investigating I noticed that the Makefile is missing a D suffix in "export CGO_ENABLE=0".  However, once I fixed this init.sh starting failing during "go get dep" from trying to install to system directories.  If I tried to workaround this using "-pkgdir <dir>" then a lot more files (mostly in the form of .a files) were getting added to the specified directory.  I first tried to workaround this by adding "CGO_ENABLED=1" to the "go get" for deps, but in total there's about 8 "go get" instance that I saw across the istio repo so rather than mess with these I just opted to delete the CGO_ENABLED line from Makefile and rely on gobuild.sh to set "CGO_ENABLED=0".  So far I've opted to leave the "CGO_ENABLED=1" on the "go get" for deps with the expectation this will help insulate the build from other parameters that might be set in the outside environment.

I simplified a few cases in the makefile from ${ISTIO_BIN}/$(@F) to just $@.  They're basically the same--the former was unnecessarily stripping off the directory path using $(@F) and appending the same directory back on again. 