### PR TITLE
Add CA option to use upstream CA for provisioning cert.

### DIFF
--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -29,6 +29,7 @@ import (
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/probe"
+	"istio.io/istio/security/pkg/caclient/grpc"
 	"istio.io/istio/security/pkg/pki/util"
 )
 
@@ -47,6 +48,18 @@ const (
 	caKeySize = 2048
 )
 
+// cATypes is the enum for the CA type.
+type cATypes int
+
+const (
+	// IntegratedCA means the Istio CA automatically interacts with upstream CA.
+	integratedCA cATypes = iota
+	// SelfSignedCA means the Istio CA uses a self signed certificate.
+	selfSignedCA
+	// PluggedCertCA means the Istio CA uses a operator-specified key/cert.
+	pluggedCertCA
+)
+
 // CertificateAuthority contains methods to be supported by a CA.
 type CertificateAuthority interface {
 	// Sign generates a certificate for a workload or CA, from the given CSR and TTL.
@@ -57,12 +70,19 @@ type CertificateAuthority interface {
 
 // IstioCAOptions holds the configurations for creating an Istio CA.
 type IstioCAOptions struct {
+	CAType cATypes
+
+	CertTTL    time.Duration
+	MaxCertTTL time.Duration
+
 	CertChainBytes   []byte
-	CertTTL          time.Duration
-	MaxCertTTL       time.Duration
 	SigningCertBytes []byte
 	SigningKeyBytes  []byte
 	RootCertBytes    []byte
+
+	UpstreamCAAddress   string
+	UpstreamCACertBytes []byte
+	UpstreamAuth        string
 
 	LivenessProbeOptions *probe.Options
 	ProbeCheckInterval   time.Duration
@@ -77,17 +97,20 @@ type IstioCA struct {
 
 	certChainBytes []byte
 	rootCertBytes  []byte
-	livenessProbe  *probe.Probe
+
+	caClient grpc.CAGrpcClient
+
+	livenessProbe *probe.Probe
 }
 
 // NewSelfSignedIstioCAOptions returns a new IstioCAOptions instance using self-signed certificate.
 func NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL time.Duration, org string, namespace string,
 	core corev1.SecretsGetter) (*IstioCAOptions, error) {
-
 	// For the first time the CA is up, it generates a self-signed key/cert pair and write it to
 	// cASecret. For subsequent restart, CA will reads key/cert from cASecret.
 	caSecret, err := core.Secrets(namespace).Get(cASecret, metav1.GetOptions{})
 	opts := &IstioCAOptions{
+		CAType:     selfSignedCA,
 		CertTTL:    certTTL,
 		MaxCertTTL: maxCertTTL,
 	}
@@ -141,6 +164,7 @@ func NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL time.Duration, o
 func NewIstioCAOptions(certChainFile, signingCertFile, signingKeyFile, rootCertFile string,
 	certTTL, maxCertTTL time.Duration) (*IstioCAOptions, error) {
 	caOpts := &IstioCAOptions{
+		CAType:     pluggedCertCA,
 		CertTTL:    certTTL,
 		MaxCertTTL: maxCertTTL,
 	}
@@ -163,6 +187,24 @@ func NewIstioCAOptions(certChainFile, signingCertFile, signingKeyFile, rootCertF
 	}
 	if rootCertBytes, err := ioutil.ReadFile(rootCertFile); err == nil {
 		caOpts.RootCertBytes = rootCertBytes
+	} else {
+		return nil, err
+	}
+	return caOpts, nil
+}
+
+// NewIntegratedIstioCAOptions returns a new IstioCAOptions instance with upstream CA configuration.
+func NewIntegratedIstioCAOptions(upstreamCAAddress, upstreamCACertFile, upstreamAuth string,
+	workloadCertTTL, maxWorkloadCertTTL time.Duration) (*IstioCAOptions, error) {
+	caOpts := &IstioCAOptions{
+		CAType:            integratedCA,
+		CertTTL:           workloadCertTTL,
+		MaxCertTTL:        maxWorkloadCertTTL,
+		UpstreamCAAddress: upstreamCAAddress,
+		UpstreamAuth:      upstreamAuth,
+	}
+	if upstreamCACertBytes, err := ioutil.ReadFile(upstreamCACertFile); err == nil {
+		caOpts.UpstreamCACertBytes = upstreamCACertBytes
 	} else {
 		return nil, err
 	}
@@ -207,6 +249,10 @@ func (ca *IstioCA) GetRootCertificate() []byte {
 // Sign takes a PEM-encoded certificate signing request and returns a signed
 // certificate.
 func (ca *IstioCA) Sign(csrPEM []byte, ttl time.Duration, forCA bool) ([]byte, error) {
+	if ca.signingCert == nil {
+		return nil, fmt.Errorf("Istio CA is not ready") // nolint
+	}
+
 	csr, err := util.ParsePemEncodedCSR(csrPEM)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is part of the multi-cluster CA configuration, and it could also support the plug-in CAs.