### PR TITLE
Handle the case that --features is a comma separated list

### DIFF
--- a/pilot/cmd/istioctl/gendeployment/cmd.go
+++ b/pilot/cmd/istioctl/gendeployment/cmd.go
@@ -165,6 +165,8 @@ func defaultInstall() *installation {
 func (i *installation) setFeatures(features []string) error {
 	if len(features) == 0 {
 		return nil
+	} else if len(features) == 1 {
+		features = strings.Split(features[0], ",")
 	}
 
 	i.Mixer = false


### PR DESCRIPTION
Handle the case that --features is a comma separated list, rather than cobra's string array syntax which required repeating the flag name (e.g. --features policy --features telemetry --features mtls).

Fixes https://github.com/istio/istio/issues/2662