### PR TITLE
Avoid mutating test input during attribute bag creation.

### DIFF
--- a/mixer/pkg/il/compiled/expressionbuilder_test.go
+++ b/mixer/pkg/il/compiled/expressionbuilder_test.go
@@ -57,6 +57,7 @@ func TestCompiledExpressions(t *testing.T) {
 
 			if exprType != test.Type {
 				tt.Fatalf("expression type mismatch: '%v' != '%v'", exprType, test.Type)
+				return
 			}
 
 			bag := ilt.NewFakeBag(test.I)

--- a/mixer/pkg/il/testing/fakebag.go
+++ b/mixer/pkg/il/testing/fakebag.go
@@ -25,14 +25,17 @@ import (
 
 // NewFakeBag creates a FakeBag and converts map[string]string to StringMap
 func NewFakeBag(attrs map[string]interface{}) *FakeBag {
-	bag := &FakeBag{}
+	bag := &FakeBag{
+		Attrs: make(map[string]interface{}, len(attrs)),
+	}
 	for k, v := range attrs {
 		if sm, ok := v.(map[string]string); ok {
-			attrs[k] = NewStringMap(k, sm, bag)
+			bag.Attrs[k] = NewStringMap(k, sm, bag)
+		} else {
+			bag.Attrs[k] = v
 		}
 	}
 
-	bag.Attrs = attrs
 	bag.referenced = make(map[string]bool)
 	return bag
 }


### PR DESCRIPTION
The recently introduced code in the fake bag for attribute testing mutates the input. This causes issues with successive test runs when -count is specified. This fix makes a full copy of the input.