### PR TITLE
Add .gitignore to ignore autogenerated addon install configs.

### DIFF
--- a/install/kubernetes/addons/.gitignore
+++ b/install/kubernetes/addons/.gitignore
@@ -1,0 +1,5 @@
+grafana.yaml
+prometheus.yaml
+servicegraph.yaml
+zipkin-to-stackdriver.yaml
+zipkin.yaml


### PR DESCRIPTION
So that no one accidentally checks them in (and modifies them).