### PR TITLE
Various fixes for Istio Helm chart (makes it work 🎉)

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         app: {{ template "grafana.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -25,17 +25,13 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
-          livenessProbe:
-            httpGet:
-              path: /logging
-              port: {{ .Values.service.internalPort }}
           readinessProbe:
             httpGet:
-              path: /logging
+              path: /login
               port: {{ .Values.service.internalPort }}
           env:
           - name: GRAFANA_PORT
-            value: {{ .Values.service.internalPort }}
+            value: {{ .Values.service.internalPort | quote }}
           - name: GF_AUTH_BASIC_ENABLED
             value: "false"
           - name: GF_AUTH_ANONYMOUS_ENABLED
@@ -46,7 +42,13 @@ spec:
             value: /data/grafana
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          - name: data
+            mountPath: /data/grafana
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -43,15 +43,14 @@ spec:
           - --connectTimeout
           - '10s' #connectTimeout
           - --serviceCluster
-          - istio-proxy
+          - {{ .Release.Name }}-ingress
           - --zipkinAddress
-          - zipkin:9411
+          - {{ .Release.Name }}-zipkin:9411
           - --statsdUdpAddress
           - {{ .Release.Name }}-mixer:9125
           - --proxyAdminPort
           - "15000"
           - --controlPlaneAuthPolicy
-
         {{- if .Values.global.securityEnabled }}
           - MUTUAL_TLS
         {{- else }}
@@ -59,6 +58,26 @@ spec:
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: "istio.{{ template "istio.serviceAccountName" . }}"
+          optional: true
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
@@ -20,8 +20,8 @@ Service account name.
 */}}
 {{- define "mixer.serviceAccountName" -}}
 {{- if .Values.global.rbacEnabled -}}
