### PR TITLE
Integration test for cloud foundry 

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -471,8 +471,11 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 					Ticker: cloudfoundry.NewTicker(cfConfig.Copilot.PollInterval),
 					Client: client,
 				},
-				ServiceDiscovery: &cloudfoundry.ServiceDiscovery{Client: client},
-				ServiceAccounts:  cloudfoundry.NewServiceAccounts(),
+				ServiceDiscovery: &cloudfoundry.ServiceDiscovery{
+					Client:  client,
+					AppPort: cfConfig.Envoy.Port,
+				},
+				ServiceAccounts: cloudfoundry.NewServiceAccounts(),
 			})
 
 		default:

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -472,8 +472,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 					Client: client,
 				},
 				ServiceDiscovery: &cloudfoundry.ServiceDiscovery{
-					Client:  client,
-					AppPort: cfConfig.Envoy.Port,
+					Client:      client,
+					ServicePort: cfConfig.ServicePort,
 				},
 				ServiceAccounts: cloudfoundry.NewServiceAccounts(),
 			})

--- a/pilot/pkg/proxy/envoy/config.go
+++ b/pilot/pkg/proxy/envoy/config.go
@@ -76,9 +76,9 @@ func (conf *Config) Write(w io.Writer) error {
 	return err
 }
 
-// buildConfig creates a proxy config with discovery services and admin port
+// BuildConfig creates a proxy config with discovery services and admin port
 // it creates config for Ingress, Egress and Sidecar proxies
