### PR TITLE
More permissive routing tests

### DIFF
--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -149,7 +149,7 @@ func (t *routing) Run() error {
 				return err
 			}
 
-			if err := tutil.Repeat(cs.check, 3, time.Second); err != nil {
+			if err := tutil.Repeat(cs.check, 5, time.Second); err != nil {
 				log.Infof("Failed the test with %v", err)
 				errs = multierror.Append(errs, multierror.Prefix(err, version+" "+cs.description))
 			} else {
@@ -184,7 +184,7 @@ func (t *routing) verifyRouting(scheme, src, dst, headerKey, headerVal string,
 	resp := t.ClientRequest(src, url, samples, fmt.Sprintf("-key %s -val %s", headerKey, headerVal))
 	count := counts(resp.Version)
 	log.Infof("request counts %v", count)
-	epsilon := 5
+	epsilon := 10
 
 	var errs error
 	for version, expected := range expectedCount {


### PR DESCRIPTION
Adds retries and makes routing check less strict. Should reduce flaky test failures while still verifying the behavior.