### PR TITLE
Webhook setup script now waits for csr signature

### DIFF
--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -108,7 +108,20 @@ done
 
 # approve and fetch the signed certificate
 kubectl certificate approve ${csrName}
-kubectl get csr ${csrName} -o jsonpath='{.status.certificate}' | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ $serverCert != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ $serverCert == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    echo "See https://istio.io/docs/setup/kubernetes/sidecar-injection.html for more details on troubleshooting." >&2
+    exit 1
+fi
+echo $serverCert | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
 
 
 # create the secret with CA cert and server cert/key

--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -111,17 +111,17 @@ kubectl certificate approve ${csrName}
 # verify certificate has been signed
 for x in $(seq 10); do
     serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
-    if [[ $serverCert != '' ]]; then
+    if [[ ${serverCert} != '' ]]; then
         break
     fi
     sleep 1
 done
-if [[ $serverCert == '' ]]; then
+if [[ ${serverCert} == '' ]]; then
     echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
     echo "See https://istio.io/docs/setup/kubernetes/sidecar-injection.html for more details on troubleshooting." >&2
     exit 1
 fi
-echo $serverCert | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
 
 
 # create the secret with CA cert and server cert/key


### PR DESCRIPTION
There's a race condition where the csr resource, upon approval, doesn't
get updated with a signed certificate immediately. This change adds
polling to block until the certificate is ready (or fails with an error
message).

/cc @ayj 