### PR TITLE
remove duplication of verifying go version from makefiles

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -33,14 +33,7 @@ export GOPATH=${GOPATH:-$GO_TOP}
 # Normally set by Makefile
 export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 
-# Ensure GO version
-GO_VERSION=$(go version | sed 's/go version go\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/g')
-GO_VERSION_MAJOR=$(echo $GO_VERSION | cut -f1 -d.)
-GO_VERSION_MINOR=$(echo $GO_VERSION | cut -f2 -d.)
-if [ "$GO_VERSION_MAJOR" -ne "1" -o "$GO_VERSION_MINOR" -ne "9" ]; then
-    echo Go version is ${GO_VERSION}. Istio compiles with Go 1.9. Please update your go.
-    exit 1
-fi
+$ROOT/bin/verify_go_version.sh
 
 # Ensure expected GOPATH setup
 if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 Istio Authors. All Rights Reserved.
+# Copyright 2017,2018 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -18,6 +18,15 @@ export GOPATH=${GOPATH:-$GO_TOP}
 # Normally set by Makefile
 export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 
+# Ensure GO version
+GO_VERSION=$(go version | sed 's/go version go\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/g')
+GO_VERSION_MAJOR=$(echo $GO_VERSION | cut -f1 -d.)
+GO_VERSION_MINOR=$(echo $GO_VERSION | cut -f2 -d.)
+if [ "$GO_VERSION_MAJOR" -ne "1" -o "$GO_VERSION_MINOR" -ne "9" ]; then
+    echo Go version is ${GO_VERSION}. Istio compiles with Go 1.9. Please update your go.
+    exit 1
+fi
+
 # Ensure expected GOPATH setup
 if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        echo "Istio not found in GOPATH/src/istio.io/"
@@ -72,4 +81,3 @@ fi
 if [ ! -f ${ROOT}/pilot/proxy/envoy/envoy ] ; then
     ln -sf ${ISTIO_BIN}/envoy ${ROOT}/pilot/proxy/envoy
 fi
-

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Init script downloads or updates envoy and the go dependencies. Called from Makefile, which sets
 # the needed environment variables.

--- a/bin/verify_go_version.sh
+++ b/bin/verify_go_version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The script verifies that go version is as required
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REQUIRED_GO_VERSION_MAJOR=1
+REQUIRED_GO_VERSION_MINOR=9
+
+GO_VERSION=$(go version | sed 's/go version go\([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/g')
+GO_VERSION_MAJOR=$(echo $GO_VERSION | cut -f1 -d.)
+GO_VERSION_MINOR=$(echo $GO_VERSION | cut -f2 -d.)
+
+function print_error_and_exit {
+    echo Your Go version is ${GO_VERSION}. Istio compiles with Go 1.9+. Please update your Go.
+    exit 1
+}
+
+if [ "$GO_VERSION_MAJOR" -lt "${REQUIRED_GO_VERSION_MAJOR}" ]; then
+   print_error_and_exit
+fi
+
+if [ "$GO_VERSION_MAJOR" -le "${REQUIRED_GO_VERSION_MAJOR}" -a \
+     "$GO_VERSION_MINOR" -lt "${REQUIRED_GO_VERSION_MINOR}" ]; then
+  print_error_and_exit
+fi

--- a/mixer/Makefile
+++ b/mixer/Makefile
@@ -1,3 +1,17 @@
+## Copyright 2017,2018 Istio Authors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
 # sed parses out the x.y version (of what may be x.y or x.y.z) and outputs "x y".
 # awk takes the two separate variables and combines them as a single value x*100+y (e.g., 1.9 is 109).
 # This single value allows the major & minor #s to be checked in a single comparison.

--- a/mixer/Makefile
+++ b/mixer/Makefile
@@ -12,11 +12,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-# sed parses out the x.y version (of what may be x.y or x.y.z) and outputs "x y".
-# awk takes the two separate variables and combines them as a single value x*100+y (e.g., 1.9 is 109).
-# This single value allows the major & minor #s to be checked in a single comparison.
-GO_VERSION=$(shell go version | sed "s/[a-z| ]*\([0-9]*\)\.\([0-9]*\).*/\1 \2/" | awk '{print $$1*100+$$2}')
-
 # note: docker/mixs to be phony to make sure rebuilding always.
 .PHONY: docker docker/mixs
 .INTERMEDIATE: check.prereqs
@@ -24,7 +19,7 @@ GO_VERSION=$(shell go version | sed "s/[a-z| ]*\([0-9]*\)\.\([0-9]*\).*/\1 \2/" 
 default: docker
 
 check.prereqs:
-	@if test $(GO_VERSION) -lt 109; then echo -n "go version 1.9+ required, found: "; go version; exit 1; fi
+	../bin/verify_go_version.sh
 
 clean:
 	rm -f docker/mixs

--- a/security/Makefile
+++ b/security/Makefile
@@ -12,9 +12,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-GOBINARY ?= go
-GO_MINOR_VERSION = $(shell $(GOBINARY) version | cut -d . -f 2)
-
 VERSION_MODULE = istio.io/istio/security/cmd/istio_ca/version
 
 .PHONY: docker
@@ -23,7 +20,7 @@ VERSION_MODULE = istio.io/istio/security/cmd/istio_ca/version
 default: docker
 
 check.prereqs:
-	@if test $(GO_MINOR_VERSION) -lt 9; then echo -n "go version 1.9+ required, found: "; go version; exit 1; fi
+	../bin/verify_go_version.sh
 
 clean:
 	rm -f docker/istio_ca

--- a/security/Makefile
+++ b/security/Makefile
@@ -1,3 +1,17 @@
+## Copyright 2017,2018 Istio Authors
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
 GOBINARY ?= go
 GO_MINOR_VERSION = $(shell $(GOBINARY) version | cut -d . -f 2)
 


### PR DESCRIPTION
Both mixer/Makefile and security/Makefile contain code to verify go version, the Makefile does not verify it.

Remove duplication of code between mixer/security Makefiles, and add verifying go version into bin/init.sh
