### PR TITLE
Introduce runtime2/dispatcher

### DIFF
--- a/mixer/pkg/adapter/check.go
+++ b/mixer/pkg/adapter/check.go
@@ -47,13 +47,18 @@ func (r *CheckResult) Combine(otherPtr interface{}) interface{} {
 		return r
 	}
 	other := otherPtr.(*CheckResult)
+	r.CombineCheckResult(other)
+	return r
+}
+
+// CombineCheckResult combines other result with self. It does not handle Status.
+func (r *CheckResult) CombineCheckResult(other *CheckResult) {
 	if r.ValidDuration > other.ValidDuration {
 		r.ValidDuration = other.ValidDuration
 	}
 	if r.ValidUseCount > other.ValidUseCount {
 		r.ValidUseCount = other.ValidUseCount
 	}
-	return r
 }
 
 func (r *CheckResult) String() string {

--- a/mixer/pkg/runtime2/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher.go
@@ -1,0 +1,448 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dispatcher is used to dispatch incoming requests to one or more handlers. The main entry point
+// is the Dispatcher struct, which implements the main runtime.Dispatcher interface.
+//
+// Once the dispatcher receives a request, it acquires the current routing table, and uses it until the end
+// of the request. Additionally, it acquires an executor from a pool, which is used to perform and track the
+// parallel calls that will be performed against the handlers. The executors scatter the calls
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/opentracing/opentracing-go"
+	tpb "istio.io/api/mixer/v1/template"
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/pool"
+	"istio.io/istio/mixer/pkg/runtime"
+	"istio.io/istio/mixer/pkg/runtime2/config"
+	"istio.io/istio/mixer/pkg/runtime2/routing"
+	"istio.io/istio/mixer/pkg/status"
+	"istio.io/istio/pkg/log"
+)
+
+// Dispatcher is the runtime2 implementation of the runtime.Dispatcher interface.
+type Dispatcher struct {
+	identityAttribute string
+
+	// Current dispatch context.
+	context *RoutingContext
+
+	// the reader-writer lock for accessing or changing the context.
+	contextLock sync.RWMutex
+
+	// pool of sessions
+	sessionPool *sessionPool
+
+	// pool of dispatch states
+	statePool *dispatchStatePool
+
+	gp *pool.GoroutinePool
+}
+
+var _ runtime.Dispatcher = &Dispatcher{}
+
+// RoutingContext is the currently active dispatching context, based on a config snapshot. As config changes,
+// the current/live RoutingContext also changes.
+type RoutingContext struct {
+	// the routing table of this context.
+	Routes *routing.Table
+
+	// the current reference count. Indicates how many calls are currently using this RoutingContext.
+	refCount int32
+}
+
+// IncRef increases the reference count on the RoutingContext.
+func (t *RoutingContext) IncRef() {
+	atomic.AddInt32(&t.refCount, 1)
+}
+
+// DecRef decreases the reference count on the RoutingContext.
+func (t *RoutingContext) DecRef() {
+	atomic.AddInt32(&t.refCount, -1)
+}
+
+// GetRefs returns the current reference count on the dispatch context.
+func (t *RoutingContext) GetRefs() int32 {
+	return atomic.LoadInt32(&t.refCount)
+}
+
+// New returns a new Dispatcher instance. The Dispatcher instance is initialized with an empty routing table.
+func New(identityAttribute string, handlerGP *pool.GoroutinePool, enableTracing bool) *Dispatcher {
+	return &Dispatcher{
+		identityAttribute: identityAttribute,
+		sessionPool:       newSessionPool(enableTracing),
+		statePool:         newDispatchStatePool(),
+		gp:                handlerGP,
+		context: &RoutingContext{
+			Routes: routing.Empty(),
+		},
+	}
+}
+
+// ChangeRoute changes the routing table on the Dispatcher which, in turn, ends up creating a new RoutingContext.
+func (d *Dispatcher) ChangeRoute(new *routing.Table) *RoutingContext {
+	newContext := &RoutingContext{
+		Routes: new,
+	}
+
+	d.contextLock.Lock()
+	old := d.context
+	d.context = newContext
+	d.contextLock.Unlock()
+
+	return old
+}
+
+// Check implementation of runtime.Dispatcher.
+func (d *Dispatcher) Check(ctx context.Context, bag attribute.Bag) (*adapter.CheckResult, error) {
+	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_CHECK, bag)
+
+	var r *adapter.CheckResult
+	err := d.dispatch(s)
+	if err == nil {
+		r = s.checkResult
+		err = s.err
+	}
+
+	d.completeSession(s)
+
+	return r, err
+}
+
+// Report implementation of runtime.Dispatcher.
+func (d *Dispatcher) Report(ctx context.Context, bag attribute.Bag) error {
+	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_REPORT, bag)
+
+	err := d.dispatch(s)
+	if err == nil {
+		err = s.err
+	}
+
+	d.completeSession(s)
+
+	return err
+}
+
+// Quota implementation of runtime.Dispatcher.
+func (d *Dispatcher) Quota(ctx context.Context, bag attribute.Bag, qma *runtime.QuotaMethodArgs) (*adapter.QuotaResult, error) {
+	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_QUOTA, bag)
+	s.quotaMethodArgs = *qma
+
+	err := d.dispatch(s)
+	if err == nil {
+		err = s.err
+	}
+
+	r := s.quotaResult
+	d.completeSession(s)
+
+	return r, err
+}
+
+// Preprocess implementation of runtime.Dispatcher.
+func (d *Dispatcher) Preprocess(ctx context.Context, bag attribute.Bag, responseBag *attribute.MutableBag) error {
+	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR, bag)
+	s.responseBag = responseBag
+
+	err := d.dispatch(s)
+	if err == nil {
+		err = s.err
+	}
+
+	d.completeSession(s)
+
+	return err
+}
+
+func (d *Dispatcher) dispatch(session *session) error {
+	// Capture the routing context locally. It can change underneath us. We also need to decRef before
+	// completing the call.
+	r := d.acquireRoutingContext()
+
+	// Lookup the value of the identity attribute, so that we can extract the namespace to use for route
+	// lookup.
+	identityAttributeValue, err := getIdentityAttributeValue(session.bag, d.identityAttribute)
+	if err != nil {
+		// early return.
+		r.DecRef()
+		updateRequestCounters(time.Since(session.start), 0, 0, err != nil)
+		log.Warnf("unable to determine identity attribute value: '%v', operation='%d'", err, session.variety)
+		return err
+	}
+	namespace := getNamespace(identityAttributeValue)
+
+	destinations := r.Routes.GetDestinations(session.variety, namespace)
+
+	// Update the context after ensuring that we will not short-circuit and return. This causes allocations.
+	session.ctx = d.updateContext(session.ctx, session.bag)
+
+	// TODO(Issue #2139): This is for old-style metadata based policy decisions. This should be eventually removed.
+	ctxProtocol, _ := session.bag.Get(config.ContextProtocolAttributeName)
+	tcp := ctxProtocol == config.ContextProtocolTCP
+
+	// Ensure that we can run dispatches to all destinations in parallel.
+	session.ensureParallelism(destinations.Count())
+
+	ninputs := 0
+	ndestinations := 0
+	for _, destination := range destinations.Entries() {
+		for _, group := range destination.InstanceGroups {
+			if !group.Matches(session.bag) || group.ResourceType.IsTCP() != tcp {
+				continue
+			}
+			ndestinations++
+
+			var state *dispatchState
+			// We dispatch multiple instances together at once to a handler for report calls. pre-acquire
+			// the state, so that we can use its instances field to stage the instance values before dispatch.
+			if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
+				state = d.statePool.get(session, destination)
+			}
+
+			for j, input := range group.Builders {
+				var instance interface{}
+				if instance, err = input(session.bag); err != nil {
+					log.Warnf("error creating instance: destination='%v', error='%v'", destination.FriendlyName, err)
+					continue
+				}
+				ninputs++
+
+				// For report templates, accumulate instances as much as possible before commencing dispatch.
+				if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
+					state.instances = append(state.instances, instance)
+					continue
+				}
+
+				// for other templates, dispatch for each instance individually.
+				state = d.statePool.get(session, destination)
+				state.instance = instance
+				if session.variety == tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR {
+					state.mapper = group.Mappers[j]
+				}
+
+				// Dispatch for singleton dispatches
+				d.dispatchToHandler(state)
+			}
+
+			if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
+				// Do a multi-instance dispatch for report.
+				d.dispatchToHandler(state)
+			}
+		}
+	}
+
+	// wait on the dispatch states and accumulate results
+	var buf *bytes.Buffer
+	code := rpc.OK
+
+	err = nil
+	for session.activeDispatches > 0 {
+		state := <-session.completed
+		session.activeDispatches--
+
+		// Aggregate errors
+		if state.err != nil {
+			err = multierror.Append(err, state.err)
+		}
+
+		st := rpc.Status{Code: int32(rpc.OK)}
+
+		switch session.variety {
+		case tpb.TEMPLATE_VARIETY_REPORT:
+			// Do nothing
+
+		case tpb.TEMPLATE_VARIETY_CHECK:
+			if session.checkResult == nil {
+				r := state.checkResult
+				session.checkResult = &r
+			} else {
+				session.checkResult.CombineCheckResult(&state.checkResult)
+			}
+			st = state.checkResult.Status
+
+		case tpb.TEMPLATE_VARIETY_QUOTA:
+			if session.quotaResult == nil {
+				r := state.quotaResult
+				session.quotaResult = &r
+			} else {
+				log.Warnf("Skipping quota op result due to previous value: '%v', op: '%s'",
+					state.quotaResult, state.destination.FriendlyName)
+			}
+			st = state.quotaResult.Status
+
+		case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
+			e := session.responseBag.Merge(state.outputBag)
+			if e != nil {
+				log.Infof("Attributes merging failed %v", err)
+				err = e
+			}
+		}
+
+		if !status.IsOK(st) {
+			if buf == nil {
+				buf = pool.GetBuffer()
+				// the first failure result's code becomes the result code for the output
+				code = rpc.Code(st.Code)
+			} else {
+				buf.WriteString(", ")
+			}
+
+			buf.WriteString(state.destination.HandlerName + ":" + st.Message)
+		}
+
+		d.statePool.put(state)
+	}
+
+	if buf != nil {
+		switch session.variety {
+		case tpb.TEMPLATE_VARIETY_CHECK:
+			session.checkResult.SetStatus(status.WithMessage(code, buf.String()))
+		case tpb.TEMPLATE_VARIETY_QUOTA:
+			session.quotaResult.SetStatus(status.WithMessage(code, buf.String()))
+		}
+		pool.PutBuffer(buf)
+	}
+
+	session.err = err
+
+	r.DecRef()
+	updateRequestCounters(time.Since(session.start), ndestinations, ninputs, err != nil)
+
+	return nil
+}
+
+func (d *Dispatcher) acquireRoutingContext() *RoutingContext {
+	d.contextLock.RLock()
+	ctx := d.context
+	ctx.IncRef()
+	d.contextLock.RUnlock()
+	return ctx
+}
+
+func (d *Dispatcher) updateContext(ctx context.Context, bag attribute.Bag) context.Context {
+	data := &adapter.RequestData{}
+
+	// fill the destination information
+	if destSrvc, found := bag.Get(d.identityAttribute); found {
+		data.DestinationService = adapter.Service{FullName: destSrvc.(string)}
+	}
+
+	return adapter.NewContextWithRequestData(ctx, data)
+}
+
+func (d *Dispatcher) beginSession(ctx context.Context, variety tpb.TemplateVariety, bag attribute.Bag) *session {
+	s := d.sessionPool.get()
+	s.start = time.Now()
+	s.variety = variety
+	s.ctx = ctx
+	s.bag = bag
+
+	return s
+}
+
+func (d *Dispatcher) completeSession(s *session) {
+	s.clear()
+	d.sessionPool.put(s)
+}
+
+func (d *Dispatcher) dispatchToHandler(s *dispatchState) {
+	s.session.activeDispatches++
+
+	d.gp.ScheduleWork(doDispatchToHandler, s)
+}
+
+func doDispatchToHandler(param interface{}) {
+	s := param.(*dispatchState)
+
+	reachedEnd := false
+
+	defer func() {
+		if reachedEnd {
+			return
+		}
+
+		r := recover()
+		s.err = fmt.Errorf("panic during handler dispatch: %v", r)
+		log.Errorf("%v", s.err)
+
+		if log.DebugEnabled() {
+			log.Debugf("stack dump for handler dispatch panic:\n%s", debug.Stack())
+		}
+
+		s.session.completed <- s
+	}()
+
+	ctx := s.session.ctx
+	var span opentracing.Span
+	var start time.Time
+	span, ctx, start = s.beginSpan(ctx)
+
+	log.Debugf("begin dispatch: destination='%s'", s.destination.FriendlyName)
+
+	switch s.destination.Template.Variety {
+	case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
+		s.outputBag, s.err = s.destination.Template.DispatchGenAttrs(
+			ctx, s.destination.Handler, s.instance, s.inputBag, s.mapper)
+
+	case tpb.TEMPLATE_VARIETY_CHECK:
+		s.checkResult, s.err = s.destination.Template.DispatchCheck(
+			ctx, s.destination.Handler, s.instance)
+
+	case tpb.TEMPLATE_VARIETY_REPORT:
+		s.err = s.destination.Template.DispatchReport(
+			ctx, s.destination.Handler, s.instances)
+
+	case tpb.TEMPLATE_VARIETY_QUOTA:
+		s.quotaResult, s.err = s.destination.Template.DispatchQuota(
+			ctx, s.destination.Handler, s.instance, s.quotaArgs)
+
+	default:
+		panic(fmt.Sprintf("unknown variety type: '%v'", s.destination.Template.Variety))
+	}
+
+	log.Debugf("complete dispatch: destination='%s' {err:%v}", s.destination.FriendlyName, s.err)
+
+	s.completeSpan(span, time.Since(start), s.err)
+	s.session.completed <- s
+
+	reachedEnd = true
+}
+
+func (s *dispatchState) beginSpan(ctx context.Context) (opentracing.Span, context.Context, time.Time) {
+	var span opentracing.Span
+	if s.session.trace {
+		span, ctx = opentracing.StartSpanFromContext(ctx, s.destination.FriendlyName)
+	}
+
+	return span, ctx, time.Now()
+}
+
+func (s *dispatchState) completeSpan(span opentracing.Span, duration time.Duration, err error) {
+	if s.session.trace {
+		logToDispatchSpan(span, s.destination.Template.Name, s.destination.HandlerName, s.destination.AdapterName, err)
+	}
+	s.destination.Counters.Update(duration, err != nil)
+}

