### PR TITLE
Log on stray go scheduled routines

### DIFF
--- a/mixer/pkg/runtime2/handler/env_test.go
+++ b/mixer/pkg/runtime2/handler/env_test.go
@@ -32,7 +32,7 @@ func TestEnv(t *testing.T) {
 		o := log.NewOptions()
 		_ = log.Configure(o)
 
-		env := NewEnv(0, "Foo", gp)
+		env := newEnv(0, "Foo", gp)
 		log := env.Logger()
 		log.Infof("Test%s", "ing")
 		log.Warningf("Test%s", "ing")

--- a/mixer/pkg/runtime2/handler/table.go
+++ b/mixer/pkg/runtime2/handler/table.go
@@ -48,9 +48,9 @@ type entry struct {
 	env env
 }
 
-// NewTable returns a new table, based on the given config snapshot. The table will re-use existing handlers as much as
+// newTable returns a new table, based on the given config snapshot. The table will re-use existing handlers as much as
 // possible from the old table.
-func NewTable(old *table, snapshot *config.Snapshot, gp *pool.GoroutinePool) *table {
+func newTable(old *table, snapshot *config.Snapshot, gp *pool.GoroutinePool) *table {
 	var f *factory
 
 	// Find all handlers, as referenced by instances, and associate to handlers.
@@ -162,7 +162,7 @@ func (t *table) Get(handlerName string) (entry, bool) {
 
 var emptyTable = &table{}
 
-// Empty returns an empty table instance.
-func Empty() *table {
+// empty returns an empty table instance.
+func empty() *table {
 	return emptyTable
 }

--- a/mixer/pkg/runtime2/handler/table.go
+++ b/mixer/pkg/runtime2/handler/table.go
@@ -133,7 +133,10 @@ func (t *Table) Cleanup(current *Table) {
 			err = panicErr
 		}
 
-		_ = entry.env.ensureWorkerClosed()
+		if reportErr := entry.env.reportStrayWorkers(); reportErr != nil {
+			log.Warnf("unable to report if there are any stray go routines scheduled by the adapter '%s': %v",
+				entry.Name, reportErr)
+		}
 
 		if err != nil {
 			t.counters.closeFailure.Inc()

--- a/mixer/pkg/runtime2/handler/table.go
+++ b/mixer/pkg/runtime2/handler/table.go
@@ -15,8 +15,6 @@
 package handler
 
 import (
-	"fmt"
-
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime2/config"
@@ -135,13 +133,7 @@ func (t *table) Cleanup(current *table) {
 			err = panicErr
 		}
 
-		if workerCloseErr := entry.env.ensureWorkerClosed(); workerCloseErr != nil {
-			if err == nil {
-				err = workerCloseErr
-			} else {
-				err = fmt.Errorf("%v, %v", err, workerCloseErr)
-			}
-		}
+		_ = entry.env.ensureWorkerClosed()
 
 		if err != nil {
 			t.counters.closeFailure.Inc()

--- a/mixer/pkg/runtime2/handler/table.go
+++ b/mixer/pkg/runtime2/handler/table.go
@@ -28,7 +28,7 @@ type Table struct {
 	counters tableCounters
 }
 
-// entry in the handler table.
+// Entry in the handler table.
 type Entry struct {
 	// Name of the Handler
 	Name string

--- a/mixer/pkg/runtime2/handler/table_test.go
+++ b/mixer/pkg/runtime2/handler/table_test.go
@@ -212,7 +212,8 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 	}
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d]", idx), func(t *testing.T) {
-			adapters := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", SpawnWorker: tt.SpawnWorker, SpawnDaemon: tt.SpawnDaemon, CloseGoRoutines: tt.CloseGoRoutines})
+			adapters := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", SpawnWorker: tt.SpawnWorker,
+			SpawnDaemon: tt.SpawnDaemon, CloseGoRoutines: tt.CloseGoRoutines})
 			templates := data.BuildTemplates()
 
 			s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)

--- a/mixer/pkg/runtime2/handler/table_test.go
+++ b/mixer/pkg/runtime2/handler/table_test.go
@@ -213,7 +213,7 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d]", idx), func(t *testing.T) {
 			adapters := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", SpawnWorker: tt.SpawnWorker,
-			SpawnDaemon: tt.SpawnDaemon, CloseGoRoutines: tt.CloseGoRoutines})
+				SpawnDaemon: tt.SpawnDaemon, CloseGoRoutines: tt.CloseGoRoutines})
 			templates := data.BuildTemplates()
 
 			s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)

