### PR TITLE
Copy all core files 

### DIFF
--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
@@ -24,6 +24,7 @@ data:
         restartPolicy: Always
       - args:
         - -c
+        #/etc/istio/proxy value here matches ConfigPathDir const in context.go
         - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
           unlimited
         command:

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -138,16 +138,16 @@ const (
 	// IngressKeyFilename is the ingress private key file name
 	IngressKeyFilename = "tls.key"
 
-	// config directory for storing envoy json config files and also core files
+	// ConfigPathDir config directory for storing envoy json config files and also core files
 	ConfigPathDir = "/etc/istio/proxy"
 
-	// envoy binary location
+	// BinaryPathFilename envoy binary location
 	BinaryPathFilename = "/usr/local/bin/envoy"
 
-	// service cluster name used in xDS calls
+	// ServiceClusterName service cluster name used in xDS calls
 	ServiceClusterName = "istio-proxy"
 
-	// discovery IP address:port
+	// DiscoveryServerAddress discovery IP address:port
 	DiscoveryServerAddress = "istio-pilot:15003"
 )
 

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -138,7 +138,9 @@ const (
 	// IngressKeyFilename is the ingress private key file name
 	IngressKeyFilename = "tls.key"
 
-	// ConfigPathDir config directory for storing envoy json config files and also core files
+	// ConfigPathDir config directory for storing envoy json config files.
+	// It also stores core files as per
+	// https://github.com/istio/istio/blob/master/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl#L27
 	ConfigPathDir = "/etc/istio/proxy"
 
 	// BinaryPathFilename envoy binary location

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -137,18 +137,30 @@ const (
 
 	// IngressKeyFilename is the ingress private key file name
 	IngressKeyFilename = "tls.key"
+
+	// config directory for storing envoy json config files and also core files
+	ConfigPathDir = "/etc/istio/proxy"
+
+	// envoy binary location
+	BinaryPathFilename = "/usr/local/bin/envoy"
+
+	// service cluster name used in xDS calls
+	ServiceClusterName = "istio-proxy"
+
+	// discovery IP address:port
+	DiscoveryServerAddress = "istio-pilot:15003"
 )
 
 // DefaultProxyConfig for individual proxies
 func DefaultProxyConfig() meshconfig.ProxyConfig {
 	return meshconfig.ProxyConfig{
-		ConfigPath:             "/etc/istio/proxy",
-		BinaryPath:             "/usr/local/bin/envoy",
-		ServiceCluster:         "istio-proxy",
+		ConfigPath:             ConfigPathDir,
+		BinaryPath:             BinaryPathFilename,
+		ServiceCluster:         ServiceClusterName,
 		AvailabilityZone:       "", //no service zone by default, i.e. AZ-aware routing is disabled
 		DrainDuration:          ptypes.DurationProto(2 * time.Second),
 		ParentShutdownDuration: ptypes.DurationProto(3 * time.Second),
-		DiscoveryAddress:       "istio-pilot:15003",
+		DiscoveryAddress:       DiscoveryServerAddress,
 		DiscoveryRefreshDelay:  ptypes.DurationProto(1 * time.Second),
 		ZipkinAddress:          "",
 		ConnectTimeout:         ptypes.DurationProto(1 * time.Second),

--- a/pilot/test/integration/access.go
+++ b/pilot/test/integration/access.go
@@ -85,15 +85,16 @@ func (a *accessLogs) check(infra *infra) error {
 				case "ingress":
 					ns = infra.IstioNamespace
 				}
+				util.CopyPodFiles(container, pod, ns, model.ConfigPathDir, infra.coreFilesDir+"/"+pod+"."+ns)
 				logs := util.FetchLogs(client, pod, ns, container)
 
 				if strings.Contains(logs, "segmentation fault") {
-					util.CopyPodFiles("istio-proxy", pod, ns, model.ConfigPathDir, infra.coreFilesDir+"/"+pod+"."+ns)
+					util.CopyPodFiles(container, pod, ns, model.ConfigPathDir, infra.coreFilesDir+"/"+pod+"."+ns)
 					return fmt.Errorf("segmentation fault %s log: %s", pod, logs)
 				}
 
 				if strings.Contains(logs, "assert failure") {
-					util.CopyPodFiles("istio-proxy", pod, ns, model.ConfigPathDir, infra.coreFilesDir)
+					util.CopyPodFiles(container, pod, ns, model.ConfigPathDir, infra.coreFilesDir+"/"+pod+"."+ns)
 					return fmt.Errorf("assert failure in %s log: %s", pod, logs)
 				}
 

--- a/pilot/test/integration/access.go
+++ b/pilot/test/integration/access.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/golang/glog"
 
 	"istio.io/istio/pilot/pkg/kube/inject"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/log"
 )
@@ -87,11 +88,12 @@ func (a *accessLogs) check(infra *infra) error {
 				logs := util.FetchLogs(client, pod, ns, container)
 
 				if strings.Contains(logs, "segmentation fault") {
-					util.CopyCoreFiles(pod, ns, "/etc/istio/proxy/core*", infra.coreFilesDir)
+					util.CopyPodFiles("istio-proxy", pod, ns, model.ConfigPathDir, infra.coreFilesDir+"/"+pod+"."+ns)
 					return fmt.Errorf("segmentation fault %s log: %s", pod, logs)
 				}
 
 				if strings.Contains(logs, "assert failure") {
+					util.CopyPodFiles("istio-proxy", pod, ns, model.ConfigPathDir, infra.coreFilesDir)
 					return fmt.Errorf("assert failure in %s log: %s", pod, logs)
 				}
 

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -210,16 +210,17 @@ func runTests(envs ...infra) {
 
 		tests := []test{
 			&http{infra: &istio},
-			&grpc{infra: &istio},
-			&tcp{infra: &istio},
-			&headless{infra: &istio},
-			&ingress{infra: &istio},
-			&egressRules{infra: &istio},
-			&routing{infra: &istio},
-			&routingToEgress{infra: &istio},
-			&zipkin{infra: &istio},
-			&authExclusion{infra: &istio},
-			&kubernetesExternalNameServices{infra: &istio},
+			/*
+				&grpc{infra: &istio},
+				&tcp{infra: &istio},
+				&headless{infra: &istio},
+				&ingress{infra: &istio},
+				&egressRules{infra: &istio},
+				&routing{infra: &istio},
+				&routingToEgress{infra: &istio},
+				&zipkin{infra: &istio},
+				&authExclusion{infra: &istio},
+				&kubernetesExternalNameServices{infra: &istio},*/
 		}
 
 		for _, test := range tests {

--- a/pilot/test/integration/driver.go
+++ b/pilot/test/integration/driver.go
@@ -210,17 +210,16 @@ func runTests(envs ...infra) {
 
 		tests := []test{
 			&http{infra: &istio},
-			/*
-				&grpc{infra: &istio},
-				&tcp{infra: &istio},
-				&headless{infra: &istio},
-				&ingress{infra: &istio},
-				&egressRules{infra: &istio},
-				&routing{infra: &istio},
-				&routingToEgress{infra: &istio},
-				&zipkin{infra: &istio},
-				&authExclusion{infra: &istio},
-				&kubernetesExternalNameServices{infra: &istio},*/
+			&grpc{infra: &istio},
+			&tcp{infra: &istio},
+			&headless{infra: &istio},
+			&ingress{infra: &istio},
+			&egressRules{infra: &istio},
+			&routing{infra: &istio},
+			&routingToEgress{infra: &istio},
+			&zipkin{infra: &istio},
+			&authExclusion{infra: &istio},
+			&kubernetesExternalNameServices{infra: &istio},
 		}
 
 		for _, test := range tests {

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -105,11 +105,17 @@ func describeNotReadyPods(items []v1.Pod, kubeconfig, ns string) {
 	}
 }
 
-// CopyCoreFiles copies files from a pod to the machine
-func CopyCoreFiles(pod, ns, source, dest string) {
-	// kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar
-	cmd := fmt.Sprintf("kubectl cp %s/%s:%s %s",
-		ns, pod, source, dest)
+// CopyPodFiles copies files from a pod to the machine
+func CopyPodFiles(container, pod, ns, source, dest string) {
+	// kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar -c container
+	cmd := ""
+	if container == "" {
+		cmd = fmt.Sprintf("kubectl cp %s/%s:%s %s",
+			ns, pod, source, dest)
+	} else {
+		cmd = fmt.Sprintf("kubectl cp %s/%s:%s %s  -c %s",
+			ns, pod, source, dest, container)
+	}
 	output, _ := Shell(cmd)
 	log.Errorf("%s\n%s", cmd, output)
 }

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -108,7 +108,7 @@ func describeNotReadyPods(items []v1.Pod, kubeconfig, ns string) {
 // CopyPodFiles copies files from a pod to the machine
 func CopyPodFiles(container, pod, ns, source, dest string) {
 	// kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar -c container
-	cmd := ""
+	var cmd string
 	if container == "" {
 		cmd = fmt.Sprintf("kubectl cp %s/%s:%s %s",
 			ns, pod, source, dest)


### PR DESCRIPTION
Fixes #3064

This copies the files in the core-file-directory/pod.namespace.

Added also the option -c "istio-proxy".