### PR TITLE
Fix mixer/pkg/perf test failure.

### DIFF
--- a/mixer/pkg/perf/controller.go
+++ b/mixer/pkg/perf/controller.go
@@ -62,7 +62,12 @@ func newController() (*Controller, error) {
 	c.rpcServer.HandleHTTP(c.rpcPath, rpcDebugPath)
 
 	go func() {
-		_ = http.Serve(c.listener, nil)
+		// Make a local copy of the listener before using. Since this function closes over c, it is possible
+		// that somebody might have called c.close() before this goroutine starts running.
+		l := c.listener
+		if l != nil {
+			_ = http.Serve(l, nil)
+		}
 	}()
 
 	log.Infof("controller is accepting connections on: %s%s", c.listener.Addr().String(), c.rpcPath)


### PR DESCRIPTION
The issue seems to be introduced when linter changes were made. In the original code, the go routine closure eagerly evaluated its parameters and captured c.listener. When the goroutine started the listener was guaranteed to be non-nil. With the updated code, the closure captures c, instead of c.listener, which can get set to nil as part of a shutdown/close.

This fix PR fixes the issue by capturing the listener locally during function start, and doing a nil check before running http.Serve.