### PR TITLE
Re-enable pprof for mixer with args consistent with Pilot

### DIFF
--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -81,6 +81,7 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 		"Path to the file for the readiness probe.")
 	serverCmd.PersistentFlags().DurationVar(&sa.ReadinessProbeOptions.UpdateInterval, "readinessProbeInterval", 0,
 		"Interval of updating file for the readiness probe.")
+	serverCmd.PersistentFlags().BoolVar(&sa.EnableProfiling, "profile", true, "Enable profiling via web interface host:port/debug/pprof")
 
 	// TODO: Remove all this stuff by the 0.5 release (don't forget all associated YAML templates and any other uses of these options in the code
 	// base & docs)

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -90,6 +90,9 @@ type Args struct {
 	// Port to use for exposing mixer self-monitoring information
 	MonitoringPort uint16
 
+	// Enable profiling via web interface host:port/debug/pprof
+	EnableProfiling bool
+
 	// Enables use of pkg/runtime2, instead of pkg/runtime.
 	UseNewRuntime bool
 
@@ -148,6 +151,7 @@ func (a *Args) String() string {
 	b.WriteString(fmt.Sprint("ExpressionEvalCacheSize: ", a.ExpressionEvalCacheSize, "\n"))
 	b.WriteString(fmt.Sprint("APIPort: ", a.APIPort, "\n"))
 	b.WriteString(fmt.Sprint("MonitoringPort: ", a.MonitoringPort, "\n"))
+	b.WriteString(fmt.Sprint("EnableProfiling: ", a.EnableProfiling, "\n"))
 	b.WriteString(fmt.Sprint("SingleThreaded: ", a.SingleThreaded, "\n"))
 	b.WriteString(fmt.Sprint("ConfigStoreURL: ", a.ConfigStoreURL, "\n"))
 	b.WriteString(fmt.Sprint("ConfigDefaultNamespace: ", a.ConfigDefaultNamespace, "\n"))

--- a/mixer/pkg/server/monitoring.go
+++ b/mixer/pkg/server/monitoring.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -37,7 +38,7 @@ const (
 	versionPath = "/version"
 )
 
-func startMonitor(port uint16) (*monitor, error) {
+func startMonitor(port uint16, enableProfiling bool) (*monitor, error) {
 	m := &monitor{
 		closed: make(chan struct{}),
 	}
@@ -60,6 +61,14 @@ func startMonitor(port uint16) (*monitor, error) {
 			log.Errorf("Unable to write version string: %v", err)
 		}
 	})
+
+	if enableProfiling {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 
 	m.monitoringServer = &http.Server{
 		Handler: mux,

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -73,7 +73,7 @@ type patchTable struct {
 		identityAttribute string, defaultConfigNamespace string, executorPool *pool.GoroutinePool,
 		handlerPool *pool.GoroutinePool, enableTracing bool) *mixerRuntime2.Runtime
 	configTracing func(serviceName string, options *tracing.Options) (io.Closer, error)
-	startMonitor  func(port uint16) (*monitor, error)
+	startMonitor  func(port uint16, enableProfiling bool) (*monitor, error)
 	listen        func(network string, address string) (net.Listener, error)
 }
 
@@ -145,7 +145,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	grpcOptions = append(grpcOptions, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(interceptors...)))
 
-	if s.monitor, err = p.startMonitor(a.MonitoringPort); err != nil {
+	if s.monitor, err = p.startMonitor(a.MonitoringPort, a.EnableProfiling); err != nil {
 		_ = s.Close()
 		return nil, fmt.Errorf("unable to setup monitoring: %v", err)
 	}

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -114,6 +114,7 @@ func newTestServer(globalCfg, serviceCfg string) (*Server, error) {
 	a.APIPort = 0
 	a.MonitoringPort = 0
 	a.LoggingOptions.LogGrpc = false // Avoid introducing a race to the server tests.
+	a.EnableProfiling = true
 	var err error
 	if a.ConfigStore, err = storetest.SetupStoreForTest(globalCfg, serviceCfg); err != nil {
 		return nil, err

--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -213,7 +213,7 @@ func TestErrors(t *testing.T) {
 					return nil, errors.New("BAD")
 				}
 			case 4:
-				pt.startMonitor = func(port uint16) (*monitor, error) {
+				pt.startMonitor = func(port uint16, enableProfiling bool) (*monitor, error) {
 					return nil, errors.New("BAD")
 				}
 			case 5:


### PR DESCRIPTION
Enable pprof at http://localhost:9093/debug/pprof/* with command line args consistent with Pilot.

Signed-off-by: Mandar U Jog <mjog@google.com>