### PR TITLE
istioctl: enable logging for all subcommands (not just create)

### DIFF
--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -90,6 +90,7 @@ and destination policies.
 
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			_ = log.Configure(loggingOptions)
 			defaultNamespace = getDefaultNamespace(kubeconfig)
 		},
 	}
@@ -101,9 +102,6 @@ and destination policies.
 			istioctl create -f example-routing.yaml
 			`,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := log.Configure(loggingOptions); err != nil {
-				return err
-			}
 			if len(args) != 0 {
 				c.Println(c.UsageString())
 				return fmt.Errorf("create takes no arguments")

--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -89,9 +89,12 @@ See https://istio.io/docs/reference/ for an overview of routing rules
 and destination policies.
 
 `,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			_ = log.Configure(loggingOptions)
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := log.Configure(loggingOptions); err != nil {
+				return err
+			}
 			defaultNamespace = getDefaultNamespace(kubeconfig)
+			return nil
 		},
 	}
 


### PR DESCRIPTION
log.Configure() is currently only called for 'create' so no other
subcommands' log.XYC calls do anything.  This change calls
log.Configure in the rootCmd prerun to enable logging options for all
istioctl subcommands.

*NOTE*
- With this change, by default, any subcommands' "info" or higher logs will be output to stdout--which was not happening prior. 