### PR TITLE
Fix #3545 - change istioctl delete to use default namespace if no namespace provided

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -365,8 +365,12 @@ istioctl delete routerule productpage-default
 				if err != nil {
 					return err
 				}
+				ns, err := handleNamespaces(namespace);
+				if err != nil {
+					return err
+				}
 				for i := 1; i < len(args); i++ {
-					if err := configClient.Delete(typ.Type, args[i], namespace); err != nil {
+					if err := configClient.Delete(typ.Type, args[i], ns); err != nil {
 						errs = multierror.Append(errs,
 							fmt.Errorf("cannot delete %s: %v", args[i], err))
 					} else {

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -365,7 +365,7 @@ istioctl delete routerule productpage-default
 				if err != nil {
 					return err
 				}
-				ns, err := handleNamespaces(namespace);
+				ns, err := handleNamespaces(namespace)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
I assume that this is the expected behavior for all the `istioctl` commands

fixes https://github.com/istio/istio/issues/3545