### PR TITLE
CircleCI and `make localTestEnv` use a versioned etcd binary

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -11,11 +11,17 @@ FROM    circleci/golang:1.9
 
 # Also installed docker, docker-compose, dockerize, jq
 
-RUN     go get github.com/coreos/etcd
-
 ARG     K8S_VER=v1.7.4
 ARG     MASTER_IP=127.0.0.1
 ARG     MASTER_CLUSTER_IP=10.99.0.1
+
+ARG     ETCD_VERSION=v3.2.15
+RUN     cd /tmp && \
+        curl -L -o etcd.tgz https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz && \
+        tar xzf etcd.tgz && \
+        sudo mv etcd-${ETCD_VERSION}-linux-amd64/etcd /usr/local/bin/etcd && \
+        rm -rf etcd*
+
 RUN     mkdir -p /tmp/apiserver && \
         cd /tmp/apiserver && \
         wget https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-apiserver && \

--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -16,6 +16,7 @@ export OUT=${TOP}/out
 export K8S_VER=v1.7.4
 export MASTER_IP=127.0.0.1
 export MASTER_CLUSTER_IP=10.99.0.1
+export ETCD_VERSION=v3.2.15
 
 # TODO: customize the ports and generate a local config
 export KUBECONFIG=${TOP}/src/istio.io/istio/.circleci/config
@@ -63,7 +64,7 @@ function getDeps() {
      curl -Lo ${TOP}/bin/kube-apiserver https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kube-apiserver && chmod +x ${TOP}/bin/kube-apiserver
    fi
    if [ ! -f $TOP/bin/etcd ] ; then
-     go get github.com/coreos/etcd
+     curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz | tar xz -O etcd-${ETCD_VERSION}-linux-amd64/etcd > ${TOP}/bin/etcd && chmod +x ${TOP}/bin/etcd
    fi
    if [ ! -f $TOP/bin/envoy ] ; then
      # Init should be run after cloning the workspace


### PR DESCRIPTION
Follow-up to #2852 

Lets see if this one passes tests...