### PR TITLE
use memstore for server tests

### DIFF
--- a/mixer/adapter/opa/opa_integration_test.go
+++ b/mixer/adapter/opa/opa_integration_test.go
@@ -23,6 +23,7 @@ import (
 	api_mixer_v1 "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/mixer/pkg/server"
 	"istio.io/istio/mixer/template"
 )
@@ -184,11 +185,13 @@ func TestServer(t *testing.T) {
 
 	args.APIPort = 0
 	args.MonitoringPort = 0
-	args.GlobalConfig = globalCfg
-	args.ServiceConfig = serviceCfg
+	args.ConfigStoreURL = "memstore://" + t.Name()
 	args.Templates = template.SupportedTmplInfo
 	args.Adapters = []adapter.InfoFn{
 		GetInfo,
+	}
+	if err := store.SetupMemstore(args.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
+		t.Fatal(err)
 	}
 
 	mixerServer, err := server.New(args)

--- a/mixer/pkg/config/store/memstore.go
+++ b/mixer/pkg/config/store/memstore.go
@@ -17,7 +17,10 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
+
+	multierror "github.com/hashicorp/go-multierror"
 )
 
 const memstoreScheme = "memstore"
@@ -37,10 +40,13 @@ type memstore struct {
 	watchCh    chan BackendEvent
 }
 
