### PR TITLE
log kubectl describe pods when a pod is problematic

### DIFF
--- a/tests/util/kubeUtils.go
+++ b/tests/util/kubeUtils.go
@@ -247,6 +247,9 @@ func CheckPodsRunning(n string) (ready bool) {
 		for _, p := range pods {
 			if status := GetPodStatus(n, p); status != podRunning {
 				log.Infof("%s in namespace %s is not running: %s", p, n, status)
+				if desc, err := Shell("kubectl describe pods -n %s %s", n, p); err != nil {
+					log.Infof("Pod description: %s", desc)
+				}
 				ready = false
 			}
 		}


### PR DESCRIPTION
This would show more detailed information of the pod when
the pod goes into error or crash loop.

Note that this relies on #2987