### PR TITLE
fixed setting SSL context for external (not in-mesh) clusters

### DIFF
--- a/pilot/pkg/proxy/envoy/route.go
+++ b/pilot/pkg/proxy/envoy/route.go
@@ -162,7 +162,7 @@ func buildOutboundCluster(hostname string, port *model.Port, labels model.Labels
 		ServiceName: key,
 		Type:        clusterType,
 		LbType:      DefaultLbType,
-		outbound:    true,
+		outbound:    !isExternal, // outbound means outbound-in-mesh. The name to be refactored later.
 		hostname:    hostname,
 		port:        port,
 		tags:        labels,

--- a/pilot/pkg/proxy/envoy/testdata/cds-ssl-context-optout.json.golden
+++ b/pilot/pkg/proxy/envoy/testdata/cds-ssl-context-optout.json.golden
@@ -169,13 +169,7 @@
      {
       "url": "tcp://httpbin.default.svc.cluster.local:80"
      }
-    ],
-    "ssl_context": {
-     "cert_chain_file": "/etc/certs/cert-chain.pem",
-     "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem",
-     "verify_subject_alt_name": []
-    }
+    ]
    },
    {
     "name": "out.httpsbin.default.svc.cluster.local|https",
@@ -187,13 +181,7 @@
      {
       "url": "tcp://httpsbin.default.svc.cluster.local:443"
      }
-    ],
-    "ssl_context": {
-     "cert_chain_file": "/etc/certs/cert-chain.pem",
-     "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem",
-     "verify_subject_alt_name": []
-    }
+    ]
    },
    {
     "name": "out.world.default.svc.cluster.local|custom",

--- a/pilot/pkg/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/pilot/pkg/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -175,13 +175,7 @@
      {
       "url": "tcp://httpbin.default.svc.cluster.local:80"
      }
-    ],
-    "ssl_context": {
-     "cert_chain_file": "/etc/certs/cert-chain.pem",
-     "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem",
-     "verify_subject_alt_name": []
-    }
+    ]
    },
    {
     "name": "out.httpsbin.default.svc.cluster.local|https",
@@ -193,13 +187,7 @@
      {
       "url": "tcp://httpsbin.default.svc.cluster.local:443"
      }
-    ],
-    "ssl_context": {
-     "cert_chain_file": "/etc/certs/cert-chain.pem",
-     "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem",
-     "verify_subject_alt_name": []
-    }
+    ]
    },
    {
     "name": "out.world.default.svc.cluster.local|custom",


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/2842.

The current PR is to fix the bug ASAP, the code should be refactored later. The outbound variable currently means "outbound-in-mesh", it is confusing and should be refactored.