### PR TITLE
using /*.circleci/ in codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,4 @@
 /pkg/       @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 /tests/     @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 
-/\.circleci/ @istio/reviewers-istio-circleci
+/*.circleci/ @istio/reviewers-istio-circleci


### PR DESCRIPTION
Sorry for the spam. Per testing in my private repo, /.circleci/, /*.circleci/, all seem to work reliably. It is unclear why it doesn't work in istio/istio. If this does not work, I will comment out circleci folder access and let it fallback to global reviewers.