### PR TITLE
Use istio.deps to locate proxy version.

### DIFF
--- a/tests/integration/example/integration.sh
+++ b/tests/integration/example/integration.sh
@@ -38,7 +38,8 @@ cd ..
 ls proxy || git clone https://github.com/istio/proxy
 cd proxy
 FL=$(mktemp)
-grep PROXY_TAG ${GOPATH}/src/istio.io/istio/istio.VERSION > $FL
+echo -n "export PROXY_TAG=" > $FL
+grep lastStableSHA ../istio/istio.deps | tail -1 |  awk '{print $2}' >> $FL
 source $FL
 rm $FL
 git pull


### PR DESCRIPTION
istio.Version is modified by builds.

Previous fix used istio.VERSION for pinning which does not work because it is modified by the build.

Signed-off-by: Mandar U Jog <mjog@google.com>