### PR TITLE
Add a few small useful files to the release archive

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -118,7 +118,7 @@ find samples install -type f \( \
   \) \
   -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 find install/tools -type f -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
-find tools -type f -not -name githubContrib -not -name ".*" -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
+find tools -type f -not -name "githubContrib*" -not -name ".*" -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 popd
 
 # Changing dir such that tar and zip files are

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -101,7 +101,7 @@ function create_windows_archive() {
   local istioctl_path="${BIN_DIR}/istioctl.exe"
 
   ${CP} "${OUTPUT_PATH}/${ISTIOCTL_SUBDIR}/istioctl-win.exe" "${istioctl_path}"
-  
+
   zip -r "${OUTPUT_PATH}/istio_${VER_STRING}_win.zip" "istio-${VER_STRING}" \
     || error_exit 'Could not create windows archive'
   rm "${istioctl_path}"
@@ -118,6 +118,7 @@ find samples install -type f \( \
   \) \
   -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 find install/tools -type f -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
+find tools -type f -not -name githubContrib -not -name ".*" -exec ${CP} --parents {} "${COMMON_FILES_DIR}" \;
 popd
 
 # Changing dir such that tar and zip files are

--- a/release/update_and_create_archives.sh
+++ b/release/update_and_create_archives.sh
@@ -68,6 +68,7 @@ function run_update() {
 
 pushd ${ROOT}
 cp LICENSE README.md "${OUTPUT_PATH}/"
+cp -r tools "${OUTPUT_PATH}/"
 popd
 
 # generate a test set of tars for images on GCR

--- a/tools/githubContrib/Contributions.txt
+++ b/tools/githubContrib/Contributions.txt
@@ -1,2 +1,2 @@
-Here is the current (as of November 2017) alphabetical list of companies and the number of contributors:
-Apache.org (1), Apprenda (1), CMU (1), Google (32), Hashbangbash (1), Hootsuite (1), Ibm (11), Redhat (1), Unknown (10)
+Here is the current (as of January 2018) alphabetical list of companies and the number of contributors:
+Apache.org (1), Apprenda (1), Calcotestudios (1), CMU (1), Google (34), Hashbangbash (1), Hootsuite (1), Ibm (11), Redhat (2), Unknown (12)


### PR DESCRIPTION
Both Debian and the perf setup are useful and small files

```
$ find tools -type f -not -name "githubContrib*" -not -name ".*" |xargs wc
      31     118    1008 tools/cache_buster.yaml
      22     122     793 tools/deb/deb_test.sh
      10      40     261 tools/deb/Dockerfile
      77     122    1555 tools/deb/envoy-insecure.json
      97     156    2703 tools/deb/envoy.json
      12      16     249 tools/deb/istio-auth-node-agent.service
      43     190    1584 tools/deb/istio-ca.sh
     181    1003    6639 tools/deb/istio-iptables.sh
      71     312    3030 tools/deb/istio-start.sh
      89     332    3690 tools/deb/istio.mk
      12      13     222 tools/deb/istio.service
      43     164    1355 tools/deb/postinst.sh
      53     314    1988 tools/deb/sidecar.env
       2      37     244 tools/githubContrib/Contributions.txt
     138     864    6805 tools/minikube.md
      30      74     700 tools/perf_istio_rules.yaml
      83     198    1730 tools/perf_k8svcs.yaml
     281     522    7084 tools/perf_k8svcs_istio.yaml
      57     157    1901 tools/rules.yml
     283     949    9057 tools/setup_perf_cluster.sh
      20     102     799 tools/setup_run
      13      43     270 tools/update_all
    1648    5848   53667 total
```