### PR TITLE
Add test log support to runtime2/testing.

### DIFF
--- a/mixer/pkg/runtime2/handler/factory_test.go
+++ b/mixer/pkg/runtime2/handler/factory_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters()
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil)
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
 	i1 := s.Instances[data.FqnI1]
@@ -42,8 +42,8 @@ func TestBasic(t *testing.T) {
 }
 
 func TestCacheUse(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters()
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil)
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
 	i1 := s.Instances[data.FqnI1]
@@ -67,8 +67,8 @@ func TestCacheUse(t *testing.T) {
 }
 
 func TestAdapterSupportsAdditionalTemplates(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", SupportedTemplates: []string{"additional-template"}})
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", SupportedTemplates: []string{"additional-template"}})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -86,8 +86,8 @@ func TestAdapterSupportsAdditionalTemplates(t *testing.T) {
 }
 
 func TestInferError(t *testing.T) {
-	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", ErrorAtInferType: true})
-	attributes := data.BuildAdapters()
+	templates := data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", ErrorAtInferType: true})
+	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -101,8 +101,8 @@ func TestInferError(t *testing.T) {
 }
 
 func TestNilBuilder(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", NilBuilder: true})
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", NilBuilder: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -116,8 +116,8 @@ func TestNilBuilder(t *testing.T) {
 }
 
 func TestBuilderDoesNotSupportTemplate(t *testing.T) {
-	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", BuilderDoesNotSupportTemplate: true})
-	attributes := data.BuildAdapters()
+	templates := data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", BuilderDoesNotSupportTemplate: true})
+	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -132,8 +132,8 @@ func TestBuilderDoesNotSupportTemplate(t *testing.T) {
 }
 
 func TestHandlerDoesNotSupportTemplate(t *testing.T) {
-	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
-	attributes := data.BuildAdapters()
+	templates := data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
+	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -149,8 +149,8 @@ func TestHandlerDoesNotSupportTemplate(t *testing.T) {
 
 func TestHandlerDoesNotSupportTemplate_ErrorDuringClose(t *testing.T) {
 	// Trigger premature close due to handler not supporting the template.
-	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", ErrorAtHandlerClose: true})
+	templates := data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", ErrorAtHandlerClose: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -166,8 +166,8 @@ func TestHandlerDoesNotSupportTemplate_ErrorDuringClose(t *testing.T) {
 
 func TestHandlerDoesNotSupportTemplate_PanicDuringClose(t *testing.T) {
 	// Trigger premature close due to handler not supporting the template.
-	templates := data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", PanicAtHandlerClose: true})
+	templates := data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true})
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", PanicAtHandlerClose: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -182,8 +182,8 @@ func TestHandlerDoesNotSupportTemplate_PanicDuringClose(t *testing.T) {
 }
 
 func TestPanicAtSetAdapterConfig(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", PanicAtSetAdapterConfig: true})
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", PanicAtSetAdapterConfig: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 	i1 := s.Instances[data.FqnI1]
@@ -198,8 +198,8 @@ func TestPanicAtSetAdapterConfig(t *testing.T) {
 }
 
 func TestFailedValidation(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", ErrorAtValidate: true})
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", ErrorAtValidate: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
@@ -215,8 +215,8 @@ func TestFailedValidation(t *testing.T) {
 }
 
 func TestPanicAtValidation(t *testing.T) {
-	templates := data.BuildTemplates()
-	attributes := data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", PanicAtValidate: true})
+	templates := data.BuildTemplates(nil)
+	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", PanicAtValidate: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 

--- a/mixer/pkg/runtime2/routing/builder_test.go
+++ b/mixer/pkg/runtime2/routing/builder_test.go
@@ -297,7 +297,7 @@ ID: 1
 			data.InstanceCheck1,
 			data.RuleCheck1,
 		},
-		Adapters: data.BuildAdapters(data.FakeAdapterSettings{Name: "acheck", ErrorAtBuild: true}),
+		Adapters: data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", ErrorAtBuild: true}),
 		// No routes are set, as the only rule is bad.
 		ExpectedTable: `
 [Routing ExpectedTable]
@@ -313,7 +313,7 @@ ID: 1
 			data.InstanceCheck1,
 			data.RuleCheck1,
 		},
-		Templates: data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true}),
+		Templates: data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", HandlerDoesNotSupportTemplate: true}),
 		ExpectedTable: `
 [Routing ExpectedTable]
 ID: 1
@@ -385,7 +385,7 @@ ID: 1
 			data.InstanceCheck1,
 			data.RuleCheck1,
 		},
-		Templates: data.BuildTemplates(data.FakeTemplateSettings{Name: "tcheck", ErrorAtCreateInstanceBuilder: true}),
+		Templates: data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tcheck", ErrorAtCreateInstanceBuilder: true}),
 		ExpectedTable: `
 [Routing ExpectedTable]
 ID: 1
@@ -433,7 +433,7 @@ ID: 1
 			data.InstanceAPA1,
 			data.RuleApa1,
 		},
-		Templates: data.BuildTemplates(data.FakeTemplateSettings{Name: "tapa", ErrorAtCreateOutputExpressions: true}),
+		Templates: data.BuildTemplates(nil, data.FakeTemplateSettings{Name: "tapa", ErrorAtCreateOutputExpressions: true}),
 
 		ExpectedTable: `
 [Routing ExpectedTable]
@@ -478,11 +478,11 @@ func TestBuilder(t *testing.T) {
 
 			templates := tst.Templates
 			if templates == nil {
-				templates = data.BuildTemplates()
+				templates = data.BuildTemplates(nil)
 			}
 			adapters := tst.Adapters
 			if adapters == nil {
-				adapters = data.BuildAdapters()
+				adapters = data.BuildAdapters(nil)
 			}
 			t, s := buildTableWithTemplatesAndAdapters(templates, adapters, serviceConfig, tst.Configs, true)
 
@@ -523,7 +523,7 @@ func normalize(str string) string {
 
 // Convenience method for building a routing Table for tests.
 func buildTable(serviceConfig string, globalConfigs []string, debugInfo bool) (*Table, *config.Snapshot) {
-	return buildTableWithTemplatesAndAdapters(data.BuildTemplates(), data.BuildAdapters(), serviceConfig, globalConfigs, debugInfo)
+	return buildTableWithTemplatesAndAdapters(data.BuildTemplates(nil), data.BuildAdapters(nil), serviceConfig, globalConfigs, debugInfo)
 }
 
 // Convenience method for building a routing Table for tests.

--- a/mixer/pkg/runtime2/testing/data/adapters.go
+++ b/mixer/pkg/runtime2/testing/data/adapters.go
@@ -26,21 +26,23 @@ import (
 )
 
 // BuildAdapters builds a standard set of testing adapters. The supplied settings is used to override behavior.
-func BuildAdapters(settings ...FakeAdapterSettings) map[string]*adapter.Info {
+func BuildAdapters(l *Logger, settings ...FakeAdapterSettings) map[string]*adapter.Info {
 	m := make(map[string]FakeAdapterSettings)
 	for _, setting := range settings {
 		m[setting.Name] = setting
 	}
 
 	var a = map[string]*adapter.Info{
-		"acheck": createFakeAdapter("acheck", m["acheck"], "tcheck", "thalt"),
-		"apa":    createFakeAdapter("apa", m["apa"], "tapa"),
+		"acheck":  createFakeAdapter("acheck", m["acheck"], l, "tcheck", "thalt"),
+		"areport": createFakeAdapter("areport", m["areport"], l, "treport"),
+		"aquota":  createFakeAdapter("aquota", m["aquota"], l, "tquota"),
+		"apa":     createFakeAdapter("apa", m["apa"], l, "tapa"),
 	}
 
 	return a
 }
 
-func createFakeAdapter(name string, s FakeAdapterSettings, defaultTemplates ...string) *adapter.Info {
+func createFakeAdapter(name string, s FakeAdapterSettings, l *Logger, defaultTemplates ...string) *adapter.Info {
 	templates := defaultTemplates
 	if s.SupportedTemplates != nil {
 		templates = s.SupportedTemplates
@@ -52,12 +54,16 @@ func createFakeAdapter(name string, s FakeAdapterSettings, defaultTemplates ...s
 		DefaultConfig:      &types.Struct{},
 		SupportedTemplates: templates,
 		NewBuilder: func() adapter.HandlerBuilder {
+			l.write(name, "NewBuilder =>")
 			if s.NilBuilder {
+				l.writeFormat(name, "NewBuilder <= nil")
 				return nil
 			}
 
+			l.writeFormat(name, "NewBuilder <=")
 			return &FakeHandlerBuilder{
 				settings: s,
+				l:        l,
 			}
 		},
 	}
@@ -80,45 +86,60 @@ var _ adapter.Env = &FakeEnv{}
 
 // FakeHandlerBuilder is a fake of HandlerBuilder.
 type FakeHandlerBuilder struct {
+	l        *Logger
 	settings FakeAdapterSettings
 }
 
 // SetAdapterConfig is an implementation of HandlerBuilder.SetAdapterConfig.
 func (f *FakeHandlerBuilder) SetAdapterConfig(cfg adapter.Config) {
+	f.l.writeFormat(f.settings.Name, "HandlerBuilder.SetAdapterConfig => '%v'", cfg)
 	if f.settings.PanicAtSetAdapterConfig {
+		f.l.write(f.settings.Name, "HandlerBuilder.SetAdapterConfig <= (PANIC)")
 		panic(f.settings.PanicData)
 	}
+	f.l.write(f.settings.Name, "HandlerBuilder.SetAdapterConfig <=")
 }
 
 // Validate is an implementation of HandlerBuilder.Validate.
 func (f *FakeHandlerBuilder) Validate() *adapter.ConfigErrors {
+	f.l.write(f.settings.Name, "HandlerBuilder.Validate =>")
 	if f.settings.PanicAtValidate {
+		f.l.write(f.settings.Name, "HandlerBuilder.Validate <= (PANIC)")
 		panic(f.settings.PanicData)
 	}
 
 	if f.settings.ErrorAtValidate {
+		f.l.write(f.settings.Name, "HandlerBuilder.Validate <= (ERROR)")
 		errs := &adapter.ConfigErrors{}
 		errs = errs.Append("field", fmt.Errorf("some validation error"))
 		return errs
 	}
+
+	f.l.write(f.settings.Name, "HandlerBuilder.Validate <= (SUCCESS)")
 	return nil
 }
 
 // Build is an implementation of HandlerBuilder.Build.
 func (f *FakeHandlerBuilder) Build(_ context.Context, env adapter.Env) (adapter.Handler, error) {
+	f.l.write(f.settings.Name, "HandlerBuilder.Build =>")
 	if f.settings.PanicAtBuild {
+		f.l.write(f.settings.Name, "HandlerBuilder.Build <= (PANIC)")
 		panic(f.settings.PanicData)
 	}
 
 	if f.settings.ErrorAtBuild {
+		f.l.write(f.settings.Name, "HandlerBuilder.Build <= (ERROR)")
 		return nil, fmt.Errorf("this adapter is not available at the moment, please come back later")
 	}
 
 	if f.settings.NilHandlerAtBuild {
+		f.l.write(f.settings.Name, "HandlerBuilder.Build <= (nil)")
 		return nil, nil
 	}
+
 	handler := &FakeHandler{
 		settings:      f.settings,
+		l:             f.l,
 		closingDaemon: make(chan bool),
 		closingWorker: make(chan bool),
 		done:          make(chan bool),
@@ -150,6 +171,7 @@ func (f *FakeHandlerBuilder) Build(_ context.Context, env adapter.Env) (adapter.
 		})
 	}
 
+	f.l.write(f.settings.Name, "HandlerBuilder.Build <= (SUCCESS)")
 	return handler, nil
 }
 
@@ -158,6 +180,7 @@ var _ adapter.HandlerBuilder = &FakeHandlerBuilder{}
 // FakeHandler is a fake implementation of adapter.Handler.
 type FakeHandler struct {
 	settings      FakeAdapterSettings
+	l             *Logger
 	refreshTicker *time.Ticker
 	closingDaemon chan bool
 	closingWorker chan bool
@@ -166,15 +189,15 @@ type FakeHandler struct {
 
 // Close is an implementation of adapter.Handler.Close.
 func (f *FakeHandler) Close() error {
-	if f.settings.CloseCalled != nil {
-		*f.settings.CloseCalled = true
-	}
+	f.l.write(f.settings.Name, "Handler.Close =>")
 
 	if f.settings.PanicAtHandlerClose {
+		f.l.write(f.settings.Name, "Handler.Close <= (PANIC)")
 		panic(f.settings.PanicData)
 	}
 
 	if f.settings.ErrorAtHandlerClose {
+		f.l.write(f.settings.Name, "Handler.Close <= (ERROR)")
 		return fmt.Errorf("error on close")
 	}
 
@@ -186,6 +209,7 @@ func (f *FakeHandler) Close() error {
 		f.refreshTicker.Stop()
 	}
 
+	f.l.write(f.settings.Name, "Handler.Close <= (SUCCESS)")
 	return nil
 }
 
@@ -209,6 +233,4 @@ type FakeAdapterSettings struct {
 	CloseGoRoutines         bool
 
 	SupportedTemplates []string
-
-	CloseCalled *bool
 }

--- a/mixer/pkg/runtime2/testing/data/logger.go
+++ b/mixer/pkg/runtime2/testing/data/logger.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Logger is used to capture the events that happen within fake adapters & templates during testing.
+type Logger struct {
+	b bytes.Buffer
+}
+
+func (l *Logger) write(name string, s string) {
+	if l != nil {
+		fmt.Fprintf(&l.b, "[%s] %s\n", name, s)
+	}
+}
+
+func (l *Logger) writeFormat(name string, format string, args ...interface{}) {
+	if l != nil {
+		s := fmt.Sprintf(format, args...)
+		l.write(name, s)
+	}
+}
+
+// Clear the contents of this logger. Useful for reducing the event output to write more readable tests.
+func (l *Logger) Clear() {
+	if l != nil {
+		l.b.Reset()
+	}
+}
+
+func (l *Logger) String() string {
+	if l == nil {
+		return ""
+	}
+
+	return l.b.String()
+}

--- a/mixer/pkg/runtime2/testing/data/templates.go
+++ b/mixer/pkg/runtime2/testing/data/templates.go
@@ -15,6 +15,7 @@
 package data
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -30,55 +31,155 @@ import (
 )
 
 // BuildTemplates builds a standard set of testing templates. The supplied settings is used to override behavior.
-func BuildTemplates(settings ...FakeTemplateSettings) map[string]*template.Info {
+func BuildTemplates(l *Logger, settings ...FakeTemplateSettings) map[string]*template.Info {
 	m := make(map[string]FakeTemplateSettings)
 	for _, setting := range settings {
 		m[setting.Name] = setting
 	}
 
 	var t = map[string]*template.Info{
-		"tcheck": createFakeTemplate("tcheck", m["tcheck"], istio_mixer_v1_template.TEMPLATE_VARIETY_CHECK),
-		"tapa":   createFakeTemplate("tapa", m["tapa"], istio_mixer_v1_template.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR),
+		"tcheck":  createFakeTemplate("tcheck", m["tcheck"], l, istio_mixer_v1_template.TEMPLATE_VARIETY_CHECK),
+		"treport": createFakeTemplate("treport", m["treport"], l, istio_mixer_v1_template.TEMPLATE_VARIETY_REPORT),
+		"tquota":  createFakeTemplate("tquota", m["tquota"], l, istio_mixer_v1_template.TEMPLATE_VARIETY_QUOTA),
+		"tapa":    createFakeTemplate("tapa", m["tapa"], l, istio_mixer_v1_template.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR),
 
 		// This is another template with check.
-		"thalt": createFakeTemplate("thalt", m["thalt"], istio_mixer_v1_template.TEMPLATE_VARIETY_CHECK),
+		"thalt": createFakeTemplate("thalt", m["thalt"], l, istio_mixer_v1_template.TEMPLATE_VARIETY_CHECK),
 	}
 
 	return t
 }
 
-func createFakeTemplate(name string, s FakeTemplateSettings, variety istio_mixer_v1_template.TemplateVariety) *template.Info {
+func createFakeTemplate(name string, s FakeTemplateSettings, l *Logger, variety istio_mixer_v1_template.TemplateVariety) *template.Info {
+	callCount := 0
+
 	return &template.Info{
 		Name:    name,
 		Variety: variety,
 		CtrCfg:  &types.Struct{},
 		InferType: func(p proto.Message, evalFn template.TypeEvalFn) (proto.Message, error) {
+			l.writeFormat(name, "InferType => p: '%+v'", p)
+
 			if s.ErrorAtInferType {
+				l.writeFormat(name, "InferType <= (FAIL)")
 				return nil, fmt.Errorf("infer type error, as requested")
 			}
 
 			_, _ = evalFn("source.name")
+			l.writeFormat(name, "InferType <= (SUCCESS)")
 			return &types.Empty{}, nil
 		},
 		BuilderSupportsTemplate: func(hndlrBuilder adapter.HandlerBuilder) bool {
+			l.write(name, "BuilderSupportsTemplate =>")
+			l.writeFormat(name, "BuilderSupportsTemplate <= %v", !s.BuilderDoesNotSupportTemplate)
 			return !s.BuilderDoesNotSupportTemplate
 		},
 		HandlerSupportsTemplate: func(hndlr adapter.Handler) bool {
+			l.write(name, "HandlerSupportsTemplate =>")
+			l.writeFormat(name, "HandlerSupportsTemplate <= %v", !s.HandlerDoesNotSupportTemplate)
 			return !s.HandlerDoesNotSupportTemplate
 		},
 		SetType: func(types map[string]proto.Message, builder adapter.HandlerBuilder) {
+			l.writeFormat(name, "SetType => types: '%+v'", types)
+			l.write(name, "SetType <=")
+		},
+		DispatchCheck: func(ctx context.Context, handler adapter.Handler, instance interface{}) (adapter.CheckResult, error) {
+			l.writeFormat(name, "DispatchCheck => instance: '%+v'", instance)
+			if s.PanicOnDispatchCheck {
+				l.write(name, "DispatchCheck <= (PANIC)")
+				panic(s.PanicData)
+			}
+
+			if s.ErrorOnDispatchCheck {
+				l.write(name, "DispatchCheck <= (ERROR)")
+				return adapter.CheckResult{}, errors.New("error at dispatch check, as expected")
+			}
+
+			result := adapter.CheckResult{}
+			if callCount < len(s.CheckResults) {
+				result = s.CheckResults[callCount]
+			}
+			callCount++
+
+			l.write(name, "DispatchCheck <= (SUCCESS)")
+			return result, nil
+		},
+		DispatchReport: func(ctx context.Context, handler adapter.Handler, instances []interface{}) error {
+			l.writeFormat(name, "DispatchReport => instances: '%+v'", instances)
+			if s.PanicOnDispatchReport {
+				l.write(name, "DispatchReport <= (PANIC)")
+				panic(s.PanicData)
+			}
+
+			if s.ErrorOnDispatchReport {
+				l.write(name, "DispatchReport <= (ERROR)")
+				return errors.New("error at dispatch report, as expected")
+			}
+
+			l.write(name, "DispatchReport <= (SUCCESS)")
+			return nil
+		},
+		DispatchQuota: func(ctx context.Context, handler adapter.Handler, instance interface{}, args adapter.QuotaArgs) (adapter.QuotaResult, error) {
+			l.writeFormat(name, "DispatchQuota => instance: '%+v'", instance)
+			if s.PanicOnDispatchQuota {
+				l.write(name, "DispatchQuota <= (PANIC)")
+				panic(s.PanicData)
+			}
+
+			if s.ErrorOnDispatchQuota {
+				l.write(name, "DispatchQuota <= (ERROR)")
+				return adapter.QuotaResult{}, errors.New("error at dispatch quota, as expected")
+			}
+
+			result := adapter.QuotaResult{}
+			if callCount < len(s.QuotaResults) {
+				result = s.QuotaResults[callCount]
+			}
+			callCount++
+
+			l.write(name, "DispatchQuota <= (SUCCESS)")
+			return result, nil
+		},
+		DispatchGenAttrs: func(ctx context.Context, handler adapter.Handler, instance interface{},
+			attrs attribute.Bag, mapper template.OutputMapperFn) (*attribute.MutableBag, error) {
+			l.writeFormat(name, "DispatchGenAttrs => instance: '%+v'", instance)
+			if s.PanicOnDispatchGenAttrs {
+				l.write(name, "DispatchGenAttrs <= (PANIC)")
+				panic(s.PanicData)
+			}
+
+			if s.ErrorOnDispatchGenAttrs {
+				l.write(name, "DispatchGenAttrs <= (ERROR)")
+				return nil, errors.New("error at dispatch quota, as expected")
+			}
+
+			outputAttrs := map[string]interface{}{}
+			if s.OutputAttrs != nil {
+				outputAttrs = s.OutputAttrs
+			}
+
+			l.write(name, "DispatchGenAttrs <= (SUCCESS)")
+			return attribute.GetFakeMutableBagForTesting(outputAttrs), nil
 
 		},
 		CreateInstanceBuilder: func(instanceName string, instanceParam proto.Message, builder *compiled.ExpressionBuilder) (template.InstanceBuilderFn, error) {
+			l.writeFormat(name, "CreateInstanceBuilder => name: '%+s', param: '%v'", instanceName, instanceParam)
 			if s.ErrorAtCreateInstanceBuilder {
+				l.writeFormat(name, "CreateInstanceBuilder <= (FAIL)")
 				return nil, errors.New("error at create instance builder")
 			}
 
+			l.writeFormat(name, "CreateInstanceBuilder <= (SUCCESS)")
+
 			return func(bag attribute.Bag) (interface{}, error) {
+				l.writeFormat(name, "InstanceBuilderFn() => name: '%s', bag: '%v'", name, bag.DebugString())
 
 				if s.ErrorAtCreateInstance {
+					l.write(name, "InstanceBuilderFn() <= (ERROR)")
 					return nil, errors.New("error at create instance")
 				}
+
+				l.write(name, "InstanceBuilderFn() <= (SUCCESS)")
 				return &types.Empty{}, nil
 			}, nil
 		},
@@ -86,8 +187,11 @@ func createFakeTemplate(name string, s FakeTemplateSettings, variety istio_mixer
 			instanceParam proto.Message,
 			finder expr.AttributeDescriptorFinder,
 			expb *compiled.ExpressionBuilder) (map[string]compiled.Expression, error) {
+			l.writeFormat(name, "CreateOutputExpressions => param: '%+v'", instanceParam)
 
+			l.writeFormat(name, "CreateOutputExpressions <= (SUCCESS)")
 			if s.ErrorAtCreateOutputExpressions {
+				l.writeFormat(name, "CreateOutputExpressions <= (FAIL)")
 				return nil, errors.New("error ar create output expressions")
 			}
 
@@ -105,4 +209,16 @@ type FakeTemplateSettings struct {
 	ErrorAtInferType               bool
 	BuilderDoesNotSupportTemplate  bool
 	HandlerDoesNotSupportTemplate  bool
+	PanicOnDispatchCheck           bool
+	ErrorOnDispatchCheck           bool
+	PanicOnDispatchReport          bool
+	ErrorOnDispatchReport          bool
+	PanicOnDispatchQuota           bool
+	ErrorOnDispatchQuota           bool
+	PanicOnDispatchGenAttrs        bool
+	ErrorOnDispatchGenAttrs        bool
+	PanicData                      interface{}
+	QuotaResults                   []adapter.QuotaResult
+	CheckResults                   []adapter.CheckResult
+	OutputAttrs                    map[string]interface{}
 }


### PR DESCRIPTION
Adding stable test event log support to aid with writing event
based tests using a baseline model.

Also apply the model in some of the existing tests.