### PR TITLE
add ClusterTypeSDS constant and use it for cluster type "sds"

### DIFF
--- a/pilot/proxy/envoy/resources.go
+++ b/pilot/proxy/envoy/resources.go
@@ -62,6 +62,9 @@ const (
 	// ClusterTypeOriginalDST name for clusters of type 'original_dst'
 	ClusterTypeOriginalDST = "original_dst"
 
+	// ClusterTypeSDS name for clusters of type 'sds'
+	ClusterTypeSDS = "sds"
+
 	// LbTypeRoundRobin is the name for round-robin LB
 	LbTypeRoundRobin = "round_robin"
 

--- a/pilot/proxy/envoy/route.go
+++ b/pilot/proxy/envoy/route.go
@@ -150,7 +150,7 @@ func buildOutboundCluster(hostname string, port *model.Port, labels model.Labels
 	cluster := &Cluster{
 		Name:        name,
 		ServiceName: key,
-		Type:        SDSName,
+		Type:        ClusterTypeSDS,
 		LbType:      DefaultLbType,
 		outbound:    true,
 		hostname:    hostname,


### PR DESCRIPTION
instead of SDSName, which is the name of the cluster for SDS, which
is accidentally the same

In a language with enumerated types, ClusterType would be an enum type,
and ClusterType.SDS would be used for the cluster type field. SDSName
would be a constact string, different from the ClusterType type.