### PR TITLE
more lint fixes

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -6,7 +6,7 @@
     "deadline": "600s",
     "minConfidence": 0.0,
     "lineLength": 160,
-    "tests": true,
+    "test": true,
     "sort": ["path"],
     "Linters": {
         "goimports": {"Command": "goimports -l --local istio.io"}
@@ -62,6 +62,7 @@
         "mixer/template/sample/.*.go",
         "mixer/test/spyAdapter/template/doc.go",
         "mixer/template/doc.go",
+        "_test\\.go:.*\\bdefer .*\\(errcheck\\)$",
         "should have a package comment",
         "composite literal uses unkeyed fields",
         "genfiles"

--- a/mixer/adapter/redisquota/redisquota_test.go
+++ b/mixer/adapter/redisquota/redisquota_test.go
@@ -609,7 +609,9 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 		}
 
 		for funcTime, funcHandler := range c.mockRedis {
-			s.Register(funcTime, funcHandler.(func(c *server.Peer, cmd string, args []string)))
+			if err = s.Register(funcTime, funcHandler.(func(c *server.Peer, cmd string, args []string))); err != nil {
+				t.Fatal(err)
+			}
 		}
 
 		b := info.NewBuilder().(*builder)

--- a/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
@@ -525,7 +525,9 @@ ident                         : dest.istio-system
 
 func TestDispatcher(t *testing.T) {
 	o := log.NewOptions()
-	log.Configure(o)
+	if err := log.Configure(o); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(tt *testing.T) {

--- a/mixer/test/e2e/e2e_apa_test.go
+++ b/mixer/test/e2e/e2e_apa_test.go
@@ -203,46 +203,48 @@ func TestApa(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		adapterInfos, spyAdapters := ConstructAdapterInfos(tt.behaviors)
+		t.Run(tt.name, func(t *testing.T) {
+			adapterInfos, spyAdapters := ConstructAdapterInfos(tt.behaviors)
 
-		args := testEnv.NewArgs()
-		args.APIPort = 0
-		args.MonitoringPort = 0
-		args.Templates = e2eTmpl.SupportedTmplInfo
-		args.Adapters = adapterInfos
-		var cerr error
-		if args.ConfigStore, cerr = storetest.SetupStoreForTest(apaGlobalCfg, tt.cfg); cerr != nil {
-			t.Fatal(cerr)
-		}
+			args := testEnv.NewArgs()
+			args.APIPort = 0
+			args.MonitoringPort = 0
+			args.Templates = tt.templates
+			args.Adapters = adapterInfos
+			var cerr error
+			if args.ConfigStore, cerr = storetest.SetupStoreForTest(apaGlobalCfg, tt.cfg); cerr != nil {
+				t.Fatal(cerr)
+			}
 
-		env, err := testEnv.New(args)
-		if err != nil {
-			t.Fatalf("fail to create mixer: %v", err)
-		}
+			env, err := testEnv.New(args)
+			if err != nil {
+				t.Fatalf("fail to create mixer: %v", err)
+			}
 
-		env.Run()
+			env.Run()
 
-		defer closeHelper(env)
+			defer closeHelper(env)
 
-		conn, err := grpc.Dial(env.Addr().String(), grpc.WithInsecure())
-		if err != nil {
-			t.Fatalf("Unable to connect to gRPC server: %v", err)
-		}
+			conn, err := grpc.Dial(env.Addr().String(), grpc.WithInsecure())
+			if err != nil {
+				t.Fatalf("Unable to connect to gRPC server: %v", err)
+			}
 
-		client := istio_mixer_v1.NewMixerClient(conn)
-		defer closeHelper(conn)
+			client := istio_mixer_v1.NewMixerClient(conn)
+			defer closeHelper(conn)
 
-		req := istio_mixer_v1.ReportRequest{
-			Attributes: []istio_mixer_v1.CompressedAttributes{
-				getAttrBag(tt.attrs,
-					args.ConfigIdentityAttribute,
-					args.ConfigIdentityAttributeDomain)},
-		}
-		_, err = client.Report(context.Background(), &req)
-		if err == nil {
-			tt.validate(t, err, spyAdapters)
-		} else {
-			t.Errorf("Got error '%v', want success", err)
-		}
+			req := istio_mixer_v1.ReportRequest{
+				Attributes: []istio_mixer_v1.CompressedAttributes{
+					getAttrBag(tt.attrs,
+						args.ConfigIdentityAttribute,
+						args.ConfigIdentityAttributeDomain)},
+			}
+			_, err = client.Report(context.Background(), &req)
+			if err == nil {
+				tt.validate(t, err, spyAdapters)
+			} else {
+				t.Errorf("Got error '%v', want success", err)
+			}
+		})
 	}
 }

--- a/mixer/test/e2e/e2e_reftracking_test.go
+++ b/mixer/test/e2e/e2e_reftracking_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"reflect"
-	"strconv"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -154,14 +153,14 @@ func TestRefTracking(t *testing.T) {
 			},
 		},
 	}
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			adapterInfos, spyAdapters := ConstructAdapterInfos(tt.behaviors)
 
 			args := testEnv.NewArgs()
 			args.APIPort = 0
 			args.MonitoringPort = 0
