### PR TITLE
Lint fixups in master

### DIFF
--- a/mixer/adapter/dogstatsd/dogstatsd.go
+++ b/mixer/adapter/dogstatsd/dogstatsd.go
@@ -48,7 +48,7 @@ type handler struct {
 func (b *builder) Build(_ context.Context, env adapter.Env) (adapter.Handler, error) {
 	ac := b.adapterConfig
 
-	client := &statsd.Client{}
+	var client = &statsd.Client{}
 	var err error
 	if ac.BufferLength > 0 {
 		client, err = statsd.NewBuffered(ac.Address, int(ac.BufferLength))
@@ -98,7 +98,7 @@ func (b *builder) Validate() (ce *adapter.ConfigErrors) {
 	// Validate the adapter handles all metrics it is being sent
 	for mname := range b.metricTypes {
 		if _, found := ac.Metrics[mname]; !found {
-			ce.Appendf("metricName", "%s is a valid metric but is not configured to be handled by the datadog adapter", mname)
+			ce = ce.Appendf("metricName", "%s is a valid metric but is not configured to be handled by the datadog adapter", mname)
 		}
 	}
 
@@ -147,7 +147,7 @@ func (h *handler) record(value *metric.Instance) error {
 	mname := value.Name
 
 	// Shouldn't fail since validation checks metric creation
-	info, _ := h.metrics[mname]
+	info := h.metrics[mname]
 
 	tagMap := make(map[string]string)
 	for k, v := range h.metrics[mname].Tags {

--- a/mixer/adapter/dogstatsd/dogstatsd_test.go
+++ b/mixer/adapter/dogstatsd/dogstatsd_test.go
@@ -222,7 +222,7 @@ func TestRecord(t *testing.T) {
 
 			var buf []byte
 			w := statsdTestWriter{bytes.NewBuffer(buf)}
-			client, err := statsd.NewWithWriter(w)
+			client, _ := statsd.NewWithWriter(w)
 			client.Namespace = b.adapterConfig.Prefix
 			client.Tags = flattenTags(b.adapterConfig.GlobalTags)
 			asp := h.(*handler)


### PR DESCRIPTION
Introduced in https://github.com/istio/istio/pull/3368
```
mixer/adapter/dogstatsd/dogstatsd.go:150:2:error: should write info := h.metrics[mname] instead of info, _ := h.metrics[mname] (S1005) (megacheck)
mixer/adapter/dogstatsd/dogstatsd.go:51:2:error: this value of client is never used (SA4006) (megacheck)
mixer/adapter/dogstatsd/dogstatsd.go:101:14:error: error return value not checked (ce.Appendf("metricName", "%s is a valid metric but is not configured to be handled by the datadog adapter", mname)) (errcheck)
mixer/adapter/dogstatsd/dogstatsd_test.go:225:12:error: this value of err is never used (SA4006) (megacheck)
```