--- a/mixer/pkg/runtime2/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher.go
@@ -178,21 +178,20 @@ func (d *Dispatcher) Preprocess(ctx context.Context, bag attribute.Bag, response
 }
 
 func (d *Dispatcher) dispatch(session *session) error {
-	// Capture the routing context locally. It can change underneath us. We also need to decRef before
-	// completing the call.
-	r := d.acquireRoutingContext()
-
 	// Lookup the value of the identity attribute, so that we can extract the namespace to use for route
 	// lookup.
 	identityAttributeValue, err := getIdentityAttributeValue(session.bag, d.identityAttribute)
 	if err != nil {
 		// early return.
-		r.DecRef()
 		updateRequestCounters(time.Since(session.start), 0, 0, err != nil)
 		log.Warnf("unable to determine identity attribute value: '%v', operation='%d'", err, session.variety)
 		return err
 	}
 	namespace := getNamespace(identityAttributeValue)
+
+	// Capture the routing context locally. It can change underneath us. We also need to decRef before
+	// completing the call.
+	r := d.acquireRoutingContext()
 
 	destinations := r.Routes.GetDestinations(session.variety, namespace)
 

--- a/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
@@ -1,0 +1,631 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	tpb "istio.io/api/mixer/v1/template"
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/pkg/log"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/il/compiled"
+	"istio.io/istio/mixer/pkg/pool"
+	"istio.io/istio/mixer/pkg/runtime"
+	"istio.io/istio/mixer/pkg/runtime2/handler"
+	"istio.io/istio/mixer/pkg/runtime2/routing"
+	"istio.io/istio/mixer/pkg/runtime2/testing/data"
+	"istio.io/istio/mixer/pkg/runtime2/testing/util"
+)
+
+var gp = pool.NewGoroutinePool(10, true)
+
+var tests = []struct {
+	// name of the test
+	name string
+
+	// fake template settings to use. Default settings will be used if empty.
+	templates []data.FakeTemplateSettings
+
+	// fake adapter settings to use. Default settings will be used if empty.
+	adapters []data.FakeAdapterSettings
+
+	// configs to use
+	config []string
+
+	// attributes to use. If left empty, a default bag will be used.
+	attr map[string]interface{}
+
+	// the variety of the operation to apply.
+	variety tpb.TemplateVariety
+
+	// quota method arguments to pass
+	qma *runtime.QuotaMethodArgs
+
+	// Attributes to see the response bag with before call
+	responseAttrs map[string]interface{}
+
+	expectedQuotaResult *adapter.QuotaResult
+
+	expectedCheckResult *adapter.CheckResult
+
+	// expected error, if specified
+	err string
+
+	// expected adapter/template log.
+	log string
+}{
+	{
+		name: "BasicCheck",
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1,
+		},
+		variety:             tpb.TEMPLATE_VARIETY_CHECK,
+		expectedCheckResult: &adapter.CheckResult{},
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicCheckError",
+		templates: []data.FakeTemplateSettings{{
+			Name:                 "tcheck",
+			ErrorOnDispatchCheck: true,
+		}},
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		err: `
+1 error occurred:
+
+* error at dispatch check, as expected
+`,
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (ERROR)
+`,
+	},
+
+	{
+		name: "CheckResultCombination",
+		templates: []data.FakeTemplateSettings{{
+			Name: "tcheck",
+			CheckResults: []adapter.CheckResult{
+				{ValidUseCount: 10, ValidDuration: time.Minute},
+				{ValidUseCount: 20, ValidDuration: time.Millisecond},
+			},
+		}},
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.InstanceCheck2,
+			data.RuleCheck1WithInstance1And2,
+		},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		expectedCheckResult: &adapter.CheckResult{
+			ValidUseCount: 10,
+			ValidDuration: time.Millisecond,
+		},
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (SUCCESS)
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "CheckResultCombinationWithError",
+		templates: []data.FakeTemplateSettings{{
+			Name: "tcheck",
+			CheckResults: []adapter.CheckResult{
+				{
+					Status: rpc.Status{
+						Code:    int32(rpc.DATA_LOSS),
+						Message: "data loss details",
+					},
+					ValidUseCount: 10,
+					ValidDuration: time.Minute,
+				},
+				{
+					Status: rpc.Status{
+						Code:    int32(rpc.DEADLINE_EXCEEDED),
+						Message: "deadline exceeded details",
+					},
+
+					ValidUseCount: 20,
+					ValidDuration: time.Millisecond,
+				},
+			},
+		}},
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.InstanceCheck2,
+			data.RuleCheck1WithInstance1And2,
+		},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		expectedCheckResult: &adapter.CheckResult{
+			Status: rpc.Status{
+				Code:    int32(rpc.DATA_LOSS),
+				Message: "hcheck1.acheck.istio-system:data loss details, hcheck1.acheck.istio-system:deadline exceeded details",
+			},
+			ValidUseCount: 10,
+			ValidDuration: time.Millisecond,
+		},
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (SUCCESS)
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicReport",
+		config: []string{
+			data.HandlerAReport1,
+			data.InstanceReport1,
+			data.RuleReport1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_REPORT,
+		log: `
+[treport] InstanceBuilderFn() => name: 'treport', bag: '---
+ident                         : dest.istio-system
+'
+[treport] InstanceBuilderFn() <= (SUCCESS)
+[treport] DispatchReport => instances: '[&Empty{}]'
+[treport] DispatchReport <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicReportError",
+		templates: []data.FakeTemplateSettings{{
+			Name: "treport",
+			ErrorOnDispatchReport: true,
+		}},
+		config: []string{
+			data.HandlerAReport1,
+			data.InstanceReport1,
+			data.RuleReport1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_REPORT,
+		err: `
+1 error occurred:
+
+* error at dispatch report, as expected
+`,
+		log: `
+[treport] InstanceBuilderFn() => name: 'treport', bag: '---
+ident                         : dest.istio-system
+'
+[treport] InstanceBuilderFn() <= (SUCCESS)
+[treport] DispatchReport => instances: '[&Empty{}]'
+[treport] DispatchReport <= (ERROR)
+`,
+	},
+
+	{
+		name: "BasicQuota",
+		config: []string{
+			data.HandlerAQuota1,
+			data.InstanceQuota1,
+			data.RuleQuota1,
+		},
+		variety:             tpb.TEMPLATE_VARIETY_QUOTA,
+		expectedQuotaResult: &adapter.QuotaResult{},
+		log: `
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicQuotaError",
+		templates: []data.FakeTemplateSettings{{
+			Name:                 "tquota",
+			ErrorOnDispatchQuota: true,
+		}},
+		config: []string{
+			data.HandlerAQuota1,
+			data.InstanceQuota1,
+			data.RuleQuota1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_QUOTA,
+		err: `
+1 error occurred:
+
+* error at dispatch quota, as expected`,
+		log: `
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (ERROR)
+`,
+	},
+
+	{
+		name: "QuotaResultCombination",
+		templates: []data.FakeTemplateSettings{{
+			Name: "tquota",
+			QuotaResults: []adapter.QuotaResult{
+				{
+					Amount:        55,
+					ValidDuration: time.Second,
+				},
+				{
+					Amount:        66,
+					ValidDuration: time.Hour,
+				},
+			},
+		}},
+		config: []string{
+			data.HandlerAQuota1,
+			data.InstanceQuota1,
+			data.InstanceQuota2,
+			data.RuleQuota1,
+			data.RuleQuota2,
+		},
+		variety: tpb.TEMPLATE_VARIETY_QUOTA,
+		expectedQuotaResult: &adapter.QuotaResult{
+			Amount:        55,
+			ValidDuration: time.Second,
+		},
+		log: `
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (SUCCESS)
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "QuotaResultCombinationWithError",
+		templates: []data.FakeTemplateSettings{{
+			Name: "tquota",
+			QuotaResults: []adapter.QuotaResult{
+				{
+					Amount:        55,
+					ValidDuration: time.Second,
+					Status: rpc.Status{
+						Code:    int32(rpc.CANCELLED),
+						Message: "cancelled details",
+					},
+				},
+				{
+					Amount:        66,
+					ValidDuration: time.Hour,
+					Status: rpc.Status{
+						Code:    int32(rpc.ABORTED),
+						Message: "aborted details",
+					},
+				},
+			},
+		}},
+		config: []string{
+			data.HandlerAQuota1,
+			data.InstanceQuota1,
+			data.InstanceQuota2,
+			data.RuleQuota1,
+			data.RuleQuota2,
+		},
+		variety: tpb.TEMPLATE_VARIETY_QUOTA,
+		expectedQuotaResult: &adapter.QuotaResult{
+			Status: rpc.Status{
+				Code:    int32(rpc.CANCELLED),
+				Message: "hquota1.aquota.istio-system:cancelled details, hquota1.aquota.istio-system:aborted details",
+			},
+			Amount:        55,
+			ValidDuration: time.Second,
+		},
+		log: `
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (SUCCESS)
+[tquota] InstanceBuilderFn() => name: 'tquota', bag: '---
+ident                         : dest.istio-system
+'
+[tquota] InstanceBuilderFn() <= (SUCCESS)
+[tquota] DispatchQuota => instance: '&Empty{}'
+[tquota] DispatchQuota <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicPreprocess",
+		config: []string{
+			data.HandlerAPA1,
+			data.InstanceAPA1,
+			data.RuleApa1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR,
+		log: `
+[tapa] InstanceBuilderFn() => name: 'tapa', bag: '---
+ident                         : dest.istio-system
+'
+[tapa] InstanceBuilderFn() <= (SUCCESS)
+[tapa] DispatchGenAttrs => instance: '&Empty{}'
+[tapa] DispatchGenAttrs <= (SUCCESS)
+`,
+	},
+
+	{
+		name: "BasicPreprocessError",
+		templates: []data.FakeTemplateSettings{{
+			Name: "tapa",
+			ErrorOnDispatchGenAttrs: true,
+		}},
+		config: []string{
+			data.HandlerAPA1,
+			data.InstanceAPA1,
+			data.RuleApa1,
+		},
+		variety: tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR,
+		err: `
+1 error occurred:
+
+* error at dispatch quota, as expected
+`,
+		log: `
+[tapa] InstanceBuilderFn() => name: 'tapa', bag: '---
+ident                         : dest.istio-system
+'
+[tapa] InstanceBuilderFn() <= (SUCCESS)
+[tapa] DispatchGenAttrs => instance: '&Empty{}'
+[tapa] DispatchGenAttrs <= (ERROR)
+
+`,
+	},
+
+	{
+		name: "ErrorExtractingIdentityAttribute",
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1,
+		},
+		attr: map[string]interface{}{
+			"ident": 23,
+		},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		err:     "identity parameter is not a string: 'ident'",
+	},
+
+	{
+		name: "InputSetDoesNotMatch",
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1WithMatchClause,
+		},
+		attr: map[string]interface{}{
+			"ident":       "dest.istio-system",
+			"target.name": "barf", // "foo*" is expected
+		},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		log:     ``, // log should be empty
+	},
+
+	{
+		name: "InstanceError",
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1,
+		},
+		templates: []data.FakeTemplateSettings{{
+			Name: "tcheck", ErrorAtCreateInstance: true,
+		}},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (ERROR)
+`,
+	},
+
+	{
+		name: "HandlerPanic",
+		config: []string{
+			data.HandlerACheck1,
+			data.InstanceCheck1,
+			data.RuleCheck1,
+		},
+		templates: []data.FakeTemplateSettings{{
+			Name: "tcheck", PanicOnDispatchCheck: true,
+		}},
+		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		err: `
+1 error occurred:
+
+* panic during handler dispatch: <nil>
+`,
+		log: `
+[tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
+ident                         : dest.istio-system
+'
+[tcheck] InstanceBuilderFn() <= (SUCCESS)
+[tcheck] DispatchCheck => instance: '&Empty{}'
+[tcheck] DispatchCheck <= (PANIC)
+`,
+	},
+}
+
+func TestDispatcher(t *testing.T) {
+	o := log.NewOptions()
+	log.Configure(o)
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(tt *testing.T) {
+
+			dispatcher := New("ident", gp, true)
+
+			l := &data.Logger{}
+
+			templates := data.BuildTemplates(l, tst.templates...)
+			adapters := data.BuildAdapters(l, tst.adapters...)
+			config := data.JoinConfigs(tst.config...)
+
+			s := util.GetSnapshot(templates, adapters, data.ServiceConfig, config)
+			h := handler.NewTable(handler.Empty(), s, pool.NewGoroutinePool(1, false))
+
+			expb := compiled.NewBuilder(s.Attributes)
+			r := routing.BuildTable(h, s, expb, "istio-system", true)
+			_ = dispatcher.ChangeRoute(r)
+
+			// clear logger, as we are not interested in adapter/template logs during config step.
+			l.Clear()
+
+			attr := tst.attr
+			if attr == nil {
+				attr = map[string]interface{}{
+					"ident": "dest.istio-system",
+				}
+			}
+			bag := attribute.GetFakeMutableBagForTesting(attr)
+
+			responseAttrs := map[string]interface{}{}
+			if tst.responseAttrs != nil {
+				responseAttrs = tst.responseAttrs
+			}
+			responseBag := attribute.GetFakeMutableBagForTesting(responseAttrs)
+
+			var err error
+			switch tst.variety {
+			case tpb.TEMPLATE_VARIETY_CHECK:
+				cres, e := dispatcher.Check(context.TODO(), bag)
+				if e == nil {
+					if !reflect.DeepEqual(cres, tst.expectedCheckResult) {
+						tt.Fatalf("check result mismatch: '%v' != '%v'", cres, tst.expectedCheckResult)
+					}
+				} else {
+					err = e
+				}
+
+			case tpb.TEMPLATE_VARIETY_REPORT:
+				err = dispatcher.Report(context.TODO(), bag)
+
+			case tpb.TEMPLATE_VARIETY_QUOTA:
+				qma := tst.qma
+				if qma == nil {
+					qma = &runtime.QuotaMethodArgs{BestEffort: true}
+				}
+				qres, e := dispatcher.Quota(context.TODO(), bag, qma)
+				if e == nil {
+					if !reflect.DeepEqual(qres, tst.expectedQuotaResult) {
+						tt.Fatalf("quota result mismatch: '%v' != '%v'", qres, tst.expectedQuotaResult)
+					}
+				} else {
+					err = e
+				}
+
+			case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
+				err = dispatcher.Preprocess(context.TODO(), bag, responseBag)
+
+			default:
+				tt.Fatalf("Unknown variety type: %v", tst.variety)
+			}
+
+			if tst.err != "" {
+				if err == nil {
+					tt.Fatalf("expected error was not thrown")
+				} else if strings.TrimSpace(tst.err) != strings.TrimSpace(err.Error()) {
+					tt.Fatalf("error mismatch: '%v' != '%v'", err, tst.err)
+				}
+			} else {
+				if err != nil {
+					tt.Fatalf("unexpected error: '%v'", err)
+				}
+			}
+
+			if strings.TrimSpace(tst.log) != strings.TrimSpace(l.String()) {
+				tt.Fatalf("template/adapter log mismatch: '%v' != '%v'", l.String(), tst.log)
+			}
+		})
+	}
+}
+
+func TestRefCount(t *testing.T) {
+	d := New("ident", gp, true)
+	old := d.ChangeRoute(routing.Empty())
+	if old.GetRefs() != 0 {
+		t.Fatalf("%d != 0", old.GetRefs())
+	}
+	old.IncRef()
+	if old.GetRefs() != 1 {
+		t.Fatalf("%d != 1", old.GetRefs())
+	}
+	old.DecRef()
+	if old.GetRefs() != 0 {
+		t.Fatalf("%d != -", old.GetRefs())
+	}
+
+}

