### PR TITLE
fix errors happening on top of Golang HEAD

### DIFF
--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -263,7 +263,7 @@ func TestCheckQuota(t *testing.T) {
 	if err != nil {
 		t.Errorf("Got %v, expected success", err)
 	} else if !status.IsOK(response.Precondition.Status) {
-		t.Errorf("Got unexpected failure %s", response.Precondition.Status)
+		t.Errorf("Got unexpected failure %+v", response.Precondition.Status)
 	} else if response.Quotas["RequestCount"].GrantedAmount != 42 {
 		t.Errorf("Got %v granted amount, expecting 42", response.Quotas["RequestCount"].GrantedAmount)
 	}

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -141,7 +141,6 @@ const reportAttributes = `
   "response.code": 200,
   "response.headers": {
      "date": "*",
-     "content-type": "text/plain; charset=utf-8",
      "content-length": "0",
      ":status": "200",
      "server": "envoy"

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -89,7 +89,6 @@ const reportAttributesOkGet = `
   "response.code": 200,
   "response.headers": {
      "date": "*",
-     "content-type": "text/plain; charset=utf-8",
      "content-length": "0",
      ":status": "200",
      "server": "envoy"

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -140,7 +140,6 @@ const reportAttributesBackendFail = `
   "response.code": 400,
   "response.headers": {
      "date": "*",
-     "content-type": "text/plain; charset=utf-8",
      "content-length": "25",
      ":status": "400",
      "server": "envoy"

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -57,7 +57,6 @@ const reportAttributesOkGet = `
   "response.code": 200,
   "response.headers": {
      "date": "*",
-     "content-type": "text/plain; charset=utf-8",
      "content-length": "0",
      ":status": "200",
      "server": "envoy"


### PR DESCRIPTION
- seemingly the compiler checks the validity of %s, here isn't
  correctly specified. Fixed by %+v
- response.header in mixer/test/client/... test example;
  the http server will not set the content-type header if the
  response body is empty, which makes these test expectations fail.
  I don't think the content type check needs to be done for those
  cases (note that 'content-type' is checked for POST request cases).