### PR TITLE
don't print unnecessary log message

### DIFF
--- a/pkg/probe/controller.go
+++ b/pkg/probe/controller.go
@@ -168,7 +168,7 @@ func (fc *fileController) onUpdate(newStatus error) {
 		}
 		_ = f.Close()
 	} else {
-		if err := os.Remove(fc.path); err != nil {
+		if err := os.Remove(fc.path); err != nil && !os.IsNotExist(err) {
 			log.Errorf("Failed to remove the path %s: %v", fc.path, err)
 		}
 	}


### PR DESCRIPTION
When a probe keeps unavailable for a while, the target file
is already removed, and os.Remove returns a not-exist error.
We don't want to flood the log with not-exist errors.