--- a/mixer/pkg/runtime2/dispatcher/dispatchstate.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatchstate.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"sync"
+
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/runtime2/routing"
+	"istio.io/istio/mixer/pkg/template"
+)
+
+// dispatchState keeps the input/output state during the dispatch to a handler. It is used as temporary
+// memory location to keep ephemeral state, thus avoiding garbage creation.
+type dispatchState struct {
+	session *session
+
+	destination *routing.Destination
+	mapper      template.OutputMapperFn
+
+	inputBag  attribute.Bag
+	quotaArgs adapter.QuotaArgs
+	instance  interface{}
+	instances []interface{}
+
+	// output state that was collected from the handler.
+	err         error
+	outputBag   *attribute.MutableBag
+	checkResult adapter.CheckResult
+	quotaResult adapter.QuotaResult
+}
+
+func (s *dispatchState) clear() {
+	s.session = nil
+	s.destination = nil
+	s.mapper = nil
+	s.inputBag = nil
+	s.quotaArgs = adapter.QuotaArgs{}
+	s.instance = nil
+	s.err = nil
+	s.outputBag = nil
+	s.checkResult = adapter.CheckResult{}
+	s.quotaResult = adapter.QuotaResult{}
+
+	if s.instances != nil {
+		// re-slice to change the length to 0 without changing capacity.
+		s.instances = s.instances[:0]
+	}
+}
+
+// pool of dispatchStates
+type dispatchStatePool struct {
+	pool sync.Pool
+}
+
+func newDispatchStatePool() *dispatchStatePool {
+	return &dispatchStatePool{
+		pool: sync.Pool{
+			New: func() interface{} {
+				return &dispatchState{}
+			},
+		},
+	}
+}
+
+func (p *dispatchStatePool) get(session *session, destination *routing.Destination) *dispatchState {
+	s := p.pool.Get().(*dispatchState)
+	s.session = session
+	s.destination = destination
+	return s
+}
+
+func (p *dispatchStatePool) put(s *dispatchState) {
+	s.clear()
+	p.pool.Put(s)
+}

