### PR TITLE
security: lint / fmt fixes

### DIFF
--- a/security/cmd/node_agent_k8s/flexvolume/driver/driver.go
+++ b/security/cmd/node_agent_k8s/flexvolume/driver/driver.go
@@ -113,7 +113,7 @@ func doMount(dstDir string, ninputs *pb.WorkloadInfo_WorkloadAttributes) error {
 	cmdMount := exec.Command("/bin/mount", "-t", "tmpfs", "-o", "size=8K", "tmpfs", dstDir)
 	err = cmdMount.Run()
 	if err != nil {
-		os.RemoveAll(newDir)
+		_ = os.RemoveAll(newDir)
 		return err
 	}
 
@@ -121,8 +121,8 @@ func doMount(dstDir string, ninputs *pb.WorkloadInfo_WorkloadAttributes) error {
 	err = os.MkdirAll(newDstDir, 0777)
 	if err != nil {
 		cmd := exec.Command("/bin/unmount", dstDir)
-		cmd.Run()
-		os.RemoveAll(newDir)
+		_ = cmd.Run()
+		_ = os.RemoveAll(newDir)
 		return err
 	}
 
@@ -131,8 +131,8 @@ func doMount(dstDir string, ninputs *pb.WorkloadInfo_WorkloadAttributes) error {
 	err = cmd.Run()
 	if err != nil {
 		cmd = exec.Command("/bin/umount", dstDir)
-		cmd.Run()
-		os.RemoveAll(newDir)
+		_ = cmd.Run()
+		_ = os.RemoveAll(newDir)
 		return err
 	}
 
@@ -142,12 +142,7 @@ func doMount(dstDir string, ninputs *pb.WorkloadInfo_WorkloadAttributes) error {
 // doUnmount perform the actual unmount work
 func doUnmount(dir string) error {
 	cmd := exec.Command("/bin/umount", dir)
-	err := cmd.Run()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 // addListener add the listener for the workload
@@ -187,7 +182,7 @@ func Mount(dir, opts string) error {
 	inp := dir + "|" + opts
 
 	ninputs, s := checkValidMountOpts(opts)
-	if s == false {
+	if !s {
 		return Failure("mount", inp, "Incomplete inputs")
 	}
 
@@ -222,9 +217,9 @@ func Unmount(dir string) error {
 	}
 
 	// unmount the bind mount
-	doUnmount(dir + "/nodeagent")
+	_ = doUnmount(dir + "/nodeagent")
 	// unmount the tmpfs
-	doUnmount(dir)
+	_ = doUnmount(dir)
 	// delete the directory that was created.
 	delDir := nodeAgentUdsHome + "/" + uid
 	err := os.Remove(delDir)
@@ -270,5 +265,5 @@ func logToSys(caller, inp, opts string) {
 	op := caller + "|"
 	op = op + inp + "|"
 	op = op + opts
-	logWrt.Warning(op)
+	_ = logWrt.Warning(op)
 }

--- a/security/cmd/node_agent_k8s/flexvolume/main.go
+++ b/security/cmd/node_agent_k8s/flexvolume/main.go
@@ -91,7 +91,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer logWrt.Close()
+	defer logWrt.Close() // nolint: errcheck
 
 	if logWrt == nil {
 		fmt.Println("am Logwrt is nil")

--- a/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient.go
+++ b/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient.go
@@ -59,7 +59,7 @@ func (c *NodeAgentClient) client() (pb.NodeAgentServiceClient, error) {
 	var opts []grpc.DialOption
 
 	opts = append(opts, grpc.WithInsecure())
-	if c.isUds == false {
+	if !c.isUds {
 		conn, err = grpc.Dial(c.dest, opts...)
 		if err != nil {
 			return nil, err
@@ -76,7 +76,7 @@ func (c *NodeAgentClient) client() (pb.NodeAgentServiceClient, error) {
 	signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
 	go func(conn *grpc.ClientConn, c chan os.Signal) {
 		<-c
-		conn.Close()
+		_ = conn.Close()
 		os.Exit(0)
 	}(conn, sigc)
 
@@ -109,5 +109,5 @@ func (c *NodeAgentClient) Close() {
 	if c.conn == nil {
 		return
 	}
-	c.conn.Close()
+	_ = c.conn.Close()
 }

--- a/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient_test.go
+++ b/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentclient_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 type FakeNodeAgentGrpcServer struct {
-	response *pb.CsrResponse
-	errorMsg string
 }
 
 func (s *FakeNodeAgentGrpcServer) WorkloadAdded(ctx context.Context, request *pb.WorkloadInfo) (*pb.NodeAgentMgmtResponse, error) {

--- a/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentserver.go
+++ b/security/cmd/node_agent_k8s/nodeagentmgmt/nodeagentserver.go
@@ -62,7 +62,7 @@ func (s *Server) Serve(isUds bool, path string) {
 
 	var lis net.Listener
 	var err error
-	if isUds == false {
+	if !isUds {
 		lis, err = net.Listen("tcp", path)
 		if err != nil {
 			log.Errorf("failed to %v", err)
@@ -83,17 +83,17 @@ func (s *Server) Serve(isUds bool, path string) {
 
 	go func(ln net.Listener, s *Server) {
 		<-s.done
-		ln.Close()
+		_ = ln.Close()
 		s.CloseAllWlds()
 	}(lis, s)
 
-	grpcServer.Serve(lis)
+	_ = grpcServer.Serve(lis)
 }
 
 // WorkloadAdded define the server side action when a workload is added.
 func (s *Server) WorkloadAdded(ctx context.Context, request *pb.WorkloadInfo) (*pb.NodeAgentMgmtResponse, error) {
 	log.Infof("The request is %v", request)
-	if _, ok := s.wlmgmts[request.Attrs.Uid]; ok == true {
+	if _, ok := s.wlmgmts[request.Attrs.Uid]; ok {
 		status := &rpc.Status{Code: int32(rpc.ALREADY_EXISTS), Message: "Already exists"}
 		return &pb.NodeAgentMgmtResponse{Status: status}, nil
 	}
@@ -107,7 +107,7 @@ func (s *Server) WorkloadAdded(ctx context.Context, request *pb.WorkloadInfo) (*
 
 // WorkloadDeleted define the server side action when a workload is deleted.
 func (s *Server) WorkloadDeleted(ctx context.Context, request *pb.WorkloadInfo) (*pb.NodeAgentMgmtResponse, error) {
-	if _, ok := s.wlmgmts[request.Attrs.Uid]; ok == false {
+	if _, ok := s.wlmgmts[request.Attrs.Uid]; !ok {
 		status := &rpc.Status{Code: int32(rpc.NOT_FOUND), Message: "Not found"}
 		return &pb.NodeAgentMgmtResponse{Status: status}, nil
 	}

--- a/security/cmd/node_agent_k8s/workloadhandler/workloadhandler.go
+++ b/security/cmd/node_agent_k8s/workloadhandler/workloadhandler.go
@@ -78,13 +78,13 @@ func (s *Server) Serve() {
 
 	go func(ln net.Listener, c chan bool) {
 		<-c
-		ln.Close()
+		_ = ln.Close()
 		log.Printf("Closed the listener.")
 		c <- true
 	}(lis, s.done)
 
 	log.Printf("workload [%v] listen", s)
-	grpcServer.Serve(lis)
+	_ = grpcServer.Serve(lis)
 }
 
 // Stop tell the server it should stop

--- a/security/pkg/cmd/flag_test.go
+++ b/security/pkg/cmd/flag_test.go
@@ -97,7 +97,7 @@ func TestInitializeBoolFlag(t *testing.T) {
 	})
 
 	_ = cmd.Flags().Parse([]string{})
-	if testBool != defaultBool {
+	if testBool != defaultBool { // nolint: megacheck
 		t.Errorf("%s: pflag parse error. Actual %t, Expected %t", testName, testBool, defaultBool)
 	}
 }

--- a/security/pkg/platform/aws_test.go
+++ b/security/pkg/platform/aws_test.go
@@ -262,8 +262,6 @@ func TestAwsGetDialOptions(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		sigFile         string
-		requestPath     string
 		expectedErr     string
 		cfg             *ClientConfig
 		expectedOptions []grpc.DialOption


### PR DESCRIPTION
See #3316 for the details, those error messages are appearing
with go 1.10rc2.

I am however a bit nervous that too many errors are left unchecked,
maybe better to refactor the code a bit to handle errors more
properly.