### PR TITLE
Refactor CA client code for multi-cluster CA

### DIFF
--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -17,10 +17,12 @@ package na
 import (
 	"fmt"
 	"os"
+
 	// TODO(nmittler): Remove this
 	_ "github.com/golang/glog"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/pkg/caclient/grpc"
 	"istio.io/istio/security/pkg/platform"
 	"istio.io/istio/security/pkg/workload"
 )
@@ -47,7 +49,7 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 		return nil, err
 	}
 
-	cAClient := &cAGrpcClientImpl{}
+	cAClient := &grpc.CAGrpcClientImpl{}
 	na.cAClient = cAClient
 
 	// TODO: Specify files for service identity cert/key instead of node agent files.

--- a/security/cmd/node_agent/na/nodeagent.go
+++ b/security/cmd/node_agent/na/nodeagent.go
@@ -19,51 +19,14 @@ import (
 	"time"
 	// TODO(nmittler): Remove this
 	_ "github.com/golang/glog"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/pkg/caclient/grpc"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/platform"
 	"istio.io/istio/security/pkg/workload"
 	pb "istio.io/istio/security/proto"
 )
-
-// CAGrpcClient is for implementing the GRPC client to talk to CA.
-type CAGrpcClient interface {
-	// Send CSR to the CA and gets the response or error.
-	SendCSR(*pb.Request, platform.Client, *Config) (*pb.Response, error)
-}
-
-// cAGrpcClientImpl is an implementation of GRPC client to talk to CA.
-type cAGrpcClientImpl struct {
-}
-
-// SendCSR sends CSR to CA through GRPC.
-func (c *cAGrpcClientImpl) SendCSR(req *pb.Request, pc platform.Client, cfg *Config) (*pb.Response, error) {
-	if cfg.IstioCAAddress == "" {
-		return nil, fmt.Errorf("istio CA address is empty")
-	}
-	dialOptions, err := pc.GetDialOptions()
-	if err != nil {
-		return nil, err
-	}
-	conn, err := grpc.Dial(cfg.IstioCAAddress, dialOptions...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial %s: %s", cfg.IstioCAAddress, err)
-	}
-	defer func() {
-		if closeErr := conn.Close(); closeErr != nil {
-			log.Errorf("Failed to close connection")
-		}
-	}()
-	client := pb.NewIstioCAServiceClient(conn)
-	resp, err := client.HandleCSR(context.Background(), req)
-	if err != nil {
-		return nil, fmt.Errorf("CSR request failed %v", err)
-	}
-	return resp, nil
-}
 
 // The real node agent implementation. This implements the "Start" function
 // in the NodeAgent interface.
