### PR TITLE
Move generate_csr code out of generate_cert.

### DIFF
--- a/security/pkg/pki/ca/generate_cert.go
+++ b/security/pkg/pki/ca/generate_cert.go
@@ -77,23 +77,6 @@ type CertOptions struct {
 // URIScheme is the URI scheme for Istio identities.
 const URIScheme = "spiffe"
 
-// GenCSR generates a X.509 certificate sign request and private key with the given options.
-func GenCSR(options CertOptions) ([]byte, []byte, error) {
-	// Generates a CSR
-	priv, err := rsa.GenerateKey(rand.Reader, options.RSAKeySize)
-	if err != nil {
-		return nil, nil, fmt.Errorf("CSR generation fails at RSA key generation (%v)", err)
-	}
-	template := GenCSRTemplate(options)
-	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, crypto.PrivateKey(priv))
-	if err != nil {
-		return nil, nil, fmt.Errorf("CSR generation fails at X509 cert request generation (%v)", err)
-	}
-
-	csr, privKey := encodePem(true, csrBytes, priv)
-	return csr, privKey, nil
-}
-
 func fatalf(template string, args ...interface{}) {
 	log.Errorf(template, args)
 	os.Exit(-1)
@@ -123,18 +106,6 @@ func GenCert(options CertOptions) ([]byte, []byte) {
 	return encodePem(false, certBytes, priv)
 }
 
-func encodePem(isCSR bool, csrOrCert []byte, priv *rsa.PrivateKey) ([]byte, []byte) {
-	encodeMsg := "CERTIFICATE"
-	if isCSR {
-		encodeMsg = "CERTIFICATE REQUEST"
-	}
-	csrOrCertPem := pem.EncodeToMemory(&pem.Block{Type: encodeMsg, Bytes: csrOrCert})
-
-	privDer := x509.MarshalPKCS1PrivateKey(priv)
-	privPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDer})
-	return csrOrCertPem, privPem
-}
-
 // LoadSignerCredsFromFiles loads the signer cert&key from the given files.
 //   signerCertFile: cert file name
 //   signerPrivFile: private key file name
@@ -161,6 +132,18 @@ func LoadSignerCredsFromFiles(signerCertFile string, signerPrivFile string) (*x5
 	return cert, key, nil
 }
 
+func encodePem(isCSR bool, csrOrCert []byte, priv *rsa.PrivateKey) ([]byte, []byte) {
+	encodeMsg := "CERTIFICATE"
+	if isCSR {
+		encodeMsg = "CERTIFICATE REQUEST"
+	}
+	csrOrCertPem := pem.EncodeToMemory(&pem.Block{Type: encodeMsg, Bytes: csrOrCert})
+
+	privDer := x509.MarshalPKCS1PrivateKey(priv)
+	privPem := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: privDer})
+	return csrOrCertPem, privPem
+}
+
 func genSerialNum() *big.Int {
 	serialNumLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNum, err := rand.Int(rand.Reader, serialNumLimit)
@@ -168,22 +151,6 @@ func genSerialNum() *big.Int {
 		fatalf("Serial number generation failure (%v)", err)
 	}
 	return serialNum
-}
-
-// GenCSRTemplate generates a certificateRequest template with the given options.
-func GenCSRTemplate(options CertOptions) x509.CertificateRequest {
-	template := x509.CertificateRequest{
-		Subject: pkix.Name{
-			Organization: []string{options.Org},
-		},
-	}
-
-	if h := options.Host; len(h) > 0 {
-		s := buildSubjectAltNameExtension(h)
-		template.ExtraExtensions = []pkix.Extension{*s}
-	}
-
-	return template
 }
 
 // genCertTemplate generates a certificate template with the given options.

