### PR TITLE
Only use output struct values when actually generated

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -396,15 +396,15 @@ spec:
   attribute_bindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
-    source.ip: $out.source_pod_ip
-    source.labels: $out.source_labels
-    source.namespace: $out.source_namespace
-    source.service: $out.source_service
-    source.serviceAccount: $out.source_service_account_name
-    destination.ip: $out.destination_pod_ip
-    destination.labels: $out.destination_labels
-    destination.namespace: $out.destination_namespace
-    destination.service: $out.destination_service
-    destination.serviceAccount: $out.destination_service_account_name
+    source.ip: $out.source_pod_ip | ip("0.0.0.0")
+    source.labels: $out.source_labels | emptyStringMap()
+    source.namespace: $out.source_namespace | "default"
+    source.service: $out.source_service | "unknown"
+    source.serviceAccount: $out.source_service_account_name | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.namespace: $out.destination_namespace | "default"
+    destination.service: $out.destination_service | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
 ---
 {{ end }}

--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -1018,14 +1018,14 @@ spec:
   attribute_bindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
-    source.ip: $out.source_pod_ip
-    source.labels: $out.source_labels
-    source.namespace: $out.source_namespace
-    source.service: $out.source_service
-    source.serviceAccount: $out.source_service_account_name
-    destination.ip: $out.destination_pod_ip
-    destination.labels: $out.destination_labels
-    destination.namespace: $out.destination_namespace
-    destination.service: $out.destination_service
-    destination.serviceAccount: $out.destination_service_account_name
+    source.ip: $out.source_pod_ip | ip("0.0.0.0")
+    source.labels: $out.source_labels | emptyStringMap()
+    source.namespace: $out.source_namespace | "default"
+    source.service: $out.source_service | "unknown"
+    source.serviceAccount: $out.source_service_account_name | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.namespace: $out.destination_namespace | "default"
+    destination.service: $out.destination_service | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
 ---

