### PR TITLE
Use proxy_init image in sidecar-injector helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
     template: |-
       initContainers:
       - name: istio-init
-        image: {{ .Values.global.sidecarInjector.repository }}:{{ .Values.global.sidecarInjector.tag }}
+        image: {{ .Values.global.proxyInit.repository }}:{{ .Values.global.proxyInit.tag }}
         args:
         - "-p"
         - {{ "{{ .MeshConfig.ProxyListenPort }}" }}

--- a/install/kubernetes/templates/helm/istio/values.yaml.tmpl
+++ b/install/kubernetes/templates/helm/istio/values.yaml.tmpl
@@ -2,6 +2,9 @@ global:
   proxy:
     repository: {PROXY_HUB}/{PROXY_IMAGE}
     tag: {PROXY_TAG}
+  proxyInit:
+    repository: {PROXY_HUB}/proxy_init
+    tag: {PROXY_TAG}
   sidecarInjector:
     repository: {PILOT_HUB}/sidecar_injector
     tag: {PILOT_TAG}


### PR DESCRIPTION
Previously the sidecar injector image would be inserted as an init container to each pod, which (as expected) doesn't do what we want.

This PR switches us to use the correct image, `proxy_init`.

/cc @luisyonaldo 
