### PR TITLE
Add Stringfy utility & StringEquals utility functions to pkg/adapter.

### DIFF
--- a/mixer/adapter/memquota/memquota.go
+++ b/mixer/adapter/memquota/memquota.go
@@ -66,17 +66,8 @@ type Limit interface {
 func matchDimensions(cfg map[string]string, inst map[string]interface{}) bool {
 	for k, val := range cfg {
 		rval := inst[k]
-		if rval == val { // this dimension matches, on to next comparison.
+		if adapter.StringEquals(rval, val) { // this dimension matches, on to next comparison.
 			continue
-		}
-
-		// if rval has a string representation then compare it with val
-		// For example net.ip has a useful string representation.
-		switch v := rval.(type) {
-		case fmt.Stringer:
-			if v.String() == val {
-				continue
-			}
 		}
 		// rval does not match val.
 		return false

--- a/mixer/adapter/prometheus/prometheus.go
+++ b/mixer/adapter/prometheus/prometheus.go
@@ -337,7 +337,7 @@ func promValue(val interface{}) (float64, error) {
 func promLabels(l map[string]interface{}) prometheus.Labels {
 	labels := make(prometheus.Labels, len(l))
 	for i, label := range l {
-		labels[i] = fmt.Sprintf("%v", label)
+		labels[i] = adapter.Stringify(label)
 	}
 	return labels
 }

--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -244,17 +244,8 @@ func (b *builder) Build(context context.Context, env adapter.Env) (adapter.Handl
 func matchDimensions(cfg *map[string]string, inst *map[string]interface{}) bool {
 	for k, val := range *cfg {
 		if rval, ok := (*inst)[k]; ok {
-			if rval == val { // this dimension matches, on to next comparison.
+			if adapter.StringEquals(rval, val) { // this dimension matches, on to next comparison.
 				continue
-			}
-
-			// if rval has a string representation then compare it with val
-			// For example net.ip has a useful string representation.
-			switch v := rval.(type) {
-			case fmt.Stringer:
-				if v.String() == val {
-					continue
-				}
 			}
 		}
 

--- a/mixer/adapter/solarwinds/metrics_handler.go
+++ b/mixer/adapter/solarwinds/metrics_handler.go
@@ -109,7 +109,7 @@ func (h *metricsHandler) handleMetric(_ context.Context, vals []*metric.Instance
 
 			for _, label := range mInfo.LabelNames {
 				// val.Dimensions[label] should exists because we have validated this before during config time.
-				m.Tags[label] = h.processLabels(val.Dimensions[label])
+				m.Tags[label] = adapter.Stringify(val.Dimensions[label])
 			}
 			measurements = append(measurements, m)
 		}
@@ -154,19 +154,4 @@ func (h *metricsHandler) aoVal(i interface{}) float64 {
 		_ = h.logger.Errorf("could not extract numeric value for %v", i)
 		return 0
 	}
-}
-
-func (h *metricsHandler) processLabels(v interface{}) string {
-	switch vv := v.(type) {
-	case int:
-	case int32:
-	case int64:
-		return strconv.FormatInt(vv, 10)
-	case float64:
-		return strconv.FormatFloat(vv, 'f', -1, 64)
-	default:
-		str, _ := v.(string)
-		return str
-	}
-	return ""
 }

--- a/mixer/adapter/stackdriver/helper/common.go
+++ b/mixer/adapter/stackdriver/helper/common.go
@@ -15,11 +15,10 @@
 package helper
 
 import (
-	"fmt"
-
 	gapiopts "google.golang.org/api/option"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
+	"istio.io/istio/mixer/pkg/adapter"
 )
 
 // ToOpts converts the Stackdriver config params to options for configuring Stackdriver clients.
@@ -38,11 +37,11 @@ func ToOpts(cfg *config.Params) (opts []gapiopts.ClientOption) {
 	return
 }
 
-// ToStringMap converts a map[string]interface{} to a map[string]string using fmt.Sprintf(%v)
+// ToStringMap converts a map[string]interface{} to a map[string]string
 func ToStringMap(in map[string]interface{}) map[string]string {
 	out := make(map[string]string, len(in))
 	for key, val := range in {
-		out[key] = fmt.Sprintf("%v", val)
+		out[key] = adapter.Stringify(val)
 	}
 	return out
 }

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -15,6 +15,7 @@
 package adapter
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"reflect"
@@ -52,6 +53,18 @@ func Stringify(v interface{}) string {
 			return string(vv)
 		case DNSName:
 			return string(vv)
+		case map[string]string:
+			var buffer bytes.Buffer
+			for k, v := range vv {
+				if buffer.Len() != 0 {
+					buffer.WriteString("&")
+				}
+				buffer.WriteString(k)
+				buffer.WriteString("=")
+				buffer.WriteString(v)
+
+			}
+			return buffer.String()
 		default:
 			return fmt.Sprintf("%v", v)
 		}

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -56,14 +57,18 @@ func Stringify(v interface{}) string {
 			return string(vv)
 		case map[string]string:
 			buffer := pool.GetBuffer()
-			for k, v := range vv {
+			keys := make([]string, 0, len(vv))
+			for k := range vv {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
 				if buffer.Len() != 0 {
 					buffer.WriteString("&")
 				}
 				buffer.WriteString(k)
 				buffer.WriteString("=")
-				buffer.WriteString(v)
-
+				buffer.WriteString(vv[k])
 			}
 			return buffer.String()
 		default:

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -1,0 +1,68 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+// This file contains common utility functions that adapters need to process content
+// of instances.
+
+// Stringify converts basic data types, supported by `istio.mixer.v1.config.descriptor.ValueType`, into string.
+// Note nil object is converted into empty "" string.
+func Stringify(v interface{}) string {
+	if v != nil {
+		// Switch on all possible ValueTypes
+		switch vv := v.(type) {
+		case string:
+			return vv
+		case int64:
+			return strconv.FormatInt(vv, 10)
+		case float64:
+			return strconv.FormatFloat(vv, 'f', -1, 64)
+		case bool:
+			return strconv.FormatBool(vv)
+		case time.Time:
+			return vv.String()
+		case time.Duration:
+			return vv.String()
+		case net.IP:
+			return vv.String()
+		case EmailAddress:
+			return string(vv)
+		case URI:
+			return string(vv)
+		case DNSName:
+			return string(vv)
+		default:
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return ""
+}
+
+// StringEquals compares if string representations of a and b are equal.
+// Note: string representation of nil object is an empty string, so StringEquals with
+// a nil object and a string of value empty "", will evaluate to true.
+func StringEquals(a interface{}, b interface{}) bool {
+	if a == b {
+		return true
+	}
+	return Stringify(a) == Stringify(b)
+}

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -70,7 +70,9 @@ func Stringify(v interface{}) string {
 				buffer.WriteString("=")
 				buffer.WriteString(vv[k])
 			}
-			return buffer.String()
+			ret := buffer.String()
+			pool.PutBuffer(buffer)
+			return ret
 		default:
 			return fmt.Sprintf("%v", v)
 		}

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors
+// Copyright 2018 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@ func Stringify(v interface{}) string {
 	return ""
 }
 
-// StringEquals compares if string representations of a and b are equal.
+// StringEquals compares if string representations of two basic data types, supported by
+// `istio.mixer.v1.config.descriptor.ValueType`, are equal.
 // Note: string representation of nil object is an empty string, so StringEquals with
 // a nil object and a string of value empty "", will evaluate to true.
 func StringEquals(a interface{}, b interface{}) bool {

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -15,13 +15,14 @@
 package adapter
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"istio.io/istio/mixer/pkg/pool"
 )
 
 // This file contains common utility functions that adapters need to process content
@@ -54,7 +55,7 @@ func Stringify(v interface{}) string {
 		case DNSName:
 			return string(vv)
 		case map[string]string:
-			var buffer bytes.Buffer
+			buffer := pool.GetBuffer()
 			for k, v := range vv {
 				if buffer.Len() != 0 {
 					buffer.WriteString("&")

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors
+// Copyright 2018 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -38,7 +38,7 @@ func TestStringify(t *testing.T) {
 		{v: URI("http://foo"), want: "http://foo"},
 		{v: DNSName("dns"), want: "dns"},
 		{v: nil, want: ""},
-		{v: map[string]string{"a": "b"}, want: "map[a:b]"},
+		{v: map[string]string{"a": "b"}, want: "a=b"},
 	}
 
 	for _, tt := range tests {
@@ -83,6 +83,7 @@ func TestStringEquals(t *testing.T) {
 		{a: "2013-02-03T00:00:00.000000Z", b: tTime, want: true},
 		{a: tTime, b: tTime, want: true},
 		{a: "a=b&c=d&e=f", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: true},
+		{a: Stringify(map[string]string{"c": "d", "e": "f", "a": "b"}), b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: true},
 		{a: "1234", b: int(1234), want: true},
 
 		{a: "foo", b: "bar", want: false},

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -39,6 +39,7 @@ func TestStringify(t *testing.T) {
 		{v: DNSName("dns"), want: "dns"},
 		{v: nil, want: ""},
 		{v: map[string]string{"a": "b"}, want: "a=b"},
+		{v: map[string]string{"c": "d", "e": "f", "a": "b"}, want: "a=b&c=d&e=f"},
 	}
 
 	for _, tt := range tests {

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -31,7 +31,7 @@ func TestStringify(t *testing.T) {
 		{v: int64(123456789), want: "123456789"},
 		{v: float64(123456789.123456), want: "123456789.123456"},
 		{v: true, want: "true"},
-		{v: testTime, want: "2013-02-03 00:00:00 +0000 UTC"},
+		{v: testTime, want: "2013-02-03T00:00:00.000000Z"},
 		{v: 3 * time.Second, want: "3s"},
 		{v: net.ParseIP("1.2.3.4"), want: "1.2.3.4"},
 		{v: EmailAddress("abcd@abcd"), want: "abcd@abcd"},
@@ -52,22 +52,49 @@ func TestStringify(t *testing.T) {
 }
 
 func TestStringEquals(t *testing.T) {
+	tDuration, _ := time.ParseDuration("1s")
+	tTime, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
+	t2Time, _ := time.Parse("2006-Jan-02", "2000-Feb-03")
 	tests := []struct {
 		a    interface{}
 		b    interface{}
 		want bool
 	}{
-		{a: "foo", b: "foo", want: true},
-		{a: float64(123456789.123456), b: float64(123456789.123456), want: true},
-		{a: float64(123456789.123456), b: "123456789.123456", want: true},
-		{a: true, b: "true", want: true},
 		{a: nil, b: "", want: true},
+		{a: "", b: nil, want: true},
+		{a: nil, b: nil, want: true},
+
+		{a: "foo", b: "foo", want: true},
+		{a: "a", b: URI("a"), want: true},
+		{a: URI("a"), b: URI("a"), want: true},
+		{a: "a", b: DNSName("a"), want: true},
+		{a: DNSName("a"), b: DNSName("a"), want: true},
+		{a: "a", b: EmailAddress("a"), want: true},
+		{a: EmailAddress("a"), b: EmailAddress("a"), want: true},
+		{a: float64(123456789.123456), b: "123456789.123456", want: true},
+		{a: float64(123456789.123456), b: float64(123456789.123456), want: true},
+		{a: true, b: "true", want: true},
+		{a: true, b: true, want: true},
+		{a: int64(1234), b: "1234", want: true},
+		{a: "1.2.3.4", b: net.ParseIP("1.2.3.4"), want: true},
+		{a: net.ParseIP("1.2.3.4"), b: net.ParseIP("1.2.3.4"), want: true},
+		{a: "1s", b: tDuration, want: true},
+		{a: tDuration, b: tDuration, want: true},
+		{a: "2013-02-03T00:00:00.000000Z", b: tTime, want: true},
+		{a: tTime, b: tTime, want: true},
+
+		{a: "foo", b: "bar", want: false},
 		{a: float64(123456789.123456), b: float64(99999.123), want: false},
 		{a: float64(123456789.123456), b: "99999.123456", want: false},
+		{a: "a", b: EmailAddress("b"), want: false},
+		{a: URI("a"), b: EmailAddress("b"), want: false},
+		{a: net.ParseIP("1.2.3.4"), b: net.ParseIP("0.0.0.0"), want: false},
+		{a: "badTimeFormat", b: tTime, want: false},
+		{a: t2Time, b: tTime, want: false},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%v,%v", tt.a, tt.b), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%T(%v),%T(%v)", tt.a, tt.a, tt.b, tt.b), func(t *testing.T) {
 			got := StringEquals(tt.a, tt.b)
 			if got != tt.want {
 				t.Errorf("got match=%v, want %v", got, tt.want)

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestStringify(t *testing.T) {
+	testTime, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
+	tests := []struct {
+		v    interface{}
+		want string
+	}{
+		{v: "foo", want: "foo"},
+		{v: int64(123456789), want: "123456789"},
+		{v: float64(123456789.123456), want: "123456789.123456"},
+		{v: true, want: "true"},
+		{v: testTime, want: "2013-02-03 00:00:00 +0000 UTC"},
+		{v: 3 * time.Second, want: "3s"},
+		{v: net.ParseIP("1.2.3.4"), want: "1.2.3.4"},
+		{v: EmailAddress("abcd@abcd"), want: "abcd@abcd"},
+		{v: URI("http://foo"), want: "http://foo"},
+		{v: DNSName("dns"), want: "dns"},
+		{v: nil, want: ""},
+		{v: map[string]string{"a": "b"}, want: "map[a:b]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("(%T) %v", tt.v, tt.v), func(t *testing.T) {
+			got := Stringify(tt.v)
+			if got != tt.want {
+				t.Errorf("got \"%s\", want \"%s\"", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringEquals(t *testing.T) {
+	tests := []struct {
+		a    interface{}
+		b    interface{}
+		want bool
+	}{
+		{a: "foo", b: "foo", want: true},
+		{a: float64(123456789.123456), b: float64(123456789.123456), want: true},
+		{a: float64(123456789.123456), b: "123456789.123456", want: true},
+		{a: true, b: "true", want: true},
+		{a: nil, b: "", want: true},
+		{a: float64(123456789.123456), b: float64(99999.123), want: false},
+		{a: float64(123456789.123456), b: "99999.123456", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v,%v", tt.a, tt.b), func(t *testing.T) {
+			got := StringEquals(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("got match=%v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -95,6 +95,7 @@ func TestStringEquals(t *testing.T) {
 		{a: "badTimeFormat", b: tTime, want: false},
 		{a: t2Time, b: tTime, want: false},
 		{a: "a=b", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: false},
+		{a: "a=b&c=d&o=o", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: false},
 		{a: "***badmapstring***", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: false},
 	}
 

--- a/mixer/pkg/adapter/instanceUtil_test.go
+++ b/mixer/pkg/adapter/instanceUtil_test.go
@@ -82,6 +82,8 @@ func TestStringEquals(t *testing.T) {
 		{a: tDuration, b: tDuration, want: true},
 		{a: "2013-02-03T00:00:00.000000Z", b: tTime, want: true},
 		{a: tTime, b: tTime, want: true},
+		{a: "a=b&c=d&e=f", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: true},
+		{a: "1234", b: int(1234), want: true},
 
 		{a: "foo", b: "bar", want: false},
 		{a: float64(123456789.123456), b: float64(99999.123), want: false},
@@ -91,6 +93,8 @@ func TestStringEquals(t *testing.T) {
 		{a: net.ParseIP("1.2.3.4"), b: net.ParseIP("0.0.0.0"), want: false},
 		{a: "badTimeFormat", b: tTime, want: false},
 		{a: t2Time, b: tTime, want: false},
+		{a: "a=b", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: false},
+		{a: "***badmapstring***", b: map[string]string{"a": "b", "c": "d", "e": "f"}, want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Adapters can use this to convert ValueType data into string.
Also, compare stringified values of two interface{} objects.

Idea is to have a shared performant code that most adapters commonly need.
