### PR TITLE
Rename HostInstances to GetSidecarServiceInstances

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -243,8 +243,8 @@ type ServiceDiscovery interface {
 	// port, hostname and labels.
 	Instances(hostname string, ports []string, labels LabelsCollection) ([]*ServiceInstance, error)
 
-	// HostInstances lists service instances for a given set of IPv4 addresses.
-	HostInstances(addrs map[string]*Node) ([]*ServiceInstance, error)
+	// GetSidecarServiceInstances returns the service instances that are hosted on (implemented by) a given Node
+	GetSidecarServiceInstances(addrs map[string]*Node) ([]*ServiceInstance, error)
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.
 	// These management ports are typically used by the platform for out of band management

--- a/pilot/pkg/proxy/envoy/config.go
+++ b/pilot/pkg/proxy/envoy/config.go
@@ -136,7 +136,7 @@ func BuildConfig(config meshconfig.ProxyConfig, pilotSAN []string) *Config {
 func buildListeners(env model.Environment, node model.Node) (Listeners, error) {
 	switch node.Type {
 	case model.Sidecar, model.Router:
-		instances, err := env.HostInstances(map[string]*model.Node{node.IPAddress: &node})
+		instances, err := env.GetSidecarServiceInstances(map[string]*model.Node{node.IPAddress: &node})
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +159,7 @@ func buildClusters(env model.Environment, node model.Node) (Clusters, error) {
 	var err error
 	switch node.Type {
 	case model.Sidecar, model.Router:
-		instances, err = env.HostInstances(map[string]*model.Node{node.IPAddress: &node})
+		instances, err = env.GetSidecarServiceInstances(map[string]*model.Node{node.IPAddress: &node})
 		if err != nil {
 			return clusters, err
 		}
@@ -293,7 +293,7 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Node, routeName strin
 	case model.Ingress:
 		httpConfigs, _ = buildIngressRoutes(mesh, node, nil, discovery, config)
 	case model.Sidecar, model.Router:
-		instances, err := discovery.HostInstances(map[string]*model.Node{node.IPAddress: &node})
+		instances, err := discovery.GetSidecarServiceInstances(map[string]*model.Node{node.IPAddress: &node})
 		if err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -608,7 +608,7 @@ func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response 
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return
 	}
-	instances, err := ds.HostInstances(map[string]*model.Node{svcNode.IPAddress: &svcNode})
+	instances, err := ds.GetSidecarServiceInstances(map[string]*model.Node{svcNode.IPAddress: &svcNode})
 	if err != nil {
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return

--- a/pilot/pkg/proxy/envoy/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/discovery_test.go
@@ -263,7 +263,7 @@ func TestClusterDiscoveryError(t *testing.T) {
 
 func TestClusterDiscoveryError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.HostInstancesError = errors.New("mock HostInstances() error")
+	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 	url := fmt.Sprintf("/v1/clusters/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -401,7 +401,7 @@ func TestRouteDiscoveryError(t *testing.T) {
 
 func TestRouteDiscoveryError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.HostInstancesError = errors.New("mock HostInstances() error")
+	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -627,7 +627,7 @@ func TestRouteDiscoveryIngressWeighted(t *testing.T) {
 
 func TestRouteDiscoveryRouterError(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.HostInstancesError = errors.New("mock HostInstances() error")
+	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.Router.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -873,7 +873,7 @@ func TestRouteDiscoverySidecarError(t *testing.T) {
 
 func TestRouteDiscoverySidecarError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.HostInstancesError = errors.New("mock HostInstances() error")
+	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.HelloProxyV1.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -913,7 +913,7 @@ func TestListenerDiscoverySidecarError(t *testing.T) {
 
 func TestListenerDiscoverySidecarError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.HostInstancesError = errors.New("mock HostInstances() error")
+	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -1064,8 +1064,8 @@ func TestDiscoveryService_AvailabilityZone(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, ds := commonSetup(t)
 			url := fmt.Sprintf("/v1/az/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
-			mock.Discovery.WantHostInstances = tt.hostInstances
-			mockDiscovery.HostInstancesError = tt.err
+			mock.Discovery.WantGetSidecarServiceInstances = tt.hostInstances
+			mockDiscovery.GetSidecarServiceInstancesError = tt.err
 			response := makeDiscoveryRequest(ds, "GET", url, t)
 			if tt.want != string(response) {
 				t.Errorf("wanted %v but received %v", tt.want, string(response))

--- a/pilot/pkg/proxy/envoy/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/mock/discovery.go
@@ -185,11 +185,11 @@ func MakeIP(service *model.Service, version int) string {
 type ServiceDiscovery struct {
 	services           map[string]*model.Service
 	versions           int
-	WantHostInstances  []*model.ServiceInstance
+	WantGetSidecarServiceInstances  []*model.ServiceInstance
 	ServicesError      error
 	GetServiceError    error
 	InstancesError     error
-	HostInstancesError error
+	GetSidecarServiceInstancesError error
 }
 
 // ClearErrors clear errors used for mocking failures during model.ServiceDiscovery interface methods
@@ -197,7 +197,7 @@ func (sd *ServiceDiscovery) ClearErrors() {
 	sd.ServicesError = nil
 	sd.GetServiceError = nil
 	sd.InstancesError = nil
-	sd.HostInstancesError = nil
+	sd.GetSidecarServiceInstancesError = nil
 }
 
 // Services implements discovery interface
@@ -247,13 +247,13 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 	return out, sd.InstancesError
 }
 
-// HostInstances implements discovery interface
-func (sd *ServiceDiscovery) HostInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
-	if sd.HostInstancesError != nil {
-		return nil, sd.HostInstancesError
+// GetSidecarServiceInstances implements discovery interface
+func (sd *ServiceDiscovery) GetSidecarServiceInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
+	if sd.GetSidecarServiceInstancesError != nil {
+		return nil, sd.GetSidecarServiceInstancesError
 	}
-	if sd.WantHostInstances != nil {
-		return sd.WantHostInstances, nil
+	if sd.WantGetSidecarServiceInstances != nil {
+		return sd.WantGetSidecarServiceInstances, nil
 	}
 	out := make([]*model.ServiceInstance, 0)
 	for _, service := range sd.services {
@@ -267,7 +267,7 @@ func (sd *ServiceDiscovery) HostInstances(addrs map[string]*model.Node) ([]*mode
 			}
 		}
 	}
-	return out, sd.HostInstancesError
+	return out, sd.GetSidecarServiceInstancesError
 }
 
 // ManagementPorts implements discovery interface

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -114,12 +114,12 @@ func (c *Controller) Instances(hostname string, ports []string,
 	return instances, errs
 }
 
-// HostInstances lists service instances for a given set of IPv4 addresses.
-func (c *Controller) HostInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
+// GetSidecarServiceInstances lists service instances for a given set of IPv4 addresses.
+func (c *Controller) GetSidecarServiceInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
 	out := make([]*model.ServiceInstance, 0)
 	var errs error
 	for _, r := range c.registries {
-		instances, err := r.HostInstances(addrs)
+		instances, err := r.GetSidecarServiceInstances(addrs)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {
@@ -129,7 +129,7 @@ func (c *Controller) HostInstances(addrs map[string]*model.Node) ([]*model.Servi
 
 	if len(out) > 0 {
 		if errs != nil {
-			log.Warnf("HostInstances() found match but encountered an error: %v", errs)
+			log.Warnf("GetSidecarServiceInstances() found match but encountered an error: %v", errs)
 		}
 		return out, nil
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -174,17 +174,17 @@ func TestGetServiceError(t *testing.T) {
 	}
 }
 
-func TestHostInstances(t *testing.T) {
+func TestGetSidecarServiceInstances(t *testing.T) {
 	aggregateCtl := buildMockController()
 
 	var svcNode model.Node
 	// Get Instances from mockAdapter1
-	instances, err := aggregateCtl.HostInstances(map[string]*model.Node{mock.HelloInstanceV0: &svcNode})
+	instances, err := aggregateCtl.GetSidecarServiceInstances(map[string]*model.Node{mock.HelloInstanceV0: &svcNode})
 	if err != nil {
-		t.Fatalf("HostInstances() encountered unexpected error: %v", err)
+		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned HostInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.HelloService.Hostname {
@@ -193,12 +193,12 @@ func TestHostInstances(t *testing.T) {
 	}
 
 	// Get Instances from mockAdapter2
-	instances, err = aggregateCtl.HostInstances(map[string]*model.Node{mock.MakeIP(mock.WorldService, 1): &svcNode})
+	instances, err = aggregateCtl.GetSidecarServiceInstances(map[string]*model.Node{mock.MakeIP(mock.WorldService, 1): &svcNode})
 	if err != nil {
-		t.Fatalf("HostInstances() encountered unexpected error: %v", err)
+		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned HostInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.WorldService.Hostname {
@@ -207,29 +207,29 @@ func TestHostInstances(t *testing.T) {
 	}
 }
 
-func TestHostInstancesError(t *testing.T) {
+func TestGetSidecarServiceInstancesError(t *testing.T) {
 	aggregateCtl := buildMockController()
 
-	discovery1.HostInstancesError = errors.New("mock HostInstances() error")
+	discovery1.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 
 	var svcNode model.Node
 	// Get Instances from client with error
-	instances, err := aggregateCtl.HostInstances(map[string]*model.Node{mock.HelloInstanceV0: &svcNode})
+	instances, err := aggregateCtl.GetSidecarServiceInstances(map[string]*model.Node{mock.HelloInstanceV0: &svcNode})
 	if err == nil {
 		t.Fatal("Aggregate controller should return error if one discovery client experiences " +
 			"error and no instances are found")
 	}
 	if len(instances) != 0 {
-		t.Fatal("HostInstances() should return no instances is client experiences error")
+		t.Fatal("GetSidecarServiceInstances() should return no instances is client experiences error")
 	}
 
 	// Get Instances from client without error
-	instances, err = aggregateCtl.HostInstances(map[string]*model.Node{mock.MakeIP(mock.WorldService, 1): &svcNode})
+	instances, err = aggregateCtl.GetSidecarServiceInstances(map[string]*model.Node{mock.MakeIP(mock.WorldService, 1): &svcNode})
 	if err != nil {
 		t.Fatal("Aggregate controller should not return error if instances are found")
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned HostInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.WorldService.Hostname {

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -100,8 +100,8 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList 
 	return instances, nil
 }
 
-// HostInstances implements a service catalog operation
-func (sd *ServiceDiscovery) HostInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
+// GetSidecarServiceInstances implements a service catalog operation
+func (sd *ServiceDiscovery) GetSidecarServiceInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
 	resp, err := sd.Client.Routes(context.Background(), new(copilotapi.RoutesRequest))
 	if err != nil {
 		return nil, fmt.Errorf("getting host instances: %s", err)

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -222,14 +222,14 @@ func TestServiceDiscovery_Instances_ClientError(t *testing.T) {
 	g.Expect(serviceModel).To(gomega.BeNil())
 }
 
-func TestServiceDiscovery_HostInstances(t *testing.T) {
+func TestServiceDiscovery_GetSidecarServiceInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
 	state.mockClient.RoutesOutput.Ret0 <- makeSampleClientResponse()
 	state.mockClient.RoutesOutput.Ret1 <- nil
 
-	instances, err := state.serviceDiscovery.HostInstances(map[string]*model.Node{"": nil})
+	instances, err := state.serviceDiscovery.GetSidecarServiceInstances(map[string]*model.Node{"": nil})
 	g.Expect(err).To(gomega.BeNil())
 
 	servicePort := &model.Port{
@@ -283,27 +283,27 @@ func TestServiceDiscovery_HostInstances(t *testing.T) {
 	}))
 }
 
-func TestServiceDiscovery_HostInstances_ClientError(t *testing.T) {
+func TestServiceDiscovery_GetSidecarServiceInstances_ClientError(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
 	state.mockClient.RoutesOutput.Ret0 <- nil
 	state.mockClient.RoutesOutput.Ret1 <- errors.New("no instances")
 
-	serviceModel, err := state.serviceDiscovery.HostInstances(map[string]*model.Node{"": nil})
+	serviceModel, err := state.serviceDiscovery.GetSidecarServiceInstances(map[string]*model.Node{"": nil})
 
 	g.Expect(err).To(gomega.MatchError("getting host instances: no instances"))
 	g.Expect(serviceModel).To(gomega.BeNil())
 }
 
-func TestServiceDiscovery_HostInstances_NotFound(t *testing.T) {
+func TestServiceDiscovery_GetSidecarServiceInstances_NotFound(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
 	state.mockClient.RoutesOutput.Ret0 <- nil
 	state.mockClient.RoutesOutput.Ret1 <- nil
 
-	instances, err := state.serviceDiscovery.HostInstances(map[string]*model.Node{"": nil})
+	instances, err := state.serviceDiscovery.GetSidecarServiceInstances(map[string]*model.Node{"": nil})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(instances).To(gomega.BeNil())
 }

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -151,8 +151,8 @@ func portMatch(instance *model.ServiceInstance, portMap map[string]bool) bool {
 	return false
 }
 
-// HostInstances lists service instances for a given set of IPv4 addresses.
-func (c *Controller) HostInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
+// GetSidecarServiceInstances lists service instances for a given set of IPv4 addresses.
+func (c *Controller) GetSidecarServiceInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
 	data, err := c.getServices()
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -349,7 +349,7 @@ func TestServicesError(t *testing.T) {
 	}
 }
 
-func TestHostInstances(t *testing.T) {
+func TestGetSidecarServiceInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
 	controller, err := NewController(ts.Server.URL, 3*time.Second)
@@ -358,21 +358,21 @@ func TestHostInstances(t *testing.T) {
 	}
 
 	var svcNode model.Node
-	services, err := controller.HostInstances(map[string]*model.Node{"172.19.0.11": &svcNode})
+	services, err := controller.GetSidecarServiceInstances(map[string]*model.Node{"172.19.0.11": &svcNode})
 	if err != nil {
-		t.Errorf("client encountered error during HostInstances(): %v", err)
+		t.Errorf("client encountered error during GetSidecarServiceInstances(): %v", err)
 	}
 	if len(services) != 1 {
-		t.Errorf("HostInstances() returned wrong # of endpoints => %q, want 1", len(services))
+		t.Errorf("GetSidecarServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
 	}
 
 	if services[0].Service.Hostname != serviceHostname("productpage") {
-		t.Errorf("HostInstances() wrong service instance returned => hostname %q, want %q",
+		t.Errorf("GetSidecarServiceInstances() wrong service instance returned => hostname %q, want %q",
 			services[0].Service.Hostname, serviceHostname("productpage"))
 	}
 }
 
-func TestHostInstancesError(t *testing.T) {
+func TestGetSidecarServiceInstancesError(t *testing.T) {
 	ts := newServer()
 	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
@@ -382,11 +382,11 @@ func TestHostInstancesError(t *testing.T) {
 
 	var svcNode model.Node
 	ts.Server.Close()
-	instances, err := controller.HostInstances(map[string]*model.Node{"172.19.0.11": &svcNode})
+	instances, err := controller.GetSidecarServiceInstances(map[string]*model.Node{"172.19.0.11": &svcNode})
 	if err == nil {
-		t.Error("HostInstances() should return error when client experiences connection problem")
+		t.Error("GetSidecarServiceInstances() should return error when client experiences connection problem")
 	}
 	if len(instances) != 0 {
-		t.Errorf("HostInstances() returned wrong # of instances: %q, want 0", len(instances))
+		t.Errorf("GetSidecarServiceInstances() returned wrong # of instances: %q, want 0", len(instances))
 	}
 }

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery.go
@@ -92,8 +92,8 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 	return out, nil
 }
 
-// HostInstances implements a service catalog operation
-func (sd *serviceDiscovery) HostInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
+// GetSidecarServiceInstances implements a service catalog operation
+func (sd *serviceDiscovery) GetSidecarServiceInstances(addrs map[string]*model.Node) ([]*model.ServiceInstance, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
 		log.Warnf("could not list Eureka instances: %v", err)

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
@@ -92,12 +92,12 @@ func TestServiceDiscoveryClientError(t *testing.T) {
 		t.Error("Instances() should return nil on error")
 	}
 
-	hostInstances, err := sd.HostInstances(make(map[string]*model.Node))
+	hostInstances, err := sd.GetSidecarServiceInstances(make(map[string]*model.Node))
 	if err == nil {
-		t.Error("HostInstances() should return error")
+		t.Error("GetSidecarServiceInstances() should return error")
 	}
 	if hostInstances != nil {
-		t.Error("HostInstances() should return nil on error")
+		t.Error("GetSidecarServiceInstances() should return nil on error")
 	}
 }
 
@@ -139,7 +139,7 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	}
 }
 
-func TestServiceDiscoveryHostInstances(t *testing.T) {
+func TestServiceDiscoveryGetSidecarServiceInstances(t *testing.T) {
 	cl := &mockClient{
 		apps: []*application{
 			{
@@ -174,9 +174,9 @@ func TestServiceDiscoveryHostInstances(t *testing.T) {
 	}
 
 	for _, tt := range instanceTests {
-		instances, err := sd.HostInstances(tt.addrs)
+		instances, err := sd.GetSidecarServiceInstances(tt.addrs)
 		if err != nil {
-			t.Errorf("HostInstances() encountered unexpected error: %v", err)
+			t.Errorf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
 		}
 		sortServiceInstances(instances)
 		if err := compare(t, instances, tt.instances); err != nil {

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -336,8 +336,8 @@ func (c *Controller) Instances(hostname string, ports []string,
 	return nil, nil
 }
 
-// HostInstances implements a service catalog operation
-func (c *Controller) HostInstances(svcNodes map[string]*model.Node) ([]*model.ServiceInstance, error) {
+// GetSidecarServiceInstances implements a service catalog operation
+func (c *Controller) GetSidecarServiceInstances(svcNodes map[string]*model.Node) ([]*model.ServiceInstance, error) {
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -221,7 +221,7 @@ func TestController_getPodAZ(t *testing.T) {
 
 }
 
-func TestHostInstances(t *testing.T) {
+func TestGetSidecarServiceInstances(t *testing.T) {
 	controller := makeFakeKubeAPIController()
 
 	k8sSaOnVM := "acct4"
@@ -244,25 +244,25 @@ func TestHostInstances(t *testing.T) {
 	svcNode.IPAddress = "128.0.0.1"
 	svcNode.ID = "pod1.nsA"
 	svcNode.Domain = "nsA.svc.cluster.local"
-	services, err := controller.HostInstances(map[string]*model.Node{"128.0.0.1": &svcNode})
+	services, err := controller.GetSidecarServiceInstances(map[string]*model.Node{"128.0.0.1": &svcNode})
 	if err != nil {
-		t.Errorf("client encountered error during HostInstances(): %v", err)
+		t.Errorf("client encountered error during GetSidecarServiceInstances(): %v", err)
 	}
 
 	if len(services) != 1 {
-		t.Errorf("HostInstances() returned wrong # of endpoints => %q, want 1", len(services))
+		t.Errorf("GetSidecarServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
 	}
 
 	hostname := serviceHostname("svc1", "nsA", domainSuffix)
 	if services[0].Service.Hostname != hostname {
-		t.Errorf("HostInstances() wrong service instance returned => hostname %q, want %q",
+		t.Errorf("GetSidecarServiceInstances() wrong service instance returned => hostname %q, want %q",
 			services[0].Service.Hostname, hostname)
 	}
 
 	svcNode.Domain = "nsWRONG.svc.cluster.local"
-	_, err = controller.HostInstances(map[string]*model.Node{"128.0.0.1": &svcNode})
+	_, err = controller.GetSidecarServiceInstances(map[string]*model.Node{"128.0.0.1": &svcNode})
 	if err == nil {
-		t.Errorf("HostInstances() should have returned error for unknown domain.")
+		t.Errorf("GetSidecarServiceInstances() should have returned error for unknown domain.")
 	}
 }
 


### PR DESCRIPTION
Name better matches what it does.

Subsequent PR will simplify the function signature to only take a single `model.Node`.  But those changes aren't quite as trivial as this.