### PR TITLE
lint / fmt fixes for common components

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -116,7 +116,7 @@ func genJekyllHTML(cmd *cobra.Command, path string) error {
 	commands := make(map[string]*cobra.Command)
 	findCommands(commands, cmd)
 
-	names := make([]string, len(commands), len(commands))
+	names := make([]string, len(commands))
 	i := 0
 	for n := range commands {
 		names[i] = n

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -114,7 +114,9 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		}
 		// Use istioctl from base version to inject the sidecar.
 		i.localPath = filepath.Join(releaseDir, "/bin/istioctl")
-		os.Chmod(i.localPath, 0755)
+		if err = os.Chmod(i.localPath, 0755); err != nil {
+			return nil, err
+		}
 	} else {
 		releaseDir = util.GetResourcePath("")
 	}

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -201,45 +200,6 @@ func checkRoutingResponse(user, version, gateway, modelFile string) (int, error)
 	}
 	closeResponseBody(resp)
 	return duration, err
-}
-
-func checkHTTPResponse(user, gateway, expr string, count int) (int, error) {
-	resp, err := http.Get(fmt.Sprintf("%s/productpage", tc.gateway))
-	if err != nil {
-		return -1, err
-	}
-
-	defer closeResponseBody(resp)
-	log.Infof("Get from page: %d", resp.StatusCode)
-	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Get response from product page failed!")
-		return -1, fmt.Errorf("status code is %d", resp.StatusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return -1, err
-	}
-
-	if expr == "" {
-		return 1, nil
-	}
-
-	re, err := regexp.Compile(expr)
-	if err != nil {
-		return -1, err
-	}
-
-	ref := re.FindAll(body, -1)
-	if ref == nil {
-		log.Infof("%v", string(body))
-		return -1, fmt.Errorf("could not find %v in response", expr)
-	}
-	if count > 0 && len(ref) < count {
-		log.Infof("%v", string(body))
-		return -1, fmt.Errorf("could not find %v # of %v in response. found %v", count, expr, len(ref))
-	}
-	return 1, nil
 }
 
 func deleteRules(ruleKeys []string) error {

--- a/tests/util/commonUtils.go
+++ b/tests/util/commonUtils.go
@@ -324,7 +324,7 @@ func ExtractTarGz(gzipStream io.Reader) error {
 			if err != nil {
 				return errors.Wrap(err, "ExtractTarGz: Create() failed")
 			}
-			defer outFile.Close()
+			defer outFile.Close() // nolint: errcheck
 			if _, err := io.Copy(outFile, tarReader); err != nil {
 				return errors.Wrap(err, "ExtractTarGz: Copy() failed")
 			}

--- a/tools/githubContrib/githubContrib.go
+++ b/tools/githubContrib/githubContrib.go
@@ -71,7 +71,7 @@ func getBodyForURL(url string) []byte {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	checkOrDie(err, "Unable to send request")
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint: errcheck
 	body, err := ioutil.ReadAll(resp.Body)
 	checkOrDie(err, "Unable to read response")
 	succ := resp.StatusCode


### PR DESCRIPTION
See #3316 for the details, those error messages are appearing
with go 1.10rc2.