### PR TITLE
in case curl is not installed or installed,  but does not support https, use wget to download envoy

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -57,13 +57,28 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     pushd $OUT
     # New version of envoy downloaded. Save it to cache, and clean any old version.
 
-    if curl --version | grep Protocols  | grep https; then
-	DOWNLOAD_COMMAND='curl -Lo -'
-    elif command -v wget > /dev/null; then
-	DOWNLOAD_COMMAND='wget -qO -'
+    DOWNLOAD_COMMAND=""
+    if command -v curl > /dev/null; then
+       if curl --version | grep Protocols  | grep https; then
+	   DOWNLOAD_COMMAND='curl -Lo -'
+       else
+           echo curl does not support https, will try wget for downloading files.
+       fi
     else
-	echo Error: curl does not support https and wget is not installed. \
-	     Cannot download envoy. Please install wget or add support of https to curl.
+       echo curl is not installed, will try wget for downloading files.
+    fi
+
+    if [ -z "${DOWNLOAD_COMMAND}" ]; then
+        if command -v wget > /dev/null; then
+	    DOWNLOAD_COMMAND='wget -qO -'
+        else
+            echo wget is not installed.
+        fi
+    fi
+
+    if [ -z "${DOWNLOAD_COMMAND}" ]; then
+        echo Error: curl is not installed or does not support https, wget is not installed. \
+             Cannot download envoy. Please install wget or add support of https to curl.
         exit 1
     fi
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -56,7 +56,18 @@ if [ ! -f vendor/envoy-$PROXYVERSION ] ; then
     mkdir -p $OUT
     pushd $OUT
     # New version of envoy downloaded. Save it to cache, and clean any old version.
-    curl -Lo - https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
+
+    if curl --version | grep Protocols  | grep https; then
+	DOWNLOAD_COMMAND='curl -Lo -'
+    elif command -v wget > /dev/null; then
+	DOWNLOAD_COMMAND='wget -qO -'
+    else
+	echo Error: curl does not support https and wget is not installed. \
+	     Cannot download envoy. Please install wget or add support of https to curl.
+        exit 1
+    fi
+
+    ${DOWNLOAD_COMMAND} https://storage.googleapis.com/istio-build/proxy/envoy-$PROXY.tar.gz | tar xz
     cp usr/local/bin/envoy $ISTIO_GO/vendor/envoy-$PROXYVERSION
     rm -f ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy/envoy
     popd
@@ -72,4 +83,3 @@ fi
 if [ ! -f ${ROOT}/pilot/proxy/envoy/envoy ] ; then
     ln -sf ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy
 fi
-


### PR DESCRIPTION
check if curl supports https and check if wget is installed
if neither of the above is true, print an error message and exit

Sometimes curl can be installed without https support.