### PR TITLE
Use correct hub variable when building test install tars

### DIFF
--- a/release/cloud_builder.sh
+++ b/release/cloud_builder.sh
@@ -91,7 +91,7 @@ if [ "${BUILD_DOCKER}" == "true" ]; then
 fi
 
 if [[ -n "${TEST_DOCKER_HUB}" ]]; then
-  VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION ISTIO_GCS=$TEST_PATH ISTIO_GCS_ISTIOCTL=istioctl-stage make istio-archive
+  VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${TEST_DOCKER_HUB} HUB=${TEST_DOCKER_HUB} VERSION=$ISTIO_VERSION TAG=$ISTIO_VERSION ISTIO_GCS=$TEST_PATH ISTIO_GCS_ISTIOCTL=istioctl-stage make istio-archive
   cp ${ISTIO_OUT}/archive/istio*z* ${OUTPUT_PATH}
   # These files are only used for testing, so use a name to help make this clear
   for TAR_FILE in ${OUTPUT_PATH}/istio?${ISTIO_VERSION}*; do


### PR DESCRIPTION
A change I made a few days ago inadvertently changed TEST_DOCKER_HUB to REL_DOCKER_HUB .

https://github.com/istio/istio/pull/3376/files#diff-2113e4c1aa9cfeb28678286d68e7a8c1

That change should have just added a HUB=${TEST_DOCKER_HUB} , but instead I incorrectly used REL_DOCKER_HUB.  This came about because I had tried to use a shared variable to pass the long list of common parameters to the two invocations of make.  I couldn't get this to work (bash kept on wanting to execute the parameters as if they were commands) so I gave up but didn't restore things properly.