### PR TITLE
Add support for GitHub use of token in Ansible installation

### DIFF
--- a/install/ansible/README.md
+++ b/install/ansible/README.md
@@ -47,6 +47,7 @@ The full list of configurable parameters is as follows:
 | Parameter | Description | Values |
 | --- | --- | --- |
 | `cluster_flavour` | Defines whether the target cluster is a Kubernetes or an Openshift cluster. | Valid values are `k8s` and `ocp` (default) |
+| `github_api_token` | The API token used for authentication when calling the GitHub API | Any valid GitHub API token or empty (default) |
 | `cmd_path` | Can be used when the user does not have the `oc` or `kubectl` binary on the PATH | Defaults to expecting the binary is on the path | 
 | `istio.release_tag_name` | Should be a valid Istio release version. If left empty, the latest Istio release will be installed | `0.2.12`, `0.3.0`, `0.4.0` (default) |
 | `istio.dest` | Destination folder you want to install on your machine istio distribution | `~/.istio` (default) |

--- a/install/ansible/istio/defaults/main.yml
+++ b/install/ansible/istio/defaults/main.yml
@@ -3,6 +3,13 @@
 # Whether the cluster is an Openshift (ocp) or upstream Kubernetes (k8s) cluster
 cluster_flavour: ocp
 
+# The GitHub token to use when calling GitHub's API
+# The token is needed in order to avoid getting Rate Limited by GitHub's API
+# Rate Limiting can easily occur in large corporate environments
+# that make outgoing calls through a small range of IPs
+# If the token is not set, then no API Token will be used
+github_api_token: ""
+
 istio:
 
   # Could be a tag "0.2.12, 0.3.0, 0.4.0" version or be empty "", then in this case, the latest release will be downloaded

--- a/install/ansible/istio/tasks/determine_latest_version.yml
+++ b/install/ansible/istio/tasks/determine_latest_version.yml
@@ -11,6 +11,7 @@
 - name: Get the tagged release
   uri:
     url: "{{ github_url }}/{{ istio_repo }}/releases/latest"
+    headers: "{{ github_api_http_headers }}"
   register: release
 
 - name: Set version

--- a/install/ansible/istio/tasks/determine_version.yml
+++ b/install/ansible/istio/tasks/determine_version.yml
@@ -3,6 +3,20 @@
     istio_version_to_use: "{{ istio.release_tag_name }}"
   when: istio.release_tag_name != ''
 
+- name: Set non-empty Authorization header dictionary
+  set_fact:
+    github_api_authorization_header:
+      Authorization: "{{'token ' + github_api_token}}"
+  when:  github_api_token != ''
+
+- name: Set empty Authorization header dictionary
+  set_fact:
+    github_api_authorization_header: {}
+  when:  github_api_token == ''
+
+- name: Set HTTP headers to use
+  set_fact:
+    github_api_http_headers: "{{ default_github_api_headers | combine(github_api_authorization_header)}}"
 
 - include_tasks: determine_latest_version.yml
   when: istio.release_tag_name == ''

--- a/install/ansible/istio/tasks/get_istio_assets.yml
+++ b/install/ansible/istio/tasks/get_istio_assets.yml
@@ -5,6 +5,7 @@
 - name: Get the tagged release
   uri:
     url: "{{ github_url }}/{{ istio_repo }}/releases/{{ release_tag }}"
+    headers: "{{ github_api_http_headers }}"
   register: release
 
 - name: Set release
@@ -22,6 +23,7 @@
 - name: Get the list of assets
   uri:
     url: "{{ assets_url }}"
+    headers: "{{ github_api_http_headers }}"
   register: assets
 
 - name: Set file extension to lookup

--- a/install/ansible/istio/vars/main.yml
+++ b/install/ansible/istio/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 github_url: https://api.github.com/repos
 istio_repo: istio/istio
+default_github_api_headers: {}
 minimum_cluster_version: 1.7.0
 addons_needing_sa:
   - "grafana"


### PR DESCRIPTION
The token is needed in order to avoid getting Rate Limited
by GitHub's API.
The default behavior is to not use a token at all but should the token
be set, it will be used for all calls to the GitHub API