### PR TITLE
IP Whitelist in Helm

### DIFF
--- a/install/kubernetes/helm/README.md
+++ b/install/kubernetes/helm/README.md
@@ -10,7 +10,7 @@ $ helm install istio --name istio --namespace=istio-system
 ```
 
 ## Configuration
-All configurable variables can be seem in `values.yaml`.
+All configurable variables can be seen in `values.yaml`.
 
 <!--- TODO:
  - describe all possible config options for the chart (values.yaml)

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -20,9 +20,9 @@ data:
         - {{ "{{ .MeshConfig.ProxyListenPort }}" }}
         - "-u"
         - 1337
-        {{ if .Values.includeIpRanges -}}
+        {{ if .Values.includeIPRanges -}}
         - "-i"
-        - {{ .Values.includeIpRanges | quote }}
+        - {{ .Values.includeIPRanges | quote }}
         {{ end -}}
         imagePullPolicy: IfNotPresent
         securityContext:

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -20,6 +20,10 @@ data:
         - {{ "{{ .MeshConfig.ProxyListenPort }}" }}
         - "-u"
         - 1337
+        {{ if .Values.includeIpRanges -}}
+        - "-i"
+        - {{ .Values.includeIpRanges | quote }}
+        {{ end -}}
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -2,7 +2,7 @@ dependencies:
   - name: sidecar-injector
     version: 0.5.0
     # repository: file://../sidecar-injector
-    condition: sidecarInjector.enabled
+    condition: sidecar-injector.enabled
   - name: ingress
     version: 0.5.0
     # repository: file://../ingress

--- a/install/kubernetes/templates/helm/istio/values.yaml.tmpl
+++ b/install/kubernetes/templates/helm/istio/values.yaml.tmpl
@@ -73,6 +73,7 @@ sidecar-injector:
   #  cpu: 100m
   #  memory: 128Mi
   nodeSelector: {}
+  includeIPRanges: {}
 
 #
 # mixer configuration

--- a/install/kubernetes/templates/helm/istio/values.yaml.tmpl
+++ b/install/kubernetes/templates/helm/istio/values.yaml.tmpl
@@ -73,6 +73,12 @@ sidecar-injector:
   #  cpu: 100m
   #  memory: 128Mi
   nodeSelector: {}
+
+  # istio egress capture whitelist
+  # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly
+  # example: includeIPRanges: "172.30.0.0/16,172.20.0.0/16"
+  # would only capture egress traffic on those two IP Ranges, all other outbound traffic would
+  # be allowed by the sidecar
   includeIPRanges: {}
 
 #

--- a/install/kubernetes/templates/helm/istio/values.yaml.tmpl
+++ b/install/kubernetes/templates/helm/istio/values.yaml.tmpl
@@ -60,7 +60,7 @@ ingress:
 #
 # sidecar-injector configuration
 #
-sidecarInjector:
+sidecar-injector:
   enabled: false
   serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1


### PR DESCRIPTION
I added an option to specify `includeIPRanges` in the helm chart in order to match the corresponding argument to `istioctl` when using automatic sidecar injection. 

I also fixed an issue with the value name for the sidecar injector where it didn't match the name of the sidecar injector subchart, and thus the values weren't available to it.