### PR TITLE
fix lint config and other lint errors

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -49,6 +49,9 @@
         "vet": "error",
         "vetshadow": "error"
     },
+    "skip": [
+        "mixer/tools/adapterlinter/testdata"
+    ],
     "exclude": [
         ".pb.go",
         "mock_*",
@@ -59,7 +62,6 @@
         "mixer/template/sample/.*.go",
         "mixer/test/spyAdapter/template/doc.go",
         "mixer/template/doc.go",
-        "mixer/tools/adapterlinter/testdata/.*",
         "should have a package comment",
         "composite literal uses unkeyed fields",
         "genfiles"

--- a/security/cmd/flexvolume/driver/driver.go
+++ b/security/cmd/flexvolume/driver/driver.go
@@ -230,7 +230,7 @@ func Mount(dir, opts string) error {
 		return failure("mount", inp, sErr)
 	}
 
-	if configuration.UseGrpc == true {
+	if configuration.UseGrpc {
 		if err := sendWorkloadAdded(ninputs); err != nil {
 			handleErrMount(dir, ninputs)
 			sErr := "Failure to notify nodeagent: " + err.Error()
@@ -261,7 +261,7 @@ func Unmount(dir string) error {
 		Attrs:        &pb.WorkloadInfo_WorkloadAttributes{Uid: uid},
 		Workloadpath: uid,
 	}
-	if configuration.UseGrpc == true {
+	if configuration.UseGrpc {
 		if err := sendWorkloadDeleted(naInp); err != nil {
 			sErr := "Failure to notify nodeagent: " + err.Error()
 			return failure("unmount", dir, sErr)
@@ -389,8 +389,7 @@ func getCredFile(uid string) string {
 // addCredentialFile is used to create a credential file when a workload with the flex-volume volume mounted is created.
 func addCredentialFile(ninputs *pb.WorkloadInfo) error {
 	//Make the directory and then write the ninputs as json to it.
-	var err error
-	err = os.MkdirAll(configuration.NodeAgentCredentialsHomeDir, 0755)
+	err := os.MkdirAll(configuration.NodeAgentCredentialsHomeDir, 0755)
 	if err != nil {
 		return err
 	}

--- a/security/cmd/flexvolume/driver/driver_test.go
+++ b/security/cmd/flexvolume/driver/driver_test.go
@@ -363,7 +363,7 @@ func TestMountCmdCredFailure(t *testing.T) {
 		}
 	}
 
-	errPath := fmt.Sprintf(filepath.Join(testDir, "fail", opts.UID+".json"))
+	errPath := filepath.Join(testDir, "fail", opts.UID+".json")
 	var gotResp Response
 	expResp := getFailure("", "", fmt.Sprintf("Failure to create credentials: open %s: no such file or directory", errPath))
 	if err := cmpStdOutput(&expResp, &gotResp); err != nil {

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -29,7 +29,6 @@ import (
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/probe"
-	"istio.io/istio/security/pkg/caclient/grpc"
 	"istio.io/istio/security/pkg/pki/util"
 )
 
@@ -97,8 +96,6 @@ type IstioCA struct {
 
 	certChainBytes []byte
 	rootCertBytes  []byte
-
-	caClient grpc.CAGrpcClient
 
 	livenessProbe *probe.Probe
 }


### PR DESCRIPTION
As I reported in #3563, the testdata directory seems somewhat
special in golang, causing a weird behavior. And actually,
this mixer/tools/adapterlinter/testdata files do not have to be
processed on our lint tasks.

exclude pattern is not a good way to avoid processing them,
use "skip" instead.

Fixes #3563

Also fixed lint errors which have been overlooked because of this.