### PR TITLE
Add ansible assertions for Kubernetes installation via Ansible

### DIFF
--- a/install/ansible/istio/tasks/assert_oc_admin.yml
+++ b/install/ansible/istio/tasks/assert_oc_admin.yml
@@ -1,0 +1,18 @@
+- name: Find users that have the admin role
+  shell: |
+    {{ cmd_path }} get ClusterRoleBinding cluster-admin -o 'jsonpath={.subjects[*].name}' 2> /dev/null
+  register: ro
+  ignore_errors: true
+
+- name: Get current logged in user
+  command: "{{ cmd_path }} whoami"
+  register: uo
+  ignore_errors: true
+
+- assert:
+    that:
+      - ro.rc == 0
+      - uo.rc == 0
+      - uo.stdout in ro.stdout
+    msg: "Make sure you use 'oc login' with a user that is an admin before running the playbook"
+

--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -19,6 +19,16 @@
 - include_tasks: set_appropriate_cmd_path.yml
   when: cmd_path is not defined
 
+- name: Extract server version
+  shell: |
+    {{ cmd_path }} version | sed -En "{{'s/kubernetes.*v([[:digit:]]\.[[:digit:]]\.[[:digit:]]).*/\1/p' if cluster_flavour == 'ocp' else 's/Server Version.*GitVersion.*v([[:digit:]]\.[[:digit:]]\.[[:digit:]]).*/\1/p'}}" | head -1
+  register: vo
+
+- assert:
+    that:
+      - "vo.stdout >= minimum_cluster_version"
+    msg: "Cluster version must be at least {{ minimum_cluster_version }}"
+
 - include_tasks: install_distro.yml
 - include_tasks: delete_resources.yml
   when: istio.delete_resources == true

--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -29,6 +29,9 @@
       - "vo.stdout >= minimum_cluster_version"
     msg: "Cluster version must be at least {{ minimum_cluster_version }}"
 
+- include_tasks: assert_oc_admin.yml
+  when: cluster_flavour == 'ocp'
+
 - include_tasks: install_distro.yml
 - include_tasks: delete_resources.yml
   when: istio.delete_resources == true

--- a/install/ansible/istio/vars/main.yml
+++ b/install/ansible/istio/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 github_url: https://api.github.com/repos
 istio_repo: istio/istio
+minimum_cluster_version: 1.7.0
 addons_needing_sa:
   - "grafana"
   - "prometheus"


### PR DESCRIPTION
The following assertions have been added:
* The cluster to be used is at least at version `1.7.0`
* In the case of Openshift, the user has logged in and that that user is an admin