### PR TITLE
Fix filename convention

### DIFF
--- a/DEV-CONVENTIONS.md
+++ b/DEV-CONVENTIONS.md
@@ -34,7 +34,7 @@ Others docs you should look at:
       - Please consider package name when selecting an interface name, and avoid
       redundancy. For example, use `adapter.AspectConfig` instead of `adapter.AdapterConfig`.
 
-      - Must use lowerCamel case for Go package names.
+      - Must use lowercase for Go package names.
 
       - Must use underscores for Go file names, e.g. type `DeviceAllocator` must reside in `device_allocator.go`.
 

--- a/DEV-CONVENTIONS.md
+++ b/DEV-CONVENTIONS.md
@@ -36,7 +36,7 @@ Others docs you should look at:
 
       - Must use lowercase for Go package names.
 
-      - Must use underscores for Go file names, e.g. type `DeviceAllocator` must reside in `device_allocator.go`.
+      - Must use camel case for Go types.
 
       - Please consider parent directory name when choosing a package name:
 
@@ -120,8 +120,9 @@ the [adapter logger interface](https://godoc.org/istio.io/istio/mixer/pkg/adapte
   - Avoid general utility packages. Packages called "util" are suspect. Instead,
   derive a name that describes your desired function.
 
-  - All filenames and directory names use camelCasing. No dashes, no underscores. The exception is for
-  unit tests which follow the Go convention of having a \_test.go suffix.
+  - Use lowercase for file and directory names.
+
+  - Use underscores for Go file names, e.g. type `DeviceAllocator` must reside in `device_allocator.go`.
 
   - All directory names should be singular unless required by existing frameworks.
   This is to avoid mixed singular and plural names in the full paths. NOTE:


### PR DESCRIPTION
Following #2886:

1. Moved the underscore file convention to Directory and file conventions
2. Removed camel case convention for file and directory names
3. Add camel case convention for Go types