### PR TITLE
Allow custom docker hub to be specified for istioctl

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -46,11 +46,17 @@ elif [[ -n ${ISTIO_VERSION} ]]; then
   VERSION="${ISTIO_VERSION}"
 fi
 
+DOCKER_HUB="docker.io/istio"
+if [[ -n ${ISTIO_DOCKER_HUB} ]]; then
+  DOCKER_HUB="${ISTIO_DOCKER_HUB}"
+fi
+
 # used by pilot/istioctl/security version package
 echo buildAppVersion    "${VERSION}"
 echo buildGitRevision   "${BUILD_GIT_REVISION}"
 echo buildUser          "$(whoami)"
 echo buildHost          "$(hostname -f)"
+echo buildDockerHub     "${DOCKER_HUB}"
 
 # used by mixer/broker version package
 echo "buildVersion ${VERSION}"

--- a/pilot/cmd/istioctl/inject.go
+++ b/pilot/cmd/istioctl/inject.go
@@ -169,7 +169,7 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 func init() {
 	rootCmd.AddCommand(injectCmd)
 
-	injectCmd.PersistentFlags().StringVar(&hub, "hub", inject.DefaultHub, "Docker hub")
+	injectCmd.PersistentFlags().StringVar(&hub, "hub", version.Info.DockerHub, "Docker hub")
 	injectCmd.PersistentFlags().StringVar(&tag, "tag", version.Info.Version, "Docker tag")
 
 	injectCmd.PersistentFlags().StringVarP(&inFilename, "filename", "f",

--- a/pilot/platform/kube/inject/inject.go
+++ b/pilot/platform/kube/inject/inject.go
@@ -81,7 +81,6 @@ const (
 const (
 	DefaultSidecarProxyUID = int64(1337)
 	DefaultVerbosity       = 2
-	DefaultHub             = "docker.io/istio"
 	DefaultImagePullPolicy = "IfNotPresent"
 )
 
@@ -219,10 +218,10 @@ func GetInitializerConfig(kube kubernetes.Interface, namespace, injectConfigName
 		c.Policy = DefaultInjectionPolicy
 	}
 	if c.Params.InitImage == "" {
-		c.Params.InitImage = InitImageName(DefaultHub, version.Info.Version, c.Params.DebugMode)
+		c.Params.InitImage = InitImageName(version.Info.DockerHub, version.Info.Version, c.Params.DebugMode)
 	}
 	if c.Params.ProxyImage == "" {
-		c.Params.ProxyImage = ProxyImageName(DefaultHub, version.Info.Version, c.Params.DebugMode)
+		c.Params.ProxyImage = ProxyImageName(version.Info.DockerHub, version.Info.Version, c.Params.DebugMode)
 	}
 	if c.Params.SidecarProxyUID == 0 {
 		c.Params.SidecarProxyUID = DefaultSidecarProxyUID

--- a/pilot/platform/kube/inject/inject_test.go
+++ b/pilot/platform/kube/inject/inject_test.go
@@ -498,8 +498,8 @@ func TestGetInitializerConfig(t *testing.T) {
 				InitializerName:   DefaultInitializerName,
 				IncludeNamespaces: []string{v1.NamespaceAll},
 				Params: Params{
-					InitImage:       InitImageName(DefaultHub, version.Info.Version, false),
-					ProxyImage:      ProxyImageName(DefaultHub, version.Info.Version, false),
+					InitImage:       InitImageName(version.Info.DockerHub, version.Info.Version, false),
+					ProxyImage:      ProxyImageName(version.Info.DockerHub, version.Info.Version, false),
 					SidecarProxyUID: DefaultSidecarProxyUID,
 					ImagePullPolicy: DefaultImagePullPolicy,
 				},

--- a/pilot/tools/version/version.go
+++ b/pilot/tools/version/version.go
@@ -20,15 +20,14 @@ import (
 	"runtime"
 )
 
-// The following fields are populated at buildtime with bazel's linkstamp
-// feature. This is equivalent to using golang directly with -ldflags -X.
-// Note that DATE is omitted as bazel aims for reproducible builds and
-// seems to strip date information from the build process.
+// The following fields are populated at build time using -ldflags -X.
+// Note that DATE is omitted for reproducible builds
 var (
 	buildAppVersion  string
 	buildGitRevision string
 	buildUser        string
 	buildHost        string
+	buildDockerHub   string
 )
 
 // BuildInfo describes version information about the binary build.
@@ -38,6 +37,7 @@ type BuildInfo struct {
 	User          string `json:"user"`
 	Host          string `json:"host"`
 	GolangVersion string `json:"golang_version"`
+	DockerHub     string `json:"hub"`
 }
 
 var (
@@ -51,13 +51,15 @@ func init() {
 	Info.User = buildUser
 	Info.Host = buildHost
 	Info.GolangVersion = runtime.Version()
+	Info.DockerHub = buildDockerHub
 }
 
 // Line combines version information into a single line
 func Line() string {
-	return fmt.Sprintf("%v@%v-%v-%v",
+	return fmt.Sprintf("%v@%v-%v-%v-%v",
 		Info.User,
 		Info.Host,
+		Info.DockerHub,
 		Info.Version,
 		Info.GitRevision)
 }
@@ -67,10 +69,12 @@ func Version() string {
 	return fmt.Sprintf(`Version: %v
 GitRevision: %v
 User: %v@%v
+Hub: %v
 GolangVersion: %v
 `,
 		Info.Version,
 		Info.GitRevision,
 		Info.User, Info.Host,
+		Info.DockerHub,
 		Info.GolangVersion)
 }

--- a/release/cloud_build.template.json
+++ b/release/cloud_build.template.json
@@ -20,7 +20,7 @@
       ],
       "name": "gcr.io/istio-testing/istio-builder:0.4.5-bazel7-go19",
       "dir": "go/src/istio.io/istio",
-      "args": [ "./release/cloud_builder.sh", "-t", "$_VER_STRING", "-o", "/output" ]
+      "args": [ "./release/cloud_builder.sh", "-h", "$_GCR_PATH", "-t", "$_VER_STRING", "-o", "/output" ]
     },
     {
       "volumes": [

--- a/release/cloud_build.template.json
+++ b/release/cloud_build.template.json
@@ -20,7 +20,7 @@
       ],
       "name": "gcr.io/istio-testing/istio-builder:0.4.5-bazel7-go19",
       "dir": "go/src/istio.io/istio",
-      "args": [ "./release/cloud_builder.sh", "-h", "$_GCR_PATH", "-t", "$_VER_STRING", "-o", "/output" ]
+      "args": [ "./release/cloud_builder.sh", "-q", "$_GCR_PATH", "-t", "$_VER_STRING", "-o", "/output" ]
     },
     {
       "volumes": [

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -31,20 +31,24 @@ OUTPUT_PATH=""
 TAG_NAME="0.0.0"
 BUILD_DEBIAN="true"
 BUILD_DOCKER="true"
+REL_DOCKER_HUB=docker.io/istio
+TEST_DOCKER_HUB=""
 
 function usage() {
   echo "$0
     -b        opts out of building debian artifacts
     -c        opts out of building docker artifacts
     -o        path to store build artifacts
+    -h        hub to use for testing (optional)
     -t <tag>  tag to use (optional, defaults to ${TAG_NAME} )"
   exit 1
 }
 
-while getopts bco:t: arg ; do
+while getopts bch:o:t: arg ; do
   case "${arg}" in
     b) BUILD_DEBIAN="false";;
     c) BUILD_DOCKER="false";;
+    h) TEST_DOCKER_HUB="${OPTARG}";;
     o) OUTPUT_PATH="${OPTARG}";;
     t) TAG_NAME="${OPTARG}";;
     *) usage;;
@@ -75,7 +79,7 @@ VERBOSE=1 make depend
 if [ "${BUILD_DEBIAN}" == "true" ]; then
   # OUT="${OUTPUT_PATH}/deb" is ignored so we'll have to do the copy
   # and hope that the name of the file doesn't change.
-  VERBOSE=1 VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make sidecar.deb
+  VERBOSE=1 VERSION=$ISTIO_VERSION ISTIO_DOCKER_HUB=$REL_DOCKER_HUB TAG=$ISTIO_VERSION make sidecar.deb
   mkdir -p ${OUTPUT_PATH}/deb
   cp ${GOPATH}/out/istio-sidecar.deb ${OUTPUT_PATH}/deb
 fi
@@ -83,11 +87,15 @@ fi
 pushd pilot
 mkdir -p "${OUTPUT_PATH}/istioctl"
 # make istioctl just outputs to pilot/cmd/istioctl
-./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl"
+ISTIO_DOCKER_HUB=${REL_DOCKER_HUB}  ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl"
+if [[ -n "${TEST_DOCKER_HUB}" ]]; then
+   mkdir -p "${OUTPUT_PATH}/istioctl-test"
+   ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl-test"
+fi
 popd
 
 if [ "${BUILD_DOCKER}" == "true" ]; then
-  VERBOSE=1 VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make docker.save
+  VERBOSE=1 VERSION=$ISTIO_VERSION ISTIO_DOCKER_HUB=$REL_DOCKER_HUB TAG=$ISTIO_VERSION make docker.save
   cp -r ${GOPATH}/out/docker ${OUTPUT_PATH}
 fi
 

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -38,17 +38,19 @@ function usage() {
   echo "$0
     -b        opts out of building debian artifacts
     -c        opts out of building docker artifacts
+    -h        docker hub to use for testing (optional)
     -o        path to store build artifacts
-    -h        hub to use for testing (optional)
+    -q        path on gcr hub to use for testing (optional, alt to -h)
     -t <tag>  tag to use (optional, defaults to ${TAG_NAME} )"
   exit 1
 }
 
-while getopts bch:o:t: arg ; do
+while getopts bch:o:q:t: arg ; do
   case "${arg}" in
     b) BUILD_DEBIAN="false";;
     c) BUILD_DOCKER="false";;
     h) TEST_DOCKER_HUB="${OPTARG}";;
