### PR TITLE
Remove the need for privileged = true for proxy_init

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.sidecarInjectEnabled }}
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
@@ -53,3 +54,4 @@ spec:
           items:
           - key: config
             path: config
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.global.sidecarInjectEnabled }}
----
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/service.yaml
@@ -1,4 +1,4 @@
----
+{{- if .Values.global.sidecarInjectEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -11,4 +11,4 @@ spec:
   - port: 443
   selector:
     istio: {{ template "sidecar-injector.name" . }}
----
+{{- end }}

--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
@@ -20,7 +20,6 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
         restartPolicy: Always
       containers:
       - name: istio-proxy

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -39,7 +39,9 @@ initContainers:
     capabilities:
       add:
       - NET_ADMIN
+    [[ if eq .DebugMode true -]]  
     privileged: true
+    [[ end -]]
   restartPolicy: Always
 [[ if eq .EnableCoreDump true -]]
 - args:

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       serviceAccountName: non-default
       volumes:
       - emptyDir:

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -90,7 +90,6 @@ spec:
               capabilities:
                 add:
                 - NET_ADMIN
-              privileged: true
           restartPolicy: OnFailure
           volumes:
           - emptyDir:

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
     spec:
       template:

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -89,7 +89,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"584bd5b45df79592194900b189319226d5aaa9dcc549846859844b35ff19d718","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"5e8951237eecd7fccd113760b0cbdbb866df6ca6a4b70f3c6d4c66796c3383f2","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       - args:
         - -c
         - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c

--- a/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
@@ -109,7 +109,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e756760ea38065cfe42a7865c7e780f1060cab0a8b7a8448b57392172581f6ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"bffe5ef2f4a5d1411a477f01d1da25c0111a8c2be6c22fd982b5847e88f9f784","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -92,7 +92,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -113,7 +113,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -92,7 +92,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -197,7 +196,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"2c407274826c5503579c754c2759254492c904e1e1efe2a2d78d693d57a9df25","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"800150adb84dbbac22b5e8c8920de16fe51b79da310aac83a48525215caa858d","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -111,7 +111,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"4fc0ad1de57c7d57839db1e26a49e01f05909a2e21ab187658dfdc9bbcbf765d","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"67aba04c0072a9777dc1b5fbefa5b802765a612265dbdf8a1c12cef0d0665a65","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -91,6 +91,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -91,7 +91,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       name: pi
     spec:

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -88,7 +88,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       restartPolicy: Never
       volumes:
       - emptyDir:

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -105,7 +105,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -88,7 +88,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -90,7 +90,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: nginx

--- a/pilot/pkg/kube/inject/testdata/single-initializer.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/single-initializer.yaml.injected
@@ -69,7 +69,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       - args:
         - -c
         - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -94,7 +94,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1fe88e0ad06b206965e8b023485f4408d44bb99846832fc78733e5e8e989932e","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"b826a2e335f1ed7d6c4fc3e2b937ebb3d84d5e7712c046c278943013c3febfef","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello


### PR DESCRIPTION
based on the comment:  https://github.com/istio/issues/issues/172#issuecomment-361348278

specifically:  "I don't see a reason why the injected container can't grant NET_CAP_ADMIN in the short term (add it to your cap adds) and we can look at tweaking the selinux policy by default."

Let's remove the privileged = true for proxy_init so that users doesn't need privileged true to deploy a micro service onto Isito.   when debug mode is enabled, we'll still allow privileged=true, this will be the workaround for now for platforms that requires it.