### PR TITLE
Revert 2891 (lets not have codeowners for .circleci)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,4 @@
 /pkg/       @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 /tests/     @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 
-/\.circleci/ @istio/reviewers-istio-circleci
+#/.circleci/ @istio/reviewers-istio-circleci

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,4 +19,5 @@
 /pkg/       @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 /tests/     @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
 
+# Do not enable this. Seems to cause the parsers to fail and not trigger auto review requests
 #/.circleci/ @istio/reviewers-istio-circleci


### PR DESCRIPTION
Reverts istio/istio#2891

We can manage circleci manually. as long as codeowners works for the rest of the repo.