### PR TITLE
Make IsNetworkFilterConfig exported

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -103,6 +103,7 @@ type FilterMixerConfig struct {
 	V2 map[string]interface{} `json:"v2,omitempty"`
 }
 
+// IsNetworkFilterConfig marks FilterMixerConfig as an implementation of NetworkFilterConfig
 func (*FilterMixerConfig) IsNetworkFilterConfig() {}
 
 // buildMixerCluster builds an outbound mixer cluster

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -103,7 +103,7 @@ type FilterMixerConfig struct {
 	V2 map[string]interface{} `json:"v2,omitempty"`
 }
 
-func (*FilterMixerConfig) isNetworkFilterConfig() {}
+func (*FilterMixerConfig) IsNetworkFilterConfig() {}
 
 // buildMixerCluster builds an outbound mixer cluster
 func buildMixerCluster(mesh *meshconfig.MeshConfig, role model.Node, mixerSAN []string) *Cluster {

--- a/pilot/pkg/proxy/envoy/v1/resources.go
+++ b/pilot/pkg/proxy/envoy/v1/resources.go
@@ -505,6 +505,7 @@ type HTTPFilterConfig struct {
 	AccessLog         []AccessLog            `json:"access_log"`
 }
 
+// IsNetworkFilterConfig marks HTTPFilterConfig as an implementation of NetworkFilterConfig
 func (*HTTPFilterConfig) IsNetworkFilterConfig() {}
 
 // HTTPFilterTraceConfig definition
@@ -575,6 +576,7 @@ type TCPProxyFilterConfig struct {
 	RouteConfig *TCPRouteConfig `json:"route_config"`
 }
 
+// IsNetworkFilterConfig marks TCPProxyFilterConfig as an implementation of NetworkFilterConfig
 func (*TCPProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // TCPRouteConfig (or generalize as RouteConfig or L4RouteConfig for TCP/UDP?)
@@ -587,12 +589,14 @@ type MongoProxyFilterConfig struct {
 	StatPrefix string `json:"stat_prefix"`
 }
 
+// IsNetworkFilterConfig marks MongoProxyFilterConfig as an implementation of NetworkFilterConfig
 func (*MongoProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // CORSFilterConfig definition
 // See: https://www.envoyproxy.io/envoy/configuration/http_filters/cors_filter.html#config-http-filters-cors
 type CORSFilterConfig struct{}
 
+// IsNetworkFilterConfig marks CORSFilterConfig as an implementation of NetworkFilterConfig
 func (*CORSFilterConfig) IsNetworkFilterConfig() {}
 
 // RedisConnPool definition
@@ -607,6 +611,7 @@ type RedisProxyFilterConfig struct {
 	StatPrefix  string         `json:"stat_prefix"`
 }
 
+// IsNetworkFilterConfig marks RedisProxyFilterConfig as an implementation of NetworkFilterConfig
 func (*RedisProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // NetworkFilter definition

--- a/pilot/pkg/proxy/envoy/v1/resources.go
+++ b/pilot/pkg/proxy/envoy/v1/resources.go
@@ -505,7 +505,7 @@ type HTTPFilterConfig struct {
 	AccessLog         []AccessLog            `json:"access_log"`
 }
 
-func (*HTTPFilterConfig) isNetworkFilterConfig() {}
+func (*HTTPFilterConfig) IsNetworkFilterConfig() {}
 
 // HTTPFilterTraceConfig definition
 type HTTPFilterTraceConfig struct {
@@ -575,7 +575,7 @@ type TCPProxyFilterConfig struct {
 	RouteConfig *TCPRouteConfig `json:"route_config"`
 }
 
-func (*TCPProxyFilterConfig) isNetworkFilterConfig() {}
+func (*TCPProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // TCPRouteConfig (or generalize as RouteConfig or L4RouteConfig for TCP/UDP?)
 type TCPRouteConfig struct {
@@ -587,13 +587,13 @@ type MongoProxyFilterConfig struct {
 	StatPrefix string `json:"stat_prefix"`
 }
 
-func (*MongoProxyFilterConfig) isNetworkFilterConfig() {}
+func (*MongoProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // CORSFilterConfig definition
 // See: https://www.envoyproxy.io/envoy/configuration/http_filters/cors_filter.html#config-http-filters-cors
 type CORSFilterConfig struct{}
 
-func (*CORSFilterConfig) isNetworkFilterConfig() {}
+func (*CORSFilterConfig) IsNetworkFilterConfig() {}
 
 // RedisConnPool definition
 type RedisConnPool struct {
@@ -607,7 +607,7 @@ type RedisProxyFilterConfig struct {
 	StatPrefix  string         `json:"stat_prefix"`
 }
 
-func (*RedisProxyFilterConfig) isNetworkFilterConfig() {}
+func (*RedisProxyFilterConfig) IsNetworkFilterConfig() {}
 
 // NetworkFilter definition
 type NetworkFilter struct {
@@ -618,7 +618,7 @@ type NetworkFilter struct {
 
 // NetworkFilterConfig is a marker interface
 type NetworkFilterConfig interface {
-	isNetworkFilterConfig()
+	IsNetworkFilterConfig()
 }
 
 // Listener definition


### PR DESCRIPTION
Before this change, it is hard to import the v1 API structures and define
a new custom NetworkFilterConfig in an external module.  A NetworkFilterConfig
needs to implement isNetworkFilterConfig, but that method is private to the v1
module.  This change makes it exported.

This is useful for people who want to write Pilot webhooks that mutate
the xDS data---the relevant data structures are already defined.

Signed-off-by: Spike Curtis <spike@tigera.io>