### PR TITLE
build tag to exclude cache tests from race-testing

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !race
+
 package cache
 
 import (

--- a/pkg/cache/lruCache_test.go
+++ b/pkg/cache/lruCache_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !race
+
 package cache
 
 import (

--- a/pkg/cache/ttlCache_test.go
+++ b/pkg/cache/ttlCache_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !race
+
 package cache
 
 import (


### PR DESCRIPTION
As @geeknoid commented previously at
https://github.com/istio/istio/issues/1943#issuecomment-348364966,
the race detection here might be falsy. The build tag excludes
those test files when `go test -race`.