### PR TITLE
bump temporarily hardcoded CLUSTER_VERSION to 1.9.2-gke.0

### DIFF
--- a/prow/cluster_lib.sh
+++ b/prow/cluster_lib.sh
@@ -31,7 +31,7 @@ CLUSTER_NAME=
 # CLUSTER_VERSION="${VERSIONS[1]}"
 
 # TODO(https://github.com/istio/istio/issues/2929)
-CLUSTER_VERSION=1.9.1-gke.0
+CLUSTER_VERSION=1.9.2-gke.0
 
 KUBE_USER="istio-prow-test-job@istio-testing.iam.gserviceaccount.com"
 CLUSTER_CREATED=false


### PR DESCRIPTION
Fixes the following error in presubmit tests. GKE cluster version is temporarily hardcoded to enable early testing of k8s 1.9.x before GKE 1.9 is fully GA.

```
W0131 18:43:26.195] ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Version "1.9.1-gke.0" is invalid.
I0131 18:43:26.642] Failed to create a new cluster
W0131 18:43:26.642] + echo 'Failed to create a new cluster'
```

@sebastienvas, alternatively we could switch to `--zone=us-central1-a` which seems to have 1.9.x available by default in non-alpha clusters.