### PR TITLE
Implement support for allowing fields to be empty in instance config.

### DIFF
--- a/mixer/adapter/list/baseline.txt
+++ b/mixer/adapter/list/baseline.txt
@@ -1,0 +1,4 @@
+abcd
+
+pqrs
+yyyy

--- a/mixer/adapter/list/list_e2e_test.go
+++ b/mixer/adapter/list/list_e2e_test.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	adapter2 "istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/adapter/test"
+	"istio.io/istio/mixer/template"
+	"os"
+	"testing"
+)
+
+var yml string = `
+{
+"configs": [
+  "../../testdata/config/listcheck.yaml",
+  "../../testdata/config/attributes.yaml"
+],
+"attributes": {
+  "destination.labels": {
+    "app": "ratings"
+  },
+  "source.labels": {
+    "version": "v1"
+  }
+},
+"baseline": "baseline.txt"
+}
+`
+
+func TestReport(t *testing.T) {
+	wd, _ := os.Getwd()
+	test.Test2(
+		t,
+		wd,
+		yml,
+		[]adapter2.InfoFn{GetInfo},
+		template.SupportedTmplInfo)
+}

--- a/mixer/adapter/list/list_e2e_test.go
+++ b/mixer/adapter/list/list_e2e_test.go
@@ -24,19 +24,19 @@ import (
 
 var yml string = `
 {
-"configs": [
-  "../../testdata/config/listcheck.yaml",
-  "../../testdata/config/attributes.yaml"
-],
-"attributes": {
-  "destination.labels": {
-    "app": "ratings"
+  "configs": [
+    "../../testdata/config/listcheck.yaml",
+    "../../testdata/config/attributes.yaml"
+  ],
+  "attributes": {
+    "destination.labels": {
+      "app": "ratings"
+    },
+    "source.labels": {
+      "version": "v1"
+    }
   },
-  "source.labels": {
-    "version": "v1"
-  }
-},
-"baseline": "baseline.txt"
+  "baseline": "baseline.txt"
 }
 `
 
@@ -45,7 +45,7 @@ func TestReport(t *testing.T) {
 	test.Test2(
 		t,
 		wd,
-		yml,
 		[]adapter2.InfoFn{GetInfo},
-		template.SupportedTmplInfo)
+		template.SupportedTmplInfo,
+		yml,)
 }

--- a/mixer/pkg/adapter/test/util.go
+++ b/mixer/pkg/adapter/test/util.go
@@ -58,46 +58,8 @@ func GetNewArgs(
 	return args, err
 }
 
