### PR TITLE
lint / format fixes

### DIFF
--- a/mixer/pkg/runtime2/runtime.go
+++ b/mixer/pkg/runtime2/runtime.go
@@ -51,8 +51,6 @@ type Runtime struct {
 
 	dispatcher *dispatcher.Dispatcher
 
-	env adapter.Env
-
 	store store.Store
 
 	handlerPool *pool.GoroutinePool
@@ -172,7 +170,9 @@ func (c *Runtime) processNewConfig() {
 
 	log.Debugf("New routes in effect:\n%s", newRoutes)
 
-	cleanupHandlers(oldContext, oldHandlers, newHandlers, maxCleanupDuration)
+	if err := cleanupHandlers(oldContext, oldHandlers, newHandlers, maxCleanupDuration); err != nil {
+		log.Errorf("Failed to cleanup handlers: %v", err)
+	}
 }
 
 // maxCleanupDuration is the maximum amount of time cleanup operation will wait

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -71,9 +71,6 @@ type Args struct {
 	// For kubernetes services it is svc.cluster.local
 	ConfigIdentityAttributeDomain string
 
-	// Enables use of pkg/runtime2, instead of pkg/runtime.
-	UseNewRuntime bool
-
 	// The logging options to use
 	LoggingOptions *log.Options
 
@@ -92,6 +89,9 @@ type Args struct {
 
 	// Port to use for exposing mixer self-monitoring information
 	MonitoringPort uint16
+
+	// Enables use of pkg/runtime2, instead of pkg/runtime.
+	UseNewRuntime bool
 
 	// Enables gRPC-level tracing
 	EnableGRPCTracing bool

--- a/mixer/test/client/check_report_disable/check_report_disable_test.go
+++ b/mixer/test/client/check_report_disable/check_report_disable_test.go
@@ -22,14 +22,6 @@ import (
 	"istio.io/istio/mixer/test/client/env"
 )
 
-const checkOnlyFlags = `
-                   "mixer_check": "on",
-`
-
-const reportOnlyFlags = `
-                   "mixer_report": "on",
-`
-
 func TestCheckReportDisable(t *testing.T) {
 	s := env.NewTestSetup(env.CheckReportDisableTest, t)
 

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/protobuf/jsonpb"
-
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -15,10 +15,9 @@
 package model
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
-
-	"fmt"
 
 	routing "istio.io/api/routing/v1alpha2"
 )

--- a/pilot/pkg/proxy/envoy/v1/gateway.go
+++ b/pilot/pkg/proxy/envoy/v1/gateway.go
@@ -19,12 +19,12 @@ import (
 	"strconv"
 	"strings"
 
+	"go.uber.org/zap"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	routing "istio.io/api/routing/v1alpha2"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
-
-	"go.uber.org/zap"
 )
 
 func buildGatewayHTTPListeners(mesh *meshconfig.MeshConfig,

--- a/pilot/pkg/proxy/envoy/v2/mesh.go
+++ b/pilot/pkg/proxy/envoy/v2/mesh.go
@@ -595,17 +595,6 @@ func (le labelEndpoints) getEndpointsMatching(labels map[string]string) endpoint
 	return out
 }
 
-// addLabelValue adds mapping to ep for attribute with labelName and value.
-func (le labelEndpoints) addLabelValue(labelName, value string, ep *Endpoint) {
-	labelKey := labelName + nameValueSeparator + value
-	epSet, found := le[labelKey]
-	if !found {
-		epSet = make(endpointSet)
-		le[labelKey] = epSet
-	}
-	epSet[ep] = true
-}
-
 // addLabelValues adds mappings to ep for each of the multi-valued attribute with name labelName.
 func (le labelEndpoints) addLabelValues(labelName string, values []string, ep *Endpoint) {
 	for _, value := range values {
@@ -1003,24 +992,6 @@ func getDestinationRuleType(ruleName string) (DestinationRuleType, string, *net.
 		return DestinationRuleName, ruleName, nil
 	}
 	return DestinationRuleService, ruleName, nil
-}
-
-// getUpdatedLabels returns a new map with appropriate attr name value appended to labels or the supplied labels depending on drt.
-// For rule names that correspond to destination service, destination ip or the destination short service name, the attrValue and respective attrName
-// are appended to labels. For CIDRs or wildcard domains that cannot be directly looked up and needs to be matched with each individual endpoint, labels
-// is returned as-is.
-func (drt DestinationRuleType) getUpdatedLabels(labels map[string]string, attrValue string) map[string]string {
-	switch drt {
-	case DestinationRuleService:
-		return newMapWithLabelValue(labels, DestinationService.AttrName(), attrValue)
-	case DestinationRuleIP:
-		return newMapWithLabelValue(labels, DestinationIP.AttrName(), attrValue)
-	case DestinationRuleName:
-		return newMapWithLabelValue(labels, DestinationName.AttrName(), attrValue)
-	default:
-		// Direct matches will not work. Scoping is done later.
-		return labels
-	}
 }
 
 // AttrName returns the string value of attr.

--- a/pilot/pkg/proxy/envoy/v2/mesh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/mesh_test.go
@@ -25,13 +25,6 @@ import (
 const (
 	testService1 = "test-service-1"
 	testService2 = "test-service-2"
-	testLabelApp = "app"
-	testLabelVer = "version"
-	testLabelEnv = "environment"
-	testLabelExp = "experiment"
-	testLabelShd = "shard"
-	testSubset1  = "test-subset-1"
-	testSubset2  = "test-subset-2"
 )
 
 // Enums used to tweak attributes while building an endpoint for testing.
@@ -68,13 +61,6 @@ var (
 		diffUser,
 		diffServiceOrder,
 		diffDomainOrder,
-	}
-	allTestLabels = []string{
-		testLabelApp,
-		testLabelVer,
-		testLabelEnv,
-		testLabelExp,
-		testLabelShd,
 	}
 
 	// Test domain sets to associate with a service.
@@ -476,22 +462,6 @@ func assertEqualEndpointLists(t *testing.T, expected, actual []*Endpoint) {
 	if len(expected) != len(actual) {
 		t.Errorf("expected endpoint count: %d do not tally with actual count: %d", len(expected), len(actual))
 	}
-}
-
-// epListDebugInfo prints out a limited set of endpoint attributes in the supplied endpoint list.
-func epListDebugInfo(epList []*Endpoint) string {
-	epListDebugInfo := "["
-	for _, ep := range epList {
-		if ep == nil {
-			continue
-		}
-		if len(epListDebugInfo) > 1 {
-			epListDebugInfo += ", "
-		}
-		epListDebugInfo += epDebugInfo(ep)
-	}
-	epListDebugInfo += "]"
-	return epListDebugInfo
 }
 
 // epDebugInfo prints out a limited set of endpoint attributes for the supplied endpoint.

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -63,7 +63,7 @@ const (
 	listenedNamespaceKey = "NAMESPACE"
 )
 
-type cliOptions struct {
+type cliOptions struct { // nolint: maligned
 	listenedNamespace       string
 	istioCaStorageNamespace string
 	kubeConfigFile          string

--- a/security/cmd/node_agent_k8s/workload/main.go
+++ b/security/cmd/node_agent_k8s/workload/main.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -64,7 +63,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to connect with server %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() // nolint: errcheck
 
 	client := pb.NewWorkloadServiceClient(conn)
 	for i := 0; i < 100; i++ {

--- a/security/pkg/probe/controller.go
+++ b/security/pkg/probe/controller.go
@@ -169,11 +169,8 @@ func (c *LivenessCheckController) checkGrpcServer() error {
 func (c *LivenessCheckController) Run() {
 	go func() {
 		t := time.NewTicker(c.interval)
-		for {
-			select {
-			case <-t.C:
-				c.livenessProbe.SetAvailable(c.checkGrpcServer())
-			}
+		for range t.C {
+			c.livenessProbe.SetAvailable(c.checkGrpcServer())
 		}
 	}()
 }

--- a/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
+++ b/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -36,8 +37,6 @@ import (
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"google.golang.org/grpc"
-
-	"net/url"
 
 	"istio.io/istio/pilot/pkg/model"
 	envoy "istio.io/istio/pilot/pkg/proxy/envoy/v1"

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -16,12 +16,11 @@ package pilot
 
 import (
 	"flag"
+	"os"
 	"strconv"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-
-	"os"
 
 	"istio.io/istio/pkg/log"
 	tutil "istio.io/istio/tests/e2e/tests/pilot/util"

--- a/tests/e2e/tests/pilot/routing_to_egress_test.go
+++ b/tests/e2e/tests/pilot/routing_to_egress_test.go
@@ -26,9 +26,8 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 
-	tutil "istio.io/istio/tests/e2e/tests/pilot/util"
-
 	"istio.io/istio/pkg/log"
+	tutil "istio.io/istio/tests/e2e/tests/pilot/util"
 )
 
 type routingToEgress struct {

--- a/tests/e2e/tests/pilot/util/infra.go
+++ b/tests/e2e/tests/pilot/util/infra.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
@@ -26,9 +27,11 @@ import (
 	"io"
 	"io/ioutil"
 	"math/big"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -36,11 +39,6 @@ import (
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"bufio"
-	"text/template"
-
-	"os"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/config/kube/crd"

--- a/tests/e2e/tests/pilot/util/util.go
+++ b/tests/e2e/tests/pilot/util/util.go
@@ -20,9 +20,8 @@ import (
 	"fmt"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
-
 	"github.com/golang/sync/errgroup"
+	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/log"
 )


### PR DESCRIPTION
The following lint errors are appearing on my environment for
some reasons -- possibly due to go 1.10rc2. Basically the fixes
themselves would look like good things to me.

Also I ran fmt.sh to clean up the code a bit.

Here are the error messages:

```
mixer/pkg/runtime2/runtime.go:54:2:error: field env is unused (U1000) (megacheck)
mixer/pkg/runtime2/runtime.go:54:2:error: unused struct field istio.io/istio/mixer/pkg/runtime2.Runtime.env (structcheck)
mixer/pkg/runtime2/runtime.go:178:17:error: error return value not checked (cleanupHandlers(oldContext, oldHandlers, newHandlers, maxCleanupDuration)) (errcheck)
mixer/pkg/server/args.go:32:11:error: struct of size 208 could be 200 (maligned)
mixer/test/client/check_report_disable/check_report_disable_test.go:25:7:error: const checkOnlyFlags is unused (U1000) (megacheck)
mixer/test/client/check_report_disable/check_report_disable_test.go:29:7:error: const reportOnlyFlags is unused (U1000) (megacheck)
mixer/test/client/check_report_disable/check_report_disable_test.go:29:7:error: unused variable or constant reportOnlyFlags (varcheck)
mixer/test/client/check_report_disable/check_report_disable_test.go:25:7:error: unused variable or constant checkOnlyFlags (varcheck)
pilot/pkg/proxy/envoy/v2/mesh.go:599:26:error: func labelEndpoints.addLabelValue is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh.go:1012:32:error: func DestinationRuleType.getUpdatedLabels is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:72:2:error: unused variable or constant allTestLabels (varcheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:34:2:error: unused variable or constant testSubset2 (varcheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:482:6:error: func epListDebugInfo is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:30:2:error: const testLabelEnv is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:29:2:error: const testLabelVer is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:28:2:error: const testLabelApp is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:33:2:error: unused variable or constant testSubset1 (varcheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:72:2:error: var allTestLabels is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:34:2:error: const testSubset2 is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:33:2:error: const testSubset1 is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:32:2:error: const testLabelShd is unused (U1000) (megacheck)
pilot/pkg/proxy/envoy/v2/mesh_test.go:31:2:error: const testLabelExp is unused (U1000) (megacheck)
security/cmd/istio_ca/main.go:66:17:error: struct of size 224 could be 216 (maligned)
security/cmd/node_agent_k8s/workload/main.go:67:18:error: error return value not checked (defer conn.Close()) (errcheck)
security/pkg/probe/controller.go:172:3:error: should use for range instead of for { select {} } (S1000) (megacheck)
```