### PR TITLE
`make clean` should not remove checked in certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,8 +467,6 @@ GENERATED_CERT_FILES:=security/docker/istio_ca.crt security/docker/istio_ca.key 
 $(GENERATED_CERT_FILES): security/bin/gen-keys.sh
 	security/bin/gen-keys.sh
 
-FILES_TO_CLEAN+=$(GENERATED_CERT_FILES)
-
 # pilot docker images
 
 docker.app: pilot/docker/pilot-test-client pilot/docker/pilot-test-server \


### PR DESCRIPTION
Commit 224a9e25 recently made istio certs fixed by removing them from
.gitignore:
- security/docker/istio_ca.crt
- security/docker/istio_ca.key
- security/docker/node_agent.crt
- security/docker/node_agent.key

Hence `make clean` should no longer remove these.

#2964 apparently made too many and controversial changes.