@@ -71,7 +34,7 @@ type nodeAgentInternal struct {
 	// Configuration specific to Node Agent
 	config       *Config
 	pc           platform.Client
-	cAClient     CAGrpcClient
+	cAClient     grpc.CAGrpcClient
 	identity     string
 	secretServer workload.SecretServer
 	certUtil     CertUtil
@@ -105,7 +68,7 @@ func (na *nodeAgentInternal) Start() error {
 
 		log.Infof("Sending CSR (retrial #%d) ...", retries)
 
-		resp, err := na.cAClient.SendCSR(req, na.pc, na.config)
+		resp, err := na.cAClient.SendCSR(req, na.pc, na.config.IstioCAAddress)
 		if err == nil && resp != nil && resp.IsApproved {
 			waitTime, ttlErr := na.certUtil.GetWaitTime(
 				resp.SignedCertChain, time.Now(), na.config.CSRGracePeriodPercentage)

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -17,64 +17,19 @@ package na
 import (
 	"bytes"
 	"fmt"
-	"net"
-	"strings"
 	"testing"
 	"time"
+
 	// TODO(nmittler): Remove this
 	_ "github.com/golang/glog"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
-
-	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 	"istio.io/istio/pkg/log"
+	mockclient "istio.io/istio/security/pkg/caclient/grpc/mock"
 	"istio.io/istio/security/pkg/platform"
 	mockpc "istio.io/istio/security/pkg/platform/mock"
 	mockutil "istio.io/istio/security/pkg/util/mock"
 	"istio.io/istio/security/pkg/workload"
 	pb "istio.io/istio/security/proto"
 )
-
-const (
-	maxCAClientSuccessReturns = 8
-)
-
-type FakeCAClient struct {
-	Counter  int
-	response *pb.Response
-	err      error
-}
-
-func (f *FakeCAClient) SendCSR(req *pb.Request, pc platform.Client, cfg *Config) (*pb.Response, error) {
-	f.Counter++
-	if f.Counter > maxCAClientSuccessReturns {
-		return nil, fmt.Errorf("terminating the test with errors")
-	}
-	return f.response, f.err
-}
-
-type FakeIstioCAGrpcServer struct {
-	IsApproved      bool
-	Status          *rpc.Status
-	SignedCertChain []byte
-
-	response *pb.Response
-	errorMsg string
-}
-
-func (s *FakeIstioCAGrpcServer) SetResponseAndError(response *pb.Response, errorMsg string) {
-	s.response = response
-	s.errorMsg = errorMsg
-}
-
-func (s *FakeIstioCAGrpcServer) HandleCSR(ctx context.Context, req *pb.Request) (*pb.Response, error) {
-	if len(s.errorMsg) > 0 {
-		return nil, fmt.Errorf(s.errorMsg)
-	}
-
-	return s.response, nil
-}
 
 type FakeCertUtil struct {
 	duration time.Duration
@@ -104,7 +59,7 @@ func TestStartWithArgs(t *testing.T) {
 	testCases := map[string]struct {
 		config      *Config
 		pc          platform.Client
-		cAClient    *FakeCAClient
+		cAClient    *mockclient.FakeCAClient
 		certUtil    FakeCertUtil
 		expectedErr string
 		sendTimes   int
@@ -113,7 +68,7 @@ func TestStartWithArgs(t *testing.T) {
 		"Success": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, &pb.Response{IsApproved: true, SignedCertChain: []byte(`TESTCERT`)}, nil},
+			cAClient:    &mockclient.FakeCAClient{0, &pb.Response{IsApproved: true, SignedCertChain: []byte(`TESTCERT`)}, nil},
 			certUtil:    FakeCertUtil{time.Duration(0), nil},
 			expectedErr: "node agent can't get the CSR approved from Istio CA after max number of retries (3)",
 			sendTimes:   12,
@@ -121,14 +76,14 @@ func TestStartWithArgs(t *testing.T) {
 		},
 		"Config Nil error": {
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, nil, nil},
+			cAClient:    &mockclient.FakeCAClient{0, nil, nil},
 			expectedErr: "node Agent configuration is nil",
 			sendTimes:   0,
 		},
 		"Platform error": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", false},
-			cAClient:    &FakeCAClient{0, nil, nil},
+			cAClient:    &mockclient.FakeCAClient{0, nil, nil},
 			expectedErr: "node Agent is not running on the right platform",
 			sendTimes:   0,
 		},
@@ -147,7 +102,7 @@ func TestStartWithArgs(t *testing.T) {
 				LoggingOptions:            log.NewOptions(),
 			},
 			pc:       mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient: &FakeCAClient{0, nil, nil},
+			cAClient: &mockclient.FakeCAClient{0, nil, nil},
 			expectedErr: "request creation fails on CSR generation (CSR generation fails at X509 cert request " +
 				"generation (crypto/rsa: message too long for RSA public key size))",
 			sendTimes: 0,
@@ -155,35 +110,35 @@ func TestStartWithArgs(t *testing.T) {
 		"Getting agent credential error": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", nil, "Err1", true},
-			cAClient:    &FakeCAClient{0, nil, nil},
+			cAClient:    &mockclient.FakeCAClient{0, nil, nil},
 			expectedErr: "request creation fails on getting agent credential (Err1)",
 			sendTimes:   0,
 		},
 		"SendCSR empty response error": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, nil, nil},
+			cAClient:    &mockclient.FakeCAClient{0, nil, nil},
 			expectedErr: "node agent can't get the CSR approved from Istio CA after max number of retries (3)",
 			sendTimes:   4,
 		},
 		"SendCSR returns error": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, nil, fmt.Errorf("error returned from CA")},
+			cAClient:    &mockclient.FakeCAClient{0, nil, fmt.Errorf("error returned from CA")},
 			expectedErr: "node agent can't get the CSR approved from Istio CA after max number of retries (3)",
 			sendTimes:   4,
 		},
 		"SendCSR not approved": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, &pb.Response{IsApproved: false}, nil},
