### PR TITLE
Adds ingress2 to perf_script and updates docs/output

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -35,7 +35,7 @@ __Option B:__ (From source) Build the deployment manifest and `istioctl` binary:
 $ ./install/updateVersion.sh # This step is only needed when using Istio from source.
 ```
 Follow the steps in the [Developer Guide](https://github.com/istio/istio/blob/master/DEV-GUIDE.md) to build the `istioctl` binary.
-Make the kubectl binary executable.
+Make the istioctl binary executable.
 ```
 $ chmod +x ./istioctl
 ```
@@ -85,6 +85,8 @@ $ kubectl get po --all-namespaces
 NAMESPACE      NAME                                                   READY     STATUS    RESTARTS   AGE
 fortio         fortio1-1966733334-xj5f6                               1/1       Running   0          8m
 fortio         fortio2-3044850348-v5f74                               1/1       Running   0          8m
+istio          echo-svc-deployment1-548647f7bf-f99qk                  2/2       Running   0          6m
+istio          echo-svc-deployment2-58f5447b75-q2x8c                  2/2       Running   0          6m
 istio-system   istio-ca-1363003450-gvtmn                              1/1       Running   0          7m
 istio-system   istio-ingress-1732553340-gv41r                         1/1       Running   0          7m
 istio-system   istio-mixer-3192291716-psskv                           3/3       Running   0          8m
@@ -133,9 +135,11 @@ can be used to perform load testing. You can call the `get_ips` function to obta
 ```
 $ get_ips
 +++ VM Ip is $VM_IP - visit http://$VM_IP/fortio/
-+++ In k8s fortio external ip: http://$EXTERNAL_IP:8080/fortio/
-+++ In k8s non istio ingress: http://$NON_ISTIO_INGRESS_IP/fortio/
-+++ In k8s istio ingress: http://$ISTIO_INGRESS_IP/fortio1/fortio/ and fortio2
++++ In k8s fortio1 external service ip: http://$FORTIO1_EXTERNAL_SVC_IP:8080/fortio/
++++ In k8s fortio2 external service ip: http://$FORTIO2_EXTERNAL_SVC_IP:8080/fortio/
++++ In k8s fortio1 non-istio ingress: http://$FORTIO1_NONISTIO_INGRESS_IP/fortio/
++++ In k8s fortio2 non-istio ingress: http://$FORTIO1_NONISTIO_INGRESS_IP/fortio/
++++ In k8s fortio1 and fortio2 istio ingress: http://$FORTIO_ISTIO_INGRESS_IP/fortio1/fortio/ and fortio2
 ```
 
 Then visit http://$ISTIO_INGRESS_IP/fortio1/fortio/ or http://$ISTIO_INGRESS_IP/fortio2/fortio/ to generate a load

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -211,7 +211,7 @@ function delete_non_istio_ingress2() {
 
 function get_non_istio_ingress_ip() {
   K8S_INGRESS_IP1=$(kubectl -n $FORTIO_NAMESPACE get ingress -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}')
-#  echo "+++ In k8s non istio ingress: http://$K8S_INGRESS_IP/fortio1/fortio/ and fortio2"
+#  echo "+++ In k8s non istio ingress: http://$K8S_INGRESS_IP1/fortio1/fortio/ and fortio2"
   echo "+++ In k8s fortio1 non-istio ingress: http://$K8S_INGRESS_IP1/fortio/"
 }
 
@@ -227,11 +227,13 @@ function get_istio_ingress_ip() {
 
 function run_fortio_test1() {
   echo "Using default loadbalancer, no istio:"
-  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO_K8S_IP:8080/echo"
+  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO1_K8S_IP:8080/echo"
+  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO2_K8S_IP:8080/echo"
 }
 function run_fortio_test2() {
   echo "Using default ingress, no istio:"
-  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP/echo"
+  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP1/echo"
+  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP2/echo"
 }
 function run_fortio_test3() {
   echo "Using istio ingress:"

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -225,18 +225,19 @@ function get_istio_ingress_ip() {
 }
 
 function run_fortio_test1() {
-  echo "Using default loadbalancer, no istio:"
+  echo "Testing VM -> fortio1 and fortio 2 external service ip's, no istio:"
   Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO1_K8S_IP:8080/echo"
   Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO2_K8S_IP:8080/echo"
 }
 function run_fortio_test2() {
-  echo "Using default ingress, no istio:"
+  echo "Testing VM -> fortio1 and fortio 2 ingresses, no istio:"
   Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP1/echo"
   Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP2/echo"
 }
 function run_fortio_test3() {
-  echo "Using istio ingress:"
+  echo "Testing VM -> fortio1 and fortio 2 ingresses, with istio:"
   Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$ISTIO_INGRESS_IP/fortio1/echo"
+  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$ISTIO_INGRESS_IP/fortio2/echo"
 }
 
 function setup_vm_all() {

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -163,13 +163,12 @@ function install_istio_cache_busting_rule() {
   Execute $ISTIOCTL create -n $ISTIO_NAMESPACE -f $FNAME
 }
 
-function get_fortio1_k8s_ip() {
-  FORTIO1_K8S_IP=$(kubectl -n $FORTIO_NAMESPACE get svc -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}')
+function get_fortio_k8s_ip() {
+  arg1=$1
+  arg2=$2
+  FORTIO1_K8S_IP=$(kubectl -n $FORTIO_NAMESPACE get svc -o jsonpath="{.items[${arg1}].status.loadBalancer.ingress[0].ip}")
   echo "+++ In k8s fortio1 non-istio external service: http://$FORTIO1_K8S_IP:8080/fortio/"
-}
-
-function get_fortio2_k8s_ip() {
-  FORTIO2_K8S_IP=$(kubectl -n $FORTIO_NAMESPACE get svc -o jsonpath='{.items[1].status.loadBalancer.ingress[0].ip}')
+  FORTIO2_K8S_IP=$(kubectl -n $FORTIO_NAMESPACE get svc -o jsonpath="{.items[${arg2}].status.loadBalancer.ingress[0].ip}")
   echo "+++ In k8s fortio2 non-istio external service: http://$FORTIO2_K8S_IP:8080/fortio/"
 }
 
@@ -287,8 +286,7 @@ function delete_all() {
 function get_ips() {
   #TODO: wait for ingresses/svcs to be ready
   get_vm_ip
-  get_fortio1_k8s_ip
-  get_fortio2_k8s_ip
+  get_fortio_k8s_ip 0 1
   get_non_istio_ingress_ip
   get_non_istio_ingress_ip2
   get_istio_ingress_ip


### PR DESCRIPTION
Previously, the `setup_perf_cluster.sh` script deployed a single non-Istio Ingress and tools/README.md contained doc bugs. This PR adds another ingress for the `fortio2` pod and updates/fixes tools/README.md.