### PR TITLE
remove redundant MYSQL_DATABASE environment variable

### DIFF
--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -14,6 +14,5 @@
 
 FROM mysql:8
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
-ENV MYSQL_DATABASE "test"
 
 COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d/mysqldb-init.sql

--- a/samples/bookinfo/src/mysql/mysqldb-init.sql
+++ b/samples/bookinfo/src/mysql/mysqldb-init.sql
@@ -2,6 +2,7 @@
  * Initialize a mysql db with a 'test' db and be able test productpage with it.
  * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
  */
+CREATE DATABASE test;
 USE test;
 
 CREATE TABLE `ratings` (

--- a/samples/bookinfo/src/mysql/mysqldb-init.sql
+++ b/samples/bookinfo/src/mysql/mysqldb-init.sql
@@ -2,7 +2,6 @@
  * Initialize a mysql db with a 'test' db and be able test productpage with it.
  * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
  */
-CREATE DATABASE test;
 USE test;
 
 CREATE TABLE `ratings` (


### PR DESCRIPTION
The test database is created by the mysqldb-init.sql script.
When MYSQL_DATABASE is set in the Dockerfile, the test database is created on image startup.

From https://hub.docker.com/_/mysql/:
_MYSQL_DATABASE
This variable is optional and allows you to specify the name of a database to be created
on image startup._

When the script tries create the database, the following error occurs:
_ERROR 1007 (HY000) at line 5: Can't create database 'test'; database exists_

To prevent the error, either the MYSQL_DATABASE variable must be removed from the Dockerfile, or CREATE DATABASE instruction must be removed from the script. Since the script is used in non-docker environments as well, it cannot be changed, so the MYSQL_DATABASE variable must be removed.

The script is used for a raw VM example - https://github.com/istio/istio/blob/master/samples/rawvm/README.md .