### PR TITLE
lint fixes

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -16,11 +16,11 @@ package metric
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 
 	"istio.io/istio/mixer/pkg/adapter"
@@ -76,7 +76,7 @@ func (b *buffered) Send() {
 	merged := merge(toSend, b.l)
 	err := b.pushMetrics(context.Background(),
 		&monitoringpb.CreateTimeSeriesRequest{
-			Name:       monitoring.MetricProjectPath(b.project),
+			Name:       fmt.Sprintf("projects/%s", b.project),
 			TimeSeries: merged,
 		})
 

--- a/mixer/tools/adapterlinter/main.go
+++ b/mixer/tools/adapterlinter/main.go
@@ -82,9 +82,7 @@ func doDir(name string) reports {
 	}
 	rpts := make(reports, 0)
 	for _, pkg := range pkgs {
-		for _, r := range doPackage(fs, pkg) {
-			rpts = append(rpts, r)
-		}
+		rpts = append(rpts, doPackage(fs, pkg)...)
 	}
 	sort.Sort(rpts)
 	return rpts


### PR DESCRIPTION
The following lint errors appear on master:
```
mixer/adapter/stackdriver/metric/bufferedClient.go:79:16:error: monitoring.MetricProjectPath is deprecated: Use fmt.Sprintf("projects/%s", project) instead.  (SA1019) (megacheck)
mixer/tools/adapterlinter/main.go:85:3:error: should replace loop with rpts = append(rpts, doPackage(fs, pkg)...) (S1011) (megacheck)
```

- bufferedClient: seems cloud.google.com/go package is updated to 0.18.0, which deprecates MetricProjectPath function.
- adapterlinter: seems a trivial warning of megacheck