### PR TITLE
Restore ingress mixer integration

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -148,7 +148,22 @@ func buildListeners(env model.Environment, node model.Node) (Listeners, error) {
 			services, env.ManagementPorts(node.IPAddress), node, env.IstioConfigStore)
 		return listeners, nil
 	case model.Ingress:
-		return buildIngressListeners(env.Mesh, nil, env.ServiceDiscovery, env.IstioConfigStore, node), nil
+		services, err := env.Services()
+		if err != nil {
+			return nil, err
+		}
+		var svc *model.Service
+		for _, s := range services {
+			if strings.HasPrefix(s.Hostname, "istio-ingress") {
+				svc = s
+				break
+			}
+		}
+		insts := make([]*model.ServiceInstance, 0, 1)
+		if svc != nil {
+			insts = append(insts, &model.ServiceInstance{Service: svc})
+		}
+		return buildIngressListeners(env.Mesh, insts, env.ServiceDiscovery, env.IstioConfigStore, node), nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
This PR restores Mixer functionality for Istio Ingress. There are two components to this PR:

1) Add the instance for istio-ingress in the envoy config generation for ingress. This is required to generate the appropriate mixer v2 config stanza for istio-proxy (needed to enable mixerclient).

2) Fix the istio component service name calculation. This PR isn't attempting to address the larger issue with service name derivation in Mixer, but rather to fix/improve the existing system for istio components themselves. A proper derivation PR is needed, but that is beyond the scope for the issue of restoring ingress-mixer functionality.

Reviewers: I'm not familiar with the pilot sections of the codebase. Please advise if there are better ways to accomplish the same functionality.

This PR was tested by making new mixer and pilot images and testing telemetry generation for istio ingress in a gke cluster.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>