### PR TITLE
add missing tools copy for archive gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,7 @@ ${ISTIO_OUT}/archive: istioctl-all LICENSE README.md istio.VERSION install/updat
 	cp ${ISTIO_OUT}/istioctl-* ${ISTIO_OUT}/archive/istioctl/
 	cp LICENSE ${ISTIO_OUT}/archive
 	cp README.md ${ISTIO_OUT}/archive
+	cp -r tools ${ISTIO_OUT}/archive
 	install/updateVersion.sh -c "$(ISTIO_DOCKER_HUB),$(VERSION)" -A "$(ISTIO_URL)/deb" \
                                  -x "$(ISTIO_DOCKER_HUB),$(VERSION)" -p "$(ISTIO_DOCKER_HUB),$(VERSION)" \
                                  -i "$(ISTIO_URL)/$(ISTIO_URL_ISTIOCTL)" \


### PR DESCRIPTION
This change adds a missing copy that's required for installer tar generation.

During the week my large make PR was pending a new tools/ directory was added to the installer tars.  That change properly updated update_and_create_archives.sh, though when I rebased (was was several times over the week) I never saw git complain about trying to merge that change into the file (which my change was deleting since it ported the functionality into the Makefile).  Consequently I overlooked adding the corresponding "cp -r tools" to the Makefile implementation.

I verified that prior to this change "make istio-archive" failed, and with this change the tars are created (I also looked into the Linux tar to confirm it has the tools/ directory tree).