-func newMemstore(u fmt.Stringer) Backend {
-	m := &memstore{data: map[Key]*BackEndResource{}}
+func createOrGetMemstore(u string) *memstore {
 	memstoreMapMutex.Lock()
-	memstoreMap[u.String()] = m
+	m, ok := memstoreMap[u]
+	if !ok {
+		m = &memstore{data: map[Key]*BackEndResource{}}
+		memstoreMap[u] = m
+	}
 	memstoreMapMutex.Unlock()
 	return m
 }
@@ -123,14 +129,36 @@ func (m *memstore) Delete(key Key) {
 // MemstoreWriter is the interface to make changes on the memstore backend. This
 // will be used by tests to set up the on-memory data in the store.
 type MemstoreWriter interface {
+	// Put adds a resource into the memstore.
 	Put(key Key, resource *BackEndResource)
+
+	// Delete removes a resource from the memstore.
 	Delete(key Key)
 }
 
-// GetMemstoreWriter returns the MemstoreWriter used for the config store URL, or nil
-// if the URL is not used.
+// GetMemstoreWriter returns the MemstoreWriter used for the config store URL. It creates
+// the memstore if the related store does not exist yet.
 func GetMemstoreWriter(u string) MemstoreWriter {
-	memstoreMapMutex.RLock()
-	defer memstoreMapMutex.RUnlock()
-	return memstoreMap[u]
+	return createOrGetMemstore(u)
+}
+
+// SetupMemstore puts the YAML-formatted config data into the memstore specified by the URL
+// u. If the memstore does not exist yet, it creates a new one.
+func SetupMemstore(u string, data ...string) error {
+	mw := GetMemstoreWriter(u)
+	var errs error
+	for i, d := range data {
+		for j, chunk := range strings.Split(d, "\n---\n") {
+			r, err := parseChunk([]byte(chunk))
+			if err != nil {
+				errs = multierror.Append(errs, fmt.Errorf("failed to parse at %d/%d: %v", i, j, err))
+				continue
+			}
+			if r == nil {
+				continue
+			}
+			mw.Put(r.Key(), &BackEndResource{Metadata: r.Metadata, Spec: r.Spec})
+		}
+	}
+	return errs
 }

--- a/mixer/pkg/config/store/memstore_test.go
+++ b/mixer/pkg/config/store/memstore_test.go
@@ -1,0 +1,121 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+)
+
+func TestGetMemstoreWriter(t *testing.T) {
+	u := "memstore://" + t.Name()
+	mw := GetMemstoreWriter(u)
+	if mw == nil {
+		t.Fatal("Failed to get memstore writer")
+	}
+
+	if mw2 := GetMemstoreWriter(u); mw != mw2 {
+		t.Errorf("Two invocation of GetMemstoreWriter needs to return the same object: %s", u)
+	}
+}
+
+const cfg1 = `
+kind: rule
+apiVersion: testing.istio.io/v1alpha1
+metadata:
+  name: foo
+  namespace: ns1
+spec:
+---
+kind: rule
+apiVersion: testing.istio.io/v1alpha1
+metadata:
+  name: bar
+  namespace: ns1
+spec:
+---
+`
+
+const cfg2 = `
+kind: rule
+apiVersion: testing.istio.io/v1alpha1
+metadata:
+  name: bazz
+  namespace: ns2
+spec:
+---
+`
+
+const errCfg = `
+kind: 1
+`
+
+func TestSetupMemstore(t *testing.T) {
+	for _, c := range []struct {
+		title   string
+		configs []string
+		ok      bool
+		count   int
+	}{
+		{
+			"merge",
+			[]string{cfg1, cfg2},
+			true,
+			3,
+		},
+		{
+			"error",
+			[]string{errCfg},
+			false,
+			0,
+		},
+		{
+			"merge-with-error",
+			[]string{cfg1, errCfg, cfg2},
+			false,
+			3,
+		},
+		{
+			"duplicate",
+			[]string{cfg1, cfg1},
+			true,
+			2,
+		},
+	} {
+		t.Run(c.title, func(t *testing.T) {
+			u := "memstore://" + t.Name()
+			err := SetupMemstore(u, c.configs...)
+			gotOK := err == nil
+			if c.ok != gotOK {
+				t.Fatalf("Failed the setup: got %v(error %v), want %v", gotOK, err, c.ok)
+			}
+			s, err := NewRegistry().NewStore(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if err = s.Init(ctx, map[string]proto.Message{"rule": &types.Empty{}}); err != nil {
+				t.Fatalf("Failed to init: %v", err)
+			}
+			if d := s.List(); len(d) != c.count {
+				t.Errorf("Got %d (%+v), Want %d", len(d), d, c.count)
+			}
+		})
+	}
+}

--- a/mixer/pkg/config/store/store.go
+++ b/mixer/pkg/config/store/store.go
@@ -251,7 +251,7 @@ func (r *Registry) NewStore(configURL string) (Store, error) {
 	case FSUrl:
 		b = newFsStore(u.Path)
 	case memstoreScheme:
-		b = newMemstore(u)
+		b = createOrGetMemstore(u.String())
 	default:
 		if builder, ok := r.builders[u.Scheme]; ok {
 			b, err = builder(u)

--- a/mixer/pkg/config/store/store_test.go
+++ b/mixer/pkg/config/store/store_test.go
@@ -50,7 +50,7 @@ func (t *testStore) Watch(ctx context.Context) (<-chan BackendEvent, error) {
 func registerTestStore(builders map[string]Builder) {
 	builders["test"] = func(u *url.URL) (Backend, error) {
 		return &testStore{
-			memstore: newMemstore(u).(*memstore),
+			memstore: createOrGetMemstore(u.String()),
 		}, nil
 	}
 }

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -65,12 +65,6 @@ type Args struct {
 	// For kubernetes services it is svc.cluster.local
 	ConfigIdentityAttributeDomain string
 
-	// Supplies a string to use for service configuration, overrides ConfigStoreURL
-	ServiceConfig string
-
-	// Supplies a string to use for global configuration, overrides ConfigStoreURL
-	GlobalConfig string
-
 	// The logging options to use
 	LoggingOptions *log.Options
 

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -112,8 +112,10 @@ func TestBasic(t *testing.T) {
 	a := NewArgs()
 	a.APIPort = 0
 	a.MonitoringPort = 0
-	a.GlobalConfig = globalCfg
-	a.ServiceConfig = serviceCfg
+	a.ConfigStoreURL = "memstore://" + t.Name()
+	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
+		t.Fatal(err)
+	}
 
 	s, err := New(a)
 	if err != nil {
@@ -135,8 +137,10 @@ func TestClient(t *testing.T) {
 	a := NewArgs()
 	a.APIPort = 0
 	a.MonitoringPort = 0
-	a.GlobalConfig = globalCfg
-	a.ServiceConfig = serviceCfg
+	a.ConfigStoreURL = "memstore://" + t.Name()
+	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
+		t.Fatal(err)
+	}
 
 	s, err := New(a)
 	if err != nil {
@@ -166,8 +170,10 @@ func TestClient(t *testing.T) {
 func TestErrors(t *testing.T) {
 	a := NewArgs()
 	a.APIWorkerPoolSize = -1
-	a.GlobalConfig = globalCfg
-	a.ServiceConfig = serviceCfg
+	a.ConfigStoreURL = "memstore://" + t.Name()
+	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
+		t.Fatal(err)
+	}
 
 	s, err := New(a)
 	if s != nil || err == nil {
@@ -177,8 +183,7 @@ func TestErrors(t *testing.T) {
 	a = NewArgs()
 	a.APIPort = 0
 	a.MonitoringPort = 0
-	a.GlobalConfig = globalCfg
-	a.ServiceConfig = serviceCfg
+	a.ConfigStoreURL = "memstore://" + t.Name()
 	a.TracingOptions.LogTraceSpans = true
 
 	for i := 0; i < 20; i++ {

--- a/mixer/test/e2e/e2e_report_test.go
+++ b/mixer/test/e2e/e2e_report_test.go
@@ -23,6 +23,7 @@ import (
 
 	istio_mixer_v1 "istio.io/api/mixer/v1"
 	pb "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/istio/mixer/pkg/config/store"
 	testEnv "istio.io/istio/mixer/pkg/server"
 	spyAdapter "istio.io/istio/mixer/test/spyAdapter"
 	e2eTmpl "istio.io/istio/mixer/test/spyAdapter/template"
@@ -134,8 +135,10 @@ func TestReport(t *testing.T) {
 			args.MonitoringPort = 0
 			args.Templates = e2eTmpl.SupportedTmplInfo
 			args.Adapters = adapterInfos
-			args.GlobalConfig = reportGlobalCfg
-			args.ServiceConfig = tt.cfg
+			args.ConfigStoreURL = "memstore://" + t.Name()
+			if err := store.SetupMemstore(args.ConfigStoreURL, reportGlobalCfg, tt.cfg); err != nil {
+				t.Fatal(err)
+			}
 
 			env, err := testEnv.New(args)
 			if err != nil {


### PR DESCRIPTION
Creating temporary files for on-memory test data looks redundant.
We already have memstore, so just use that.

This means that the GlobalConfig / ServiceConfig server args
(which inherited from the older style of config) are unnecessary
anymore. Removing them.