-{{- template "mixer.fullname" . -}}
+{{- template "mixer.fullname" . -}}-service-account
 {{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
+{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
 {{- end -}}
 {{- end -}}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -354,18 +354,25 @@ spec:
     - tcpbytesent.metric
     - tcpbytereceived.metric
 ---
+
 apiVersion: "config.istio.io/v1alpha2"
 kind: kubernetesenv
 metadata:
   name: handler
   namespace: {{ .Release.Namespace }}
 spec:
+  # when running from mixer root, use the following config after adding a
+  # symbolic link to a kubernetes config file via:
+  #
+  # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
+  #
+  # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
 
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
-  name: kubeattrgenrule
+  name: kubeattrgenrulerule
   namespace: {{ .Release.Namespace }}
 spec:
   actions:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
@@ -38,6 +38,24 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
+  name: circonuses.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: circonus
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: circonus
+    plural: circonuses
+    singular: circonus
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
   name: deniers.config.istio.io
   labels:
     app: {{ template "mixer.name" . }}
@@ -56,40 +74,21 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  name: listcheckers.config.istio.io
+  name: fluentds.config.istio.io
   labels:
     app: {{ template "mixer.name" . }}
-    package: listchecker
+    package: fluentd
     istio: mixer-adapter
 spec:
   group: config.istio.io
   names:
-    kind: listchecker
-    plural: listcheckers
-    singular: listchecker
+    kind: fluentd
+    plural: fluentds
+    singular: fluentd
   scope: Namespaced
   version: v1alpha2
-
 ---
 
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: kuberneteses.config.istio.io
-  labels:
-    app: {{ template "mixer.name" . }}
-    package: adapter.template.kubernetes
-    istio: mixer-instance
-spec:
-  group: config.istio.io
-  names:
-    kind: kubernetes
-    plural: kuberneteses
-    singular: kubernetes
-  scope: Namespaced
-  version: v1alpha2
-
----
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -104,6 +103,24 @@ spec:
     kind: kubernetesenv
     plural: kubernetesenvs
     singular: kubernetesenv
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: listcheckers.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: listchecker
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: listchecker
+    plural: listcheckers
+    singular: listchecker
   scope: Namespaced
   version: v1alpha2
 ---
@@ -147,6 +164,24 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
+  name: opas.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: opa
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: opa
+    plural: opas
+    singular: opa
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
   name: prometheuses.config.istio.io
   labels:
     app: {{ template "mixer.name" . }}
@@ -158,6 +193,60 @@ spec:
     kind: prometheus
     plural: prometheuses
     singular: prometheus
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: rbacs.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: rbac
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: rbac
+    plural: rbacs
+    singular: rbac
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicecontrols.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: servicecontrol
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: servicecontrol
+    plural: servicecontrols
+    singular: servicecontrol
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: solarwindses.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: solarwinds
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: solarwinds
+    plural: solarwindses
+    singular: solarwinds
   scope: Namespaced
   version: v1alpha2
 ---
@@ -219,17 +308,35 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  name: svcctrls.config.istio.io
+  name: apikeys.config.istio.io
   labels:
     app: {{ template "mixer.name" . }}
-    package: svcctrl
-    istio: mixer-adapter
+    package: apikey
+    istio: mixer-instance
 spec:
   group: config.istio.io
   names:
-    kind: svcctrl
-    plural: svcctrls
-    singular: svcctrl
+    kind: apikey
+    plural: apikeys
+    singular: apikey
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: authorizations.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: authorization
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: authorization
+    plural: authorizations
+    singular: authorization
   scope: Namespaced
   version: v1alpha2
 ---
@@ -248,6 +355,24 @@ spec:
     kind: checknothing
     plural: checknothings
     singular: checknothing
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: kuberneteses.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: adapter.template.kubernetes
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: kubernetes
+    plural: kuberneteses
+    singular: kubernetes
   scope: Namespaced
   version: v1alpha2
 ---
@@ -338,5 +463,77 @@ spec:
     kind: reportnothing
     plural: reportnothings
     singular: reportnothing
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicecontrolreports.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: servicecontrolreport
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: servicecontrolreport
+    plural: servicecontrolreports
+    singular: servicecontrolreport
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: tracespans.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: tracespan
+    istio: mixer-instance
+spec:
+  group: config.istio.io
+  names:
+    kind: tracespan
+    plural: tracespans
+    singular: tracespan
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: serviceroles.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: istio.io.mixer
+    istio: rbac
+spec:
+  group: config.istio.io
+  names:
+    kind: ServiceRole
+    plural: serviceroles
+    singular: servicerole
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: servicerolebindings.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: istio.io.mixer
+    istio: rbac
+spec:
+  group: config.istio.io
+  names:
+    kind: ServiceRoleBinding
+    plural: servicerolebindings
+    singular: servicerolebinding
   scope: Namespaced
   version: v1alpha2

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -42,10 +42,12 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:
           - containerPort: 9091
+          - containerPort: 9093
           - containerPort: 9094
           - containerPort: 42422
           args:
-            - --configStoreURL=k8s://
+            - --configStoreURL=fs:///etc/opt/mixer/configroot
+            - --configStore2URL=k8s://
             - --configDefaultNamespace={{ .Release.Namespace }}
             - --zipkinURL=http://zipkin:9411/api/v1/spans
             - --logtostderr
@@ -65,7 +67,7 @@ spec:
           - "2"
           - --controlPlaneAuthPolicy
         {{- if .Values.global.securityEnabled }}
-          - MUTUAL_TLSN
+          - MUTUAL_TLS
           - --customConfigFile
           - /etc/istio/proxy/envoy_mixer_auth.json
         {{- else }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/_helpers.tpl
@@ -20,8 +20,8 @@ Service account name.
 */}}
 {{- define "pilot.serviceAccountName" -}}
 {{- if .Values.global.rbacEnabled -}}
-{{- template "pilot.fullname" . -}}
+{{- template "pilot.fullname" . -}}-service-account
 {{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
+{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
 {{- end -}}
 {{- end -}}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         app: {{ template "pilot.name" . }}
         release: {{ .Release.Name }}
         istio: pilot
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: {{ template "pilot.serviceAccountName" . }}
       containers:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           - name: config-volume
-            mountPath: /etc//config
+            mountPath: /etc/istio/config
         - name: {{ template "pilot.name" . }}-proxy
           image: "{{ .Values.global.proxy.repository }}:{{ .Values.global.proxy.tag }}"
           imagePullPolicy: {{ .Values.global.proxy.imagePullPolicy }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
         {{- if .Values.global.securityEnabled }}
           - MUTUAL_TLS
           - --customConfigFile
-          - /etc//proxy/envoy_pilot_auth.json
+          - /etc/istio/proxy/envoy_pilot_auth.json
         {{- else }}
           - NONE #--controlPlaneAuthPolicy
           - --customConfigFile

--- a/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
@@ -9,10 +9,14 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
-    - port: 15003
-      name: http-discovery
-    - port: 443
-      name: admission-webhook
+  - port: 15003
+    name: http-discovery
+  - port: 8080
+    name: http-legacy-discovery
+  - port: 9093
+    name: http-monitoring
+  - port: 443
+    name: admission-webhook
   selector:
     app: {{ template "pilot.name" . }}
     release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: {{ .Release.Namespace }};{{ .Release.Namespace}}-mixer;prometheus
+        regex: {{ .Release.Namespace }};{{ .Release.Name }}-mixer;prometheus
 
     - job_name: 'envoy'
       # Override the global default and scrape targets from this job every 5 seconds.
@@ -38,7 +38,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: {{ .Release.Namespace }};{{ .Release.Namespace}}-mixer;statsd-prom
+        regex: {{ .Release.Namespace }};{{ .Release.Name }}-mixer;statsd-prom
 
     - job_name: 'mixer'
       # Override the global default and scrape targets from this job every 5 seconds.
@@ -52,7 +52,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: {{ .Release.Namespace }};{{ .Release.Namespace}}-mixer;http-monitoring
+        regex: {{ .Release.Namespace }};{{ .Release.Name }}-mixer;http-monitoring
 
     - job_name: 'pilot'
       # Override the global default and scrape targets from this job every 5 seconds.
@@ -66,7 +66,7 @@ data:
       relabel_configs:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
-        regex: {{ .Release.Namespace }};{{ .Release.Namespace}}-pilot;http-monitoring
+        regex: {{ .Release.Namespace }};{{ .Release.Name }}-pilot;http-monitoring
 
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: prometheus
+          name: {{ template "prometheus.fullname" . }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -16,6 +14,8 @@ spec:
       labels:
         app: {{ template "prometheus.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "prometheus.fullname" . }}
+  # we use the normal name here (e.g. 'prometheus')
+  # as grafana is configured to use this as a data source
+  name: {{ template "prometheus.name" . }}
   labels:
     app: {{ template "prometheus.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
@@ -20,8 +20,8 @@ Service account name.
 */}}
 {{- define "security.serviceAccountName" -}}
 {{- if .Values.global.rbacEnabled -}}
-{{- template "security.fullname" . -}}
+{{- template "security.fullname" . -}}-service-account
 {{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
+{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
 {{- end -}}
 {{- end -}}

--- a/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
@@ -7,5 +7,5 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: {{ template "security.fullname" . }}
+  name: {{ template "security.serviceAccountName" . }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -16,6 +14,8 @@ spec:
       labels:
         app: {{ template "servicegraph.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: {{ template "sidecar-injector.name" . }}
         release: {{ .Release.Name }}
+        istio: sidecar-injector
     spec:
       containers:
         - name: {{ .Chart.Name }}-webhook

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -7,8 +7,6 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -16,6 +14,8 @@ spec:
       labels:
         app: {{ template "zipkin.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
       discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15003
       #
       # Zipkin trace collector
-      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
+      zipkinAddress: {{ .Release.Name}}-zipkin.{{ .Release.Namespace }}:9411
       #
       # Statsd metrics collector. istio mixer exposes a UDP endpoint
       # to collect and convert statsd metrics into Prometheus metrics.

--- a/install/kubernetes/templates/helm/istio/values.yaml.tmpl
+++ b/install/kubernetes/templates/helm/istio/values.yaml.tmpl
@@ -140,8 +140,8 @@ grafana:
   service:
     name: http
     type: ClusterIP
-    externalPort: 9000
-    internalPort: 9000
+    externalPort: 3000
+    internalPort: 3000
   ingress:
     enabled: false
     # Used to create an Ingress record.


### PR DESCRIPTION
I've spent the last day or so working with the Helm chart to deploy an Istio control plane reliably.

This is a changeset of all the patches required to make it work with Istio 0.5.0 and 0.4.0, as well as with (and without) mTLS enabled.

Note: #3303 and #3302 are *also* required in order to make the Helm chart work fully.

I've tested this with mTLS enabled as well as disabled, plus along with this patch: https://github.com/istio/istio/commit/3b2674ebed6b6dccb634742518fb0825dd4c1c42 it should also work on 0.4.0 (although I've not run e2e tests against this environment).

I've confirmed the new chart working by running the bookinfo e2e tests with mTLS enabled as well as disabled.

I guess this is a pre-req for making the Helm chart the authoritative source of truth for manifests.