### PR TITLE
bugfix: generate sidecar injection configmap install files from template

### DIFF
--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
@@ -1,105 +1,107 @@
 kind: ConfigMap
 metadata:
   name: istio-inject
+  namespace: {ISTIO_NAMESPACE}
 apiVersion: v1
 data:
-  policy: enabled
-  template: |-
-    initContainers:
-    - name: istio-init
-      image: {PILOT_HUB}/proxy_init:{PILOT_TAG}
-      args:
-      - "-p"
-      - {{ .MeshConfig.ProxyListenPort }}
-      - "-u"
-      - 1337
-      imagePullPolicy: IfNotPresent
-      securityContext:
-        capabilities:
-          add:
-          - NET_ADMIN
-        privileged: true
-      restartPolicy: Always
-    - args:
-      - -c
-      - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-        unlimited
-      command:
-      - /bin/sh
-      image: alpine
-      imagePullPolicy: IfNotPresent
-      name: enable-core-dump
-      resources: {}
-      securityContext:
-        privileged: true
-    containers:
-    - name: istio-proxy
-      image: {PILOT_HUB}/{PROXY_IMAGE}:{PILOT_TAG}
-      args:
-      - proxy
-      - sidecar
-      - --configPath
-      - {{ .ProxyConfig.ConfigPath }}
-      - --binaryPath
-      - {{ .ProxyConfig.BinaryPath }}
-      - --serviceCluster
-      {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-      - {{ index .ObjectMeta.Labels "app" }}
-      {{ else -}}
-      - "istio-proxy"
-      {{ end -}}
-      - --drainDuration
-      - 2s
-      - --parentShutdownDuration
-      - 3s
-      - --discoveryAddress
-      - {{ .ProxyConfig.DiscoveryAddress }}
-      - --discoveryRefreshDelay
-      - 1s
-      - --zipkinAddress
-      - {{ .ProxyConfig.ZipkinAddress }}
-      - --connectTimeout
-      - 1s
-      - --statsdUdpAddress
-      - {{ .ProxyConfig.StatsdUdpAddress }}
-      - --proxyAdminPort
-      - {{ .ProxyConfig.ProxyAdminPort }}
-      - --controlPlaneAuthPolicy
-      - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
-      env:
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: INSTANCE_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      imagePullPolicy: IfNotPresent
-      securityContext:
+  config: |
+    policy: enabled
+    template: |-
+      initContainers:
+      - name: istio-init
+        image: {PILOT_HUB}/proxy_init:{PILOT_TAG}
+        args:
+        - "-p"
+        - {{ .MeshConfig.ProxyListenPort }}
+        - "-u"
+        - 1337
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
           privileged: true
-          readOnlyRootFilesystem: false
-          runAsUser: 1337
-      restartPolicy: Always
-      volumeMounts:
-      - mountPath: /etc/istio/proxy
-        name: istio-envoy
-      - mountPath: /etc/certs/
-        name: istio-certs
-        readOnly: true
-    volumes:
-    - emptyDir:
-        medium: Memory
-      name: istio-envoy
-    - name: istio-certs
-      secret:
-        optional: true
-        {{ if eq .Spec.ServiceAccountName "" -}}
-        secretName: istio.default
+        restartPolicy: Always
+      - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
+          unlimited
+        command:
+        - /bin/sh
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        name: enable-core-dump
+        resources: {}
+        securityContext:
+          privileged: true
+      containers:
+      - name: istio-proxy
+        image: {PILOT_HUB}/{PROXY_IMAGE}:{PILOT_TAG}
+        args:
+        - proxy
+        - sidecar
+        - --configPath
+        - {{ .ProxyConfig.ConfigPath }}
+        - --binaryPath
+        - {{ .ProxyConfig.BinaryPath }}
+        - --serviceCluster
+        {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+        - {{ index .ObjectMeta.Labels "app" }}
         {{ else -}}
-        secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+        - "istio-proxy"
         {{ end -}}
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - {{ .ProxyConfig.DiscoveryAddress }}
+        - --discoveryRefreshDelay
+        - 1s
+        - --zipkinAddress
+        - {{ .ProxyConfig.ZipkinAddress }}
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - {{ .ProxyConfig.StatsdUdpAddress }}
+        - --proxyAdminPort
+        - {{ .ProxyConfig.ProxyAdminPort }}
+        - --controlPlaneAuthPolicy
+        - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsUser: 1337
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          {{ if eq .Spec.ServiceAccountName "" -}}
+          secretName: istio.default
+          {{ else -}}
+          secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+          {{ end -}}

--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
@@ -4,7 +4,7 @@ metadata:
   namespace: {ISTIO_NAMESPACE}
 apiVersion: v1
 data:
-  config:
+  config: |
     policy: enabled
     template: |-
       initContainers:

--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
@@ -1,105 +1,107 @@
 kind: ConfigMap
 metadata:
   name: istio-inject
+  namespace: {ISTIO_NAMESPACE}
 apiVersion: v1
 data:
-  policy: enabled
-  template: |-
-    initContainers:
-    - name: istio-init
-      image: {PILOT_HUB}/proxy_init:{PILOT_TAG}
-      args:
-      - "-p"
-      - {{ .MeshConfig.ProxyListenPort }}
-      - "-u"
-      - 1337
-      imagePullPolicy: IfNotPresent
-      securityContext:
-        capabilities:
-          add:
-          - NET_ADMIN
-        privileged: true
-      restartPolicy: Always
-    - args:
-      - -c
-      - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-        unlimited
-      command:
-      - /bin/sh
-      image: alpine
-      imagePullPolicy: IfNotPresent
-      name: enable-core-dump
-      resources: {}
-      securityContext:
-        privileged: true
-    containers:
-    - name: istio-proxy
-      image: {PILOT_HUB}/{PROXY_IMAGE}:{PILOT_TAG}
-      args:
-      - proxy
-      - sidecar
-      - --configPath
-      - {{ .ProxyConfig.ConfigPath }}
-      - --binaryPath
-      - {{ .ProxyConfig.BinaryPath }}
-      - --serviceCluster
-      {{ if ne "" (index .ObjectMeta.Labels "app") -}}
-      - {{ index .ObjectMeta.Labels "app" }}
-      {{ else -}}
-      - "istio-proxy"
-      {{ end -}}
-      - --drainDuration
-      - 2s
-      - --parentShutdownDuration
-      - 3s
-      - --discoveryAddress
-      - {{ .ProxyConfig.DiscoveryAddress }}
-      - --discoveryRefreshDelay
-      - 1s
-      - --zipkinAddress
-      - {{ .ProxyConfig.ZipkinAddress }}
-      - --connectTimeout
-      - 1s
-      - --statsdUdpAddress
-      - {{ .ProxyConfig.StatsdUdpAddress }}
-      - --proxyAdminPort
-      - {{ .ProxyConfig.ProxyAdminPort }}
-      - --controlPlaneAuthPolicy
-      - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
-      env:
-      - name: POD_NAME
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.name
-      - name: POD_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      - name: INSTANCE_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
-      imagePullPolicy: IfNotPresent
-      securityContext:
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsUser: 1337
-      restartPolicy: Always
-      volumeMounts:
-      - mountPath: /etc/istio/proxy
-        name: istio-envoy
-      - mountPath: /etc/certs/
-        name: istio-certs
-        readOnly: true
-    volumes:
-    - emptyDir:
-        medium: Memory
-      name: istio-envoy
-    - name: istio-certs
-      secret:
-        optional: true
-        {{ if eq .Spec.ServiceAccountName "" -}}
-        secretName: istio.default
+  config:
+    policy: enabled
+    template: |-
+      initContainers:
+      - name: istio-init
+        image: {PILOT_HUB}/proxy_init:{PILOT_TAG}
+        args:
+        - "-p"
+        - {{ .MeshConfig.ProxyListenPort }}
+        - "-u"
+        - 1337
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        restartPolicy: Always
+      - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
+          unlimited
+        command:
+        - /bin/sh
+        image: alpine
+        imagePullPolicy: IfNotPresent
+        name: enable-core-dump
+        resources: {}
+        securityContext:
+          privileged: true
+      containers:
+      - name: istio-proxy
+        image: {PILOT_HUB}/{PROXY_IMAGE}:{PILOT_TAG}
+        args:
+        - proxy
+        - sidecar
+        - --configPath
+        - {{ .ProxyConfig.ConfigPath }}
+        - --binaryPath
+        - {{ .ProxyConfig.BinaryPath }}
+        - --serviceCluster
+        {{ if ne "" (index .ObjectMeta.Labels "app") -}}
+        - {{ index .ObjectMeta.Labels "app" }}
         {{ else -}}
-        secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+        - "istio-proxy"
         {{ end -}}
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - {{ .ProxyConfig.DiscoveryAddress }}
+        - --discoveryRefreshDelay
+        - 1s
+        - --zipkinAddress
+        - {{ .ProxyConfig.ZipkinAddress }}
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - {{ .ProxyConfig.StatsdUdpAddress }}
+        - --proxyAdminPort
+        - {{ .ProxyConfig.ProxyAdminPort }}
+        - --controlPlaneAuthPolicy
+        - {{ .ProxyConfig.ControlPlaneAuthPolicy }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          {{ if eq .Spec.ServiceAccountName "" -}}
+          secretName: istio.default
+          {{ else -}}
+          secretName: {{ printf "istio.%s" .Spec.ServiceAccountName }}
+          {{ end -}}

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -135,6 +135,8 @@ function merge_files() {
   ISTIO_ONE_NAMESPACE=$DEST/istio-one-namespace.yaml
   ISTIO_ONE_NAMESPACE_AUTH=$DEST/istio-one-namespace-auth.yaml
   ISTIO_SIDECAR_INJECTOR=$DEST/istio-sidecar-injector.yaml
+  ISTIO_SIDECAR_INJECTOR_CONFIGMAP_DEBUG=$DEST/istio-sidecar-injector-configmap-debug.yaml
+  ISTIO_SIDECAR_INJECTOR_CONFIGMAP_RELEASE=$DEST/istio-sidecar-injector-configmap-release.yaml
   ISTIO_CA_PLUGIN_CERTS=$DEST/istio-ca-plugin-certs.yaml
 
 
@@ -185,6 +187,14 @@ function merge_files() {
   echo "# GENERATED FILE. Use with Kubernetes 1.9+" > $ISTIO_SIDECAR_INJECTOR
   echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_SIDECAR_INJECTOR
   cat ${SRC}/istio-sidecar-injector.yaml.tmpl >> $ISTIO_SIDECAR_INJECTOR
+
+  echo "# GENERATED FILE. Use with Kubernetes 1.9+" > $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_DEBUG
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_DEBUG
+  cat ${SRC}/istio-sidecar-injector-configmap-debug.yaml.tmpl >> $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_DEBUG
+
+  echo "# GENERATED FILE. Use with Kubernetes 1.9+" > $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_RELEASE
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_RELEASE
+  cat ${SRC}/istio-sidecar-injector-configmap-release.yaml.tmpl >> $ISTIO_SIDECAR_INJECTOR_CONFIGMAP_RELEASE
 
   echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CA_PLUGIN_CERTS
   echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CA_PLUGIN_CERTS
@@ -254,6 +264,8 @@ function update_istio_install() {
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ca-one-namespace.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ca-plugin-certs.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-sidecar-injector.yaml.tmpl
+  execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-sidecar-injector-configmap-debug.yaml.tmpl
+  execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-sidecar-injector-configmap-release.yaml.tmpl
 
   execute_sed "s|image: {PILOT_HUB}/\(.*\):{PILOT_TAG}|image: ${PILOT_HUB}/\1:${PILOT_TAG}|" istio-pilot.yaml.tmpl
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PILOT_HUB}/${PROXY_IMAGE}:${PILOT_TAG}|" istio-pilot.yaml.tmpl
@@ -266,6 +278,12 @@ function update_istio_install() {
   execute_sed "s|{PILOT_HUB}|${PILOT_HUB}|" istio-sidecar-injector.yaml.tmpl
   execute_sed "s|{PILOT_TAG}|${PILOT_TAG}|" istio-sidecar-injector.yaml.tmpl
   execute_sed "s|{PROXY_IMAGE}|${PROXY_IMAGE}|" istio-sidecar-injector.yaml.tmpl
+
+  execute_sed "s|{PILOT_HUB}|${PILOT_HUB}|" istio-sidecar-injector-configmap-debug.yaml.tmpl
+  execute_sed "s|{PILOT_TAG}|${PILOT_TAG}|" istio-sidecar-injector-configmap-debug.yaml.tmpl
+  execute_sed "s|{PILOT_HUB}|${PILOT_HUB}|" istio-sidecar-injector-configmap-release.yaml.tmpl
+  execute_sed "s|{PILOT_TAG}|${PILOT_TAG}|" istio-sidecar-injector-configmap-release.yaml.tmpl
+
 
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PILOT_HUB}/${PROXY_IMAGE}:${PILOT_TAG}|" istio-ingress.yaml.tmpl
   popd


### PR DESCRIPTION
The configmap install templates were out-of-date and not being updated by updateVersion.sh. Without this change the webhook is missing essential configuration to start.