### PR TITLE
Add script for e2e tests where Istio is already installed.

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2017,2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Script entry into Istio smoketest run with a k8s cluster with Istio installed.
+# This is intended as a smoketest for external callers that require a simple
+# script entry point.
+#
+# Usage: e2e_istio_preinstalled.sh bookinfo|simple
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+[[ $1 == "bookinfo" || $1 == "simple" ]] || { echo "$1 is not a legal test name"; exit 1; }
+
+HUB=gcr.io/istio-testing
+TAG=`git rev-parse HEAD`
+
+go test -v -timeout 20m ./tests/e2e/tests/$1 -args \
+--skip_setup --namespace istio-system \
+--mixer_tag ${TAG} --pilot_tag ${TAG} --ca_tag ${TAG} \
+--mixer_hub ${HUB} --pilot_hub ${HUB} --ca_hub ${HUB} \
+--istioctl_url https://storage.googleapis.com/istio-artifacts/pilot/${TAG}/artifacts/istioctl


### PR DESCRIPTION
This script has two purposes:
1. Add a convenient script entry point for external test frameworks (in this case k8s e2e integration tests).
2. Run tests against a cluster where Istio components are already installed (e.g. where Istio is a selected k8s addon). 
The caller is expected to have checked out istio repo at the desired sha1 to test against.