### PR TITLE
Fix the bookinfo sample installation with Ansible

### DIFF
--- a/install/ansible/istio/tasks/bookinfo_cmd.j2
+++ b/install/ansible/istio/tasks/bookinfo_cmd.j2
@@ -2,4 +2,4 @@
 {{ cmd_path }} adm policy add-scc-to-user privileged -z default -n {{ sample_namespace }}
 {% endif %}
 {{ cmd_path }} apply -n {{ sample_namespace }} -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/kube/bookinfo.yaml)
-{{ cmd_path }} expose svc productpage
+{{ cmd_path }} expose svc productpage -n {{ sample_namespace }}


### PR DESCRIPTION
We need to specify the the namespace when performing expose