### PR TITLE
mixer e2e: add a store flag to limit target namespaces

### DIFF
--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -76,7 +76,6 @@ spec:
         - containerPort: 9094
         - containerPort: 42422
         args:
-          - --configStoreURL=fs:///etc/opt/mixer/configroot
           - --configStoreURL=k8s://
           - --configDefaultNamespace={ISTIO_NAMESPACE}
           - --zipkinURL=http://zipkin:9411/api/v1/spans

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -341,6 +342,10 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 
 	if !*clusterWide {
 		content = replacePattern(k, content, istioSystem, k.Namespace)
+		// Customize mixer's configStoreURL to limit watching resources in the testing namespace.
+		vs := url.Values{}
+		vs.Add("ns", *namespace)
+		content = replacePattern(k, content, "--configStoreURL=k8s://", fmt.Sprintf("'--configStoreURL=k8s://?%s'", vs.Encode()))
 	}
 
 	// Replace long refresh delays with short ones for the sake of tests.

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -345,7 +345,7 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 		// Customize mixer's configStoreURL to limit watching resources in the testing namespace.
 		vs := url.Values{}
 		vs.Add("ns", *namespace)
-		content = replacePattern(k, content, "--configStoreURL=k8s://", fmt.Sprintf("'--configStoreURL=k8s://?%s'", vs.Encode()))
+		content = replacePattern(k, content, "--configStoreURL=k8s://", "--configStoreURL=k8s://?%s"+vs.Encode())
 	}
 
 	// Replace long refresh delays with short ones for the sake of tests.


### PR DESCRIPTION
Previously the e2e test does not customize mixer config, so
mixer config actually watch all resources in the cluster,
even when it's not cluster-wide test.

This is wrong and inefficient. We should limit watching
resources on the testing namespace. Mixer already has this
feature, this PR simply customize the flag to behave like that.