### PR TITLE
Add support for unmarshaling LDS JSON

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery_test.go
@@ -131,7 +131,7 @@ func TestDiscoveryLDSWebHooks(t *testing.T) {
 		if r.URL.Path != url {
 			t.Errorf("WebHook expected URL: %s, got %s", url, r.URL.Path)
 		}
-		fmt.Fprintln(w, "'listeners': [ {'name': 'Hello-LDS-WebHook'}]")
+		fmt.Fprintln(w, `{"listeners": [ {"name": "Hello-LDS-WebHook"}]}`)
 	}))
 	defer ts.Close()
 
@@ -149,7 +149,7 @@ func TestDiscoveryCDSWebHooks(t *testing.T) {
 		if r.URL.Path != url {
 			t.Errorf("WebHook expected URL: %s, got %s", url, r.URL.Path)
 		}
-		fmt.Fprintln(w, "'clusters': [ {'name': 'Hello-CDS-WebHook'}]")
+		fmt.Fprintln(w, `{"clusters": [ {"name": "Hello-CDS-WebHook"}]}`)
 	}))
 	defer ts.Close()
 
@@ -167,7 +167,7 @@ func TestDiscoveryRDSWebHooks(t *testing.T) {
 		if r.URL.Path != url {
 			t.Errorf("WebHook expected URL: %s, got %s", url, r.URL.Path)
 		}
-		fmt.Fprintln(w, "'routes': [ {'name': 'Hello-RDS-WebHook'}]")
+		fmt.Fprintln(w, `{"routes": [ {"name": "Hello-RDS-WebHook"}]}`)
 	}))
 	defer ts.Close()
 

--- a/pilot/pkg/proxy/envoy/v1/resources.go
+++ b/pilot/pkg/proxy/envoy/v1/resources.go
@@ -15,6 +15,10 @@
 package v1
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -624,6 +628,57 @@ type NetworkFilter struct {
 // NetworkFilterConfig is a marker interface
 type NetworkFilterConfig interface {
 	IsNetworkFilterConfig()
+}
+
+// NetworkFilterTypes maps filter names to types of structs that implement them. It is used when unmarshaling JSON data.
+// To add your own NetworkFilter types, add additional entries to this map prior to calling json.Unmarshal.
+var NetworkFilterTypes = map[string]reflect.Type{
+	RedisProxyFilter:      reflect.TypeOf(RedisProxyFilterConfig{}),
+	CORSFilter:            reflect.TypeOf(CORSFilterConfig{}),
+	MongoProxyFilter:      reflect.TypeOf(MongoProxyFilterConfig{}),
+	TCPProxyFilter:        reflect.TypeOf(TCPProxyFilterConfig{}),
+	HTTPConnectionManager: reflect.TypeOf(HTTPFilterConfig{}),
+	MixerFilter:           reflect.TypeOf(FilterMixerConfig{}),
+}
+
+// UnmarshalJSON handles custom unmarshal logic for the NetworkFilter struct. This is needed because the config field
+// depends on the filter name.
+func (nf *NetworkFilter) UnmarshalJSON(b []byte) error {
+
+	// First, unmarshal to a generic data structure so we can get the name.
+	var j interface{}
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+	m := j.(map[string]interface{})
+	n, ok := m["name"].(string)
+	if !ok {
+		return errors.New("filter missing name field")
+	}
+
+	// Once we have the name, we can look up the concrete type of the config field.
+	t, ok := NetworkFilterTypes[n]
+	if !ok {
+		return fmt.Errorf("unknown filter name: %s", n)
+	}
+	v := reflect.New(t)
+
+	// Since Unmarshal takes a []byte, we re-marshall the config and then call Unmarshal on it.
+	cfgBytes, err := json.Marshal(m["config"])
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(cfgBytes, v.Interface())
+	if err != nil {
+		return err
+	}
+
+	// Fill in the NetworkFilter
+	nf.Name = n
+	nf.Type = m["type"].(string)
+	nf.Config = v.Interface().(NetworkFilterConfig)
+	return nil
 }
 
 // Listener definition

--- a/pilot/pkg/proxy/envoy/v1/resources_test.go
+++ b/pilot/pkg/proxy/envoy/v1/resources_test.go
@@ -1,0 +1,49 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestUnmarshalLDS(t *testing.T) {
+	type ldsResponse struct {
+		Listeners Listeners `json:"listeners"`
+	}
+
+	files, err := ioutil.ReadDir("testdata")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for _, f := range files {
+		n := f.Name()
+		if strings.HasPrefix(n, "lds") && strings.HasSuffix(n, ".json.golden") {
+			t.Run(n, func(t *testing.T) {
+				var lds ldsResponse
+				c, err := ioutil.ReadFile("testdata/" + n)
+				if err != nil {
+					t.Fatalf(err.Error())
+				}
+				err = json.Unmarshal(c, &lds)
+				if err != nil {
+					t.Errorf("failed to unmarshal %s: %v", n, err)
+				}
+			})
+		}
+	}
+}

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-webhook.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-webhook.json.golden
@@ -1,1 +1,1 @@
-'clusters': [ {'name': 'Hello-CDS-WebHook'}]
+{"clusters": [ {"name": "Hello-CDS-WebHook"}]}

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-webhook.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-webhook.json.golden
@@ -1,1 +1,1 @@
-'listeners': [ {'name': 'Hello-LDS-WebHook'}]
+{"listeners": [ {"name": "Hello-LDS-WebHook"}]}

--- a/pilot/pkg/proxy/envoy/v1/testdata/rds-webhook.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/rds-webhook.json.golden
@@ -1,1 +1,1 @@
-'routes': [ {'name': 'Hello-RDS-WebHook'}]
+{"routes": [ {"name": "Hello-RDS-WebHook"}]}


### PR DESCRIPTION
Being able to unmarshal LDS data generated by Pilot is very useful for webhook writers.

Attempting to `Unmarshal` LDS data generated by Pilot using its own data structures fails because `NetworkFilter` contains a `Config` field which is a marker interface rather than concrete type.

This adds an explicit `UnmarshalJSON` method to handle.

I also fix up the existing Webhook tests so they return valid JSON objects, since my UT picks up `lds-webhook.json.golden`