### PR TITLE
convention of singular vs. plural nouns for types

### DIFF
--- a/DEV-CONVENTIONS.md
+++ b/DEV-CONVENTIONS.md
@@ -38,6 +38,8 @@ Others docs you should look at:
 
       - Must use underscores for Go file names, e.g. type `DeviceAllocator` must reside in `device_allocator.go`.
 
+      - Use singular nouns for types unless they represent a collection. Use plural nouns for collections.
+
       - Please consider parent directory name when choosing a package name:
 
           - `adapters/factMapper/tracker.go` should say `package factMapper` not `package factmapperadapter`.


### PR DESCRIPTION
I did not find a reference to it. Maybe it is too obvious and should not be part of code conventions. I am open to the opinions.