### PR TITLE
Remove the log line that is causing excessive test output 

### DIFF
--- a/mixer/pkg/il/interpreter/interpreter_test.go
+++ b/mixer/pkg/il/interpreter/interpreter_test.go
@@ -2405,7 +2405,6 @@ func runTestProgram(t *testing.T, p *il.Program, test test) {
 		if err != nil {
 			t.Fatal(s.Error())
 		}
-		t.Log(s)
 	}
 	if s.Error() != nil {
 		if len(test.err) == 0 {


### PR DESCRIPTION
After the introduction of -v flag on go tests in CircleCI, the log output is excessive.
