### PR TITLE
Pilot renames

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	role     model.Node
+	role     model.Proxy
 	registry serviceregistry.ServiceRegistry
 
 	// proxy config flags (named identically)

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -47,8 +47,8 @@ type Environment struct {
 	MixerSAN []string
 }
 
-// Node defines the proxy attributes used by xDS identification
-type Node struct {
+// Proxy defines the proxy attributes used by xDS identification
+type Proxy struct {
 	// Type specifies the node type
 	Type NodeType
 
@@ -89,7 +89,7 @@ func IsApplicationNodeType(nType NodeType) bool {
 }
 
 // ServiceNode encodes the proxy node attributes into a URI-acceptable string
-func (node Node) ServiceNode() string {
+func (node Proxy) ServiceNode() string {
 	return strings.Join([]string{
 		string(node.Type), node.IPAddress, node.ID, node.Domain,
 	}, serviceNodeSeparator)
@@ -97,9 +97,9 @@ func (node Node) ServiceNode() string {
 }
 
 // ParseServiceNode is the inverse of service node function
-func ParseServiceNode(s string) (Node, error) {
+func ParseServiceNode(s string) (Proxy, error) {
 	parts := strings.Split(s, serviceNodeSeparator)
-	out := Node{}
+	out := Proxy{}
 
 	if len(parts) != 4 {
 		return out, fmt.Errorf("missing parts in the service node %q", s)

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestServiceNode(t *testing.T) {
 	nodes := []struct {
-		in  model.Node
+		in  model.Proxy
 		out string
 	}{
 		{
@@ -33,7 +33,7 @@ func TestServiceNode(t *testing.T) {
 			out: "sidecar~10.1.1.0~v0.default~default.svc.cluster.local",
 		},
 		{
-			in: model.Node{
+			in: model.Proxy{
 				Type:   model.Ingress,
 				ID:     "random",
 				Domain: "local",

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -247,7 +247,7 @@ type ServiceDiscovery interface {
 	// port, hostname and labels.
 	Instances(hostname string, ports []string, labels LabelsCollection) ([]*ServiceInstance, error)
 
-	// GetSidecarServiceInstances returns the service instances that co-located with a given Proxy
+	// GetProxyServiceInstances returns the service instances that co-located with a given Proxy
 	//
 	// Co-located generally means running in the same network namespace and security context.
 	//
@@ -264,7 +264,7 @@ type ServiceDiscovery interface {
 	// though with a different ServicePort and NetworkEndpoint for each.  If any of these overlapping
 	// services are not HTTP or H2-based, behavior is undefined, since the listener may not be able to
 	// determine the intendend destination of a connection without a Host header on the request.
-	GetSidecarServiceInstances(Proxy) ([]*ServiceInstance, error)
+	GetProxyServiceInstances(Proxy) ([]*ServiceInstance, error)
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.
 	// These management ports are typically used by the platform for out of band management

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -247,7 +247,12 @@ type ServiceDiscovery interface {
 	// port, hostname and labels.
 	Instances(hostname string, ports []string, labels LabelsCollection) ([]*ServiceInstance, error)
 
-	// GetSidecarServiceInstances returns the service instances that are hosted on (implemented by) a given Node
+	// GetSidecarServiceInstances returns the service instances that co-located with a given Proxy
+	//
+	// Co-located generally means running in the same network namespace and security context.
+	//
+	// A Proxy operating as a Sidecar will return a non-empty slice.  A stand-alone Proxy
+	// will return an empty slice.
 	//
 	// There are two reasons why this returns multiple ServiceInstances instead of one:
 	// - A ServiceInstance has a single NetworkEndpoint which has a single Port.  But a Service
@@ -259,7 +264,7 @@ type ServiceDiscovery interface {
 	// though with a different ServicePort and NetworkEndpoint for each.  If any of these overlapping
 	// services are not HTTP or H2-based, behavior is undefined, since the listener may not be able to
 	// determine the intendend destination of a connection without a Host header on the request.
-	GetSidecarServiceInstances(Node) ([]*ServiceInstance, error)
+	GetSidecarServiceInstances(Proxy) ([]*ServiceInstance, error)
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.
 	// These management ports are typically used by the platform for out of band management

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -293,7 +293,7 @@ func buildSidecarListenersClusters(
 		clusters = append(clusters, httpOutbound.clusters()...)
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
 			mesh:             mesh,
-			node:             node,
+			proxy:            node,
 			nodeInstances:    nodeInstances,
 			routeConfig:      nil,
 			ip:               listenAddress,
@@ -362,7 +362,7 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 // options required to build an HTTPListener
 type buildHTTPListenerOpts struct { // nolint: maligned
 	mesh             *meshconfig.MeshConfig
-	node             model.Proxy
+	proxy            model.Proxy
 	nodeInstances    []*model.ServiceInstance
 	routeConfig      *HTTPRouteConfig
 	ip               string
@@ -392,7 +392,7 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *Listener {
 	filters = append([]HTTPFilter{filter}, filters...)
 
 	if opts.mesh.MixerCheckServer != "" || opts.mesh.MixerReportServer != "" {
-		mixerConfig := buildHTTPMixerFilterConfig(opts.mesh, opts.node, opts.nodeInstances, opts.outboundListener, opts.store)
+		mixerConfig := buildHTTPMixerFilterConfig(opts.mesh, opts.proxy, opts.nodeInstances, opts.outboundListener, opts.store)
 		filter := HTTPFilter{
 			Type:   decoder,
 			Name:   MixerFilter,
@@ -572,7 +572,7 @@ func buildOutboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy, nodeI
 
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
 			mesh:             mesh,
-			node:             node,
+			proxy:            node,
 			nodeInstances:    nodeInstances,
 			routeConfig:      routeConfig,
 			ip:               WildcardAddress,
@@ -865,7 +865,7 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 			routeConfig := &HTTPRouteConfig{VirtualHosts: []*VirtualHost{host}}
 			listener = buildHTTPListener(buildHTTPListenerOpts{
 				mesh:             mesh,
-				node:             node,
+				proxy:            node,
 				nodeInstances:    nodeInstances,
 				routeConfig:      routeConfig,
 				ip:               endpoint.Address,

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -137,7 +137,7 @@ func BuildConfig(config meshconfig.ProxyConfig, pilotSAN []string) *Config {
 func buildListeners(env model.Environment, node model.Proxy) (Listeners, error) {
 	switch node.Type {
 	case model.Sidecar:
-		proxyInstances, err := env.GetSidecarServiceInstances(node)
+		proxyInstances, err := env.GetProxyServiceInstances(node)
 		if err != nil {
 			return nil, err
 		}
@@ -178,7 +178,7 @@ func buildClusters(env model.Environment, node model.Proxy) (Clusters, error) {
 	var err error
 	switch node.Type {
 	case model.Sidecar, model.Router:
-		proxyInstances, err = env.GetSidecarServiceInstances(node)
+		proxyInstances, err = env.GetProxyServiceInstances(node)
 		if err != nil {
 			return clusters, err
 		}
@@ -322,7 +322,7 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 	case model.Ingress:
 		httpConfigs, _ = buildIngressRoutes(mesh, node, nil, discovery, config)
 	case model.Sidecar:
-		proxyInstances, err := discovery.GetSidecarServiceInstances(node)
+		proxyInstances, err := discovery.GetProxyServiceInstances(node)
 		if err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -294,7 +294,7 @@ func buildSidecarListenersClusters(
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
 			mesh:             mesh,
 			proxy:            node,
-			nodeInstances:    nodeInstances,
+			proxyInstances:   nodeInstances,
 			routeConfig:      nil,
 			ip:               listenAddress,
 			port:             int(mesh.ProxyHttpPort),
@@ -363,7 +363,7 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 type buildHTTPListenerOpts struct { // nolint: maligned
 	mesh             *meshconfig.MeshConfig
 	proxy            model.Proxy
-	nodeInstances    []*model.ServiceInstance
+	proxyInstances   []*model.ServiceInstance
 	routeConfig      *HTTPRouteConfig
 	ip               string
 	port             int
@@ -392,7 +392,7 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *Listener {
 	filters = append([]HTTPFilter{filter}, filters...)
 
 	if opts.mesh.MixerCheckServer != "" || opts.mesh.MixerReportServer != "" {
-		mixerConfig := buildHTTPMixerFilterConfig(opts.mesh, opts.proxy, opts.nodeInstances, opts.outboundListener, opts.store)
+		mixerConfig := buildHTTPMixerFilterConfig(opts.mesh, opts.proxy, opts.proxyInstances, opts.outboundListener, opts.store)
 		filter := HTTPFilter{
 			Type:   decoder,
 			Name:   MixerFilter,
@@ -573,7 +573,7 @@ func buildOutboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy, nodeI
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
 			mesh:             mesh,
 			proxy:            node,
-			nodeInstances:    nodeInstances,
+			proxyInstances:   nodeInstances,
 			routeConfig:      routeConfig,
 			ip:               WildcardAddress,
 			port:             port,
@@ -770,7 +770,7 @@ func buildOutboundTCPListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 }
 
 // buildInboundListeners creates listeners for the server-side (inbound)
-// configuration for co-located service nodeInstances. The function also returns
+// configuration for co-located service proxyInstances. The function also returns
 // all inbound clusters since they are statically declared in the proxy
 // configuration and do not utilize CDS.
 func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
@@ -816,7 +816,7 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 			// Websocket enabled routes need to have an explicit use_websocket : true
 			// This setting needs to be enabled on Envoys at both sender and receiver end
 			if protocol == model.ProtocolHTTP {
-				// get all the route rules applicable to the nodeInstances
+				// get all the route rules applicable to the proxyInstances
 				rules := config.RouteRulesByDestination(nodeInstances, node.Domain)
 
 				// sort for output uniqueness
@@ -866,7 +866,7 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 			listener = buildHTTPListener(buildHTTPListenerOpts{
 				mesh:             mesh,
 				proxy:            node,
-				nodeInstances:    nodeInstances,
+				proxyInstances:   nodeInstances,
 				routeConfig:      routeConfig,
 				ip:               endpoint.Address,
 				port:             endpoint.Port,

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -600,7 +600,7 @@ func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response 
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return
 	}
-	proxyInstances, err := ds.GetSidecarServiceInstances(svcNode)
+	proxyInstances, err := ds.GetProxyServiceInstances(svcNode)
 	if err != nil {
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -600,17 +600,17 @@ func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response 
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return
 	}
-	nodeInstances, err := ds.GetSidecarServiceInstances(svcNode)
+	proxyInstances, err := ds.GetSidecarServiceInstances(svcNode)
 	if err != nil {
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return
 	}
-	if len(nodeInstances) <= 0 {
+	if len(proxyInstances) <= 0 {
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone couldn't find the given cluster node")
 		return
 	}
 	// All instances are going to have the same IP addr therefore will all be in the same AZ
-	writeResponse(response, []byte(nodeInstances[0].AvailabilityZone))
+	writeResponse(response, []byte(proxyInstances[0].AvailabilityZone))
 }
 
 // ListClusters responds to CDS requests for all outbound clusters

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -581,7 +581,7 @@ func (ds *DiscoveryService) ListEndpoints(request *restful.Request, response *re
 	writeResponse(response, out)
 }
 
-func (ds *DiscoveryService) parseDiscoveryRequest(request *restful.Request) (model.Node, error) {
+func (ds *DiscoveryService) parseDiscoveryRequest(request *restful.Request) (model.Proxy, error) {
 	nodeInfo := request.PathParameter(ServiceNode)
 	svcNode, err := model.ParseServiceNode(nodeInfo)
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v1/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery_test.go
@@ -263,7 +263,7 @@ func TestClusterDiscoveryError(t *testing.T) {
 
 func TestClusterDiscoveryError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
+	mockDiscovery.GetProxyServiceInstancesError = errors.New("mock GetProxyServiceInstances() error")
 	url := fmt.Sprintf("/v1/clusters/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -401,7 +401,7 @@ func TestRouteDiscoveryError(t *testing.T) {
 
 func TestRouteDiscoveryError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
+	mockDiscovery.GetProxyServiceInstancesError = errors.New("mock GetProxyServiceInstances() error")
 	url := fmt.Sprintf("/v1/routes/80/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -878,7 +878,7 @@ func TestRouteDiscoverySidecarError(t *testing.T) {
 
 func TestRouteDiscoverySidecarError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
+	mockDiscovery.GetProxyServiceInstancesError = errors.New("mock GetProxyServiceInstances() error")
 	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.HelloProxyV1.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -918,7 +918,7 @@ func TestListenerDiscoverySidecarError(t *testing.T) {
 
 func TestListenerDiscoverySidecarError2(t *testing.T) {
 	_, _, ds := commonSetup(t)
-	mockDiscovery.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
+	mockDiscovery.GetProxyServiceInstancesError = errors.New("mock GetProxyServiceInstances() error")
 	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
 	response := getDiscoveryResponse(ds, "GET", url, t)
 	if response.StatusCode != http.StatusServiceUnavailable {
@@ -1056,7 +1056,7 @@ func TestDiscoveryService_AvailabilityZone(t *testing.T) {
 			want:             "AvailabilityZone couldn't find the given cluster node",
 		},
 		{
-			name: "when GetSidecarServiceInstances errors return that error",
+			name: "when GetProxyServiceInstances errors return that error",
 			err:  errors.New("bang"),
 			want: "AvailabilityZone bang",
 		},
@@ -1065,8 +1065,8 @@ func TestDiscoveryService_AvailabilityZone(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, _, ds := commonSetup(t)
 			url := fmt.Sprintf("/v1/az/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
-			mock.Discovery.WantGetSidecarServiceInstances = tt.sidecarInstances
-			mockDiscovery.GetSidecarServiceInstancesError = tt.err
+			mock.Discovery.WantGetProxyServiceInstances = tt.sidecarInstances
+			mockDiscovery.GetProxyServiceInstancesError = tt.err
 			response := makeDiscoveryRequest(ds, "GET", url, t)
 			if tt.want != string(response) {
 				t.Errorf("wanted %v but received %v", tt.want, string(response))

--- a/pilot/pkg/proxy/envoy/v1/externalservice.go
+++ b/pilot/pkg/proxy/envoy/v1/externalservice.go
@@ -33,7 +33,7 @@ func buildExternalServicePort(port *routingv2.Port) *model.Port {
 	}
 }
 
-func buildExternalServiceHTTPRoutes(mesh *meshconfig.MeshConfig, node model.Node,
+func buildExternalServiceHTTPRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
 	nodeInstances []*model.ServiceInstance, config model.IstioConfigStore,
 	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
 
@@ -170,7 +170,7 @@ func buildExternalServiceCluster(mesh *meshconfig.MeshConfig,
 
 // buildExternalServiceVirtualHost from the perspective of the 'sidecar' node.
 func buildExternalServiceVirtualHost(serviceName string, externalService *routingv2.ExternalService, portName, destination string,
-	mesh *meshconfig.MeshConfig, node model.Node, port *model.Port, nodeInstances []*model.ServiceInstance,
+	mesh *meshconfig.MeshConfig, node model.Proxy, port *model.Port, nodeInstances []*model.ServiceInstance,
 	config model.IstioConfigStore) *VirtualHost {
 
 	service := &model.Service{Hostname: destination}

--- a/pilot/pkg/proxy/envoy/v1/externalservice.go
+++ b/pilot/pkg/proxy/envoy/v1/externalservice.go
@@ -34,7 +34,7 @@ func buildExternalServicePort(port *routingv2.Port) *model.Port {
 }
 
 func buildExternalServiceHTTPRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
-	nodeInstances []*model.ServiceInstance, config model.IstioConfigStore,
+	proxyInstances []*model.ServiceInstance, config model.IstioConfigStore,
 	httpConfigs HTTPRouteConfigs) HTTPRouteConfigs {
 
 	externalServiceConfigs := config.ExternalServices()
@@ -50,7 +50,7 @@ func buildExternalServiceHTTPRoutes(mesh *meshconfig.MeshConfig, node model.Prox
 				for _, host := range externalService.Hosts {
 					httpConfig.VirtualHosts = append(httpConfig.VirtualHosts,
 						buildExternalServiceVirtualHost(meshName, externalService, port.Name, host, mesh,
-							node, modelPort, nodeInstances, config))
+							node, modelPort, proxyInstances, config))
 				}
 			default:
 				// handled elsewhere

--- a/pilot/pkg/proxy/envoy/v1/externalservice.go
+++ b/pilot/pkg/proxy/envoy/v1/externalservice.go
@@ -170,7 +170,7 @@ func buildExternalServiceCluster(mesh *meshconfig.MeshConfig,
 
 // buildExternalServiceVirtualHost from the perspective of the 'sidecar' node.
 func buildExternalServiceVirtualHost(serviceName string, externalService *routingv2.ExternalService, portName, destination string,
-	mesh *meshconfig.MeshConfig, node model.Proxy, port *model.Port, nodeInstances []*model.ServiceInstance,
+	mesh *meshconfig.MeshConfig, node model.Proxy, port *model.Port, proxyInstances []*model.ServiceInstance,
 	config model.IstioConfigStore) *VirtualHost {
 
 	service := &model.Service{Hostname: destination}
@@ -181,7 +181,7 @@ func buildExternalServiceVirtualHost(serviceName string, externalService *routin
 
 	// FIXME: clusters generated if the routing rule routes traffic to other services will be constructed incorrectly
 	// FIXME: similarly, routing rules for other services that route to this external service will be constructed incorrectly
-	routes := buildDestinationHTTPRoutes(node, service, port, nodeInstances, config, buildClusterFunc)
+	routes := buildDestinationHTTPRoutes(node, service, port, proxyInstances, config, buildClusterFunc)
 
 	// inject Mixer calls per route.
 	// every route here belongs to the same destination.service, ie serviceName

--- a/pilot/pkg/proxy/envoy/v1/gateway.go
+++ b/pilot/pkg/proxy/envoy/v1/gateway.go
@@ -73,7 +73,7 @@ func buildPhysicalGatewayListener(
 
 	opts := buildHTTPListenerOpts{
 		mesh:             mesh,
-		node:             node,
+		proxy:            node,
 		nodeInstances:    nil, // only required to support deprecated mixerclient behavior
 		routeConfig:      nil,
 		ip:               WildcardAddress,

--- a/pilot/pkg/proxy/envoy/v1/gateway.go
+++ b/pilot/pkg/proxy/envoy/v1/gateway.go
@@ -74,7 +74,7 @@ func buildPhysicalGatewayListener(
 	opts := buildHTTPListenerOpts{
 		mesh:             mesh,
 		proxy:            node,
-		nodeInstances:    nil, // only required to support deprecated mixerclient behavior
+		proxyInstances:   nil, // only required to support deprecated mixerclient behavior
 		routeConfig:      nil,
 		ip:               WildcardAddress,
 		port:             int(server.Port.Number),

--- a/pilot/pkg/proxy/envoy/v1/gateway.go
+++ b/pilot/pkg/proxy/envoy/v1/gateway.go
@@ -28,7 +28,7 @@ import (
 )
 
 func buildGatewayHTTPListeners(mesh *meshconfig.MeshConfig,
-	configStore model.IstioConfigStore, node model.Node) (Listeners, error) {
+	configStore model.IstioConfigStore, node model.Proxy) (Listeners, error) {
 
 	gateways, err := configStore.List(model.Gateway.Type, model.NamespaceAll)
 	if err != nil {
@@ -66,7 +66,7 @@ func buildGatewayHTTPListeners(mesh *meshconfig.MeshConfig,
 
 func buildPhysicalGatewayListener(
 	mesh *meshconfig.MeshConfig,
-	node model.Node,
+	node model.Proxy,
 	config model.IstioConfigStore,
 	server *routing.Server,
 ) *Listener {
@@ -122,7 +122,7 @@ func tlsToSSLContext(tls *routing.Server_TLSOptions, protocol string) *SSLContex
 }
 
 // buildGatewayHTTPRoutes creates HTTP route configs for a single external port on a gateway
-func buildGatewayVirtualHosts(configStore model.IstioConfigStore, node model.Node, listenerPort int) (*HTTPRouteConfig, error) {
+func buildGatewayVirtualHosts(configStore model.IstioConfigStore, node model.Proxy, listenerPort int) (*HTTPRouteConfig, error) {
 	gateways, err := configStore.List(model.Gateway.Type, model.NamespaceAll)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func buildGatewayVirtualHosts(configStore model.IstioConfigStore, node model.Nod
 
 func buildDestinationHTTPRoutesForGatewayVirtualHost(
 	allRules []model.Config,
-	node model.Node, config model.IstioConfigStore,
+	node model.Proxy, config model.IstioConfigStore,
 	externalPort int,
 	buildCluster buildClusterFunc,
 	gatewayName string, externalHostname string) ([]*HTTPRoute, error) {

--- a/pilot/pkg/proxy/envoy/v1/ingress.go
+++ b/pilot/pkg/proxy/envoy/v1/ingress.go
@@ -35,7 +35,7 @@ func buildIngressListeners(mesh *meshconfig.MeshConfig, nodeInstances []*model.S
 
 	opts := buildHTTPListenerOpts{
 		mesh:             mesh,
-		node:             ingress,
+		proxy:            ingress,
 		nodeInstances:    nodeInstances,
 		routeConfig:      nil,
 		ip:               WildcardAddress,

--- a/pilot/pkg/proxy/envoy/v1/ingress.go
+++ b/pilot/pkg/proxy/envoy/v1/ingress.go
@@ -31,7 +31,7 @@ import (
 
 func buildIngressListeners(mesh *meshconfig.MeshConfig, nodeInstances []*model.ServiceInstance, discovery model.ServiceDiscovery,
 	config model.IstioConfigStore,
-	ingress model.Node) Listeners {
+	ingress model.Proxy) Listeners {
 
 	opts := buildHTTPListenerOpts{
 		mesh:             mesh,
@@ -67,7 +67,7 @@ func buildIngressListeners(mesh *meshconfig.MeshConfig, nodeInstances []*model.S
 	return listeners
 }
 
-func buildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Node,
+func buildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
 	nodeInstances []*model.ServiceInstance,
 	discovery model.ServiceDiscovery,
 	config model.IstioConfigStore) (HTTPRouteConfigs, string) {
@@ -150,7 +150,7 @@ func buildIngressVhostDomains(vhost string, port int) []string {
 }
 
 // buildIngressRoute translates an ingress rule to an Envoy route
-func buildIngressRoute(mesh *meshconfig.MeshConfig, node model.Node,
+func buildIngressRoute(mesh *meshconfig.MeshConfig, node model.Proxy,
 	nodeInstances []*model.ServiceInstance, rule model.Config,
 	discovery model.ServiceDiscovery,
 	config model.IstioConfigStore) ([]*HTTPRoute, string, error) {

--- a/pilot/pkg/proxy/envoy/v1/ingress.go
+++ b/pilot/pkg/proxy/envoy/v1/ingress.go
@@ -36,7 +36,7 @@ func buildIngressListeners(mesh *meshconfig.MeshConfig, nodeInstances []*model.S
 	opts := buildHTTPListenerOpts{
 		mesh:             mesh,
 		proxy:            ingress,
-		nodeInstances:    nodeInstances,
+		proxyInstances:   nodeInstances,
 		routeConfig:      nil,
 		ip:               WildcardAddress,
 		port:             80,

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -433,13 +433,13 @@ func buildJWKSURIClusterNameAndAddress(raw string) (string, string, bool, error)
 
 // buildMixerAuthFilterClusters builds the necessary clusters for the
 // JWT auth filter to fetch public keys from the specified jwks_uri.
-func buildMixerAuthFilterClusters(config model.IstioConfigStore, mesh *meshconfig.MeshConfig, nodeInstances []*model.ServiceInstance) Clusters {
+func buildMixerAuthFilterClusters(config model.IstioConfigStore, mesh *meshconfig.MeshConfig, proxyInstances []*model.ServiceInstance) Clusters {
 	type authCluster struct {
 		name   string
 		useSSL bool
 	}
 	authClusters := map[string]authCluster{}
-	for _, instance := range nodeInstances {
+	for _, instance := range proxyInstances {
 		for _, policy := range config.EndUserAuthenticationPolicySpecByDestination(instance) {
 			for _, jwt := range policy.Spec.(*mccpb.EndUserAuthenticationPolicySpec).Jwts {
 				if name, address, ssl, err := buildJWKSURIClusterNameAndAddress(jwt.JwksUri); err != nil {

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -209,7 +209,7 @@ func buildMixerOpaqueConfig(check, forward bool, destinationService string) map[
 
 // Mixer filter uses outbound configuration by default (forward attributes,
 // but not invoke check calls)  ServiceInstances belong to the Proxy.
-func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *FilterMixerConfig { // nolint: lll
+func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, proxyInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *FilterMixerConfig { // nolint: lll
 	filter := &FilterMixerConfig{
 		MixerAttributes: map[string]string{
 			AttrDestinationIP:  role.IPAddress,
@@ -241,11 +241,11 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 	var labels map[string]string
 	// Note: instances are all running on mode.Proxy named 'role'
 	// So instance labels are the workload / Proxy labels.
-	if len(nodeInstances) > 0 {
-		labels = nodeInstances[0].Labels
-		v2.DefaultDestinationService = nodeInstances[0].Service.Hostname
+	if len(proxyInstances) > 0 {
+		labels = proxyInstances[0].Labels
+		v2.DefaultDestinationService = proxyInstances[0].Service.Hostname
 		//TODO remove this once listener config is removed.
-		filter.MixerAttributes[AttrDestinationService] = nodeInstances[0].Service.Hostname
+		filter.MixerAttributes[AttrDestinationService] = proxyInstances[0].Service.Hostname
 	}
 	addStandardNodeAttributes(v2.MixerAttributes.Attributes, AttrDestinationPrefix, role, labels)
 
@@ -258,7 +258,7 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 		addStandardNodeAttributes(v2.ForwardAttributes.Attributes, AttrSourcePrefix, role, labels)
 	}
 
-	for _, instance := range nodeInstances {
+	for _, instance := range proxyInstances {
 		v2.ServiceConfigs[instance.Service.Hostname] = serviceConfig(instance.Service.Hostname, instance, config,
 			outboundRoute || mesh.DisablePolicyChecks, outboundRoute)
 	}

--- a/pilot/pkg/proxy/envoy/v1/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/mock/discovery.go
@@ -185,11 +185,11 @@ func MakeIP(service *model.Service, version int) string {
 type ServiceDiscovery struct {
 	services                        map[string]*model.Service
 	versions                        int
-	WantGetSidecarServiceInstances  []*model.ServiceInstance
+	WantGetProxyServiceInstances  []*model.ServiceInstance
 	ServicesError                   error
 	GetServiceError                 error
 	InstancesError                  error
-	GetSidecarServiceInstancesError error
+	GetProxyServiceInstancesError error
 }
 
 // ClearErrors clear errors used for mocking failures during model.ServiceDiscovery interface methods
@@ -197,7 +197,7 @@ func (sd *ServiceDiscovery) ClearErrors() {
 	sd.ServicesError = nil
 	sd.GetServiceError = nil
 	sd.InstancesError = nil
-	sd.GetSidecarServiceInstancesError = nil
+	sd.GetProxyServiceInstancesError = nil
 }
 
 // Services implements discovery interface
@@ -247,13 +247,13 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 	return out, sd.InstancesError
 }
 
-// GetSidecarServiceInstances implements discovery interface
-func (sd *ServiceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
-	if sd.GetSidecarServiceInstancesError != nil {
-		return nil, sd.GetSidecarServiceInstancesError
+// GetProxyServiceInstances implements discovery interface
+func (sd *ServiceDiscovery) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+	if sd.GetProxyServiceInstancesError != nil {
+		return nil, sd.GetProxyServiceInstancesError
 	}
-	if sd.WantGetSidecarServiceInstances != nil {
-		return sd.WantGetSidecarServiceInstances, nil
+	if sd.WantGetProxyServiceInstances != nil {
+		return sd.WantGetProxyServiceInstances, nil
 	}
 	out := make([]*model.ServiceInstance, 0)
 	for _, service := range sd.services {
@@ -267,7 +267,7 @@ func (sd *ServiceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*mod
 			}
 		}
 	}
-	return out, sd.GetSidecarServiceInstancesError
+	return out, sd.GetProxyServiceInstancesError
 }
 
 // ManagementPorts implements discovery interface

--- a/pilot/pkg/proxy/envoy/v1/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/mock/discovery.go
@@ -49,25 +49,25 @@ var (
 	}
 	HelloInstanceV0 = MakeIP(HelloService, 0)
 	HelloInstanceV1 = MakeIP(HelloService, 1)
-	HelloProxyV0    = model.Node{
+	HelloProxyV0    = model.Proxy{
 		Type:      model.Sidecar,
 		IPAddress: HelloInstanceV0,
 		ID:        "v0.default",
 		Domain:    "default.svc.cluster.local",
 	}
-	HelloProxyV1 = model.Node{
+	HelloProxyV1 = model.Proxy{
 		Type:      model.Sidecar,
 		IPAddress: HelloInstanceV1,
 		ID:        "v1.default",
 		Domain:    "default.svc.cluster.local",
 	}
-	Ingress = model.Node{
+	Ingress = model.Proxy{
 		Type:      model.Ingress,
 		IPAddress: "10.3.3.3",
 		ID:        "ingress.default",
 		Domain:    "default.svc.cluster.local",
 	}
-	Router = model.Node{
+	Router = model.Proxy{
 		Type:      model.Router,
 		IPAddress: "10.3.3.5",
 		ID:        "router.default",
@@ -248,7 +248,7 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 }
 
 // GetSidecarServiceInstances implements discovery interface
-func (sd *ServiceDiscovery) GetSidecarServiceInstances(node model.Node) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	if sd.GetSidecarServiceInstancesError != nil {
 		return nil, sd.GetSidecarServiceInstancesError
 	}

--- a/pilot/pkg/proxy/envoy/v1/policy.go
+++ b/pilot/pkg/proxy/envoy/v1/policy.go
@@ -37,7 +37,7 @@ func isDestinationExcludedForMTLS(serviceName string, mtlsExcludedServices []str
 
 // applyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
 func applyClusterPolicy(cluster *Cluster,
-	nodeInstances []*model.ServiceInstance,
+	proxyInstances []*model.ServiceInstance,
 	config model.IstioConfigStore,
 	mesh *meshconfig.MeshConfig,
 	accounts model.ServiceAccounts,
@@ -63,7 +63,7 @@ func applyClusterPolicy(cluster *Cluster,
 	}
 
 	// apply destination policies
-	policyConfig := config.Policy(nodeInstances, cluster.hostname, cluster.labels)
+	policyConfig := config.Policy(proxyInstances, cluster.hostname, cluster.labels)
 
 	// if no policy is configured apply destination rule if one exists
 	if policyConfig == nil {

--- a/pilot/pkg/proxy/envoy/v1/watcher.go
+++ b/pilot/pkg/proxy/envoy/v1/watcher.go
@@ -56,7 +56,7 @@ type CertSource struct {
 
 type watcher struct {
 	agent    proxy.Agent
-	role     model.Node
+	role     model.Proxy
 	config   meshconfig.ProxyConfig
 	certs    []CertSource
 	pilotSAN []string
@@ -64,7 +64,7 @@ type watcher struct {
 
 // NewWatcher creates a new watcher instance from a proxy agent and a set of monitored certificate paths
 // (directories with files in them)
-func NewWatcher(config meshconfig.ProxyConfig, agent proxy.Agent, role model.Node,
+func NewWatcher(config meshconfig.ProxyConfig, agent proxy.Agent, role model.Proxy,
 	certs []CertSource, pilotSAN []string) Watcher {
 	return &watcher{
 		agent:    agent,

--- a/pilot/pkg/proxy/envoy/v1/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/v1/watcher_test.go
@@ -57,7 +57,7 @@ func TestRunReload(t *testing.T) {
 		},
 	}
 	config := model.DefaultProxyConfig()
-	node := model.Node{
+	node := model.Proxy{
 		Type: model.Ingress,
 		ID:   "random",
 	}
@@ -176,7 +176,7 @@ func Test_watcher_retrieveAZ(t *testing.T) {
 					called <- true
 				},
 			}
-			node := model.Node{
+			node := model.Proxy{
 				Type:      tt.nodeType,
 				ID:        "id",
 				Domain:    "domain",

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -125,7 +125,7 @@ func (c *Controller) Instances(hostname string, ports []string,
 }
 
 // GetSidecarServiceInstances lists service instances hosted on a given node
-func (c *Controller) GetSidecarServiceInstances(node model.Node) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	out := make([]*model.ServiceInstance, 0)
 	var errs error
 	for _, r := range c.registries {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -124,12 +124,12 @@ func (c *Controller) Instances(hostname string, ports []string,
 	return instances, errs
 }
 
-// GetSidecarServiceInstances lists service instances hosted on a given node
-func (c *Controller) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+// GetProxyServiceInstances lists service instances co-located with a given proxy
+func (c *Controller) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	out := make([]*model.ServiceInstance, 0)
 	var errs error
 	for _, r := range c.registries {
-		instances, err := r.GetSidecarServiceInstances(node)
+		instances, err := r.GetProxyServiceInstances(node)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {
@@ -139,7 +139,7 @@ func (c *Controller) GetSidecarServiceInstances(node model.Proxy) ([]*model.Serv
 
 	if len(out) > 0 {
 		if errs != nil {
-			log.Warnf("GetSidecarServiceInstances() found match but encountered an error: %v", errs)
+			log.Warnf("GetProxyServiceInstances() found match but encountered an error: %v", errs)
 		}
 		return out, nil
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -178,7 +178,7 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	aggregateCtl := buildMockController()
 
 	// Get Instances from mockAdapter1
-	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Node{IPAddress: mock.HelloInstanceV0})
+	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
 	if err != nil {
 		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	}
 
 	// Get Instances from mockAdapter2
-	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Node{IPAddress: mock.MakeIP(mock.WorldService, 1)})
+	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
 	if err != nil {
 		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
 	}
@@ -212,7 +212,7 @@ func TestGetSidecarServiceInstancesError(t *testing.T) {
 	discovery1.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
 
 	// Get Instances from client with error
-	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Node{IPAddress: mock.HelloInstanceV0})
+	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
 	if err == nil {
 		t.Fatal("Aggregate controller should return error if one discovery client experiences " +
 			"error and no instances are found")
@@ -222,7 +222,7 @@ func TestGetSidecarServiceInstancesError(t *testing.T) {
 	}
 
 	// Get Instances from client without error
-	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Node{IPAddress: mock.MakeIP(mock.WorldService, 1)})
+	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
 	if err != nil {
 		t.Fatal("Aggregate controller should not return error if instances are found")
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -174,16 +174,16 @@ func TestGetServiceError(t *testing.T) {
 	}
 }
 
-func TestGetSidecarServiceInstances(t *testing.T) {
+func TestGetProxyServiceInstances(t *testing.T) {
 	aggregateCtl := buildMockController()
 
 	// Get Instances from mockAdapter1
-	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
+	instances, err := aggregateCtl.GetProxyServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
 	if err != nil {
-		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
+		t.Fatalf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetProxyServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.HelloService.Hostname {
@@ -192,12 +192,12 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	}
 
 	// Get Instances from mockAdapter2
-	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
+	instances, err = aggregateCtl.GetProxyServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
 	if err != nil {
-		t.Fatalf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
+		t.Fatalf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetProxyServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.WorldService.Hostname {
@@ -206,28 +206,28 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	}
 }
 
-func TestGetSidecarServiceInstancesError(t *testing.T) {
+func TestGetProxyServiceInstancesError(t *testing.T) {
 	aggregateCtl := buildMockController()
 
-	discovery1.GetSidecarServiceInstancesError = errors.New("mock GetSidecarServiceInstances() error")
+	discovery1.GetProxyServiceInstancesError = errors.New("mock GetProxyServiceInstances() error")
 
 	// Get Instances from client with error
-	instances, err := aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
+	instances, err := aggregateCtl.GetProxyServiceInstances(model.Proxy{IPAddress: mock.HelloInstanceV0})
 	if err == nil {
 		t.Fatal("Aggregate controller should return error if one discovery client experiences " +
 			"error and no instances are found")
 	}
 	if len(instances) != 0 {
-		t.Fatal("GetSidecarServiceInstances() should return no instances is client experiences error")
+		t.Fatal("GetProxyServiceInstances() should return no instances is client experiences error")
 	}
 
 	// Get Instances from client without error
-	instances, err = aggregateCtl.GetSidecarServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
+	instances, err = aggregateCtl.GetProxyServiceInstances(model.Proxy{IPAddress: mock.MakeIP(mock.WorldService, 1)})
 	if err != nil {
 		t.Fatal("Aggregate controller should not return error if instances are found")
 	}
 	if len(instances) != 5 {
-		t.Fatalf("Returned GetSidecarServiceInstances' amount %d is not correct", len(instances))
+		t.Fatalf("Returned GetProxyServiceInstances' amount %d is not correct", len(instances))
 	}
 	for _, inst := range instances {
 		if inst.Service.Hostname != mock.WorldService.Hostname {

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -100,10 +100,10 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList 
 	return instances, nil
 }
 
-// GetSidecarServiceInstances returns all service instances running on a particular node
+// GetSidecarServiceInstances returns all service instances running on a particular proxy
 // Cloud Foundry integration is currently ingress-only -- there is no sidecar support yet.
 // So this function always returns an empty slice.
-func (sd *ServiceDiscovery) GetSidecarServiceInstances(node model.Node) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) GetSidecarServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
 

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -100,10 +100,10 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList 
 	return instances, nil
 }
 
-// GetSidecarServiceInstances returns all service instances running on a particular proxy
+// GetProxyServiceInstances returns all service instances running on a particular proxy
 // Cloud Foundry integration is currently ingress-only -- there is no sidecar support yet.
 // So this function always returns an empty slice.
-func (sd *ServiceDiscovery) GetSidecarServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
 

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -227,7 +227,7 @@ func TestServiceDiscovery_GetSidecarServiceInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
-	instances, err := state.serviceDiscovery.GetSidecarServiceInstances(model.Node{IPAddress: "not-checked"})
+	instances, err := state.serviceDiscovery.GetSidecarServiceInstances(model.Proxy{IPAddress: "not-checked"})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(instances).To(gomega.BeEmpty())
 }

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -223,11 +223,11 @@ func TestServiceDiscovery_Instances_ClientError(t *testing.T) {
 	g.Expect(serviceModel).To(gomega.BeNil())
 }
 
-func TestServiceDiscovery_GetSidecarServiceInstances(t *testing.T) {
+func TestServiceDiscovery_GetProxyServiceInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
-	instances, err := state.serviceDiscovery.GetSidecarServiceInstances(model.Proxy{IPAddress: "not-checked"})
+	instances, err := state.serviceDiscovery.GetProxyServiceInstances(model.Proxy{IPAddress: "not-checked"})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(instances).To(gomega.BeEmpty())
 }

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -151,8 +151,8 @@ func portMatch(instance *model.ServiceInstance, portMap map[string]bool) bool {
 	return false
 }
 
-// GetSidecarServiceInstances lists service instances for a given set of IPv4 addresses.
-func (c *Controller) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+// GetProxyServiceInstances lists service instances co-located with a given proxy
+func (c *Controller) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	data, err := c.getServices()
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -152,7 +152,7 @@ func portMatch(instance *model.ServiceInstance, portMap map[string]bool) bool {
 }
 
 // GetSidecarServiceInstances lists service instances for a given set of IPv4 addresses.
-func (c *Controller) GetSidecarServiceInstances(node model.Node) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	data, err := c.getServices()
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -349,7 +349,7 @@ func TestServicesError(t *testing.T) {
 	}
 }
 
-func TestGetSidecarServiceInstances(t *testing.T) {
+func TestGetProxyServiceInstances(t *testing.T) {
 	ts := newServer()
 	defer ts.Server.Close()
 	controller, err := NewController(ts.Server.URL, 3*time.Second)
@@ -357,21 +357,21 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	services, err := controller.GetSidecarServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
+	services, err := controller.GetProxyServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
 	if err != nil {
-		t.Errorf("client encountered error during GetSidecarServiceInstances(): %v", err)
+		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
 	}
 	if len(services) != 1 {
-		t.Errorf("GetSidecarServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
+		t.Errorf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
 	}
 
 	if services[0].Service.Hostname != serviceHostname("productpage") {
-		t.Errorf("GetSidecarServiceInstances() wrong service instance returned => hostname %q, want %q",
+		t.Errorf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
 			services[0].Service.Hostname, serviceHostname("productpage"))
 	}
 }
 
-func TestGetSidecarServiceInstancesError(t *testing.T) {
+func TestGetProxyServiceInstancesError(t *testing.T) {
 	ts := newServer()
 	controller, err := NewController(ts.Server.URL, 3*time.Second)
 	if err != nil {
@@ -380,11 +380,11 @@ func TestGetSidecarServiceInstancesError(t *testing.T) {
 	}
 
 	ts.Server.Close()
-	instances, err := controller.GetSidecarServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
+	instances, err := controller.GetProxyServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
 	if err == nil {
-		t.Error("GetSidecarServiceInstances() should return error when client experiences connection problem")
+		t.Error("GetProxyServiceInstances() should return error when client experiences connection problem")
 	}
 	if len(instances) != 0 {
-		t.Errorf("GetSidecarServiceInstances() returned wrong # of instances: %q, want 0", len(instances))
+		t.Errorf("GetProxyServiceInstances() returned wrong # of instances: %q, want 0", len(instances))
 	}
 }

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -357,7 +357,7 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	services, err := controller.GetSidecarServiceInstances(model.Node{IPAddress: "172.19.0.11"})
+	services, err := controller.GetSidecarServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
 	if err != nil {
 		t.Errorf("client encountered error during GetSidecarServiceInstances(): %v", err)
 	}
@@ -380,7 +380,7 @@ func TestGetSidecarServiceInstancesError(t *testing.T) {
 	}
 
 	ts.Server.Close()
-	instances, err := controller.GetSidecarServiceInstances(model.Node{IPAddress: "172.19.0.11"})
+	instances, err := controller.GetSidecarServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
 	if err == nil {
 		t.Error("GetSidecarServiceInstances() should return error when client experiences connection problem")
 	}

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery.go
@@ -93,7 +93,7 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 }
 
 // GetSidecarServiceInstances implements a service catalog operation
-func (sd *serviceDiscovery) GetSidecarServiceInstances(node model.Node) ([]*model.ServiceInstance, error) {
+func (sd *serviceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
 		log.Warnf("could not list Eureka instances: %v", err)

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery.go
@@ -92,8 +92,8 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 	return out, nil
 }
 
-// GetSidecarServiceInstances implements a service catalog operation
-func (sd *serviceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+// GetProxyServiceInstances returns service instances co-located with a proxy
+func (sd *serviceDiscovery) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
 		log.Warnf("could not list Eureka instances: %v", err)
@@ -103,7 +103,7 @@ func (sd *serviceDiscovery) GetSidecarServiceInstances(node model.Proxy) ([]*mod
 
 	out := make([]*model.ServiceInstance, 0)
 	for _, instance := range convertServiceInstances(services, apps) {
-		if node.IPAddress == instance.Endpoint.Address {
+		if proxy.IPAddress == instance.Endpoint.Address {
 			out = append(out, instance)
 		}
 	}

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
@@ -92,12 +92,12 @@ func TestServiceDiscoveryClientError(t *testing.T) {
 		t.Error("Instances() should return nil on error")
 	}
 
-	hostInstances, err := sd.GetSidecarServiceInstances(model.Proxy{})
+	hostInstances, err := sd.GetProxyServiceInstances(model.Proxy{})
 	if err == nil {
-		t.Error("GetSidecarServiceInstances() should return error")
+		t.Error("GetProxyServiceInstances() should return error")
 	}
 	if hostInstances != nil {
-		t.Error("GetSidecarServiceInstances() should return nil on error")
+		t.Error("GetProxyServiceInstances() should return nil on error")
 	}
 }
 
@@ -139,7 +139,7 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	}
 }
 
-func TestServiceDiscoveryGetSidecarServiceInstances(t *testing.T) {
+func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	cl := &mockClient{
 		apps: []*application{
 			{
@@ -171,9 +171,9 @@ func TestServiceDiscoveryGetSidecarServiceInstances(t *testing.T) {
 	}
 
 	for _, tt := range instanceTests {
-		instances, err := sd.GetSidecarServiceInstances(tt.node)
+		instances, err := sd.GetProxyServiceInstances(tt.node)
 		if err != nil {
-			t.Errorf("GetSidecarServiceInstances() encountered unexpected error: %v", err)
+			t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 		}
 		sortServiceInstances(instances)
 		if err := compare(t, instances, tt.instances); err != nil {

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
@@ -92,7 +92,7 @@ func TestServiceDiscoveryClientError(t *testing.T) {
 		t.Error("Instances() should return nil on error")
 	}
 
-	hostInstances, err := sd.GetSidecarServiceInstances(model.Node{})
+	hostInstances, err := sd.GetSidecarServiceInstances(model.Proxy{})
 	if err == nil {
 		t.Error("GetSidecarServiceInstances() should return error")
 	}
@@ -158,11 +158,11 @@ func TestServiceDiscoveryGetSidecarServiceInstances(t *testing.T) {
 	serviceB := makeService("b.default.svc.local", []int{7070}, nil)
 
 	instanceTests := []struct {
-		node      model.Node
+		node      model.Proxy
 		instances []*model.ServiceInstance
 	}{
 		{
-			node: model.Node{IPAddress: "10.0.0.1"},
+			node: model.Proxy{IPAddress: "10.0.0.1"},
 			instances: []*model.ServiceInstance{
 				makeServiceInstance(serviceA, "10.0.0.1", 9090, nil),
 				makeServiceInstance(serviceB, "10.0.0.1", 7070, nil),

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -337,7 +337,7 @@ func (c *Controller) Instances(hostname string, ports []string,
 }
 
 // GetSidecarServiceInstances implements a service catalog operation
-func (c *Controller) GetSidecarServiceInstances(svcNode model.Node) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetSidecarServiceInstances(svcNode model.Proxy) ([]*model.ServiceInstance, error) {
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -336,17 +336,17 @@ func (c *Controller) Instances(hostname string, ports []string,
 	return nil, nil
 }
 
-// GetSidecarServiceInstances implements a service catalog operation
-func (c *Controller) GetSidecarServiceInstances(svcNode model.Proxy) ([]*model.ServiceInstance, error) {
+// GetProxyServiceInstances returns service instances co-located with a given proxy
+func (c *Controller) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {
 		ep := *item.(*v1.Endpoints)
 		for _, ss := range ep.Subsets {
 			for _, ea := range ss.Addresses {
-				if svcNode.IPAddress == ea.IP {
+				if proxy.IPAddress == ea.IP {
 					if kubeNodes[ea.IP] == nil {
-						err := parseKubeServiceNode(ea.IP, &svcNode, kubeNodes)
+						err := parseKubeServiceNode(ea.IP, &proxy, kubeNodes)
 						if err != nil {
 							return out, err
 						}

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -221,7 +221,7 @@ func TestController_getPodAZ(t *testing.T) {
 
 }
 
-func TestGetSidecarServiceInstances(t *testing.T) {
+func TestGetProxyServiceInstances(t *testing.T) {
 	controller := makeFakeKubeAPIController()
 
 	k8sSaOnVM := "acct4"
@@ -244,25 +244,25 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	svcNode.IPAddress = "128.0.0.1"
 	svcNode.ID = "pod1.nsA"
 	svcNode.Domain = "nsA.svc.cluster.local"
-	services, err := controller.GetSidecarServiceInstances(svcNode)
+	services, err := controller.GetProxyServiceInstances(svcNode)
 	if err != nil {
-		t.Errorf("client encountered error during GetSidecarServiceInstances(): %v", err)
+		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
 	}
 
 	if len(services) != 1 {
-		t.Errorf("GetSidecarServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
+		t.Errorf("GetProxyServiceInstances() returned wrong # of endpoints => %q, want 1", len(services))
 	}
 
 	hostname := serviceHostname("svc1", "nsA", domainSuffix)
 	if services[0].Service.Hostname != hostname {
-		t.Errorf("GetSidecarServiceInstances() wrong service instance returned => hostname %q, want %q",
+		t.Errorf("GetProxyServiceInstances() wrong service instance returned => hostname %q, want %q",
 			services[0].Service.Hostname, hostname)
 	}
 
 	svcNode.Domain = "nsWRONG.svc.cluster.local"
-	_, err = controller.GetSidecarServiceInstances(svcNode)
+	_, err = controller.GetProxyServiceInstances(svcNode)
 	if err == nil {
-		t.Errorf("GetSidecarServiceInstances() should have returned error for unknown domain.")
+		t.Errorf("GetProxyServiceInstances() should have returned error for unknown domain.")
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -239,7 +239,7 @@ func TestGetSidecarServiceInstances(t *testing.T) {
 	portNames := []string{"test-port"}
 	createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
 
-	var svcNode model.Node
+	var svcNode model.Proxy
 	svcNode.Type = model.Ingress
 	svcNode.IPAddress = "128.0.0.1"
 	svcNode.ID = "pod1.nsA"

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -200,7 +200,7 @@ func parseDomain(nodeDomain string) (namespace string, err error) {
 	return
 }
 
-func parseKubeServiceNode(IPAddress string, node *model.Node, kubeNodes map[string]*kubeServiceNode) (err error) {
+func parseKubeServiceNode(IPAddress string, node *model.Proxy, kubeNodes map[string]*kubeServiceNode) (err error) {
 	podname, namespace, err := parsePodID(node.ID)
 	if err != nil {
 		return

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -370,7 +370,7 @@ func TestProbesToPortsConversion(t *testing.T) {
 }
 
 func TestParseKubeServiceNode(t *testing.T) {
-	var svcNode model.Node
+	var svcNode model.Proxy
 	ipaddr := "128.0.0.1"
 	kubeNodes := make(map[string]*kubeServiceNode)
 
@@ -393,7 +393,7 @@ func TestParseKubeServiceNode(t *testing.T) {
 }
 
 func TestParseKubeServiceNodeErrors(t *testing.T) {
-	var svcNode model.Node
+	var svcNode model.Proxy
 	ipaddr := "128.0.0.1"
 	kubeNodes := make(map[string]*kubeServiceNode)
 


### PR DESCRIPTION
this is meant to clean-up some confusion in the Pilot models:

- `model.Node` --> `model.Proxy`
- `GetSidecarServiceInstances` --> `GetProxyServiceInstances`

Rationale: In Kubernetes, "Node" means "container host."  But here we mean a proxy.  A proxy is often a "sidecar" but may also be a standalone ingress proxy deployed to a VM.
