### PR TITLE
update makefile format doc

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -263,7 +263,7 @@ You can automatically format the source code to follow our conventions by going 
 top of the repo and entering:
 
 ```shell
-make fmt
+make format
 ```
 
 ### Running the linters


### PR DESCRIPTION
after https://github.com/istio/istio/commit/e841588047a32ee60a84139eb94ee5a3044e083d
```
make fmt 
```

has been deleted,It can not be used, I  updated doc, to make new user use 

```
make format
```