### PR TITLE
prow: run only auth enabled tests for pilot e2e

### DIFF
--- a/prow/istio-pilot-e2e.sh
+++ b/prow/istio-pilot-e2e.sh
@@ -55,4 +55,4 @@ ln -sf "${HOME}/.kube/config" ${ROOT}/pilot/pkg/kube/config
 HUB="gcr.io/istio-testing"
 
 cd ${GOPATH}/src/istio.io/istio
-make depend e2e_pilot HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=true -use-sidecar-injector=true -use-admission-webhook=false"
+make depend e2e_pilot HUB="${HUB}" TAG="${GIT_SHA}" TESTOPTS="-mixer=true -use-sidecar-injector=true -use-admission-webhook=false -auth=enable"


### PR DESCRIPTION
We are running two full tests with and without auth. I think we should move the non auth to periodic tests, in an attempt to cut down test verification time.