-			args.Templates = e2eTmpl.SupportedTmplInfo
+			args.Templates = tt.templates
 			args.Adapters = adapterInfos
 			var cerr error
 			if args.ConfigStore, cerr = storetest.SetupStoreForTest(refTrackingGlobalCfg, tt.cfg); cerr != nil {

--- a/mixer/test/e2e/e2e_report_test.go
+++ b/mixer/test/e2e/e2e_report_test.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -126,14 +125,14 @@ func TestReport(t *testing.T) {
 			},
 		},
 	}
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			adapterInfos, spyAdapters := ConstructAdapterInfos(tt.behaviors)
 
 			args := testEnv.NewArgs()
 			args.APIPort = 0
 			args.MonitoringPort = 0
-			args.Templates = e2eTmpl.SupportedTmplInfo
+			args.Templates = tt.templates
 			args.Adapters = adapterInfos
 			var cerr error
 			if args.ConfigStore, cerr = storetest.SetupStoreForTest(reportGlobalCfg, tt.cfg); cerr != nil {

--- a/pilot/pkg/model/gateway_test.go
+++ b/pilot/pkg/model/gateway_test.go
@@ -177,7 +177,7 @@ func TestMergeGateways(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// we want to save the original state of tt.a for printing if we fail the test, so we'll merge into a new gateway struct.
 			actual := &routing.Gateway{}
-			MergeGateways(actual, tt.a)
+			MergeGateways(actual, tt.a) // nolint: errcheck
 			err := MergeGateways(actual, tt.b)
 			if err != tt.expectedErrPrefix && !strings.HasPrefix(err.Error(), tt.expectedErrPrefix.Error()) {
 				t.Fatalf("%s: got err %v, wanted %v", tt.name, err, tt.expectedErrPrefix)

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -154,7 +154,7 @@ func TestBasic(t *testing.T) {
 				}
 
 				c.f()
-				Sync()
+				Sync() // nolint: errcheck
 			})
 
 			if err != nil {
@@ -262,7 +262,7 @@ func TestRotateNoStdout(t *testing.T) {
 	}
 
 	Error("HELLO")
-	Sync()
+	Sync() // nolint: errcheck
 
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -289,7 +289,7 @@ func TestRotateAndStdout(t *testing.T) {
 		}
 
 		Error("HELLO")
-		Sync()
+		Sync() // nolint: errcheck
 
 		content, err := ioutil.ReadFile(file)
 		if err != nil {

--- a/pkg/tracing/config_test.go
+++ b/pkg/tracing/config_test.go
@@ -123,7 +123,7 @@ func TestSpanLogger(t *testing.T) {
 		sl.Error("ERROR")
 		sl.Infof("INFO")
 
-		log.Sync()
+		log.Sync() // nolint: errcheck
 	})
 
 	if err != nil {

--- a/security/cmd/flexvolume/driver/driver_test.go
+++ b/security/cmd/flexvolume/driver/driver_test.go
@@ -123,14 +123,14 @@ func testInitStdIo() {
 	outC = make(chan string)
 	go func() {
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		io.Copy(&buf, r) // nolint: errcheck
 		outC <- buf.String()
 	}()
 }
 
 // Will block waiting for data on the channel.
 func readStdOut() string {
-	pipeOut.Close()
+	pipeOut.Close() // nolint: errcheck
 	os.Stdout = oldOut
 	fmt.Println("Waiting for output")
 	return <-outC
@@ -569,6 +569,6 @@ func TestMain(m *testing.M) {
 
 	r := m.Run()
 
-	os.RemoveAll(testDir)
+	os.RemoveAll(testDir) // nolint: errcheck
 	os.Exit(r)
 }

--- a/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
+++ b/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
@@ -232,7 +232,7 @@ func (testState *testState) runEnvoy(discoveryAddr string) error {
 	cleanupSignal := errors.New("test cleanup")
 	testState.addCleanupTask(func() {
 		abortCh <- cleanupSignal
-		os.RemoveAll(config.ConfigPath)
+		os.RemoveAll(config.ConfigPath) // nolint: errcheck
 	})
 
 	go func() {
@@ -285,9 +285,9 @@ func runFakeApp(port int) {
 			"received-host-header": r.Host,
 			"received-headers":     r.Header,
 		}
-		json.NewEncoder(w).Encode(responseData)
+		json.NewEncoder(w).Encode(responseData) // nolint: errcheck
 	})
-	go http.ListenAndServe(fmt.Sprintf(":%d", port), fakeAppHandler)
+	go http.ListenAndServe(fmt.Sprintf(":%d", port), fakeAppHandler) // nolint: errcheck
 }
 
 func runPilot(copilotConfigFile, istioConfigDir string, port int) (*gexec.Session, error) {

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -255,7 +255,9 @@ func upgradeControlPlane() error {
 	if !util.CheckPodsRunning(k.Kube.Namespace) {
 		return fmt.Errorf("can't get all pods running")
 	}
-	util.Shell("kubectl get all -n %s -o wide", k.Kube.Namespace)
+	if _, err = util.Shell("kubectl get all -n %s -o wide", k.Kube.Namespace); err != nil {
+		return err
+	}
 	// Update gateway address
 	tc.gateway = "http://" + k.Kube.Ingress
 	return nil


### PR DESCRIPTION
noticed that "tests" is specified in lintconfig_base.json incorrectly.
It's "test" actually.

By changing this, I've met some new lint errors in test.go files,
mostly on errcheck. This PR includes fixes on them.

Note: I've seen several patterns of `defer something.Close()`,
which does not check the errors. I think this is very common among
our code base, and I don't think this has problem if that's within
test code. I added an exclude pattern for this.