### PR TITLE
Update APA field set tracking

### DIFF
--- a/mixer/adapter/kubernetesenv/template/template_handler.gen.go
+++ b/mixer/adapter/kubernetesenv/template/template_handler.gen.go
@@ -162,107 +162,107 @@ func NewOutput() *Output {
 }
 
 func (o *Output) SetSourcePodIp(val net.IP) {
-	o.fieldsSet["SourcePodIp"] = true
+	o.fieldsSet["source_pod_ip"] = true
 	o.SourcePodIp = val
 }
 
 func (o *Output) SetSourcePodName(val string) {
-	o.fieldsSet["SourcePodName"] = true
+	o.fieldsSet["source_pod_name"] = true
 	o.SourcePodName = val
 }
 
 func (o *Output) SetSourceLabels(val map[string]string) {
-	o.fieldsSet["SourceLabels"] = true
+	o.fieldsSet["source_labels"] = true
 	o.SourceLabels = val
 }
 
 func (o *Output) SetSourceNamespace(val string) {
-	o.fieldsSet["SourceNamespace"] = true
+	o.fieldsSet["source_namespace"] = true
 	o.SourceNamespace = val
 }
 
 func (o *Output) SetSourceService(val string) {
-	o.fieldsSet["SourceService"] = true
+	o.fieldsSet["source_service"] = true
 	o.SourceService = val
 }
 
 func (o *Output) SetSourceServiceAccountName(val string) {
-	o.fieldsSet["SourceServiceAccountName"] = true
+	o.fieldsSet["source_service_account_name"] = true
 	o.SourceServiceAccountName = val
 }
 
 func (o *Output) SetSourceHostIp(val net.IP) {
-	o.fieldsSet["SourceHostIp"] = true
+	o.fieldsSet["source_host_ip"] = true
 	o.SourceHostIp = val
 }
 
 func (o *Output) SetDestinationPodIp(val net.IP) {
-	o.fieldsSet["DestinationPodIp"] = true
+	o.fieldsSet["destination_pod_ip"] = true
 	o.DestinationPodIp = val
 }
 
 func (o *Output) SetDestinationPodName(val string) {
-	o.fieldsSet["DestinationPodName"] = true
+	o.fieldsSet["destination_pod_name"] = true
 	o.DestinationPodName = val
 }
 
 func (o *Output) SetDestinationLabels(val map[string]string) {
-	o.fieldsSet["DestinationLabels"] = true
+	o.fieldsSet["destination_labels"] = true
 	o.DestinationLabels = val
 }
 
 func (o *Output) SetDestinationNamespace(val string) {
-	o.fieldsSet["DestinationNamespace"] = true
+	o.fieldsSet["destination_namespace"] = true
 	o.DestinationNamespace = val
 }
 
 func (o *Output) SetDestinationService(val string) {
-	o.fieldsSet["DestinationService"] = true
+	o.fieldsSet["destination_service"] = true
 	o.DestinationService = val
 }
 
 func (o *Output) SetDestinationServiceAccountName(val string) {
-	o.fieldsSet["DestinationServiceAccountName"] = true
+	o.fieldsSet["destination_service_account_name"] = true
 	o.DestinationServiceAccountName = val
 }
 
 func (o *Output) SetDestinationHostIp(val net.IP) {
-	o.fieldsSet["DestinationHostIp"] = true
+	o.fieldsSet["destination_host_ip"] = true
 	o.DestinationHostIp = val
 }
 
 func (o *Output) SetOriginPodIp(val net.IP) {
-	o.fieldsSet["OriginPodIp"] = true
+	o.fieldsSet["origin_pod_ip"] = true
 	o.OriginPodIp = val
 }
 
 func (o *Output) SetOriginPodName(val string) {
-	o.fieldsSet["OriginPodName"] = true
+	o.fieldsSet["origin_pod_name"] = true
 	o.OriginPodName = val
 }
 
 func (o *Output) SetOriginLabels(val map[string]string) {
-	o.fieldsSet["OriginLabels"] = true
+	o.fieldsSet["origin_labels"] = true
 	o.OriginLabels = val
 }
 
 func (o *Output) SetOriginNamespace(val string) {
-	o.fieldsSet["OriginNamespace"] = true
+	o.fieldsSet["origin_namespace"] = true
 	o.OriginNamespace = val
 }
 
 func (o *Output) SetOriginService(val string) {
-	o.fieldsSet["OriginService"] = true
+	o.fieldsSet["origin_service"] = true
 	o.OriginService = val
 }
 
 func (o *Output) SetOriginServiceAccountName(val string) {
-	o.fieldsSet["OriginServiceAccountName"] = true
+	o.fieldsSet["origin_service_account_name"] = true
 	o.OriginServiceAccountName = val
 }
 
 func (o *Output) SetOriginHostIp(val net.IP) {
-	o.fieldsSet["OriginHostIp"] = true
+	o.fieldsSet["origin_host_ip"] = true
 	o.OriginHostIp = val
 }
 

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	pb "istio.io/api/mixer/v1/config"
-	descriptor "istio.io/api/mixer/v1/config/descriptor"
+	"istio.io/api/mixer/v1/config/descriptor"
 	"istio.io/istio/mixer/pkg/expr"
 )
 
