### PR TITLE
Need to use 1.9 which is the first index

### DIFF
--- a/prow/cluster_lib.sh
+++ b/prow/cluster_lib.sh
@@ -28,7 +28,7 @@ NUM_NODES=1
 CLUSTER_NAME=
 
 IFS=';' VERSIONS=($(gcloud container get-server-config --project=${PROJECT_NAME} --zone=${ZONE} --format='value(validMasterVersions)'))
-CLUSTER_VERSION="${VERSIONS[1]}"
+CLUSTER_VERSION="${VERSIONS[0]}"
 
 KUBE_USER="istio-prow-test-job@istio-testing.iam.gserviceaccount.com"
 CLUSTER_CREATED=false


### PR DESCRIPTION
Apparently zsh arrays index starts at 1 while bash index starts at 0, which is why I got inconsistent results.