### PR TITLE
move config-checksum value to annotations

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     istio: mixer
+  annotations:
     checksum/config-volume: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.replicaCount }}


### PR DESCRIPTION
Fixes #2993.
It may be possible to use {{ template "istio.configmap.checksum" . }} instead of using inlined code. 
I'm unclear if it is meant to, and **will actually** select the local or global (mesh) `configmap.yaml`, though.