### PR TITLE
Go build: In verbose mode, also output commands in gobuild.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 # Output control
 #-----------------------------------------------------------------------------
 # Invoke make VERBOSE=1 to enable echoing of the command being executed
-VERBOSE ?= 0
+export VERBOSE ?= 0
 # Place the variable Q in front of a command to control echoing of the command being executed.
 Q = $(if $(filter 1,$VERBOSE),,@)
 # Use the variable H to add a header (equivalent to =>) to informational output

--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -15,6 +15,14 @@
 # limitations under the License.
 #
 # This script builds and link stamps the output
+
+VERBOSE=${VERBOSE:-"0"}
+V=""
+if [[ "${VERBOSE}" == "1" ]];then
+    V="-x"
+    set -x
+fi
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUT=${1:?"output path"}
@@ -22,12 +30,6 @@ VERSION_PACKAGE=${2:?"version go package"} # istio.io/istio/pkg/version
 BUILDPATH=${3:?"path to build"}
 
 set -e
-
-VERBOSE=${VERBOSE:-"0"}
-V=""
-if [[ "${VERBOSE}" == "1" ]];then
-    V="-x"
-fi
 
 GOOS=${GOOS:-linux}
 GOARCH=${GOARCH:-amd64}


### PR DESCRIPTION
This is useful for debug purposes, in order to see the entire
`go build` command line being executed.