### PR TITLE
add isExternal parameter to buildOutboundCluster and build strict_dns cluster for external kubernetes services

### DIFF
--- a/pilot/proxy/envoy/config.go
+++ b/pilot/proxy/envoy/config.go
@@ -568,7 +568,7 @@ func buildDestinationHTTPRoutes(sidecar model.Node, service *model.Service,
 
 		if useDefaultRoute {
 			// default route for the destination is always the lowest priority route
-			cluster := buildOutboundCluster(service.Hostname, servicePort, nil)
+			cluster := buildOutboundCluster(service.Hostname, servicePort, nil, service.External())
 			routes = append(routes, buildDefaultRoute(cluster))
 		}
 
@@ -577,7 +577,7 @@ func buildDestinationHTTPRoutes(sidecar model.Node, service *model.Service,
 	case model.ProtocolHTTPS:
 		// as an exception, external name HTTPS port is sent in plain-text HTTP/1.1
 		if service.External() {
-			cluster := buildOutboundCluster(service.Hostname, servicePort, nil)
+			cluster := buildOutboundCluster(service.Hostname, servicePort, nil, service.External())
 			return []*HTTPRoute{buildDefaultRoute(cluster)}
 		}
 
@@ -673,7 +673,8 @@ func buildOutboundTCPListeners(mesh *meshconfig.MeshConfig, sidecar model.Node,
 						}
 						cluster = originalDstCluster
 					} else {
-						cluster = buildOutboundCluster(service.Hostname, servicePort, nil)
+						cluster = buildOutboundCluster(service.Hostname, servicePort, nil,
+							service.External())
 						tcpClusters = append(tcpClusters, cluster)
 					}
 					route := buildTCPRoute(cluster, nil)
@@ -685,7 +686,7 @@ func buildOutboundTCPListeners(mesh *meshconfig.MeshConfig, sidecar model.Node,
 					}
 					tcpListeners = append(tcpListeners, listener)
 				} else {
-					cluster := buildOutboundCluster(service.Hostname, servicePort, nil)
+					cluster := buildOutboundCluster(service.Hostname, servicePort, nil, service.External())
 					route := buildTCPRoute(cluster, []string{service.Address})
 					config := &TCPRouteConfig{Routes: []*TCPRoute{route}}
 					listener := buildTCPListener(


### PR DESCRIPTION
External kubernetes services cannot work with SDS (EDS), since SDS (EDS) does not provide endpoint info for kubernetes external services:
see https://github.com/istio/istio/blob/master/pilot/proxy/envoy/discovery.go#L491

The current problem is reported in istio-users group: https://groups.google.com/forum/#!topic/istio-users/ZeWduT_Pgcc.