### PR TITLE
test setup: update etcd package path to reflect removal of cmd

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -11,7 +11,7 @@ FROM    circleci/golang:1.9
 
 # Also installed docker, docker-compose, dockerize, jq
 
-RUN     go get github.com/coreos/etcd/cmd/etcd
+RUN     go get github.com/coreos/etcd
 
 ARG     K8S_VER=v1.7.4
 ARG     MASTER_IP=127.0.0.1

--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -63,7 +63,7 @@ function getDeps() {
      curl -Lo ${TOP}/bin/kube-apiserver https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-apiserver && chmod +x ${TOP}/bin/kube-apiserver
    fi
    if [ ! -f $TOP/bin/etcd ] ; then
-     go get github.com/coreos/etcd/cmd/etcd
+     go get github.com/coreos/etcd
    fi
    if [ ! -f $TOP/bin/envoy ] ; then
      # Init should be run after cloning the workspace


### PR DESCRIPTION
we were running 
```
go get github.com/coreos/etcd/cmd/etcd
```
but there is no such package anymore.

Some recent changes in etcd have remove the `cmd/etcd` package and lifted the `main` upt to the repo root.  There is now only `github.com/coreos/etcd`