### PR TITLE
A few enhancements to istio-proxy-cfg.py

### DIFF
--- a/bin/istio-proxy-cfg.py
+++ b/bin/istio-proxy-cfg.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 
 import os
-import requests
-import json
-import subprocess
-import collections
-import argparse
-import yaml
 import sys
+
+import argparse
+import collections
+import json
+import random
+import requests
+import subprocess
+import yaml
 import time
 
 POD = collections.namedtuple('Pod', ['name', 'namespace', 'ip', 'labels'])
@@ -21,6 +23,9 @@ POD = collections.namedtuple('Pod', ['name', 'namespace', 'ip', 'labels'])
 PILOT_SVC = "istio-pilot"
 ISTIO_NS = "istio-system"
 CLUSTER = "istio-proxy"
+ENVOY_PORT = 15000
+LOCAL_PORT_START = 50000
+LOCAL_PORT_STOP = 60000
 
 class XDS(object):
 
@@ -136,38 +141,22 @@ class XDS(object):
 
 class Proxy(object):
 
-    def __init__(self, pod):
-        self.pod = pod
+    def __init__(self, envoy_url):
+        self.envoy_url = envoy_url
 
     def query(self, path, use_json=True):
-        if not path.startswith("/"):
-            path = "/" + path
-
-        cname = "istio-proxy"
-        if "ingress" in self.pod.name:
-            cname = "istio-ingress"
-
-        cmd = "kubectl -n {pod.namespace} exec -i -t {pod.name} -c {cname} -- curl http://localhost:15000{path}".format(
-            pod=self.pod,
-            path=path,
-            cname=cname
-        )
-        print cmd
-        # The result is returned as a list of json objects.
-        # { "a": "b"
-        # }
-        # { "c": "d"
-        # }
-        # Note the lack of "," between objects
-        # Convert it into an array of objects
-        s = subprocess.check_output(cmd.split())
-
+        url = self.envoy_url + path
+        print url
+        try:
+            s = requests.post(url)
+        except Exception as ex:
+            print ex
+            print "Is envoy accessible at %s?" % url
+            sys.exit(-1)
         if use_json:
-            s = s.replace('}\r\n{', '},\r\n{')
-            s = s.replace('}\n{', '},\n{')
-            return json.loads("[" + s + "]")
+            return s.json()
         else:
-            return s
+            return s.text
 
     def routes(self):
         return self.query("/routes")
@@ -219,6 +208,28 @@ def searchpod(pi, searchstr):
     return pods
 
 
