### PR TITLE
x509 error with certificate-authority-data: pin mergo dependency against kubernetes/client-go compatible version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -556,8 +556,7 @@
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
-  version = "0.3.2"
+  revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -1130,7 +1129,7 @@
     "routing/v1alpha1",
     "routing/v1alpha2"
   ]
-  revision = "6ce328b48d94e90f3c8022e811b875453da05477"
+  revision = "145be4868f169e496d90e258b45b34a1755dabe1"
 
 [[projects]]
   name = "istio.io/fortio"
@@ -1432,6 +1431,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f29290fe3a84c7338dce54e5b4e945d14b13f4d502822992ddf2c54f3bee827"
+  inputs-digest = "7aaf154c968d1682989350af2bd5d9ca3d2f56a5a06ee7a5b9545d84bf2cf7e9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,6 +40,13 @@ required = [
   version = "^1.8.2" # match istio/api
 
 
+# Lock mergo against kubernetes/client-go's version to fix merging related kubeconfig bugs
+# related to CertificateAuthorityData/certificate-authority-data failures
+# https://github.com/kubernetes/client-go/blob/7cd1d3291b7d9b1e2d54d4b69eb65995eaf8888e/tools/clientcmd/client_config.go#L160-L162
+[[override]]
+  name = "github.com/imdario/mergo"
+  revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
+
 # When necessary, override transitive contraints that might be pinned
 # to older versions (e.g. ingress-nginx pinned to 1.8).
 #


### PR DESCRIPTION
This issue was noticed when istioctl returned
"x509: certificate signed by unknown authority"
in combination with a cluster in ~/.kube/config that
specifies its cluster certificate using certificate-authority-data.

The merging in
https://github.com/kubernetes/client-go/blob/b6a34c5a002893138005771f76480e7166da9310/tools/clientcmd/loader.go#L225-L227
results in `CertificateAuthorityData` containing the base64-decoded
certificate twice, which results in the x509 error.

Potentially related to https://github.com/kubernetes/client-go/blob/7cd1d3291b7d9b1e2d54d4b69eb65995eaf8888e/tools/clientcmd/client_config.go#L160-L162.
Not sure if that's the right way to fix that issue, I'd also appreciate
some pointers on the best approach to add tests for this.