### PR TITLE
pilot lint/fmt fixes

### DIFF
--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -27,7 +27,6 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"go.uber.org/multierr"
-
 	"k8s.io/apimachinery/pkg/util/yaml"
 	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -350,7 +350,7 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Node, routeName strin
 }
 
 // options required to build an HTTPListener
-type buildHTTPListenerOpts struct {
+type buildHTTPListenerOpts struct { // nolint: maligned
 	mesh             *meshconfig.MeshConfig
 	node             model.Node
 	instances        []*model.ServiceInstance

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -763,7 +763,7 @@ func (ds *DiscoveryService) invokeWebhook(path string, payload []byte, methodNam
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint: errcheck
 
 	out, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v1/externalservice.go
+++ b/pilot/pkg/proxy/envoy/v1/externalservice.go
@@ -121,7 +121,7 @@ func buildExternalServiceCluster(mesh *meshconfig.MeshConfig,
 
 		if !found {
 			// default to the external service port
-			url := fmt.Sprintf("tcp://%s:%d", endpoint.Address, int(port.Port))
+			url := fmt.Sprintf("tcp://%s:%d", endpoint.Address, port.Port)
 			hosts = append(hosts, Host{URL: url})
 		}
 	}

--- a/pilot/test/integration/kubernetes_external_name_services.go
+++ b/pilot/test/integration/kubernetes_external_name_services.go
@@ -29,10 +29,7 @@ func (t *kubernetesExternalNameServices) String() string {
 }
 
 func (t *kubernetesExternalNameServices) setup() error {
-	if err := t.applyConfig("rule-rewrite-authority-externalbin.yaml.tmpl", nil); err != nil {
-		return err
-	}
-	return nil
+	return t.applyConfig("rule-rewrite-authority-externalbin.yaml.tmpl", nil)
 }
 
 func (t *kubernetesExternalNameServices) teardown() {


### PR DESCRIPTION
See #3316 for the details, those lint errors started appearing
with go 1.10rc2.