+    q) TEST_DOCKER_HUB="gcr.io/${OPTARG}";;
     o) OUTPUT_PATH="${OPTARG}";;
     t) TAG_NAME="${OPTARG}";;
     *) usage;;

--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -89,8 +89,8 @@ mkdir -p "${OUTPUT_PATH}/istioctl"
 # make istioctl just outputs to pilot/cmd/istioctl
 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB}  ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl"
 if [[ -n "${TEST_DOCKER_HUB}" ]]; then
-   mkdir -p "${OUTPUT_PATH}/istioctl-test"
-   ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl-test"
+   mkdir -p "${OUTPUT_PATH}/istioctl-stage"
+   ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} ./bin/upload-istioctl -r -o "${OUTPUT_PATH}/istioctl-stage"
 fi
 popd
 

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -26,6 +26,7 @@ set -x
 
 TEMP_DIR="$(mktemp -d /tmp/istio.version.XXXX)"
 BASE_DIR="$TEMP_DIR"
+ISTIOCTL_SUBDIR=istioctl
 OUTPUT_PATH=""
 VER_STRING=""
 
@@ -33,6 +34,7 @@ function usage() {
   echo "$0
     -d <path> path to use for temp directory                  (optional, randomized default is ${BASE_DIR} )
     -o <path> path where build output/artifacts are stored    (required)
+    -i <name> subdirectory in -o path to use for istioctl     (optional)
     -v <ver>  version info to include in filename (e.g., 1.0) (required)"
   exit 1
 }
