### PR TITLE
Bump up cluster nodes for pilot e2e tests on prow

### DIFF
--- a/prow/cluster_lib.sh
+++ b/prow/cluster_lib.sh
@@ -24,7 +24,7 @@
 PROJECT_NAME=istio-testing
 ZONE=us-central1-f
 MACHINE_TYPE=n1-standard-4
-NUM_NODES=1
+NUM_NODES=${NUM_NODES:-1}
 CLUSTER_NAME=
 
 IFS=';' VERSIONS=($(gcloud container get-server-config --project=${PROJECT_NAME} --zone=${ZONE} --format='value(validMasterVersions)'))

--- a/prow/istio-pilot-e2e.sh
+++ b/prow/istio-pilot-e2e.sh
@@ -32,6 +32,7 @@ set -x
 source ${ROOT}/prow/lib.sh
 setup_and_export_git_sha
 
+export NUM_NODES=4
 source "${ROOT}/prow/cluster_lib.sh"
 
 trap delete_cluster EXIT

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -87,14 +87,14 @@ e2e_upgrade: istioctl generate_yaml
 e2e_all: e2e_simple e2e_mixer e2e_bookinfo
 
 e2e_pilot: istioctl generate_yaml
-	go test -v -timeout 30m ./tests/e2e/tests/pilot ${TESTOPTS} -hub ${HUB} -tag ${TAG}
+	go test -v -timeout 20m ./tests/e2e/tests/pilot ${TESTOPTS} -hub ${HUB} -tag ${TAG}
 
 # Target for running e2e pilot in a minikube env. Used by CI
 test/minikube/auth/e2e_pilot: istioctl generate_yaml
 	mkdir -p ${OUT_DIR}/logs
 	kubectl create ns istio-system || true
 	kubectl create ns istio-test || true
-	go test -test.v -timeout 30m ./tests/e2e/tests/pilot -args \
+	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
 		--skip-cleanup --mixer=true --auth=enable \
 		-errorlogsdir=${OUT_DIR}/logs \


### PR DESCRIPTION
The pilot e2e tests appear to be extremely flaky and take significantly
longer with a single node.  Bumping up to 4 seems to vastly greatly
things.