### PR TITLE
Default deb config should work with default istio.yaml

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -14,6 +14,8 @@ spec:
   ports:
   - port: 15003
     protocol: TCP
+  - port: 8080
+    protocol: TCP
   selector:
     istio: pilot
 ---

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -43,7 +43,7 @@ ISTIO_SYSTEM_NAMESPACE=${ISTIO_SYSTEM_NAMESPACE:-istio-system}
 # The default matches the default istio.yaml - use sidecar.env to override this if you
 # enable auth. This requires node-agent to be running.
 ISTIO_PILOT_PORT=${ISTIO_PILOT_PORT:-8080}
-CONTROL_PLANE_AUTH_POLICY=${CONTROL_PLANE_AUTH_POLICY:-NONE}
+ISTIO_CP_AUTH=${ISTIO_CP_AUTH:-NONE}
 
 
 if [ -z "${ISTIO_SVC_IP:-}" ]; then
@@ -66,4 +66,4 @@ fi
 ${ISTIO_BIN_BASE}/istio-iptables.sh
 
 # Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${AGENT_FLAGS:-} --serviceCluster $SVC --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} --controlPlaneAuthPolicy $CONTROL_PLANE_AUTH_POLICY 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" istio-proxy
+exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS:-} --serviceCluster $SVC --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} --controlPlaneAuthPolicy $CONTROL_PLANE_AUTH_POLICY 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" istio-proxy

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -39,8 +39,11 @@ ISTIO_CFG=${ISTIO_CFG:-/var/lib/istio}
 NS=${ISTIO_NAMESPACE:-default}
 SVC=${ISTIO_SERVICE:-rawvm}
 ISTIO_SYSTEM_NAMESPACE=${ISTIO_SYSTEM_NAMESPACE:-istio-system}
-ISTIO_PILOT_PORT=${ISTIO_PILOT_PORT:-15003}
-CONTROL_PLANE_AUTH_POLICY=${CONTROL_PLANE_AUTH_POLICY:-MUTUAL_TLS}
+
+# The default matches the default istio.yaml - use sidecar.env to override this if you
+# enable auth. This requires node-agent to be running.
+ISTIO_PILOT_PORT=${ISTIO_PILOT_PORT:-8080}
+CONTROL_PLANE_AUTH_POLICY=${CONTROL_PLANE_AUTH_POLICY:-NONE}
 
 
 if [ -z "${ISTIO_SVC_IP:-}" ]; then
@@ -62,10 +65,5 @@ fi
 # Update iptables, based on config file
 ${ISTIO_BIN_BASE}/istio-iptables.sh
 
-if [ -f ${ISTIO_BIN_BASE}/pilot-agent ]; then
-  exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy --serviceCluster $SVC --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} --controlPlaneAuthPolicy $CONTROL_PLANE_AUTH_POLICY 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" istio-proxy
-else
-  ENVOY_CFG=${ENVOY_CFG:-${ISTIO_CFG}/envoy/envoy.json}
-  # Run envoy directly - agent not installed. This should be used only for debugging/testing standalone envoy
-  exec su -s /bin/bash -c "exec ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-fi
+# Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
+exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${AGENT_FLAGS:-} --serviceCluster $SVC --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} --controlPlaneAuthPolicy $CONTROL_PLANE_AUTH_POLICY 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" istio-proxy

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -27,7 +27,7 @@
 # If istio-pilot is configured with mTLS authentication (--controlPlaneAuthPolicy MUTUAL_TLS ) you must
 # also configure the mesh expansion machines:
 # ISTIO_PILOT_PORT=15003
-# CONTROL_PLANE_AUTH_POLICY=MUTUAL_TLS
+# ISTIO_CP_AUTH=MUTUAL_TLS
 
 # Fine tunning - useful if installing/building binaries instead of using the .deb file, or running
 # multiple instances.
@@ -40,7 +40,7 @@
 # ENVOY_USER=istio-proxy
 
 # Uncomment to enable debugging
-# AGENT_FLAGS="--proxyLogLevel debug"
+# ISTIO_AGENT_FLAGS="--proxyLogLevel debug"
 
 # Directory for stdout redirection. The redirection is required because envoy attempts to open
 # /dev/stdout - must be a real file. Will be used for access logs. Additional config for logsaver

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -24,7 +24,10 @@
 # Needed if the host has multiple IP.
 # ISTIO_SVC_IP=
 
-
+# If istio-pilot is configured with mTLS authentication (--controlPlaneAuthPolicy MUTUAL_TLS ) you must
+# also configure the mesh expansion machines:
+# ISTIO_PILOT_PORT=15003
+# CONTROL_PLANE_AUTH_POLICY=MUTUAL_TLS
 
 # Fine tunning - useful if installing/building binaries instead of using the .deb file, or running
 # multiple instances.
@@ -37,7 +40,7 @@
 # ENVOY_USER=istio-proxy
 
 # Uncomment to enable debugging
-# ISTIO_DEBUG="-l debug"
+# AGENT_FLAGS="--proxyLogLevel debug"
 
 # Directory for stdout redirection. The redirection is required because envoy attempts to open
 # /dev/stdout - must be a real file. Will be used for access logs. Additional config for logsaver


### PR DESCRIPTION
Current defaults are valid for the istio-auth.yaml

For 0.6 we should make 15003 use mTLS (if CA exists), to allow gradual adoption and opt-in, 
with some workloads using 8080/insecure and some using 15003 mTLS. We can't have all or nothing, 
and SNI sniffing is not yet ready.