### PR TITLE
log errors when translating objects

### DIFF
--- a/pilot/pkg/config/kube/crd/controller.go
+++ b/pilot/pkg/config/kube/crd/controller.go
@@ -142,7 +142,7 @@ func (c *controller) RegisterEventHandler(typ string, f func(model.Config, model
 		if ok {
 			config, err := ConvertObject(schema, item, c.client.domainSuffix)
 			if err != nil {
-				log.Warnf("error translating object %#v", object)
+				log.Warnf("error translating object %#v %v", object, err)
 			} else {
 				f(*config, ev)
 			}


### PR DESCRIPTION
This is for 2 bugs i am currently investigating, we currently are not logging the actual error of the translation.
https://github.com/istio/istio/issues/3580
https://github.com/istio/istio/issues/3581

The output now looks like
```
2018-02-17T14:46:29.478339Z	warn	error translating object &amp;crd.ExternalService{TypeMeta:v1.TypeMeta{Kind:"ExternalService", APIVersion:"config.istio.io/v1alpha2"}, ObjectMeta:v1.ObjectMeta{Name:"app-dev", GenerateName:"", Namespace:"istio-system", SelfLink:"/apis/config.istio.io/v1alpha2/namespaces/istio-system/externalservices/app-dev", UID:"8f9c9887-13e1-11e8-88d6-0a63dce50dbe", ResourceVersion:"809807", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63654468813, loc:(*time.Location)(0x1f00e20)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:map[string]interface {}{"discovery":"dns", "hosts":[]interface {}{"app-dev.example.com"}, "ports":[]interface {}{map[string]interface {}{"name":"gateway-http", "number":0x50, "protocol":"http"}}}} YAML decoding error: discovery: dns
hosts:
- app-dev.example.com
ports:
- name: gateway-http
  number: 80
  protocol: http
 unknown value "dns" for enum istio.routing.v1alpha2.ExternalService_Discovery

```