### PR TITLE
fix webhook cert provisioning script on osx

### DIFF
--- a/install/kubernetes/webhook-patch-ca-bundle.sh
+++ b/install/kubernetes/webhook-patch-ca-bundle.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | openssl base64 )
+export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n')
 
 if command -v envsubst >/dev/null 2>&1; then
     envsubst

--- a/install/kubernetes/webhook-patch-ca-bundle.sh
+++ b/install/kubernetes/webhook-patch-ca-bundle.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 -w0)
+export CA_BUNDLE=$(kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | openssl base64 )
 
 if command -v envsubst >/dev/null 2>&1; then
     envsubst


### PR DESCRIPTION
cfssl install instructions for OSX are not as straightforward as on
linux. Use openssl instead to simplify demo setup.

base64 takes different arguments for decode on linux and osx (-d and
-D respectively). Use `openssl base64 -d -A` instead.