### PR TITLE
use of k8s.io/gengo/namer for pluralizing CRD names

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1375,6 +1375,15 @@
   version = "v0.0.3"
 
 [[projects]]
+  branch = "master"
+  name = "k8s.io/gengo"
+  packages = [
+    "namer",
+    "types"
+  ]
+  revision = "8394c995ab8fbe52216f38d0e1a37de36d820528"
+
+[[projects]]
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
@@ -1431,6 +1440,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "91ee849d35c467869abcb70ec42d3741294fa59e3fcf8220387b5d8b71c196a8"
+  inputs-digest = "84d09b05670f2e3972c636067fa940d1d86c0f518a877054cf9ea93974403409"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/mixer/cmd/mixs/cmd/crd.go
+++ b/mixer/cmd/mixs/cmd/crd.go
@@ -25,6 +25,8 @@ import (
 	"istio.io/istio/mixer/pkg/adapter"
 	mixerRuntime "istio.io/istio/mixer/pkg/runtime"
 	"istio.io/istio/mixer/pkg/template"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
 )
 
 // Group is the K8s API group.
@@ -104,21 +106,9 @@ type crdVar struct {
 	Version    string
 }
 
-// pluralize gives a plural the way k8s like it.
-// https://github.com/kubernetes/gengo/blob/master/namer/plural_namer.go
-func pluralize(singular string) string {
-	switch string(singular[len(singular)-1]) {
-	case "s", "x":
-		return singular + "es"
-	case "y":
-		return singular[:len(singular)-1] + "ies"
-	default:
-		return singular + "s"
-	}
-}
-
 func newCrdVar(shrtName, implName, label string) *crdVar {
-	plural := pluralize(shrtName)
+	namer := namer.NewPrivatePluralNamer(map[string]string{})
+	plural := namer.Name(&types.Type{Name: types.Name{Name: shrtName}})
 	return &crdVar{
 		ShrtName:   shrtName,
 		ImplName:   implName,

--- a/mixer/cmd/mixs/cmd/crd.go
+++ b/mixer/cmd/mixs/cmd/crd.go
@@ -20,13 +20,13 @@ import (
 	gotemplate "text/template"
 
 	"github.com/spf13/cobra"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
 
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/mixer/pkg/adapter"
 	mixerRuntime "istio.io/istio/mixer/pkg/runtime"
 	"istio.io/istio/mixer/pkg/template"
-	"k8s.io/gengo/namer"
-	"k8s.io/gengo/types"
 )
 
 // Group is the K8s API group.

--- a/mixer/cmd/mixs/cmd/crd_test.go
+++ b/mixer/cmd/mixs/cmd/crd_test.go
@@ -32,6 +32,7 @@ var empty = ``
 var exampleAdapters = []adptr.InfoFn{
 	func() adptr.Info { return adptr.Info{Name: "foo-bar"} },
 	func() adptr.Info { return adptr.Info{Name: "abcd"} },
+	func() adptr.Info { return adptr.Info{Name: "apikey"} },
 }
 var exampleAdaptersCrd = `
 kind: CustomResourceDefinition
@@ -63,6 +64,22 @@ spec:
     kind: abcd
     plural: abcds
     singular: abcd
+  scope: Namespaced
+  version: v1alpha2
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: apikeys.config.istio.io
+  labels:
+    package: apikey
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: apikey
+    plural: apikeys
+    singular: apikey
   scope: Namespaced
   version: v1alpha2
 ---`

--- a/mixer/cmd/mixs/cmd/validator.go
+++ b/mixer/cmd/mixs/cmd/validator.go
@@ -30,6 +30,8 @@ import (
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/mixer/pkg/runtime"
 	"istio.io/istio/mixer/pkg/template"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
 )
 
 func validatorCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {
@@ -38,8 +40,9 @@ func validatorCmd(info map[string]template.Info, adapters []adapter.InfoFn, prin
 	tmplRepo := template.NewRepository(info)
 	kinds := runtime.KindMap(config.AdapterInfoMap(adapters, tmplRepo.SupportsTemplate), info)
 	vc.ResourceNames = make([]string, 0, len(kinds))
+	namer := namer.NewPrivatePluralNamer(map[string]string{})
 	for name := range kinds {
-		vc.ResourceNames = append(vc.ResourceNames, pluralize(name))
+		vc.ResourceNames = append(vc.ResourceNames, namer.Name(&types.Type{Name: types.Name{Name: name}}))
 	}
 	vc.Validator = store.NewValidator(nil, kinds)
 	validatorCmd := &cobra.Command{

--- a/mixer/cmd/mixs/cmd/validator.go
+++ b/mixer/cmd/mixs/cmd/validator.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
 
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -30,8 +32,6 @@ import (
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/mixer/pkg/runtime"
 	"istio.io/istio/mixer/pkg/template"
-	"k8s.io/gengo/namer"
-	"k8s.io/gengo/types"
 )
 
 func validatorCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf, fatalf shared.FormatFn) *cobra.Command {


### PR DESCRIPTION
As changed in #3101, `apikey`'s plural should be `apikeys`, now `k8s.io/gengo/namer` supports that, and seems working with k8s 1.8.5 or so. This PR changes the code of `mixs crd` command to use the same namer.