### PR TITLE
allow cleanup.sh scripts to be re-run without outputing errors

### DIFF
--- a/samples/bookinfo/consul/cleanup.sh
+++ b/samples/bookinfo/consul/cleanup.sh
@@ -28,7 +28,7 @@ fi
 
 echo "using NAMESPACE=${NAMESPACE}"
 
-for rule in $(istioctl get -n ${NAMESPACE} routerules | awk '{print $1}'); do
+for rule in $(istioctl get -n ${NAMESPACE} routerules | grep -v 'No resources found' | awk '{print $1}'); do
   istioctl delete routerule $rule;
 done
 #istioctl delete mixer-rule ratings-ratelimit

--- a/samples/bookinfo/eureka/cleanup.sh
+++ b/samples/bookinfo/eureka/cleanup.sh
@@ -28,7 +28,7 @@ fi
 
 echo "using NAMESPACE=${NAMESPACE}"
 
-for rule in $(istioctl get -n ${NAMESPACE} routerules | awk '{print $1}'); do
+for rule in $(istioctl get -n ${NAMESPACE} routerules | grep -v 'No resources found' | awk '{print $1}'); do
   istioctl delete routerule $rule;
 done
 #istioctl delete mixer-rule ratings-ratelimit

--- a/samples/bookinfo/kube/cleanup.sh
+++ b/samples/bookinfo/kube/cleanup.sh
@@ -28,7 +28,7 @@ fi
 
 echo "using NAMESPACE=${NAMESPACE}"
 
-for rule in $(istioctl get -n ${NAMESPACE} routerules); do
+for rule in $(istioctl get -n ${NAMESPACE} routerules | grep -v 'No resources found'); do
   istioctl delete -n ${NAMESPACE} routerule $rule;
 done
 #istioctl delete mixer-rule ratings-ratelimit


### PR DESCRIPTION
output before:

````
istio-0.5.1 %  samples/bookinfo/kube/cleanup.sh

namespace ? [default]
using NAMESPACE=default
Error: 1 error occurred:

* cannot delete No: routerules.config.istio.io "No" not found
Error: 1 error occurred:

* cannot delete resources: routerules.config.istio.io "resources" not found
Error: 1 error occurred:

* cannot delete found.: routerules.config.istio.io "found." not found
Application cleanup may take up to one minute
Application cleanup successful
````

output after:

````
istio-0.5.1 %  samples/bookinfo/kube/cleanup.sh

namespace ? [default]
using NAMESPACE=default
Application cleanup may take up to one minute
Application cleanup successful
````