### PR TITLE
added default discovery port.  

### DIFF
--- a/install/kubernetes/templates/istio-pilot.yaml.tmpl
+++ b/install/kubernetes/templates/istio-pilot.yaml.tmpl
@@ -90,7 +90,7 @@ spec:
       - name: discovery
         image: {PILOT_HUB}/pilot:{PILOT_TAG}
         imagePullPolicy: IfNotPresent
-        args: ["discovery", "-v", "2", "--admission-service", "istio-pilot"]
+        args: ["discovery", "-v", "2", "--port", "8080", "--admission-service", "istio-pilot"]
         ports:
         - containerPort: 8080
         - containerPort: 443

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/pilot/cmd"
 	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
 )
@@ -95,7 +96,7 @@ func init() {
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", "cluster.local",
 		"DNS domain suffix")
 
-	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.Port, "port", 8080,
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.Port, "port", model.DefaultDiscoveryPort,
 		"Discovery service port")
 	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.MonitoringPort, "monitoringPort", 9093,
 		"HTTP port to use for the exposing pilot self-monitoring information")

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -137,6 +137,9 @@ const (
 
 	// IngressKeyFilename is the ingress private key file name
 	IngressKeyFilename = "tls.key"
+
+	// DefaultDiscoveryPort is the default discovery port used by pilot and discovery
+	DefaultDiscoveryPort = 15003
 )
 
 // DefaultProxyConfig for individual proxies
@@ -148,7 +151,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		AvailabilityZone:       "", //no service zone by default, i.e. AZ-aware routing is disabled
 		DrainDuration:          ptypes.DurationProto(2 * time.Second),
 		ParentShutdownDuration: ptypes.DurationProto(3 * time.Second),
-		DiscoveryAddress:       "istio-pilot:15003",
+		DiscoveryAddress:       fmt.Sprintf("istio-pilot:%d", DefaultDiscoveryPort),
 		DiscoveryRefreshDelay:  ptypes.DurationProto(1 * time.Second),
 		ZipkinAddress:          "",
 		ConnectTimeout:         ptypes.DurationProto(1 * time.Second),

--- a/pilot/test/integration/testdata/pilot.yaml.tmpl
+++ b/pilot/test/integration/testdata/pilot.yaml.tmpl
@@ -87,11 +87,12 @@ spec:
         - {{.Registry}}
         - --eurekaserverURL
         - http://eureka:8080
+        - --port=8080
 {{if .UseAdmissionWebhook}}
         - --admission-service={{.AdmissionServiceName}}
 {{end}}
         ports:
-        - containerPort: 15003
+        - containerPort: 8080
 {{if .DebugPort}}
         - containerPort: {{.DebugPort}}
         volumeMounts:

--- a/pilot/test/integration/testdata/pilot.yaml.tmpl
+++ b/pilot/test/integration/testdata/pilot.yaml.tmpl
@@ -91,7 +91,7 @@ spec:
         - --admission-service={{.AdmissionServiceName}}
 {{end}}
         ports:
-        - containerPort: 8080
+        - containerPort: 15003
 {{if .DebugPort}}
         - containerPort: {{.DebugPort}}
         volumeMounts:


### PR DESCRIPTION
pilot-proxy and discovery currently have inconsistent default ports.  Discovery server is defaulting to 8080, and proxy talks to discovery:15003 by default.