--- a/mixer/pkg/runtime2/handler/table_test.go
+++ b/mixer/pkg/runtime2/handler/table_test.go
@@ -38,7 +38,7 @@ var globalCfgI2 = data.JoinConfigs(data.HandlerACheck1, data.InstanceCheck1, dat
 func TestNew_EmptyConfig(t *testing.T) {
 	s := config.Empty()
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 	e, found := table.Get(data.FqnACheck1)
 	if found {
 		t.Fatal("found")
@@ -55,7 +55,7 @@ func TestNew_EmptyOldTable(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 	e, found := table.Get(data.FqnACheck1)
 	if !found {
 		t.Fatal("not found")
@@ -72,13 +72,13 @@ func TestNew_Reuse(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// NewTable again using the same config, but add fault to the adapter to detect change.
 	adapters = data.BuildAdapters(data.FakeAdapterSettings{Name: "tcheck", ErrorAtBuild: true})
 	s = util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table2 := NewTable(table, s, nil)
+	table2 := newTable(table, s, nil)
 
 	if len(table2.entries) != 1 {
 		t.Fatal("size")
@@ -95,12 +95,12 @@ func TestNew_NoReuse_DifferentConfig(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// NewTable again using the slightly different config
 	s = util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfgI2)
 
-	table2 := NewTable(table, s, nil)
+	table2 := newTable(table, s, nil)
 
 	if len(table2.entries) != 1 {
 		t.Fatal("size")
@@ -143,7 +143,7 @@ func TestTable_Get_Empty(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	table := Empty()
+	table := empty()
 
 	if len(table.entries) > 0 {
 		t.Fail()
@@ -157,11 +157,11 @@ func TestCleanup_Basic(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	s = config.Empty()
 
-	table2 := NewTable(table, s, nil)
+	table2 := newTable(table, s, nil)
 
 	table.Cleanup(table2)
 
@@ -216,12 +216,12 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 			s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 			s.ID = int64(idx * 2)
 
-			oldTable := NewTable(Empty(), s, pool.NewGoroutinePool(5, false))
+			oldTable := newTable(empty(), s, pool.NewGoroutinePool(5, false))
 
 			s = config.Empty()
 			s.ID = int64(idx*2 + 1)
 
-			newTable := NewTable(oldTable, s, nil)
+			newTable := newTable(oldTable, s, nil)
 
 			oldTable.Cleanup(newTable)
 
@@ -249,10 +249,10 @@ func TestCleanup_NoChange(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// use same config again.
-	table2 := NewTable(table, s, nil)
+	table2 := newTable(table, s, nil)
 
 	table.Cleanup(table2)
 
@@ -267,10 +267,10 @@ func TestCleanup_EmptyNewTable(t *testing.T) {
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
 
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// Use an empty table as current.
-	table.Cleanup(Empty())
+	table.Cleanup(empty())
 }
 
 func TestCleanup_WithStartupError(t *testing.T) {
@@ -279,14 +279,14 @@ func TestCleanup_WithStartupError(t *testing.T) {
 	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	if _, found := table.Get(data.FqnACheck1); found {
 		t.Fail()
 	}
 
 	// use different config to force cleanup
-	table2 := NewTable(table, config.Empty(), nil)
+	table2 := newTable(table, config.Empty(), nil)
 
 	table.Cleanup(table2)
 
@@ -302,10 +302,10 @@ func TestCleanup_CloseError(t *testing.T) {
 	templates := data.BuildTemplates()
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// use different config to force cleanup
-	table2 := NewTable(table, config.Empty(), nil)
+	table2 := newTable(table, config.Empty(), nil)
 
 	table.Cleanup(table2)
 
@@ -324,10 +324,10 @@ func TestCleanup_ClosePanic(t *testing.T) {
 	templates := data.BuildTemplates()
 
 	s := util.GetSnapshot(templates, adapters, data.ServiceConfig, globalCfg)
-	table := NewTable(Empty(), s, nil)
+	table := newTable(empty(), s, nil)
 
 	// use different config to force cleanup
-	table2 := NewTable(table, config.Empty(), nil)
+	table2 := newTable(table, config.Empty(), nil)
 
 	table.Cleanup(table2)
 

--- a/mixer/pkg/runtime2/handler/table_test.go
+++ b/mixer/pkg/runtime2/handler/table_test.go
@@ -221,6 +221,9 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 			oldTable := NewTable(Empty(), s, pool.NewGoroutinePool(5, false))
 
 			s = config.Empty()
+			// Every iteration of this test is working with two different config snapshot (old and new). We need to
+			// allocate distinct config ids to each of the config snapshot for all the iterations. Multiplying
+			// by 2 and adding 1, give unique ids per iteration [(0,1), (1,2), ...]
 			s.ID = int64(idx*2 + 1)
 
 			newTable := NewTable(oldTable, s, nil)
@@ -237,7 +240,7 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 				t.Fatalf("expected %v worker stray routines; got %v", tt.wantWorkerStrayRoutine, *m.GetGauge().Value)
 			}
 
-			c = oldTable.entries["hcheck1.acheck.istio-system"].env.counters.daemons
+			c = oldTable.entries[data.FqnACheck1].env.counters.daemons
 			m = new(dto.Metric)
 			_ = c.Write(m)
 			if *m.GetGauge().Value != tt.wantDaemonStrayRoutine {


### PR DESCRIPTION
Log if go routine are not properly closed by adapters after they have been closed() on the handler interface.

Based on offline discussion with @ozevren I have also made a change where now the CloseFailure counter is reported on the old snapshot config instead of new snapshot config. This is done because miss behaving handler is actually tied to the old config and not the one which the mixer has already flipped to.