--- a/mixer/pkg/runtime2/dispatcher/dispatchstate_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatchstate_test.go
@@ -1,0 +1,96 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/attribute"
+
+	"istio.io/istio/mixer/pkg/runtime2/routing"
+)
+
+func TestDispatchStatePool(t *testing.T) {
+	session := &session{}
+	dest := &routing.Destination{}
+
+	pool := newDispatchStatePool()
+
+	// Prime the pool
+	states := make([]*dispatchState, 100)
+	for i := 0; i < 100; i++ {
+		s := pool.get(nil, nil)
+		states[i] = s
+	}
+	for i := 0; i < 100; i++ {
+		pool.put(states[i])
+	}
+
+	// test cleaning
+	for i := 0; i < 100; i++ {
+		s := pool.get(session, dest)
+		s.instance = "instanc"
+		states[i] = s
+	}
+	for i := 0; i < 100; i++ {
+		pool.put(states[i])
+	}
+
+	expected := &dispatchState{}
+
+	for i := 0; i < 100; i++ {
+		s := pool.get(nil, nil)
+		if !reflect.DeepEqual(s, expected) {
+			t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
+		}
+	}
+}
+
+func TestDispatchState_Clear(t *testing.T) {
+	state := &dispatchState{
+		instance:    "instance",
+		session:     &session{},
+		quotaResult: adapter.QuotaResult{Amount: 64},
+		checkResult: adapter.CheckResult{ValidUseCount: 32},
+		err:         errors.New("err"),
+		destination: &routing.Destination{},
+		inputBag:    attribute.GetMutableBag(nil),
+		outputBag:   attribute.GetMutableBag(nil),
+		quotaArgs:   adapter.QuotaArgs{BestEffort: true},
+		mapper: func(attrs attribute.Bag) (*attribute.MutableBag, error) {
+			return nil, nil
+		},
+		instances: make([]interface{}, 10),
+	}
+
+	state.clear()
+
+	expected := &dispatchState{
+		instances: make([]interface{}, 0, 10),
+	}
+
+	if !reflect.DeepEqual(state, expected) {
+		t.Fail()
+	}
+	if cap(state.instances) != 10 {
+		t.Fail()
+	}
+	if len(state.instances) != 0 {
+		t.Fail()
+	}
+}