+			cAClient:    &mockclient.FakeCAClient{0, &pb.Response{IsApproved: false}, nil},
 			expectedErr: "node agent can't get the CSR approved from Istio CA after max number of retries (3)",
 			sendTimes:   4,
 		},
 		"SendCSR parsing error": {
 			config:      &generalConfig,
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient:    &FakeCAClient{0, &pb.Response{IsApproved: true, SignedCertChain: []byte(`TESTCERT`)}, nil},
+			cAClient:    &mockclient.FakeCAClient{0, &pb.Response{IsApproved: true, SignedCertChain: []byte(`TESTCERT`)}, nil},
 			certUtil:    FakeCertUtil{time.Duration(0), fmt.Errorf("cert parsing error")},
 			expectedErr: "node agent can't get the CSR approved from Istio CA after max number of retries (3)",
 			sendTimes:   4,
@@ -216,140 +171,6 @@ func TestStartWithArgs(t *testing.T) {
 		if c.fileContent != nil && !bytes.Equal(fakeFileUtil.WriteContent["cert_file"], c.fileContent) {
 			t.Errorf("Test case [%s]: cert file content incorrect: %s VS (expected) %s",
 				id, fakeFileUtil.WriteContent["cert_file"], c.fileContent)
-		}
-	}
-}
-
-func TestSendCSRAgainstLocalInstance(t *testing.T) {
-	// create a local grpc server
-	s := grpc.NewServer()
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Errorf("failed to listen: %v", err)
-	}
-	serv := FakeIstioCAGrpcServer{}
-
-	go func() {
-		defer func() {
-			s.Stop()
-		}()
-		pb.RegisterIstioCAServiceServer(s, &serv)
-		reflection.Register(s)
-		if err := s.Serve(lis); err != nil {
-			t.Errorf("failed to serve: %v", err)
-		}
-	}()
-
-	// The goroutine starting the server may not be ready, results in flakiness.
-	time.Sleep(1 * time.Second)
-
-	defaultServerResponse := pb.Response{
-		IsApproved:      true,
-		Status:          &rpc.Status{Code: int32(rpc.OK), Message: "OK"},
-		SignedCertChain: nil,
-	}
-
-	testCases := map[string]struct {
-		config      *Config
-		pc          platform.Client
-		res         pb.Response
-		resErr      string
-		cAClient    *cAGrpcClientImpl
-		expectedErr string
-		certUtil    FakeCertUtil
-	}{
-		"IstioCAAddress is empty": {
-			config: &Config{
-				IstioCAAddress: "",
-				RSAKeySize:     512,
-			},
-			pc: mockpc.FakeClient{[]grpc.DialOption{
-				grpc.WithInsecure(),
-			}, "", "service1", "", []byte{}, "", true},
-			res:         defaultServerResponse,
-			cAClient:    &cAGrpcClientImpl{},
-			expectedErr: "istio CA address is empty",
-		},
-		"IstioCAAddress is incorrect": {
-			config: &Config{
-				IstioCAAddress: lis.Addr().String() + "1",
-				RSAKeySize:     512,
-			},
-			pc: mockpc.FakeClient{[]grpc.DialOption{
-				grpc.WithInsecure(),
-			}, "", "service1", "", []byte{}, "", true},
-			res:         defaultServerResponse,
-			cAClient:    &cAGrpcClientImpl{},
-			expectedErr: "CSR request failed rpc error: code = Unavailable desc = all SubConns are in TransientFailure",
-		},
-		"Without Insecure option": {
-			config: &Config{
-				IstioCAAddress: lis.Addr().String(),
-				RSAKeySize:     512,
-			},
-			pc:       mockpc.FakeClient{[]grpc.DialOption{}, "", "service1", "", []byte{}, "", true},
-			res:      defaultServerResponse,
-			cAClient: &cAGrpcClientImpl{},
-			expectedErr: fmt.Sprintf("failed to dial %s: grpc: no transport security set "+
-				"(use grpc.WithInsecure() explicitly or set credentials)", lis.Addr().String()),
-		},
-		"Error from GetDialOptions": {
-			config: &Config{
-				IstioCAAddress: lis.Addr().String(),
-				RSAKeySize:     512,
-			},
-			pc: mockpc.FakeClient{[]grpc.DialOption{
-				grpc.WithInsecure(),
-			}, "Error from GetDialOptions", "service1", "", []byte{}, "", true},
-			res:         defaultServerResponse,
-			cAClient:    &cAGrpcClientImpl{},
-			expectedErr: "Error from GetDialOptions",
-		},
-		"SendCSR not approved": {
-			config: &Config{
-				IstioCAAddress: lis.Addr().String(),
-				RSAKeySize:     512,
-			},
-			pc: mockpc.FakeClient{[]grpc.DialOption{
-				grpc.WithInsecure(),
-			}, "", "service1", "", []byte{}, "", true},
-			res:         defaultServerResponse,
-			cAClient:    &cAGrpcClientImpl{},
-			expectedErr: "",
-		},
-	}
-
-	for id, c := range testCases {
-		fakeFileUtil := mockutil.FakeFileUtil{
-			ReadContent:  make(map[string][]byte),
-			WriteContent: make(map[string][]byte),
-		}
-
-		fakeWorkloadIO, _ := workload.NewSecretServer(
-			workload.Config{
-				Mode:                          workload.SecretFile,
-				FileUtil:                      fakeFileUtil,
-				ServiceIdentityCertFile:       "cert_file",
-				ServiceIdentityPrivateKeyFile: "key_file",
-			},
-		)
-
-		na := nodeAgentInternal{c.config, c.pc, c.cAClient, "service1", fakeWorkloadIO, c.certUtil}
-
-		serv.SetResponseAndError(&c.res, c.resErr)
-
-		_, req, _ := na.createRequest()
-		_, err := na.cAClient.SendCSR(req, na.pc, na.config)
-		if len(c.expectedErr) > 0 {
-			if err == nil {
-				t.Errorf("Error expected: %v", c.expectedErr)
-			} else if !strings.Contains(err.Error(), c.expectedErr) {
-				t.Errorf("%s: incorrect error message: got [%s] VS want [%s]", id, err.Error(), c.expectedErr)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Unexpected expected: %v", err)
-			}
 		}
 	}
 }

