### PR TITLE
Fixes cache buster doc bug

### DIFF
--- a/tools/cache_buster.yaml
+++ b/tools/cache_buster.yaml
@@ -18,7 +18,7 @@ kind: rule
 metadata:
   name: mixercachebuster
 spec:
-  # one direction 1->2 won't be cached, 2->1 will use the cache
+  # one direction 1->2 will use the cache, while 2->1 will not use the cache.
   # TODO: parametrize the namespace of find a way to get short names to work:
   # TODO: this appears to always bust the cache, even if dest is echosrv1 !
   match: destination.service == "echosrv1.istio.svc.cluster.local" && request.headers["x-request-id"] == "foo"


### PR DESCRIPTION
cache_buster.yaml incorrectly documented the direction of caching. This PR fixes the documentation to reflect the correct direction of caching.