--- a/mixer/pkg/runtime2/dispatcher/monitoring.go
+++ b/mixer/pkg/runtime2/dispatcher/monitoring.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	buckets           = []float64{.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
+	countBuckets      = []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 15, 20}
+	requestLabelNames = []string{errorStr}
+
+	requestCountVector = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "mixer",
+		Subsystem: "dispatcher",
+		Name:      "request_count",
+		Help:      "Total number of requests that are handled by Mixer.",
+	}, requestLabelNames)
+	requestCount          = requestCountVector.WithLabelValues("false")
+	requestWithErrorCount = requestCountVector.WithLabelValues("true")
+
+	requestDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "mixer",
+			Subsystem: "dispatcher",
+			Name:      "request_duration",
+			Help:      "Histogram of times for requests handled by Mixer.",
+			Buckets:   buckets,
+		})
+
+	destinationsPerRequest = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "mixer",
+		Subsystem: "dispatcher",
+		Name:      "destinations_per_request",
+		Help:      "Histogram of destination handlers dispatched to per request, by Mixer.",
+		Buckets:   countBuckets,
+	})
+
+	instancesPerRequest = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "mixer",
+		Subsystem: "dispatcher",
+		Name:      "instances_per_request",
+		Help:      "Histogram of inputs dispatched per request, by Mixer.",
+		Buckets:   countBuckets,
+	})
+)
+
+func init() {
+	prometheus.MustRegister(requestCountVector)
+	prometheus.MustRegister(destinationsPerRequest)
+	prometheus.MustRegister(instancesPerRequest)
+	prometheus.MustRegister(requestDuration)
+}
+
+// updateRequestCounters updates request related counters. Duration is the total request handling duration. Destinations
+// is the number of destinations (i.a. handlers) that were dispatched to, during handling. Similarly, inputs is the
+// total number of instances that got created and sent to the adapter. Failure indicates whether at least one of the
+// dispatches had an error.
+func updateRequestCounters(duration time.Duration, destinations int, inputs int, failure bool) {
+	if failure {
+		requestWithErrorCount.Inc()
+	} else {
+		requestCount.Inc()
+	}
+
+	destinationsPerRequest.Observe(float64(destinations))
+	instancesPerRequest.Observe(float64(inputs))
+	requestDuration.Observe(duration.Seconds())
+}

