### PR TITLE
Add ansible playbook that can install Istio on k8s or ocp

### DIFF
--- a/install/ansible/README.md
+++ b/install/ansible/README.md
@@ -1,0 +1,110 @@
+Table of Contents
+=================
+
+   * [Ansible playbook to install Istio](#ansible-playbook-to-install-istio)
+      * [Prerequisites](#prerequisites)
+      * [Execution](#execution)
+      * [Typical use cases](#typical-use-cases)
+
+# Ansible playbook to install Istio
+
+The Ansible scenario defined within this project will let you to : 
+
+- Install `Istio` Distribution and set the path of the `istioctl` go client (if you execute the command manually)
+- Deploy Istio on Openshift or Kubernetes by specifying different parameters (version, enable auth, deploy bookinfo, ...)
+- Specify the addons to be deployed such as `Grafana`, `Prometheus`, `Servicegraph`, `Zipkin` or `Jaeger`
+
+## Prerequisites
+
+- [Ansible 2.4](http://docs.ansible.com/ansible/latest/intro_installation.html)
+
+Refer to the Ansible Installation Doc on how to install Ansible on your machine.
+To use [Minishift](https://docs.openshift.org/latest/minishift/command-ref/minishift_start.html) or [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/) for local clusters, please refer to their respective documentation. 
+
+## Execution
+
+The role assumes that the user :
+- Can access a Kubernetes or Openshift cluster via `kubectl` or `oc` respectively and is authenticated against the cluster. 
+- Has the `admin` role on the OpenShift platform
+
+Remark : Furthermore the minimum Kubernetes version that is compatible is `1.7.0` (`3.7.0` is the corresponding OpenShift version).   
+
+**Important**: All invocations of the Ansible playbooks need to take place at the `install/ansible` path.
+Failing to do so will result in unexpected errors 
+
+The simplest execution command looks like the following:
+ 
+```bash
+ansible-playbook main.yml
+```
+
+Remarks:
+- The role tries it's best to be idempotent, so running the playbook multiple times should be have the same effect as running it a single time.   
+- The default parameters that apply to this role can be found in `istio/defaults/main.yml`.
+
+The full list of configurable parameters is as follows:
+
+| Parameter | Description | Values |
+| --- | --- | --- |
+| `cluster_flavour` | Defines whether the target cluster is a Kubernetes or an Openshift cluster. | Valid values are `k8s` and `ocp` (default) |
+| `cmd_path` | Can be used when the user does not have the `oc` or `kubectl` binary on the PATH | Defaults to expecting the binary is on the path | 
+| `istio.release_tag_name` | Should be a valid Istio release version. If left empty, the latest Istio release will be installed | `0.2.12`, `0.3.0`, `0.4.0` (default) |
+| `istio.dest` | Destination folder you want to install on your machine istio distribution | `~/.istio` (default) |
+| `istio.auth` | Boolean value to install istio using MUTUAL_TLS | `true` and `false` (default) |
+| `istio.namespace` | The namespace where istio will be installed | `istio-system` (default) |
+| `istio.addon` | Which Istio addons should be installed as well | This field is an array field, which by default contains `grafana`, `prometheus`, `zipkin` and `servicegraph` |
+| `istio.jaeger` | Whether or not Jaeger tracing should also be installed | `true` and `false` (default)|
+| `istio.bookinfo` | Whether or not to install Istio's Book Info showcase | `true` and `false` (default)|
+| `istio.bookinfo_namespace` | The namespace into which to install Book Info showcase | `bookinfo` (default) |
+| `istio.delete_resources` | Boolean value to delete resources created under the istio namespace | `true` and `false` (default)|
+
+
+An example of an invocation where we want to deploy Jaeger instead of Zipkin would be:
+```bash
+ansible-playbook main.yml -e '{"istio": {"jaeger": true}}'
+```
+
+
+This playbook will take care of downloading and installing Istio locally on your machine, before deploying the necessary Kubernetes / Openshift
+pods, services etc. on to the cluster
+
+### Note on istio.delete_resources
+
+Activating the `istio.delete_resources` flag will result in any Istio related resources being deleted from the cluster before Istio is reinstalled.
+
+In order to avoid any inconsistency issues, this flag should only be used to reinstall the same version of Istio on a cluster. If a new version
+of Istio need to be reinstalled, then it is advisable to delete the `istio-system` namespace before executing the playbook (in which case the 
+`istio.delete_resources` flag does not need to be activated)  
+
+## Typical use cases
+
+The following commands are some examples of how a user could install Istio using this Ansible role
+
+- User executes installs Istio accepting all defaults
+```bash
+ansible-playbook main.yml
+```
+
+- User installs Istio on to a Kubernetes cluster 
+```bash
+ansible-playbook main.yml -e '{"cluster_flavour": "k8s"}' 
+```
+
+- User installs Istio on to a Kubernetes cluster and the path to `kubectl` is expicitly set (perhaps it's not on the PATH)
+```bash
+ansible-playbook main.yml -e '{"cluster_flavour": "k8s", "cmd_path": "~/kubectl"}' 
+```
+
+- User wants to install Istio on Openshift with settings other than the default
+```bash
+ansible-playbook main.yml -e '{"istio": {"release_tag_name": "0.4.0", "auth": true, "jaeger": true, "delete_resources": true}}'
+```
+
+- User wants to install Istio on Openshift but with custom add-on settings
+```bash
+ansible-playbook main.yml -e '{"istio": {"delete_resources": true, "addon": ["grafana", "prometheus"]}}'
+```
+
+The list of available addons can be found at `istio/vars.main.yml` under the name `istio_all_addons`.
+Jaeger is not installed using the `addons` property, but can be installed by enabling `"jaeger": true` like in one of the previous examples.
+It should be noted that when Jaeger is enabled, Zipkin is disabled whether or not it's been selected in the addons section.

--- a/install/ansible/ansible.cfg
+++ b/install/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+#Needed to be able to override selected variables from the command line
+hash_behaviour=merge

--- a/install/ansible/istio/defaults/main.yml
+++ b/install/ansible/istio/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+
+# Whether the cluster is an Openshift (ocp) or upstream Kubernetes (k8s) cluster
+cluster_flavour: ocp
+
+istio:
+
+  # Could be a tag "0.2.12, 0.3.0, 0.4.0" version or be empty "", then in this case, the latest release will be downloaded
+  release_tag_name: "0.4.0"
+
+  # Folder where you want to install the distro on your machine. By default, we will install it here ~/.istio
+  dest: "~/.istio"
+
+  # Install istio with or without istio-auth module
+  auth: false
+
+  # OpenShift project / Kubernetes namespace to be created
+  namespace: istio-system
+
+  addon: "{{ istio_all_addons }}"
+
+  # Whether or not Jaeger should be installed as well
+  jaeger: false
+
+  # Whether or not the Bookinfo showcase should be installed as well
+  bookinfo: false
+
+  # Namespace where bookinfo sample will be deployed (if so configured)
+  bookinfo_namespace: bookinfo
+
+  # Whether or not to open apps in the browser
+  open_apps: false
+
+  # Whether to delete resources that might exist from previous Istio installations
+  delete_resources: false

--- a/install/ansible/istio/meta/main.yml
+++ b/install/ansible/istio/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/install/ansible/istio/tasks/add_serviceaccount_to_addon.yml
+++ b/install/ansible/istio/tasks/add_serviceaccount_to_addon.yml
@@ -1,0 +1,30 @@
+# Adds ServiceAccount to add-ons that need them and do not have them defined
+# This is done in order to avoid giving scc anyuid to the default ServiceAccount
+
+- set_fact:
+    add_on_file_path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
+
+- name: Determine whether a ServiceAccount is present in the {{ add_on_name }} file
+  command: grep 'serviceAccountName' {{ add_on_file_path }}
+  register: go
+  ignore_errors: true
+
+- name: Add ServiceAccount to {{ add_on_name }} add-on
+  replace:
+    path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
+    regexp: '^(\s*)containers:\s*$'
+    replace: '\1serviceAccountName: istio-{{ add_on_name }}-service-account\n\1containers:'
+    backup: yes
+  when: go.stdout_lines | length == 0
+
+- set_fact:
+    add_on_definition_path: /tmp/{{ add_on_name }}-service-account
+
+- name: Apply ServiceAccount from template for {{ add_on_name }}
+  command: "{{ cmd_path }} create serviceaccount istio-{{ add_on_name }}-service-account -n istio-system"
+  ignore_errors: true
+
+- name: Define SCC rules to enable containers running with UID zero for Addon service accounts for {{ add_on_name }}
+  command: "{{ cmd_path }} adm policy add-scc-to-user anyuid -z istio-{{ add_on_name }}-service-account -n istio-system"
+  when: cluster_flavour == 'ocp'
+

--- a/install/ansible/istio/tasks/add_to_path.yml
+++ b/install/ansible/istio/tasks/add_to_path.yml
@@ -1,0 +1,24 @@
+- name: Add Istio to PATH
+  shell: |
+    ISTIO_BIN_DIR=$(cd {{ istio_dir }}/bin; pwd)
+    echo "########################################################################################"
+    echo "Execute this command within your terminal to include the bin direcrtory of the istioctl client !"
+    echo  export PATH='$'PATH:$ISTIO_BIN_DIR
+    echo "Then, you will be able within your shell to call the istioctl client"
+    echo "istioctl [command]"
+    echo "########################################################################################"
+  register: r
+
+- debug: msg="{{ r.stdout.split('\n') }}"
+
+# PATH=$PATH:$ISTIO_BIN_DIR; export PATH
+
+#    shell: ISTIO_BIN_DIR=$(cd {{ istio_dir }}/bin; pwd) | echo $ISTIO_BIN_DIR
+#    register: r
+
+# - debug: var=r
+#
+# - lineinfile:
+#     path: ms
+#     regexp: '.istio-{{ istio.istio_version_to_use }}'
+#     line: "\n# Istio\nexport PATH=$PATH:{{ r.stdout }}"

--- a/install/ansible/istio/tasks/bookinfo_cmd.j2
+++ b/install/ansible/istio/tasks/bookinfo_cmd.j2
@@ -1,0 +1,4 @@
+{{ cmd_path }} new-project {{ istio.bookinfo_namespace }}
+{{ cmd_path }} adm policy add-scc-to-user privileged -z default -n {{ istio.bookinfo_namespace }}
+{{ cmd_path }} apply -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/kube/bookinfo.yaml)
+{{ cmd_path }} expose svc productpage

--- a/install/ansible/istio/tasks/change_scc.yml
+++ b/install/ansible/istio/tasks/change_scc.yml
@@ -1,0 +1,9 @@
+# Openshift by default does not allow containers running with UID 0. Enable containers running with UID 0 for Istio’s service accounts
+- name: Define SCC rules to enable containers running with UID zero for Istio service accounts
+  shell: "{{ cmd_path }} adm policy add-scc-to-user anyuid -z {{ item }} -n istio-system"
+  with_items:
+    - istio-ingress-service-account
+    - istio-egress-service-account
+    - istio-pilot-service-account
+    - istio-mixer-service-account
+    - istio-ca-service-account

--- a/install/ansible/istio/tasks/create_namespace.yml
+++ b/install/ansible/istio/tasks/create_namespace.yml
@@ -1,0 +1,9 @@
+- name: Check if namespace exists
+  shell: "{{ cmd_path }} get namespace/{{ istio.namespace }} --ignore-not-found=true"
+  register: r
+
+- name: Create namespace (if it doesn't exist)
+  shell: "{{ cmd_path }} create namespace istio-system"
+  when:
+    - r.stderr != ""
+    - r.stderr.find("NotFound") != -1

--- a/install/ansible/istio/tasks/create_namespace_free_definition_file.yml
+++ b/install/ansible/istio/tasks/create_namespace_free_definition_file.yml
@@ -1,0 +1,17 @@
+- name: Create temp directory that will the modified definition file
+  command: mktemp -d -t ansible.XXXXXXXXXX
+  register: temp_output
+
+- name: Define var containing copied definition file
+  set_fact:
+    istio_copied_definition_file_full_path: "{{ temp_output.stdout }}/def.yml"
+
+- name: Copy definition file
+  command: "cp {{ istio_definition_full_path }} {{ istio_copied_definition_file_full_path }}"
+
+- name: Remove lines corresponding to namespace
+  replace:
+    path: "{{ istio_copied_definition_file_full_path }}"
+    regexp: '^\s*apiVersion: v1\s*\n+\s*kind: Namespace\s*\n+\s*metadata:\s*\n+\s*name: istio-system\s*$'
+    replace: ''
+

--- a/install/ansible/istio/tasks/delete_resources.yml
+++ b/install/ansible/istio/tasks/delete_resources.yml
@@ -1,0 +1,35 @@
+# Copies the istio definition file and removes the namespace from it
+# This is done some we can avoid deleting the namespace
+# At the end a variable named istio_copied_definition_file_full_path will be available which contains the path
+# of the new file
+- import_tasks: create_namespace_free_definition_file.yml
+
+- name: Delete Addons
+  command: "{{ cmd_path }} delete -f {{ istio_dir }}/{{ istio_k8s_install_path }}/addons/{{ item }}.yaml --ignore-not-found=true -n {{ istio.namespace }}"
+  ignore_errors: true
+  with_items: "{{ istio_all_addons }}"
+
+- name: Delete Addon ServiceAccounts
+  command: "{{ cmd_path }} delete sa istio-{{ item }}-service-account --ignore-not-found=true -n {{ istio.namespace }}"
+  ignore_errors: true
+  with_items: "{{ istio_all_addons }}"
+
+- name: Delete Jaeger info
+  shell: |
+    {{ cmd_path }} process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/all-in-one/jaeger-all-in-one-template.yml | {{ cmd_path }} delete --ignore-not-found=true -f -
+    {{ cmd_path }} delete svc jaeger --ignore-not-found=true
+  ignore_errors: true
+
+
+- name: Delete content from Istio Kubernetes file
+  command: "{{ cmd_path }} delete -f {{ istio_copied_definition_file_full_path }} --ignore-not-found=true -n {{ istio.namespace }}"
+  when: not istio.auth
+  ignore_errors: true
+
+- name: Delete whatever else might be left over
+  command: "{{ cmd_path }} delete all --all -n {{ istio.namespace }}"
+  ignore_errors: true
+
+- name: Wait for the previous command to complete
+  pause:
+    seconds: 30

--- a/install/ansible/istio/tasks/determine_latest_version.yml
+++ b/install/ansible/istio/tasks/determine_latest_version.yml
@@ -1,0 +1,18 @@
+- name: Set release tag to latest
+  set_fact:
+    release_tag: 'latest'
+  when: istio.release_tag_name == ''
+
+- name: Set release tag to specific versioned
+  set_fact:
+    release_tag: "tags/{{ istio.release_tag_name }}"
+  when: istio.release_tag_name != ''
+
+- name: Get the tagged release
+  uri:
+    url: "{{ github_url }}/{{ istio_repo }}/releases/latest"
+  register: release
+
+- name: Set version
+  set_fact:
+    istio_version_to_use: "{{ release.json.tag_name }}"

--- a/install/ansible/istio/tasks/determine_version.yml
+++ b/install/ansible/istio/tasks/determine_version.yml
@@ -1,0 +1,12 @@
+- name: Use specified version
+  set_fact:
+    istio_version_to_use: "{{ istio.release_tag_name }}"
+  when: istio.release_tag_name != ''
+
+
+- include_tasks: determine_latest_version.yml
+  when: istio.release_tag_name == ''
+
+- name: Show Istio version to be used
+  debug:
+    msg: "Will use Istio version {{ istio_version_to_use }}"

--- a/install/ansible/istio/tasks/get_istio_assets.yml
+++ b/install/ansible/istio/tasks/get_istio_assets.yml
@@ -1,0 +1,37 @@
+- name: Set release tag to specific versioned
+  set_fact:
+    release_tag: "tags/{{ istio_version_to_use }}"
+
+- name: Get the tagged release
+  uri:
+    url: "{{ github_url }}/{{ istio_repo }}/releases/{{ release_tag }}"
+  register: release
+
+- name: Set release
+  set_fact:
+    assets_url: "{{ release.json.assets_url }}"
+
+- name: Should have an assets_url
+  assert:
+    that: assets_url is defined
+
+# - name: debug
+#   debug:
+#     var: assets_url
+
+- name: Get the list of assets
+  uri:
+    url: "{{ assets_url }}"
+  register: assets
+
+- name: Set file extension to lookup
+  set_fact:
+    ext_pattern: "{{'.*osx.*' if ansible_os_family == 'Darwin' else '.*linux.*'}}"
+
+- name: Extract the matching download url
+  set_fact:
+    asset_url: "{{assets.json | map(attribute='browser_download_url') | select('match', ext_pattern) | first}}"
+
+- name: Extract the name of the asset
+  set_fact:
+    asset_name: "{{ asset_url | basename }}"

--- a/install/ansible/istio/tasks/install.yml
+++ b/install/ansible/istio/tasks/install.yml
@@ -1,0 +1,28 @@
+- name: Get Assets according to the platform
+  import_tasks: get_istio_assets.yml
+
+- name: Create a temp dir
+  command: mktemp -d -t ansible.XXXXXXXXXX
+  register: temp_output
+
+- name: Download the asset
+  get_url:
+    url: "{{ asset_url }}"
+    dest: "{{ temp_output.stdout }}/{{ asset_name }}"
+
+- name: Unzip the archive
+  command: "unzip {{ asset_name }} -d {{ istio.dest }}"
+  args:
+    chdir: "{{ temp_output.stdout }}"
+  when: asset_name | search('zip')
+
+- name: Untar the archive
+  command: "tar -xvzf {{ asset_name }} -C {{ istio.dest }}"
+  args:
+    chdir: "{{ temp_output.stdout }}"
+  when: asset_name | search('tar.gz')
+
+- name: Remove the temp directory
+  file:
+    path: "{{ temp_output.stdout }}"
+    state: absent

--- a/install/ansible/istio/tasks/install_addons.yml
+++ b/install/ansible/istio/tasks/install_addons.yml
@@ -1,0 +1,17 @@
+- include_tasks: add_serviceaccount_to_addon.yml
+    add_on_name="{{item}}"
+  with_items: "{{ selected_addons_needing_sa }}"
+  when: cluster_flavour == 'ocp'
+
+- include_tasks: install_istio_addons.yml
+  when: is_istioaddon_iterable
+
+- name: Install Jaeger on Openshift
+  shell: |
+    {{ cmd_path }} process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/all-in-one/jaeger-all-in-one-template.yml | {{ cmd_path }} create -n istio-system -f -
+  when: istio.jaeger == true and cluster_flavour == 'ocp'
+
+- name: Install Jaeger on Kubernetes
+  shell: |
+    {{ cmd_path }} create -f https://raw.githubusercontent.com/jaegertracing/jaeger-kubernetes/master/all-in-one/jaeger-all-in-one-template.yml -n istio-system
+  when: istio.jaeger == true and cluster_flavour == 'k8s'

--- a/install/ansible/istio/tasks/install_bookinfo.yml
+++ b/install/ansible/istio/tasks/install_bookinfo.yml
@@ -1,0 +1,23 @@
+# We can't simply execute the standard bookinfo installation script using shell
+# because Ansible doesn't play nicely with bash's process substitution
+
+- name: Create temp directory that will contain the installation script
+  command: mktemp -d -t ansible.XXXXXXXXXX
+  register: temp_output
+
+- name: Set command full path
+  set_fact:
+    bookinfo_cmd_full_path: "{{ temp_output.stdout }}/bookinfo_cmd"
+
+- name: Copy command into temp directory
+  template: src=bookinfo_cmd.j2 dest={{ bookinfo_cmd_full_path }}
+
+- name: Make command executable
+  file: dest={{ bookinfo_cmd_full_path }} mode=a+x
+
+- name: Install Book info example
+  command : "bash -c {{ bookinfo_cmd_full_path }}"
+
+- name: Show helpful bookinfo message
+  debug:
+    msg: "Bookinfo is being deployed in namespace {{ istio.bookinfo_namespace }}"

--- a/install/ansible/istio/tasks/install_distro.yml
+++ b/install/ansible/istio/tasks/install_distro.yml
@@ -1,0 +1,29 @@
+- name: Create parent folder where distrio will be installed
+  file:
+    path: '{{ istio.dest }}'
+    state: directory
+    mode: 0755
+
+- import_tasks: determine_version.yml
+
+- name: Define var containing Istio dir
+  set_fact:
+    istio_dir: "{{ istio.dest }}/istio-{{ istio_version_to_use }}"
+
+- name: Check if Istio distro folder exists under parent
+  stat:
+    path: "{{ istio_dir }}"
+  register: p
+
+- name: Show istio installation path
+  debug: var=p.stat.path
+
+- name: Install Istio distribution
+  include_tasks: install.yml
+  when: not p.stat.exists
+
+- name: Set istio dir
+  import_tasks: set_istio_distro_vars.yml
+
+- name: Add istio bin dir to PATH
+  import_tasks: add_to_path.yml

--- a/install/ansible/istio/tasks/install_istio_addons.yml
+++ b/install/ansible/istio/tasks/install_istio_addons.yml
@@ -1,0 +1,6 @@
+- name: Install addons from Istio definition file
+  shell: |
+    {{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml
+    {{ cmd_path }} expose svc {{ item }} -n istio-system
+  with_items: "{{ istio.addon | difference(disabled_addons) }}"
+  ignore_errors: true

--- a/install/ansible/istio/tasks/install_on_cluster.yml
+++ b/install/ansible/istio/tasks/install_on_cluster.yml
@@ -1,0 +1,13 @@
+- name: Deploy Istio from kubernetes file
+  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio.yaml"
+  when: not istio.auth
+  ignore_errors: true
+
+- name: Deploy Istio Auth from kubernetes file
+  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-auth.yaml"
+  when: istio.auth
+  ignore_errors: true
+
+- name: Deploy Addons defined such as Grafana, ...
+  import_tasks: install_addons.yml
+

--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+- include_tasks: set_implicitly_disabled_addons.yml
+
+- name: Is istio.addon be iterable
+  set_fact:
+    is_istioaddon_iterable: "{{ istio.addon is defined and istio.addon is iterable }}"
+
+- name: Determine addons that need ServiceAccounts
+  set_fact:
+    selected_addons_needing_sa: "{{ istio.addon | intersect(addons_needing_sa) | difference(disabled_addons) }}"
+  when: is_istioaddon_iterable == true
+
+- name: Set selected_addons_needing_sa to empty array
+  set_fact:
+    selected_addons_needing_sa: "[]"
+  when: is_istioaddon_iterable == false
+
+- include_tasks: set_appropriate_cmd_path.yml
+  when: cmd_path is not defined
+
+- include_tasks: install_distro.yml
+- include_tasks: delete_resources.yml
+  when: istio.delete_resources == true
+- include_tasks: create_namespace.yml
+- include_tasks: change_scc.yml
+  when: cluster_flavour == 'ocp'
+- include_tasks: install_on_cluster.yml
+
+- name: Install bookinfo showcase
+  include_tasks: install_bookinfo.yml
+  when: istio.bookinfo

--- a/install/ansible/istio/tasks/set_appropriate_cmd_path.yml
+++ b/install/ansible/istio/tasks/set_appropriate_cmd_path.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Assume that command is already on the PATH
+  set_fact:
+    cmd_path: "{{'oc' if cluster_flavour == 'ocp' else 'kubectl' }}"
+  when: cmd_path is not defined

--- a/install/ansible/istio/tasks/set_implicitly_disabled_addons.yml
+++ b/install/ansible/istio/tasks/set_implicitly_disabled_addons.yml
@@ -1,0 +1,12 @@
+# This file will result in the disabled_plugins variables being set
+# The functionality is needed because some features are mutually exclusive
+# (for example when Jaeger is enabled, Zipkin needs to be disabled)
+
+- name: Set default / empty disabled addons
+  set_fact:
+    disabled_addons: "[]"
+
+- name: Set zipkin disabled addon
+  set_fact:
+    disabled_addons: "{{ disabled_addons }} + [ 'zipkin' ]"
+  when: istio.jaeger == true

--- a/install/ansible/istio/tasks/set_istio_distro_vars.yml
+++ b/install/ansible/istio/tasks/set_istio_distro_vars.yml
@@ -1,0 +1,11 @@
+- name: Define var containg Istio definition file name
+  set_fact:
+    istio_definition_file_name: "{{'istio-auth.yaml' if istio.auth == true else 'istio.yaml'}}"
+
+- name: Define var containg Istio definition file full path
+  set_fact:
+    istio_definition_full_path: "{{ istio_dir }}/{{ istio_k8s_install_path }}/{{ istio_definition_file_name }}"
+
+- name: Show the full path of the definition file to be used
+  debug:
+    msg: "Using the following file to install Istio onto Kubernetes {{ istio_definition_full_path }}"

--- a/install/ansible/istio/vars/main.yml
+++ b/install/ansible/istio/vars/main.yml
@@ -1,0 +1,14 @@
+---
+github_url: https://api.github.com/repos
+istio_repo: istio/istio
+addons_needing_sa:
+  - "grafana"
+  - "prometheus"
+
+istio_all_addons:
+  - "grafana"
+  - "prometheus"
+  - "servicegraph"
+  - "zipkin"
+
+istio_k8s_install_path: "install/kubernetes"

--- a/install/ansible/main.yml
+++ b/install/ansible/main.yml
@@ -1,0 +1,20 @@
+---
+- hosts: localhost
+  gather_facts: true
+
+  pre_tasks:
+    # We require Ansible 2.4 or newer
+    - name: Check Ansible version
+      assert:
+        that: '(ansible_version.major, ansible_version.minor, ansible_version.revision) >= (2, 4, 0)'
+        msg: 'Please install the recommended version 2.4+. You have Ansible {{ ansible_version.string }}.'
+      run_once: yes
+
+    - name: Playbook runs correctly only on Linux or Mac OSX
+      assert:
+        that: 'ansible_system == "Linux" or ansible_os_family == "Darwin"'
+        msg: 'The playbook can only be run on Linux or Mac OSX systems'
+      run_once: yes
+
+  roles:
+    - istio


### PR DESCRIPTION
This PR implements #2763.

As you can see from the changes, we have added the ansible playbook inside `install/ansible` directory. Along with the playbook the README provides all the relevant documentation.

Furthermore the team has developed some [scripts](https://github.com/snowdrop/spring-boot-quickstart-istio/tree/master/scripts) that aided us with our dealing with Istio, that you might find useful.
Specifically under the `minikube` and `minishift` directories you will find some scripts we used to ensure that common cases work correctly on the respective clusters.
If you would like us to donate those as well, we would be more than happy to do so.

Regards