### PR TITLE
fix versioning in istioctl

### DIFF
--- a/pilot/bin/upload-istioctl
+++ b/pilot/bin/upload-istioctl
@@ -53,7 +53,7 @@ done
 [[ "${BIN_DIR}" != '.' ]] && trap cleanup exit
 
 GOBUILD="${ROOT}/../bin/gobuild.sh"
-VERSION_PACKAGE=istio.io/istio/pilot/tools/version
+VERSION_PACKAGE=istio.io/istio/pkg/version
 
 STATIC=0 GOOS=linux ${GOBUILD} "${BIN_DIR}/istioctl-linux" ${VERSION_PACKAGE} istio.io/istio/pilot/cmd/istioctl
 


### PR DESCRIPTION
istioctl just reports a bunch of "unknown" for its version (and other commands).  This only happens when istioctl is built using upload-istioctl, but that's what the release build uses (at least for now, I've already had a pending PR for awhile that gets rid of this).

I tested locally that without this change i saw the unknowns, and with it I saw some actual version information when I ran "istioctl-linux version".