--- a/mixer/pkg/runtime2/dispatcher/session.go
+++ b/mixer/pkg/runtime2/dispatcher/session.go
@@ -1,0 +1,127 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	tpb "istio.io/api/mixer/v1/template"
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/runtime"
+	"istio.io/istio/pkg/log"
+)
+
+const queueAllocSize = 64
+
+// session represents a call session to the Dispatcher. It contains all the mutable state needed for handling the
+// call. It is used as temporary memory location to keep ephemeral state, thus avoiding garbage creation.
+type session struct {
+
+	// The variety of the operation that is being performed.
+	variety tpb.TemplateVariety
+
+	// start time of the session.
+	start time.Time
+
+	// input parameters that was collected as part of the call.
+	ctx             context.Context
+	bag             attribute.Bag
+	quotaMethodArgs runtime.QuotaMethodArgs
+	responseBag     *attribute.MutableBag
+
+	// output parameters that gets collected / accumulated as result.
+	checkResult *adapter.CheckResult
+	quotaResult *adapter.QuotaResult
+	err         error
+
+	//  handler dispatching related parameters
+
+	// The current number of activeDispatches handler dispatches.
+	activeDispatches int
+
+	// channel for collecting states of completed dispatches.
+	completed chan *dispatchState
+
+	// whether to trace spans or not
+	trace bool
+}
+
+// pool of sessions
+type sessionPool struct {
+	sessions sync.Pool
+}
+
+func (s *session) ensureParallelism(minParallelism int) {
+	// Resize the channel to accommodate the parallelism, if necessary.
+	if cap(s.completed) < minParallelism {
+		allocSize := ((minParallelism / queueAllocSize) + 1) * queueAllocSize
+		s.completed = make(chan *dispatchState, allocSize)
+	}
+}
+
+func (s *session) clear() {
+	s.variety = 0
+	s.ctx = nil
+	s.bag = nil
+	s.quotaMethodArgs = runtime.QuotaMethodArgs{}
+	s.responseBag = nil
+
+	s.start = time.Time{}
+
+	s.activeDispatches = 0
+	s.err = nil
+	s.quotaResult = nil
+	s.checkResult = nil
+
+	// Drain the channel
+	exit := false
+	for !exit {
+		select {
+		case <-s.completed:
+			log.Warn("Leaked dispatch state discovered!")
+			continue
+		default:
+			exit = true
+		}
+	}
+}
+
+// returns a new pool of sessions that uses the provided go-routine pool to execute dispatches.
+func newSessionPool(enableTracing bool) *sessionPool {
+	return &sessionPool{
+		sessions: sync.Pool{
+			New: func() interface{} {
+				return &session{
+					trace: enableTracing,
+				}
+			},
+		},
+	}
+}
+
+// returns a session from the pool that can support the specified number of parallel executions.
+func (p *sessionPool) get() *session {
+	session := p.sessions.Get().(*session)
+
+	return session
+}
+
+func (p *sessionPool) put(session *session) {
+	session.clear()
+	p.sessions.Put(session)
+}

