### PR TITLE
Ensure command line flags are passed through

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -58,10 +58,6 @@ ISTIO_GO=$(cd $(dirname $0)/..; pwd)
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${GIT_SHA}"
 
-if [[ -z "${E2E_ARGS:-}" ]]; then
-  E2E_ARGS="$@"
-else
-  E2E_ARGS+=("$@")
-fi
+E2E_ARGS+=" $@"
 echo 'Running Integration Tests'
 time ISTIO_DOCKER_HUB=$HUB E2E_ARGS="$E2E_ARGS" make e2e_all


### PR DESCRIPTION
After https://github.com/istio/istio/pull/2960 went in, I tried to enable VM test but the flag --test_vm still was not passed in based on the Prow log on smoke test https://github.com/istio/istio/pull/2444. It turns out --auth_enable flag was not passed in either.