### PR TITLE
added a test for Kubernetes ExternalName service for httpbin.org

### DIFF
--- a/pilot/test/integration/infra.go
+++ b/pilot/test/integration/infra.go
@@ -268,6 +268,9 @@ func (infra *infra) setup() error {
 	if err := deploy("external-wikipedia.yaml.tmpl", infra.Namespace); err != nil {
 		return err
 	}
+	if err := deploy("externalbin.yaml.tmpl", infra.Namespace); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"istio.io/istio/pkg/log"
 )
 

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -59,10 +59,10 @@ func (t *kubernetesExternalNameServices) run() error {
 				name := fmt.Sprintf("HTTP connection from %s to %s%s", src, dst, domain)
 				funcs[name] = (func(src, dst, domain string) func() status {
 					url := fmt.Sprintf("http://%s%s", dst, domain)
-                                        extra := ""
-                                        if !withIstioProxy {
-                                            extra = "-key Host -val " + externalHost
-                                        }
+					extra := ""
+					if !withIstioProxy {
+						extra = "-key Host -val " + externalHost
+					}
 					return func() status {
 						resp := t.clientRequest(src, url, 1, extra)
 						if len(resp.code) > 0 && resp.code[0] == httpOk {

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -27,15 +27,23 @@ func (t *kubernetesExternalNameServices) String() string {
 }
 
 func (t *kubernetesExternalNameServices) setup() error {
+	if err := t.applyConfig("rule-rewrite-authority-externalbin.yaml.tmpl", nil); err != nil {
+		return err
+	}
 	return nil
 }
 
 func (t *kubernetesExternalNameServices) teardown() {
+	log.Info("Cleaning up route rules...")
+	if err := t.deleteAllConfigs(); err != nil {
+		log.Warna(err)
+	}
 }
 
 func (t *kubernetesExternalNameServices) run() error {
+
 	srcPods := []string{"a", "b", "t"}
-	dstServices := []string{"externalwikipedia"}
+	dstServices := []string{"externalwikipedia", "externalbin"}
 
 	funcs := make(map[string]func() status)
 	for _, src := range srcPods {

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"istio.io/istio/pkg/log"
 )
 
 type kubernetesExternalNameServices struct {

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -43,18 +43,28 @@ func (t *kubernetesExternalNameServices) teardown() {
 
 func (t *kubernetesExternalNameServices) run() error {
 
-	srcPods := []string{"a", "b", "t"}
-	dstServices := []string{"externalwikipedia", "externalbin"}
+	// map of source pods to test, to boolean that is true if the pod has Istio proxy
+	srcPods := map[string]bool{"a": true, "b": true, "t": false}
+
+	// map of destination external name services to their external hosts
+	dstServices := map[string]string{
+		"externalwikipedia": "wikipedia.org",
+		"externalbin":       "httpbin.org",
+	}
 
 	funcs := make(map[string]func() status)
-	for _, src := range srcPods {
-		for _, dst := range dstServices {
+	for src, withIstioProxy := range srcPods {
+		for dst, externalHost := range dstServices {
 			for _, domain := range []string{"", "." + t.Namespace} {
 				name := fmt.Sprintf("HTTP connection from %s to %s%s", src, dst, domain)
 				funcs[name] = (func(src, dst, domain string) func() status {
 					url := fmt.Sprintf("http://%s%s", dst, domain)
+                                        extra := ""
+                                        if !withIstioProxy {
+                                            extra = "-key Host -val " + externalHost
+                                        }
 					return func() status {
-						resp := t.clientRequest(src, url, 1, "")
+						resp := t.clientRequest(src, url, 1, extra)
 						if len(resp.code) > 0 && resp.code[0] == httpOk {
 							return nil
 						}

--- a/pilot/test/integration/testdata/externalbin.yaml.tmpl
+++ b/pilot/test/integration/testdata/externalbin.yaml.tmpl
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: externalbin
+spec:
+  type: ExternalName
+  externalName: httpbin.org
+  ports:
+  - port: 80
+  # important to set protocol name
+    name: http

--- a/pilot/test/integration/testdata/rule-rewrite-authority-externalbin.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-rewrite-authority-externalbin.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: externalbin-rewrite-rule
+  namespace: default
+spec:
+  destination:
+    name: externalbin
+  rewrite:
+    authority: httpbin.org


### PR DESCRIPTION
the test requires a HTTP rewrite route rule to rewrite the authority to be
httpbin.org