### PR TITLE
CODEOWNERS: Create new pkg/tests teams to reduce noise

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,12 +12,8 @@
 /samples/   @istio/reviewers-istio-samples
 /install/   @istio/reviewers-istio-install
 /tools/     @costinm @ldemailly
-
-# This is intentional. These folders are collective responsibility of all
-# devs in istio team whose components (pilot/mixer/security/broker) share
-# code from pkg or use tests from tests/ including e2e tests.
-/pkg/       @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
-/tests/     @istio/reviewers-istio-pilot @istio/reviewers-istio-security @istio/reviewers-istio-mixer @istio/reviewers-istio-galley @istio/reviewers-istio-broker
+/pkg/       @istio/reviewers-istio-pkg
+/tests/     @istio/reviewers-istio-tests
 
 # Do not enable this. Seems to cause the parsers to fail and not trigger auto review requests
 #/.circleci/ @istio/reviewers-istio-circleci


### PR DESCRIPTION
Current structure seems to be confusing to folks, when code under pkg and tests triggers review requests from everyone.
I have put them into separate teams. Interested folks should request to become a member of this team, to receive notifications about PRs for these folders.