### PR TITLE
Fix data race issue mixer/pkg/server/server_test.

### DIFF
--- a/mixer/pkg/attribute/list.gen.go
+++ b/mixer/pkg/attribute/list.gen.go
@@ -3,13 +3,13 @@
 
 package attribute
 
-func GlobalList() ([]string) { 
+func GlobalList() ([]string) {
     tmp := make([]string, len(globalList))
     copy(tmp, globalList)
     return tmp
 }
 
-var ( 
+var (
     globalList = []string{
 		"source.ip",
 		"source.port",

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -113,6 +113,7 @@ func TestBasic(t *testing.T) {
 	a.APIPort = 0
 	a.MonitoringPort = 0
 	a.ConfigStoreURL = "memstore://" + t.Name()
+	a.LoggingOptions.LogGrpc = false // Avoid introducing a race to the server tests.
 	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
 		t.Fatal(err)
 	}
@@ -138,6 +139,7 @@ func TestClient(t *testing.T) {
 	a.APIPort = 0
 	a.MonitoringPort = 0
 	a.ConfigStoreURL = "memstore://" + t.Name()
+	a.LoggingOptions.LogGrpc = false // Avoid introducing a race to the server tests.
 	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
 		t.Fatal(err)
 	}
@@ -171,6 +173,7 @@ func TestErrors(t *testing.T) {
 	a := NewArgs()
 	a.APIWorkerPoolSize = -1
 	a.ConfigStoreURL = "memstore://" + t.Name()
+	a.LoggingOptions.LogGrpc = false // Avoid introducing a race to the server tests.
 	if err := store.SetupMemstore(a.ConfigStoreURL, globalCfg, serviceCfg); err != nil {
 		t.Fatal(err)
 	}
@@ -185,6 +188,7 @@ func TestErrors(t *testing.T) {
 	a.MonitoringPort = 0
 	a.ConfigStoreURL = "memstore://" + t.Name()
 	a.TracingOptions.LogTraceSpans = true
+	a.LoggingOptions.LogGrpc = false // Avoid introducing a race to the server tests.
 
 	for i := 0; i < 20; i++ {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -173,7 +173,9 @@ func Configure(options *Options) error {
 	_ = zap.RedirectStdLog(logger)
 
 	// capture gRPC logging
-	grpclog.SetLogger(zapgrpc.NewLogger(logger.WithOptions(zap.AddCallerSkip(2))))
+	if options.LogGrpc {
+		grpclog.SetLogger(zapgrpc.NewLogger(logger.WithOptions(zap.AddCallerSkip(2))))
+	}
 
 	return nil
 }

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -90,6 +90,11 @@ type Options struct {
 	// IncludeCallerSourceLocation determines whether log messages include the source location of the caller.
 	IncludeCallerSourceLocation bool
 
+	// LogGrpc indicates that Grpc logs should be captured. The default is true.
+	// This is not exposed through the command-line flags, as this flag is mainly useful for testing: Grpc
+	// stack will hold on to the logger even though it gets closed. This causes data races.
+	LogGrpc bool
+
 	stackTraceLevel string
 	outputLevel     string
 }
@@ -104,6 +109,7 @@ func NewOptions() *Options {
 		RotationMaxBackups: defaultRotationMaxBackups,
 		outputLevel:        string(defaultOutputLevel),
 		stackTraceLevel:    string(defaultStackTraceLevel),
+		LogGrpc:            true,
 	}
 }
 

--- a/pkg/log/options_test.go
+++ b/pkg/log/options_test.go
@@ -37,6 +37,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_target stdout --log_target stderr", Options{
@@ -47,6 +48,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_callers", Options{
@@ -58,6 +60,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:              defaultRotationMaxAge,
 			RotationMaxSize:             defaultRotationMaxSize,
 			RotationMaxBackups:          defaultRotationMaxBackups,
+			LogGrpc:                     true,
 		}},
 
 		{"--log_stacktrace_level debug", Options{
@@ -68,6 +71,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_stacktrace_level info", Options{
@@ -78,6 +82,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_stacktrace_level warn", Options{
@@ -88,6 +93,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_stacktrace_level error", Options{
@@ -98,6 +104,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_stacktrace_level none", Options{
@@ -108,6 +115,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_output_level debug", Options{
@@ -118,6 +126,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_output_level info", Options{
@@ -128,6 +137,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_output_level warn", Options{
@@ -138,6 +148,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_output_level error", Options{
@@ -148,6 +159,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_output_level none", Options{
@@ -158,6 +170,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_rotate foobar", Options{
@@ -169,6 +182,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_rotate_max_age 1234", Options{
@@ -179,6 +193,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     1234,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_rotate_max_size 1234", Options{
@@ -189,6 +204,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    1234,
 			RotationMaxBackups: defaultRotationMaxBackups,
+			LogGrpc:            true,
 		}},
 
 		{"--log_rotate_max_backups 1234", Options{
@@ -199,6 +215,7 @@ func TestOpts(t *testing.T) {
 			RotationMaxAge:     defaultRotationMaxAge,
 			RotationMaxSize:    defaultRotationMaxSize,
 			RotationMaxBackups: 1234,
+			LogGrpc:            true,
 		}},
 	}
 


### PR DESCRIPTION
This is mainly a test issue. The code here is expected to run at most once during a process' lifecycle. The test is rerunning this code many times. Most of the code here is resilient to rerunning. However, gRpc is holding onto the logger that it was set as part of initialization. Overwriting this causes data race issues.

This fix side-steps the problem by adding an internal flag (i.e. no command-line presence) for controlling the setting of the gRpc logger. The server package explicitly sets the flag to false to avoid registering a logger with gRpc.