### PR TITLE
Supporting AllUsers subject in Istio RBAC.

### DIFF
--- a/mixer/adapter/rbac/rbacStore.go
+++ b/mixer/adapter/rbac/rbacStore.go
@@ -126,13 +126,28 @@ func (rs *configStore) CheckPermission(inst *authorization.Instance, env adapter
 		for _, binding := range bindings {
 			subjects := binding.GetSubjects()
 			for _, subject := range subjects {
-				if subject.GetUser() != "" && subject.GetUser() != user {
-					continue
+				foundMatch := false
+				if subject.GetUser() != "" {
+					if subject.GetUser() == "*" || subject.GetUser() == user {
+						foundMatch = true
+					} else {
+						// Found a mismatch, try next subject.
+						continue
+					}
 				}
-				if subject.GetGroup() != "" && subject.GetGroup() != groups {
-					continue
+				if subject.GetGroup() != "" {
+					if subject.GetGroup() == "*" || subject.GetGroup() == groups {
+						foundMatch = true
+					} else {
+						// Found a mismatch, try next subject.
+						continue
+					}
 				}
-				if checkSubject(instSub, subject.GetProperties()) {
+				subProp := subject.GetProperties()
+				if len(subProp) != 0 && checkSubject(instSub, subProp) {
+					foundMatch = true
+				}
+				if foundMatch {
 					return true, nil
 				}
 			}

--- a/mixer/adapter/rbac/rbacStore_test.go
+++ b/mixer/adapter/rbac/rbacStore_test.go
@@ -150,6 +150,31 @@ func setupRBACStore() *configStore {
 
 	rn["role4"] = newRoleInfo(role4Spec)
 	rn["role4"].setBinding("binding4", binding4Spec)
+
+	role5Spec := &rbacproto.ServiceRole{
+		Rules: []*rbacproto.AccessRule{
+			{
+				Services:    []string{"abc"},
+				Methods:     []string{"GET"},
+			},
+		},
+	}
+
+	binding5Spec := &rbacproto.ServiceRoleBinding{
+		Subjects: []*rbacproto.Subject{
+			{
+				User: "*",
+			},
+		},
+		RoleRef: &rbacproto.RoleRef{
+			Kind: "ServiceRole",
+			Name: "role5",
+		},
+	}
+
+	rn["role5"] = newRoleInfo(role5Spec)
+	rn["role5"].setBinding("binding5", binding5Spec)
+
 	return s
 }
 
@@ -177,6 +202,7 @@ func TestRBACStore_CheckPermission(t *testing.T) {
 		{"ns1", "fishpond", "/pond/a", "GET", "v1", "abcfish", "serv", "svc@gserviceaccount.com", true},
 		{"ns1", "fishpond", "/pond/review", "GET", "v1", "mynamespace", "xyz", "alice@yahoo.com", true},
 		{"ns1", "fishpond", "/pond/review", "GET", "v1", "mynamespace", "xyz", "bob@yahoo.com", false},
+		{"ns1", "abc", "/index", "GET", "", "mynamespace", "xyz", "anyuser", true},
 	}
 
 	for _, c := range cases {

--- a/mixer/adapter/rbac/rbacStore_test.go
+++ b/mixer/adapter/rbac/rbacStore_test.go
@@ -154,8 +154,8 @@ func setupRBACStore() *configStore {
 	role5Spec := &rbacproto.ServiceRole{
 		Rules: []*rbacproto.AccessRule{
 			{
-				Services:    []string{"abc"},
-				Methods:     []string{"GET"},
+				Services: []string{"abc"},
+				Methods:  []string{"GET"},
 			},
 		},
 	}


### PR DESCRIPTION
In some cases, we need to have RBAC policy that allows AllUsers to
access an API. This change implements it. If subject in
ServiceRoleBinding is set to
  user: "*", or
  group: "*",
it means all users are allowed.