### PR TITLE
Wire runtime2 to the command-line flags in Mixer and add perf tests

### DIFF
--- a/mixer/pkg/perf/config.go
+++ b/mixer/pkg/perf/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	EnableLog               bool   `json:"enableLog,omitempty"`
 	EnableDebugLog          bool   `json:"enableDebugLog,omitempty"`
 	SingleThreaded          bool   `json:"singleThreaded,omitempty"`
+	UseRuntime2             bool   `json:"useRuntime2,omitempty"`
 
 	// Templates is the name of the templates to use in this test. If left empty, a standard set of templates
 	// will be used.

--- a/mixer/pkg/perf/server.go
+++ b/mixer/pkg/perf/server.go
@@ -90,6 +90,7 @@ func initializeArgs(settings *Settings, setup *Setup) (*testEnv.Args, error) {
 	args.ConfigIdentityAttribute = setup.Config.IdentityAttribute
 	args.ConfigIdentityAttributeDomain = setup.Config.IdentityAttributeDomain
 	args.SingleThreaded = setup.Config.SingleThreaded
+	args.UseNewRuntime = setup.Config.UseRuntime2
 
 	if setup.Config.EnableDebugLog {
 		// Override enableLog. This should skip the next if conditional

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -71,6 +71,9 @@ type Args struct {
 	// For kubernetes services it is svc.cluster.local
 	ConfigIdentityAttributeDomain string
 
+	// Enables use of pkg/runtime2, instead of pkg/runtime.
+	UseNewRuntime bool
+
 	// The logging options to use
 	LoggingOptions *log.Options
 
@@ -110,6 +113,7 @@ func NewArgs() *Args {
 		ConfigDefaultNamespace:        mixerRuntime.DefaultConfigNamespace,
 		ConfigIdentityAttribute:       "destination.service",
 		ConfigIdentityAttributeDomain: "svc.cluster.local",
+		UseNewRuntime:                 false,
 		LoggingOptions:                log.NewOptions(),
 		TracingOptions:                tracing.NewOptions(),
 		LivenessProbeOptions:          &probe.Options{},
@@ -149,6 +153,7 @@ func (a *Args) String() string {
 	b.WriteString(fmt.Sprint("ConfigDefaultNamespace: ", a.ConfigDefaultNamespace, "\n"))
 	b.WriteString(fmt.Sprint("ConfigIdentityAttribute: ", a.ConfigIdentityAttribute, "\n"))
 	b.WriteString(fmt.Sprint("ConfigIdentityAttributeDomain: ", a.ConfigIdentityAttributeDomain, "\n"))
+	b.WriteString(fmt.Sprint("UseNewRuntime: ", a.UseNewRuntime, "\n"))
 	b.WriteString(fmt.Sprintf("LoggingOptions: %#v\n", *a.LoggingOptions))
 	b.WriteString(fmt.Sprintf("TracingOptions: %#v\n", *a.TracingOptions))
 	return b.String()

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -35,6 +35,7 @@ import (
 	"istio.io/istio/mixer/pkg/il/evaluator"
 	"istio.io/istio/mixer/pkg/pool"
 	mixerRuntime "istio.io/istio/mixer/pkg/runtime"
+	mixerRuntime2 "istio.io/istio/mixer/pkg/runtime2"
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/probe"
@@ -68,6 +69,9 @@ type patchTable struct {
 		gp *pool.GoroutinePool, handlerPool *pool.GoroutinePool,
 		identityAttribute string, defaultConfigNamespace string, s store.Store, adapterInfo map[string]*adapter.Info,
 		templateInfo map[string]template.Info) (mixerRuntime.Dispatcher, error)
+	newRuntime2 func(s store.Store, templates map[string]*template.Info, adapters map[string]*adapter.Info,
+		identityAttribute string, defaultConfigNamespace string, executorPool *pool.GoroutinePool,
+		handlerPool *pool.GoroutinePool, enableTracing bool) *mixerRuntime2.Runtime
 	configTracing func(serviceName string, options *tracing.Options) (io.Closer, error)
 	startMonitor  func(port uint16) (*monitor, error)
 	listen        func(network string, address string) (net.Listener, error)
@@ -83,6 +87,7 @@ func newPatchTable() *patchTable {
 		newILEvaluator: evaluator.NewILEvaluator,
 		newStore:       func(r2 *store.Registry, configURL string) (store.Store, error) { return r2.NewStore(configURL) },
 		newRuntime:     mixerRuntime.New,
+		newRuntime2:    mixerRuntime2.New,
 		configTracing:  tracing.Configure,
 		startMonitor:   startMonitor,
 		listen:         net.Listen,
@@ -170,10 +175,26 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	}
 
 	var dispatcher mixerRuntime.Dispatcher
-	if dispatcher, err = p.newRuntime(eval, evaluator.NewTypeChecker(), eval, s.gp, s.adapterGP,
-		a.ConfigIdentityAttribute, a.ConfigDefaultNamespace, st, adapterMap, a.Templates); err != nil {
-		_ = s.Close()
-		return nil, fmt.Errorf("unable to create runtime dispatcherForTesting: %v", err)
+	if a.UseNewRuntime {
+		templateMap := make(map[string]*template.Info, len(a.Templates))
+		for k, v := range a.Templates {
+			t := v // Make a local copy, otherwise we end up capturing the location of the last entry
+			templateMap[k] = &t
+		}
+
+		runtime := p.newRuntime2(st, templateMap, adapterMap, a.ConfigIdentityAttribute, a.ConfigDefaultNamespace,
+			s.gp, s.adapterGP, a.TracingOptions.TracingEnabled())
+		if err = runtime.StartListening(); err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("unable to create runtime2 dispatcherForTesting: %v", err)
+		}
+		dispatcher = runtime.Dispatcher()
+	} else {
+		if dispatcher, err = p.newRuntime(eval, evaluator.NewTypeChecker(), eval, s.gp, s.adapterGP,
+			a.ConfigIdentityAttribute, a.ConfigDefaultNamespace, st, adapterMap, a.Templates); err != nil {
+			_ = s.Close()
+			return nil, fmt.Errorf("unable to create runtime dispatcherForTesting: %v", err)
+		}
 	}
 	s.dispatcher = dispatcher
 

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -180,6 +180,7 @@ func TestErrors(t *testing.T) {
 	}
 
 	a = NewArgs()
+	a.UseNewRuntime = false
 	a.APIPort = 0
 	a.MonitoringPort = 0
 	a.TracingOptions.LogTraceSpans = true
@@ -195,6 +196,7 @@ func TestErrors(t *testing.T) {
 					return nil, errors.New("BAD")
 				}
 			case 1:
+				// TODO: Runtime2 does not return error on the new path. Once we switch over, we can remove this case.
 				pt.newRuntime = func(eval expr.Evaluator, typeChecker expr.TypeChecker, vocab mixerRuntime.VocabularyChangeListener, gp *pool.GoroutinePool,
 					handlerPool *pool.GoroutinePool,
 					identityAttribute string, defaultConfigNamespace string, s store.Store, adapterInfo map[string]*adapter.Info,

--- a/mixer/test/e2e/e2e_apa_test.go
+++ b/mixer/test/e2e/e2e_apa_test.go
@@ -100,7 +100,7 @@ metadata:
   name: rule2
   namespace: istio-system
 spec:
-  selector: match(target.name, "*")
+  match: match(target.name, "*")
   actions:
   - handler: fakeHandlerConfig.fakeHandler
     instances:
@@ -130,7 +130,7 @@ metadata:
   name: rule1
   namespace: istio-system
 spec:
-  selector: match(target.name, "*")
+  match: match(target.name, "*")
   actions:
   - handler: fakeHandlerConfig.fakeHandler
     instances:

--- a/mixer/test/perf/multimetric_test.go
+++ b/mixer/test/perf/multimetric_test.go
@@ -60,3 +60,13 @@ func Benchmark_Multi_Metric(b *testing.B) {
 
 	perf.Run(b, &setup, settings)
 }
+
+func Benchmark_Multi_Metric_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseMultiMetricSetup
+	setup.Config.UseRuntime2 = true
+
+	perf.Run(b, &setup, settings)
+}

--- a/mixer/test/perf/norule_test.go
+++ b/mixer/test/perf/norule_test.go
@@ -75,11 +75,31 @@ func Benchmark_NoRule_Report(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
+func Benchmark_NoRule_Report_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseNoRuleReportSetup
+	setup.Config.UseRuntime2 = true
+
+	perf.Run(b, &setup, settings)
+}
+
 func Benchmark_NoRule_Check(b *testing.B) {
 	settings := baseSettings
 	settings.RunMode = perf.InProcessBypassGrpc
 
 	setup := baseNoRuleCheckSetup
+
+	perf.Run(b, &setup, settings)
+}
+
+func Benchmark_NoRule_Check_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseNoRuleCheckSetup
+	setup.Config.UseRuntime2 = true
 
 	perf.Run(b, &setup, settings)
 }

--- a/mixer/test/perf/singlecheck_test.go
+++ b/mixer/test/perf/singlecheck_test.go
@@ -58,3 +58,13 @@ func Benchmark_Single_Check(b *testing.B) {
 
 	perf.Run(b, &setup, settings)
 }
+
+func Benchmark_Single_Check_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseSingleCheckSetup
+	setup.Config.UseRuntime2 = true
+
+	perf.Run(b, &setup, settings)
+}

--- a/mixer/test/perf/singlemetric_test.go
+++ b/mixer/test/perf/singlemetric_test.go
@@ -57,6 +57,15 @@ func Benchmark_Single_Metric(b *testing.B) {
 	settings.RunMode = perf.InProcessBypassGrpc
 
 	setup := baseSingleMetricSetup
+	perf.Run(b, &setup, settings)
+}
+
+func Benchmark_Single_Metric_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseSingleMetricSetup
+	setup.Config.UseRuntime2 = true
 
 	perf.Run(b, &setup, settings)
 }

--- a/mixer/test/perf/singlereport_test.go
+++ b/mixer/test/perf/singlereport_test.go
@@ -55,6 +55,15 @@ func Benchmark_Single_Report(b *testing.B) {
 	settings.RunMode = perf.InProcessBypassGrpc
 
 	setup := baseSingleReportSetup
+	perf.Run(b, &setup, settings)
+}
+
+func Benchmark_Single_Report_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseSingleReportSetup
+	setup.Config.UseRuntime2 = true
 
 	perf.Run(b, &setup, settings)
 }
@@ -64,6 +73,17 @@ func Benchmark_Single_Report_SuccessCondition(b *testing.B) {
 	settings.RunMode = perf.InProcessBypassGrpc
 
 	setup := baseSingleReportSetup
+	setup.Config.Global = joinConfigs(h1Noop, i1ReportNothing, r3UsingH1AndI1Conditional)
+
+	perf.Run(b, &setup, settings)
+}
+
+func Benchmark_Single_Report_SuccessCondition_R2(b *testing.B) {
+	settings := baseSettings
+	settings.RunMode = perf.InProcessBypassGrpc
+
+	setup := baseSingleReportSetup
+	setup.Config.UseRuntime2 = true
 	setup.Config.Global = joinConfigs(h1Noop, i1ReportNothing, r3UsingH1AndI1Conditional)
 
 	perf.Run(b, &setup, settings)


### PR DESCRIPTION
+ Adds command-line flag to opt-in to runtime2
+ Implements perf tests targeting the runtime2 Dispatcher interface.