### PR TITLE
generate_cert returns error instead of force exit in case of error

### DIFF
--- a/security/cmd/generate_cert/main.go
+++ b/security/cmd/generate_cert/main.go
@@ -97,7 +97,7 @@ func main() {
 		}
 	}
 
-	certPem, privPem := ca.GenCert(ca.CertOptions{
+	certPem, privPem, err := ca.GenCert(ca.CertOptions{
 		Host:         *host,
 		NotBefore:    getNotBefore(),
 		TTL:          *validFor,
@@ -109,6 +109,11 @@ func main() {
 		IsClient:     *isClient,
 		RSAKeySize:   *keySize,
 	})
+
+	if err != nil {
+		log.Errora(err)
+		os.Exit(-1)
+	}
 
 	saveCreds(certPem, privPem)
 	fmt.Printf("Certificate and private files successfully saved in %s and %s\n", *outCert, *outPriv)

--- a/security/cmd/node_agent/na/nodeagent.go
+++ b/security/cmd/node_agent/na/nodeagent.go
@@ -123,7 +123,7 @@ func (na *nodeAgentInternal) createRequest() ([]byte, *pb.CsrRequest, error) {
 		RSAKeySize: na.config.RSAKeySize,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("request creation fails on CSR generation (%v)", err)
+		return nil, nil, err
 	}
 
 	cred, err := na.pc.GetAgentCredential()

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -44,7 +44,13 @@ func (f FakeCertUtil) GetWaitTime(certBytes []byte, now time.Time, gracePeriodPe
 }
 
 func TestStartWithArgs(t *testing.T) {
-	generalPcConfig := platform.ClientConfig{OnPremConfig: platform.OnPremConfig{"ca_file", "pkey", "cert_file"}}
+	generalPcConfig := platform.ClientConfig{
+		OnPremConfig: platform.OnPremConfig{
+			RootCACertFile: "ca_file",
+			KeyFile:        "pkey",
+			CertChainFile:  "cert_file",
+		},
+	}
 	generalConfig := Config{
 		IstioCAAddress:     "ca_addr",
 		ServiceIdentityOrg: "Google Inc.",
@@ -101,11 +107,10 @@ func TestStartWithArgs(t *testing.T) {
 				PlatformConfig:            generalPcConfig,
 				LoggingOptions:            log.NewOptions(),
 			},
-			pc:       mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
-			cAClient: &mockclient.FakeCAClient{0, nil, nil},
-			expectedErr: "request creation fails on CSR generation (CSR generation fails at X509 cert request " +
-				"generation (crypto/rsa: message too long for RSA public key size))",
-			sendTimes: 0,
+			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
+			cAClient:    &mockclient.FakeCAClient{0, nil, nil},
+			expectedErr: "CSR creation failed (crypto/rsa: message too long for RSA public key size)",
+			sendTimes:   0,
 		},
 		"Getting agent credential error": {
 			config:      &generalConfig,

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -95,7 +95,10 @@ func NewSelfSignedIstioCA(caCertTTL, certTTL, maxCertTTL time.Duration, org stri
 			IsSelfSigned: true,
 			RSAKeySize:   caKeySize,
 		}
-		pemCert, pemKey := GenCert(options)
+		pemCert, pemKey, err := GenCert(options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate cert and key for Istio CA: %v", err)
+		}
 
 		opts.SigningCertBytes = pemCert
 		opts.SigningKeyBytes = pemKey
@@ -113,7 +116,7 @@ func NewSelfSignedIstioCA(caCertTTL, certTTL, maxCertTTL time.Duration, org stri
 			},
 			Type: istioCASecretType,
 		}
-		_, err := core.Secrets(namespace).Create(secret)
+		_, err = core.Secrets(namespace).Create(secret)
 		if err != nil {
 			log.Errorf("Failed to write secret to CA (error: %s). This CA will not persist when restart.", err)
 		}
@@ -175,11 +178,14 @@ func (ca *IstioCA) Sign(csrPEM []byte, ttl time.Duration) ([]byte, error) {
 			"requested TTL %s is greater than the max allowed TTL %s", ttl, ca.maxCertTTL)
 	}
 
-	tmpl := ca.generateCertificateTemplate(csr, ttl)
+	tmpl, err := ca.generateCertificateTemplate(csr, ttl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate cert template (%v)", err)
+	}
 
 	bytes, err := x509.CreateCertificate(rand.Reader, tmpl, ca.signingCert, csr.PublicKey, ca.signingKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to generate cert (%v)", err)
 	}
 
 	block := &pem.Block{
@@ -194,13 +200,18 @@ func (ca *IstioCA) Sign(csrPEM []byte, ttl time.Duration) ([]byte, error) {
 	return chain, nil
 }
 
-func (ca *IstioCA) generateCertificateTemplate(request *x509.CertificateRequest, ttl time.Duration) *x509.Certificate {
+func (ca *IstioCA) generateCertificateTemplate(request *x509.CertificateRequest, ttl time.Duration) (*x509.Certificate, error) {
 	exts := append(request.Extensions, request.ExtraExtensions...)
+
+	serialNumber, err := genSerialNum()
+	if err != nil {
+		return nil, err
+	}
 
 	now := time.Now()
 
 	return &x509.Certificate{
-		SerialNumber: genSerialNum(),
+		SerialNumber: serialNumber,
 		Subject:      request.Subject,
 		NotAfter:     now.Add(ttl),
 		NotBefore:    now,
@@ -213,7 +224,7 @@ func (ca *IstioCA) generateCertificateTemplate(request *x509.CertificateRequest,
 		EmailAddresses:        request.EmailAddresses,
 		IPAddresses:           request.IPAddresses,
 		SignatureAlgorithm:    request.SignatureAlgorithm,
-	}
+	}, nil
 }
 
 // verify that the cert chain, root cert and signing key/cert match.

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -363,7 +363,10 @@ func TestSignCSR(t *testing.T) {
 	if san == nil {
 		t.Errorf("No SAN extension is found in the certificate")
 	}
-	expected := buildSubjectAltNameExtension(host)
+	expected, err := buildSubjectAltNameExtension(host)
+	if err != nil {
+		t.Error(err)
+	}
 	if !reflect.DeepEqual(expected, san) {
 		t.Errorf("Unexpected extensions: wanted %v but got %v", expected, san)
 	}
@@ -405,7 +408,10 @@ func createCA() (CertificateAuthority, error) {
 		Org:          "Root CA",
 		RSAKeySize:   2048,
 	}
-	rootCertBytes, rootKeyBytes := GenCert(rootCAOpts)
+	rootCertBytes, rootKeyBytes, err := GenCert(rootCAOpts)
+	if err != nil {
+		return nil, err
+	}
 
 	rootCert, err := pki.ParsePemEncodedCertificate(rootCertBytes)
 	if err != nil {
@@ -426,7 +432,10 @@ func createCA() (CertificateAuthority, error) {
 		SignerCert:   rootCert,
 		SignerPriv:   rootKey,
 	}
-	intermediateCert, intermediateKey := GenCert(intermediateCAOpts)
+	intermediateCert, intermediateKey, err := GenCert(intermediateCAOpts)
+	if err != nil {
+		return nil, err
+	}
 
 	caOpts := &IstioCAOptions{
 		CertChainBytes:   intermediateCert,

--- a/security/pkg/pki/ca/controller/secret_test.go
+++ b/security/pkg/pki/ca/controller/secret_test.go
@@ -202,7 +202,10 @@ func TestUpdateSecret(t *testing.T) {
 			TTL:          tc.ttl,
 			RSAKeySize:   512,
 		}
-		bs, _ := ca.GenCert(opts)
+		bs, _, err := ca.GenCert(opts)
+		if err != nil {
+			t.Error(err)
+		}
 		scrt.Data[CertChainID] = bs
 
 		controller.scrtUpdated(nil, scrt)

--- a/security/pkg/pki/ca/generate_cert_test.go
+++ b/security/pkg/pki/ca/generate_cert_test.go
@@ -99,7 +99,11 @@ func TestGenCert(t *testing.T) {
 		RSAKeySize:   512,
 	}
 
-	caCertPem, caPrivPem := GenCert(caCertOptions)
+	caCertPem, caPrivPem, err := GenCert(caCertOptions)
+	if err != nil {
+		t.Error(err)
+	}
+
 	fields := &tu.VerifyFields{
 		NotBefore:   caCertNotBefore,
 		TTL:         caCertTTL,
@@ -108,7 +112,7 @@ func TestGenCert(t *testing.T) {
 		IsCA:        true,
 		Org:         "MyOrg",
 	}
-	if err := tu.VerifyCertificate(caPrivPem, caCertPem, caCertPem, caCertOptions.Host, fields); err != nil {
+	if tu.VerifyCertificate(caPrivPem, caCertPem, caCertPem, caCertOptions.Host, fields) != nil {
 		t.Error(err)
 	}
 
@@ -277,7 +281,10 @@ func TestGenCert(t *testing.T) {
 
 	for _, c := range cases {
 		certOptions := c.certOptions
-		certPem, privPem := GenCert(certOptions)
+		certPem, privPem, err := GenCert(certOptions)
+		if err != nil {
+			t.Error(err)
+		}
 		if e := tu.VerifyCertificate(privPem, certPem, caCertPem, certOptions.Host, c.verifyFields); e != nil {
 			t.Error(e)
 		}


### PR DESCRIPTION
generate_cert is a general library to be used in multiple places, it should return error message in case of error, instead of force exit the process.