### PR TITLE
TAG should come from checked out version HEAD.

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -18,7 +18,7 @@
 # Script entry into Istio smoketest run with a k8s cluster with Istio installed.
 # This is intended as a smoketest for external callers that require a simple
 # script entry point. $WORKSPACE is the root dir into which the Istio repo is
-# expected to be cloned.
+# expected to be cloned at the desired version.
 #
 # Usage: e2e_istio_preinstalled.sh all|bookinfo|mixer|simple
 
@@ -33,8 +33,8 @@ declare -a tests
 
 HUB=gcr.io/istio-testing
 
-cd ${WORKSPACE}/github.com/istio
-git reset --hard ${TAG}
+cd ${WORKSPACE}/github.com/istio/istio
+TAG=`git rev-parse HEAD`
 
 for t in ${tests[@]}; do
   go test -v -timeout 20m ./tests/e2e/tests/${t} -args \


### PR DESCRIPTION
Changing this from being passed in from test environment to being implicitly the version set by the environment for the repo. This is because we always want the script version to be the same as the go test code version it is calling.