### PR TITLE
Fix Grafana graphs by filtering the unknown service.

### DIFF
--- a/addons/grafana/grafana-dashboard.json
+++ b/addons/grafana/grafana-dashboard.json
@@ -1297,7 +1297,7 @@
         "options": [],
         "query": "label_values(source_service)",
         "refresh": 1,
-        "regex": "",
+        "regex": ".+",
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],


### PR DESCRIPTION
The new behavior is that an "unknown" service is logging metrics as ingress to `istio-ingress.istio-system`. This filters that.

Now `istio-ingress` shows up as it's own service w/ graphs, but some don't work with the traffic coming from "unknown". I'll keep working on that, but at least this change fixes the whole page not working from the "unknown" service showing up in the selector at the top.
