### PR TITLE
Fix the setup script for VMs, add back to pilot port for upgrades

### DIFF
--- a/install/kubernetes/templates/istio-pilot.yaml.tmpl
+++ b/install/kubernetes/templates/istio-pilot.yaml.tmpl
@@ -56,6 +56,8 @@ spec:
   ports:
   - port: 15003
     name: http-discovery
+  - port: 8080
+    name: http-legacy-discovery
   - port: 443
     name: admission-webhook
   selector:

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -57,14 +57,10 @@ function istioNetworkInit() {
 function istioInstall() {
   echo "*** Fetching istio packages..."
   # Current URL for the debian files artifacts. Will be replaced by a proper apt repo.
-  curl -f -L ${PILOT_DEBIAN_URL}/istio-agent.deb > ${ISTIO_STAGING}/istio-agent.deb
-  curl -f -L ${AUTH_DEBIAN_URL}/istio-auth-node-agent.deb > ${ISTIO_STAGING}/istio-auth-node-agent.deb
-  curl -f -L ${PROXY_DEBIAN_URL}/istio-proxy.deb > ${ISTIO_STAGING}/istio-proxy.deb
+  curl -f -L ${PILOT_DEBIAN_URL}/istio-sidecar.deb > ${ISTIO_STAGING}/istio-sidecar.deb
 
   # Install istio binaries
-  dpkg -i ${ISTIO_STAGING}/istio-proxy.deb
-  dpkg -i ${ISTIO_STAGING}/istio-agent.deb
-  dpkg -i ${ISTIO_STAGING}/istio-auth-node-agent.deb
+  dpkg -i ${ISTIO_STAGING}/istio-sidecar.deb
 
   mkdir -p /etc/certs
 

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -57,6 +57,8 @@ function istioNetworkInit() {
 function istioInstall() {
   echo "*** Fetching istio packages..."
   # Current URL for the debian files artifacts. Will be replaced by a proper apt repo.
+  rm -f istio-sidecar.deb
+  echo curl -f -L ${PILOT_DEBIAN_URL}/istio-sidecar.deb > ${ISTIO_STAGING}/istio-sidecar.deb
   curl -f -L ${PILOT_DEBIAN_URL}/istio-sidecar.deb > ${ISTIO_STAGING}/istio-sidecar.deb
 
   # Install istio binaries
@@ -97,6 +99,7 @@ function istioRestart() {
 if [[ ${1:-} == "initNetwork" ]] ; then
   istioNetworkInit
 elif [[ ${1:-} == "istioInstall" ]] ; then
+  istioVersionSource
   istioInstall
   istioRestart
 elif [[ ${1:-} == "help" ]] ; then


### PR DESCRIPTION
First part matches the new distribution (single debian file).

The second is useful for cases where istio apps using older versions of pods (which were attempting to use port 8080). Also we will need to adjust 15003 to use mTLS, to allow gradual adoption of auth (i.e. a mix of auth and no-auth ), in which case we need to keep using 8080.