### PR TITLE
do not touch pilot/pkg/kube/config at setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ checkvars:
 	@if test -z "$(TAG)"; then echo "TAG missing"; exit 1; fi
 	@if test -z "$(HUB)"; then echo "HUB missing"; exit 1; fi
 
-setup: pilot/pkg/kube/config
+setup:
 
 #-----------------------------------------------------------------------------
 # Target: depend
@@ -532,7 +532,7 @@ artifacts: docker
 	@echo 'To be added'
 
 pilot/pkg/kube/config:
-	touch $@
+	@echo 'nothing needs to be done for' $@
 
 kubelink:
 	ln -fs ~/.kube/config pilot/pkg/kube/

--- a/Makefile
+++ b/Makefile
@@ -531,9 +531,6 @@ push: checkvars clean.installgen installgen
 artifacts: docker
 	@echo 'To be added'
 
-pilot/pkg/kube/config:
-	@echo 'nothing needs to be done for' $@
-
 kubelink:
 	ln -fs ~/.kube/config pilot/pkg/kube/
 


### PR DESCRIPTION
This file does not have to exist anymore, and touching it causes
unexpected test failures. Fixes #2835