### PR TITLE
Fix the grafana service account, missing namespace.

### DIFF
--- a/install/kubernetes/templates/addons/grafana.yaml.tmpl
+++ b/install/kubernetes/templates/addons/grafana.yaml.tmpl
@@ -55,4 +55,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: grafana
+  namespace: {ISTIO_NAMESPACE}
 ---


### PR DESCRIPTION
Grafana is currently broken. #2465 is missing the namespace, similar to the recent problem with Prometheus.

Do we need a `ClusterRole` and `ClusterRoleBinding`?