### PR TITLE
Remove unguarded log.Info from request path

### DIFF
--- a/mixer/pkg/template/template.go
+++ b/mixer/pkg/template/template.go
@@ -29,7 +29,6 @@ import (
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/expr"
 	"istio.io/istio/mixer/pkg/il/compiled"
-	"istio.io/istio/pkg/log"
 )
 
 type (

--- a/mixer/pkg/template/template.go
+++ b/mixer/pkg/template/template.go
@@ -287,8 +287,6 @@ func NewOutputMapperFn(expressions map[string]compiled.Expression) OutputMapperF
 			switch v := val.(type) {
 			case net.IP:
 				// conversion to []byte necessary based on current IP_ADDRESS handling within Mixer
-				// TODO: remove
-				log.Info("converting net.IP to []byte")
 				if v4 := v.To4(); v4 != nil {
 					resultBag.Set(attrName, []byte(v4))
 					continue


### PR DESCRIPTION
Remove `log.Info` from request path.
It causes excessive usage of zap.log and lock contention.

