### PR TITLE
Fixing accidental rename of server->bootstrap

### DIFF
--- a/broker/pkg/server/broker.go
+++ b/broker/pkg/server/broker.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package server provides HTTP open service broker API bootstrap bindings.
+// Package server provides HTTP open service broker API server bindings.
 package server
 
 import (

--- a/mixer/test/client/auth/auth_test.go
+++ b/mixer/test/client/auth/auth_test.go
@@ -192,7 +192,7 @@ const FailedReportAttributes = `
 
 func TestJWTAuth(t *testing.T) {
 	s := env.NewTestSetupV2(env.JWTAuthTest, t)
-	// pubkey server is the same as backend bootstrap.
+	// pubkey server is the same as backend server.
 	// Empty audiences.
 	env.AddJwtAuth(s.V2().HTTPServerConf, &mccpb.JWT{
 		Issuer:              JwtIssuer,

--- a/tests/e2e/framework/rawVM.go
+++ b/tests/e2e/framework/rawVM.go
@@ -211,7 +211,7 @@ func (vm *GCPRawVM) provision() error {
 			 --can-ip-forward \
 			 --service-account %s \
 			 --scopes "https://www.googleapis.com/auth/cloud-platform" \
-			 --tags "http-server","https-bootstrap" \
+			 --tags "http-server","https-server" \
 			 --image %s \
 			 --image-project %s \
 			 --boot-disk-size "10" \


### PR DESCRIPTION
These were introduced by #2739 (commit 49485f1c0787028e95e6de73cf597c333724b773)