### PR TITLE
fix comments in mysql script to fit both MySQL client and MySQL shell

### DIFF
--- a/samples/bookinfo/src/mysql/mysqldb-init.sql
+++ b/samples/bookinfo/src/mysql/mysqldb-init.sql
@@ -1,7 +1,6 @@
-/*
- * Initialize a mysql db with a 'test' db and be able test productpage with it.
- * mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
- */
+# Initialize a mysql db with a 'test' db and be able test productpage with it.
+# mysql -h 127.0.0.1 -ppassword < mysqldb-init.sql
+
 CREATE DATABASE test;
 USE test;
 


### PR DESCRIPTION
both of them accept # as a comment, while only MySQL client accepts c-style comments