### PR TITLE
Hardcode 1.9.1-gke.0 cluster version until 1.9 is GA

### DIFF
--- a/prow/cluster_lib.sh
+++ b/prow/cluster_lib.sh
@@ -26,8 +26,13 @@ ZONE=us-central1-f
 MACHINE_TYPE=n1-standard-4
 NUM_NODES=1
 CLUSTER_NAME=
-IFS=';' VERSIONS=($(gcloud container get-server-config --project=${PROJECT_NAME} --zone=${ZONE} --format='value(validMasterVersions)'))
-CLUSTER_VERSION="${VERSIONS[1]}"
+
+# IFS=';' VERSIONS=($(gcloud container get-server-config --project=${PROJECT_NAME} --zone=${ZONE} --format='value(validMasterVersions)'))
+# CLUSTER_VERSION="${VERSIONS[1]}"
+
+# TODO(https://github.com/istio/istio/issues/2929)
+CLUSTER_VERSION=1.9.1-gke.0
+
 KUBE_USER="istio-prow-test-job@istio-testing.iam.gserviceaccount.com"
 CLUSTER_CREATED=false
 


### PR DESCRIPTION
Enable early testing of 1.9 on GKE by forcing the cluster version and
using --enable-kubernetes-alpha. This change should be reverted once
GKE 1.9 is GA.