### PR TITLE
Run bin/fmt.sh on the source base.

### DIFF
--- a/broker/cmd/brks/cmd/root.go
+++ b/broker/cmd/brks/cmd/root.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/broker/cmd/shared"
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/version"

--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -8,6 +8,9 @@
     "lineLength": 160,
     "tests": true,
     "sort": ["path"],
+    "Linters": {
+        "goimports": {"Command": "goimports -l --local istio.io"}
+    },
     "enable": [
         "deadcode",
         "errcheck",

--- a/mixer/adapter/prometheus/prometheus.go
+++ b/mixer/adapter/prometheus/prometheus.go
@@ -27,11 +27,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/gogo/protobuf/proto"
 	"istio.io/istio/mixer/adapter/prometheus/config"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/template/metric"

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/tracing"

--- a/mixer/cmd/mixs/cmd/probe.go
+++ b/mixer/cmd/mixs/cmd/probe.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/probe"

--- a/mixer/cmd/mixs/cmd/root.go
+++ b/mixer/cmd/mixs/cmd/root.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/template"

--- a/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
@@ -22,10 +22,8 @@ import (
 	"time"
 
 	tpb "istio.io/api/mixer/v1/template"
-	"istio.io/istio/mixer/pkg/adapter"
-	"istio.io/istio/pkg/log"
-
 	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
+	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/il/compiled"
 	"istio.io/istio/mixer/pkg/pool"
@@ -34,6 +32,7 @@ import (
 	"istio.io/istio/mixer/pkg/runtime2/routing"
 	"istio.io/istio/mixer/pkg/runtime2/testing/data"
 	"istio.io/istio/mixer/pkg/runtime2/testing/util"
+	"istio.io/istio/pkg/log"
 )
 
 var gp = pool.NewGoroutinePool(10, true)

--- a/mixer/pkg/runtime2/dispatcher/dispatchstate_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatchstate_test.go
@@ -21,7 +21,6 @@ import (
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
-
 	"istio.io/istio/mixer/pkg/runtime2/routing"
 )
 

--- a/mixer/pkg/runtime2/handler/table_test.go
+++ b/mixer/pkg/runtime2/handler/table_test.go
@@ -15,15 +15,13 @@
 package handler
 
 import (
+	"fmt"
 	"strings"
 	"testing"
-
-	"fmt"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-
-	"time"
 
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime2/config"

--- a/mixer/pkg/runtime2/testing/data/adapters.go
+++ b/mixer/pkg/runtime2/testing/data/adapters.go
@@ -17,10 +17,9 @@ package data
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gogo/protobuf/types"
-
-	"time"
 
 	"istio.io/istio/mixer/pkg/adapter"
 )

--- a/mixer/test/client/env/mixer_server.go
+++ b/mixer/test/client/env/mixer_server.go
@@ -22,9 +22,8 @@ import (
 
 	"google.golang.org/grpc"
 
-	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
-
 	mixerpb "istio.io/api/mixer/v1"
+	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/mockapi"
 )

--- a/pilot/cmd/istioctl/inject.go
+++ b/pilot/cmd/istioctl/inject.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd"
@@ -31,8 +32,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const configMapKey = "mesh"

--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -40,6 +40,8 @@ import (
 	"path"
 
 	"github.com/spf13/cobra/doc"
+	"k8s.io/client-go/util/homedir"
+
 	"istio.io/istio/pilot/cmd"
 	"istio.io/istio/pilot/cmd/istioctl/gendeployment"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
@@ -48,7 +50,6 @@ import (
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
-	"k8s.io/client-go/util/homedir"
 )
 
 const (

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"os"
 	"time"
-
 	// TODO(nmittler): Remove this
 	_ "github.com/golang/glog"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/pilot/cmd"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pkg/collateral"

--- a/pilot/cmd/sidecar-injector/main.go
+++ b/pilot/cmd/sidecar-injector/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/pilot/cmd"
 	"istio.io/istio/pilot/pkg/kube/inject"
 	"istio.io/istio/pkg/collateral"

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -28,11 +28,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
-
-	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pilot/cmd"
-	"istio.io/istio/pkg/log"
-
 	"k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/core/v1"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/cmd"
+	"istio.io/istio/pkg/log"
 )
 
 var (

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -17,11 +17,9 @@ package collateral
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"os"
 	"sort"
-
-	"html"
-
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/spf13/cobra/doc"
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/probe"

--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
 	"github.com/spf13/cobra/doc"
+
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"testing"
 	"time"
-
 	// TODO(nmittler): Remove this
 	_ "github.com/golang/glog"
+
 	"istio.io/istio/pkg/log"
 	mockclient "istio.io/istio/security/pkg/caclient/grpc/mock"
 	"istio.io/istio/security/pkg/platform"

--- a/security/cmd/node_agent_k8s/flexvolume/main.go
+++ b/security/cmd/node_agent_k8s/flexvolume/main.go
@@ -20,6 +20,7 @@ import (
 	"log/syslog"
 
 	"github.com/spf13/cobra"
+
 	"istio.io/istio/security/cmd/node_agent_k8s/flexvolume/driver"
 )
 

--- a/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient.go
+++ b/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	pb "istio.io/istio/security/proto"
 )
 

--- a/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentserver.go
+++ b/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentserver.go
@@ -20,6 +20,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	rpc "istio.io/gogo-genproto/googleapis/google/rpc"
 	"istio.io/istio/pkg/log"
 	mwi "istio.io/istio/security/cmd/node_agent_k8s/mgmtwlhintf"

--- a/security/cmd/node_agent_k8s/workloadhandler/auth.go
+++ b/security/cmd/node_agent_k8s/workloadhandler/auth.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	"golang.org/x/net/context"
-
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 )

--- a/security/pkg/platform/aws.go
+++ b/security/pkg/platform/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fullsailor/pkcs7"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
 	"istio.io/istio/security/pkg/pki/util"
 )
 

--- a/security/pkg/server/grpc/server.go
+++ b/security/pkg/server/grpc/server.go
@@ -25,8 +25,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-
 	"google.golang.org/grpc/status"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/ca"
 	"istio.io/istio/security/pkg/pki/util"

--- a/security/pkg/server/grpc/server_test.go
+++ b/security/pkg/server/grpc/server_test.go
@@ -24,8 +24,8 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
-
 	"google.golang.org/grpc/status"
+
 	"istio.io/istio/security/pkg/pki/ca"
 	pb "istio.io/istio/security/proto"
 )


### PR DESCRIPTION
- bin/fmt.sh has been running goimports with the -local istio.io option,
but gometalinter wasn't using that option, leading to inconsistent
verification.