-func buildConfig(config meshconfig.ProxyConfig, pilotSAN []string) *Config {
+func BuildConfig(config meshconfig.ProxyConfig, pilotSAN []string) *Config {
 	listeners := Listeners{}
 
 	clusterRDS := buildCluster(config.DiscoveryAddress, RDSName, config.ConnectTimeout)

--- a/pilot/pkg/proxy/envoy/config_test.go
+++ b/pilot/pkg/proxy/envoy/config_test.go
@@ -484,7 +484,7 @@ func TestProxyConfig(t *testing.T) {
 
 	proxyConfig := makeProxyConfig()
 	for _, c := range cases {
-		config := buildConfig(proxyConfig, nil)
+		config := BuildConfig(proxyConfig, nil)
 		if config == nil {
 			t.Fatal("Failed to generate config")
 		}
@@ -509,7 +509,7 @@ func TestProxyConfigControlPlaneAuth(t *testing.T) {
 
 	proxyConfig := makeProxyConfigControlPlaneAuth()
 	for _, c := range cases {
-		config := buildConfig(proxyConfig, pilotSAN)
+		config := BuildConfig(proxyConfig, pilotSAN)
 		if config == nil {
 			t.Fatal("Failed to generate config")
 		}

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -101,7 +101,7 @@ func (w *watcher) Run(ctx context.Context) {
 }
 
 func (w *watcher) Reload() {
-	config := buildConfig(w.config, w.pilotSAN)
+	config := BuildConfig(w.config, w.pilotSAN)
 
 	// compute hash of dependent certificates
 	h := sha256.New()

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -363,7 +363,7 @@ func TestEnvoyRun(t *testing.T) {
 
 	config.ConfigPath = "tmp"
 
-	envoyConfig := buildConfig(config, nil)
+	envoyConfig := BuildConfig(config, nil)
 	envoyProxy := envoy{config: config, node: "my-node", extraArgs: []string{"--mode", "validate"}}
 	abortCh := make(chan error, 1)
 

--- a/pilot/pkg/serviceregistry/cloudfoundry/config.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/config.go
@@ -35,9 +35,15 @@ type CopilotConfig struct {
 	PollInterval     time.Duration `yaml:"poll_interval" validate:"nonzero"`
 }
 
+// EnvoyConfig describes how the Cloud Foundry platform adapter communicates with Envoy
+type EnvoyConfig struct {
+	Port int `yaml:"port" validate:"nonzero"`
+}
+
 // Config for the Cloud Foundry platform adapter
 type Config struct {
 	Copilot CopilotConfig `yaml:"copilot"`
+	Envoy   EnvoyConfig   `yaml:"envoy"`
 }
 
 // LoadConfig reads configuration data from a YAML file

--- a/pilot/pkg/serviceregistry/cloudfoundry/config.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/config.go
@@ -35,15 +35,13 @@ type CopilotConfig struct {
 	PollInterval     time.Duration `yaml:"poll_interval" validate:"nonzero"`
 }
 
-// EnvoyConfig describes how the Cloud Foundry platform adapter communicates with Envoy
-type EnvoyConfig struct {
-	Port int `yaml:"port" validate:"nonzero"`
-}
-
 // Config for the Cloud Foundry platform adapter
 type Config struct {
 	Copilot CopilotConfig `yaml:"copilot"`
-	Envoy   EnvoyConfig   `yaml:"envoy"`
+
+	// Cloud Foundry currently only supports applications exposing a single HTTP or TCP port
+	// It is typically set to 8080.
+	ServicePort int `yaml:"service_port" validate:"nonzero"`
 }
 
 // LoadConfig reads configuration data from a YAML file

--- a/pilot/pkg/serviceregistry/cloudfoundry/config_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/config_test.go
@@ -60,6 +60,9 @@ func newTestState() *testState {
 				Address:          "https://copilot.dns.address:port",
 				PollInterval:     90 * time.Second,
 			},
+			Envoy: cloudfoundry.EnvoyConfig{
+				Port: 8080,
+			},
 		},
 	}
 }

--- a/pilot/pkg/serviceregistry/cloudfoundry/config_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/config_test.go
@@ -60,9 +60,7 @@ func newTestState() *testState {
 				Address:          "https://copilot.dns.address:port",
 				PollInterval:     90 * time.Second,
 			},
-			Envoy: cloudfoundry.EnvoyConfig{
-				Port: 8080,
-			},
+			ServicePort: 8080,
 		},
 	}
 }

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -25,6 +25,8 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/cloudfoundry"
 )
 
+const ServiceDiscoveryPort = 8080
+
 func makeSampleClientResponse() *api.RoutesResponse {
 	return &api.RoutesResponse{
 		Backends: map[string]*api.BackendSet{
@@ -66,7 +68,8 @@ func newSDTestState() *sdTestState {
 
 	// initialize object under test
 	serviceDiscovery := &cloudfoundry.ServiceDiscovery{
-		Client: mockClient,
+		Client:  mockClient,
+		AppPort: ServiceDiscoveryPort,
 	}
 
 	return &sdTestState{
@@ -92,11 +95,11 @@ func TestServiceDiscovery_Services(t *testing.T) {
 	g.Expect(serviceModels).To(gomega.ConsistOf([]*model.Service{
 		{
 			Hostname: "process-guid-a.cfapps.internal",
-			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
+			Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
 		},
 		{
 			Hostname: "process-guid-b.cfapps.internal",
-			Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
+			Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
 		},
 	}))
 }
@@ -125,7 +128,7 @@ func TestServiceDiscovery_GetService_Success(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(serviceModel).To(gomega.Equal(&model.Service{
 		Hostname: "process-guid-b.cfapps.internal",
-		Ports:    []*model.Port{{Port: 8080, Protocol: model.ProtocolHTTP}},
+		Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
 	}))
 }
 
@@ -166,7 +169,7 @@ func TestServiceDiscovery_Instances_Filtering(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 
 	servicePort := &model.Port{
-		Port:     8080,
+		Port:     ServiceDiscoveryPort,
 		Protocol: model.ProtocolHTTP,
 	}
 	service := &model.Service{
@@ -230,7 +233,7 @@ func TestServiceDiscovery_HostInstances(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 
 	servicePort := &model.Port{
-		Port:     8080,
+		Port:     ServiceDiscoveryPort,
 		Protocol: model.ProtocolHTTP,
 	}
 

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -25,7 +25,7 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/cloudfoundry"
 )
 
-const ServiceDiscoveryPort = 8080
+const defaultServicePort = 8080
 
 func makeSampleClientResponse() *api.RoutesResponse {
 	return &api.RoutesResponse{
@@ -68,8 +68,8 @@ func newSDTestState() *sdTestState {
 
 	// initialize object under test
 	serviceDiscovery := &cloudfoundry.ServiceDiscovery{
-		Client:  mockClient,
-		AppPort: ServiceDiscoveryPort,
+		Client:      mockClient,
+		ServicePort: defaultServicePort,
 	}
 
 	return &sdTestState{
@@ -95,11 +95,11 @@ func TestServiceDiscovery_Services(t *testing.T) {
 	g.Expect(serviceModels).To(gomega.ConsistOf([]*model.Service{
 		{
 			Hostname: "process-guid-a.cfapps.internal",
-			Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
+			Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP}},
 		},
 		{
 			Hostname: "process-guid-b.cfapps.internal",
-			Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
+			Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP}},
 		},
 	}))
 }
@@ -128,7 +128,7 @@ func TestServiceDiscovery_GetService_Success(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(serviceModel).To(gomega.Equal(&model.Service{
 		Hostname: "process-guid-b.cfapps.internal",
-		Ports:    []*model.Port{{Port: ServiceDiscoveryPort, Protocol: model.ProtocolHTTP}},
+		Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP}},
 	}))
 }
 
@@ -169,7 +169,7 @@ func TestServiceDiscovery_Instances_Filtering(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 
 	servicePort := &model.Port{
-		Port:     ServiceDiscoveryPort,
+		Port:     defaultServicePort,
 		Protocol: model.ProtocolHTTP,
 	}
 	service := &model.Service{
@@ -233,7 +233,7 @@ func TestServiceDiscovery_HostInstances(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 
 	servicePort := &model.Port{
-		Port:     ServiceDiscoveryPort,
+		Port:     defaultServicePort,
 		Protocol: model.ProtocolHTTP,
 	}
 

--- a/pilot/test/integration/cloudfoundry/copilot_test.go
+++ b/pilot/test/integration/cloudfoundry/copilot_test.go
@@ -1,0 +1,277 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/copilot/api"
+	"code.cloudfoundry.org/copilot/testhelpers"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"google.golang.org/grpc"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/proxy/envoy"
+	"istio.io/istio/pilot/pkg/serviceregistry/cloudfoundry"
+	"istio.io/istio/pilot/test/integration/cloudfoundry/mock"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	appPort           = 9000
+	pilotPort         = 5555
+	copilotAddr       = "127.0.0.1:5000"
+	pilotAddr         = "127.0.0.1:5555"
+	registrationRoute = "http://127.0.0.1:5555/v1/registration"
+	listenersRoute    = "http://127.0.0.1:5555/v1/listeners/x/router~x~x~x"
+	appEnvoyListener  = "http://127.0.0.1:6666"
+)
+
+func TestEdgeRouterWithMockCopilot(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	fakeApp(appPort)
+	t.Logf("fake app is running on port %d", appPort)
+
+	testState := newTestState(copilotAddr)
+	defer testState.tearDown()
+	copilotTLSConfig := testState.creds.ServerTLSConfig()
+
+	quitCopilotServer := make(chan struct{})
+
+	testState.addCleanupTask(func() { close(quitCopilotServer) })
+
+	t.Log("starting mock copilot grpc server...")
+
+	mockCopilot, err := bootMockCopilotInBackground(copilotAddr, copilotTLSConfig, quitCopilotServer)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	mockCopilot.PopulateRoute("abc.com", "127.0.0.1", appPort)
+
+	err = testState.config.Save(testState.configFilePath)
+	g.Expect(err).To(gomega.BeNil())
+
+	t.Log("building pilot...")
+
+	pilotSession, err := runPilot(testState.configFilePath, pilotPort)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	testState.addCleanupTask(func() {
+		pilotSession.Terminate()
+		g.Eventually(pilotSession, "5s").Should(gexec.Exit())
+	})
+
+	t.Log("checking if pilot ready")
+	g.Eventually(pilotSession.Out, "10s").Should(gbytes.Say(`READY`))
+
+	t.Log("checking if pilot received routes from copilot")
+	g.Eventually(func() (string, error) {
+		return curlPilot(registrationRoute)
+	}).Should(gomega.ContainSubstring("abc.com"))
+
+	g.Eventually(func() (string, error) {
+		return curlPilot(listenersRoute)
+	}).Should(gomega.ContainSubstring("http_connection_manager"))
+
+	t.Log("run envoy...")
+
+	err = testState.runEnvoy(pilotAddr)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	t.Log("curling the app with expected host header")
+
+	g.Eventually(func() error {
+		respData, err := curlApp(appEnvoyListener, "abc.com")
+		if err != nil {
+			return err
+		}
+		if respData != "hello" {
+			return fmt.Errorf("unexpected response data: %s", respData)
+		}
+		return nil
+	}, "5s", "100ms").Should(gomega.Succeed())
+}
+
+type testState struct {
+	// generated credentials for server and client
+	creds testhelpers.MTLSCredentials
+
+	// path on disk to store the config.yaml
+	configFilePath string
+
+	config *cloudfoundry.Config
+
+	cleanupTasks []func()
+	mutex        sync.Mutex
+}
+
+func (testState *testState) addCleanupTask(task func()) {
+	testState.mutex.Lock()
+	defer testState.mutex.Unlock()
+	testState.cleanupTasks = append(testState.cleanupTasks, task)
+}
+
+func newTestState(mockServerAddress string) *testState {
+	creds := testhelpers.GenerateMTLS()
+	clientTLSFiles := creds.CreateClientTLSFiles()
+	return &testState{
+		creds:          creds,
+		configFilePath: filepath.Join(creds.TempDir, "config.yaml"),
+		config: &cloudfoundry.Config{
+			Copilot: cloudfoundry.CopilotConfig{
+				ServerCACertPath: clientTLSFiles.ServerCA,
+				ClientCertPath:   clientTLSFiles.ClientCert,
+				ClientKeyPath:    clientTLSFiles.ClientKey,
+				Address:          mockServerAddress,
+				PollInterval:     10 * time.Second,
+			},
+			Envoy: cloudfoundry.EnvoyConfig{
+				Port: 6666,
+			},
+		},
+	}
+}
+
+func (testState *testState) runEnvoy(discoveryAddr string) error {
+	config := model.DefaultProxyConfig()
+	dir := os.Getenv("ISTIO_BIN")
+	var err error
+	if len(dir) == 0 {
+		dir, err = os.Getwd()
+		if err != nil {
+			return err
+		}
+	}
+
+	config.BinaryPath = path.Join(dir, "envoy")
+
+	config.ConfigPath = "tmp"
+	config.DiscoveryAddress = discoveryAddr
+	config.ServiceCluster = "x"
+
+	envoyConfig := envoy.BuildConfig(config, nil)
+	envoyProxy := envoy.NewProxy(config, "router~x~x~x", string(log.ErrorLevel))
+	abortCh := make(chan error, 1)
+
+	testState.addCleanupTask(func() {
+		abortCh <- errors.New("test cleanup")
+		os.RemoveAll(config.ConfigPath)
+	})
+
+	go envoyProxy.Run(envoyConfig, 0, abortCh)
+
+	return nil
+}
+
+func (testState *testState) tearDown() {
+	for i := len(testState.cleanupTasks) - 1; i >= 0; i-- {
+		testState.cleanupTasks[i]()
+	}
+}
+
+func bootMockCopilotInBackground(listenAddress string, tlsConfig *tls.Config, quit <-chan struct{}) (*mock.CopilotHandler, error) {
+	handler := &mock.CopilotHandler{
+		RoutesResponseData: make(map[string]*api.BackendSet),
+	}
+	l, err := tls.Listen("tcp", listenAddress, tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+	grpcServer := grpc.NewServer()
+	api.RegisterIstioCopilotServer(grpcServer, handler)
+	errChan := make(chan error)
+	go func() {
+		errChan <- grpcServer.Serve(l)
+	}()
+	go func() {
+		select {
+		case e := <-errChan:
+			fmt.Printf("grpc server errored: %s", e)
+			return
+		case <-quit:
+			grpcServer.Stop()
+			return
+		}
+	}()
+	return handler, nil
+}
+
+func fakeApp(port int) {
+	fakeAppHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`hello`))
+	})
+	go http.ListenAndServe(fmt.Sprintf(":%d", port), fakeAppHandler)
+
+}
+
+func runPilot(cfConfig string, port int) (*gexec.Session, error) {
+	path, err := gexec.Build("istio.io/istio/pilot/cmd/pilot-discovery")
+	if err != nil {
+		return nil, err
+	}
+
+	pilotCmd := exec.Command(path, "discovery",
+		"--configDir", "/dev/null",
+		"--registries", "CloudFoundry",
+		"--cfConfig", cfConfig,
+		"--meshConfig", "/dev/null",
+		"--port", fmt.Sprintf("%d", port),
+	)
+	return gexec.Start(pilotCmd, nil, nil)
+}
+
+func curlPilot(apiEndpoint string) (string, error) {
+	resp, err := http.DefaultClient.Get(apiEndpoint)
+	if err != nil {
+		return "", err
+	}
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(respBytes), nil
+}
+
+func curlApp(endpoint, hostHeader string) (string, error) {
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Host = hostHeader
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected response code %d", resp.StatusCode)
+	}
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(respBytes), nil
+}

--- a/pilot/test/integration/cloudfoundry/copilot_test.go
+++ b/pilot/test/integration/cloudfoundry/copilot_test.go
@@ -149,9 +149,7 @@ func newTestState(mockServerAddress string) *testState {
 				Address:          mockServerAddress,
 				PollInterval:     10 * time.Second,
 			},
-			Envoy: cloudfoundry.EnvoyConfig{
-				Port: 6666,
-			},
+			ServicePort: 6666,
 		},
 	}
 }

--- a/pilot/test/integration/cloudfoundry/mock/copilot.go
+++ b/pilot/test/integration/cloudfoundry/mock/copilot.go
@@ -1,0 +1,55 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"sync"
+
+	"code.cloudfoundry.org/copilot/api"
+)
+
+type CopilotHandler struct {
+	RoutesResponseData map[string]*api.BackendSet
+	mutex              sync.Mutex
+}
+
+func (h *CopilotHandler) PopulateRoute(host string, ipAddr string, port int) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	backendSet := h.RoutesResponseData[host]
+	if backendSet == nil {
+		backendSet = &api.BackendSet{}
+	}
+	backendSet.Backends = append(backendSet.Backends, &api.Backend{
+		Address: ipAddr,
+		Port:    uint32(port),
+	})
+	h.RoutesResponseData[host] = backendSet
+}
+
+func (h *CopilotHandler) Health(context.Context, *api.HealthRequest) (*api.HealthResponse, error) {
+	return &api.HealthResponse{
+		Healthy: true,
+	}, nil
+}
+
+func (h *CopilotHandler) Routes(context.Context, *api.RoutesRequest) (*api.RoutesResponse, error) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+	return &api.RoutesResponse{
+		Backends: h.RoutesResponseData,
+	}, nil
+}


### PR DESCRIPTION
We're looking at two approaches for Cloud Foundry integrations tests (see https://github.com/istio/istio/issues/2204). This PR is a draft implementation for the approach with a mock copilot (see [doc here](https://docs.google.com/document/d/1oe9QeOv0Kon9sYYJTOU_NUIsU67nnd1T1RWpDV7MFY4/edit#heading=h.4qspo56v5jcy))

The test is still rough around the edges, but we wanted to get feedback first before we invested too much more time.

Maybe before merge?:
- we're currently using the `envoyproxy/envoy` docker image.  should we switch to  `gcr.io/istio-testing/proxy` image instead?
- should we use ephemeral ports instead of hard-coded ones?

We plan to work on the more complete end-to-end integration test in a subsequent PR.


cc: @rosenhouse 