+def start_port_forward(pod_name, namespace, remote_port):
+    local_port = random.randrange(LOCAL_PORT_START, LOCAL_PORT_STOP)
+    port_forward_pid = ""
+    url = ""
+    try:
+        port_forward_pid = subprocess.Popen("kubectl --namespace={namespace} port-forward {pod_name} {local_port}:{remote_port}".format(pod_name=pod_name, namespace=namespace, local_port=local_port, remote_port=remote_port).split()).pid
+    except:
+        print("Failed to create port-forward for pod %s.%s with remote port %s" % (pod_name, namespace, remote_port))
+        raise
+    else:
+        url = "http://localhost:{port}".format(port=local_port)
+        # wait until the port-forward process is fully up
+        while True:
+            try:
+                requests.get(url)
+            except:
+                time.sleep(.1)
+            else:
+                break
+    return url, port_forward_pid
+
+
 def find_pilot_url():
     try:
         pilot_svc = subprocess.check_output(
@@ -244,37 +255,13 @@ def find_pilot_url():
         pilot_url = "http://{ip}:{port}".format(ip=pilot_spec['clusterIP'], port=pilot_port)
 
         try:
-            subprocess.check_output("curl -s --connect-timeout 2 {url}".format(url=pilot_url).split())
+            requests.get(pilot_url, timeout=2)
         except:
             print "It seems that you are running outside the k8s cluster"
             print "Let's try to create a port-forward to access pilot"
-            while True:
-                local_port = raw_input("Enter local port number (default %s, ctrl-C to abort): " % pilot_port)
-                if local_port == "":
-                    local_port = "%s" % pilot_port
-                try:
-                    local_port = int(local_port)
-                except:
-                    pass
-                else:
-                    break
-            print "local port is %s" % local_port
-            try:
-                pod_name = subprocess.check_output("kubectl --namespace=istio-system get -l istio=pilot pod -o=jsonpath={.items[0].metadata.name}".split())
-                port_forward_pid = subprocess.Popen("kubectl --namespace=istio-system port-forward {pod_name} {local_port}:{remote_port}".format(pod_name=pod_name, local_port=local_port, remote_port=pilot_port).split()).pid
-            except:
-                print("Failed to create port-forward. Please use the option --pilot_url")
-                raise
-            else:
-                pilot_url = "http://localhost:{port}".format(port=local_port)
-                # wait until the port-forward process is fully up
-                while True:
-                    try:
-                        subprocess.check_output("curl -s --connect-timeout 2 {url}".format(url=pilot_url).split())
-                    except:
-			time.sleep(.1)
-                    else:
-                        break
+            cmd = "kubectl --namespace=%s get -l istio=pilot pod -o=jsonpath={.items[0].metadata.name}" % (ISTIO_NS)
+            pod_name = subprocess.check_output(cmd.split())
+            pilot_url, port_forward_pid = start_port_forward(pod_name, ISTIO_NS, pilot_port)
 
     return pilot_url, port_forward_pid
 
@@ -292,10 +279,6 @@ def main(args):
         return -1
 
     pod = pods[0]
-    pilot_url = args.pilot_url
-    port_forward_pid = ""
-    if not pilot_url:
-        pilot_url, port_forward_pid = find_pilot_url()
 
     if args.output is None:
         output_dir = "./" + pod.name
@@ -308,51 +291,63 @@ def main(args):
         if not os.path.isdir(output_dir):
             raise
 
-    output_file = output_dir + "/" + "pilot_xds.json"
-    op = open(output_file, "wt")
-    print "Fetching from Pilot for pod %s in %s namespace" % (pod.name, pod.namespace)
-    xds = XDS(url=pilot_url)
-    data = xds.lds(pod, True)
-    yaml.safe_dump(data, op, default_flow_style=False,
-                   allow_unicode=False, indent=2)
-    print "Wrote ", output_file
+    if not args.skip_pilot:
+        pilot_url = args.pilot_url
+        pilot_port_forward_pid = ""
+        if not pilot_url:
+            pilot_url, pilot_port_forward_pid = find_pilot_url()
 
-    print("Fetching from Envoy for pod %s in %s namespace" % (pod.name, pod.namespace))
-    pr = Proxy(pod)
-    output_file = output_dir + "/" + "proxy_routes.json"
-    op = open(output_file, "wt")
-    data = pr.routes()
-    yaml.safe_dump(data, op, default_flow_style=False,
-                   allow_unicode=False, indent=2)
-    print "Wrote ", output_file
-
-    output_file = output_dir + "/" + "proxy_listeners.json"
-    op = open(output_file, "wt")
-    data = pr.listeners()
-    yaml.safe_dump(data, op, default_flow_style=False,
-                   allow_unicode=False, indent=2)
-    print "Wrote ", output_file
-
-    output_file = output_dir + "/" + "proxy_clusters.json"
-    op = open(output_file, "wt")
-    data = pr.clusters()
-    op.write(data)
-    print "Wrote ", output_file
-
-    if args.cache_stats:
-        output_file = output_dir + "/" + "stats_xds.json"
+        output_file = output_dir + "/" + "pilot_xds.json"
         op = open(output_file, "wt")
-        data = xds.cache_stats()
-        print("Fetching Pilot cache stats")
+        print "Fetching from Pilot for pod %s in %s namespace" % (pod.name, pod.namespace)
+        xds = XDS(url=pilot_url)
+        data = xds.lds(pod, True)
         yaml.safe_dump(data, op, default_flow_style=False,
                        allow_unicode=False, indent=2)
         print "Wrote ", output_file
 
-    if args.clear_cache_stats:
-        xds.clear_cache_stats()
+        if args.cache_stats:
+            output_file = output_dir + "/" + "stats_xds.json"
+            op = open(output_file, "wt")
+            data = xds.cache_stats()
+            print("Fetching Pilot cache stats")
+            yaml.safe_dump(data, op, default_flow_style=False,
+                           allow_unicode=False, indent=2)
+            print "Wrote ", output_file
 
-    if port_forward_pid:
-        subprocess.call(["kill", "%s" % port_forward_pid])
+        if args.clear_cache_stats:
+            xds.clear_cache_stats()
+
+        if pilot_port_forward_pid:
+            subprocess.call(["kill", "%s" % pilot_port_forward_pid])
+
+
+    if not args.skip_envoy:
+        envoy_url, envoy_port_forward_pid = start_port_forward(pod.name, pod.namespace, ENVOY_PORT)
+        print("Fetching from Envoy for pod %s in %s namespace" % (pod.name, pod.namespace))
+        pr = Proxy(envoy_url)
+        output_file = output_dir + "/" + "proxy_routes.json"
+        op = open(output_file, "wt")
+        data = pr.routes()
+        yaml.safe_dump(data, op, default_flow_style=False,
+                       allow_unicode=False, indent=2)
+        print "Wrote ", output_file
+
+        output_file = output_dir + "/" + "proxy_listeners.json"
+        op = open(output_file, "wt")
+        data = pr.listeners()
+        yaml.safe_dump(data, op, default_flow_style=False,
+                       allow_unicode=False, indent=2)
+        print "Wrote ", output_file
+
+        output_file = output_dir + "/" + "proxy_clusters.json"
+        op = open(output_file, "wt")
+        data = pr.clusters()
+        op.write(data)
+        print "Wrote ", output_file
+
+        if envoy_port_forward_pid:
+            subprocess.call(["kill", "%s" % envoy_port_forward_pid])
 
     return 0
 
@@ -368,6 +363,10 @@ if __name__ == "__main__":
     parser.add_argument("podname", help="podname must be either name.namespace.podip or name.namespace or any string that is a pod's label or a prefix of a pod's name. ingress, mixer, istio-ca, product-page all work")
     parser.add_argument(
         "--output", help="A directory where output files are saved. default is the current directory")
+    parser.add_argument(
+        "--skip_envoy", action='store_true', help="Fetch Envoy configuration from a pod")
+    parser.add_argument(
+        "--skip_pilot", action='store_true', help="Fetch from pilot Proxy configuration for a pod")
     parser.add_argument(
         "--cache_stats", action='store_true', help="Fetch Pilot cache stats")
     parser.add_argument(


### PR DESCRIPTION
Made a few enhancements:

- pilot_url doesn't have to be provided, but can be found out from the cluster
- cache_stats can be queried. This is useful to find out who are talking to pilot for xds
- podname can be a prefix of a pod's name
- clarify the help strings.

Although I think podname as name.namespace.ip or name.namespace is not necessary, I kept them in.