### PR TITLE
Disable external svc tests, they cause intermittent failures

### DIFF
--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -219,7 +219,7 @@ func runTests(envs ...infra) {
 			&routingToEgress{infra: &istio},
 			&zipkin{infra: &istio},
 			&authExclusion{infra: &istio},
-			&kubernetesExternalNameServices{infra: &istio},
+			//&kubernetesExternalNameServices{infra: &istio},
 		}
 
 		for _, test := range tests {

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -14,6 +14,7 @@
 
 package main
 
+/*
 import (
 	"fmt"
 
@@ -77,3 +78,4 @@ func (t *kubernetesExternalNameServices) run() error {
 	}
 	return parallel(funcs)
 }
+*/


### PR DESCRIPTION
Disable temporarily the external svc tests, they cause failures.

@vadimeisenbergibm 