### PR TITLE
Fix go build for servicegraph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ $(MIXER_GO_BINS): depend
 	bin/gobuild.sh $@ istio.io/istio/pkg/version ./mixer/cmd/$(@F)
 
 ${ISTIO_OUT}/servicegraph: depend
-	bin/gobuild.sh $@ istio.io/istio/pkg/version ./mixer/example/$(@F)
+	bin/gobuild.sh $@ istio.io/istio/pkg/version ./mixer/example/$(@F)/cmd/server/main.go
 
 SECURITY_GO_BINS:=${ISTIO_OUT}/node_agent ${ISTIO_OUT}/istio_ca
 $(SECURITY_GO_BINS): depend


### PR DESCRIPTION
The Makefile target for servicegraph is not correct. This PR attempts to
fix this by updating the target.

After this fix, the docker.io image for servicegraph:0.5.0 will need to
updated, etc.

Related issues: https://github.com/istio/issues/issues/179, https://github.com/istio/istio/issues/3015