@@ -510,6 +510,37 @@ end`,
 		AstErr: "could not convert '242233' to TIMESTAMP. expected format: '" + time.RFC3339 + "'",
 		conf:   exprEvalAttrs,
 	},
+	{
+		E:    "emptyStringMap()",
+		Type: descriptor.STRING_MAP,
+		IL: `
+fn eval() interface
+  call emptyStringMap
+  ret
+end
+`,
+		R:          map[string]string{},
+		I:          map[string]interface{}{},
+		Referenced: []string{},
+		conf:       exprEvalAttrs,
+	},
+	{
+		E:          `source.labels | emptyStringMap()`,
+		Type:       descriptor.STRING_MAP,
+		I:          map[string]interface{}{},
+		R:          map[string]string{},
+		Referenced: []string{"source.labels"},
+		conf:       exprEvalAttrs,
+	},
+	// TODO: uncomment the following lines when short-circuiting for externs is added
+	//{
+	//	E:    `emptyStringMap() | source.labels`,
+	//	Type: descriptor.STRING_MAP,
+	//	I:    map[string]interface{}{"source.labels": map[string]string{"test": "foo"}},
+	//	R:    map[string]string{},
+	//	Referenced: []string{},
+	//	conf: exprEvalAttrs,
+	//},
 
 	// Tests from expr/eval_test.go TestCEXLEval
 	{
@@ -2419,6 +2450,9 @@ var exprEvalAttrs = map[string]*pb.AttributeManifest_AttributeInfo{
 	},
 	"servicename": {
 		ValueType: descriptor.STRING,
+	},
+	"source.labels": {
+		ValueType: descriptor.STRING_MAP,
 	},
 }
 

--- a/mixer/pkg/il/testing/util.go
+++ b/mixer/pkg/il/testing/util.go
@@ -16,6 +16,7 @@ package ilt
 
 import (
 	"net"
+	"reflect"
 )
 
 // AreEqual checks for equality of given values. It handles comparison of []byte as a special case.
@@ -28,5 +29,5 @@ func AreEqual(e interface{}, a interface{}) bool {
 		return false
 	}
 
-	return a == e
+	return reflect.DeepEqual(a, e)
 }

--- a/mixer/template/sample/apa/Apa_handler.gen.go
+++ b/mixer/template/sample/apa/Apa_handler.gen.go
@@ -57,6 +57,8 @@ type Instance struct {
 
 // Output struct is returned by the attribute producing adapters that handle this template.
 type Output struct {
+	fieldsSet map[string]bool
+
 	Int64Primitive int64
 
 	BoolPrimitive bool
@@ -74,6 +76,60 @@ type Output struct {
 	OutIp net.IP
 
 	OutStrMap map[string]string
+}
+
+func NewOutput() *Output {
+	return &Output{fieldsSet: make(map[string]bool)}
+}
+
+func (o *Output) SetInt64Primitive(val int64) {
+	o.fieldsSet["int64Primitive"] = true
+	o.Int64Primitive = val
+}
+
+func (o *Output) SetBoolPrimitive(val bool) {
+	o.fieldsSet["boolPrimitive"] = true
+	o.BoolPrimitive = val
+}
+
+func (o *Output) SetDoublePrimitive(val float64) {
+	o.fieldsSet["doublePrimitive"] = true
+	o.DoublePrimitive = val
+}
+
+func (o *Output) SetStringPrimitive(val string) {
+	o.fieldsSet["stringPrimitive"] = true
+	o.StringPrimitive = val
+}
+
+func (o *Output) SetTimeStamp(val time.Time) {
+	o.fieldsSet["timeStamp"] = true
+	o.TimeStamp = val
+}
+
+func (o *Output) SetDuration(val time.Duration) {
+	o.fieldsSet["duration"] = true
+	o.Duration = val
+}
+
+func (o *Output) SetEmail(val adapter.EmailAddress) {
+	o.fieldsSet["email"] = true
+	o.Email = val
+}
+
+func (o *Output) SetOutIp(val net.IP) {
+	o.fieldsSet["out_ip"] = true
+	o.OutIp = val
+}
+
+func (o *Output) SetOutStrMap(val map[string]string) {
+	o.fieldsSet["out_str_map"] = true
+	o.OutStrMap = val
+}
+
+func (o *Output) WasSet(field string) bool {
+	_, found := o.fieldsSet[field]
+	return found
 }
 
 type Resource1 struct {

--- a/mixer/template/sample/dispatch_test.go
+++ b/mixer/template/sample/dispatch_test.go
@@ -126,19 +126,49 @@ func TestDispatchQuota_Failure(t *testing.T) {
 	}
 }
 
-func TestDispatchGenAttrs_Success(t *testing.T) {
-	h := &mockHandler{
-		apaOutput: sample_apa.Output{
-			StringPrimitive: "This is an output",
-			Int64Primitive:  defaultApaAttributes["ai"].(int64),
-			OutIp:           net.ParseIP("2.3.4.5"),
+var sampleApaInstanceParam = sample_apa.InstanceParam{
+	StringPrimitive:                "as",
+	Int64Primitive:                 "ai",
+	TimeStamp:                      "ats",
+	DoublePrimitive:                "ad",
+	BoolPrimitive:                  "ab",
+	Duration:                       "adr",
+	Email:                          "`email@email`",
+	OptionalIP:                     `ip("0.0.0.0")`,
+	DimensionsFixedInt64ValueDType: map[string]string{"ai2": "ai2"},
+	Res3Map: map[string]*sample_apa.Resource3InstanceParam{
+		"r3": {
+			StringPrimitive:                "as2",
+			Duration:                       "adr",
+			TimeStamp:                      "ats",
+			BoolPrimitive:                  "ab",
+			DoublePrimitive:                "ad",
+			Int64Primitive:                 "ai3",
+			DimensionsFixedInt64ValueDType: map[string]string{"ai4": "ai4"},
 		},
+	},
+	AttributeBindings: map[string]string{
+		"generated.ai": "$out.int64Primitive",
+		"generated.as": "$out.stringPrimitive",
+		"generated.ip": "$out.out_ip",
+	},
+}
+
+func TestDispatchGenAttrs_Success(t *testing.T) {
+
+	out := sample_apa.NewOutput()
+	out.SetStringPrimitive("This is an output")
+	out.SetInt64Primitive(defaultApaAttributes["ai"].(int64))
+	out.SetOutIp(net.ParseIP("2.3.4.5"))
+
+	h := &mockHandler{
+		apaOutput: *out,
 	}
 
 	bag := attribute.GetFakeMutableBagForTesting(defaultApaAttributes)
 	f := finder{combineManifests(defaultAttributeInfos, SupportedTmplInfo[sample_apa.TemplateName].AttributeManifests...)}
 	builder := compiled.NewBuilder(f)
-	expressions, err := SupportedTmplInfo[sample_apa.TemplateName].CreateOutputExpressions(&defaultApaInstanceParam, f, builder)
+	expressions, err := SupportedTmplInfo[sample_apa.TemplateName].CreateOutputExpressions(&sampleApaInstanceParam, f, builder)
 	if err != nil {
 		t.Fatalf("Unexpected CreateOutputExpressions error: %v", err)
 	}

--- a/mixer/template/sample/template.gen.go
+++ b/mixer/template/sample/template.gen.go
@@ -871,7 +871,7 @@ var (
 					abag = newWrapperAttrBag(
 						func(name string) (value interface{}, found bool) {
 							field := strings.TrimPrefix(name, fullOutName)
-							if len(field) != len(name) {
+							if len(field) != len(name) && out.WasSet(field) {
 								switch field {
 
 								case "int64Primitive":
@@ -966,7 +966,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) {
+						if len(field) != len(name) && out.WasSet(field) {
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/template/sample/template.gen_test.go
+++ b/mixer/template/sample/template.gen_test.go
@@ -1698,6 +1698,18 @@ attribute_bindings:
 }
 
 func TestProcessApa(t *testing.T) {
+
+	handlerOut := istio_mixer_adapter_sample_myapa.NewOutput()
+	handlerOut.SetBoolPrimitive(true)
+	handlerOut.SetDoublePrimitive(1237)
+	handlerOut.SetStringPrimitive("1237")
+	handlerOut.SetTimeStamp(time.Date(2019, time.January, 01, 0, 0, 0, 0, time.UTC))
+	handlerOut.SetDuration(10 * time.Second)
+	handlerOut.SetInt64Primitive(1237)
+	handlerOut.SetEmail(adapter.EmailAddress("updatedfoo@bar.com"))
+	handlerOut.SetOutIp(net.ParseIP("1.2.3.4"))
+	handlerOut.SetOutStrMap(map[string]string{"a": "b"})
+
 	for _, tst := range []struct {
 		name         string
 		instName     string
@@ -1743,17 +1755,7 @@ func TestProcessApa(t *testing.T) {
 				},
 			},
 			hdlr: &fakeMyApaHandler{
-				retOutput: &istio_mixer_adapter_sample_myapa.Output{
-					BoolPrimitive:   true,
-					DoublePrimitive: 1237,
-					StringPrimitive: "1237",
-					TimeStamp:       time.Date(2019, time.January, 01, 0, 0, 0, 0, time.UTC),
-					Duration:        10 * time.Second,
-					Int64Primitive:  1237,
-					Email:           adapter.EmailAddress("updatedfoo@bar.com"),
-					OutIp:           net.ParseIP("1.2.3.4"),
-					OutStrMap:       map[string]string{"a": "b"},
-				},
+				retOutput: handlerOut,
 			},
 			wantOutAttrs: map[string]interface{}{
 				"source.mystring":          "1237",

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -599,7 +599,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) {
+						if len(field) != len(name) && out.WasSet(field) {
 							switch field {
 
 							case "source_pod_ip":

--- a/mixer/test/e2e/e2e_apa_test.go
+++ b/mixer/test/e2e/e2e_apa_test.go
@@ -141,6 +141,14 @@ spec:
 )
 
 func TestApa(t *testing.T) {
+
+	out := apaTmpl.NewOutput()
+	out.SetStringPrimitive("gen-str")
+	out.SetInt64Primitive(int64(1000))
+	out.SetDoublePrimitive(float64(1000.1000))
+	out.SetBoolPrimitive(true)
+	out.SetStringMap(map[string]string{"k1": "v1"})
+
 	tests := []testData{
 		{
 			name: "Apa",
@@ -149,15 +157,7 @@ func TestApa(t *testing.T) {
 				{
 					Name: "fakeHandler",
 					Handler: spyAdapter.HandlerBehavior{
-						GenerateSampleApaOutput: &apaTmpl.Output{
-							StringPrimitive: "gen-str",
-							Int64Primitive:  int64(1000),
-							DoublePrimitive: float64(1000.1000),
-							BoolPrimitive:   true,
-							StringMap: map[string]string{
-								"k1": "v1",
-							},
-						},
+						GenerateSampleApaOutput: out,
 					},
 				},
 			},

--- a/mixer/test/spyAdapter/template/apa/tmpl_handler.gen.go
+++ b/mixer/test/spyAdapter/template/apa/tmpl_handler.gen.go
@@ -41,6 +41,8 @@ type Instance struct {
 
 // Output struct is returned by the attribute producing adapters that handle this template.
 type Output struct {
+	fieldsSet map[string]bool
+
 	Int64Primitive int64
 
 	BoolPrimitive bool
@@ -50,6 +52,40 @@ type Output struct {
 	StringPrimitive string
 
 	StringMap map[string]string
+}
+
+func NewOutput() *Output {
+	return &Output{fieldsSet: make(map[string]bool)}
+}
+
+func (o *Output) SetInt64Primitive(val int64) {
+	o.fieldsSet["int64Primitive"] = true
+	o.Int64Primitive = val
+}
+
+func (o *Output) SetBoolPrimitive(val bool) {
+	o.fieldsSet["boolPrimitive"] = true
+	o.BoolPrimitive = val
+}
+
+func (o *Output) SetDoublePrimitive(val float64) {
+	o.fieldsSet["doublePrimitive"] = true
+	o.DoublePrimitive = val
+}
+
+func (o *Output) SetStringPrimitive(val string) {
+	o.fieldsSet["stringPrimitive"] = true
+	o.StringPrimitive = val
+}
+
+func (o *Output) SetStringMap(val map[string]string) {
+	o.fieldsSet["stringMap"] = true
+	o.StringMap = val
+}
+
+func (o *Output) WasSet(field string) bool {
+	_, found := o.fieldsSet[field]
+	return found
 }
 
 // HandlerBuilder must be implemented by adapters if they want to

--- a/mixer/test/spyAdapter/template/template.gen.go
+++ b/mixer/test/spyAdapter/template/template.gen.go
@@ -324,7 +324,7 @@ var (
 					abag = newWrapperAttrBag(
 						func(name string) (value interface{}, found bool) {
 							field := strings.TrimPrefix(name, fullOutName)
-							if len(field) != len(name) {
+							if len(field) != len(name) && out.WasSet(field) {
 								switch field {
 
 								case "int64Primitive":
@@ -403,7 +403,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) {
+						if len(field) != len(name) && out.WasSet(field) {
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -544,7 +544,7 @@ var (
             outBag := newWrapperAttrBag(
                 func(name string) (value interface{}, found bool) {
                     field := strings.TrimPrefix(name, fullOutName)
-                    if len(field) != len(name) {
+                    if len(field) != len(name) && out.WasSet(field) {
                         switch field {
                             {{range .OutputTemplateMessage.Fields}}
                             case "{{.ProtoName}}":

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -1034,7 +1034,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) {
+						if len(field) != len(name) && out.WasSet(field) {
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/tools/codegen/pkg/interfacegen/template/interface.go
+++ b/mixer/tools/codegen/pkg/interfacegen/template/interface.go
@@ -22,6 +22,7 @@ package {{.GoPackageName}}
 
 import (
   "context"
+  "strings"
   "istio.io/istio/mixer/pkg/adapter"
   "istio.io/istio/mixer/pkg/adapter"
   $$additional_imports$$
@@ -62,7 +63,7 @@ func NewOutput() (*Output) {
 
 {{range .OutputTemplateMessage.Fields}}
 func (o *Output) Set{{.GoName}}(val {{replaceGoValueTypeToInterface .GoType}}{{reportTypeUsed .GoType}}) { 
-   o.fieldsSet["{{.GoName}}"] = true
+   o.fieldsSet["{{.ProtoName}}"] = true
    o.{{.GoName}} = val
 }
 {{end}}

--- a/mixer/tools/codegen/pkg/interfacegen/testdata/apa/template_handler.gen.go.golden
+++ b/mixer/tools/codegen/pkg/interfacegen/testdata/apa/template_handler.gen.go.golden
@@ -77,32 +77,32 @@ func NewOutput() *Output {
 }
 
 func (o *Output) SetInt64Primitive(val int64) {
-	o.fieldsSet["Int64Primitive"] = true
+	o.fieldsSet["int64Primitive"] = true
 	o.Int64Primitive = val
 }
 
 func (o *Output) SetBoolPrimitive(val bool) {
-	o.fieldsSet["BoolPrimitive"] = true
+	o.fieldsSet["boolPrimitive"] = true
 	o.BoolPrimitive = val
 }
 
 func (o *Output) SetDoublePrimitive(val float64) {
-	o.fieldsSet["DoublePrimitive"] = true
+	o.fieldsSet["doublePrimitive"] = true
 	o.DoublePrimitive = val
 }
 
 func (o *Output) SetStringPrimitive(val string) {
-	o.fieldsSet["StringPrimitive"] = true
+	o.fieldsSet["stringPrimitive"] = true
 	o.StringPrimitive = val
 }
 
 func (o *Output) SetTimeStamp(val time.Time) {
-	o.fieldsSet["TimeStamp"] = true
+	o.fieldsSet["timeStamp"] = true
 	o.TimeStamp = val
 }
 
 func (o *Output) SetDuration(val time.Duration) {
-	o.fieldsSet["Duration"] = true
+	o.fieldsSet["duration"] = true
 	o.Duration = val
 }
 


### PR DESCRIPTION
This PR completes the work started in PR #3530. It switches from GoName to ProtoName
for field-checking and adds some more tests to the il packages to check on behavior
of `emptyStringMap`.

Most of the code changes are directly related to running `go generate ./mixer/...`.