### PR TITLE
Reuse kubernetesenv client controllers per distinct kubeconfig

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -436,10 +436,3 @@ func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface,
 func newInterface(c *rest.Config) (k8s.Interface, error) {
 	return k8s.NewForConfig(c)
 }
-
-func configKey(config *rest.Config) string {
-	if config == nil {
-		return ""
-	}
-	return config.Host + config.Prefix + config.APIPath
-}

--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -424,7 +424,7 @@ func istioComponentName(name string) string {
 	return "istio-" + name
 }
 
-func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface, error) {
+func newKubernetesConfig(kubeconfigPath string, env adapter.Env) (*rest.Config, error) {
 	env.Logger().Infof("getting kubeconfig from: %#v", kubeconfigPath)
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil || config == nil {

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 
 	"istio.io/istio/mixer/adapter/kubernetesenv/config"
 	kubernetes_apa_tmpl "istio.io/istio/mixer/adapter/kubernetesenv/template"
@@ -39,14 +40,31 @@ type fakeK8sBuilder struct {
 	calledEnv  adapter.Env
 }
 
-func (b *fakeK8sBuilder) build(path string, env adapter.Env) (kubernetes.Interface, error) {
+func (b *fakeK8sBuilder) conf(path string, env adapter.Env) (*rest.Config, error) {
 	b.calledPath = path
 	b.calledEnv = env
+	return &rest.Config{Host: "host", APIPath: "apipath", Prefix: "prefix"}, nil
+}
+
+func clientset(*rest.Config) (kubernetes.Interface, error) {
 	return fake.NewSimpleClientset(), nil
 }
 
-func errorClientBuilder(path string, env adapter.Env) (kubernetes.Interface, error) {
+func nilConf(path string, env adapter.Env) (*rest.Config, error) {
+	return nil, nil
+}
+
+func errorConfigBuilder(path string, env adapter.Env) (*rest.Config, error) {
 	return nil, errors.New("can't build k8s client")
+}
+
+func errorClientset(*rest.Config) (kubernetes.Interface, error) {
+	return nil, errors.New("failure building clientset from config")
+}
+
+func newFakeBuilder() *builder {
+	fb := &fakeK8sBuilder{}
+	return newBuilder(fb.conf, clientset)
 }
 
 // note: not using TestAdapterInvariants here because of kubernetes dependency.
@@ -54,7 +72,7 @@ func errorClientBuilder(path string, env adapter.Env) (kubernetes.Interface, err
 // test / e2e test must be written to validate the builder in relation to a
 // real kubernetes cluster.
 func TestBuilder(t *testing.T) {
-	b := newBuilder((&fakeK8sBuilder{}).build)
+	b := newFakeBuilder()
 
 	if err := b.Validate(); err != nil {
 		t.Errorf("ValidateConfig() => builder can't validate its default configuration: %v", err)
@@ -71,7 +89,7 @@ func TestBuilder_ValidateConfigErrors(t *testing.T) {
 		{"bad cluster domain name", &config.Params{ClusterDomainName: "something.silly", PodLabelForService: "app"}, 3},
 	}
 
-	b := newBuilder((&fakeK8sBuilder{}).build)
+	b := newFakeBuilder()
 
 	for _, v := range tests {
 		b.SetAdapterConfig(v.conf)
@@ -88,18 +106,21 @@ func TestBuilder_ValidateConfigErrors(t *testing.T) {
 
 func TestBuilder_BuildAttributesGenerator(t *testing.T) {
 	tests := []struct {
-		name    string
-		testFn  clientFactoryFn
-		conf    adapter.Config
-		wantErr bool
+		name        string
+		configFn    configFactoryFn
+		clientsetFn clientsetFactoryFn
+		conf        adapter.Config
+		wantErr     bool
 	}{
-		{"success", (&fakeK8sBuilder{}).build, conf, false},
-		{"builder error", errorClientBuilder, conf, true},
+		{"success", (&fakeK8sBuilder{}).conf, clientset, conf, false},
+		{"success -- nil config", nilConf, clientset, conf, false},
+		{"builder error -- config", errorConfigBuilder, clientset, conf, true},
+		{"builder error -- clientset", (&fakeK8sBuilder{}).conf, errorClientset, conf, true},
 	}
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			b := newBuilder(v.testFn)
+			b := newBuilder(v.configFn, v.clientsetFn)
 			b.SetAdapterConfig(v.conf)
 			_, err := b.Build(context.Background(), test.NewEnv(t))
 			if err == nil && v.wantErr {
@@ -109,6 +130,24 @@ func TestBuilder_BuildAttributesGenerator(t *testing.T) {
 				t.Fatalf("Got error, wanted none: %v", err)
 			}
 		})
+	}
+}
+
+func TestBuilder_ControllerCache(t *testing.T) {
+	b := newFakeBuilder()
+
+	for i := 0; i < 10; i++ {
+		if _, err := b.Build(context.Background(), test.NewEnv(t)); err != nil {
+			t.Errorf("error in builder: %v", err)
+		}
+	}
+
+	if b.controllers.Stats().Hits != 9 {
+		t.Errorf("Got %v hits, want 9", b.controllers.Stats().Hits)
+	}
+
+	if b.controllers.Stats().Misses != 1 {
+		t.Errorf("Got %v misses, want 1", b.controllers.Stats().Misses)
 	}
 }
 
@@ -132,7 +171,7 @@ func TestBuilder_BuildAttributesGeneratorWithEnvVar(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(t *testing.T) {
-			b := newBuilder(v.clientFactory.build)
+			b := newBuilder(v.clientFactory.conf, clientset)
 			b.SetAdapterConfig(v.conf)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -376,7 +415,7 @@ func TestKubegen_Generate(t *testing.T) {
 		objs = append(objs, pod)
 	}
 
-	builder := newBuilder(func(string, adapter.Env) (kubernetes.Interface, error) {
+	builder := newBuilder((&fakeK8sBuilder{}).conf, func(*rest.Config) (kubernetes.Interface, error) {
 		return fake.NewSimpleClientset(objs...), nil
 	})
 

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -142,12 +142,8 @@ func TestBuilder_ControllerCache(t *testing.T) {
 		}
 	}
 
-	if b.controllers.Stats().Hits != 9 {
-		t.Errorf("Got %v hits, want 9", b.controllers.Stats().Hits)
-	}
-
-	if b.controllers.Stats().Misses != 1 {
-		t.Errorf("Got %v misses, want 1", b.controllers.Stats().Misses)
+	if len(b.controllers) != 1 {
+		t.Errorf("Got %v controllers, want 1", len(b.controllers))
 	}
 }
 


### PR DESCRIPTION
This PR creates a cache of controllers in the kubernetesenv adapter builder, keyed
by the extracted k8s config host, apipath, and prefix. This is an attempt to prevent
or limit Mixer from creating multiple watchers for the same k8s API server.

This PR attempts to resolve the observed issue on the test cluster in which a Mixer, with
k8senv handler config, was created in each testing namespace. This led to there being N
Mixers with N configured k8senv controllers, each watching Pods (n^2 watches). This mitigation
should limit this to N distinct controllers across the test cluster.

Fixes #2903 

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>