### PR TITLE
Fix the docker push, use a constant tag to avoid polution.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,8 @@ jobs:
   docker-push:
     <<: *defaults
     resource_class: xlarge
+    environment:
+      TAG: circleci-nightly
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This should be used with transient clusters or with tools like keel, which can upgrade pods
by looking at the sha that the label points to. 

K8S will not upgrade if the tag doesn't change. 

TODO: also change the repo to istio-nightly, when it is ready.

CircleCI has nightly builds pushing docker images, which can be auto-picked by tools like keel.sh
(see the weekly test-env configs as an example)