### PR TITLE
Update discovery cache to listen to changes to all configs

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -337,20 +337,12 @@ func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCach
 	}
 
 	if configCache != nil {
+		// TODO: changes should not trigger a full recompute of LDS/RDS/CDS/EDS
+		// (especially mixerclient HTTP and quota)
 		configHandler := func(model.Config, model.Event) { out.clearCache() }
-		configCache.RegisterEventHandler(model.RouteRule.Type, configHandler)
-		configCache.RegisterEventHandler(model.IngressRule.Type, configHandler)
-		configCache.RegisterEventHandler(model.EgressRule.Type, configHandler)
-		configCache.RegisterEventHandler(model.DestinationPolicy.Type, configHandler)
-
-		// TODO: Changes to mixerclient HTTP and Quota should not
-		// trigger recompute of full LDS/RDS/CDS/EDS
-		configCache.RegisterEventHandler(model.HTTPAPISpec.Type, configHandler)
-		configCache.RegisterEventHandler(model.HTTPAPISpecBinding.Type, configHandler)
-		configCache.RegisterEventHandler(model.QuotaSpec.Type, configHandler)
-		configCache.RegisterEventHandler(model.QuotaSpecBinding.Type, configHandler)
-		configCache.RegisterEventHandler(model.EndUserAuthenticationPolicySpec.Type, configHandler)
-		configCache.RegisterEventHandler(model.EndUserAuthenticationPolicySpecBinding.Type, configHandler)
+		for _, descriptor := range model.IstioConfigTypes {
+			configCache.RegisterEventHandler(descriptor.Type, configHandler)
+		}
 	}
 
 	return out, nil


### PR DESCRIPTION
The discovery cache was ignoring updates to v1alpha2 configs. This effectively broke v1alpha2 rules.