--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -184,7 +184,7 @@ func newBuilder(clientFactory clientFactoryFn) *builder {
 }
 
 func (h *handler) GenerateKubernetesAttributes(ctx context.Context, inst *ktmpl.Instance) (*ktmpl.Output, error) {
-	out := &ktmpl.Output{}
+	out := ktmpl.NewOutput()
 	if inst.DestinationUid != "" {
 		if p, found := h.findPod(inst.DestinationUid); found {
 			h.fillDestinationAttrs(p, out, h.params)
@@ -300,34 +300,34 @@ func keyFromUID(uid string) string {
 
 func (h *handler) fillOriginAttrs(p *v1.Pod, o *ktmpl.Output, params *config.Params) {
 	if len(p.Labels) > 0 {
-		o.OriginLabels = p.Labels
+		o.SetOriginLabels(p.Labels)
 	}
 	if len(p.Name) > 0 {
-		o.OriginPodName = p.Name
+		o.SetOriginPodName(p.Name)
 	}
 	if len(p.Namespace) > 0 {
-		o.OriginNamespace = p.Namespace
+		o.SetOriginNamespace(p.Namespace)
 	}
 	if len(p.Spec.ServiceAccountName) > 0 {
-		o.OriginServiceAccountName = p.Spec.ServiceAccountName
+		o.SetOriginServiceAccountName(p.Spec.ServiceAccountName)
 	}
 	if len(p.Status.PodIP) > 0 {
-		o.OriginPodIp = net.ParseIP(p.Status.PodIP)
+		o.SetOriginPodIp(net.ParseIP(p.Status.PodIP))
 	}
 	if len(p.Status.HostIP) > 0 {
-		o.OriginHostIp = net.ParseIP(p.Status.HostIP)
+		o.SetOriginHostIp(net.ParseIP(p.Status.HostIP))
 	}
 	if app, found := p.Labels[params.PodLabelForService]; found {
 		n, err := canonicalName(app, p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.OriginService = n
+			o.SetOriginService(n)
 		} else {
 			h.env.Logger().Warningf("OriginService not set: %v", err)
 		}
 	} else if app, found := p.Labels[params.PodLabelForIstioComponentService]; found {
 		n, err := canonicalName(app, p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.OriginService = n
+			o.SetOriginService(n)
 		} else {
 			h.env.Logger().Warningf("OriginService not set: %v", err)
 		}
@@ -336,34 +336,34 @@ func (h *handler) fillOriginAttrs(p *v1.Pod, o *ktmpl.Output, params *config.Par
 
 func (h *handler) fillDestinationAttrs(p *v1.Pod, o *ktmpl.Output, params *config.Params) {
 	if len(p.Labels) > 0 {
-		o.DestinationLabels = p.Labels
+		o.SetDestinationLabels(p.Labels)
 	}
 	if len(p.Name) > 0 {
-		o.DestinationPodName = p.Name
+		o.SetDestinationPodName(p.Name)
 	}
 	if len(p.Namespace) > 0 {
-		o.DestinationNamespace = p.Namespace
+		o.SetDestinationNamespace(p.Namespace)
 	}
 	if len(p.Spec.ServiceAccountName) > 0 {
-		o.DestinationServiceAccountName = p.Spec.ServiceAccountName
+		o.SetDestinationServiceAccountName(p.Spec.ServiceAccountName)
 	}
 	if len(p.Status.PodIP) > 0 {
-		o.DestinationPodIp = net.ParseIP(p.Status.PodIP)
+		o.SetDestinationPodIp(net.ParseIP(p.Status.PodIP))
 	}
 	if len(p.Status.HostIP) > 0 {
-		o.DestinationHostIp = net.ParseIP(p.Status.HostIP)
+		o.SetDestinationHostIp(net.ParseIP(p.Status.HostIP))
 	}
 	if app, found := p.Labels[params.PodLabelForService]; found {
 		n, err := canonicalName(app, p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.DestinationService = n
+			o.SetDestinationService(n)
 		} else {
 			h.env.Logger().Warningf("DestinationService not set: %v", err)
 		}
 	} else if app, found := p.Labels[params.PodLabelForIstioComponentService]; found {
 		n, err := canonicalName(istioComponentName(app), p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.DestinationService = n
+			o.SetDestinationService(n)
 		} else {
 			h.env.Logger().Warningf("DestinationService not set: %v", err)
 		}
@@ -372,34 +372,34 @@ func (h *handler) fillDestinationAttrs(p *v1.Pod, o *ktmpl.Output, params *confi
 
 func (h *handler) fillSourceAttrs(p *v1.Pod, o *ktmpl.Output, params *config.Params) {
 	if len(p.Labels) > 0 {
-		o.SourceLabels = p.Labels
+		o.SetSourceLabels(p.Labels)
 	}
 	if len(p.Name) > 0 {
-		o.SourcePodName = p.Name
+		o.SetSourcePodName(p.Name)
 	}
 	if len(p.Namespace) > 0 {
-		o.SourceNamespace = p.Namespace
+		o.SetSourceNamespace(p.Namespace)
 	}
 	if len(p.Spec.ServiceAccountName) > 0 {
-		o.SourceServiceAccountName = p.Spec.ServiceAccountName
+		o.SetSourceServiceAccountName(p.Spec.ServiceAccountName)
 	}
 	if len(p.Status.PodIP) > 0 {
-		o.SourcePodIp = net.ParseIP(p.Status.PodIP)
+		o.SetSourcePodIp(net.ParseIP(p.Status.PodIP))
 	}
 	if len(p.Status.HostIP) > 0 {
-		o.SourceHostIp = net.ParseIP(p.Status.HostIP)
+		o.SetSourceHostIp(net.ParseIP(p.Status.HostIP))
 	}
 	if app, found := p.Labels[params.PodLabelForService]; found {
 		n, err := canonicalName(app, p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.SourceService = n
+			o.SetSourceService(n)
 		} else {
 			h.env.Logger().Warningf("SourceService not set: %v", err)
 		}
 	} else if app, found := p.Labels[params.PodLabelForIstioComponentService]; found {
 		n, err := canonicalName(istioComponentName(app), p.Namespace, params.ClusterDomainName)
 		if err == nil {
-			o.SourceService = n
+			o.SetSourceService(n)
 		} else {
 			h.env.Logger().Warningf("SourceService not set: %v", err)
 		}

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -222,138 +222,117 @@ func TestKubegen_Generate(t *testing.T) {
 		OriginUid:      "kubernetes://badsvcuid",
 	}
 
-	sourceUIDOut := &kubernetes_apa_tmpl.Output{
-		SourceLabels: map[string]string{
-			"app":       "test",
-			"something": "",
-		},
-		SourcePodIp:              net.ParseIP("10.10.10.1"),
-		SourceHostIp:             net.ParseIP("10.1.1.10"),
-		SourceNamespace:          "testns",
-		SourcePodName:            "test-pod",
-		SourceService:            "test.testns.svc.cluster.local",
-		SourceServiceAccountName: "test",
-	}
+	sourceUIDOut := kubernetes_apa_tmpl.NewOutput()
+	sourceUIDOut.SetSourceLabels(map[string]string{
+		"app":       "test",
+		"something": "",
+	})
+	sourceUIDOut.SetSourcePodIp(net.ParseIP("10.10.10.1"))
+	sourceUIDOut.SetSourceHostIp(net.ParseIP("10.1.1.10"))
+	sourceUIDOut.SetSourceNamespace("testns")
+	sourceUIDOut.SetSourcePodName("test-pod")
+	sourceUIDOut.SetSourceService("test.testns.svc.cluster.local")
+	sourceUIDOut.SetSourceServiceAccountName("test")
 
 	nsAppLabelIn := &kubernetes_apa_tmpl.Instance{
 		SourceUid: "kubernetes://alt-pod.testns",
 	}
 
-	nsAppLabelOut := &kubernetes_apa_tmpl.Output{
-		SourceLabels: map[string]string{
-			"app": "alt-svc.testns",
-		},
-		SourceService:   "alt-svc.testns.svc.cluster.local",
-		SourceNamespace: "testns",
-		SourcePodName:   "alt-pod",
-	}
+	nsAppLabelOut := kubernetes_apa_tmpl.NewOutput()
+	nsAppLabelOut.SetSourceLabels(map[string]string{
+		"app": "alt-svc.testns",
+	})
+	nsAppLabelOut.SetSourceService("alt-svc.testns.svc.cluster.local")
+	nsAppLabelOut.SetSourceNamespace("testns")
+	nsAppLabelOut.SetSourcePodName("alt-pod")
 
 	svcClusterIn := &kubernetes_apa_tmpl.Instance{SourceUid: "kubernetes://pod-cluster.testns"}
 
-	svcClusterOut := &kubernetes_apa_tmpl.Output{
-		SourceLabels: map[string]string{
-			"app": "alt-svc-with-cluster.testns.svc.cluster:8080",
-		},
-		SourceService:   "alt-svc-with-cluster.testns.svc.cluster.local",
-		SourceNamespace: "testns",
-		SourcePodName:   "pod-cluster",
-	}
+	svcClusterOut := kubernetes_apa_tmpl.NewOutput()
+	svcClusterOut.SetSourceLabels(map[string]string{"app": "alt-svc-with-cluster.testns.svc.cluster:8080"})
+	svcClusterOut.SetSourceService("alt-svc-with-cluster.testns.svc.cluster.local")
+	svcClusterOut.SetSourceNamespace("testns")
+	svcClusterOut.SetSourcePodName("pod-cluster")
 
 	longSvcClusterIn := &kubernetes_apa_tmpl.Instance{SourceUid: "kubernetes://long-pod.testns"}
 
-	longSvcClusterOut := &kubernetes_apa_tmpl.Output{
-		SourceLabels: map[string]string{
-			"app": "long-svc.testns.svc.cluster.local.solar",
-		},
-		SourceService:   "long-svc.testns.svc.cluster.local.solar",
-		SourceNamespace: "testns",
-		SourcePodName:   "long-pod",
-	}
+	longSvcClusterOut := kubernetes_apa_tmpl.NewOutput()
+	longSvcClusterOut.SetSourceLabels(map[string]string{
+		"app": "long-svc.testns.svc.cluster.local.solar",
+	})
+	longSvcClusterOut.SetSourceService("long-svc.testns.svc.cluster.local.solar")
+	longSvcClusterOut.SetSourceNamespace("testns")
+	longSvcClusterOut.SetSourcePodName("long-pod")
 
 	emptySvcIn := &kubernetes_apa_tmpl.Instance{DestinationUid: "kubernetes://empty.testns"}
 
-	emptyServiceOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels: map[string]string{
-			"app": "",
-		},
-		DestinationNamespace: "testns",
-		DestinationPodName:   "empty",
-	}
+	emptyServiceOut := kubernetes_apa_tmpl.NewOutput()
+	emptyServiceOut.SetDestinationLabels(map[string]string{"app": ""})
+	emptyServiceOut.SetDestinationNamespace("testns")
+	emptyServiceOut.SetDestinationPodName("empty")
 
 	badDestinationSvcIn := &kubernetes_apa_tmpl.Instance{DestinationUid: "kubernetes://bad-svc-pod.testns"}
 
-	badDestinationOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels: map[string]string{
-			"app": ":",
-		},
-		DestinationNamespace: "testns",
-		DestinationPodName:   "bad-svc-pod",
-	}
+	badDestinationOut := kubernetes_apa_tmpl.NewOutput()
+	badDestinationOut.SetDestinationLabels(map[string]string{
+		"app": ":",
+	})
+	badDestinationOut.SetDestinationNamespace("testns")
+	badDestinationOut.SetDestinationPodName("bad-svc-pod")
 
 	ipDestinationSvcIn := &kubernetes_apa_tmpl.Instance{DestinationIp: net.ParseIP("192.168.234.3")}
 
-	ipDestinationOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels: map[string]string{
-			"app": "ipAddr",
-		},
-		DestinationNamespace: "testns",
-		DestinationPodName:   "ip-svc-pod",
-		DestinationService:   "ipAddr.testns.svc.cluster.local",
-		DestinationPodIp:     net.ParseIP("192.168.234.3"),
-	}
+	ipDestinationOut := kubernetes_apa_tmpl.NewOutput()
+	ipDestinationOut.SetDestinationLabels(map[string]string{
+		"app": "ipAddr",
+	})
+	ipDestinationOut.SetDestinationNamespace("testns")
+	ipDestinationOut.SetDestinationPodName("ip-svc-pod")
+	ipDestinationOut.SetDestinationService("ipAddr.testns.svc.cluster.local")
+	ipDestinationOut.SetDestinationPodIp(net.ParseIP("192.168.234.3"))
 
 	istioDestinationSvcIn := &kubernetes_apa_tmpl.Instance{
 		DestinationUid: "kubernetes://ingress.istio-system",
 		SourceUid:      "kubernetes://test-pod.testns",
 	}
 
-	istioDestinationOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels: map[string]string{
-			"istio": "ingress",
-		},
-		DestinationNamespace: "istio-system",
-		DestinationPodName:   "ingress",
-		DestinationService:   "istio-ingress.istio-system.svc.cluster.local",
-	}
+	istioDestinationOut := kubernetes_apa_tmpl.NewOutput()
+	istioDestinationOut.SetDestinationLabels(map[string]string{"istio": "ingress"})
+	istioDestinationOut.SetDestinationNamespace("istio-system")
+	istioDestinationOut.SetDestinationPodName("ingress")
+	istioDestinationOut.SetDestinationService("istio-ingress.istio-system.svc.cluster.local")
 
-	istioDestinationWithSrcOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels:        map[string]string{"istio": "ingress"},
-		DestinationNamespace:     "istio-system",
-		DestinationPodName:       "ingress",
-		DestinationService:       "istio-ingress.istio-system.svc.cluster.local",
-		SourceServiceAccountName: "test",
-		SourceService:            "test.testns.svc.cluster.local",
-		SourceLabels:             map[string]string{"app": "test", "something": ""},
-		SourceNamespace:          "testns",
-		SourcePodIp:              net.ParseIP("10.10.10.1"),
-		SourceHostIp:             net.ParseIP("10.1.1.10"),
-		SourcePodName:            "test-pod",
-	}
+	istioDestinationWithSrcOut := kubernetes_apa_tmpl.NewOutput()
+	istioDestinationWithSrcOut.SetDestinationLabels(map[string]string{"istio": "ingress"})
+	istioDestinationWithSrcOut.SetDestinationNamespace("istio-system")
+	istioDestinationWithSrcOut.SetDestinationPodName("ingress")
+	istioDestinationWithSrcOut.SetDestinationService("istio-ingress.istio-system.svc.cluster.local")
+	istioDestinationWithSrcOut.SetSourceServiceAccountName("test")
+	istioDestinationWithSrcOut.SetSourceService("test.testns.svc.cluster.local")
+	istioDestinationWithSrcOut.SetSourceLabels(map[string]string{"app": "test", "something": ""})
+	istioDestinationWithSrcOut.SetSourceNamespace("testns")
+	istioDestinationWithSrcOut.SetSourcePodIp(net.ParseIP("10.10.10.1"))
+	istioDestinationWithSrcOut.SetSourceHostIp(net.ParseIP("10.1.1.10"))
+	istioDestinationWithSrcOut.SetSourcePodName("test-pod")
 
 	ipAppSvcIn := &kubernetes_apa_tmpl.Instance{
 		DestinationUid: "kubernetes://ipApp.testns",
 	}
 
-	ipAppDestinationOut := &kubernetes_apa_tmpl.Output{
-		DestinationLabels: map[string]string{
-			"app": "10.1.10.1",
-		},
-		DestinationNamespace: "testns",
-		DestinationPodName:   "ipApp",
-	}
+	ipAppDestinationOut := kubernetes_apa_tmpl.NewOutput()
+	ipAppDestinationOut.SetDestinationLabels(map[string]string{"app": "10.1.10.1"})
+	ipAppDestinationOut.SetDestinationNamespace("testns")
+	ipAppDestinationOut.SetDestinationPodName("ipApp")
 
 	mixerIn := &kubernetes_apa_tmpl.Instance{
 		SourceUid: "kubernetes://mixer.istio-system",
 	}
 
-	mixerOut := &kubernetes_apa_tmpl.Output{
-		SourceLabels: map[string]string{
-			"istio": "istio-mixer",
-		},
-		SourceService:   "istio-mixer.istio-system.svc.cluster.local",
-		SourceNamespace: "istio-system",
-		SourcePodName:   "mixer",
-	}
+	mixerOut := kubernetes_apa_tmpl.NewOutput()
+	mixerOut.SetSourceLabels(map[string]string{"istio": "istio-mixer"})
+	mixerOut.SetSourceService("istio-mixer.istio-system.svc.cluster.local")
+	mixerOut.SetSourceNamespace("istio-system")
+	mixerOut.SetSourcePodName("mixer")
 
 	confWithIngressLookups := *conf
 	confWithIngressLookups.LookupIngressSourceAndOriginValues = true

--- a/mixer/adapter/kubernetesenv/template/template_handler.gen.go
+++ b/mixer/adapter/kubernetesenv/template/template_handler.gen.go
@@ -91,6 +91,7 @@ type Instance struct {
 // OutputTemplate refers to the output from the adapter. It is used inside the attribute_binding section of the config
 // to assign values to the generated attributes using the `$out.<field name of the OutputTemplate>` syntax.
 type Output struct {
+	fieldsSet map[string]bool
 
 	// Refers to source pod ip address. attribute_bindings can refer to this field using $out.source_pod_ip
 	SourcePodIp net.IP
@@ -154,6 +155,120 @@ type Output struct {
 
 	// Refers to origin pod host ip address. attribute_bindings can refer to this field using $out.origin_host_ip
 	OriginHostIp net.IP
+}
+
+func NewOutput() *Output {
+	return &Output{fieldsSet: make(map[string]bool)}
+}
+
+func (o *Output) SetSourcePodIp(val net.IP) {
+	o.fieldsSet["SourcePodIp"] = true
+	o.SourcePodIp = val
+}
+
+func (o *Output) SetSourcePodName(val string) {
+	o.fieldsSet["SourcePodName"] = true
+	o.SourcePodName = val
+}
+
+func (o *Output) SetSourceLabels(val map[string]string) {
+	o.fieldsSet["SourceLabels"] = true
+	o.SourceLabels = val
+}
+
+func (o *Output) SetSourceNamespace(val string) {
+	o.fieldsSet["SourceNamespace"] = true
+	o.SourceNamespace = val
+}
+
+func (o *Output) SetSourceService(val string) {
+	o.fieldsSet["SourceService"] = true
+	o.SourceService = val
+}
+
+func (o *Output) SetSourceServiceAccountName(val string) {
+	o.fieldsSet["SourceServiceAccountName"] = true
+	o.SourceServiceAccountName = val
+}
+
+func (o *Output) SetSourceHostIp(val net.IP) {
+	o.fieldsSet["SourceHostIp"] = true
+	o.SourceHostIp = val
+}
+
+func (o *Output) SetDestinationPodIp(val net.IP) {
+	o.fieldsSet["DestinationPodIp"] = true
+	o.DestinationPodIp = val
+}
+
+func (o *Output) SetDestinationPodName(val string) {
+	o.fieldsSet["DestinationPodName"] = true
+	o.DestinationPodName = val
+}
+
+func (o *Output) SetDestinationLabels(val map[string]string) {
+	o.fieldsSet["DestinationLabels"] = true
+	o.DestinationLabels = val
+}
+
+func (o *Output) SetDestinationNamespace(val string) {
+	o.fieldsSet["DestinationNamespace"] = true
+	o.DestinationNamespace = val
+}
+
+func (o *Output) SetDestinationService(val string) {
+	o.fieldsSet["DestinationService"] = true
+	o.DestinationService = val
+}
+
+func (o *Output) SetDestinationServiceAccountName(val string) {
+	o.fieldsSet["DestinationServiceAccountName"] = true
+	o.DestinationServiceAccountName = val
+}
+
+func (o *Output) SetDestinationHostIp(val net.IP) {
+	o.fieldsSet["DestinationHostIp"] = true
+	o.DestinationHostIp = val
+}
+
+func (o *Output) SetOriginPodIp(val net.IP) {
+	o.fieldsSet["OriginPodIp"] = true
+	o.OriginPodIp = val
+}
+
+func (o *Output) SetOriginPodName(val string) {
+	o.fieldsSet["OriginPodName"] = true
+	o.OriginPodName = val
+}
+
+func (o *Output) SetOriginLabels(val map[string]string) {
+	o.fieldsSet["OriginLabels"] = true
+	o.OriginLabels = val
+}
+
+func (o *Output) SetOriginNamespace(val string) {
+	o.fieldsSet["OriginNamespace"] = true
+	o.OriginNamespace = val
+}
+
+func (o *Output) SetOriginService(val string) {
+	o.fieldsSet["OriginService"] = true
+	o.OriginService = val
+}
+
+func (o *Output) SetOriginServiceAccountName(val string) {
+	o.fieldsSet["OriginServiceAccountName"] = true
+	o.OriginServiceAccountName = val
+}
+
+func (o *Output) SetOriginHostIp(val net.IP) {
+	o.fieldsSet["OriginHostIp"] = true
+	o.OriginHostIp = val
+}
+
+func (o *Output) WasSet(field string) bool {
+	_, found := o.fieldsSet[field]
+	return found
 }
 
 // HandlerBuilder must be implemented by adapters if they want to

--- a/mixer/pkg/il/runtime/externs.go
+++ b/mixer/pkg/il/runtime/externs.go
@@ -36,6 +36,7 @@ var Externs = map[string]interpreter.Extern{
 	"matches":         interpreter.ExternFromFn("matches", externMatches),
 	"startsWith":      interpreter.ExternFromFn("startsWith", externStartsWith),
 	"endsWith":        interpreter.ExternFromFn("endsWith", externEndsWith),
+	"emptyStringMap":  interpreter.ExternFromFn("emptyStringMap", externEmptyStringMap),
 }
 
 // ExternFunctionMetadata is the type-metadata about externs. It gets used during compilations.
@@ -75,6 +76,11 @@ var ExternFunctionMetadata = []expr.FunctionMetadata{
 		TargetType:    config.STRING,
 		ReturnType:    config.BOOL,
 		ArgumentTypes: []config.ValueType{config.STRING},
+	},
+	{
+		Name:          "emptyStringMap",
+		ReturnType:    config.STRING_MAP,
+		ArgumentTypes: []config.ValueType{},
 	},
 }
 
@@ -125,4 +131,8 @@ func externStartsWith(str string, prefix string) bool {
 
 func externEndsWith(str string, suffix string) bool {
 	return strings.HasSuffix(str, suffix)
+}
+
+func externEmptyStringMap() map[string]string {
+	return map[string]string{}
 }

--- a/mixer/pkg/il/runtime/externs_test.go
+++ b/mixer/pkg/il/runtime/externs_test.go
@@ -169,3 +169,10 @@ func TestExternEndsWith(t *testing.T) {
 		}
 	}
 }
+
+func TestExternEmptyStringMap(t *testing.T) {
+	m := externEmptyStringMap()
+	if len(m) != 0 {
+		t.Errorf("emptyStringMap() returned non-empty map: %#v", m)
+	}
+}

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -456,7 +456,7 @@ var (
 					abag = newWrapperAttrBag(
 						func(name string) (value interface{}, found bool) {
 							field := strings.TrimPrefix(name, fullOutName)
-							if len(field) != len(name) {
+							if len(field) != len(name) && out.WasSet(field) {
 								switch field {
 
 								case "source_pod_ip":

--- a/mixer/testdata/config/kubernetesenv.yaml
+++ b/mixer/testdata/config/kubernetesenv.yaml
@@ -39,14 +39,14 @@ spec:
   attribute_bindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
-    source.ip: $out.source_pod_ip
-    source.labels: $out.source_labels
-    source.namespace: $out.source_namespace
-    source.service: $out.source_service
-    source.serviceAccount: $out.source_service_account_name
-    destination.ip: $out.destination_pod_ip
-    destination.labels: $out.destination_labels
-    destination.namespace: $out.destination_namespace
-    destination.service: $out.destination_service
-    destination.serviceAccount: $out.destination_service_account_name
+    source.ip: $out.source_pod_ip | ip("0.0.0.0")
+    source.labels: $out.source_labels | emptyStringMap()
+    source.namespace: $out.source_namespace | "default"
+    source.service: $out.source_service | "unknown"
+    source.serviceAccount: $out.source_service_account_name | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.namespace: $out.destination_namespace | "default"
+    destination.service: $out.destination_service | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
 ---

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -433,7 +433,7 @@ var (
                     abag = newWrapperAttrBag(
                         func(name string) (value interface{}, found bool) {
                             field := strings.TrimPrefix(name, fullOutName)
-                            if len(field) != len(name) {
+                            if len(field) != len(name) && out.WasSet(field) {
                                 switch field {
                                     {{range .OutputTemplateMessage.Fields}}
                                     case "{{.ProtoName}}":

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -931,7 +931,7 @@ var (
 					abag = newWrapperAttrBag(
 						func(name string) (value interface{}, found bool) {
 							field := strings.TrimPrefix(name, fullOutName)
-							if len(field) != len(name) {
+							if len(field) != len(name) && out.WasSet(field) {
 								switch field {
 
 								case "int64Primitive":

--- a/mixer/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/mixer/tools/codegen/pkg/interfacegen/template/interface.go
@@ -49,10 +49,27 @@ type Instance struct {
 //
 {{.OutputTemplateMessage.Comment}}{{end}}
 type Output struct {
+  fieldsSet map[string]bool
   {{range .OutputTemplateMessage.Fields}}
   {{.Comment}}
   {{.GoName}} {{replaceGoValueTypeToInterface .GoType}}{{reportTypeUsed .GoType}}
   {{end}}
+}
+
+func NewOutput() (*Output) {
+  return &Output{fieldsSet: make(map[string]bool)}
+}
+
+{{range .OutputTemplateMessage.Fields}}
+func (o *Output) Set{{.GoName}}(val {{replaceGoValueTypeToInterface .GoType}}{{reportTypeUsed .GoType}}) { 
+   o.fieldsSet["{{.GoName}}"] = true
+   o.{{.GoName}} = val
+}
+{{end}}
+
+func (o *Output) WasSet(field string) bool {
+   _, found := o.fieldsSet[field]
+   return found
 }
 {{end}}
 

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/apa/template_handler.gen.go.golden
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/apa/template_handler.gen.go.golden
@@ -57,6 +57,8 @@ type Instance struct {
 
 // Output struct is returned by the attribute producing adapters that handle this template.
 type Output struct {
+	fieldsSet map[string]bool
+
 	Int64Primitive int64
 
 	BoolPrimitive bool
@@ -68,6 +70,45 @@ type Output struct {
 	TimeStamp time.Time
 
 	Duration time.Duration
+}
+
+func NewOutput() *Output {
+	return &Output{fieldsSet: make(map[string]bool)}
+}
+
+func (o *Output) SetInt64Primitive(val int64) {
+	o.fieldsSet["Int64Primitive"] = true
+	o.Int64Primitive = val
+}
+
+func (o *Output) SetBoolPrimitive(val bool) {
+	o.fieldsSet["BoolPrimitive"] = true
+	o.BoolPrimitive = val
+}
+
+func (o *Output) SetDoublePrimitive(val float64) {
+	o.fieldsSet["DoublePrimitive"] = true
+	o.DoublePrimitive = val
+}
+
+func (o *Output) SetStringPrimitive(val string) {
+	o.fieldsSet["StringPrimitive"] = true
+	o.StringPrimitive = val
+}
+
+func (o *Output) SetTimeStamp(val time.Time) {
+	o.fieldsSet["TimeStamp"] = true
+	o.TimeStamp = val
+}
+
+func (o *Output) SetDuration(val time.Duration) {
+	o.fieldsSet["Duration"] = true
+	o.Duration = val
+}
+
+func (o *Output) WasSet(field string) bool {
+	_, found := o.fieldsSet[field]
+	return found
 }
 
 type Resource1 struct {

--- a/tests/e2e/tests/pilot/testdata/mixer.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/mixer.yaml.tmpl
@@ -1005,14 +1005,14 @@ spec:
   attribute_bindings:
     # Fill the new attributes from the adapter produced output.
     # $out refers to an instance of OutputTemplate message
-    source.ip: $out.source_pod_ip
-    source.labels: $out.source_labels
-    source.namespace: $out.source_namespace
-    source.service: $out.source_service
-    source.serviceAccount: $out.source_service_account_name
-    destination.ip: $out.destination_pod_ip
-    destination.labels: $out.destination_labels
-    destination.namespace: $out.destination_namespace
-    destination.service: $out.destination_service
-    destination.serviceAccount: $out.destination_service_account_name
+    source.ip: $out.source_pod_ip | ip("0.0.0.0")
+    source.labels: $out.source_labels | emptyStringMap()
+    source.namespace: $out.source_namespace | "default"
+    source.service: $out.source_service | "unknown"
+    source.serviceAccount: $out.source_service_account_name | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.namespace: $out.destination_namespace | "default"
+    destination.service: $out.destination_service | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
 ---


### PR DESCRIPTION
This PR is an approach to improving data quality for data generated by preprocess
adapters. The PR updates the generated code for Output structs for preprocess adapters
by adding SetXXXX() methods to the Output type that keep track of attributes that
were set. The generated code that checks for attribute values then also checks to see
if an attribute value was set.

In support of those changes, this PR adds a new expr Fn to Mixer: `emptyStringMap()`. This
new expr allows creation of default values for string_map expressions.

Finally, the PR updates the various config components for kubernetesenv adapters throughout
the repo.

This should eliminate the `source.service == ""` data issues that appeared when the new preprocessor
adapter mechanisms were put in place (as well as other zero-value related issues).