--- a/mixer/pkg/runtime2/dispatcher/session_test.go
+++ b/mixer/pkg/runtime2/dispatcher/session_test.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	tpb "istio.io/api/mixer/v1/template"
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/runtime"
+)
+
+func TestSessionPool(t *testing.T) {
+	expected := &session{}
+
+	pool := newSessionPool(false)
+
+	// Prime the pool
+	sessions := make([]*session, 100)
+	for i := 0; i < 100; i++ {
+		s := pool.get()
+		sessions[i] = s
+	}
+	for i := 0; i < 100; i++ {
+		pool.put(sessions[i])
+	}
+
+	// test cleaning
+	for i := 0; i < 100; i++ {
+		s := pool.get()
+		s.activeDispatches = 53 + i
+		sessions[i] = s
+	}
+	for i := 0; i < 100; i++ {
+		pool.put(sessions[i])
+	}
+
+	for i := 0; i < 100; i++ {
+		s := pool.get()
+		if !reflect.DeepEqual(s, expected) {
+			t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
+		}
+	}
+}
+
+func TestSessionPool_TracingStickiness(t *testing.T) {
+	pool := newSessionPool(true)
+
+	s := pool.get()
+
+	expected := &session{trace: true}
+	if !reflect.DeepEqual(s, expected) {
+		t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
+	}
+	if !s.trace {
+		t.Fail()
+	}
+}
+
+func TestSession_Clear(t *testing.T) {
+	s := &session{
+		trace:            true,
+		start:            time.Now(),
+		activeDispatches: 23,
+		bag:              attribute.GetMutableBag(nil),
+		completed:        make(chan *dispatchState, 10),
+		err:              errors.New("some error"),
+		ctx:              context.TODO(),
+		checkResult:      &adapter.CheckResult{ValidUseCount: 53},
+		quotaResult:      &adapter.QuotaResult{Amount: 23},
+		quotaMethodArgs:  runtime.QuotaMethodArgs{BestEffort: true},
+		variety:          tpb.TEMPLATE_VARIETY_CHECK,
+		responseBag:      attribute.GetMutableBag(nil),
+	}
+
+	s.clear()
+
+	// check s.completed separately, as reflect.DeepEqual doesn't deal with it well.
+	if s.completed == nil {
+		t.Fail()
+	}
+	s.completed = nil
+
+	expected := &session{
+		trace: true,
+	}
+
+	if !reflect.DeepEqual(s, expected) {
+		t.Fatalf("'%+v' != '%+v'", s, expected)
+	}
+}
+
+func TestSession_Clear_LeftOverWork(t *testing.T) {
+	s := &session{
+		completed: make(chan *dispatchState, 10),
+	}
+
+	s.completed <- &dispatchState{}
+	s.clear()
+
+	select {
+	case <-s.completed:
+		t.Fatal("Channel should have been drained")
+	default:
+	}
+}
+
+func TestSession_EnsureParallelism(t *testing.T) {
+	s := &session{
+		completed: make(chan *dispatchState, 10),
+	}
+
+	s.ensureParallelism(5)
+	if cap(s.completed) != 10 {
+		t.Fail()
+	}
+
+	s.ensureParallelism(11)
+	if cap(s.completed) < 11 {
+		t.Fail()
+	}
+}

--- a/mixer/pkg/runtime2/dispatcher/tracing.go
+++ b/mixer/pkg/runtime2/dispatcher/tracing.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+	tracelog "github.com/opentracing/opentracing-go/log"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/pkg/status"
+)
+
+const (
+	meshFunction = "meshFunction"
+	handlerName  = "handler"
+	adapterName  = "adapter"
+	responseCode = "response_code"
+	responseMsg  = "response_message"
+	errorStr     = "error"
+)
+
+// LogToDispatchSpan logs to the given Span in a structured manner. Span must be valid.
+func logToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, err error) {
+	st := status.OK
+	if err != nil {
+		st = status.WithError(err)
+	}
+
+	span.LogFields(
+		tracelog.String(meshFunction, template),
+		tracelog.String(handlerName, handler),
+		tracelog.String(adapterName, adapter),
+		tracelog.String(responseCode, rpc.Code_name[st.Code]),
+		tracelog.String(responseMsg, st.Message),
+		tracelog.Bool(errorStr, err != nil),
+	)
+}

