### PR TITLE
Removes setup_vm_firewall from run_tests in perf script

### DIFF
--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -248,7 +248,6 @@ function get_ips() {
 
 function run_tests() {
   update_gcp_opts
-  setup_vm_firewall
   get_ips
   run_fortio_test1
   run_fortio_test2


### PR DESCRIPTION
`setup_vm_firewall` gets called by create vm/cluster functions. It is unnecessarily called in the `run_tests` function.

Fixes Issue #3284 