### PR TITLE
 Update prometheus config to handle multiple mixer instances

### DIFF
--- a/install/kubernetes/addons/prometheus.yaml
+++ b/install/kubernetes/addons/prometheus.yaml
@@ -15,24 +15,42 @@ data:
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.istio-system:42422']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-mixer;prometheus
 
     - job_name: 'envoy'
       # Override the global default and scrape targets from this job every 5 seconds.
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.istio-system:9102']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-mixer;statsd-prom
 
     - job_name: 'mixer'
       # Override the global default and scrape targets from this job every 5 seconds.
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.istio-system:9093']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-system;istio-mixer;http-health
 ---
 apiVersion: v1
 kind: Service

--- a/install/kubernetes/templates/addons/prometheus.yaml.tmpl
+++ b/install/kubernetes/templates/addons/prometheus.yaml.tmpl
@@ -15,24 +15,42 @@ data:
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.{ISTIO_NAMESPACE}:42422']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: {ISTIO_NAMESPACE};istio-mixer;prometheus
 
     - job_name: 'envoy'
       # Override the global default and scrape targets from this job every 5 seconds.
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.{ISTIO_NAMESPACE}:9102']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: {ISTIO_NAMESPACE};istio-mixer;statsd-prom
 
     - job_name: 'mixer'
       # Override the global default and scrape targets from this job every 5 seconds.
       scrape_interval: 5s
       # metrics_path defaults to '/metrics'
       # scheme defaults to 'http'.
-      static_configs:
-      - targets: ['istio-mixer.{ISTIO_NAMESPACE}:9093']
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: {ISTIO_NAMESPACE};istio-mixer;http-health
 ---
 apiVersion: v1
 kind: Service

--- a/mixer/adapter/prometheus/prometheus.go
+++ b/mixer/adapter/prometheus/prometheus.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/gogo/protobuf/proto"
+
 	"istio.io/istio/mixer/adapter/prometheus/config"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/template/metric"

--- a/security/pkg/server/grpc/server.go
+++ b/security/pkg/server/grpc/server.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"google.golang.org/grpc/status"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki"
 	"istio.io/istio/security/pkg/pki/ca"

--- a/security/pkg/server/grpc/server_test.go
+++ b/security/pkg/server/grpc/server_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"google.golang.org/grpc/status"
+
 	"istio.io/istio/security/pkg/pki/ca"
 	pb "istio.io/istio/security/proto"
 )


### PR DESCRIPTION
Prometheus config now uses the Kubernetes service discovery features to find all the mixer endpoints behind the istio-mixer service.

https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<kubernetes_sd_config>
https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml

Fixes #2746 #2531
