### PR TITLE
Update runtime2 bootstrapgen bindings to incorporate referencing-check.

### DIFF
--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -2255,6 +2255,16 @@ end`,
 		},
 		R: false,
 	},
+	{
+		E:    `emptyStringMap()`,
+		Type: descriptor.STRING_MAP,
+		IL: `
+ fn eval() interface
+  call emptyStringMap
+  ret
+end`,
+		R: map[string]string{},
+	},
 }
 
 // TestInfo is a structure that contains detailed test information. Depending

--- a/mixer/pkg/il/testing/util.go
+++ b/mixer/pkg/il/testing/util.go
@@ -16,6 +16,7 @@ package ilt
 
 import (
 	"net"
+	"reflect"
 )
 
 // AreEqual checks for equality of given values. It handles comparison of []byte as a special case.
@@ -28,5 +29,5 @@ func AreEqual(e interface{}, a interface{}) bool {
 		return false
 	}
 
-	return a == e
+	return reflect.DeepEqual(e, a)
 }

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -544,7 +544,7 @@ var (
             outBag := newWrapperAttrBag(
                 func(name string) (value interface{}, found bool) {
                     field := strings.TrimPrefix(name, fullOutName)
-                    if len(field) != len(name) {
+                    if len(field) != len(name) && out.WasSet(field) {
                         switch field {
                             {{range .OutputTemplateMessage.Fields}}
                             case "{{.ProtoName}}":

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -1034,7 +1034,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) {
+						if len(field) != len(name) && out.WasSet(field) {
 							switch field {
 
 							case "int64Primitive":


### PR DESCRIPTION
+ Also, add an expression test for emptyStringMap().