### PR TITLE
Add istio-system namespace to zipkin-to-stackdriver yaml

### DIFF
--- a/install/kubernetes/addons/zipkin-to-stackdriver.yaml
+++ b/install/kubernetes/addons/zipkin-to-stackdriver.yaml
@@ -36,6 +36,7 @@ metadata:
 spec:
   ports:
   - name: zipkin
+    namespace: istio-system
     port: 9411
   selector:
     app: zipkin-to-stackdriver


### PR DESCRIPTION
to fix #2333 