### PR TITLE
Update Pilot config descriptor lists

### DIFF
--- a/pilot/cmd/istioctl/main.go
+++ b/pilot/cmd/istioctl/main.go
@@ -646,12 +646,15 @@ func printYamlOutput(configClient *crd.Client, configList []model.Config) {
 }
 
 func newClient() (*crd.Client, error) {
+	// TODO: use model.IstioConfigTypes once model.IngressRule is deprecated
 	return crd.NewClient(kubeconfig, model.ConfigDescriptor{
 		model.RouteRule,
 		model.V1alpha2RouteRule,
 		model.Gateway,
 		model.EgressRule,
+		model.ExternalService,
 		model.DestinationPolicy,
+		model.DestinationRule,
 		model.HTTPAPISpec,
 		model.HTTPAPISpecBinding,
 		model.QuotaSpec,

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -68,11 +68,15 @@ const (
 )
 
 var (
+	// TODO: use model.IstioConfigTypes once model.IngressRule is deprecated
 	configDescriptor = model.ConfigDescriptor{
 		model.RouteRule,
 		model.V1alpha2RouteRule,
+		model.Gateway,
 		model.EgressRule,
+		model.ExternalService,
 		model.DestinationPolicy,
+		model.DestinationRule,
 		model.HTTPAPISpec,
 		model.HTTPAPISpecBinding,
 		model.QuotaSpec,


### PR DESCRIPTION
Use model.IstioConfigTypes instead of hardcoded lists.