### PR TITLE
Change mock services to use separate port object

### DIFF
--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -317,19 +317,19 @@ func TestMatchSource(t *testing.T) {
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
 			svc:       &routing.IstioService{Name: "world"},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.GetPortHTTP(mock.HelloService), 0, "")},
 			want:      false,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
 			svc:       &routing.IstioService{Name: "hello"},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.GetPortHTTP(mock.HelloService), 0, "")},
 			want:      true,
 		},
 		{
 			meta:      model.ConfigMeta{Name: "test", Namespace: "default", Domain: "cluster.local"},
 			svc:       &routing.IstioService{Name: "hello", Labels: map[string]string{"version": "v0"}},
-			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")},
+			instances: []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.GetPortHTTP(mock.HelloService), 0, "")},
 			want:      true,
 		},
 	}
@@ -392,7 +392,7 @@ func (errorStore) Delete(typ, name, namespace string) error {
 }
 
 func TestRouteRules(t *testing.T) {
-	instance := mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")
+	instance := mock.MakeInstance(mock.HelloService, mock.GetPortHTTP(mock.HelloService), 0, "")
 
 	testCases := []struct {
 		configType string
@@ -456,7 +456,7 @@ func TestRouteRules(t *testing.T) {
 				t.Error("RouteRules() => expected no match for source-matched rules")
 			}
 
-			world := mock.MakeInstance(mock.WorldService, mock.PortHTTP, 0, "")
+			world := mock.MakeInstance(mock.WorldService, mock.GetPortHTTP(mock.WorldService), 0, "")
 			if out := store.RouteRulesByDestination([]*model.ServiceInstance{world}, mock.HelloProxyV0.Domain); len(out) != 1 ||
 				!reflect.DeepEqual(tc.spec, out[0].Spec) {
 				t.Errorf("RouteRulesByDestination() => got %#v, want %#v", out, tc.spec)
@@ -523,7 +523,7 @@ func TestEgressRules(t *testing.T) {
 func TestPolicy(t *testing.T) {
 	store := model.MakeIstioStore(memory.Make(model.IstioConfigTypes))
 	labels := map[string]string{"version": "v1"}
-	instances := []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.PortHTTP, 0, "")}
+	instances := []*model.ServiceInstance{mock.MakeInstance(mock.HelloService, mock.GetPortHTTP(mock.HelloService), 0, "")}
 
 	policy1 := &routing.DestinationPolicy{
 		Source: &routing.IstioService{

--- a/pilot/pkg/proxy/envoy/v1/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/mock/discovery.go
@@ -24,14 +24,8 @@ import (
 
 // Mock values
 var (
-	HelloService = MakeService("hello.default.svc.cluster.local", "10.1.0.0")
-	WorldService = MakeService("world.default.svc.cluster.local", "10.2.0.0")
-	PortHTTP     = &model.Port{
-		Name:                 "http",
-		Port:                 80, // target port 80
-		Protocol:             model.ProtocolHTTP,
-		AuthenticationPolicy: meshconfig.AuthenticationPolicy_INHERIT,
-	}
+	HelloService   = MakeService("hello.default.svc.cluster.local", "10.1.0.0")
+	WorldService   = MakeService("world.default.svc.cluster.local", "10.2.0.0")
 	ExtHTTPService = MakeExternalHTTPService("httpbin.default.svc.cluster.local",
 		"httpbin.org", "")
 	ExtHTTPSService = MakeExternalHTTPSService("httpsbin.default.svc.cluster.local",
@@ -89,8 +83,12 @@ func MakeService(hostname, address string) *model.Service {
 		Hostname: hostname,
 		Address:  address,
 		Ports: []*model.Port{
-			PortHTTP,
 			{
+				Name:                 "http",
+				Port:                 80, // target port 80
+				Protocol:             model.ProtocolHTTP,
+				AuthenticationPolicy: meshconfig.AuthenticationPolicy_INHERIT,
+			}, {
 				Name:                 "http-status",
 				Port:                 81, // target port 1081
 				Protocol:             model.ProtocolHTTP,

--- a/pilot/pkg/proxy/envoy/v1/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/mock/discovery.go
@@ -26,6 +26,7 @@ import (
 var (
 	HelloService   = MakeService("hello.default.svc.cluster.local", "10.1.0.0")
 	WorldService   = MakeService("world.default.svc.cluster.local", "10.2.0.0")
+	PortHTTPName   = "http"
 	ExtHTTPService = MakeExternalHTTPService("httpbin.default.svc.cluster.local",
 		"httpbin.org", "")
 	ExtHTTPSService = MakeExternalHTTPSService("httpsbin.default.svc.cluster.local",
@@ -84,7 +85,7 @@ func MakeService(hostname, address string) *model.Service {
 		Address:  address,
 		Ports: []*model.Port{
 			{
-				Name:                 "http",
+				Name:                 PortHTTPName,
 				Port:                 80, // target port 80
 				Protocol:             model.ProtocolHTTP,
 				AuthenticationPolicy: meshconfig.AuthenticationPolicy_INHERIT,
@@ -165,6 +166,18 @@ func MakeInstance(service *model.Service, port *model.Port, version int, az stri
 		Labels:           map[string]string{"version": fmt.Sprintf("v%d", version)},
 		AvailabilityZone: az,
 	}
+}
+
+// GetPortHTTP returns the port which name is PortHTTPName. Returns nil if such
+// a port does not exist (should not happenen if service is create via
+// mock MakeSericve)
+func GetPortHTTP(service *model.Service) *model.Port {
+	for _, port := range service.Ports {
+		if port.Name == PortHTTPName {
+			return port
+		}
+	}
+	return nil
 }
 
 // MakeIP creates a fake IP address for a service and instance version

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optin.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optin.json.golden
@@ -89,13 +89,7 @@
     "service_name": "hello.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
-    "lb_type": "round_robin",
-    "ssl_context": {
-     "cert_chain_file": "/etc/certs/cert-chain.pem",
-     "private_key_file": "/etc/certs/key.pem",
-     "ca_cert_file": "/etc/certs/root-cert.pem",
-     "verify_subject_alt_name": []
-    }
+    "lb_type": "round_robin"
    },
    {
     "name": "out.hello.default.svc.cluster.local|http-status",

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optout.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optout.json.golden
@@ -118,7 +118,13 @@
     "service_name": "hello.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
-    "lb_type": "round_robin"
+    "lb_type": "round_robin",
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "verify_subject_alt_name": []
+    }
    },
    {
     "name": "out.hello.default.svc.cluster.local|http-status",

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -241,7 +241,7 @@ func TestInstances(t *testing.T) {
 
 	// Get Instances from mockAdapter1
 	instances, err := aggregateCtl.Instances(mock.HelloService.Hostname,
-		[]string{mock.PortHTTP.Name},
+		[]string{mock.PortHttpName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() encountered unexpected error: %v", err)
@@ -253,14 +253,14 @@ func TestInstances(t *testing.T) {
 		if instance.Service.Hostname != mock.HelloService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHTTP.Name); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}
 
 	// Get Instances from mockAdapter2
 	instances, err = aggregateCtl.Instances(mock.WorldService.Hostname,
-		[]string{mock.PortHTTP.Name},
+		[]string{mock.PortHttpName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() encountered unexpected error: %v", err)
@@ -272,7 +272,7 @@ func TestInstances(t *testing.T) {
 		if instance.Service.Hostname != mock.WorldService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHTTP.Name); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}
@@ -285,7 +285,7 @@ func TestInstancesError(t *testing.T) {
 
 	// Get Instances from client with error
 	instances, err := aggregateCtl.Instances(mock.HelloService.Hostname,
-		[]string{mock.PortHTTP.Name},
+		[]string{mock.PortHttpName},
 		model.LabelsCollection{})
 	if err == nil {
 		t.Fatal("Aggregate controller should return error if one discovery client experiences " +
@@ -297,7 +297,7 @@ func TestInstancesError(t *testing.T) {
 
 	// Get Instances from client without error
 	instances, err = aggregateCtl.Instances(mock.WorldService.Hostname,
-		[]string{mock.PortHTTP.Name},
+		[]string{mock.PortHttpName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() should not return error is instances are found: %v", err)
@@ -309,7 +309,7 @@ func TestInstancesError(t *testing.T) {
 		if instance.Service.Hostname != mock.WorldService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHTTP.Name); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -241,7 +241,7 @@ func TestInstances(t *testing.T) {
 
 	// Get Instances from mockAdapter1
 	instances, err := aggregateCtl.Instances(mock.HelloService.Hostname,
-		[]string{mock.PortHttpName},
+		[]string{mock.PortHTTPName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() encountered unexpected error: %v", err)
@@ -253,14 +253,14 @@ func TestInstances(t *testing.T) {
 		if instance.Service.Hostname != mock.HelloService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHTTPName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}
 
 	// Get Instances from mockAdapter2
 	instances, err = aggregateCtl.Instances(mock.WorldService.Hostname,
-		[]string{mock.PortHttpName},
+		[]string{mock.PortHTTPName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() encountered unexpected error: %v", err)
@@ -272,7 +272,7 @@ func TestInstances(t *testing.T) {
 		if instance.Service.Hostname != mock.WorldService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHTTPName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}
@@ -285,7 +285,7 @@ func TestInstancesError(t *testing.T) {
 
 	// Get Instances from client with error
 	instances, err := aggregateCtl.Instances(mock.HelloService.Hostname,
-		[]string{mock.PortHttpName},
+		[]string{mock.PortHTTPName},
 		model.LabelsCollection{})
 	if err == nil {
 		t.Fatal("Aggregate controller should return error if one discovery client experiences " +
@@ -297,7 +297,7 @@ func TestInstancesError(t *testing.T) {
 
 	// Get Instances from client without error
 	instances, err = aggregateCtl.Instances(mock.WorldService.Hostname,
-		[]string{mock.PortHttpName},
+		[]string{mock.PortHTTPName},
 		model.LabelsCollection{})
 	if err != nil {
 		t.Fatalf("Instances() should not return error is instances are found: %v", err)
@@ -309,7 +309,7 @@ func TestInstancesError(t *testing.T) {
 		if instance.Service.Hostname != mock.WorldService.Hostname {
 			t.Fatal("Returned instance's hostname does not match desired value")
 		}
-		if _, ok := instance.Service.Ports.Get(mock.PortHttpName); !ok {
+		if _, ok := instance.Service.Ports.Get(mock.PortHTTPName); !ok {
 			t.Fatal("Returned instance does not contain desired port")
 		}
 	}


### PR DESCRIPTION
Before, HelloService and WorldService mock sharing the PortHttp object. This cause incorrect behavior when modifying this port for testing (e.g adding auth annotation), as the change will be applied to both services instead of just the desired one.