### PR TITLE
Add grafana to release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,9 +481,9 @@ SECURITY_DOCKER:=docker.istio-ca docker.istio-ca-test docker.node-agent docker.n
 $(SECURITY_DOCKER): security/docker/Dockerfile$$(suffix $$@)
 	time (cd security/docker && docker build -t $(subst docker.,,$@) -f Dockerfile$(suffix $@) .)
 
+# grafana image
 
-# start.sh grafana-dashboard.json import_dashboard.sh
-docker.grafana:	mixer/deploy/kube/conf/Dockerfile $(GRAFANA_FILES)
+docker.grafana: mixer/deploy/kube/conf/Dockerfile $(GRAFANA_FILES)
 	time (cd mixer/deploy/kube/conf && docker build -t grafana -f Dockerfile .)
 
 DOCKER_TARGETS:=$(PILOT_DOCKER) $(SERVICEGRAPH_DOCKER) $(MIXER_DOCKER) $(SECURITY_DOCKER) docker.grafana

--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,10 @@ NODE_AGENT_TEST_FILES:=security/docker/start_app.sh \
                        security/docker/node_agent.crt \
                        security/docker/node_agent.key
 
+GRAFANA_FILES:=mixer/deploy/kube/conf/import_dashboard.sh \
+               mixer/deploy/kube/conf/start.sh \
+               mixer/deploy/kube/conf/grafana-dashboard.json
+
 # copied/generated files for docker build
 
 .SECONDEXPANSION: #allow $@ to be used in dependency list
@@ -477,7 +481,12 @@ SECURITY_DOCKER:=docker.istio-ca docker.istio-ca-test docker.node-agent docker.n
 $(SECURITY_DOCKER): security/docker/Dockerfile$$(suffix $$@)
 	time (cd security/docker && docker build -t $(subst docker.,,$@) -f Dockerfile$(suffix $@) .)
 
-DOCKER_TARGETS:=$(PILOT_DOCKER) $(SERVICEGRAPH_DOCKER) $(MIXER_DOCKER) $(SECURITY_DOCKER)
+
+# start.sh grafana-dashboard.json import_dashboard.sh
+docker.grafana:	mixer/deploy/kube/conf/Dockerfile $(GRAFANA_FILES)
+	time (cd mixer/deploy/kube/conf && docker build -t grafana -f Dockerfile .)
+
+DOCKER_TARGETS:=$(PILOT_DOCKER) $(SERVICEGRAPH_DOCKER) $(MIXER_DOCKER) $(SECURITY_DOCKER) docker.grafana
 
 docker.all: $(DOCKER_TARGETS)
 


### PR DESCRIPTION
The build of the grafana docker image disappeared after the migration from bazel to make.

This change adds grafana to the build.  I made a release build with this change and verified that a grafana tar is stored in GCS and a grafana image is pushed to the GCR I indicated.

This change is needed for the monthly release.