### PR TITLE
Disable vm test in cluster wide

### DIFF
--- a/prow/e2e-cluster_wide-auth.sh
+++ b/prow/e2e-cluster_wide-auth.sh
@@ -49,4 +49,4 @@ get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
 setup_cluster
 
 echo 'Running cluster-wide e2e rbac, auth Tests'
-${ROOT}/prow/e2e-suite-rbac-auth.sh --cluster_wide "$@"
+${ROOT}/prow/e2e-suite.sh --auth_enable --cluster_wide "$@"


### PR DESCRIPTION
Cluster provisioning is enabled on cluster wide test, and vm test has not been updated to use the pre-provisioned VM and is creating instead a VM in the main testing project. The VM test is using local network IP, and the cluster and the VM are not in the same project which makes communication between those 2 impossible.

Disabling the vm test for now until we can take advantage of the provisioned VM