### PR TITLE
Update Cobra.go to print version on stdout

### DIFF
--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -27,9 +27,11 @@ func CobraCommand() *cobra.Command {
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if short {
-				cmd.Printf("%s\n", Info)
+// 				cmd.Printf("%s\n", Info)
+				fmt.Println(Info)
 			} else {
-				cmd.Printf("%s", Info.LongForm())
+// 				cmd.Printf("%s", Info.LongForm())
+				fmt.Println(Info.LongForm())
 			}
 		},
 	}

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -16,6 +16,7 @@ package version
 
 import (
 	"github.com/spf13/cobra"
+	"fmt"
 )
 
 // CobraCommand returns a command used to print version information.
@@ -27,10 +28,8 @@ func CobraCommand() *cobra.Command {
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if short {
-// 				cmd.Printf("%s\n", Info)
 				fmt.Println(Info)
 			} else {
-// 				cmd.Printf("%s", Info.LongForm())
 				fmt.Println(Info.LongForm())
 			}
 		},

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -15,8 +15,9 @@
 package version
 
 import (
-	"github.com/spf13/cobra"
 	"fmt"
+
+	"github.com/spf13/cobra"
 )
 
 // CobraCommand returns a command used to print version information.


### PR DESCRIPTION
Change Printf  in order to be able to parse result of command line istioctl version (ie. istioctl version | grep -I 0.5.1)