### PR TITLE
update parsing of release build status

### DIFF
--- a/release/cloud_build.template.json
+++ b/release/cloud_build.template.json
@@ -8,7 +8,7 @@
 	}
       ],
       "name": "gcr.io/istio-testing/istio-builder:0.4.6",
-      "args": [ "-c", "repo init -u \"$_MFEST_URL\" -m \"$_MFEST_FILE\" -b \"$_MFEST_VER\" && repo sync && cp .repo/manifest.xml /output/" ],
+      "args": [ "-c", "repo init -u \"$_MFEST_URL\" -m \"$_MFEST_FILE\" -b \"$_MFEST_VER\" && repo sync && cp .repo/manifest.xml /output/ && echo \"$_MFEST_VER\" > /output/green_build_sha.txt" ],
       "entrypoint": "bash"
     },
     {

--- a/release/gcb_build_lib.sh
+++ b/release/gcb_build_lib.sh
@@ -50,7 +50,7 @@ function parse_result_file {
 
   [[ -z "${INPUT_FILE}" ]] && usage
 
-  local STATUS_VALUE=$(parse_json_for_string $INPUT_FILE "status")
+  local STATUS_VALUE=$(parse_json_for_first_string $INPUT_FILE "status")
   local ERROR_VALUE=""
   local ERROR_CODE=""
   local ERROR_STATUS=""
@@ -93,6 +93,7 @@ function parse_result_file {
       ;;
     *)
       echo "unrecognized status: ${STATUS_VALUE}"
+      cat $INPUT_FILE
       BUILD_FAILED=1
       return 2
   esac

--- a/release/json_parse_shared.sh
+++ b/release/json_parse_shared.sh
@@ -12,7 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#                                                                                                                                                                      ################################################################################
+#
+################################################################################
 
 set -o errexit
 set -o nounset
@@ -65,6 +66,24 @@ function parse_json_for_string() {
     return 0
   fi
   RESULT=$(grep -Eo " *\"${KEY}\": *\".*\",?" ${FILENAME} |
+           sed "s/ *\"${KEY}\": *\"\(.*\)\",*/\1/")
+  echo $RESULT
+  return 0
+}
+
+# parse for a key with a quoted string and return the string contents
+# parse this when you expect multiple instances but will settle for the first
+function parse_json_for_first_string() {
+  local FILENAME=$1
+  local KEY=$2
+  local RESULT=""
+
+  local LINE_COUNT=$(grep -c -Eo " *\"${KEY}\":.*?[^\\\\]\",?" ${FILENAME})
+  if [ "$LINE_COUNT" == "0" ]; then
+    echo "Missing line for ${KEY}: $LINE_COUNT" >&2
+    return 0
+  fi
+  RESULT=$(grep -Eo " *\"${KEY}\": *\".*\",?" ${FILENAME} | head --lines=1 |
            sed "s/ *\"${KEY}\": *\"\(.*\)\",*/\1/")
   echo $RESULT
   return 0

--- a/release/pipline/dags/istio_common_dag.py
+++ b/release/pipline/dags/istio_common_dag.py
@@ -220,8 +220,9 @@ def MakeCommonDag(name='istio_daily_flow_test',
     -u "{{ settings.MFEST_URL }}" \
     -t "{{ m_commit }}" -m "{{ settings.MFEST_FILE }}" \
     -a {{ settings.SVC_ACCT }}
+    BUILD_RET=$?
     echo "{{ m_commit }}" >> green_build_sha.txt
-    gsutil cp green_build_sha.txt gs://{{ settings.GCS_BUILD_PATH }}/green_build_sha.txt
+    gsutil cp green_build_sha.txt gs://{{ settings.GCS_BUILD_PATH }}/green_build_sha.txt && exit $BUILD_RET
     """
 
   build = BashOperator(

--- a/release/pipline/dags/istio_common_dag.py
+++ b/release/pipline/dags/istio_common_dag.py
@@ -221,6 +221,7 @@ def MakeCommonDag(name='istio_daily_flow_test',
     -t "{{ m_commit }}" -m "{{ settings.MFEST_FILE }}" \
     -a {{ settings.SVC_ACCT }}
     """
+  # NOTE: if you add commands to build_template after start_gcb_build.sh then take care to preserve its return value
 
   build = BashOperator(
       task_id='run_cloud_builder', bash_command=build_template, dag=common_dag)

--- a/release/pipline/dags/istio_common_dag.py
+++ b/release/pipline/dags/istio_common_dag.py
@@ -220,9 +220,6 @@ def MakeCommonDag(name='istio_daily_flow_test',
     -u "{{ settings.MFEST_URL }}" \
     -t "{{ m_commit }}" -m "{{ settings.MFEST_FILE }}" \
     -a {{ settings.SVC_ACCT }}
-    BUILD_RET=$?
-    echo "{{ m_commit }}" >> green_build_sha.txt
-    gsutil cp green_build_sha.txt gs://{{ settings.GCS_BUILD_PATH }}/green_build_sha.txt && exit $BUILD_RET
     """
 
   build = BashOperator(


### PR DESCRIPTION
While looking through today's build log I noticed:

<pre>+++ grep -c -Eo ' *"status":.*?[^\\]",?' /tmp/build.response.Rav7
++ local LINE_COUNT=4
++ '[' 4 '!=' 1 ']'
++ echo 'Missing or ambiguous lines for status: 4'
Missing or ambiguous lines for status: 4
</pre>
...
<pre>- unrecognized status:
BUILD_FAILED=1
return 2</pre>

The build wasn't recognized as failed, cause I think the "Copying file://green_build_sha.txt" step that now follows the build must replace the overall status (I also tried to fix this).

Anyway, the issue with ambiguous status is because the builder is now reporting additional information for each step, e.g.:
<pre>"timing": {
  "startTime": "2018-02-21T19:22:27.228407430Z",
  "endTime": "2018-02-21T19:23:42.831693458Z"
},
"status": "SUCCESS"
</pre>
So there's now multiple instance of "status" attributes in the json.  This change has the bash just take the first status (which is for the overall build) and ignore any other status lines that follow.  An example start of the json result is:
<pre>{
  "id": "29eeadab-efdb-4946-a510-8331c6d6ff6f",
  "status": "SUCCESS",
  "createTime": "2018-02-21T19:22:25.186365818Z",
  "startTime": "2018-02-21T19:22:25.882807954Z",
  "finishTime": "2018-02-21T19:23:43.753677Z",
</pre>