### PR TITLE
show log after discovery service started

### DIFF
--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -407,8 +407,6 @@ func (ds *DiscoveryService) Register(container *restful.Container) {
 // connections. Content serving is started by this method, but is executed asynchronously. Serving can be cancelled
 // at any time by closing the provided stop channel.
 func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
-	log.Infof("Starting discovery service at %v", ds.server.Addr)
-
 	addr := ds.server.Addr
 	if addr == "" {
 		addr = ":http"
@@ -433,6 +431,7 @@ func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
 		}
 	}()
 
+	log.Infof("Discovery service started at %s", listener.Addr().String())
 	return listener.Addr(), nil
 }
 


### PR DESCRIPTION
When ```ds.server.Addr``` is null, the log ```log.Infof("Starting discovery service at %v", ds.server.Addr)``` makes no sense. This PR is to show log after discovery service started.