### PR TITLE
Fix BookInfo sample when using k8s for Ansible installation

### DIFF
--- a/install/ansible/istio/tasks/bookinfo_cmd.j2
+++ b/install/ansible/istio/tasks/bookinfo_cmd.j2
@@ -1,4 +1,6 @@
-{{ cmd_path }} new-project {{ istio.bookinfo_namespace }}
+{{ cmd_path }} create namespace {{ istio.bookinfo_namespace }}
+{% if cluster_flavour == 'ocp' %}
 {{ cmd_path }} adm policy add-scc-to-user privileged -z default -n {{ istio.bookinfo_namespace }}
+{% endif %}
 {{ cmd_path }} apply -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/kube/bookinfo.yaml)
 {{ cmd_path }} expose svc productpage


### PR DESCRIPTION
The template now ensures that the Openshift specific
`adm policy add-scc-to-user`
is only executed when the cluster flavor is Openshift
Furthermore we use the generic command for creating namespaces instead
of the Openshift specific one