### PR TITLE
Streamline tests

### DIFF
--- a/prow/e2e-smoke.sh
+++ b/prow/e2e-smoke.sh
@@ -29,4 +29,4 @@ set -u
 set -x
 
 echo 'Running smoke test with rbac, auth Tests'
-./prow/e2e-suite.sh -s bookinfo --auth_enable "$@"
+./prow/e2e-suite.sh --auth_enable "$@"

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -58,5 +58,10 @@ ISTIO_GO=$(cd $(dirname $0)/..; pwd)
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${GIT_SHA}"
 
+if [[ -z "${E2E_ARGS:-}" ]]; then
+  E2E_ARGS="$@"
+else
+  E2E_ARGS+=("$@")
+fi
 echo 'Running Integration Tests'
-time ISTIO_DOCKER_HUB=$HUB TESTOPTS="$@" make e2e_all
+time ISTIO_DOCKER_HUB=$HUB E2E_ARGS="$E2E_ARGS" make e2e_all

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -58,13 +58,5 @@ ISTIO_GO=$(cd $(dirname $0)/..; pwd)
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${GIT_SHA}"
 
-# Download envoy and go deps, and build istioctl used by the test.
-make depend istioctl generate_yaml
-
-mkdir -p ${GOPATH}/src/istio.io/istio/_artifacts
-
-# It seems logs are generated on tmp ?
-trap "cp -a /tmp/istio* ${GOPATH}/src/istio.io/istio/_artifacts" EXIT
-
 echo 'Running Integration Tests'
-time make e2e_all
+time ISTIO_DOCKER_HUB=$HUB make TESTOPTS="$@" e2e_all

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -59,4 +59,4 @@ export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${GIT_SHA}"
 
 echo 'Running Integration Tests'
-time ISTIO_DOCKER_HUB=$HUB make TESTOPTS="$@" e2e_all
+time ISTIO_DOCKER_HUB=$HUB TESTOPTS="$@" make e2e_all

--- a/prow/istio-pilot-e2e.sh
+++ b/prow/istio-pilot-e2e.sh
@@ -55,5 +55,4 @@ ln -sf "${HOME}/.kube/config" ${ROOT}/pilot/pkg/kube/config
 HUB="gcr.io/istio-testing"
 
 cd ${GOPATH}/src/istio.io/istio
-./bin/init.sh
 make e2e_pilot HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=true -use-sidecar-injector=true -use-admission-webhook=false"

--- a/prow/istio-pilot-e2e.sh
+++ b/prow/istio-pilot-e2e.sh
@@ -55,4 +55,4 @@ ln -sf "${HOME}/.kube/config" ${ROOT}/pilot/pkg/kube/config
 HUB="gcr.io/istio-testing"
 
 cd ${GOPATH}/src/istio.io/istio
-make e2e_pilot HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=true -use-sidecar-injector=true -use-admission-webhook=false"
+make depend e2e_pilot HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=true -use-sidecar-injector=true -use-admission-webhook=false"

--- a/prow/istio-postsubmit.sh
+++ b/prow/istio-postsubmit.sh
@@ -59,4 +59,4 @@ time make localTestEnv test
 HUB="gcr.io/istio-testing"
 TAG="${GIT_SHA}"
 # upload images
-time make push HUB="${HUB}" TAG="${TAG}"
+time ISTIO_DOCKER_HUB="${HUB}" make push HUB="${HUB}" TAG="${TAG}"

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -69,8 +69,6 @@ else
   GIT_SHA="$(git rev-parse --verify HEAD)"
 fi
 
-echo 'Initialize'
-${ROOT}/bin/init.sh
 echo 'Build'
 (cd ${ROOT}; make build)
 
@@ -84,7 +82,7 @@ if [[ -n $(git diff) ]]; then
 fi
 
 # upload images - needed by the subsequent tests
-time make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
+time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
 
 # run security e2e test
 CERT_DIR=$(make where-is-docker-temp) ${ROOT}/security/bin/e2e.sh --hub "gcr.io/istio-testing" --tag "${GIT_SHA}"


### PR DESCRIPTION
Some parts of the test seem at best sub-optimal. This change does the following:

* Removes the now unhandled "-s bookinfo".
* Additional parameters are now passed to make e2e_all.  There's probably a more elegant way to handle E2E_ARGS than what I came up with.
* I also set ISTIO_DOCKER_HUB so istioctl is built to point to the HUB that's used.  I'm not sure if this really helps but it seems like this is the direction that other tests have been headed.  I suppose it's getting worthwhile to just have bin/get_workspace_status use HUB instead of the more special-purpose ISTIO_DOCKER_HUB.
* Replace bin/init.sh with "make depend" (or remove it entirely if the top-level Makefile is being used, as it has appropriate dependencies set).