--- a/security/pkg/caclient/grpc/client.go
+++ b/security/pkg/caclient/grpc/client.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/pkg/platform"
+	pb "istio.io/istio/security/proto"
+)
+
+// CAGrpcClient is for implementing the GRPC client to talk to CA.
+type CAGrpcClient interface {
+	// Send CSR to the CA and gets the response or error.
+	SendCSR(*pb.Request, platform.Client, string) (*pb.Response, error)
+}
+
+// CAGrpcClientImpl is an implementation of GRPC client to talk to CA.
+type CAGrpcClientImpl struct {
+}
+
+// SendCSR sends CSR to CA through GRPC.
+func (c *CAGrpcClientImpl) SendCSR(req *pb.Request, pc platform.Client, caAddress string) (*pb.Response, error) {
+	if caAddress == "" {
+		return nil, fmt.Errorf("istio CA address is empty")
+	}
+	dialOptions, err := pc.GetDialOptions()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := grpc.Dial(caAddress, dialOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial %s: %v", caAddress, err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Errorf("Failed to close connection")
+		}
+	}()
+	client := pb.NewIstioCAServiceClient(conn)
+	resp, err := client.HandleCSR(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("CSR request failed %v", err)
+	}
+	return resp, nil
+}

--- a/security/pkg/caclient/grpc/client_test.go
+++ b/security/pkg/caclient/grpc/client_test.go
@@ -1,0 +1,166 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpc
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/security/pkg/pki/ca"
+	"istio.io/istio/security/pkg/platform"
+	mockpc "istio.io/istio/security/pkg/platform/mock"
+	pb "istio.io/istio/security/proto"
+)
+
+type FakeIstioCAGrpcServer struct {
+	IsApproved      bool
+	Status          *rpc.Status
+	SignedCertChain []byte
+
+	response *pb.Response
+	errorMsg string
+}
+
+func (s *FakeIstioCAGrpcServer) SetResponseAndError(response *pb.Response, errorMsg string) {
+	s.response = response
+	s.errorMsg = errorMsg
+}
+
+func (s *FakeIstioCAGrpcServer) HandleCSR(ctx context.Context, req *pb.Request) (*pb.Response, error) {
+	if len(s.errorMsg) > 0 {
+		return nil, fmt.Errorf(s.errorMsg)
+	}
+
+	return s.response, nil
+}
+
+func TestSendCSRAgainstLocalInstance(t *testing.T) {
+	// create a local grpc server
+	s := grpc.NewServer()
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Errorf("failed to listen: %v", err)
+	}
+	serv := FakeIstioCAGrpcServer{}
+
+	go func() {
+		defer func() {
+			s.Stop()
+		}()
+		pb.RegisterIstioCAServiceServer(s, &serv)
+		reflection.Register(s)
+		if err := s.Serve(lis); err != nil {
+			t.Errorf("failed to serve: %v", err)
+		}
+	}()
+
+	// The goroutine starting the server may not be ready, results in flakiness.
+	time.Sleep(1 * time.Second)
+
+	defaultServerResponse := pb.Response{
+		IsApproved:      true,
+		Status:          &rpc.Status{Code: int32(rpc.OK), Message: "OK"},
+		SignedCertChain: nil,
+	}
+
+	testCases := map[string]struct {
+		caAddress   string
+		pc          platform.Client
+		respErr     string
+		expectedErr string
+	}{
+		"IstioCAAddress is empty": {
+			caAddress: "",
+			pc: mockpc.FakeClient{[]grpc.DialOption{
+				grpc.WithInsecure(),
+			}, "", "service1", "", []byte{}, "", true},
+			expectedErr: "istio CA address is empty",
+		},
+		"IstioCAAddress is incorrect": {
+			caAddress: lis.Addr().String() + "1",
+			pc: mockpc.FakeClient{[]grpc.DialOption{
+				grpc.WithInsecure(),
+			}, "", "service1", "", []byte{}, "", true},
+			expectedErr: "CSR request failed rpc error: code = Unavailable desc = all SubConns are in TransientFailure",
+		},
+		"Without Insecure option": {
+			caAddress: lis.Addr().String(),
+			pc:        mockpc.FakeClient{[]grpc.DialOption{}, "", "service1", "", []byte{}, "", true},
+			expectedErr: fmt.Sprintf("failed to dial %s: grpc: no transport security set "+
+				"(use grpc.WithInsecure() explicitly or set credentials)", lis.Addr().String()),
+		},
+		"Error from GetDialOptions": {
+			caAddress: lis.Addr().String(),
+			pc: mockpc.FakeClient{[]grpc.DialOption{
+				grpc.WithInsecure(),
+			}, "Error from GetDialOptions", "service1", "", []byte{}, "", true},
+			expectedErr: "Error from GetDialOptions",
+		},
+		"SendCSR not approved": {
+			caAddress: lis.Addr().String(),
+			pc: mockpc.FakeClient{[]grpc.DialOption{
+				grpc.WithInsecure(),
+			}, "", "service1", "", []byte{}, "", true},
+			expectedErr: "",
+		},
+	}
+
+	for id, c := range testCases {
+		csr, _, err := ca.GenCSR(ca.CertOptions{
+			Host:       "service1",
+			Org:        "orgA",
+			RSAKeySize: 512,
+		})
+		if err != nil {
+			t.Errorf("CSR generation failure (%v)", err)
+		}
+
+		cred, err := c.pc.GetAgentCredential()
+		if err != nil {
+			t.Errorf("Error getting credential (%v)", err)
+		}
+
+		req := &pb.Request{
+			CsrPem:              csr,
+			NodeAgentCredential: cred,
+			CredentialType:      c.pc.GetCredentialType(),
+			RequestedTtlMinutes: 60,
+		}
+
+		serv.SetResponseAndError(&defaultServerResponse, "")
+
+		client := &CAGrpcClientImpl{}
+		_, err = client.SendCSR(req, c.pc, c.caAddress)
+		if len(c.expectedErr) > 0 {
+			if err == nil {
+				t.Errorf("Error expected: %v", c.expectedErr)
+			} else if !strings.Contains(err.Error(), c.expectedErr) {
+				t.Errorf("%s: incorrect error message: got [%s] VS want [%s]", id, err.Error(), c.expectedErr)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected expected: %v", err)
+			}
+		}
+	}
+}

--- a/security/pkg/caclient/grpc/mock/fakeclient.go
+++ b/security/pkg/caclient/grpc/mock/fakeclient.go
@@ -1,0 +1,40 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"fmt"
+
+	"istio.io/istio/security/pkg/platform"
+	pb "istio.io/istio/security/proto"
+)
+
+const (
+	maxCAClientSuccessReturns = 8
+)
+
+type FakeCAClient struct {
+	Counter  int
+	Response *pb.Response
+	Err      error
+}
+
+func (f *FakeCAClient) SendCSR(req *pb.Request, pc platform.Client, addr string) (*pb.Response, error) {
+	f.Counter++
+	if f.Counter > maxCAClientSuccessReturns {
+		return nil, fmt.Errorf("terminating the test with errors")
+	}
+	return f.Response, f.Err
+}


### PR DESCRIPTION
Move the CA client code out of the node agent code to make it reusable for multi-cluster CA-CA communication.