### PR TITLE
Add cluster that is generated by the v1alpha2 route rule mirror

### DIFF
--- a/pilot/test/integration/testdata/rule-default-route-mirrored.yaml.tmpl
+++ b/pilot/test/integration/testdata/rule-default-route-mirrored.yaml.tmpl
@@ -6,9 +6,5 @@ spec:
   destination:
     name: c
   precedence: 1
-  route:
-    - labels:
-         version: v1
-      weight: 100
   mirror:
     name: b


### PR DESCRIPTION
The same bug exists in v1alpha1 but this PR does not fix the code v1alpha code.

edit:
Fixed the logic in v1alpha1 for good measure.