-func Test(t *testing.T, wd string, attrs map[string]interface{}, baselineFile string, args *server.Args) {
-	dat, err := ioutil.ReadFile(baselineFile)
-	if err != nil {
-		panic(nil)
-	}
-	fmt.Println("err came back", err)
-	fmt.Print(string(dat))
 
-	env, err := server.New(args)
-	if err != nil {
-		t.Fatalf("fail to create mixer: %v", err)
-	}
-
-	env.Run()
-
-	defer closeHelper(env)
-
-	conn, err := grpc.Dial(env.Addr().String(), grpc.WithInsecure())
-	if err != nil {
-		t.Fatalf("Unable to connect to gRPC server: %v", err)
-	}
-
-	client := istio_mixer_v1.NewMixerClient(conn)
-	defer closeHelper(conn)
-
-	{
-
-		req := istio_mixer_v1.CheckRequest{
-			Attributes: getAttrBag(attrs,
-				args.ConfigIdentityAttribute,
-				args.ConfigIdentityAttributeDomain),
-		}
-
-
-		_, err = client.Check(context.Background(), &req)
-	}
-}
-
-
-func Test2(t *testing.T, wd string, yml string, fns []adapter.InfoFn, tmpls map[string]template.Info) {
+func Test2(t *testing.T, wd string, fns []adapter.InfoFn, tmpls map[string]template.Info, yml string) {
 	b := []byte(yml)
 	var m Setup
 	err := json.Unmarshal(b, &m)

--- a/mixer/pkg/adapter/test/util.go
+++ b/mixer/pkg/adapter/test/util.go
@@ -1,0 +1,186 @@
+package test
+
+import (
+	"io/ioutil"
+	"fmt"
+	"istio.io/api/mixer/v1"
+	"log"
+	"io"
+	"context"
+	"istio.io/istio/mixer/pkg/attribute"
+	"testing"
+	"istio.io/istio/mixer/pkg/server"
+	"google.golang.org/grpc"
+	"istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/mixer/pkg/template"
+	"istio.io/istio/mixer/pkg/adapter"
+	"github.com/ghodss/yaml"
+	"path"
+	"encoding/json"
+)
+
+type Setup struct {
+	// Baseline content
+	BaselinePath string `json:"baseline"`
+
+	ConfigsPaths []string `json:"configs,omitempty"`
+
+	Attributes map[string]interface{}  `json:"attributes,omitempty"`
+}
+
+// marshallSetup converts a setup object into YAML serialized form.
+func marshallSetup(setup *Setup) ([]byte, error) {
+	return yaml.Marshal(setup)
+}
+
+// unmarshallSetup reads a setup object from a YAML serialized form.
+func unmarshallSetup(bytes []byte, setup *Setup) error {
+	return yaml.Unmarshal(bytes, setup)
+}
+
+func GetNewArgs(
+	supportedTemplates map[string]template.Info,
+	adapters []adapter.InfoFn,
+	dataFilesFullPath ...string) (*server.Args, error) {
+	args := server.NewArgs()
+	args.Templates = supportedTemplates
+	args.Adapters = adapters
+	args.ConfigStoreURL = "memstore://tmp22"
+	data := make([]string, 0)
+	for _, f := range dataFilesFullPath {
+		if d, err := ioutil.ReadFile(f); err != nil {
+			return nil, err
+		} else {
+			data = append(data, string(d))
+		}
+	}
+	err := store.SetupMemstore(args.ConfigStoreURL,data...)
+	return args, err
+}
+
+func Test(t *testing.T, wd string, attrs map[string]interface{}, baselineFile string, args *server.Args) {
+	dat, err := ioutil.ReadFile(baselineFile)
+	if err != nil {
+		panic(nil)
+	}
+	fmt.Println("err came back", err)
+	fmt.Print(string(dat))
+
+	env, err := server.New(args)
+	if err != nil {
+		t.Fatalf("fail to create mixer: %v", err)
+	}
+
+	env.Run()
+
+	defer closeHelper(env)
+
+	conn, err := grpc.Dial(env.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Unable to connect to gRPC server: %v", err)
+	}
+
+	client := istio_mixer_v1.NewMixerClient(conn)
+	defer closeHelper(conn)
+
+	{
+
+		req := istio_mixer_v1.CheckRequest{
+			Attributes: getAttrBag(attrs,
+				args.ConfigIdentityAttribute,
+				args.ConfigIdentityAttributeDomain),
+		}
+
+
+		_, err = client.Check(context.Background(), &req)
+	}
+}
+
+
+func Test2(t *testing.T, wd string, yml string, fns []adapter.InfoFn, tmpls map[string]template.Info) {
+	b := []byte(yml)
+	var m Setup
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dat, err := ioutil.ReadFile(path.Join(wd, m.BaselinePath))
+	if err != nil {
+		panic(nil)
+	}
+	fmt.Println("err came back", err)
+	fmt.Print(string(dat))
+
+
+	fullCfgs := make([]string, 0)
+	for _, f := range m.ConfigsPaths {
+		fullCfgs = append(fullCfgs, path.Join(wd, f))
+	}
+
+	args, err := GetNewArgs(
+		tmpls,
+		fns,
+		fullCfgs...)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := server.New(args)
+	if err != nil {
+		t.Fatalf("fail to create mixer: %v", err)
+	}
+
+	env.Run()
+
+	defer closeHelper(env)
+
+	conn, err := grpc.Dial(env.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Unable to connect to gRPC server: %v", err)
+	}
+
+	client := istio_mixer_v1.NewMixerClient(conn)
+	defer closeHelper(conn)
+
+	{
+
+		req := istio_mixer_v1.CheckRequest{
+			Attributes: getAttrBag(m.Attributes,
+				args.ConfigIdentityAttribute,
+				args.ConfigIdentityAttributeDomain),
+		}
+
+
+		_, err = client.Check(context.Background(), &req)
+	}
+}
+
+func closeHelper(c io.Closer) {
+	err := c.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func getAttrBag(attrs map[string]interface{}, identityAttr, identityAttrDomain string) istio_mixer_v1.CompressedAttributes {
+	requestBag := attribute.GetMutableBag(nil)
+	requestBag.Set(identityAttr, identityAttrDomain)
+	for k, v := range attrs {
+		switch v.(type) {
+		case map[string]interface{}:
+			mapCast := make(map[string]string, len(v.(map[string]interface{})))
+
+			for k1, v1 := range v.(map[string]interface{}) {
+				mapCast[k1] = v1.(string)
+			}
+			requestBag.Set(k, mapCast)
+		default:
+			requestBag.Set(k, v)
+		}
+	}
+
+	var attrProto istio_mixer_v1.CompressedAttributes
+	requestBag.ToProto(&attrProto, nil, 0)
+	return attrProto
+}

--- a/mixer/template/sample/createinstance_test.go
+++ b/mixer/template/sample/createinstance_test.go
@@ -201,7 +201,7 @@ func TestCreateInstanceBuilder(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(actual, tst.expect) {
-				tt.Fatalf("Instance mismatch, got='%+v', want:'%+v'", actual, tst.expect)
+				tt.Fatalf("Instance mismatch,\ngot =%+v\nwant=%+v", actual, tst.expect)
 			}
 		})
 	}
@@ -676,6 +676,45 @@ func generateReportTests() []createInstanceTest {
 		attrs:    defaultReportAttributes,
 		param:    nil,
 		expect:   nil,
+	}
+	tests = append(tests, t)
+
+	emptyFieldsParam := sample_report.InstanceParam{
+		// missing all fields
+		Res1: &sample_report.Res1InstanceParam{
+		// missing all fields
+		},
+	}
+	t = createInstanceTest{
+		name:     "unspecified fields in param - valid",
+		template: sample_report.TemplateName,
+		attrs:    defaultReportAttributes,
+		param:    &emptyFieldsParam,
+		expect: &sample_report.Instance{
+			Name:            "instance1",
+			Value:           nil,
+			Dimensions:      map[string]interface{}{},
+			BoolPrimitive:   false,
+			DoublePrimitive: 0.0,
+			Int64Primitive:  0,
+			StringPrimitive: "",
+			Int64Map:        map[string]int64{},
+			TimeStamp:       time.Time{},
+			Duration:        time.Duration(0),
+			Res1: &sample_report.Res1{
+				Value:           nil,
+				Dimensions:      map[string]interface{}{},
+				BoolPrimitive:   false,
+				DoublePrimitive: 0.0,
+				Int64Primitive:  0,
+				StringPrimitive: "",
+				Int64Map:        map[string]int64{},
+				TimeStamp:       time.Time{},
+				Duration:        time.Duration(0),
+				Res2:            nil,
+				Res2Map:         map[string]*sample_report.Res2{},
+			},
+		},
 	}
 	tests = append(tests, t)
 

--- a/mixer/template/sample/template.gen.go
+++ b/mixer/template/sample/template.gen.go
@@ -146,94 +146,86 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.OptionalIP == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"OptionalIP")
-					}
-					if t, e := tEvalFn(param.OptionalIP); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OptionalIP", e)
+					if param.OptionalIP != "" {
+						if t, e := tEvalFn(param.OptionalIP); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OptionalIP", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OptionalIP", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OptionalIP", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.Email == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Email")
-					}
-					if t, e := tEvalFn(param.Email); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Email", e)
+					if param.Email != "" {
+						if t, e := tEvalFn(param.Email); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Email", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Email", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Email", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
 					return nil, err
@@ -249,14 +241,13 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
-					}
-					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+					if param.Str != "" {
+						if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return nil, err
@@ -272,14 +263,13 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
-					}
-					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+					if param.Str != "" {
+						if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return nil, err
@@ -295,74 +285,68 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					return nil, err
@@ -467,7 +451,13 @@ var (
 					var err error
 					_ = err
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -475,7 +465,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -483,7 +479,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -491,7 +493,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -507,7 +515,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -515,7 +529,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -536,7 +556,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					OptionalIP, err := mapper.Eval(param.OptionalIP, attrs)
+					var OptionalIPInterface interface{}
+					var OptionalIP net.IP
+					if param.OptionalIP != "" {
+						if OptionalIPInterface, err = mapper.Eval(param.OptionalIP, attrs); err == nil {
+							OptionalIP = net.IP(OptionalIPInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"OptionalIP", instName, err)
@@ -544,7 +570,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Email, err := mapper.Eval(param.Email, attrs)
+					var EmailInterface interface{}
+					var Email adapter.EmailAddress
+					if param.Email != "" {
+						if EmailInterface, err = mapper.Eval(param.Email, attrs); err == nil {
+							Email = adapter.EmailAddress(EmailInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Email", instName, err)
@@ -557,13 +589,13 @@ var (
 
 						Name: instName,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -575,15 +607,15 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res3Map: Res3Map,
 
-						OptionalIP: net.IP(OptionalIP.([]uint8)),
+						OptionalIP: OptionalIP,
 
-						Email: adapter.EmailAddress(Email.(string)),
+						Email: Email,
 					}, nil
 				}
 
@@ -596,7 +628,13 @@ var (
 					var err error
 					_ = err
 
-					Str, err := mapper.Eval(param.Str, attrs)
+					var StrInterface interface{}
+					var Str string
+					if param.Str != "" {
+						if StrInterface, err = mapper.Eval(param.Str, attrs); err == nil {
+							Str = StrInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Str", instName, err)
@@ -623,7 +661,7 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource1{
 
-						Str: Str.(string),
+						Str: Str,
 
 						SelfRefRes1: SelfRefRes1,
 
@@ -640,7 +678,13 @@ var (
 					var err error
 					_ = err
 
-					Str, err := mapper.Eval(param.Str, attrs)
+					var StrInterface interface{}
+					var Str string
+					if param.Str != "" {
+						if StrInterface, err = mapper.Eval(param.Str, attrs); err == nil {
+							Str = StrInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Str", instName, err)
@@ -672,7 +716,7 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource2{
 
-						Str: Str.(string),
+						Str: Str,
 
 						Res3: Res3,
 
@@ -689,7 +733,13 @@ var (
 					var err error
 					_ = err
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -697,7 +747,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -705,7 +761,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -713,7 +775,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -729,7 +797,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -737,7 +811,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -748,13 +828,13 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource3{
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -766,9 +846,9 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 					}, nil
 				}
 
@@ -1060,23 +1140,22 @@ var (
 
 					var err error = nil
 
-					if param.CheckExpression == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"CheckExpression")
-					}
-					if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"CheckExpression", e)
+					if param.CheckExpression != "" {
+						if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"CheckExpression", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"CheckExpression", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"CheckExpression", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.StringMap {
+					for k, v := range param.StringMap {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"StringMap", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "StringMap", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"StringMap", t, istio_mixer_v1_config_descriptor.STRING)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "StringMap", k), t, istio_mixer_v1_config_descriptor.STRING)
 						}
 					}
 
@@ -1103,9 +1182,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1115,78 +1193,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res2 != nil {
@@ -1202,7 +1274,7 @@ var (
 
 						if infrdType.Res2Map[k], err = BuildRes2(v, path+"Res2Map["+k+"]."); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Res2Map", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Res2Map", k), err)
 						}
 					}
 
@@ -1222,9 +1294,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1234,18 +1305,17 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
 					return infrdType, err
@@ -1296,7 +1366,13 @@ var (
 					var err error
 					_ = err
 
-					CheckExpression, err := mapper.Eval(param.CheckExpression, attrs)
+					var CheckExpressionInterface interface{}
+					var CheckExpression string
+					if param.CheckExpression != "" {
+						if CheckExpressionInterface, err = mapper.Eval(param.CheckExpression, attrs); err == nil {
+							CheckExpression = CheckExpressionInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"CheckExpression", instName, err)
@@ -1325,7 +1401,7 @@ var (
 
 						Name: instName,
 
-						CheckExpression: CheckExpression.(string),
+						CheckExpression: CheckExpression,
 
 						StringMap: func(m map[string]interface{}) map[string]string {
 							res := make(map[string]string, len(m))
@@ -1350,7 +1426,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1366,7 +1445,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1374,7 +1459,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -1382,7 +1473,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -1390,7 +1487,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -1406,7 +1509,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -1414,7 +1523,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -1450,13 +1565,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -1468,9 +1583,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res2: Res2,
 
@@ -1487,7 +1602,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1503,7 +1621,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1518,7 +1642,7 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 					}, nil
 				}
 
@@ -1630,17 +1754,17 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					for _, v := range param.BoolMap {
+					for k, v := range param.BoolMap {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"BoolMap", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "BoolMap", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolMap", t, istio_mixer_v1_config_descriptor.BOOL)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "BoolMap", k), t, istio_mixer_v1_config_descriptor.BOOL)
 						}
 					}
 
@@ -1667,9 +1791,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1679,78 +1802,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res2 != nil {
@@ -1766,7 +1883,7 @@ var (
 
 						if infrdType.Res2Map[k], err = BuildRes2(v, path+"Res2Map["+k+"]."); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Res2Map", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Res2Map", k), err)
 						}
 					}
 
@@ -1786,9 +1903,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1798,18 +1914,17 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
 					return infrdType, err
@@ -1914,7 +2029,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1930,7 +2048,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1938,7 +2062,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -1946,7 +2076,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -1954,7 +2090,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -1970,7 +2112,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -1978,7 +2126,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2014,13 +2168,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -2032,9 +2186,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res2: Res2,
 
@@ -2051,7 +2205,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2067,7 +2224,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2082,7 +2245,7 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 					}, nil
 				}
 
@@ -2188,9 +2351,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2200,78 +2362,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res1 != nil {
@@ -2297,9 +2453,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2309,78 +2464,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res2 != nil {
@@ -2396,7 +2545,7 @@ var (
 
 						if infrdType.Res2Map[k], err = BuildRes2(v, path+"Res2Map["+k+"]."); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Res2Map", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Res2Map", k), err)
 						}
 					}
 
@@ -2416,9 +2565,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2428,78 +2576,71 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
-					}
-					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+					if param.IpAddr != "" {
+						if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
-					}
-					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+					if param.DnsName != "" {
+						if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
-					}
-					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+					if param.EmailAddr != "" {
+						if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
-					}
-					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+					if param.Uri != "" {
+						if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 					}
 
 					return infrdType, err
@@ -2549,7 +2690,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2565,7 +2709,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2573,7 +2723,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -2581,7 +2737,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -2589,7 +2751,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -2605,7 +2773,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -2613,7 +2787,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2638,13 +2818,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -2656,9 +2836,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res1: Res1,
 					}, nil
@@ -2673,7 +2853,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2689,7 +2872,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2697,7 +2886,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -2705,7 +2900,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -2713,7 +2914,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -2729,7 +2936,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -2737,7 +2950,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2773,13 +2992,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -2791,9 +3010,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res2: Res2,
 
@@ -2810,7 +3029,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2826,7 +3048,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2834,7 +3062,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -2842,7 +3076,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2850,7 +3090,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					IpAddr, err := mapper.Eval(param.IpAddr, attrs)
+					var IpAddrInterface interface{}
+					var IpAddr net.IP
+					if param.IpAddr != "" {
+						if IpAddrInterface, err = mapper.Eval(param.IpAddr, attrs); err == nil {
+							IpAddr = net.IP(IpAddrInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"IpAddr", instName, err)
@@ -2858,7 +3104,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DnsName, err := mapper.Eval(param.DnsName, attrs)
+					var DnsNameInterface interface{}
+					var DnsName adapter.DNSName
+					if param.DnsName != "" {
+						if DnsNameInterface, err = mapper.Eval(param.DnsName, attrs); err == nil {
+							DnsName = adapter.DNSName(DnsNameInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DnsName", instName, err)
@@ -2866,7 +3118,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					EmailAddr, err := mapper.Eval(param.EmailAddr, attrs)
+					var EmailAddrInterface interface{}
+					var EmailAddr adapter.EmailAddress
+					if param.EmailAddr != "" {
+						if EmailAddrInterface, err = mapper.Eval(param.EmailAddr, attrs); err == nil {
+							EmailAddr = adapter.EmailAddress(EmailAddrInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EmailAddr", instName, err)
@@ -2874,7 +3132,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Uri, err := mapper.Eval(param.Uri, attrs)
+					var UriInterface interface{}
+					var Uri adapter.URI
+					if param.Uri != "" {
+						if UriInterface, err = mapper.Eval(param.Uri, attrs); err == nil {
+							Uri = adapter.URI(UriInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Uri", instName, err)
@@ -2889,19 +3153,19 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
-						IpAddr: net.IP(IpAddr.([]uint8)),
+						IpAddr: IpAddr,
 
-						DnsName: adapter.DNSName(DnsName.(string)),
+						DnsName: DnsName,
 
-						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
+						EmailAddr: EmailAddr,
 
-						Uri: adapter.URI(Uri.(string)),
+						Uri: Uri,
 					}, nil
 				}
 
@@ -3043,44 +3307,64 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -3098,14 +3382,24 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	b.bldRes3Map = make(map[string]*builder_istio_mixer_adapter_sample_myapa_Resource3, len(param.Res3Map))
@@ -3117,14 +3411,24 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 		b.bldRes3Map[k] = vb
 	}
 
-	b.bldOptionalIP, expType, err = expb.Compile(param.OptionalIP)
-	if err != nil {
-		return nil, template.NewErrorPath("OptionalIP", err)
+	if param.OptionalIP == "" {
+		b.bldOptionalIP = nil
+	} else {
+		b.bldOptionalIP, expType, err = expb.Compile(param.OptionalIP)
+		if err != nil {
+			return nil, template.NewErrorPath("OptionalIP", err)
+		}
+
 	}
 
-	b.bldEmail, expType, err = expb.Compile(param.Email)
-	if err != nil {
-		return nil, template.NewErrorPath("Email", err)
+	if param.Email == "" {
+		b.bldEmail = nil
+	} else {
+		b.bldEmail, expType, err = expb.Compile(param.Email)
+		if err != nil {
+			return nil, template.NewErrorPath("Email", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -3155,29 +3459,45 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Instance{}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -3191,17 +3511,25 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
-
-	r.Duration = vIface.(time.Duration)
 
 	r.Res3Map = make(map[string]*istio_mixer_adapter_sample_myapa.Resource3, len(b.bldRes3Map))
 	for k, v := range b.bldRes3Map {
@@ -3210,17 +3538,25 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 		}
 	}
 
-	if vIface, err = b.bldOptionalIP.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("OptionalIP", err)
+	if b.bldOptionalIP != nil {
+
+		if vIface, err = b.bldOptionalIP.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("OptionalIP", err)
+		}
+
+		r.OptionalIP = net.IP(vIface.([]uint8))
+
 	}
 
-	r.OptionalIP = net.IP(vIface.([]uint8))
+	if b.bldEmail != nil {
 
-	if vIface, err = b.bldEmail.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Email", err)
+		if vIface, err = b.bldEmail.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Email", err)
+		}
+
+		r.Email = adapter.EmailAddress(vIface.(string))
+
 	}
-
-	r.Email = adapter.EmailAddress(vIface.(string))
 
 	return r, template.ErrorPath{}
 }
@@ -3262,14 +3598,19 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldStr, expType, err = expb.Compile(param.Str)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
+	if param.Str == "" {
+		b.bldStr = nil
+	} else {
+		b.bldStr, expType, err = expb.Compile(param.Str)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
-		return nil, template.NewErrorPath("Str", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
+			return nil, template.NewErrorPath("Str", err)
+		}
+
 	}
 
 	if b.bldSelfRefRes1, errp = newBuilder_istio_mixer_adapter_sample_myapa_Resource1(expb, param.SelfRefRes1); !errp.IsNil() {
@@ -3308,18 +3649,30 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource1) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource1{}
 
-	vString, err = b.bldStr.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
-	r.Str = vString
+	if b.bldStr != nil {
 
-	if r.SelfRefRes1, errp = b.bldSelfRefRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("SelfRefRes1")
+		vString, err = b.bldStr.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
+		r.Str = vString
+
 	}
 
-	if r.ResRef2, errp = b.bldResRef2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("ResRef2")
+	if b.bldSelfRefRes1 != nil {
+
+		if r.SelfRefRes1, errp = b.bldSelfRefRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("SelfRefRes1")
+		}
+
+	}
+
+	if b.bldResRef2 != nil {
+
+		if r.ResRef2, errp = b.bldResRef2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("ResRef2")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -3362,14 +3715,19 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldStr, expType, err = expb.Compile(param.Str)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
+	if param.Str == "" {
+		b.bldStr = nil
+	} else {
+		b.bldStr, expType, err = expb.Compile(param.Str)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
-		return nil, template.NewErrorPath("Str", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
+			return nil, template.NewErrorPath("Str", err)
+		}
+
 	}
 
 	if b.bldRes3, errp = newBuilder_istio_mixer_adapter_sample_myapa_Resource3(expb, param.Res3); !errp.IsNil() {
@@ -3413,14 +3771,22 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource2) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource2{}
 
-	vString, err = b.bldStr.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
-	r.Str = vString
+	if b.bldStr != nil {
 
-	if r.Res3, errp = b.bldRes3.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res3")
+		vString, err = b.bldStr.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
+		r.Str = vString
+
+	}
+
+	if b.bldRes3 != nil {
+
+		if r.Res3, errp = b.bldRes3.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res3")
+		}
+
 	}
 
 	r.Res3Map = make(map[string]*istio_mixer_adapter_sample_myapa.Resource3, len(b.bldRes3Map))
@@ -3486,44 +3852,64 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource3(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -3541,14 +3927,24 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource3(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -3579,29 +3975,45 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource3) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource3{}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -3615,17 +4027,25 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource3) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
-
-	r.Duration = vIface.(time.Duration)
 
 	return r, template.ErrorPath{}
 }
@@ -3667,14 +4087,19 @@ func newBuilder_istio_mixer_adapter_sample_check_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldCheckExpression, expType, err = expb.Compile(param.CheckExpression)
-	if err != nil {
-		return nil, template.NewErrorPath("CheckExpression", err)
-	}
+	if param.CheckExpression == "" {
+		b.bldCheckExpression = nil
+	} else {
+		b.bldCheckExpression, expType, err = expb.Compile(param.CheckExpression)
+		if err != nil {
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.CheckExpression)
-		return nil, template.NewErrorPath("CheckExpression", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.CheckExpression)
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
+
 	}
 
 	b.bldStringMap = make(map[string]compiled.Expression, len(param.StringMap))
@@ -3724,11 +4149,15 @@ func (b *builder_istio_mixer_adapter_sample_check_Template) build(
 
 	r := &istio_mixer_adapter_sample_check.Instance{}
 
-	vString, err = b.bldCheckExpression.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("CheckExpression", err)
+	if b.bldCheckExpression != nil {
+
+		vString, err = b.bldCheckExpression.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
+		r.CheckExpression = vString
+
 	}
-	r.CheckExpression = vString
 
 	r.StringMap = make(map[string]string, len(b.bldStringMap))
 
@@ -3742,8 +4171,12 @@ func (b *builder_istio_mixer_adapter_sample_check_Template) build(
 
 	}
 
-	if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res1")
+	if b.bldRes1 != nil {
+
+		if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res1")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -3818,9 +4251,14 @@ func newBuilder_istio_mixer_adapter_sample_check_Res1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -3833,44 +4271,64 @@ func newBuilder_istio_mixer_adapter_sample_check_Res1(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -3888,14 +4346,24 @@ func newBuilder_istio_mixer_adapter_sample_check_Res1(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes2, errp = newBuilder_istio_mixer_adapter_sample_check_Res2(expb, param.Res2); !errp.IsNil() {
@@ -3939,11 +4407,15 @@ func (b *builder_istio_mixer_adapter_sample_check_Res1) build(
 
 	r := &istio_mixer_adapter_sample_check.Res1{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -3957,29 +4429,45 @@ func (b *builder_istio_mixer_adapter_sample_check_Res1) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -3993,20 +4481,32 @@ func (b *builder_istio_mixer_adapter_sample_check_Res1) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes2 != nil {
 
-	if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res2")
+		if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res2")
+		}
+
 	}
 
 	r.Res2Map = make(map[string]*istio_mixer_adapter_sample_check.Res2, len(b.bldRes2Map))
@@ -4056,9 +4556,14 @@ func newBuilder_istio_mixer_adapter_sample_check_Res2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4071,14 +4576,19 @@ func newBuilder_istio_mixer_adapter_sample_check_Res2(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -4109,11 +4619,15 @@ func (b *builder_istio_mixer_adapter_sample_check_Res2) build(
 
 	r := &istio_mixer_adapter_sample_check.Res2{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4127,11 +4641,15 @@ func (b *builder_istio_mixer_adapter_sample_check_Res2) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if b.bldInt64Primitive != nil {
+
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
+
 	}
-	r.Int64Primitive = vInt
 
 	return r, template.ErrorPath{}
 }
@@ -4254,8 +4772,12 @@ func (b *builder_istio_mixer_adapter_sample_quota_Template) build(
 
 	}
 
-	if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res1")
+	if b.bldRes1 != nil {
+
+		if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res1")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -4330,9 +4852,14 @@ func newBuilder_istio_mixer_adapter_sample_quota_Res1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4345,44 +4872,64 @@ func newBuilder_istio_mixer_adapter_sample_quota_Res1(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -4400,14 +4947,24 @@ func newBuilder_istio_mixer_adapter_sample_quota_Res1(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes2, errp = newBuilder_istio_mixer_adapter_sample_quota_Res2(expb, param.Res2); !errp.IsNil() {
@@ -4451,11 +5008,15 @@ func (b *builder_istio_mixer_adapter_sample_quota_Res1) build(
 
 	r := &istio_mixer_adapter_sample_quota.Res1{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4469,29 +5030,45 @@ func (b *builder_istio_mixer_adapter_sample_quota_Res1) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -4505,20 +5082,32 @@ func (b *builder_istio_mixer_adapter_sample_quota_Res1) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes2 != nil {
 
-	if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res2")
+		if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res2")
+		}
+
 	}
 
 	r.Res2Map = make(map[string]*istio_mixer_adapter_sample_quota.Res2, len(b.bldRes2Map))
@@ -4568,9 +5157,14 @@ func newBuilder_istio_mixer_adapter_sample_quota_Res2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4583,14 +5177,19 @@ func newBuilder_istio_mixer_adapter_sample_quota_Res2(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -4621,11 +5220,15 @@ func (b *builder_istio_mixer_adapter_sample_quota_Res2) build(
 
 	r := &istio_mixer_adapter_sample_quota.Res2{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4639,11 +5242,15 @@ func (b *builder_istio_mixer_adapter_sample_quota_Res2) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if b.bldInt64Primitive != nil {
+
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
+
 	}
-	r.Int64Primitive = vInt
 
 	return r, template.ErrorPath{}
 }
@@ -4713,9 +5320,14 @@ func newBuilder_istio_mixer_adapter_sample_report_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4728,44 +5340,64 @@ func newBuilder_istio_mixer_adapter_sample_report_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -4783,14 +5415,24 @@ func newBuilder_istio_mixer_adapter_sample_report_Template(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes1, errp = newBuilder_istio_mixer_adapter_sample_report_Res1(expb, param.Res1); !errp.IsNil() {
@@ -4825,11 +5467,15 @@ func (b *builder_istio_mixer_adapter_sample_report_Template) build(
 
 	r := &istio_mixer_adapter_sample_report.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4843,29 +5489,45 @@ func (b *builder_istio_mixer_adapter_sample_report_Template) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -4879,20 +5541,32 @@ func (b *builder_istio_mixer_adapter_sample_report_Template) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes1 != nil {
 
-	if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res1")
+		if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res1")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -4967,9 +5641,14 @@ func newBuilder_istio_mixer_adapter_sample_report_Res1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4982,44 +5661,64 @@ func newBuilder_istio_mixer_adapter_sample_report_Res1(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -5037,14 +5736,24 @@ func newBuilder_istio_mixer_adapter_sample_report_Res1(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes2, errp = newBuilder_istio_mixer_adapter_sample_report_Res2(expb, param.Res2); !errp.IsNil() {
@@ -5088,11 +5797,15 @@ func (b *builder_istio_mixer_adapter_sample_report_Res1) build(
 
 	r := &istio_mixer_adapter_sample_report.Res1{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5106,29 +5819,45 @@ func (b *builder_istio_mixer_adapter_sample_report_Res1) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -5142,20 +5871,32 @@ func (b *builder_istio_mixer_adapter_sample_report_Res1) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes2 != nil {
 
-	if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res2")
+		if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res2")
+		}
+
 	}
 
 	r.Res2Map = make(map[string]*istio_mixer_adapter_sample_report.Res2, len(b.bldRes2Map))
@@ -5229,9 +5970,14 @@ func newBuilder_istio_mixer_adapter_sample_report_Res2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -5244,44 +5990,79 @@ func newBuilder_istio_mixer_adapter_sample_report_Res2(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.IpAddr == "" {
+		b.bldIpAddr = nil
+	} else {
+		b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
 	}
 
-	b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+	if param.DnsName == "" {
+		b.bldDnsName = nil
+	} else {
+		b.bldDnsName, expType, err = expb.Compile(param.DnsName)
+		if err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
 	}
 
-	b.bldDnsName, expType, err = expb.Compile(param.DnsName)
-	if err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+	if param.EmailAddr == "" {
+		b.bldEmailAddr = nil
+	} else {
+		b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
 	}
 
-	b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
-	}
+	if param.Uri == "" {
+		b.bldUri = nil
+	} else {
+		b.bldUri, expType, err = expb.Compile(param.Uri)
+		if err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
 
-	b.bldUri, expType, err = expb.Compile(param.Uri)
-	if err != nil {
-		return nil, template.NewErrorPath("Uri", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -5312,11 +6093,15 @@ func (b *builder_istio_mixer_adapter_sample_report_Res2) build(
 
 	r := &istio_mixer_adapter_sample_report.Res2{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5330,47 +6115,75 @@ func (b *builder_istio_mixer_adapter_sample_report_Res2) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
-	}
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	r.TimeStamp = vIface.(time.Time)
-
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldTimeStamp != nil {
 
-	if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.IpAddr = net.IP(vIface.([]uint8))
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.DnsName = adapter.DNSName(vIface.(string))
+	if b.bldIpAddr != nil {
 
-	if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
+		if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
+		r.IpAddr = net.IP(vIface.([]uint8))
+
 	}
 
-	r.EmailAddr = adapter.EmailAddress(vIface.(string))
+	if b.bldDnsName != nil {
 
-	if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Uri", err)
+		if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
+		r.DnsName = adapter.DNSName(vIface.(string))
+
 	}
 
-	r.Uri = adapter.URI(vIface.(string))
+	if b.bldEmailAddr != nil {
+
+		if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
+		r.EmailAddr = adapter.EmailAddress(vIface.(string))
+
+	}
+
+	if b.bldUri != nil {
+
+		if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
+
+		r.Uri = adapter.URI(vIface.(string))
+
+	}
 
 	return r, template.ErrorPath{}
 }

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -303,6 +303,9 @@ type inferTypeTest struct {
 
 func getExprEvalFunc(err error) func(string) (pb.ValueType, error) {
 	return func(expr string) (pb.ValueType, error) {
+		if err != nil {
+			return pb.VALUE_TYPE_UNSPECIFIED, err
+		}
 		expr = strings.ToLower(expr)
 		retType := pb.VALUE_TYPE_UNSPECIFIED
 		if strings.HasSuffix(expr, "string") {
@@ -326,7 +329,7 @@ func getExprEvalFunc(err error) func(string) (pb.ValueType, error) {
 
 		if retType == pb.VALUE_TYPE_UNSPECIFIED {
 			tc := evaluator.NewTypeChecker()
-			retType, _ = tc.EvalType(expr, createAttributeDescriptorFinder(nil))
+			retType, err = tc.EvalType(expr, createAttributeDescriptorFinder(nil))
 		}
 		return retType, err
 	}
@@ -340,7 +343,6 @@ func TestInferTypeForSampleReport(t *testing.T) {
 value: source.int64
 int64Primitive: source.int64
 boolPrimitive: source.bool
-doublePrimitive: source.double
 stringPrimitive: source.string
 timeStamp: source.timestamp
 duration: source.duration
@@ -410,49 +412,59 @@ res1:
 			},
 		},
 		{
-			name: "MissingAField",
+			name: "MissingAFieldValid",
 			instYamlCfg: `
-value: source.int64
+# value: source.int64 # missing ValueType field
 # int64Primitive: source.int64 # missing int64Primitive
-boolPrimitive: source.bool
+# boolPrimitive: source.bool # missing int64Primitive
 doublePrimitive: source.double
 stringPrimitive: source.string
 timeStamp: source.timestamp
 duration: source.duration
-dimensions:
-  source: source.string
-  target: source.string
-`,
-			cstrParam:     &sample_report.InstanceParam{},
-			typeEvalError: nil,
-			wantErr:       "expression for field 'Int64Primitive' cannot be empty",
-			willPanic:     false,
-		},
-		{
-			name: "MissingAFieldSubMsg",
-			instYamlCfg: `
-value: source.int64
-int64Primitive: source.int64
-boolPrimitive: source.bool
-doublePrimitive: source.double
-stringPrimitive: source.string
-timeStamp: source.timestamp
-duration: source.duration
-dimensions:
-  source: source.string
-  target: source.string
+#dimensions: # missing int64Primitive
+#  source: source.string
+#  target: source.string
 res1:
-  value: source.int64
+  # value: source.int64 # missing ValueType field
   # int64Primitive: source.int64 # missing int64Primitive
   boolPrimitive: source.bool
-  doublePrimitive: source.double
-  stringPrimitive: source.string
-  timeStamp: source.timestamp
-  duration: source.duration
+  # doublePrimitive: source.double
+  # stringPrimitive: source.string
+  # timeStamp: source.timestamp
+  # duration: source.duration
 `,
 			cstrParam:     &sample_report.InstanceParam{},
 			typeEvalError: nil,
-			wantErr:       "expression for field 'Res1.Int64Primitive' cannot be empty",
+			wantErr:       "",
+			willPanic:     false,
+			wantType: &sample_report.Type{
+				Value:      pb.VALUE_TYPE_UNSPECIFIED,
+				Dimensions: map[string]pb.ValueType{},
+				Res1: &sample_report.Res1Type{
+					Value:      pb.VALUE_TYPE_UNSPECIFIED,
+					Dimensions: map[string]pb.ValueType{},
+					Res2:       nil,
+					Res2Map:    map[string]*sample_report.Res2Type{},
+				},
+			},
+		},
+		{
+			name: "NotValidMissingExpressionInMap",
+			instYamlCfg: `
+# value: source.int64 # missing ValueType field
+# int64Primitive: source.int64 # missing int64Primitive
+# boolPrimitive: source.bool # missing boolPrimitive
+doublePrimitive: source.double
+stringPrimitive: source.string
+timeStamp: source.timestamp
+duration: source.duration
+dimensions:
+# bad expression below.
+  source:
+`,
+			cstrParam:     &sample_report.InstanceParam{},
+			typeEvalError: nil,
+			wantErr:       "failed to evaluate expression for field 'Dimensions[source]'",
 			willPanic:     false,
 		},
 		{
@@ -1049,6 +1061,68 @@ func TestProcessReport(t *testing.T) {
 								Uri:            adapter.URI("myURI"),
 							},
 						},
+					},
+				},
+				{
+					Name:            "bar",
+					Value:           int64(2),
+					Dimensions:      map[string]interface{}{"k": int64(3)},
+					BoolPrimitive:   true,
+					DoublePrimitive: 1.2,
+					Int64Primitive:  54362,
+					StringPrimitive: "mystring",
+					Int64Map:        map[string]int64{"b": int64(1)},
+					TimeStamp:       time.Date(2017, time.January, 01, 0, 0, 0, 0, time.UTC),
+					Duration:        10 * time.Second,
+				},
+			},
+		},
+		{
+			name: " ValidMissingFieldsInConfig",
+			insts: map[string]proto.Message{
+				"foo": &sample_report.InstanceParam{
+					// missing all fields
+					Res1: &sample_report.Res1InstanceParam{
+					// missing all fields
+					},
+				},
+				"bar": &sample_report.InstanceParam{
+					Value:           "2",
+					Dimensions:      map[string]string{"k": "3"},
+					BoolPrimitive:   "true",
+					DoublePrimitive: "1.2",
+					Int64Primitive:  "54362",
+					StringPrimitive: `"mystring"`,
+					Int64Map:        map[string]string{"b": "1"},
+					TimeStamp:       "request.timestamp",
+					Duration:        "request.duration",
+				},
+			},
+			hdlr: &fakeReportHandler{},
+			wantInstance: []*sample_report.Instance{
+				{
+					Name:            "foo",
+					Value:           nil,
+					Dimensions:      map[string]interface{}{},
+					BoolPrimitive:   false,
+					DoublePrimitive: 0.0,
+					Int64Primitive:  0,
+					StringPrimitive: "",
+					Int64Map:        map[string]int64{},
+					TimeStamp:       time.Time{},
+					Duration:        time.Duration(0),
+					Res1: &sample_report.Res1{
+						Value:           nil,
+						Dimensions:      map[string]interface{}{},
+						BoolPrimitive:   false,
+						DoublePrimitive: 0.0,
+						Int64Primitive:  0,
+						StringPrimitive: "",
+						Int64Map:        map[string]int64{},
+						TimeStamp:       time.Time{},
+						Duration:        time.Duration(0),
+						Res2:            nil,
+						Res2Map:         map[string]*sample_report.Res2{},
 					},
 				},
 				{

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -145,64 +145,58 @@ var (
 
 					var err error = nil
 
-					if param.SourceUid == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SourceUid")
-					}
-					if t, e := tEvalFn(param.SourceUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SourceUid", e)
+					if param.SourceUid != "" {
+						if t, e := tEvalFn(param.SourceUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SourceUid", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SourceUid", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SourceUid", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.SourceIp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SourceIp")
-					}
-					if t, e := tEvalFn(param.SourceIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SourceIp", e)
+					if param.SourceIp != "" {
+						if t, e := tEvalFn(param.SourceIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SourceIp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SourceIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SourceIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DestinationUid == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DestinationUid")
-					}
-					if t, e := tEvalFn(param.DestinationUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DestinationUid", e)
+					if param.DestinationUid != "" {
+						if t, e := tEvalFn(param.DestinationUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DestinationUid", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DestinationUid", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DestinationUid", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.DestinationIp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DestinationIp")
-					}
-					if t, e := tEvalFn(param.DestinationIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DestinationIp", e)
+					if param.DestinationIp != "" {
+						if t, e := tEvalFn(param.DestinationIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DestinationIp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DestinationIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DestinationIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.OriginUid == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"OriginUid")
-					}
-					if t, e := tEvalFn(param.OriginUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OriginUid", e)
+					if param.OriginUid != "" {
+						if t, e := tEvalFn(param.OriginUid); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OriginUid", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OriginUid", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OriginUid", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.OriginIp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"OriginIp")
-					}
-					if t, e := tEvalFn(param.OriginIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OriginIp", e)
+					if param.OriginIp != "" {
+						if t, e := tEvalFn(param.OriginIp); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"OriginIp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OriginIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"OriginIp", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
 					return nil, err
@@ -340,7 +334,13 @@ var (
 					var err error
 					_ = err
 
-					SourceUid, err := mapper.Eval(param.SourceUid, attrs)
+					var SourceUidInterface interface{}
+					var SourceUid string
+					if param.SourceUid != "" {
+						if SourceUidInterface, err = mapper.Eval(param.SourceUid, attrs); err == nil {
+							SourceUid = SourceUidInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"SourceUid", instName, err)
@@ -348,7 +348,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					SourceIp, err := mapper.Eval(param.SourceIp, attrs)
+					var SourceIpInterface interface{}
+					var SourceIp net.IP
+					if param.SourceIp != "" {
+						if SourceIpInterface, err = mapper.Eval(param.SourceIp, attrs); err == nil {
+							SourceIp = net.IP(SourceIpInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"SourceIp", instName, err)
@@ -356,7 +362,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DestinationUid, err := mapper.Eval(param.DestinationUid, attrs)
+					var DestinationUidInterface interface{}
+					var DestinationUid string
+					if param.DestinationUid != "" {
+						if DestinationUidInterface, err = mapper.Eval(param.DestinationUid, attrs); err == nil {
+							DestinationUid = DestinationUidInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DestinationUid", instName, err)
@@ -364,7 +376,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DestinationIp, err := mapper.Eval(param.DestinationIp, attrs)
+					var DestinationIpInterface interface{}
+					var DestinationIp net.IP
+					if param.DestinationIp != "" {
+						if DestinationIpInterface, err = mapper.Eval(param.DestinationIp, attrs); err == nil {
+							DestinationIp = net.IP(DestinationIpInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DestinationIp", instName, err)
@@ -372,7 +390,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					OriginUid, err := mapper.Eval(param.OriginUid, attrs)
+					var OriginUidInterface interface{}
+					var OriginUid string
+					if param.OriginUid != "" {
+						if OriginUidInterface, err = mapper.Eval(param.OriginUid, attrs); err == nil {
+							OriginUid = OriginUidInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"OriginUid", instName, err)
@@ -380,7 +404,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					OriginIp, err := mapper.Eval(param.OriginIp, attrs)
+					var OriginIpInterface interface{}
+					var OriginIp net.IP
+					if param.OriginIp != "" {
+						if OriginIpInterface, err = mapper.Eval(param.OriginIp, attrs); err == nil {
+							OriginIp = net.IP(OriginIpInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"OriginIp", instName, err)
@@ -393,17 +423,17 @@ var (
 
 						Name: instName,
 
-						SourceUid: SourceUid.(string),
+						SourceUid: SourceUid,
 
-						SourceIp: net.IP(SourceIp.([]uint8)),
+						SourceIp: SourceIp,
 
-						DestinationUid: DestinationUid.(string),
+						DestinationUid: DestinationUid,
 
-						DestinationIp: net.IP(DestinationIp.([]uint8)),
+						DestinationIp: DestinationIp,
 
-						OriginUid: OriginUid.(string),
+						OriginUid: OriginUid,
 
-						OriginIp: net.IP(OriginIp.([]uint8)),
+						OriginIp: OriginIp,
 					}, nil
 				}
 
@@ -781,134 +811,121 @@ var (
 
 					var err error = nil
 
-					if param.ApiVersion == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiVersion")
-					}
-					if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiVersion", e)
+					if param.ApiVersion != "" {
+						if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiVersion", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiOperation == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiOperation")
-					}
-					if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiOperation", e)
+					if param.ApiOperation != "" {
+						if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiOperation", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiProtocol == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiProtocol")
-					}
-					if t, e := tEvalFn(param.ApiProtocol); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiProtocol", e)
+					if param.ApiProtocol != "" {
+						if t, e := tEvalFn(param.ApiProtocol); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiProtocol", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiProtocol", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiProtocol", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiService == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiService")
-					}
-					if t, e := tEvalFn(param.ApiService); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiService", e)
+					if param.ApiService != "" {
+						if t, e := tEvalFn(param.ApiService); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiService", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiService", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiService", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiKey == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiKey")
-					}
-					if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiKey", e)
+					if param.ApiKey != "" {
+						if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiKey", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestTime == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestTime")
-					}
-					if t, e := tEvalFn(param.RequestTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestTime", e)
+					if param.RequestTime != "" {
+						if t, e := tEvalFn(param.RequestTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestTime", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.RequestMethod == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestMethod")
-					}
-					if t, e := tEvalFn(param.RequestMethod); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestMethod", e)
+					if param.RequestMethod != "" {
+						if t, e := tEvalFn(param.RequestMethod); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestMethod", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestMethod", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestMethod", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestPath == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestPath")
-					}
-					if t, e := tEvalFn(param.RequestPath); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestPath", e)
+					if param.RequestPath != "" {
+						if t, e := tEvalFn(param.RequestPath); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestPath", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestPath", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestPath", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.RequestBytes == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"RequestBytes")
-					}
-					if t, e := tEvalFn(param.RequestBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestBytes", e)
+					if param.RequestBytes != "" {
+						if t, e := tEvalFn(param.RequestBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"RequestBytes", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestBytes", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"RequestBytes", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseTime == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseTime")
-					}
-					if t, e := tEvalFn(param.ResponseTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseTime", e)
+					if param.ResponseTime != "" {
+						if t, e := tEvalFn(param.ResponseTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseTime", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.ResponseCode == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseCode")
-					}
-					if t, e := tEvalFn(param.ResponseCode); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseCode", e)
+					if param.ResponseCode != "" {
+						if t, e := tEvalFn(param.ResponseCode); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseCode", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseCode", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseCode", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseBytes == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseBytes")
-					}
-					if t, e := tEvalFn(param.ResponseBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseBytes", e)
+					if param.ResponseBytes != "" {
+						if t, e := tEvalFn(param.ResponseBytes); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseBytes", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseBytes", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseBytes", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.ResponseLatency == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ResponseLatency")
-					}
-					if t, e := tEvalFn(param.ResponseLatency); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseLatency", e)
+					if param.ResponseLatency != "" {
+						if t, e := tEvalFn(param.ResponseLatency); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ResponseLatency", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseLatency", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ResponseLatency", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					return infrdType, err
@@ -948,7 +965,13 @@ var (
 					var err error
 					_ = err
 
-					ApiVersion, err := mapper.Eval(param.ApiVersion, attrs)
+					var ApiVersionInterface interface{}
+					var ApiVersion string
+					if param.ApiVersion != "" {
+						if ApiVersionInterface, err = mapper.Eval(param.ApiVersion, attrs); err == nil {
+							ApiVersion = ApiVersionInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiVersion", instName, err)
@@ -956,7 +979,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiOperation, err := mapper.Eval(param.ApiOperation, attrs)
+					var ApiOperationInterface interface{}
+					var ApiOperation string
+					if param.ApiOperation != "" {
+						if ApiOperationInterface, err = mapper.Eval(param.ApiOperation, attrs); err == nil {
+							ApiOperation = ApiOperationInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiOperation", instName, err)
@@ -964,7 +993,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiProtocol, err := mapper.Eval(param.ApiProtocol, attrs)
+					var ApiProtocolInterface interface{}
+					var ApiProtocol string
+					if param.ApiProtocol != "" {
+						if ApiProtocolInterface, err = mapper.Eval(param.ApiProtocol, attrs); err == nil {
+							ApiProtocol = ApiProtocolInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiProtocol", instName, err)
@@ -972,7 +1007,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiService, err := mapper.Eval(param.ApiService, attrs)
+					var ApiServiceInterface interface{}
+					var ApiService string
+					if param.ApiService != "" {
+						if ApiServiceInterface, err = mapper.Eval(param.ApiService, attrs); err == nil {
+							ApiService = ApiServiceInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiService", instName, err)
@@ -980,7 +1021,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiKey, err := mapper.Eval(param.ApiKey, attrs)
+					var ApiKeyInterface interface{}
+					var ApiKey string
+					if param.ApiKey != "" {
+						if ApiKeyInterface, err = mapper.Eval(param.ApiKey, attrs); err == nil {
+							ApiKey = ApiKeyInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiKey", instName, err)
@@ -988,7 +1035,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					RequestTime, err := mapper.Eval(param.RequestTime, attrs)
+					var RequestTimeInterface interface{}
+					var RequestTime time.Time
+					if param.RequestTime != "" {
+						if RequestTimeInterface, err = mapper.Eval(param.RequestTime, attrs); err == nil {
+							RequestTime = RequestTimeInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"RequestTime", instName, err)
@@ -996,7 +1049,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					RequestMethod, err := mapper.Eval(param.RequestMethod, attrs)
+					var RequestMethodInterface interface{}
+					var RequestMethod string
+					if param.RequestMethod != "" {
+						if RequestMethodInterface, err = mapper.Eval(param.RequestMethod, attrs); err == nil {
+							RequestMethod = RequestMethodInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"RequestMethod", instName, err)
@@ -1004,7 +1063,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					RequestPath, err := mapper.Eval(param.RequestPath, attrs)
+					var RequestPathInterface interface{}
+					var RequestPath string
+					if param.RequestPath != "" {
+						if RequestPathInterface, err = mapper.Eval(param.RequestPath, attrs); err == nil {
+							RequestPath = RequestPathInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"RequestPath", instName, err)
@@ -1012,7 +1077,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					RequestBytes, err := mapper.Eval(param.RequestBytes, attrs)
+					var RequestBytesInterface interface{}
+					var RequestBytes int64
+					if param.RequestBytes != "" {
+						if RequestBytesInterface, err = mapper.Eval(param.RequestBytes, attrs); err == nil {
+							RequestBytes = RequestBytesInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"RequestBytes", instName, err)
@@ -1020,7 +1091,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ResponseTime, err := mapper.Eval(param.ResponseTime, attrs)
+					var ResponseTimeInterface interface{}
+					var ResponseTime time.Time
+					if param.ResponseTime != "" {
+						if ResponseTimeInterface, err = mapper.Eval(param.ResponseTime, attrs); err == nil {
+							ResponseTime = ResponseTimeInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ResponseTime", instName, err)
@@ -1028,7 +1105,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ResponseCode, err := mapper.Eval(param.ResponseCode, attrs)
+					var ResponseCodeInterface interface{}
+					var ResponseCode int64
+					if param.ResponseCode != "" {
+						if ResponseCodeInterface, err = mapper.Eval(param.ResponseCode, attrs); err == nil {
+							ResponseCode = ResponseCodeInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ResponseCode", instName, err)
@@ -1036,7 +1119,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ResponseBytes, err := mapper.Eval(param.ResponseBytes, attrs)
+					var ResponseBytesInterface interface{}
+					var ResponseBytes int64
+					if param.ResponseBytes != "" {
+						if ResponseBytesInterface, err = mapper.Eval(param.ResponseBytes, attrs); err == nil {
+							ResponseBytes = ResponseBytesInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ResponseBytes", instName, err)
@@ -1044,7 +1133,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ResponseLatency, err := mapper.Eval(param.ResponseLatency, attrs)
+					var ResponseLatencyInterface interface{}
+					var ResponseLatency time.Duration
+					if param.ResponseLatency != "" {
+						if ResponseLatencyInterface, err = mapper.Eval(param.ResponseLatency, attrs); err == nil {
+							ResponseLatency = ResponseLatencyInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ResponseLatency", instName, err)
@@ -1057,31 +1152,31 @@ var (
 
 						Name: instName,
 
-						ApiVersion: ApiVersion.(string),
+						ApiVersion: ApiVersion,
 
-						ApiOperation: ApiOperation.(string),
+						ApiOperation: ApiOperation,
 
-						ApiProtocol: ApiProtocol.(string),
+						ApiProtocol: ApiProtocol,
 
-						ApiService: ApiService.(string),
+						ApiService: ApiService,
 
-						ApiKey: ApiKey.(string),
+						ApiKey: ApiKey,
 
-						RequestTime: RequestTime.(time.Time),
+						RequestTime: RequestTime,
 
-						RequestMethod: RequestMethod.(string),
+						RequestMethod: RequestMethod,
 
-						RequestPath: RequestPath.(string),
+						RequestPath: RequestPath,
 
-						RequestBytes: RequestBytes.(int64),
+						RequestBytes: RequestBytes,
 
-						ResponseTime: ResponseTime.(time.Time),
+						ResponseTime: ResponseTime,
 
-						ResponseCode: ResponseCode.(int64),
+						ResponseCode: ResponseCode,
 
-						ResponseBytes: ResponseBytes.(int64),
+						ResponseBytes: ResponseBytes,
 
-						ResponseLatency: ResponseLatency.(time.Duration),
+						ResponseLatency: ResponseLatency,
 					}, nil
 				}
 
@@ -1187,54 +1282,49 @@ var (
 
 					var err error = nil
 
-					if param.Api == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Api")
-					}
-					if t, e := tEvalFn(param.Api); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Api", e)
+					if param.Api != "" {
+						if t, e := tEvalFn(param.Api); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Api", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Api", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Api", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiVersion == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiVersion")
-					}
-					if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiVersion", e)
+					if param.ApiVersion != "" {
+						if t, e := tEvalFn(param.ApiVersion); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiVersion", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiVersion", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiOperation == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiOperation")
-					}
-					if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiOperation", e)
+					if param.ApiOperation != "" {
+						if t, e := tEvalFn(param.ApiOperation); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiOperation", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiOperation", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ApiKey == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ApiKey")
-					}
-					if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiKey", e)
+					if param.ApiKey != "" {
+						if t, e := tEvalFn(param.ApiKey); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ApiKey", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ApiKey", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Timestamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Timestamp")
-					}
-					if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Timestamp", e)
+					if param.Timestamp != "" {
+						if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Timestamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Timestamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Timestamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
 					return infrdType, err
@@ -1275,7 +1365,13 @@ var (
 					var err error
 					_ = err
 
-					Api, err := mapper.Eval(param.Api, attrs)
+					var ApiInterface interface{}
+					var Api string
+					if param.Api != "" {
+						if ApiInterface, err = mapper.Eval(param.Api, attrs); err == nil {
+							Api = ApiInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Api", instName, err)
@@ -1283,7 +1379,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiVersion, err := mapper.Eval(param.ApiVersion, attrs)
+					var ApiVersionInterface interface{}
+					var ApiVersion string
+					if param.ApiVersion != "" {
+						if ApiVersionInterface, err = mapper.Eval(param.ApiVersion, attrs); err == nil {
+							ApiVersion = ApiVersionInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiVersion", instName, err)
@@ -1291,7 +1393,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiOperation, err := mapper.Eval(param.ApiOperation, attrs)
+					var ApiOperationInterface interface{}
+					var ApiOperation string
+					if param.ApiOperation != "" {
+						if ApiOperationInterface, err = mapper.Eval(param.ApiOperation, attrs); err == nil {
+							ApiOperation = ApiOperationInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiOperation", instName, err)
@@ -1299,7 +1407,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ApiKey, err := mapper.Eval(param.ApiKey, attrs)
+					var ApiKeyInterface interface{}
+					var ApiKey string
+					if param.ApiKey != "" {
+						if ApiKeyInterface, err = mapper.Eval(param.ApiKey, attrs); err == nil {
+							ApiKey = ApiKeyInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ApiKey", instName, err)
@@ -1307,7 +1421,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Timestamp, err := mapper.Eval(param.Timestamp, attrs)
+					var TimestampInterface interface{}
+					var Timestamp time.Time
+					if param.Timestamp != "" {
+						if TimestampInterface, err = mapper.Eval(param.Timestamp, attrs); err == nil {
+							Timestamp = TimestampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Timestamp", instName, err)
@@ -1320,15 +1440,15 @@ var (
 
 						Name: instName,
 
-						Api: Api.(string),
+						Api: Api,
 
-						ApiVersion: ApiVersion.(string),
+						ApiVersion: ApiVersion,
 
-						ApiOperation: ApiOperation.(string),
+						ApiOperation: ApiOperation,
 
-						ApiKey: ApiKey.(string),
+						ApiKey: ApiKey,
 
-						Timestamp: Timestamp.(time.Time),
+						Timestamp: Timestamp,
 					}, nil
 				}
 
@@ -1463,24 +1583,22 @@ var (
 
 					var err error = nil
 
-					if param.User == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"User")
-					}
-					if t, e := tEvalFn(param.User); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"User", e)
+					if param.User != "" {
+						if t, e := tEvalFn(param.User); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"User", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"User", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"User", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Groups == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Groups")
-					}
-					if t, e := tEvalFn(param.Groups); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Groups", e)
+					if param.Groups != "" {
+						if t, e := tEvalFn(param.Groups); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Groups", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Groups", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Groups", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					infrdType.Properties = make(map[string]istio_mixer_v1_config_descriptor.ValueType, len(param.Properties))
@@ -1489,7 +1607,7 @@ var (
 
 						if infrdType.Properties[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Properties", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Properties", k), err)
 						}
 					}
 
@@ -1508,44 +1626,40 @@ var (
 
 					var err error = nil
 
-					if param.Namespace == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Namespace")
-					}
-					if t, e := tEvalFn(param.Namespace); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Namespace", e)
+					if param.Namespace != "" {
+						if t, e := tEvalFn(param.Namespace); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Namespace", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Namespace", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Namespace", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Service == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Service")
-					}
-					if t, e := tEvalFn(param.Service); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Service", e)
+					if param.Service != "" {
+						if t, e := tEvalFn(param.Service); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Service", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Service", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Service", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Method == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Method")
-					}
-					if t, e := tEvalFn(param.Method); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Method", e)
+					if param.Method != "" {
+						if t, e := tEvalFn(param.Method); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Method", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Method", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Method", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.Path == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Path")
-					}
-					if t, e := tEvalFn(param.Path); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Path", e)
+					if param.Path != "" {
+						if t, e := tEvalFn(param.Path); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Path", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Path", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Path", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					infrdType.Properties = make(map[string]istio_mixer_v1_config_descriptor.ValueType, len(param.Properties))
@@ -1554,7 +1668,7 @@ var (
 
 						if infrdType.Properties[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Properties", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Properties", k), err)
 						}
 					}
 
@@ -1642,7 +1756,13 @@ var (
 					var err error
 					_ = err
 
-					User, err := mapper.Eval(param.User, attrs)
+					var UserInterface interface{}
+					var User string
+					if param.User != "" {
+						if UserInterface, err = mapper.Eval(param.User, attrs); err == nil {
+							User = UserInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"User", instName, err)
@@ -1650,7 +1770,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Groups, err := mapper.Eval(param.Groups, attrs)
+					var GroupsInterface interface{}
+					var Groups string
+					if param.Groups != "" {
+						if GroupsInterface, err = mapper.Eval(param.Groups, attrs); err == nil {
+							Groups = GroupsInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Groups", instName, err)
@@ -1669,9 +1795,9 @@ var (
 					_ = param
 					return &authorization.Subject{
 
-						User: User.(string),
+						User: User,
 
-						Groups: Groups.(string),
+						Groups: Groups,
 
 						Properties: Properties,
 					}, nil
@@ -1686,7 +1812,13 @@ var (
 					var err error
 					_ = err
 
-					Namespace, err := mapper.Eval(param.Namespace, attrs)
+					var NamespaceInterface interface{}
+					var Namespace string
+					if param.Namespace != "" {
+						if NamespaceInterface, err = mapper.Eval(param.Namespace, attrs); err == nil {
+							Namespace = NamespaceInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Namespace", instName, err)
@@ -1694,7 +1826,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Service, err := mapper.Eval(param.Service, attrs)
+					var ServiceInterface interface{}
+					var Service string
+					if param.Service != "" {
+						if ServiceInterface, err = mapper.Eval(param.Service, attrs); err == nil {
+							Service = ServiceInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Service", instName, err)
@@ -1702,7 +1840,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Method, err := mapper.Eval(param.Method, attrs)
+					var MethodInterface interface{}
+					var Method string
+					if param.Method != "" {
+						if MethodInterface, err = mapper.Eval(param.Method, attrs); err == nil {
+							Method = MethodInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Method", instName, err)
@@ -1710,7 +1854,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Path, err := mapper.Eval(param.Path, attrs)
+					var PathInterface interface{}
+					var Path string
+					if param.Path != "" {
+						if PathInterface, err = mapper.Eval(param.Path, attrs); err == nil {
+							Path = PathInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Path", instName, err)
@@ -1729,13 +1879,13 @@ var (
 					_ = param
 					return &authorization.Action{
 
-						Namespace: Namespace.(string),
+						Namespace: Namespace,
 
-						Service: Service.(string),
+						Service: Service,
 
-						Method: Method.(string),
+						Method: Method,
 
-						Path: Path.(string),
+						Path: Path,
 
 						Properties: Properties,
 					}, nil
@@ -1970,14 +2120,13 @@ var (
 
 					var err error = nil
 
-					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if t, e := tEvalFn(param.Value); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Value", e)
+					if param.Value != "" {
+						if t, e := tEvalFn(param.Value); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Value", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Value", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Value", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return infrdType, err
@@ -2018,7 +2167,13 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var ValueInterface interface{}
+					var Value string
+					if param.Value != "" {
+						if ValueInterface, err = mapper.Eval(param.Value, attrs); err == nil {
+							Value = ValueInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2031,7 +2186,7 @@ var (
 
 						Name: instName,
 
-						Value: Value.(string),
+						Value: Value,
 					}, nil
 				}
 
@@ -2133,38 +2288,35 @@ var (
 
 						if infrdType.Variables[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Variables", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Variables", k), err)
 						}
 					}
 
-					if param.Timestamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Timestamp")
-					}
-					if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Timestamp", e)
+					if param.Timestamp != "" {
+						if t, e := tEvalFn(param.Timestamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Timestamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Timestamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Timestamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Severity == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Severity")
-					}
-					if t, e := tEvalFn(param.Severity); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Severity", e)
+					if param.Severity != "" {
+						if t, e := tEvalFn(param.Severity); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Severity", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Severity", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Severity", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.MonitoredResourceType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"MonitoredResourceType")
-					}
-					if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"MonitoredResourceType", e)
+					if param.MonitoredResourceType != "" {
+						if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"MonitoredResourceType", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"MonitoredResourceType", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"MonitoredResourceType", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					infrdType.MonitoredResourceDimensions = make(map[string]istio_mixer_v1_config_descriptor.ValueType, len(param.MonitoredResourceDimensions))
@@ -2173,7 +2325,7 @@ var (
 
 						if infrdType.MonitoredResourceDimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"MonitoredResourceDimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "MonitoredResourceDimensions", k), err)
 						}
 					}
 
@@ -2222,7 +2374,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Timestamp, err := mapper.Eval(param.Timestamp, attrs)
+					var TimestampInterface interface{}
+					var Timestamp time.Time
+					if param.Timestamp != "" {
+						if TimestampInterface, err = mapper.Eval(param.Timestamp, attrs); err == nil {
+							Timestamp = TimestampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Timestamp", instName, err)
@@ -2230,7 +2388,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Severity, err := mapper.Eval(param.Severity, attrs)
+					var SeverityInterface interface{}
+					var Severity string
+					if param.Severity != "" {
+						if SeverityInterface, err = mapper.Eval(param.Severity, attrs); err == nil {
+							Severity = SeverityInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Severity", instName, err)
@@ -2238,7 +2402,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					MonitoredResourceType, err := mapper.Eval(param.MonitoredResourceType, attrs)
+					var MonitoredResourceTypeInterface interface{}
+					var MonitoredResourceType string
+					if param.MonitoredResourceType != "" {
+						if MonitoredResourceTypeInterface, err = mapper.Eval(param.MonitoredResourceType, attrs); err == nil {
+							MonitoredResourceType = MonitoredResourceTypeInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"MonitoredResourceType", instName, err)
@@ -2261,11 +2431,11 @@ var (
 
 						Variables: Variables,
 
-						Timestamp: Timestamp.(time.Time),
+						Timestamp: Timestamp,
 
-						Severity: Severity.(string),
+						Severity: Severity,
 
-						MonitoredResourceType: MonitoredResourceType.(string),
+						MonitoredResourceType: MonitoredResourceType,
 
 						MonitoredResourceDimensions: MonitoredResourceDimensions,
 					}, nil
@@ -2374,9 +2544,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2386,18 +2555,17 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.MonitoredResourceType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"MonitoredResourceType")
-					}
-					if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"MonitoredResourceType", e)
+					if param.MonitoredResourceType != "" {
+						if t, e := tEvalFn(param.MonitoredResourceType); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"MonitoredResourceType", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"MonitoredResourceType", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"MonitoredResourceType", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					infrdType.MonitoredResourceDimensions = make(map[string]istio_mixer_v1_config_descriptor.ValueType, len(param.MonitoredResourceDimensions))
@@ -2406,7 +2574,7 @@ var (
 
 						if infrdType.MonitoredResourceDimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"MonitoredResourceDimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "MonitoredResourceDimensions", k), err)
 						}
 					}
 
@@ -2447,7 +2615,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2463,7 +2634,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					MonitoredResourceType, err := mapper.Eval(param.MonitoredResourceType, attrs)
+					var MonitoredResourceTypeInterface interface{}
+					var MonitoredResourceType string
+					if param.MonitoredResourceType != "" {
+						if MonitoredResourceTypeInterface, err = mapper.Eval(param.MonitoredResourceType, attrs); err == nil {
+							MonitoredResourceType = MonitoredResourceTypeInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"MonitoredResourceType", instName, err)
@@ -2488,7 +2665,7 @@ var (
 
 						Dimensions: Dimensions,
 
-						MonitoredResourceType: MonitoredResourceType.(string),
+						MonitoredResourceType: MonitoredResourceType,
 
 						MonitoredResourceDimensions: MonitoredResourceDimensions,
 					}, nil
@@ -2602,7 +2779,7 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
@@ -2898,64 +3075,58 @@ var (
 
 					var err error = nil
 
-					if param.TraceId == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TraceId")
-					}
-					if t, e := tEvalFn(param.TraceId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TraceId", e)
+					if param.TraceId != "" {
+						if t, e := tEvalFn(param.TraceId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TraceId", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TraceId", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TraceId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.SpanId == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SpanId")
-					}
-					if t, e := tEvalFn(param.SpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SpanId", e)
+					if param.SpanId != "" {
+						if t, e := tEvalFn(param.SpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SpanId", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanId", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.ParentSpanId == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"ParentSpanId")
-					}
-					if t, e := tEvalFn(param.ParentSpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ParentSpanId", e)
+					if param.ParentSpanId != "" {
+						if t, e := tEvalFn(param.ParentSpanId); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"ParentSpanId", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ParentSpanId", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"ParentSpanId", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.SpanName == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"SpanName")
-					}
-					if t, e := tEvalFn(param.SpanName); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SpanName", e)
+					if param.SpanName != "" {
+						if t, e := tEvalFn(param.SpanName); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"SpanName", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanName", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"SpanName", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					if param.StartTime == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StartTime")
-					}
-					if t, e := tEvalFn(param.StartTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StartTime", e)
+					if param.StartTime != "" {
+						if t, e := tEvalFn(param.StartTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StartTime", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StartTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StartTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.EndTime == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EndTime")
-					}
-					if t, e := tEvalFn(param.EndTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EndTime", e)
+					if param.EndTime != "" {
+						if t, e := tEvalFn(param.EndTime); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EndTime", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EndTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EndTime", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
 					infrdType.SpanTags = make(map[string]istio_mixer_v1_config_descriptor.ValueType, len(param.SpanTags))
@@ -2964,7 +3135,7 @@ var (
 
 						if infrdType.SpanTags[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"SpanTags", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "SpanTags", k), err)
 						}
 					}
 
@@ -3005,7 +3176,13 @@ var (
 					var err error
 					_ = err
 
-					TraceId, err := mapper.Eval(param.TraceId, attrs)
+					var TraceIdInterface interface{}
+					var TraceId string
+					if param.TraceId != "" {
+						if TraceIdInterface, err = mapper.Eval(param.TraceId, attrs); err == nil {
+							TraceId = TraceIdInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TraceId", instName, err)
@@ -3013,7 +3190,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					SpanId, err := mapper.Eval(param.SpanId, attrs)
+					var SpanIdInterface interface{}
+					var SpanId string
+					if param.SpanId != "" {
+						if SpanIdInterface, err = mapper.Eval(param.SpanId, attrs); err == nil {
+							SpanId = SpanIdInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"SpanId", instName, err)
@@ -3021,7 +3204,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					ParentSpanId, err := mapper.Eval(param.ParentSpanId, attrs)
+					var ParentSpanIdInterface interface{}
+					var ParentSpanId string
+					if param.ParentSpanId != "" {
+						if ParentSpanIdInterface, err = mapper.Eval(param.ParentSpanId, attrs); err == nil {
+							ParentSpanId = ParentSpanIdInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"ParentSpanId", instName, err)
@@ -3029,7 +3218,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					SpanName, err := mapper.Eval(param.SpanName, attrs)
+					var SpanNameInterface interface{}
+					var SpanName string
+					if param.SpanName != "" {
+						if SpanNameInterface, err = mapper.Eval(param.SpanName, attrs); err == nil {
+							SpanName = SpanNameInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"SpanName", instName, err)
@@ -3037,7 +3232,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StartTime, err := mapper.Eval(param.StartTime, attrs)
+					var StartTimeInterface interface{}
+					var StartTime time.Time
+					if param.StartTime != "" {
+						if StartTimeInterface, err = mapper.Eval(param.StartTime, attrs); err == nil {
+							StartTime = StartTimeInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StartTime", instName, err)
@@ -3045,7 +3246,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					EndTime, err := mapper.Eval(param.EndTime, attrs)
+					var EndTimeInterface interface{}
+					var EndTime time.Time
+					if param.EndTime != "" {
+						if EndTimeInterface, err = mapper.Eval(param.EndTime, attrs); err == nil {
+							EndTime = EndTimeInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EndTime", instName, err)
@@ -3066,17 +3273,17 @@ var (
 
 						Name: instName,
 
-						TraceId: TraceId.(string),
+						TraceId: TraceId,
 
-						SpanId: SpanId.(string),
+						SpanId: SpanId,
 
-						ParentSpanId: ParentSpanId.(string),
+						ParentSpanId: ParentSpanId,
 
-						SpanName: SpanName.(string),
+						SpanName: SpanName,
 
-						StartTime: StartTime.(time.Time),
+						StartTime: StartTime,
 
-						EndTime: EndTime.(time.Time),
+						EndTime: EndTime,
 
 						SpanTags: SpanTags,
 					}, nil
@@ -3204,49 +3411,79 @@ func newBuilder_adapter_template_kubernetes_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldSourceUid, expType, err = expb.Compile(param.SourceUid)
-	if err != nil {
-		return nil, template.NewErrorPath("SourceUid", err)
+	if param.SourceUid == "" {
+		b.bldSourceUid = nil
+	} else {
+		b.bldSourceUid, expType, err = expb.Compile(param.SourceUid)
+		if err != nil {
+			return nil, template.NewErrorPath("SourceUid", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SourceUid)
+			return nil, template.NewErrorPath("SourceUid", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SourceUid)
-		return nil, template.NewErrorPath("SourceUid", err)
+	if param.SourceIp == "" {
+		b.bldSourceIp = nil
+	} else {
+		b.bldSourceIp, expType, err = expb.Compile(param.SourceIp)
+		if err != nil {
+			return nil, template.NewErrorPath("SourceIp", err)
+		}
+
 	}
 
-	b.bldSourceIp, expType, err = expb.Compile(param.SourceIp)
-	if err != nil {
-		return nil, template.NewErrorPath("SourceIp", err)
+	if param.DestinationUid == "" {
+		b.bldDestinationUid = nil
+	} else {
+		b.bldDestinationUid, expType, err = expb.Compile(param.DestinationUid)
+		if err != nil {
+			return nil, template.NewErrorPath("DestinationUid", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.DestinationUid)
+			return nil, template.NewErrorPath("DestinationUid", err)
+		}
+
 	}
 
-	b.bldDestinationUid, expType, err = expb.Compile(param.DestinationUid)
-	if err != nil {
-		return nil, template.NewErrorPath("DestinationUid", err)
+	if param.DestinationIp == "" {
+		b.bldDestinationIp = nil
+	} else {
+		b.bldDestinationIp, expType, err = expb.Compile(param.DestinationIp)
+		if err != nil {
+			return nil, template.NewErrorPath("DestinationIp", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.DestinationUid)
-		return nil, template.NewErrorPath("DestinationUid", err)
+	if param.OriginUid == "" {
+		b.bldOriginUid = nil
+	} else {
+		b.bldOriginUid, expType, err = expb.Compile(param.OriginUid)
+		if err != nil {
+			return nil, template.NewErrorPath("OriginUid", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.OriginUid)
+			return nil, template.NewErrorPath("OriginUid", err)
+		}
+
 	}
 
-	b.bldDestinationIp, expType, err = expb.Compile(param.DestinationIp)
-	if err != nil {
-		return nil, template.NewErrorPath("DestinationIp", err)
-	}
+	if param.OriginIp == "" {
+		b.bldOriginIp = nil
+	} else {
+		b.bldOriginIp, expType, err = expb.Compile(param.OriginIp)
+		if err != nil {
+			return nil, template.NewErrorPath("OriginIp", err)
+		}
 
-	b.bldOriginUid, expType, err = expb.Compile(param.OriginUid)
-	if err != nil {
-		return nil, template.NewErrorPath("OriginUid", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.OriginUid)
-		return nil, template.NewErrorPath("OriginUid", err)
-	}
-
-	b.bldOriginIp, expType, err = expb.Compile(param.OriginIp)
-	if err != nil {
-		return nil, template.NewErrorPath("OriginIp", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -3277,41 +3514,65 @@ func (b *builder_adapter_template_kubernetes_Template) build(
 
 	r := &adapter_template_kubernetes.Instance{}
 
-	vString, err = b.bldSourceUid.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("SourceUid", err)
-	}
-	r.SourceUid = vString
+	if b.bldSourceUid != nil {
 
-	if vIface, err = b.bldSourceIp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("SourceIp", err)
-	}
+		vString, err = b.bldSourceUid.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("SourceUid", err)
+		}
+		r.SourceUid = vString
 
-	r.SourceIp = net.IP(vIface.([]uint8))
-
-	vString, err = b.bldDestinationUid.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DestinationUid", err)
-	}
-	r.DestinationUid = vString
-
-	if vIface, err = b.bldDestinationIp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("DestinationIp", err)
 	}
 
-	r.DestinationIp = net.IP(vIface.([]uint8))
+	if b.bldSourceIp != nil {
 
-	vString, err = b.bldOriginUid.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("OriginUid", err)
-	}
-	r.OriginUid = vString
+		if vIface, err = b.bldSourceIp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("SourceIp", err)
+		}
 
-	if vIface, err = b.bldOriginIp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("OriginIp", err)
+		r.SourceIp = net.IP(vIface.([]uint8))
+
 	}
 
-	r.OriginIp = net.IP(vIface.([]uint8))
+	if b.bldDestinationUid != nil {
+
+		vString, err = b.bldDestinationUid.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DestinationUid", err)
+		}
+		r.DestinationUid = vString
+
+	}
+
+	if b.bldDestinationIp != nil {
+
+		if vIface, err = b.bldDestinationIp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("DestinationIp", err)
+		}
+
+		r.DestinationIp = net.IP(vIface.([]uint8))
+
+	}
+
+	if b.bldOriginUid != nil {
+
+		vString, err = b.bldOriginUid.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("OriginUid", err)
+		}
+		r.OriginUid = vString
+
+	}
+
+	if b.bldOriginIp != nil {
+
+		if vIface, err = b.bldOriginIp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("OriginIp", err)
+		}
+
+		r.OriginIp = net.IP(vIface.([]uint8))
+
+	}
 
 	return r, template.ErrorPath{}
 }
@@ -3393,119 +3654,184 @@ func newBuilder_servicecontrolreport_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldApiVersion, expType, err = expb.Compile(param.ApiVersion)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiVersion", err)
+	if param.ApiVersion == "" {
+		b.bldApiVersion = nil
+	} else {
+		b.bldApiVersion, expType, err = expb.Compile(param.ApiVersion)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiVersion)
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiVersion)
-		return nil, template.NewErrorPath("ApiVersion", err)
+	if param.ApiOperation == "" {
+		b.bldApiOperation = nil
+	} else {
+		b.bldApiOperation, expType, err = expb.Compile(param.ApiOperation)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiOperation)
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+
 	}
 
-	b.bldApiOperation, expType, err = expb.Compile(param.ApiOperation)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiOperation", err)
+	if param.ApiProtocol == "" {
+		b.bldApiProtocol = nil
+	} else {
+		b.bldApiProtocol, expType, err = expb.Compile(param.ApiProtocol)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiProtocol", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiProtocol)
+			return nil, template.NewErrorPath("ApiProtocol", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiOperation)
-		return nil, template.NewErrorPath("ApiOperation", err)
+	if param.ApiService == "" {
+		b.bldApiService = nil
+	} else {
+		b.bldApiService, expType, err = expb.Compile(param.ApiService)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiService", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiService)
+			return nil, template.NewErrorPath("ApiService", err)
+		}
+
 	}
 
-	b.bldApiProtocol, expType, err = expb.Compile(param.ApiProtocol)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiProtocol", err)
+	if param.ApiKey == "" {
+		b.bldApiKey = nil
+	} else {
+		b.bldApiKey, expType, err = expb.Compile(param.ApiKey)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiKey)
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiProtocol)
-		return nil, template.NewErrorPath("ApiProtocol", err)
+	if param.RequestTime == "" {
+		b.bldRequestTime = nil
+	} else {
+		b.bldRequestTime, expType, err = expb.Compile(param.RequestTime)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestTime", err)
+		}
+
 	}
 
-	b.bldApiService, expType, err = expb.Compile(param.ApiService)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiService", err)
+	if param.RequestMethod == "" {
+		b.bldRequestMethod = nil
+	} else {
+		b.bldRequestMethod, expType, err = expb.Compile(param.RequestMethod)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestMethod", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.RequestMethod)
+			return nil, template.NewErrorPath("RequestMethod", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiService)
-		return nil, template.NewErrorPath("ApiService", err)
+	if param.RequestPath == "" {
+		b.bldRequestPath = nil
+	} else {
+		b.bldRequestPath, expType, err = expb.Compile(param.RequestPath)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestPath", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.RequestPath)
+			return nil, template.NewErrorPath("RequestPath", err)
+		}
+
 	}
 
-	b.bldApiKey, expType, err = expb.Compile(param.ApiKey)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiKey", err)
+	if param.RequestBytes == "" {
+		b.bldRequestBytes = nil
+	} else {
+		b.bldRequestBytes, expType, err = expb.Compile(param.RequestBytes)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestBytes", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.RequestBytes)
+			return nil, template.NewErrorPath("RequestBytes", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiKey)
-		return nil, template.NewErrorPath("ApiKey", err)
+	if param.ResponseTime == "" {
+		b.bldResponseTime = nil
+	} else {
+		b.bldResponseTime, expType, err = expb.Compile(param.ResponseTime)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseTime", err)
+		}
+
 	}
 
-	b.bldRequestTime, expType, err = expb.Compile(param.RequestTime)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestTime", err)
+	if param.ResponseCode == "" {
+		b.bldResponseCode = nil
+	} else {
+		b.bldResponseCode, expType, err = expb.Compile(param.ResponseCode)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseCode", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.ResponseCode)
+			return nil, template.NewErrorPath("ResponseCode", err)
+		}
+
 	}
 
-	b.bldRequestMethod, expType, err = expb.Compile(param.RequestMethod)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestMethod", err)
+	if param.ResponseBytes == "" {
+		b.bldResponseBytes = nil
+	} else {
+		b.bldResponseBytes, expType, err = expb.Compile(param.ResponseBytes)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseBytes", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.ResponseBytes)
+			return nil, template.NewErrorPath("ResponseBytes", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.RequestMethod)
-		return nil, template.NewErrorPath("RequestMethod", err)
-	}
+	if param.ResponseLatency == "" {
+		b.bldResponseLatency = nil
+	} else {
+		b.bldResponseLatency, expType, err = expb.Compile(param.ResponseLatency)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseLatency", err)
+		}
 
-	b.bldRequestPath, expType, err = expb.Compile(param.RequestPath)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestPath", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.RequestPath)
-		return nil, template.NewErrorPath("RequestPath", err)
-	}
-
-	b.bldRequestBytes, expType, err = expb.Compile(param.RequestBytes)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestBytes", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.RequestBytes)
-		return nil, template.NewErrorPath("RequestBytes", err)
-	}
-
-	b.bldResponseTime, expType, err = expb.Compile(param.ResponseTime)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseTime", err)
-	}
-
-	b.bldResponseCode, expType, err = expb.Compile(param.ResponseCode)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseCode", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.ResponseCode)
-		return nil, template.NewErrorPath("ResponseCode", err)
-	}
-
-	b.bldResponseBytes, expType, err = expb.Compile(param.ResponseBytes)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseBytes", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.ResponseBytes)
-		return nil, template.NewErrorPath("ResponseBytes", err)
-	}
-
-	b.bldResponseLatency, expType, err = expb.Compile(param.ResponseLatency)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseLatency", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -3536,83 +3862,135 @@ func (b *builder_servicecontrolreport_Template) build(
 
 	r := &servicecontrolreport.Instance{}
 
-	vString, err = b.bldApiVersion.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiVersion", err)
-	}
-	r.ApiVersion = vString
+	if b.bldApiVersion != nil {
 
-	vString, err = b.bldApiOperation.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiOperation", err)
-	}
-	r.ApiOperation = vString
+		vString, err = b.bldApiVersion.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+		r.ApiVersion = vString
 
-	vString, err = b.bldApiProtocol.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiProtocol", err)
-	}
-	r.ApiProtocol = vString
-
-	vString, err = b.bldApiService.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiService", err)
-	}
-	r.ApiService = vString
-
-	vString, err = b.bldApiKey.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiKey", err)
-	}
-	r.ApiKey = vString
-
-	if vIface, err = b.bldRequestTime.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("RequestTime", err)
 	}
 
-	r.RequestTime = vIface.(time.Time)
+	if b.bldApiOperation != nil {
 
-	vString, err = b.bldRequestMethod.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestMethod", err)
-	}
-	r.RequestMethod = vString
+		vString, err = b.bldApiOperation.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+		r.ApiOperation = vString
 
-	vString, err = b.bldRequestPath.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestPath", err)
-	}
-	r.RequestPath = vString
-
-	vInt, err = b.bldRequestBytes.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("RequestBytes", err)
-	}
-	r.RequestBytes = vInt
-
-	if vIface, err = b.bldResponseTime.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("ResponseTime", err)
 	}
 
-	r.ResponseTime = vIface.(time.Time)
+	if b.bldApiProtocol != nil {
 
-	vInt, err = b.bldResponseCode.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseCode", err)
-	}
-	r.ResponseCode = vInt
+		vString, err = b.bldApiProtocol.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiProtocol", err)
+		}
+		r.ApiProtocol = vString
 
-	vInt, err = b.bldResponseBytes.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ResponseBytes", err)
-	}
-	r.ResponseBytes = vInt
-
-	if vIface, err = b.bldResponseLatency.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("ResponseLatency", err)
 	}
 
-	r.ResponseLatency = vIface.(time.Duration)
+	if b.bldApiService != nil {
+
+		vString, err = b.bldApiService.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiService", err)
+		}
+		r.ApiService = vString
+
+	}
+
+	if b.bldApiKey != nil {
+
+		vString, err = b.bldApiKey.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+		r.ApiKey = vString
+
+	}
+
+	if b.bldRequestTime != nil {
+
+		if vIface, err = b.bldRequestTime.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("RequestTime", err)
+		}
+
+		r.RequestTime = vIface.(time.Time)
+
+	}
+
+	if b.bldRequestMethod != nil {
+
+		vString, err = b.bldRequestMethod.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestMethod", err)
+		}
+		r.RequestMethod = vString
+
+	}
+
+	if b.bldRequestPath != nil {
+
+		vString, err = b.bldRequestPath.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestPath", err)
+		}
+		r.RequestPath = vString
+
+	}
+
+	if b.bldRequestBytes != nil {
+
+		vInt, err = b.bldRequestBytes.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("RequestBytes", err)
+		}
+		r.RequestBytes = vInt
+
+	}
+
+	if b.bldResponseTime != nil {
+
+		if vIface, err = b.bldResponseTime.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("ResponseTime", err)
+		}
+
+		r.ResponseTime = vIface.(time.Time)
+
+	}
+
+	if b.bldResponseCode != nil {
+
+		vInt, err = b.bldResponseCode.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseCode", err)
+		}
+		r.ResponseCode = vInt
+
+	}
+
+	if b.bldResponseBytes != nil {
+
+		vInt, err = b.bldResponseBytes.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ResponseBytes", err)
+		}
+		r.ResponseBytes = vInt
+
+	}
+
+	if b.bldResponseLatency != nil {
+
+		if vIface, err = b.bldResponseLatency.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("ResponseLatency", err)
+		}
+
+		r.ResponseLatency = vIface.(time.Duration)
+
+	}
 
 	return r, template.ErrorPath{}
 }
@@ -3662,49 +4040,74 @@ func newBuilder_apikey_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldApi, expType, err = expb.Compile(param.Api)
-	if err != nil {
-		return nil, template.NewErrorPath("Api", err)
+	if param.Api == "" {
+		b.bldApi = nil
+	} else {
+		b.bldApi, expType, err = expb.Compile(param.Api)
+		if err != nil {
+			return nil, template.NewErrorPath("Api", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Api)
+			return nil, template.NewErrorPath("Api", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Api)
-		return nil, template.NewErrorPath("Api", err)
+	if param.ApiVersion == "" {
+		b.bldApiVersion = nil
+	} else {
+		b.bldApiVersion, expType, err = expb.Compile(param.ApiVersion)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiVersion)
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+
 	}
 
-	b.bldApiVersion, expType, err = expb.Compile(param.ApiVersion)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiVersion", err)
+	if param.ApiOperation == "" {
+		b.bldApiOperation = nil
+	} else {
+		b.bldApiOperation, expType, err = expb.Compile(param.ApiOperation)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiOperation)
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiVersion)
-		return nil, template.NewErrorPath("ApiVersion", err)
+	if param.ApiKey == "" {
+		b.bldApiKey = nil
+	} else {
+		b.bldApiKey, expType, err = expb.Compile(param.ApiKey)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiKey)
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+
 	}
 
-	b.bldApiOperation, expType, err = expb.Compile(param.ApiOperation)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiOperation", err)
-	}
+	if param.Timestamp == "" {
+		b.bldTimestamp = nil
+	} else {
+		b.bldTimestamp, expType, err = expb.Compile(param.Timestamp)
+		if err != nil {
+			return nil, template.NewErrorPath("Timestamp", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiOperation)
-		return nil, template.NewErrorPath("ApiOperation", err)
-	}
-
-	b.bldApiKey, expType, err = expb.Compile(param.ApiKey)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiKey", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ApiKey)
-		return nil, template.NewErrorPath("ApiKey", err)
-	}
-
-	b.bldTimestamp, expType, err = expb.Compile(param.Timestamp)
-	if err != nil {
-		return nil, template.NewErrorPath("Timestamp", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -3735,35 +4138,55 @@ func (b *builder_apikey_Template) build(
 
 	r := &apikey.Instance{}
 
-	vString, err = b.bldApi.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Api", err)
-	}
-	r.Api = vString
+	if b.bldApi != nil {
 
-	vString, err = b.bldApiVersion.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiVersion", err)
-	}
-	r.ApiVersion = vString
+		vString, err = b.bldApi.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Api", err)
+		}
+		r.Api = vString
 
-	vString, err = b.bldApiOperation.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiOperation", err)
-	}
-	r.ApiOperation = vString
-
-	vString, err = b.bldApiKey.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ApiKey", err)
-	}
-	r.ApiKey = vString
-
-	if vIface, err = b.bldTimestamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Timestamp", err)
 	}
 
-	r.Timestamp = vIface.(time.Time)
+	if b.bldApiVersion != nil {
+
+		vString, err = b.bldApiVersion.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiVersion", err)
+		}
+		r.ApiVersion = vString
+
+	}
+
+	if b.bldApiOperation != nil {
+
+		vString, err = b.bldApiOperation.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiOperation", err)
+		}
+		r.ApiOperation = vString
+
+	}
+
+	if b.bldApiKey != nil {
+
+		vString, err = b.bldApiKey.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ApiKey", err)
+		}
+		r.ApiKey = vString
+
+	}
+
+	if b.bldTimestamp != nil {
+
+		if vIface, err = b.bldTimestamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Timestamp", err)
+		}
+
+		r.Timestamp = vIface.(time.Time)
+
+	}
 
 	return r, template.ErrorPath{}
 }
@@ -3837,12 +4260,20 @@ func (b *builder_authorization_Template) build(
 
 	r := &authorization.Instance{}
 
-	if r.Subject, errp = b.bldSubject.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Subject")
+	if b.bldSubject != nil {
+
+		if r.Subject, errp = b.bldSubject.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Subject")
+		}
+
 	}
 
-	if r.Action, errp = b.bldAction.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Action")
+	if b.bldAction != nil {
+
+		if r.Action, errp = b.bldAction.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Action")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -3885,24 +4316,34 @@ func newBuilder_authorization_Subject(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldUser, expType, err = expb.Compile(param.User)
-	if err != nil {
-		return nil, template.NewErrorPath("User", err)
+	if param.User == "" {
+		b.bldUser = nil
+	} else {
+		b.bldUser, expType, err = expb.Compile(param.User)
+		if err != nil {
+			return nil, template.NewErrorPath("User", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.User)
+			return nil, template.NewErrorPath("User", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.User)
-		return nil, template.NewErrorPath("User", err)
-	}
+	if param.Groups == "" {
+		b.bldGroups = nil
+	} else {
+		b.bldGroups, expType, err = expb.Compile(param.Groups)
+		if err != nil {
+			return nil, template.NewErrorPath("Groups", err)
+		}
 
-	b.bldGroups, expType, err = expb.Compile(param.Groups)
-	if err != nil {
-		return nil, template.NewErrorPath("Groups", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Groups)
+			return nil, template.NewErrorPath("Groups", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Groups)
-		return nil, template.NewErrorPath("Groups", err)
 	}
 
 	b.bldProperties = make(map[string]compiled.Expression, len(param.Properties))
@@ -3943,17 +4384,25 @@ func (b *builder_authorization_Subject) build(
 
 	r := &authorization.Subject{}
 
-	vString, err = b.bldUser.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("User", err)
-	}
-	r.User = vString
+	if b.bldUser != nil {
 
-	vString, err = b.bldGroups.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Groups", err)
+		vString, err = b.bldUser.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("User", err)
+		}
+		r.User = vString
+
 	}
-	r.Groups = vString
+
+	if b.bldGroups != nil {
+
+		vString, err = b.bldGroups.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Groups", err)
+		}
+		r.Groups = vString
+
+	}
 
 	r.Properties = make(map[string]interface{}, len(b.bldProperties))
 
@@ -4015,44 +4464,64 @@ func newBuilder_authorization_Action(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldNamespace, expType, err = expb.Compile(param.Namespace)
-	if err != nil {
-		return nil, template.NewErrorPath("Namespace", err)
+	if param.Namespace == "" {
+		b.bldNamespace = nil
+	} else {
+		b.bldNamespace, expType, err = expb.Compile(param.Namespace)
+		if err != nil {
+			return nil, template.NewErrorPath("Namespace", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Namespace)
+			return nil, template.NewErrorPath("Namespace", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Namespace)
-		return nil, template.NewErrorPath("Namespace", err)
+	if param.Service == "" {
+		b.bldService = nil
+	} else {
+		b.bldService, expType, err = expb.Compile(param.Service)
+		if err != nil {
+			return nil, template.NewErrorPath("Service", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Service)
+			return nil, template.NewErrorPath("Service", err)
+		}
+
 	}
 
-	b.bldService, expType, err = expb.Compile(param.Service)
-	if err != nil {
-		return nil, template.NewErrorPath("Service", err)
+	if param.Method == "" {
+		b.bldMethod = nil
+	} else {
+		b.bldMethod, expType, err = expb.Compile(param.Method)
+		if err != nil {
+			return nil, template.NewErrorPath("Method", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Method)
+			return nil, template.NewErrorPath("Method", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Service)
-		return nil, template.NewErrorPath("Service", err)
-	}
+	if param.Path == "" {
+		b.bldPath = nil
+	} else {
+		b.bldPath, expType, err = expb.Compile(param.Path)
+		if err != nil {
+			return nil, template.NewErrorPath("Path", err)
+		}
 
-	b.bldMethod, expType, err = expb.Compile(param.Method)
-	if err != nil {
-		return nil, template.NewErrorPath("Method", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Path)
+			return nil, template.NewErrorPath("Path", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Method)
-		return nil, template.NewErrorPath("Method", err)
-	}
-
-	b.bldPath, expType, err = expb.Compile(param.Path)
-	if err != nil {
-		return nil, template.NewErrorPath("Path", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Path)
-		return nil, template.NewErrorPath("Path", err)
 	}
 
 	b.bldProperties = make(map[string]compiled.Expression, len(param.Properties))
@@ -4093,29 +4562,45 @@ func (b *builder_authorization_Action) build(
 
 	r := &authorization.Action{}
 
-	vString, err = b.bldNamespace.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Namespace", err)
-	}
-	r.Namespace = vString
+	if b.bldNamespace != nil {
 
-	vString, err = b.bldService.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Service", err)
-	}
-	r.Service = vString
+		vString, err = b.bldNamespace.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Namespace", err)
+		}
+		r.Namespace = vString
 
-	vString, err = b.bldMethod.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Method", err)
 	}
-	r.Method = vString
 
-	vString, err = b.bldPath.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Path", err)
+	if b.bldService != nil {
+
+		vString, err = b.bldService.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Service", err)
+		}
+		r.Service = vString
+
 	}
-	r.Path = vString
+
+	if b.bldMethod != nil {
+
+		vString, err = b.bldMethod.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Method", err)
+		}
+		r.Method = vString
+
+	}
+
+	if b.bldPath != nil {
+
+		vString, err = b.bldPath.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Path", err)
+		}
+		r.Path = vString
+
+	}
 
 	r.Properties = make(map[string]interface{}, len(b.bldProperties))
 
@@ -4217,14 +4702,19 @@ func newBuilder_listentry_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Value)
-		return nil, template.NewErrorPath("Value", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Value)
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -4255,11 +4745,15 @@ func (b *builder_listentry_Template) build(
 
 	r := &listentry.Instance{}
 
-	vString, err = b.bldValue.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if b.bldValue != nil {
+
+		vString, err = b.bldValue.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+		r.Value = vString
+
 	}
-	r.Value = vString
 
 	return r, template.ErrorPath{}
 }
@@ -4319,29 +4813,44 @@ func newBuilder_logentry_Template(
 		b.bldVariables[k] = exp
 	}
 
-	b.bldTimestamp, expType, err = expb.Compile(param.Timestamp)
-	if err != nil {
-		return nil, template.NewErrorPath("Timestamp", err)
+	if param.Timestamp == "" {
+		b.bldTimestamp = nil
+	} else {
+		b.bldTimestamp, expType, err = expb.Compile(param.Timestamp)
+		if err != nil {
+			return nil, template.NewErrorPath("Timestamp", err)
+		}
+
 	}
 
-	b.bldSeverity, expType, err = expb.Compile(param.Severity)
-	if err != nil {
-		return nil, template.NewErrorPath("Severity", err)
+	if param.Severity == "" {
+		b.bldSeverity = nil
+	} else {
+		b.bldSeverity, expType, err = expb.Compile(param.Severity)
+		if err != nil {
+			return nil, template.NewErrorPath("Severity", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Severity)
+			return nil, template.NewErrorPath("Severity", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Severity)
-		return nil, template.NewErrorPath("Severity", err)
-	}
+	if param.MonitoredResourceType == "" {
+		b.bldMonitoredResourceType = nil
+	} else {
+		b.bldMonitoredResourceType, expType, err = expb.Compile(param.MonitoredResourceType)
+		if err != nil {
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
 
-	b.bldMonitoredResourceType, expType, err = expb.Compile(param.MonitoredResourceType)
-	if err != nil {
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.MonitoredResourceType)
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.MonitoredResourceType)
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
 	}
 
 	b.bldMonitoredResourceDimensions = make(map[string]compiled.Expression, len(param.MonitoredResourceDimensions))
@@ -4394,23 +4903,35 @@ func (b *builder_logentry_Template) build(
 
 	}
 
-	if vIface, err = b.bldTimestamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Timestamp", err)
+	if b.bldTimestamp != nil {
+
+		if vIface, err = b.bldTimestamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Timestamp", err)
+		}
+
+		r.Timestamp = vIface.(time.Time)
+
 	}
 
-	r.Timestamp = vIface.(time.Time)
+	if b.bldSeverity != nil {
 
-	vString, err = b.bldSeverity.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Severity", err)
-	}
-	r.Severity = vString
+		vString, err = b.bldSeverity.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Severity", err)
+		}
+		r.Severity = vString
 
-	vString, err = b.bldMonitoredResourceType.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
 	}
-	r.MonitoredResourceType = vString
+
+	if b.bldMonitoredResourceType != nil {
+
+		vString, err = b.bldMonitoredResourceType.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
+		r.MonitoredResourceType = vString
+
+	}
 
 	r.MonitoredResourceDimensions = make(map[string]interface{}, len(b.bldMonitoredResourceDimensions))
 
@@ -4468,9 +4989,14 @@ func newBuilder_metric_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4483,14 +5009,19 @@ func newBuilder_metric_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldMonitoredResourceType, expType, err = expb.Compile(param.MonitoredResourceType)
-	if err != nil {
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
-	}
+	if param.MonitoredResourceType == "" {
+		b.bldMonitoredResourceType = nil
+	} else {
+		b.bldMonitoredResourceType, expType, err = expb.Compile(param.MonitoredResourceType)
+		if err != nil {
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.MonitoredResourceType)
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.MonitoredResourceType)
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
+
 	}
 
 	b.bldMonitoredResourceDimensions = make(map[string]compiled.Expression, len(param.MonitoredResourceDimensions))
@@ -4531,11 +5062,15 @@ func (b *builder_metric_Template) build(
 
 	r := &metric.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4549,11 +5084,15 @@ func (b *builder_metric_Template) build(
 
 	}
 
-	vString, err = b.bldMonitoredResourceType.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("MonitoredResourceType", err)
+	if b.bldMonitoredResourceType != nil {
+
+		vString, err = b.bldMonitoredResourceType.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("MonitoredResourceType", err)
+		}
+		r.MonitoredResourceType = vString
+
 	}
-	r.MonitoredResourceType = vString
 
 	r.MonitoredResourceDimensions = make(map[string]interface{}, len(b.bldMonitoredResourceDimensions))
 
@@ -4761,54 +5300,84 @@ func newBuilder_tracespan_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldTraceId, expType, err = expb.Compile(param.TraceId)
-	if err != nil {
-		return nil, template.NewErrorPath("TraceId", err)
+	if param.TraceId == "" {
+		b.bldTraceId = nil
+	} else {
+		b.bldTraceId, expType, err = expb.Compile(param.TraceId)
+		if err != nil {
+			return nil, template.NewErrorPath("TraceId", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.TraceId)
+			return nil, template.NewErrorPath("TraceId", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.TraceId)
-		return nil, template.NewErrorPath("TraceId", err)
+	if param.SpanId == "" {
+		b.bldSpanId = nil
+	} else {
+		b.bldSpanId, expType, err = expb.Compile(param.SpanId)
+		if err != nil {
+			return nil, template.NewErrorPath("SpanId", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SpanId)
+			return nil, template.NewErrorPath("SpanId", err)
+		}
+
 	}
 
-	b.bldSpanId, expType, err = expb.Compile(param.SpanId)
-	if err != nil {
-		return nil, template.NewErrorPath("SpanId", err)
+	if param.ParentSpanId == "" {
+		b.bldParentSpanId = nil
+	} else {
+		b.bldParentSpanId, expType, err = expb.Compile(param.ParentSpanId)
+		if err != nil {
+			return nil, template.NewErrorPath("ParentSpanId", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ParentSpanId)
+			return nil, template.NewErrorPath("ParentSpanId", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SpanId)
-		return nil, template.NewErrorPath("SpanId", err)
+	if param.SpanName == "" {
+		b.bldSpanName = nil
+	} else {
+		b.bldSpanName, expType, err = expb.Compile(param.SpanName)
+		if err != nil {
+			return nil, template.NewErrorPath("SpanName", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SpanName)
+			return nil, template.NewErrorPath("SpanName", err)
+		}
+
 	}
 
-	b.bldParentSpanId, expType, err = expb.Compile(param.ParentSpanId)
-	if err != nil {
-		return nil, template.NewErrorPath("ParentSpanId", err)
+	if param.StartTime == "" {
+		b.bldStartTime = nil
+	} else {
+		b.bldStartTime, expType, err = expb.Compile(param.StartTime)
+		if err != nil {
+			return nil, template.NewErrorPath("StartTime", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.ParentSpanId)
-		return nil, template.NewErrorPath("ParentSpanId", err)
-	}
+	if param.EndTime == "" {
+		b.bldEndTime = nil
+	} else {
+		b.bldEndTime, expType, err = expb.Compile(param.EndTime)
+		if err != nil {
+			return nil, template.NewErrorPath("EndTime", err)
+		}
 
-	b.bldSpanName, expType, err = expb.Compile(param.SpanName)
-	if err != nil {
-		return nil, template.NewErrorPath("SpanName", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.SpanName)
-		return nil, template.NewErrorPath("SpanName", err)
-	}
-
-	b.bldStartTime, expType, err = expb.Compile(param.StartTime)
-	if err != nil {
-		return nil, template.NewErrorPath("StartTime", err)
-	}
-
-	b.bldEndTime, expType, err = expb.Compile(param.EndTime)
-	if err != nil {
-		return nil, template.NewErrorPath("EndTime", err)
 	}
 
 	b.bldSpanTags = make(map[string]compiled.Expression, len(param.SpanTags))
@@ -4849,41 +5418,65 @@ func (b *builder_tracespan_Template) build(
 
 	r := &tracespan.Instance{}
 
-	vString, err = b.bldTraceId.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("TraceId", err)
-	}
-	r.TraceId = vString
+	if b.bldTraceId != nil {
 
-	vString, err = b.bldSpanId.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("SpanId", err)
-	}
-	r.SpanId = vString
+		vString, err = b.bldTraceId.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("TraceId", err)
+		}
+		r.TraceId = vString
 
-	vString, err = b.bldParentSpanId.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("ParentSpanId", err)
-	}
-	r.ParentSpanId = vString
-
-	vString, err = b.bldSpanName.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("SpanName", err)
-	}
-	r.SpanName = vString
-
-	if vIface, err = b.bldStartTime.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("StartTime", err)
 	}
 
-	r.StartTime = vIface.(time.Time)
+	if b.bldSpanId != nil {
 
-	if vIface, err = b.bldEndTime.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("EndTime", err)
+		vString, err = b.bldSpanId.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("SpanId", err)
+		}
+		r.SpanId = vString
+
 	}
 
-	r.EndTime = vIface.(time.Time)
+	if b.bldParentSpanId != nil {
+
+		vString, err = b.bldParentSpanId.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("ParentSpanId", err)
+		}
+		r.ParentSpanId = vString
+
+	}
+
+	if b.bldSpanName != nil {
+
+		vString, err = b.bldSpanName.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("SpanName", err)
+		}
+		r.SpanName = vString
+
+	}
+
+	if b.bldStartTime != nil {
+
+		if vIface, err = b.bldStartTime.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("StartTime", err)
+		}
+
+		r.StartTime = vIface.(time.Time)
+
+	}
+
+	if b.bldEndTime != nil {
+
+		if vIface, err = b.bldEndTime.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("EndTime", err)
+		}
+
+		r.EndTime = vIface.(time.Time)
+
+	}
 
 	r.SpanTags = make(map[string]interface{}, len(b.bldSpanTags))
 

--- a/mixer/test/spyAdapter/template/template.gen.go
+++ b/mixer/test/spyAdapter/template/template.gen.go
@@ -125,44 +125,40 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return nil, err
@@ -236,7 +232,13 @@ var (
 					var err error
 					_ = err
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -244,7 +246,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -252,7 +260,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -260,7 +274,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -273,13 +293,13 @@ var (
 
 						Name: instName,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 					}, nil
 				}
 
@@ -530,9 +550,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -542,7 +561,7 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
@@ -583,7 +602,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -724,44 +746,64 @@ func newBuilder_sampleapa_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -792,29 +834,45 @@ func (b *builder_sampleapa_Template) build(
 
 	r := &sampleapa.Instance{}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	return r, template.ErrorPath{}
 }
@@ -852,9 +910,14 @@ func newBuilder_samplereport_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -895,11 +958,15 @@ func (b *builder_samplereport_Template) build(
 
 	r := &samplereport.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 

--- a/mixer/tools/codegen/pkg/bootstrapgen/generator.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/generator.go
@@ -96,7 +96,9 @@ func (g *Generator) Generate(fdsFiles map[string]string) error {
 		template.FuncMap{
 			"getValueType": func(goType modelgen.TypeInfo) string {
 				return primitiveToValueType[strings.Replace(goType.Name, " ", "", -1)]
-
+			},
+			"getUnspecifiedValueType": func() string {
+				return fullGoNameOfValueTypePkgName + istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED.String()
 			},
 			"isAliasType": func(goType string) bool {
 				_, found := aliasTypes[goType]

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -177,7 +177,7 @@ var (
                             {{else}}
                                 if infrdType.{{.GoName}}[k], err = tEvalFn(v); err != nil {
                             {{end}}
-                                    return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path + "{{.GoName}}", err)
+                                    return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path + fmt.Sprintf("%s[%s]","{{.GoName}}", k), err)
                                 }
                             }
                         {{else}}
@@ -190,9 +190,8 @@ var (
                                 }
                             {{else}}
                                 if param.{{.GoName}} == "" {
-                                    return nil, fmt.Errorf("expression for field '%s' cannot be empty", path + "{{.GoName}}")
-                                }
-                                if infrdType.{{.GoName}}, err = tEvalFn(param.{{.GoName}}); err != nil {
+                                    infrdType.{{.GoName}} = {{getUnspecifiedValueType}}
+                                } else if infrdType.{{.GoName}}, err = tEvalFn(param.{{.GoName}}); err != nil {
                                     return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path + "{{.GoName}}", err)
                                 }
                             {{end}}
@@ -200,25 +199,24 @@ var (
                         {{end}}
                     {{else}}
                         {{if .GoType.IsMap}}
-                            for _, v := range param.{{.GoName}} {
+                            for k, v := range param.{{.GoName}} {
                                 if t, e := tEvalFn(v); e != nil || t != {{getValueType .GoType.MapValue}} {
                                     if e != nil {
-                                        return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path + "{{.GoName}}", e)
+                                        return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path + fmt.Sprintf("%s[%s]","{{.GoName}}", k), e)
                                     }
                                     return nil, fmt.Errorf(
-                                        "error type checking for field '%s': Evaluated expression type %v want %v", path + "{{.GoName}}", t, {{getValueType .GoType.MapValue}})
+                                        "error type checking for field '%s': Evaluated expression type %v want %v", path + fmt.Sprintf("%s[%s]","{{.GoName}}", k), t, {{getValueType .GoType.MapValue}})
                                 }
                             }
                         {{else}}
-                            if param.{{.GoName}} == "" {
-                                return nil, fmt.Errorf("expression for field '%s' cannot be empty", path + "{{.GoName}}")
-                            }
-                            if t, e := tEvalFn(param.{{.GoName}}); e != nil || t != {{getValueType .GoType}} {
-                                if e != nil {
-                                    return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path + "{{.GoName}}", e)
-                                }
-                                return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path + "{{.GoName}}", t, {{getValueType .GoType}})
-                            }
+							if param.{{.GoName}} != "" {
+								if t, e := tEvalFn(param.{{.GoName}}); e != nil || t != {{getValueType .GoType}} {
+									if e != nil {
+										return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path + "{{.GoName}}", e)
+									}
+									return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path + "{{.GoName}}", t, {{getValueType .GoType}})
+                            	}
+							}
                         {{end}}
                     {{end}}
                 {{end}}
@@ -332,8 +330,31 @@ var (
                     {{if .GoType.IsResourceMessage}}
                     {{$typeName := getTypeName .GoType}}
                     {{.GoName}}, err := {{getBuildFnName $typeName}}(instName, param.{{.GoName}}, path + "{{.GoName}}.")
-                    {{else }}
-                    {{.GoName}}, err := mapper.Eval(param.{{.GoName}}, attrs)
+                    {{else if .GoType.IsValueType}}
+					var {{.GoName}} interface{}
+					if param.{{.GoName}} != "" {
+						{{.GoName}}, err = mapper.Eval(param.{{.GoName}}, attrs)
+					}
+					{{else}}
+
+					{{if isAliasType .GoType.Name}}
+					var {{.GoName}}Interface interface{}
+					var {{.GoName}} {{.GoType.Name}}
+					if param.{{.GoName}} != "" {
+						if {{.GoName}}Interface, err = mapper.Eval(param.{{.GoName}}, attrs); err == nil {
+							{{.GoName}} = {{.GoType.Name}}({{.GoName}}Interface.({{getAliasType .GoType.Name}})){{reportTypeUsed .GoType}}
+						}
+					}
+					{{else}}
+					var {{.GoName}}Interface interface{}
+					var {{.GoName}} {{.GoType.Name}}
+					if param.{{.GoName}} != "" {
+						if {{.GoName}}Interface, err = mapper.Eval(param.{{.GoName}}, attrs); err == nil {
+							{{.GoName}} = {{.GoName}}Interface.({{.GoType.Name}}){{reportTypeUsed .GoType}}
+						}
+					}
+					{{end}}
+
                     {{end}}
                 {{end}}
                     if err != nil {
@@ -364,11 +385,7 @@ var (
                                     return res
                                 }({{.GoName}}),
                             {{else}}
-                                {{if isAliasType .GoType.Name}}
-                                {{.GoName}}: {{.GoType.Name}}({{.GoName}}.({{getAliasType .GoType.Name}})),{{reportTypeUsed .GoType}}
-                                {{else}}
-                                {{.GoName}}: {{.GoName}}.({{.GoType.Name}}),{{reportTypeUsed .GoType}}
-                                {{end}}
+                                {{.GoName}}: {{.GoName}},
                             {{end}}
                         {{end}}
                     {{end}}
@@ -440,25 +457,25 @@ var (
                     }
                     resultBag := attribute.GetMutableBag(nil)
                     for attrName, outExpr := range instParam.AttributeBindings {
-                ex := strings.Replace(outExpr, "$out.", fullOutName, -1)
-                        val, err := mapper.Eval(ex, abag)
-            if err != nil {
-                    return nil, err
-                }
-            switch v := val.(type) {
-            case net.IP:
-                // conversion to []byte necessary based on current IP_ADDRESS handling within Mixer
-                // TODO: remove
-                if v4 := v.To4(); v4 != nil {
-                    resultBag.Set(attrName, []byte(v4))
-                    continue
-                }
-                resultBag.Set(attrName, []byte(v.To16()))
-            default:
-                resultBag.Set(attrName, val)
-            }
-        }
-        return resultBag, nil
+						ex := strings.Replace(outExpr, "$out.", fullOutName, -1)
+						val, err := mapper.Eval(ex, abag)
+						if err != nil {
+							return nil, err
+						}
+						switch v := val.(type) {
+						case net.IP:
+						// conversion to []byte necessary based on current IP_ADDRESS handling within Mixer
+						// TODO: remove
+						if v4 := v.To4(); v4 != nil {
+							resultBag.Set(attrName, []byte(v4))
+							continue
+						}
+						resultBag.Set(attrName, []byte(v.To16()))
+						default:
+						resultBag.Set(attrName, val)
+						}
+        			}
+        			return resultBag, nil
                     {{end}}
                 },
             {{end}}
@@ -732,23 +749,26 @@ var (
                     {{end}}
                 {{else}}
                     {{if $f.GoType.IsResourceMessage}}
-	                    {{/* Construct the builder instance for sub-message field types. */}}
-                        if b.{{builderFieldName $f}}, errp = {{getNewMessageBuilderFnName $t $f.GoType}}(expb, param.{{$f.GoName}}); !errp.IsNil() {
-                            return nil, errp.WithPrefix("{{$f.GoName}}")
-                        }
+						{{/* Construct the builder instance for sub-message field types. */}}
+						if b.{{builderFieldName $f}}, errp = {{getNewMessageBuilderFnName $t $f.GoType}}(expb, param.{{$f.GoName}}); !errp.IsNil() {
+							return nil, errp.WithPrefix("{{$f.GoName}}")
+						}
                     {{else}}
 	                    {{/* Construct the compiled.Expression for fields of basic type. */}}
-                        b.{{builderFieldName $f}}, expType, err = expb.Compile(param.{{$f.GoName}})
-                        if err != nil {
-                            return nil, template.NewErrorPath("{{$f.GoName}}", err)
-                        }
-						{{if isPrimitiveType $f.GoType}}
-							if expType != {{getValueType $f.GoType}} {
-								err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", {{getValueType $f.GoType}}, expType, param.{{$f.GoName}})
+						if param.{{$f.GoName}} == "" {
+							b.{{builderFieldName $f}} = nil
+						} else {
+							b.{{builderFieldName $f}}, expType, err = expb.Compile(param.{{$f.GoName}})
+							if err != nil {
 								return nil, template.NewErrorPath("{{$f.GoName}}", err)
 							}
-						{{end}}
-
+							{{if isPrimitiveType $f.GoType}}
+								if expType != {{getValueType $f.GoType}} {
+									err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", {{getValueType $f.GoType}}, expType, param.{{$f.GoName}})
+									return nil, template.NewErrorPath("{{$f.GoName}}", err)
+								}
+							{{end}}
+						}
                     {{end}}
                 {{end}}
  
@@ -823,6 +843,7 @@ var (
                         }
                     {{end}}
                 {{else}}
+					if b.{{builderFieldName $f}} != nil {
                     {{if $f.GoType.IsResourceMessage}}
 	                        if r.{{$f.GoName}}, errp = b.{{builderFieldName $f}}.build(attrs); !errp.IsNil() {
                             return nil, errp.WithPrefix("{{$f.GoName}}")
@@ -849,6 +870,7 @@ var (
 	                        {{end}}
 						{{end}}
                     {{end}}
+					}
                 {{end}}
             {{end}}
  

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -148,114 +148,104 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
-					}
-					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+					if param.IpAddr != "" {
+						if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
-					}
-					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+					if param.DnsName != "" {
+						if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
-					}
-					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+					if param.EmailAddr != "" {
+						if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
-					}
-					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+					if param.Uri != "" {
+						if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 					}
 
 					return nil, err
@@ -271,14 +261,13 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
-					}
-					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+					if param.Str != "" {
+						if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return nil, err
@@ -294,14 +283,13 @@ var (
 
 					var err error = nil
 
-					if param.Str == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Str")
-					}
-					if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+					if param.Str != "" {
+						if t, e := tEvalFn(param.Str); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Str", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Str", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					return nil, err
@@ -317,74 +305,68 @@ var (
 
 					var err error = nil
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					return nil, err
@@ -497,7 +479,13 @@ var (
 					var err error
 					_ = err
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -505,7 +493,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -513,7 +507,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -521,7 +521,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -537,7 +543,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -545,7 +557,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -566,7 +584,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					IpAddr, err := mapper.Eval(param.IpAddr, attrs)
+					var IpAddrInterface interface{}
+					var IpAddr net.IP
+					if param.IpAddr != "" {
+						if IpAddrInterface, err = mapper.Eval(param.IpAddr, attrs); err == nil {
+							IpAddr = net.IP(IpAddrInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"IpAddr", instName, err)
@@ -574,7 +598,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DnsName, err := mapper.Eval(param.DnsName, attrs)
+					var DnsNameInterface interface{}
+					var DnsName adapter.DNSName
+					if param.DnsName != "" {
+						if DnsNameInterface, err = mapper.Eval(param.DnsName, attrs); err == nil {
+							DnsName = adapter.DNSName(DnsNameInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DnsName", instName, err)
@@ -582,7 +612,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					EmailAddr, err := mapper.Eval(param.EmailAddr, attrs)
+					var EmailAddrInterface interface{}
+					var EmailAddr adapter.EmailAddress
+					if param.EmailAddr != "" {
+						if EmailAddrInterface, err = mapper.Eval(param.EmailAddr, attrs); err == nil {
+							EmailAddr = adapter.EmailAddress(EmailAddrInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EmailAddr", instName, err)
@@ -590,7 +626,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Uri, err := mapper.Eval(param.Uri, attrs)
+					var UriInterface interface{}
+					var Uri adapter.URI
+					if param.Uri != "" {
+						if UriInterface, err = mapper.Eval(param.Uri, attrs); err == nil {
+							Uri = adapter.URI(UriInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Uri", instName, err)
@@ -603,13 +645,13 @@ var (
 
 						Name: instName,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -621,19 +663,19 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res3Map: Res3Map,
 
-						IpAddr: net.IP(IpAddr.([]uint8)),
+						IpAddr: IpAddr,
 
-						DnsName: adapter.DNSName(DnsName.(string)),
+						DnsName: DnsName,
 
-						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
+						EmailAddr: EmailAddr,
 
-						Uri: adapter.URI(Uri.(string)),
+						Uri: Uri,
 					}, nil
 				}
 
@@ -646,7 +688,13 @@ var (
 					var err error
 					_ = err
 
-					Str, err := mapper.Eval(param.Str, attrs)
+					var StrInterface interface{}
+					var Str string
+					if param.Str != "" {
+						if StrInterface, err = mapper.Eval(param.Str, attrs); err == nil {
+							Str = StrInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Str", instName, err)
@@ -673,7 +721,7 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource1{
 
-						Str: Str.(string),
+						Str: Str,
 
 						SelfRefRes1: SelfRefRes1,
 
@@ -690,7 +738,13 @@ var (
 					var err error
 					_ = err
 
-					Str, err := mapper.Eval(param.Str, attrs)
+					var StrInterface interface{}
+					var Str string
+					if param.Str != "" {
+						if StrInterface, err = mapper.Eval(param.Str, attrs); err == nil {
+							Str = StrInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Str", instName, err)
@@ -722,7 +776,7 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource2{
 
-						Str: Str.(string),
+						Str: Str,
 
 						Res3: Res3,
 
@@ -739,7 +793,13 @@ var (
 					var err error
 					_ = err
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -747,7 +807,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -755,7 +821,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -763,7 +835,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -779,7 +857,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -787,7 +871,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -798,13 +888,13 @@ var (
 					_ = param
 					return &istio_mixer_adapter_sample_myapa.Resource3{
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						DimensionsFixedInt64ValueDType: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -816,9 +906,9 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 					}, nil
 				}
 
@@ -1127,9 +1217,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1139,75 +1228,69 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					if param.AnotherValueType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
-					}
-					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
+						infrdType.AnotherValueType = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"AnotherValueType", err)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.CheckExpression == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"CheckExpression")
-					}
-					if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"CheckExpression", e)
+					if param.CheckExpression != "" {
+						if t, e := tEvalFn(param.CheckExpression); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"CheckExpression", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"CheckExpression", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"CheckExpression", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					if param.Res1 != nil {
@@ -1233,9 +1316,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1245,78 +1327,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res2 != nil {
@@ -1332,7 +1408,7 @@ var (
 
 						if infrdType.Res2Map[k], err = BuildRes2(v, path+"Res2Map["+k+"]."); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Res2Map", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Res2Map", k), err)
 						}
 					}
 
@@ -1352,9 +1428,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1364,78 +1439,71 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
-					if param.IpAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"IpAddr")
-					}
-					if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+					if param.IpAddr != "" {
+						if t, e := tEvalFn(param.IpAddr); e != nil || t != istio_mixer_v1_config_descriptor.IP_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"IpAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"IpAddr", t, istio_mixer_v1_config_descriptor.IP_ADDRESS)
 					}
 
-					if param.DnsName == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DnsName")
-					}
-					if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+					if param.DnsName != "" {
+						if t, e := tEvalFn(param.DnsName); e != nil || t != istio_mixer_v1_config_descriptor.DNS_NAME {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DnsName", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DnsName", t, istio_mixer_v1_config_descriptor.DNS_NAME)
 					}
 
-					if param.EmailAddr == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"EmailAddr")
-					}
-					if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+					if param.EmailAddr != "" {
+						if t, e := tEvalFn(param.EmailAddr); e != nil || t != istio_mixer_v1_config_descriptor.EMAIL_ADDRESS {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"EmailAddr", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"EmailAddr", t, istio_mixer_v1_config_descriptor.EMAIL_ADDRESS)
 					}
 
-					if param.Uri == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Uri")
-					}
-					if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+					if param.Uri != "" {
+						if t, e := tEvalFn(param.Uri); e != nil || t != istio_mixer_v1_config_descriptor.URI {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Uri", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Uri", t, istio_mixer_v1_config_descriptor.URI)
 					}
 
 					return infrdType, err
@@ -1486,7 +1554,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1502,7 +1573,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1510,7 +1587,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -1518,7 +1601,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -1526,7 +1615,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -1534,7 +1629,10 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					AnotherValueType, err := mapper.Eval(param.AnotherValueType, attrs)
+					var AnotherValueType interface{}
+					if param.AnotherValueType != "" {
+						AnotherValueType, err = mapper.Eval(param.AnotherValueType, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"AnotherValueType", instName, err)
@@ -1550,7 +1648,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					CheckExpression, err := mapper.Eval(param.CheckExpression, attrs)
+					var CheckExpressionInterface interface{}
+					var CheckExpression string
+					if param.CheckExpression != "" {
+						if CheckExpressionInterface, err = mapper.Eval(param.CheckExpression, attrs); err == nil {
+							CheckExpression = CheckExpressionInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"CheckExpression", instName, err)
@@ -1575,13 +1679,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						AnotherValueType: AnotherValueType,
 
@@ -1595,7 +1699,7 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						CheckExpression: CheckExpression.(string),
+						CheckExpression: CheckExpression,
 
 						Res1: Res1,
 					}, nil
@@ -1610,7 +1714,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1626,7 +1733,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1634,7 +1747,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -1642,7 +1761,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -1650,7 +1775,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -1666,7 +1797,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -1674,7 +1811,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -1710,13 +1853,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -1728,9 +1871,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res2: Res2,
 
@@ -1747,7 +1890,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -1763,7 +1909,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -1771,7 +1923,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -1779,7 +1937,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -1787,7 +1951,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					IpAddr, err := mapper.Eval(param.IpAddr, attrs)
+					var IpAddrInterface interface{}
+					var IpAddr net.IP
+					if param.IpAddr != "" {
+						if IpAddrInterface, err = mapper.Eval(param.IpAddr, attrs); err == nil {
+							IpAddr = net.IP(IpAddrInterface.([]uint8))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"IpAddr", instName, err)
@@ -1795,7 +1965,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DnsName, err := mapper.Eval(param.DnsName, attrs)
+					var DnsNameInterface interface{}
+					var DnsName adapter.DNSName
+					if param.DnsName != "" {
+						if DnsNameInterface, err = mapper.Eval(param.DnsName, attrs); err == nil {
+							DnsName = adapter.DNSName(DnsNameInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DnsName", instName, err)
@@ -1803,7 +1979,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					EmailAddr, err := mapper.Eval(param.EmailAddr, attrs)
+					var EmailAddrInterface interface{}
+					var EmailAddr adapter.EmailAddress
+					if param.EmailAddr != "" {
+						if EmailAddrInterface, err = mapper.Eval(param.EmailAddr, attrs); err == nil {
+							EmailAddr = adapter.EmailAddress(EmailAddrInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"EmailAddr", instName, err)
@@ -1811,7 +1993,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Uri, err := mapper.Eval(param.Uri, attrs)
+					var UriInterface interface{}
+					var Uri adapter.URI
+					if param.Uri != "" {
+						if UriInterface, err = mapper.Eval(param.Uri, attrs); err == nil {
+							Uri = adapter.URI(UriInterface.(string))
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Uri", instName, err)
@@ -1826,19 +2014,19 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
-						IpAddr: net.IP(IpAddr.([]uint8)),
+						IpAddr: IpAddr,
 
-						DnsName: adapter.DNSName(DnsName.(string)),
+						DnsName: DnsName,
 
-						EmailAddr: adapter.EmailAddress(EmailAddr.(string)),
+						EmailAddr: EmailAddr,
 
-						Uri: adapter.URI(Uri.(string)),
+						Uri: Uri,
 					}, nil
 				}
 
@@ -1935,9 +2123,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -1947,64 +2134,59 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					if param.AnotherValueType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
-					}
-					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
+						infrdType.AnotherValueType = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"AnotherValueType", err)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
@@ -2046,7 +2228,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2062,7 +2247,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2070,7 +2261,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -2078,7 +2275,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -2086,7 +2289,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -2094,7 +2303,10 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					AnotherValueType, err := mapper.Eval(param.AnotherValueType, attrs)
+					var AnotherValueType interface{}
+					if param.AnotherValueType != "" {
+						AnotherValueType, err = mapper.Eval(param.AnotherValueType, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"AnotherValueType", instName, err)
@@ -2119,13 +2331,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						AnotherValueType: AnotherValueType,
 
@@ -2243,9 +2455,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2255,85 +2466,78 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					if param.AnotherValueType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
-					}
-					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
+						infrdType.AnotherValueType = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"AnotherValueType", err)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res1 != nil {
@@ -2359,9 +2563,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2371,78 +2574,72 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
-					for _, v := range param.Int64Map {
+					for k, v := range param.Int64Map {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Int64Map", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Map", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "Int64Map", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
-					if param.TimeStamp == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"TimeStamp")
-					}
-					if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+					if param.TimeStamp != "" {
+						if t, e := tEvalFn(param.TimeStamp); e != nil || t != istio_mixer_v1_config_descriptor.TIMESTAMP {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"TimeStamp", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"TimeStamp", t, istio_mixer_v1_config_descriptor.TIMESTAMP)
 					}
 
-					if param.Duration == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Duration")
-					}
-					if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+					if param.Duration != "" {
+						if t, e := tEvalFn(param.Duration); e != nil || t != istio_mixer_v1_config_descriptor.DURATION {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Duration", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Duration", t, istio_mixer_v1_config_descriptor.DURATION)
 					}
 
 					if param.Res2 != nil {
@@ -2458,7 +2655,7 @@ var (
 
 						if infrdType.Res2Map[k], err = BuildRes2(v, path+"Res2Map["+k+"]."); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Res2Map", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Res2Map", k), err)
 						}
 					}
 
@@ -2478,9 +2675,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2490,18 +2686,17 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
 					return infrdType, err
@@ -2551,7 +2746,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2567,7 +2765,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2575,7 +2779,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -2583,7 +2793,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -2591,7 +2807,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -2599,7 +2821,10 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					AnotherValueType, err := mapper.Eval(param.AnotherValueType, attrs)
+					var AnotherValueType interface{}
+					if param.AnotherValueType != "" {
+						AnotherValueType, err = mapper.Eval(param.AnotherValueType, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"AnotherValueType", instName, err)
@@ -2615,7 +2840,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -2623,7 +2854,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2648,13 +2885,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						AnotherValueType: AnotherValueType,
 
@@ -2668,9 +2905,9 @@ var (
 							return res
 						}(DimensionsFixedInt64ValueDType),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res1: Res1,
 					}, nil
@@ -2685,7 +2922,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2701,7 +2941,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2709,7 +2955,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -2717,7 +2969,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -2725,7 +2983,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -2741,7 +3005,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					TimeStamp, err := mapper.Eval(param.TimeStamp, attrs)
+					var TimeStampInterface interface{}
+					var TimeStamp time.Time
+					if param.TimeStamp != "" {
+						if TimeStampInterface, err = mapper.Eval(param.TimeStamp, attrs); err == nil {
+							TimeStamp = TimeStampInterface.(time.Time)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"TimeStamp", instName, err)
@@ -2749,7 +3019,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Duration, err := mapper.Eval(param.Duration, attrs)
+					var DurationInterface interface{}
+					var Duration time.Duration
+					if param.Duration != "" {
+						if DurationInterface, err = mapper.Eval(param.Duration, attrs); err == nil {
+							Duration = DurationInterface.(time.Duration)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Duration", instName, err)
@@ -2785,13 +3061,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						Int64Map: func(m map[string]interface{}) map[string]int64 {
 							res := make(map[string]int64, len(m))
@@ -2803,9 +3079,9 @@ var (
 							return res
 						}(Int64Map),
 
-						TimeStamp: TimeStamp.(time.Time),
+						TimeStamp: TimeStamp,
 
-						Duration: Duration.(time.Duration),
+						Duration: Duration,
 
 						Res2: Res2,
 
@@ -2822,7 +3098,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -2838,7 +3117,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -2853,7 +3138,7 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 					}, nil
 				}
 
@@ -2960,9 +3245,8 @@ var (
 					var err error = nil
 
 					if param.Value == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Value")
-					}
-					if infrdType.Value, err = tEvalFn(param.Value); err != nil {
+						infrdType.Value = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.Value, err = tEvalFn(param.Value); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Value", err)
 					}
 
@@ -2972,64 +3256,59 @@ var (
 
 						if infrdType.Dimensions[k], err = tEvalFn(v); err != nil {
 
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"Dimensions", err)
+							return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "Dimensions", k), err)
 						}
 					}
 
-					if param.Int64Primitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"Int64Primitive")
-					}
-					if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+					if param.Int64Primitive != "" {
+						if t, e := tEvalFn(param.Int64Primitive); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"Int64Primitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"Int64Primitive", t, istio_mixer_v1_config_descriptor.INT64)
 					}
 
-					if param.BoolPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"BoolPrimitive")
-					}
-					if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+					if param.BoolPrimitive != "" {
+						if t, e := tEvalFn(param.BoolPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.BOOL {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"BoolPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"BoolPrimitive", t, istio_mixer_v1_config_descriptor.BOOL)
 					}
 
-					if param.DoublePrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"DoublePrimitive")
-					}
-					if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+					if param.DoublePrimitive != "" {
+						if t, e := tEvalFn(param.DoublePrimitive); e != nil || t != istio_mixer_v1_config_descriptor.DOUBLE {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"DoublePrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"DoublePrimitive", t, istio_mixer_v1_config_descriptor.DOUBLE)
 					}
 
-					if param.StringPrimitive == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"StringPrimitive")
-					}
-					if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
-						if e != nil {
-							return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+					if param.StringPrimitive != "" {
+						if t, e := tEvalFn(param.StringPrimitive); e != nil || t != istio_mixer_v1_config_descriptor.STRING {
+							if e != nil {
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s': %v", path+"StringPrimitive", e)
+							}
+							return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 						}
-						return nil, fmt.Errorf("error type checking for field '%s': Evaluated expression type %v want %v", path+"StringPrimitive", t, istio_mixer_v1_config_descriptor.STRING)
 					}
 
 					if param.AnotherValueType == "" {
-						return nil, fmt.Errorf("expression for field '%s' cannot be empty", path+"AnotherValueType")
-					}
-					if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
+						infrdType.AnotherValueType = istio_mixer_v1_config_descriptor.VALUE_TYPE_UNSPECIFIED
+					} else if infrdType.AnotherValueType, err = tEvalFn(param.AnotherValueType); err != nil {
 						return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"AnotherValueType", err)
 					}
 
-					for _, v := range param.DimensionsFixedInt64ValueDType {
+					for k, v := range param.DimensionsFixedInt64ValueDType {
 						if t, e := tEvalFn(v); e != nil || t != istio_mixer_v1_config_descriptor.INT64 {
 							if e != nil {
-								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+"DimensionsFixedInt64ValueDType", e)
+								return nil, fmt.Errorf("failed to evaluate expression for field '%s'; %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), e)
 							}
 							return nil, fmt.Errorf(
-								"error type checking for field '%s': Evaluated expression type %v want %v", path+"DimensionsFixedInt64ValueDType", t, istio_mixer_v1_config_descriptor.INT64)
+								"error type checking for field '%s': Evaluated expression type %v want %v", path+fmt.Sprintf("%s[%s]", "DimensionsFixedInt64ValueDType", k), t, istio_mixer_v1_config_descriptor.INT64)
 						}
 					}
 
@@ -3070,7 +3349,10 @@ var (
 					var err error
 					_ = err
 
-					Value, err := mapper.Eval(param.Value, attrs)
+					var Value interface{}
+					if param.Value != "" {
+						Value, err = mapper.Eval(param.Value, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Value", instName, err)
@@ -3086,7 +3368,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					Int64Primitive, err := mapper.Eval(param.Int64Primitive, attrs)
+					var Int64PrimitiveInterface interface{}
+					var Int64Primitive int64
+					if param.Int64Primitive != "" {
+						if Int64PrimitiveInterface, err = mapper.Eval(param.Int64Primitive, attrs); err == nil {
+							Int64Primitive = Int64PrimitiveInterface.(int64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"Int64Primitive", instName, err)
@@ -3094,7 +3382,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					BoolPrimitive, err := mapper.Eval(param.BoolPrimitive, attrs)
+					var BoolPrimitiveInterface interface{}
+					var BoolPrimitive bool
+					if param.BoolPrimitive != "" {
+						if BoolPrimitiveInterface, err = mapper.Eval(param.BoolPrimitive, attrs); err == nil {
+							BoolPrimitive = BoolPrimitiveInterface.(bool)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"BoolPrimitive", instName, err)
@@ -3102,7 +3396,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					DoublePrimitive, err := mapper.Eval(param.DoublePrimitive, attrs)
+					var DoublePrimitiveInterface interface{}
+					var DoublePrimitive float64
+					if param.DoublePrimitive != "" {
+						if DoublePrimitiveInterface, err = mapper.Eval(param.DoublePrimitive, attrs); err == nil {
+							DoublePrimitive = DoublePrimitiveInterface.(float64)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"DoublePrimitive", instName, err)
@@ -3110,7 +3410,13 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					StringPrimitive, err := mapper.Eval(param.StringPrimitive, attrs)
+					var StringPrimitiveInterface interface{}
+					var StringPrimitive string
+					if param.StringPrimitive != "" {
+						if StringPrimitiveInterface, err = mapper.Eval(param.StringPrimitive, attrs); err == nil {
+							StringPrimitive = StringPrimitiveInterface.(string)
+						}
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"StringPrimitive", instName, err)
@@ -3118,7 +3424,10 @@ var (
 						return nil, errors.New(msg)
 					}
 
-					AnotherValueType, err := mapper.Eval(param.AnotherValueType, attrs)
+					var AnotherValueType interface{}
+					if param.AnotherValueType != "" {
+						AnotherValueType, err = mapper.Eval(param.AnotherValueType, attrs)
+					}
 
 					if err != nil {
 						msg := fmt.Sprintf("failed to evaluate field '%s' for instance '%s': %v", path+"AnotherValueType", instName, err)
@@ -3143,13 +3452,13 @@ var (
 
 						Dimensions: Dimensions,
 
-						Int64Primitive: Int64Primitive.(int64),
+						Int64Primitive: Int64Primitive,
 
-						BoolPrimitive: BoolPrimitive.(bool),
+						BoolPrimitive: BoolPrimitive,
 
-						DoublePrimitive: DoublePrimitive.(float64),
+						DoublePrimitive: DoublePrimitive,
 
-						StringPrimitive: StringPrimitive.(string),
+						StringPrimitive: StringPrimitive,
 
 						AnotherValueType: AnotherValueType,
 
@@ -3311,44 +3620,64 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -3366,14 +3695,24 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	b.bldRes3Map = make(map[string]*builder_istio_mixer_adapter_sample_myapa_Resource3, len(param.Res3Map))
@@ -3385,24 +3724,44 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Template(
 		b.bldRes3Map[k] = vb
 	}
 
-	b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+	if param.IpAddr == "" {
+		b.bldIpAddr = nil
+	} else {
+		b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
 	}
 
-	b.bldDnsName, expType, err = expb.Compile(param.DnsName)
-	if err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+	if param.DnsName == "" {
+		b.bldDnsName = nil
+	} else {
+		b.bldDnsName, expType, err = expb.Compile(param.DnsName)
+		if err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
 	}
 
-	b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
+	if param.EmailAddr == "" {
+		b.bldEmailAddr = nil
+	} else {
+		b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
 	}
 
-	b.bldUri, expType, err = expb.Compile(param.Uri)
-	if err != nil {
-		return nil, template.NewErrorPath("Uri", err)
+	if param.Uri == "" {
+		b.bldUri = nil
+	} else {
+		b.bldUri, expType, err = expb.Compile(param.Uri)
+		if err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -3433,29 +3792,45 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Instance{}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -3469,17 +3844,25 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
-
-	r.Duration = vIface.(time.Duration)
 
 	r.Res3Map = make(map[string]*istio_mixer_adapter_sample_myapa.Resource3, len(b.bldRes3Map))
 	for k, v := range b.bldRes3Map {
@@ -3488,29 +3871,45 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Template) build(
 		}
 	}
 
-	if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+	if b.bldIpAddr != nil {
+
+		if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
+		r.IpAddr = net.IP(vIface.([]uint8))
+
 	}
 
-	r.IpAddr = net.IP(vIface.([]uint8))
+	if b.bldDnsName != nil {
 
-	if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+		if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
+		r.DnsName = adapter.DNSName(vIface.(string))
+
 	}
 
-	r.DnsName = adapter.DNSName(vIface.(string))
+	if b.bldEmailAddr != nil {
 
-	if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
+		if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
+		r.EmailAddr = adapter.EmailAddress(vIface.(string))
+
 	}
 
-	r.EmailAddr = adapter.EmailAddress(vIface.(string))
+	if b.bldUri != nil {
 
-	if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Uri", err)
+		if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
+
+		r.Uri = adapter.URI(vIface.(string))
+
 	}
-
-	r.Uri = adapter.URI(vIface.(string))
 
 	return r, template.ErrorPath{}
 }
@@ -3552,14 +3951,19 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldStr, expType, err = expb.Compile(param.Str)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
+	if param.Str == "" {
+		b.bldStr = nil
+	} else {
+		b.bldStr, expType, err = expb.Compile(param.Str)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
-		return nil, template.NewErrorPath("Str", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
+			return nil, template.NewErrorPath("Str", err)
+		}
+
 	}
 
 	if b.bldSelfRefRes1, errp = newBuilder_istio_mixer_adapter_sample_myapa_Resource1(expb, param.SelfRefRes1); !errp.IsNil() {
@@ -3598,18 +4002,30 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource1) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource1{}
 
-	vString, err = b.bldStr.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
-	r.Str = vString
+	if b.bldStr != nil {
 
-	if r.SelfRefRes1, errp = b.bldSelfRefRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("SelfRefRes1")
+		vString, err = b.bldStr.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
+		r.Str = vString
+
 	}
 
-	if r.ResRef2, errp = b.bldResRef2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("ResRef2")
+	if b.bldSelfRefRes1 != nil {
+
+		if r.SelfRefRes1, errp = b.bldSelfRefRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("SelfRefRes1")
+		}
+
+	}
+
+	if b.bldResRef2 != nil {
+
+		if r.ResRef2, errp = b.bldResRef2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("ResRef2")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -3652,14 +4068,19 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldStr, expType, err = expb.Compile(param.Str)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
+	if param.Str == "" {
+		b.bldStr = nil
+	} else {
+		b.bldStr, expType, err = expb.Compile(param.Str)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
-		return nil, template.NewErrorPath("Str", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.Str)
+			return nil, template.NewErrorPath("Str", err)
+		}
+
 	}
 
 	if b.bldRes3, errp = newBuilder_istio_mixer_adapter_sample_myapa_Resource3(expb, param.Res3); !errp.IsNil() {
@@ -3703,14 +4124,22 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource2) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource2{}
 
-	vString, err = b.bldStr.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Str", err)
-	}
-	r.Str = vString
+	if b.bldStr != nil {
 
-	if r.Res3, errp = b.bldRes3.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res3")
+		vString, err = b.bldStr.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Str", err)
+		}
+		r.Str = vString
+
+	}
+
+	if b.bldRes3 != nil {
+
+		if r.Res3, errp = b.bldRes3.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res3")
+		}
+
 	}
 
 	r.Res3Map = make(map[string]*istio_mixer_adapter_sample_myapa.Resource3, len(b.bldRes3Map))
@@ -3776,44 +4205,64 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource3(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -3831,14 +4280,24 @@ func newBuilder_istio_mixer_adapter_sample_myapa_Resource3(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -3869,29 +4328,45 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource3) build(
 
 	r := &istio_mixer_adapter_sample_myapa.Resource3{}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -3905,17 +4380,25 @@ func (b *builder_istio_mixer_adapter_sample_myapa_Resource3) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
-
-	r.Duration = vIface.(time.Duration)
 
 	return r, template.ErrorPath{}
 }
@@ -3985,9 +4468,14 @@ func newBuilder_istio_mixer_template_list_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4000,49 +4488,74 @@ func newBuilder_istio_mixer_template_list_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
 	}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+	if param.AnotherValueType == "" {
+		b.bldAnotherValueType = nil
+	} else {
+		b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
+		if err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
-	if err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -4060,14 +4573,19 @@ func newBuilder_istio_mixer_template_list_Template(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldCheckExpression, expType, err = expb.Compile(param.CheckExpression)
-	if err != nil {
-		return nil, template.NewErrorPath("CheckExpression", err)
-	}
+	if param.CheckExpression == "" {
+		b.bldCheckExpression = nil
+	} else {
+		b.bldCheckExpression, expType, err = expb.Compile(param.CheckExpression)
+		if err != nil {
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.CheckExpression)
-		return nil, template.NewErrorPath("CheckExpression", err)
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.CheckExpression)
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
+
 	}
 
 	if b.bldRes1, errp = newBuilder_istio_mixer_template_list_Res1(expb, param.Res1); !errp.IsNil() {
@@ -4102,11 +4620,15 @@ func (b *builder_istio_mixer_template_list_Template) build(
 
 	r := &istio_mixer_template_list.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4120,35 +4642,55 @@ func (b *builder_istio_mixer_template_list_Template) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-	r.DoublePrimitive = vDouble
-
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-	r.StringPrimitive = vString
-
-	if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
-	r.AnotherValueType = vIface
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
+	}
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
+
+	if b.bldAnotherValueType != nil {
+
+		if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
+
+		r.AnotherValueType = vIface
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -4162,14 +4704,22 @@ func (b *builder_istio_mixer_template_list_Template) build(
 
 	}
 
-	vString, err = b.bldCheckExpression.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("CheckExpression", err)
-	}
-	r.CheckExpression = vString
+	if b.bldCheckExpression != nil {
 
-	if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res1")
+		vString, err = b.bldCheckExpression.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("CheckExpression", err)
+		}
+		r.CheckExpression = vString
+
+	}
+
+	if b.bldRes1 != nil {
+
+		if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res1")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -4244,9 +4794,14 @@ func newBuilder_istio_mixer_template_list_Res1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4259,44 +4814,64 @@ func newBuilder_istio_mixer_template_list_Res1(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -4314,14 +4889,24 @@ func newBuilder_istio_mixer_template_list_Res1(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes2, errp = newBuilder_istio_mixer_template_list_Res2(expb, param.Res2); !errp.IsNil() {
@@ -4365,11 +4950,15 @@ func (b *builder_istio_mixer_template_list_Res1) build(
 
 	r := &istio_mixer_template_list.Res1{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4383,29 +4972,45 @@ func (b *builder_istio_mixer_template_list_Res1) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -4419,20 +5024,32 @@ func (b *builder_istio_mixer_template_list_Res1) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes2 != nil {
 
-	if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res2")
+		if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res2")
+		}
+
 	}
 
 	r.Res2Map = make(map[string]*istio_mixer_template_list.Res2, len(b.bldRes2Map))
@@ -4506,9 +5123,14 @@ func newBuilder_istio_mixer_template_list_Res2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4521,44 +5143,79 @@ func newBuilder_istio_mixer_template_list_Res2(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.IpAddr == "" {
+		b.bldIpAddr = nil
+	} else {
+		b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
 	}
 
-	b.bldIpAddr, expType, err = expb.Compile(param.IpAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+	if param.DnsName == "" {
+		b.bldDnsName = nil
+	} else {
+		b.bldDnsName, expType, err = expb.Compile(param.DnsName)
+		if err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
 	}
 
-	b.bldDnsName, expType, err = expb.Compile(param.DnsName)
-	if err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+	if param.EmailAddr == "" {
+		b.bldEmailAddr = nil
+	} else {
+		b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
+		if err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
 	}
 
-	b.bldEmailAddr, expType, err = expb.Compile(param.EmailAddr)
-	if err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
-	}
+	if param.Uri == "" {
+		b.bldUri = nil
+	} else {
+		b.bldUri, expType, err = expb.Compile(param.Uri)
+		if err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
 
-	b.bldUri, expType, err = expb.Compile(param.Uri)
-	if err != nil {
-		return nil, template.NewErrorPath("Uri", err)
 	}
 
 	return b, template.ErrorPath{}
@@ -4589,11 +5246,15 @@ func (b *builder_istio_mixer_template_list_Res2) build(
 
 	r := &istio_mixer_template_list.Res2{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4607,47 +5268,75 @@ func (b *builder_istio_mixer_template_list_Res2) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
-	}
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	r.TimeStamp = vIface.(time.Time)
-
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldTimeStamp != nil {
 
-	if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("IpAddr", err)
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.IpAddr = net.IP(vIface.([]uint8))
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("DnsName", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.DnsName = adapter.DNSName(vIface.(string))
+	if b.bldIpAddr != nil {
 
-	if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("EmailAddr", err)
+		if vIface, err = b.bldIpAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("IpAddr", err)
+		}
+
+		r.IpAddr = net.IP(vIface.([]uint8))
+
 	}
 
-	r.EmailAddr = adapter.EmailAddress(vIface.(string))
+	if b.bldDnsName != nil {
 
-	if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Uri", err)
+		if vIface, err = b.bldDnsName.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("DnsName", err)
+		}
+
+		r.DnsName = adapter.DNSName(vIface.(string))
+
 	}
 
-	r.Uri = adapter.URI(vIface.(string))
+	if b.bldEmailAddr != nil {
+
+		if vIface, err = b.bldEmailAddr.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("EmailAddr", err)
+		}
+
+		r.EmailAddr = adapter.EmailAddress(vIface.(string))
+
+	}
+
+	if b.bldUri != nil {
+
+		if vIface, err = b.bldUri.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Uri", err)
+		}
+
+		r.Uri = adapter.URI(vIface.(string))
+
+	}
 
 	return r, template.ErrorPath{}
 }
@@ -4709,9 +5398,14 @@ func newBuilder_istio_mixer_template_quota_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4724,49 +5418,74 @@ func newBuilder_istio_mixer_template_quota_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
 	}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+	if param.AnotherValueType == "" {
+		b.bldAnotherValueType = nil
+	} else {
+		b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
+		if err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
-	if err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -4812,11 +5531,15 @@ func (b *builder_istio_mixer_template_quota_Template) build(
 
 	r := &istio_mixer_template_quota.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -4830,35 +5553,55 @@ func (b *builder_istio_mixer_template_quota_Template) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-	r.DoublePrimitive = vDouble
-
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-	r.StringPrimitive = vString
-
-	if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
-	r.AnotherValueType = vIface
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
+	}
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
+
+	if b.bldAnotherValueType != nil {
+
+		if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
+
+		r.AnotherValueType = vIface
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -4944,9 +5687,14 @@ func newBuilder_istio_mixer_template_log_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -4959,49 +5707,74 @@ func newBuilder_istio_mixer_template_log_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
 	}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+	if param.AnotherValueType == "" {
+		b.bldAnotherValueType = nil
+	} else {
+		b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
+		if err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
-	if err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -5019,14 +5792,24 @@ func newBuilder_istio_mixer_template_log_Template(
 		b.bldDimensionsFixedInt64ValueDType[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes1, errp = newBuilder_istio_mixer_template_log_Res1(expb, param.Res1); !errp.IsNil() {
@@ -5061,11 +5844,15 @@ func (b *builder_istio_mixer_template_log_Template) build(
 
 	r := &istio_mixer_template_log.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5079,35 +5866,55 @@ func (b *builder_istio_mixer_template_log_Template) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-	r.DoublePrimitive = vDouble
-
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-	r.StringPrimitive = vString
-
-	if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
-	r.AnotherValueType = vIface
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
+	}
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
+
+	if b.bldAnotherValueType != nil {
+
+		if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
+
+		r.AnotherValueType = vIface
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 
@@ -5121,20 +5928,32 @@ func (b *builder_istio_mixer_template_log_Template) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes1 != nil {
 
-	if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res1")
+		if r.Res1, errp = b.bldRes1.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res1")
+		}
+
 	}
 
 	return r, template.ErrorPath{}
@@ -5209,9 +6028,14 @@ func newBuilder_istio_mixer_template_log_Res1(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -5224,44 +6048,64 @@ func newBuilder_istio_mixer_template_log_Res1(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
 	}
 
 	b.bldInt64Map = make(map[string]compiled.Expression, len(param.Int64Map))
@@ -5279,14 +6123,24 @@ func newBuilder_istio_mixer_template_log_Res1(
 		b.bldInt64Map[k] = exp
 	}
 
-	b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
-	if err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if param.TimeStamp == "" {
+		b.bldTimeStamp = nil
+	} else {
+		b.bldTimeStamp, expType, err = expb.Compile(param.TimeStamp)
+		if err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
 	}
 
-	b.bldDuration, expType, err = expb.Compile(param.Duration)
-	if err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+	if param.Duration == "" {
+		b.bldDuration = nil
+	} else {
+		b.bldDuration, expType, err = expb.Compile(param.Duration)
+		if err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
 	}
 
 	if b.bldRes2, errp = newBuilder_istio_mixer_template_log_Res2(expb, param.Res2); !errp.IsNil() {
@@ -5330,11 +6184,15 @@ func (b *builder_istio_mixer_template_log_Res1) build(
 
 	r := &istio_mixer_template_log.Res1{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5348,29 +6206,45 @@ func (b *builder_istio_mixer_template_log_Res1) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
 	}
-	r.DoublePrimitive = vDouble
 
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
 	}
-	r.StringPrimitive = vString
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
 
 	r.Int64Map = make(map[string]int64, len(b.bldInt64Map))
 
@@ -5384,20 +6258,32 @@ func (b *builder_istio_mixer_template_log_Res1) build(
 
 	}
 
-	if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("TimeStamp", err)
+	if b.bldTimeStamp != nil {
+
+		if vIface, err = b.bldTimeStamp.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("TimeStamp", err)
+		}
+
+		r.TimeStamp = vIface.(time.Time)
+
 	}
 
-	r.TimeStamp = vIface.(time.Time)
+	if b.bldDuration != nil {
 
-	if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Duration", err)
+		if vIface, err = b.bldDuration.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Duration", err)
+		}
+
+		r.Duration = vIface.(time.Duration)
+
 	}
 
-	r.Duration = vIface.(time.Duration)
+	if b.bldRes2 != nil {
 
-	if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
-		return nil, errp.WithPrefix("Res2")
+		if r.Res2, errp = b.bldRes2.build(attrs); !errp.IsNil() {
+			return nil, errp.WithPrefix("Res2")
+		}
+
 	}
 
 	r.Res2Map = make(map[string]*istio_mixer_template_log.Res2, len(b.bldRes2Map))
@@ -5447,9 +6333,14 @@ func newBuilder_istio_mixer_template_log_Res2(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -5462,14 +6353,19 @@ func newBuilder_istio_mixer_template_log_Res2(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
 	return b, template.ErrorPath{}
@@ -5500,11 +6396,15 @@ func (b *builder_istio_mixer_template_log_Res2) build(
 
 	r := &istio_mixer_template_log.Res2{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5518,11 +6418,15 @@ func (b *builder_istio_mixer_template_log_Res2) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if b.bldInt64Primitive != nil {
+
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
+
 	}
-	r.Int64Primitive = vInt
 
 	return r, template.ErrorPath{}
 }
@@ -5584,9 +6488,14 @@ func newBuilder_istio_mixer_template_metric_Template(
 	var expType istio_mixer_v1_config_descriptor.ValueType
 	_ = expType
 
-	b.bldValue, expType, err = expb.Compile(param.Value)
-	if err != nil {
-		return nil, template.NewErrorPath("Value", err)
+	if param.Value == "" {
+		b.bldValue = nil
+	} else {
+		b.bldValue, expType, err = expb.Compile(param.Value)
+		if err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
 	}
 
 	b.bldDimensions = make(map[string]compiled.Expression, len(param.Dimensions))
@@ -5599,49 +6508,74 @@ func newBuilder_istio_mixer_template_metric_Template(
 		b.bldDimensions[k] = exp
 	}
 
-	b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.Int64Primitive == "" {
+		b.bldInt64Primitive = nil
+	} else {
+		b.bldInt64Primitive, expType, err = expb.Compile(param.Int64Primitive)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.INT64 {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.INT64 {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.INT64, expType, param.Int64Primitive)
-		return nil, template.NewErrorPath("Int64Primitive", err)
+	if param.BoolPrimitive == "" {
+		b.bldBoolPrimitive = nil
+	} else {
+		b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.BOOL {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+
 	}
 
-	b.bldBoolPrimitive, expType, err = expb.Compile(param.BoolPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.DoublePrimitive == "" {
+		b.bldDoublePrimitive = nil
+	} else {
+		b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.DOUBLE {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+
 	}
 
-	if expType != istio_mixer_v1_config_descriptor.BOOL {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.BOOL, expType, param.BoolPrimitive)
-		return nil, template.NewErrorPath("BoolPrimitive", err)
+	if param.StringPrimitive == "" {
+		b.bldStringPrimitive = nil
+	} else {
+		b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
+		if expType != istio_mixer_v1_config_descriptor.STRING {
+			err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+
 	}
 
-	b.bldDoublePrimitive, expType, err = expb.Compile(param.DoublePrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
+	if param.AnotherValueType == "" {
+		b.bldAnotherValueType = nil
+	} else {
+		b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
+		if err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
 
-	if expType != istio_mixer_v1_config_descriptor.DOUBLE {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.DOUBLE, expType, param.DoublePrimitive)
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-
-	b.bldStringPrimitive, expType, err = expb.Compile(param.StringPrimitive)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	if expType != istio_mixer_v1_config_descriptor.STRING {
-		err = fmt.Errorf("instance field type mismatch: expected='%v', actual='%v', expression='%s'", istio_mixer_v1_config_descriptor.STRING, expType, param.StringPrimitive)
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-
-	b.bldAnotherValueType, expType, err = expb.Compile(param.AnotherValueType)
-	if err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
 	b.bldDimensionsFixedInt64ValueDType = make(map[string]compiled.Expression, len(param.DimensionsFixedInt64ValueDType))
@@ -5687,11 +6621,15 @@ func (b *builder_istio_mixer_template_metric_Template) build(
 
 	r := &istio_mixer_template_metric.Instance{}
 
-	if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("Value", err)
-	}
+	if b.bldValue != nil {
 
-	r.Value = vIface
+		if vIface, err = b.bldValue.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("Value", err)
+		}
+
+		r.Value = vIface
+
+	}
 
 	r.Dimensions = make(map[string]interface{}, len(b.bldDimensions))
 
@@ -5705,35 +6643,55 @@ func (b *builder_istio_mixer_template_metric_Template) build(
 
 	}
 
-	vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("Int64Primitive", err)
-	}
-	r.Int64Primitive = vInt
+	if b.bldInt64Primitive != nil {
 
-	vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("BoolPrimitive", err)
-	}
-	r.BoolPrimitive = vBool
+		vInt, err = b.bldInt64Primitive.EvaluateInteger(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("Int64Primitive", err)
+		}
+		r.Int64Primitive = vInt
 
-	vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("DoublePrimitive", err)
-	}
-	r.DoublePrimitive = vDouble
-
-	vString, err = b.bldStringPrimitive.EvaluateString(attrs)
-	if err != nil {
-		return nil, template.NewErrorPath("StringPrimitive", err)
-	}
-	r.StringPrimitive = vString
-
-	if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
-		return nil, template.NewErrorPath("AnotherValueType", err)
 	}
 
-	r.AnotherValueType = vIface
+	if b.bldBoolPrimitive != nil {
+
+		vBool, err = b.bldBoolPrimitive.EvaluateBoolean(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("BoolPrimitive", err)
+		}
+		r.BoolPrimitive = vBool
+
+	}
+
+	if b.bldDoublePrimitive != nil {
+
+		vDouble, err = b.bldDoublePrimitive.EvaluateDouble(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("DoublePrimitive", err)
+		}
+		r.DoublePrimitive = vDouble
+
+	}
+
+	if b.bldStringPrimitive != nil {
+
+		vString, err = b.bldStringPrimitive.EvaluateString(attrs)
+		if err != nil {
+			return nil, template.NewErrorPath("StringPrimitive", err)
+		}
+		r.StringPrimitive = vString
+
+	}
+
+	if b.bldAnotherValueType != nil {
+
+		if vIface, err = b.bldAnotherValueType.Evaluate(attrs); err != nil {
+			return nil, template.NewErrorPath("AnotherValueType", err)
+		}
+
+		r.AnotherValueType = vIface
+
+	}
 
 	r.DimensionsFixedInt64ValueDType = make(map[string]int64, len(b.bldDimensionsFixedInt64ValueDType))
 


### PR DESCRIPTION
NOTE: For map fields, if user has provided a key, they must provide a valid value, else it will be an error during typeinference. But for any other non map fields (referencing primitives, submessages, valueType) user can now choose to skip providing any expression, and we will generate instance object with primitives zero defaults.

This is implementation of spec https://goo.gl/ipfdGG