### PR TITLE
Make jaeger installation the same as other addons in Ansible playbook

### DIFF
--- a/install/ansible/README.md
+++ b/install/ansible/README.md
@@ -53,8 +53,7 @@ The full list of configurable parameters is as follows:
 | `istio.dest` | Destination folder you want to install on your machine istio distribution | `~/.istio` (default) |
 | `istio.auth` | Boolean value to install istio using MUTUAL_TLS | `true` and `false` (default) |
 | `istio.namespace` | The namespace where istio will be installed | `istio-system` (default) |
-| `istio.addon` | Which Istio addons should be installed as well | This field is an array field, which by default contains `grafana`, `prometheus`, `zipkin` and `servicegraph` |
-| `istio.jaeger` | Whether or not Jaeger tracing should also be installed | `true` and `false` (default)|
+| `istio.addon` | Which Istio addons should be installed as well | This field is an array field, which by default contains `grafana`, `prometheus`, `zipkin`, `jaeger` (disables Zipkin if selected) and `servicegraph` |
 | `istio.delete_resources` | Boolean value to delete resources created under the istio namespace | `true` and `false` (default)|
 | `istio.samples` | Array containing the names of the samples that should be installed | Valid names are: `bookinfo`, `helloworld`, `httpbin`, `sleep` 
 
@@ -90,19 +89,19 @@ ansible-playbook main.yml
 ansible-playbook main.yml -e '{"cluster_flavour": "k8s"}' 
 ```
 
-- User installs Istio on to a Kubernetes cluster and the path to `kubectl` is expicitly set (perhaps it's not on the PATH)
+- User installs Istio on to a Kubernetes cluster and the path to `kubectl` is explicitly set (perhaps it's not on the PATH)
 ```bash
 ansible-playbook main.yml -e '{"cluster_flavour": "k8s", "cmd_path": "~/kubectl"}' 
 ```
 
 - User wants to install Istio on Openshift with settings other than the default
 ```bash
-ansible-playbook main.yml -e '{"istio": {"release_tag_name": "0.4.0", "auth": true, "jaeger": true, "delete_resources": true}}'
+ansible-playbook main.yml -e '{"istio": {"release_tag_name": "0.4.0", "auth": true, "delete_resources": true}}'
 ```
 
 - User wants to install Istio on Openshift but with custom add-on settings
 ```bash
-ansible-playbook main.yml -e '{"istio": {"delete_resources": true, "addon": ["grafana", "prometheus"]}}'
+ansible-playbook main.yml -e '{"istio": {"delete_resources": true, "addon": ["grafana", "prometheus", "jaeger"]}}'
 ```
 
 - User wants to install Istio on Openshift and additionally wants to deploy some of the samples
@@ -111,5 +110,4 @@ ansible-playbook main.yml -e '{"istio": {"samples": ["helloworld", "bookinfo"]}}
 ```
 
 The list of available addons can be found at `istio/vars.main.yml` under the name `istio_all_addons`.
-Jaeger is not installed using the `addons` property, but can be installed by enabling `"jaeger": true` like in one of the previous examples.
 It should be noted that when Jaeger is enabled, Zipkin is disabled whether or not it's been selected in the addons section.

--- a/install/ansible/istio/tasks/install_addons.yml
+++ b/install/ansible/istio/tasks/install_addons.yml
@@ -9,9 +9,15 @@
 - name: Install Jaeger on Openshift
   shell: |
     {{ cmd_path }} process -f https://raw.githubusercontent.com/jaegertracing/jaeger-openshift/master/all-in-one/jaeger-all-in-one-template.yml | {{ cmd_path }} create -n istio-system -f -
-  when: istio.jaeger == true and cluster_flavour == 'ocp'
+  when:
+    - is_istioaddon_iterable
+    - "'jaeger' in istio.addon"
+    - "cluster_flavour == 'ocp'"
 
 - name: Install Jaeger on Kubernetes
   shell: |
     {{ cmd_path }} create -f https://raw.githubusercontent.com/jaegertracing/jaeger-kubernetes/master/all-in-one/jaeger-all-in-one-template.yml -n istio-system
-  when: istio.jaeger == true and cluster_flavour == 'k8s'
+  when:
+    - is_istioaddon_iterable
+    - "'jaeger' in istio.addon"
+    - "cluster_flavour == 'k8s'"

--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- include_tasks: set_implicitly_disabled_addons.yml
-
 - name: Is istio.addon be iterable
   set_fact:
     is_istioaddon_iterable: "{{ istio.addon is defined and istio.addon is iterable }}"
+
+- include_tasks: set_implicitly_disabled_addons.yml
 
 - name: Determine addons that need ServiceAccounts
   set_fact:

--- a/install/ansible/istio/tasks/set_implicitly_disabled_addons.yml
+++ b/install/ansible/istio/tasks/set_implicitly_disabled_addons.yml
@@ -9,4 +9,6 @@
 - name: Set zipkin disabled addon
   set_fact:
     disabled_addons: "{{ disabled_addons }} + [ 'zipkin' ]"
-  when: istio.jaeger == true
+  when:
+    - is_istioaddon_iterable
+    - "'jaeger' in istio.addon"


### PR DESCRIPTION
This PR removed the `istio.jaeger` flag and simply makes `jaeger` one of the options in `istio.addon`