@@ -46,6 +48,7 @@ function error_exit() {
 while getopts d:o:v: arg ; do
   case "${arg}" in
     d) BASE_DIR="${OPTARG}";;
+    i) ISTIOCTL_SUBDIR="${OPTARG}";;
     o) OUTPUT_PATH="${OPTARG}";;
     v) VER_STRING="${OPTARG}";;
     *) usage;;
@@ -73,7 +76,7 @@ fi
 function create_linux_archive() {
   local istioctl_path="${BIN_DIR}/istioctl"
 
-  ${CP} "${OUTPUT_PATH}/istioctl/istioctl-linux" "${istioctl_path}"
+  ${CP} "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}/istioctl-linux" "${istioctl_path}"
   chmod 755 "${istioctl_path}"
 
   ${TAR} --owner releng --group releng -czvf \
@@ -85,7 +88,7 @@ function create_linux_archive() {
 function create_osx_archive() {
   local istioctl_path="${BIN_DIR}/istioctl"
 
-  ${CP} "${OUTPUT_PATH}/istioctl/istioctl-osx" "${istioctl_path}"
+  ${CP} "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}/istioctl-osx" "${istioctl_path}"
   chmod 755 "${istioctl_path}"
 
   ${TAR} --owner releng --group releng -czvf \
@@ -97,7 +100,7 @@ function create_osx_archive() {
 function create_windows_archive() {
   local istioctl_path="${BIN_DIR}/istioctl.exe"
 
-  ${CP} "${OUTPUT_PATH}/istioctl/istioctl-win.exe" "${istioctl_path}"
+  ${CP} "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}/istioctl-win.exe" "${istioctl_path}"
   
   zip -r "${OUTPUT_PATH}/istio_${VER_STRING}_win.zip" "istio-${VER_STRING}" \
     || error_exit 'Could not create windows archive'

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -45,7 +45,7 @@ function error_exit() {
   exit ${2:-1}
 }
 
-while getopts d:o:v: arg ; do
+while getopts d:i:o:v: arg ; do
   case "${arg}" in
     d) BASE_DIR="${OPTARG}";;
     i) ISTIOCTL_SUBDIR="${OPTARG}";;

--- a/release/update_and_create_archives.sh
+++ b/release/update_and_create_archives.sh
@@ -58,13 +58,11 @@ done
 [[ -z "${OUTPUT_PATH}"  ]] && usage
 [[ -z "${VER_STRING}"   ]] && usage
 
-function copy_and_archive() {
+function run_update() {
   # can't seem to set/override PROXY_HUB, FORTIO_HUB ("docker.io/istio"), FORTIO_TAG ("0.3.1")
   ${ROOT}/install/updateVersion.sh -c "${DOCKER_HUB_TAG}" -A "${DEBIAN_URL}"   -x "${DOCKER_HUB_TAG}" \
                                    -p "${DOCKER_HUB_TAG}" -i "${ISTIOCTL_URL}" -P "${DEBIAN_URL}" \
                                    -r "${VER_STRING}" -E "${DEBIAN_URL}" -d "${OUTPUT_PATH}"
-  
-  ${ROOT}/release/create_release_archives.sh -v "${VER_STRING}" -o "${OUTPUT_PATH}"
   return 0
 }
 
@@ -85,7 +83,8 @@ if [[ -n "${GCR_TEST_PATH}" && -n "${GCS_TEST_PATH}" ]]; then
   COMMON_URL="https://storage.googleapis.com/${GCS_TEST_PATH}"
   ISTIOCTL_URL="${COMMON_URL}/istioctl"
   DEBIAN_URL="${COMMON_URL}/deb"
-  copy_and_archive
+  run_update
+  ${ROOT}/release/create_release_archives.sh -v "${VER_STRING}" -o "${OUTPUT_PATH}" -i "istioctl-test"
 
   # These files are only used for testing, so use a name to help make this clear
   for TAR_FILE in ${OUTPUT_PATH}/istio?${VER_STRING}*; do
@@ -101,4 +100,5 @@ DOCKER_HUB_TAG="docker.io/istio,${VER_STRING}"
 COMMON_URL="https://storage.googleapis.com/istio-release/releases/${VER_STRING}"
 ISTIOCTL_URL="${COMMON_URL}/istioctl"
 DEBIAN_URL="${COMMON_URL}/deb"
-copy_and_archive
+run_update
+${ROOT}/release/create_release_archives.sh -v "${VER_STRING}" -o "${OUTPUT_PATH}"

--- a/release/update_and_create_archives.sh
+++ b/release/update_and_create_archives.sh
@@ -81,10 +81,10 @@ if [[ -n "${GCR_TEST_PATH}" && -n "${GCS_TEST_PATH}" ]]; then
 
   DOCKER_HUB_TAG="gcr.io/${GCR_TEST_PATH},${VER_STRING}"
   COMMON_URL="https://storage.googleapis.com/${GCS_TEST_PATH}"
-  ISTIOCTL_URL="${COMMON_URL}/istioctl"
+  ISTIOCTL_URL="${COMMON_URL}/istioctl-stage"
   DEBIAN_URL="${COMMON_URL}/deb"
   run_update
-  ${ROOT}/release/create_release_archives.sh -v "${VER_STRING}" -o "${OUTPUT_PATH}" -i "istioctl-test"
+  ${ROOT}/release/create_release_archives.sh -v "${VER_STRING}" -o "${OUTPUT_PATH}" -i "istioctl-stage"
 
   # These files are only used for testing, so use a name to help make this clear
   for TAR_FILE in ${OUTPUT_PATH}/istio?${VER_STRING}*; do


### PR DESCRIPTION
This change is intended to address https://github.com/istio/istio/issues/2713
Currently istioctl hard-codes docker.io/istio and this impacts the ability to test a build w/o pushing it to docker hub.

This change allows the hub to be customized via bin/get_workspace_status.  The hub defaults to docker.io/istio but can be overriden by setting an ISTIO_DOCKER_HUB environment variable.  This isn't my 1st choice on approaches but is following the approach that's already used for the version/tag (which is also via bin/get_workspace_status and by setting the ISTIO_VERSION environment variable).

I'm not clear on what the json attribute of 'BuildInfo' is used for.

release/cloud_build.template.json will now pass a -q <GCR path> to release/cloud_builder.sh (the same -q parameter is also passed to other scripts).  When this parameter is passed a customized set of istioctl files will be placed in istioctl-stage/ .

release/update_and_create_archives.sh will now use the "istioctl-stage" subdir rather than the usual "istioctl" subdir when running updateVersion.sh for the test tar files.  The "istioctl-stage" path is also passed for the test files to create_release_archives.sh so the customized istioctl files are placed in the usual bin/ dir in the tars.

I tested by running a test build and confirming that the Linux tars (for regular vs testonly) have the appropriate GCS and docker paths reported in istio.VERSION and by running "istioctl version".

