### PR TITLE
Fix the pkg/perf nil issue in the clientserver code path as well.

### DIFF
--- a/mixer/pkg/perf/clientserver.go
+++ b/mixer/pkg/perf/clientserver.go
@@ -88,19 +88,21 @@ func (s *ClientServer) registerWithController(controllerLoc ServiceLocation) err
 func (s *ClientServer) initializeRPCServer() error {
 	// Setup ClientServer's rpc rpcServer first. We will publish this to the controller next.
 	var err error
-	if s.listener, err = net.Listen("tcp", "127.0.0.1:"); err != nil {
+	var l net.Listener
+	if l, err = net.Listen("tcp", "127.0.0.1:"); err != nil {
 		return err
 	}
+	s.listener = l
 
-	s.rpcPath = generatePath("client", s.listener.Addr())
-	rpcDebugPath := generateDebugPath("client", s.listener.Addr())
+	s.rpcPath = generatePath("client")
+	rpcDebugPath := generateDebugPath("client")
 
 	s.rpcServer = rpc.NewServer()
 	_ = s.rpcServer.Register(s)
 	s.rpcServer.HandleHTTP(s.rpcPath, rpcDebugPath)
 
 	go func() {
-		_ = http.Serve(s.listener, nil)
+		_ = http.Serve(l, nil)
 	}()
 
 	log.Infof("ClientServer listening on: %s", s.location())

--- a/mixer/pkg/perf/common.go
+++ b/mixer/pkg/perf/common.go
@@ -16,10 +16,9 @@ package perf
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path"
-	"strings"
+	"time"
 )
 
 // ServiceLocation is a struct that combines the address and the path of an rpc server.
@@ -35,28 +34,15 @@ func (s ServiceLocation) String() string {
 	return s.Address + s.Path
 }
 
-// generateHTTPPathDiscriminatorFromAddress is used to create a discrimination string to be used in http paths. The rpc package uses
-// the global http demultiplexer, which doesn't have an unregistration mechanism and cannot handle multiple
-// registrations. Using a discriminator helps deal with the issue.
-//
-// The FromAddress suffix is needed as this is the official way to suppress the interfacer goling warning *sigh*.
-func generateHTTPPathDiscriminatorFromAddress(a net.Addr) string {
-	// Parse the address and extract the port. This should be a good enough discriminator value.
-
-	address := a.String()
-	idx := strings.LastIndex(address, ":")
-	return address[idx+1:]
-}
-
 // generatePath is used to generate the HTTP rpc path for a given component.
-func generatePath(component string, a net.Addr) string {
-	discriminator := generateHTTPPathDiscriminatorFromAddress(a)
+func generatePath(component string) string {
+	discriminator := fmt.Sprintf("ns%d", time.Now().Nanosecond())
 	return fmt.Sprintf("/%s/perf/mixer/%s/_goRPC_", component, discriminator)
 }
 
 // generateDebugPath is used to generate the HTTP rpc debug path for a given component.
-func generateDebugPath(component string, a net.Addr) string {
-	discriminator := generateHTTPPathDiscriminatorFromAddress(a)
+func generateDebugPath(component string) string {
+	discriminator := fmt.Sprintf("nsd%d", time.Now().Nanosecond())
 	return fmt.Sprintf("/debug/%s/perf/mixer/%s/rpc", component, discriminator)
 }
 

--- a/mixer/pkg/perf/controller.go
+++ b/mixer/pkg/perf/controller.go
@@ -49,25 +49,22 @@ func newController() (*Controller, error) {
 
 	// Setup a TCP listener at a random port.
 	var err error
-	if c.listener, err = net.Listen("tcp", "127.0.0.1:"); err != nil {
+	var l net.Listener
+	if l, err = net.Listen("tcp", "127.0.0.1:"); err != nil {
 		return nil, err
 	}
+	c.listener = l
 
 	// Generate HTTP paths to listen on
-	c.rpcPath = generatePath("controller", c.listener.Addr())
-	rpcDebugPath := generateDebugPath("controller", c.listener.Addr())
+	c.rpcPath = generatePath("controller")
+	rpcDebugPath := generateDebugPath("controller")
 
 	c.rpcServer = rpc.NewServer()
 	_ = c.rpcServer.Register(c)
 	c.rpcServer.HandleHTTP(c.rpcPath, rpcDebugPath)
 
 	go func() {
-		// Make a local copy of the listener before using. Since this function closes over c, it is possible
-		// that somebody might have called c.close() before this goroutine starts running.
-		l := c.listener
-		if l != nil {
-			_ = http.Serve(l, nil)
-		}
+		_ = http.Serve(l, nil)
 	}()
 
 	log.Infof("controller is accepting connections on: %s%s", c.listener.Addr().String(), c.rpcPath)


### PR DESCRIPTION
Same problem, different code path.

Also, make the code more resilient to rerunning with go test -count xxx. The previous code suffered from port re-use issues.