### PR TITLE
only warn when registry specified multiple times

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -368,7 +368,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 	for _, r := range args.Service.Registries {
 		serviceRegistry := ServiceRegistry(r)
 		if _, exists := registered[serviceRegistry]; exists {
-			return multierror.Prefix(nil, r+" registry specified multiple times.")
+			log.Warnf("%s registry specified multiple times.", r)
+			continue
 		}
 		registered[serviceRegistry] = true
 		log.Infof("Adding %s registry adapter", serviceRegistry)


### PR DESCRIPTION
When service registry was specified multiple times, there is no need to break the server creation. We can only ignore the duplication, give warnings, then continue to new the server.