--- a/mixer/pkg/runtime2/dispatcher/util.go
+++ b/mixer/pkg/runtime2/dispatcher/util.go
@@ -1,0 +1,68 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"fmt"
+
+	"istio.io/istio/mixer/pkg/attribute"
+)
+
+// getIdentityAttributeValue from the attribute bag, based on the id attribute.
+func getIdentityAttributeValue(attrs attribute.Bag, idAttribute string) (string, error) {
+
+	v, ok := attrs.Get(idAttribute)
+	if !ok {
+		return "", fmt.Errorf("identity parameter not found: '%s'", idAttribute)
+	}
+
+	var destination string
+	if destination, ok = v.(string); !ok {
+		return "", fmt.Errorf("identity parameter is not a string: '%s'", idAttribute)
+	}
+
+	return destination, nil
+}
+
+// getNamespace returns the namespace portion of a given fully qualified destination name. If the destination
+// namespace cannot be deduced, then empty string is returned.
+func getNamespace(destination string) string {
+	l := len(destination)
+
+	idx1 := -1
+	for i := 0; i < l; i++ {
+		if destination[i] == '.' {
+			idx1 = i
+			break
+		}
+	}
+	if idx1 == -1 {
+		return ""
+	}
+
+	idx2 := -1
+	for i := idx1 + 1; i < l; i++ {
+		if destination[i] == '.' {
+			idx2 = i
+			break
+		}
+	}
+
+	if idx2 == -1 {
+		idx2 = len(destination)
+	}
+
+	return destination[idx1+1 : idx2]
+}

--- a/mixer/pkg/runtime2/dispatcher/util_test.go
+++ b/mixer/pkg/runtime2/dispatcher/util_test.go
@@ -1,0 +1,78 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"strings"
+	"testing"
+
+	"istio.io/istio/mixer/pkg/attribute"
+)
+
+func TestGetIdentityAttributeValue(t *testing.T) {
+	bag := attribute.GetFakeMutableBagForTesting(map[string]interface{}{
+		"ident":     "value",
+		"nonstring": 23,
+	})
+
+	result, err := getIdentityAttributeValue(bag, "ident")
+	if err != nil {
+		t.Fail()
+	}
+	if result != "value" {
+		t.Fail()
+	}
+
+	_, err = getIdentityAttributeValue(bag, "nonstring")
+	if err == nil {
+		t.Fail()
+	}
+
+	_, err = getIdentityAttributeValue(bag, "nonexistent")
+	if err == nil {
+		t.Fail()
+	}
+}
+
+func TestGetNamespace(t *testing.T) {
+	tests := []struct {
+		dest string
+		ns   string
+	}{
+		{dest: "", ns: ""},
+		{dest: "foo", ns: ""},
+		{dest: "foo.bar", ns: "bar"},
+		{dest: "foo.bar.baz", ns: "bar"},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.dest, func(tt *testing.T) {
+			// Compare it to the original algorithm
+			actual := ""
+			splits := strings.SplitN(tst.dest, ".", 3) // we only care about service and namespace.
+			if len(splits) > 1 {
+				actual = splits[1]
+			}
+			if actual != tst.ns {
+				tt.Fatalf("'%s' != '%s' (Original)", actual, tst.ns)
+			}
+
+			actual = getNamespace(tst.dest)
+			if actual != tst.ns {
+				tt.Fatalf("'%s' != '%s'", actual, tst.ns)
+			}
+		})
+	}
+}

--- a/mixer/pkg/runtime2/testing/data/data.go
+++ b/mixer/pkg/runtime2/testing/data/data.go
@@ -95,6 +95,36 @@ metadata:
 spec:
 `
 
+// InstanceReport1 is a standard testing instance for template treport.
+var InstanceReport1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: treport
+metadata:
+  name: ireport1
+  namespace: istio-system
+spec:
+`
+
+// InstanceQuota1 is a standard testing instance for template tquota.
+var InstanceQuota1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: tquota
+metadata:
+  name: iquota1
+  namespace: istio-system
+spec:
+`
+
+// InstanceQuota2 is a copy of InstanceQuota1 with a different name.
+var InstanceQuota2 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: tquota
+metadata:
+  name: iquota2
+  namespace: istio-system
+spec:
+`
+
 // InstanceAPA1 is an APA instance
 var InstanceAPA1 = `
 apiVersion: "config.istio.io/v1alpha2"
@@ -137,6 +167,32 @@ metadata:
   namespace: ns2
 spec:
 `
+
+// HandlerAReport1 is a handler of type acheck with name hreport1.
+var HandlerAReport1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: areport
+metadata:
+  name: hreport1
+  namespace: istio-system
+spec:
+`
+
+// FqnAReport1 is the fully qualified name of HandlerAReport1.
+var FqnAReport1 = "hreport1.areport.istio-system"
+
+// HandlerAQuota1 is a handler of type aquota with name hquota1.
+var HandlerAQuota1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: aquota
+metadata:
+  name: hquota1
+  namespace: istio-system
+spec:
+`
+
+// FqnAQuota1 is the fully qualified name of HandlerAReport1.
+var FqnAQuota1 = "hquota1.aquota.istio-system"
 
 // HandlerAPA1 is an APA handler.
 var HandlerAPA1 = `
@@ -353,6 +409,48 @@ spec:
     instances:
     - icheck1.tcheck.istio-system
     - ihalt1.thalt.istio-system
+`
+
+// RuleReport1 is a standard testing instance config with name rreport1. It references I1 and H1.
+var RuleReport1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: rreport1
+  namespace: istio-system
+spec:
+  actions:
+  - handler: hreport1.areport
+    instances:
+    - ireport1.treport.istio-system
+`
+
+// RuleQuota1 is a standard testing instance config with name rquota1. It references I1 and H1.
+var RuleQuota1 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: rquota1
+  namespace: istio-system
+spec:
+  actions:
+  - handler: hquota1.aquota
+    instances:
+    - iquota1.tquota.istio-system
+`
+
+// RuleQuota2 references iquota1 and hquota1.
+var RuleQuota2 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: rquota2
+  namespace: istio-system
+spec:
+  actions:
+  - handler: hquota1.aquota
+    instances:
+    - iquota2.tquota.istio-system
 `
 
 // RuleApa1 is a rule that target APA.


### PR DESCRIPTION
Introducing runtime2/dispatcher.

This PR introduces an optimized runtime.Dispatcher implementation.
The new Dispatcher uses two sets of pooled objects to reduce garbage
generation during the dispatch. It also avoids creating closures and
other garbage generating constructs as much as possible.

NOTE1: I am not happy with the structure of the main-line dispatch function. I can possibly split an "aggregator method" for aggregating results at the end, at best. But this does not yield a very good refactoring. Feel free to comment on the structure. If you have opinions to better this, I'd like to hear it.

NOTE2: Please *do* look at tracing and monitoring code. Some of the counters have changed from the original. Mainly the error code based one (it was impossible to write this in a backward compat manner without generating considerable garbage) , and the config resolution time one (it is different type of call-path, comparable part should now be a constant).