### PR TITLE
Refine the node agent logic

### DIFF
--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -62,7 +62,8 @@ func init() {
 	flags.IntVar(&naConfig.RSAKeySize, "key-size", 2048, "Size of generated private key")
 	flags.StringVar(&naConfig.IstioCAAddress,
 		"ca-address", "istio-ca:8060", "Istio CA address")
-	flags.StringVar(&naConfig.Env, "env", "onprem", "Node Environment : onprem | gcp | aws")
+	flags.StringVar(&naConfig.Env, "env", "unspecified",
+		"Node Environment : unspecified | onprem | gcp | aws")
 
 	flags.StringVar(&naConfig.PlatformConfig.OnPremConfig.CertChainFile, "onprem-cert-chain",
 		"/etc/certs/cert-chain.pem", "Node Agent identity cert file in on premise environment")

--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 
+  "cloud.google.com/go/compute/metadata"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/caclient/grpc"
 	"istio.io/istio/security/pkg/platform"
@@ -40,7 +42,8 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 		certUtil: CertUtilImpl{},
 	}
 
-	if pc, err := platform.NewClient(cfg.Env, cfg.PlatformConfig, cfg.IstioCAAddress); err == nil {
+	env := determinePlatform(cfg)
+	if pc, err := platform.NewClient(env, cfg.PlatformConfig, cfg.IstioCAAddress); err == nil {
 		na.pc = pc
 	} else {
 		return nil, err
@@ -51,11 +54,25 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 
 	// TODO: Specify files for service identity cert/key instead of node agent files.
 	secretServer, err := workload.NewSecretServer(
-		workload.NewSecretFileServerConfig(cfg.PlatformConfig.OnPremConfig.CertChainFile, cfg.PlatformConfig.OnPremConfig.KeyFile))
+		workload.NewSecretFileServerConfig(cfg.PlatformConfig.OnPremConfig.CertChainFile,
+			cfg.PlatformConfig.OnPremConfig.KeyFile))
 	if err != nil {
 		log.Errorf("Workload IO creation error: %v", err)
 		os.Exit(-1)
 	}
 	na.secretServer = secretServer
 	return na, nil
+}
+
+
+// determinePlatform choose the right platform. If the env is specified in cfg.Env,
+// then we will use it. Otherwise nodeagent will detect the platform for you.
+func determinePlatform(cfg *Config) string {
+	if cfg.Env != "unspecified" {
+		return cfg.Env
+	}
+	if metadata.OnGCE() {
+		return "gcp"
+	}
+	return "onprem"
 }

--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"os"
 
-  "cloud.google.com/go/compute/metadata"
+	"cloud.google.com/go/compute/metadata"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/caclient/grpc"
@@ -63,7 +63,6 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 	na.secretServer = secretServer
 	return na, nil
 }
-
 
 // determinePlatform choose the right platform. If the env is specified in cfg.Env,
 // then we will use it. Otherwise nodeagent will detect the platform for you.

--- a/security/cmd/node_agent/na/nafactory_test.go
+++ b/security/cmd/node_agent/na/nafactory_test.go
@@ -40,6 +40,12 @@ func TestNewNodeAgent(t *testing.T) {
 			},
 			expectedErr: "",
 		},
+		"unspecified env test": {
+			config: &Config{
+				Env: "unspecified",
+			},
+			expectedErr: "",
+		},
 		"Unsupported env test": {
 			config: &Config{
 				Env: "somethig else",
@@ -61,6 +67,5 @@ func TestNewNodeAgent(t *testing.T) {
 		} else if err != nil {
 			t.Errorf("%s: Unexpected Error: %v", id, err)
 		}
-
 	}
 }


### PR DESCRIPTION
The env is default to 'unspecified', and if this value is provided, e.g. 'gcp', then we will take this value. Otherwise, node agent will detect the environment automatically. 

This change provides several benefits:
- Customers do not need to provide any env variable, which makes their user experience better. For example, if the node agent is running on gcp, they don't have to specify anything.

- They still have the flexibility to test different set up, in the above example, if they want to test onprem case on gcp, they can still do it by specifying the env to be 'onprem'.