### PR TITLE
Fix docker tar generation for release builds

### DIFF
--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -91,7 +91,7 @@ if [ "${BUILD_DOCKER}" == "true" ]; then
 fi
 
 if [[ -n "${TEST_DOCKER_HUB}" ]]; then
-  VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION ISTIO_GCS=$TEST_PATH ISTIO_GCS_ISTIOCTL=istioctl-stage make istio-archive
+  VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION ISTIO_GCS=$TEST_PATH ISTIO_GCS_ISTIOCTL=istioctl-stage make istio-archive
   cp ${ISTIO_OUT}/archive/istio*z* ${OUTPUT_PATH}
   # These files are only used for testing, so use a name to help make this clear
   for TAR_FILE in ${OUTPUT_PATH}/istio?${ISTIO_VERSION}*; do
@@ -101,7 +101,7 @@ if [[ -n "${TEST_DOCKER_HUB}" ]]; then
   cp ${ISTIO_OUT}/istioctl-* ${OUTPUT_PATH}/istioctl-stage
 fi
 
-VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make ${MAKE_TARGETS}
+VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION make ${MAKE_TARGETS}
 cp ${ISTIO_OUT}/archive/istio*z* ${OUTPUT_PATH}
 mkdir -p "${OUTPUT_PATH}/istioctl"
 cp ${ISTIO_OUT}/istioctl-* ${OUTPUT_PATH}/istioctl

--- a/release/publish_release.sh
+++ b/release/publish_release.sh
@@ -270,11 +270,11 @@ if [[ "${DO_DOCKERHUB}" == "true" || "${DO_GCRHUB}" == "true" ]]; then
     docker load -i "${TAR_PATH}"
 
     if [[ "${DO_DOCKERHUB}" == "true" ]]; then
-      docker tag "${IMAGE_NAME}" "${DOCKER_DEST}/${IMAGE_NAME}:${VERSION}"
+      docker tag "istio/${IMAGE_NAME}:${VERSION}" "${DOCKER_DEST}/${IMAGE_NAME}:${VERSION}"
       docker push "${DOCKER_DEST}/${IMAGE_NAME}:${VERSION}"
     fi
     if [[ "${DO_GCRHUB}" == "true" ]]; then
-      docker tag "${IMAGE_NAME}" "${GCR_DEST}/${IMAGE_NAME}:${VERSION}"
+      docker tag "istio/${IMAGE_NAME}:${VERSION}" "${GCR_DEST}/${IMAGE_NAME}:${VERSION}"
       gcloud docker -- push "${GCR_DEST}/${IMAGE_NAME}:${VERSION}"
     fi
   done

--- a/release/store_artifacts.sh
+++ b/release/store_artifacts.sh
@@ -26,6 +26,9 @@ set -x
 DEFAULT_GCS_PREFIX="istio-testing/builds"
 DEFAULT_GCR_PREFIX="istio-testing"
 
+# hub that was baked into image name during build
+SRC_DOCKER_HUB=docker.io/istio
+
 GCS_PREFIX=""
 GCR_PREFIX=""
 
@@ -89,7 +92,7 @@ if [[ "${PUSH_DOCKER}" == "true" ]]; then
       break
     fi
     docker load -i "${TAR_PATH}"
-    docker tag "${IMAGE_NAME}" "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
+    docker tag "${SRC_DOCKER_HUB}/${IMAGE_NAME}:${VER_STRING}" "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
     gcloud docker -- push "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
   done
 fi

--- a/release/store_artifacts.sh
+++ b/release/store_artifacts.sh
@@ -26,9 +26,6 @@ set -x
 DEFAULT_GCS_PREFIX="istio-testing/builds"
 DEFAULT_GCR_PREFIX="istio-testing"
 
-# hub that was baked into image name during build
-SRC_DOCKER_HUB=docker.io/istio
-
 GCS_PREFIX=""
 GCR_PREFIX=""
 
@@ -92,7 +89,7 @@ if [[ "${PUSH_DOCKER}" == "true" ]]; then
       break
     fi
     docker load -i "${TAR_PATH}"
-    docker tag "${SRC_DOCKER_HUB}/${IMAGE_NAME}:${VER_STRING}" "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
+    docker tag "istio/${IMAGE_NAME}:${VER_STRING}" "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
     gcloud docker -- push "${GCR_PATH}/${IMAGE_NAME}:${VER_STRING}"
   done
 fi

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -148,7 +148,7 @@ docker.all: $(DOCKER_TARGETS)
 # to make a $(ISTIO_OUT)/docker/XXX.tar.gz from the docker XXX image
 # note that $(subst docker.,,$(TGT)) strips off the "docker." prefix, leaving just the XXX
 $(foreach TGT,$(DOCKER_TARGETS),$(eval tar.$(TGT): $(TGT) | $(ISTIO_DOCKER_TAR) ; \
-   time (docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT)).tar $(subst docker.,,$(TGT)) && \
+   time (docker save -o ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT)).tar $(HUB)/$(subst docker.,,$(TGT)):$(TAG) && \
          gzip ${ISTIO_DOCKER_TAR}/$(subst docker.,,$(TGT)).tar)))
 
 # create a DOCKER_TAR_TARGETS that's each of DOCKER_TARGETS with a tar. prefix


### PR DESCRIPTION
This change allows release builds to complete successfully.

The baseline docker targets used to build images as $(IMAGE) (which implies $(IMAGE):latest) and yesterday a change was committed that changed this to $(HUB)/$(IMAGE):$(TAG) but didn't update the tar-generation rule to reflect this name change.  This change primarily updates the tar-generation rule to reflect the change.

The release build doesn't care about the HUB (it just wants the tar files), but I can't set an empty hub (the Makefile doesn't permit one, but even if it did the image name would probably end up with a '/' prefix).  The Makefile's default hub is "istio", and this name is also now baked into the tar so I had to update release/store_artifacts.sh and release/publish_release.sh to reflect this change.

I also changed release/cloud_builder.sh to specify a HUB.  This is just to help insulate the build from any change to the default HUB in the top-level Makefile.  Although "docker.io/istio" is specified the docker tool seems to implicitly change this to just "istio".

I tested that a release build can complete successfully with this change, though I did no testing of the artifacts to see if there's any 2nd order side effects.