--- a/security/pkg/pki/ca/generate_cert_test.go
+++ b/security/pkg/pki/ca/generate_cert_test.go
@@ -16,8 +16,6 @@ package ca
 
 import (
 	"crypto/x509"
-	"encoding/pem"
-	"strings"
 	"testing"
 	"time"
 
@@ -26,54 +24,6 @@ import (
 )
 
 var now = time.Now().Round(time.Second).UTC()
-
-func TestGenCSR(t *testing.T) {
-	// Options to generate a CSR.
-	csrOptions := CertOptions{
-		Host:       "test_ca.com",
-		Org:        "MyOrg",
-		RSAKeySize: 512,
-	}
-
-	csrPem, _, err := GenCSR(csrOptions)
-
-	if err != nil {
-		t.Errorf("failed to gen CSR")
-	}
-
-	pemBlock, _ := pem.Decode(csrPem)
-	if pemBlock == nil {
-		t.Errorf("failed to decode csr")
-	}
-	csr, err := x509.ParseCertificateRequest(pemBlock.Bytes)
-	if err != nil {
-		t.Errorf("failed to parse csr")
-	}
-	if err = csr.CheckSignature(); err != nil {
-		t.Errorf("csr signature is invalid")
-	}
-	if csr.Subject.Organization[0] != "MyOrg" {
-		t.Errorf("csr subject does not match")
-	}
-	if !strings.HasSuffix(string(csr.Extensions[0].Value[:]), "test_ca.com") {
-		t.Errorf("csr host does not match")
-	}
-}
-
-func TestGenCSRWithInvalidOption(t *testing.T) {
-	// Options with invalid Key size.
-	csrOptions := CertOptions{
-		Host:       "test_ca.com",
-		Org:        "MyOrg",
-		RSAKeySize: -1,
-	}
-
-	csr, priv, err := GenCSR(csrOptions)
-
-	if err == nil || csr != nil || priv != nil {
-		t.Errorf("Should have failed")
-	}
-}
 
 func TestLoadSignerCredsFromFiles(t *testing.T) {
 	testCases := map[string]struct {

--- a/security/pkg/pki/ca/generate_csr.go
+++ b/security/pkg/pki/ca/generate_csr.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	_ "github.com/golang/glog"
 )
 
 // GenCSR generates a X.509 certificate sign request and private key with the given options.

--- a/security/pkg/pki/ca/generate_csr.go
+++ b/security/pkg/pki/ca/generate_csr.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides utility methods to generate X.509 certificates with different
+// options. This implementation is Largely inspired from
+// https://golang.org/src/crypto/tls/generate_cert.go.
+
+package ca
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	_ "github.com/golang/glog"
+)
+
+// GenCSR generates a X.509 certificate sign request and private key with the given options.
+func GenCSR(options CertOptions) ([]byte, []byte, error) {
+	// Generates a CSR
+	priv, err := rsa.GenerateKey(rand.Reader, options.RSAKeySize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CSR generation fails at RSA key generation (%v)", err)
+	}
+	template := GenCSRTemplate(options)
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, crypto.PrivateKey(priv))
+	if err != nil {
+		return nil, nil, fmt.Errorf("CSR generation fails at X509 cert request generation (%v)", err)
+	}
+
+	csr, privKey := encodePem(true, csrBytes, priv)
+	return csr, privKey, nil
+}
+
+// GenCSRTemplate generates a certificateRequest template with the given options.
+func GenCSRTemplate(options CertOptions) x509.CertificateRequest {
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			Organization: []string{options.Org},
+		},
+	}
+
+	if h := options.Host; len(h) > 0 {
+		s := buildSubjectAltNameExtension(h)
+		template.ExtraExtensions = []pkix.Extension{*s}
+	}
+
+	return template
+}

--- a/security/pkg/pki/ca/generate_csr_test.go
+++ b/security/pkg/pki/ca/generate_csr_test.go
@@ -1,0 +1,70 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ca
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+func TestGenCSR(t *testing.T) {
+	// Options to generate a CSR.
+	csrOptions := CertOptions{
+		Host:       "test_ca.com",
+		Org:        "MyOrg",
+		RSAKeySize: 512,
+	}
+
+	csrPem, _, err := GenCSR(csrOptions)
+
+	if err != nil {
+		t.Errorf("failed to gen CSR")
+	}
+
+	pemBlock, _ := pem.Decode(csrPem)
+	if pemBlock == nil {
+		t.Errorf("failed to decode csr")
+	}
+	csr, err := x509.ParseCertificateRequest(pemBlock.Bytes)
+	if err != nil {
+		t.Errorf("failed to parse csr")
+	}
+	if err = csr.CheckSignature(); err != nil {
+		t.Errorf("csr signature is invalid")
+	}
+	if csr.Subject.Organization[0] != "MyOrg" {
+		t.Errorf("csr subject does not match")
+	}
+	if !strings.HasSuffix(string(csr.Extensions[0].Value[:]), "test_ca.com") {
+		t.Errorf("csr host does not match")
+	}
+}
+
+func TestGenCSRWithInvalidOption(t *testing.T) {
+	// Options with invalid Key size.
+	csrOptions := CertOptions{
+		Host:       "test_ca.com",
+		Org:        "MyOrg",
+		RSAKeySize: -1,
+	}
+
+	csr, priv, err := GenCSR(csrOptions)
+
+	if err == nil || csr != nil || priv != nil {
+		t.Errorf("Should have failed")
+	}
+}


### PR DESCRIPTION
This is part of the refactoring of Istio CA.