### PR TITLE
Add e2e tests to verify mixer report and check for ingress

### DIFF
--- a/samples/bookinfo/kube/mixer-rule-ingress-denial.yaml
+++ b/samples/bookinfo/kube/mixer-rule-ingress-denial.yaml
@@ -1,0 +1,28 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: denier
+metadata:
+  name: handler
+  namespace: istio-system
+spec:
+  status:
+    code: 7
+    message: Not allowed
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: checknothing
+metadata:
+  name: denyrequest
+  namespace: istio-system
+spec:
+ 
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: denyingress
+  namespace: istio-system
+spec:
+  match: destination.labels["istio"] == "ingress" && request.headers["x-user"] == ""
+  actions:
+  - handler: handler.denier.istio-system
+    instances: [ denyrequest.checknothing.istio-system ]

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -361,7 +361,6 @@ func TestIngressReport(t *testing.T) {
 	}
 }
 
-
 func TestTcpMetrics(t *testing.T) {
 	if err := replaceRouteRule(tcpDbRule); err != nil {
 		t.Fatalf("Could not update reviews routing rule: %v", err)

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -251,20 +251,24 @@ func errorf(t *testing.T, format string, args ...interface{}) {
 	t.Errorf(format, args...)
 }
 
-func TestGlobalReport(t *testing.T) {
+func TestMetric(t *testing.T) {
+	checkMetricReport(t, promAPI, "productpage")
+}
+
+func TestIngressMetric(t *testing.T) {
+	checkMetricReport(t, promAPI, "istio-ingress")
+}
+
+// checkMetricReport checks whether report works for the given service
+// by visiting productpage and comparing request_count metric.
+func checkMetricReport(t *testing.T, serviceName string) {
 	// setup prometheus API
 	promAPI, err := promAPI()
 	if err != nil {
 		t.Fatalf("Could not build prometheus API client: %v", err)
 	}
 
-	checkMetricReport(t, promAPI, "productpage")
-	checkMetricReport(t, promAPI, "istio-ingress")
-}
 
-// checkMetricReport checks whether report works for the given service
-// by visiting productpage and comparing request_count metric.
-func checkMetricReport(t *testing.T, promAPI v1.API, serviceName string) {
 	t.Logf("Check request count metric for %s", serviceName)
 
 	// establish baseline by querying request count metric.
@@ -285,7 +289,7 @@ func checkMetricReport(t *testing.T, promAPI v1.API, serviceName string) {
 	t.Logf("Baseline established: prior200s = %f", prior200s)
 	t.Log("Visiting product page...")
 
-	// visit production page.
+	// visit product page.
 	if errNew := visitProductPage(productPageTimeout, http.StatusOK); errNew != nil {
 		t.Fatalf("Test app setup failure: %v", errNew)
 	}
@@ -426,6 +430,9 @@ func TestNewMetrics(t *testing.T) {
 
 func TestDenials(t *testing.T) {
 	testDenials(t, denialRule)
+}
+
+func TestIngressDenials(t *testing.T) {
 	testDenials(t, ingressDenialRule)
 }
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -312,7 +312,7 @@ func TestIngressReport(t *testing.T) {
 		t.Fatalf("Could not build prometheus API client: %v", err)
 	}
 
-	// establish baseline
+	// establish baseline by querying request count metric with istio-ingress as destination.
 	t.Log("Establishing metrics baseline for test...")
 	query := fmt.Sprintf("istio_request_count{%s=\"%s\"}", destLabel, fqdn("istio-ingress"))
 	t.Logf("prometheus query: %s", query)
@@ -330,6 +330,7 @@ func TestIngressReport(t *testing.T) {
 	t.Logf("Baseline established: prior200s = %f", prior200s)
 	t.Log("Visiting product page...")
 
+	// visit production page as well as ingress.
 	if errNew := visitProductPage(productPageTimeout, http.StatusOK); errNew != nil {
 		t.Fatalf("Test app setup failure: %v", errNew)
 	}

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -252,11 +252,11 @@ func errorf(t *testing.T, format string, args ...interface{}) {
 }
 
 func TestMetric(t *testing.T) {
-	checkMetricReport(t, promAPI, "productpage")
+	checkMetricReport(t, "productpage")
 }
 
 func TestIngressMetric(t *testing.T) {
-	checkMetricReport(t, promAPI, "istio-ingress")
+	checkMetricReport(t, "istio-ingress")
 }
 
 // checkMetricReport checks whether report works for the given service
@@ -267,7 +267,6 @@ func checkMetricReport(t *testing.T, serviceName string) {
 	if err != nil {
 		t.Fatalf("Could not build prometheus API client: %v", err)
 	}
-
 
 	t.Logf("Check request count metric for %s", serviceName)
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -280,7 +280,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	}
 	allowPrometheusSync()
 
-	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	t.Log("Successfully sent request(s) to /productpage; checking metrics...")
 
 	query = fmt.Sprintf("istio_request_count{%s=\"%s\",%s=\"200\"}", destLabel, fqdn("productpage"), responseCodeLabel)
 	t.Logf("prometheus query: %s", query)
@@ -288,7 +288,7 @@ func TestGlobalCheckAndReport(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	log.Infof("promvalue := %s", value.String())
+	t.Logf("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {
@@ -336,7 +336,7 @@ func TestIngressReport(t *testing.T) {
 	}
 	allowPrometheusSync()
 
-	log.Info("Successfully sent request(s) to /productpage; checking metrics...")
+	t.Log("Successfully sent request(s) to /productpage; checking metrics...")
 
 	query = fmt.Sprintf("istio_request_count{%s=\"%s\",%s=\"200\"}", destLabel, fqdn("istio-ingress"), responseCodeLabel)
 	t.Logf("prometheus query: %s", query)
@@ -344,7 +344,7 @@ func TestIngressReport(t *testing.T) {
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	log.Infof("promvalue := %s", value.String())
+	t.Logf("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {


### PR DESCRIPTION
Fix #3418 

This test is duplicated from globalcheckandreport with ingress as destination in request count query.