### PR TITLE
Fix nil-check issue that recent linter fixes has exposed.

### DIFF
--- a/mixer/pkg/perf/server.go
+++ b/mixer/pkg/perf/server.go
@@ -110,7 +110,7 @@ func initializeArgs(settings *Settings, setup *Setup) (*testEnv.Args, error) {
 }
 
 func (s *server) shutdown() {
-	if s != nil {
+	if s.s != nil {
 		if err := s.s.Close(); err != nil {
 			log.Error(err.Error())
 			_ = log.Sync()


### PR DESCRIPTION
The original code was performing a wrong check and set nil. The linter fixes changed the set-nil part, but not the nil-check part.