### PR TITLE
remove a flaky / incorrect test

### DIFF
--- a/mixer/pkg/config/store/queue_test.go
+++ b/mixer/pkg/config/store/queue_test.go
@@ -17,7 +17,6 @@ package store
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -121,36 +120,4 @@ func TestQueueCancelClosesOutputChannel(t *testing.T) {
 	}()
 	close(q.closec)
 	<-donec
-}
-
-func TestQueueCancelSync(t *testing.T) {
-	chin := make(chan BackendEvent)
-	q := newQueue(chin, map[string]proto.Message{"Handler": &cfg.Handler{}})
-	for i := 0; i < choutBufSize+5; i++ {
-		chin <- BackendEvent{
-			Type:  Update,
-			Key:   Key{Kind: "Handler", Namespace: "ns", Name: fmt.Sprintf("%d", i)},
-			Value: &BackEndResource{},
-		}
-	}
-	close(q.closec)
-	// Wait for the queue's run loop to end.
-	time.Sleep(time.Millisecond)
-	// Read the bufferred events.
-	for i := 0; i < choutBufSize; i++ {
-		ev, ok := <-q.chout
-		if !ok {
-			// Sometimes items less than 'choutBufSize' are stored into the queue, but that's
-			// acceptable. That can happen due to goroutine scheduling.
-			break
-		}
-		if ev.Name != fmt.Sprintf("%d", i) {
-			t.Errorf("Got name %s Want %d", ev.Name, i)
-		}
-	}
-	// After the buffer runs out, it should return an empty since it's closed due to cancel.
-
-	if ev, ok := <-q.chout; ok {
-		t.Errorf("Got %+v, Want empty", ev)
-	}
 }


### PR DESCRIPTION
As reported, the test case TestQueueCancelSync is flakey, but
actually that's because the test case is based on a wrong assumption. The test case
assumes that `select` chooses the clause of `donec` after closing
it, but there's a race condition that another clause can proceed
(and can be chosen), which causes the flake.

By considering this, the test case should be rather removed.

Fixes #3646