### PR TITLE
Output the long form of the version info for command-line usage.

### DIFF
--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -20,11 +20,21 @@ import (
 
 // CobraCommand is a command used to print version information.
 func CobraCommand() *cobra.Command {
-	return &cobra.Command{
+	var short bool
+
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("%s\n", Info)
+			if short {
+				cmd.Printf("%s\n", Info)
+			} else {
+				cmd.Printf("%s", Info.LongForm())
+			}
 		},
 	}
+
+	cmd.PersistentFlags().BoolVarP(&short, "short", "s", short, "Displays a short form of the version information")
+
+	return cmd
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -48,6 +48,12 @@ var (
 )
 
 // String produces a single-line version info
+//
+// This looks like:
+//
+// ```
+// user@host-<docker hub>-<version>-<git revision>-<build status>
+// ```
 func (b BuildInfo) String() string {
 	return fmt.Sprintf("%v@%v-%v-%v-%v-%v",
 		b.User,
@@ -59,6 +65,17 @@ func (b BuildInfo) String() string {
 }
 
 // LongForm returns a multi-line version information
+//
+// This looks like:
+//
+// ```
+// Version: <version>
+// GitRevision: <git revision>
+// User: user@host
+// Hub: <docker hub>
+// GolangVersion: go1.9.2
+// BuildStatus: <build status>
+// ```
 func (b BuildInfo) LongForm() string {
 	return fmt.Sprintf(`Version: %v
 GitRevision: %v


### PR DESCRIPTION
Also introduces the -s option to output the short form explicitly.