### PR TITLE
No more dep in makefile/build - long live dep through vendor/

### DIFF
--- a/DEV-GUIDE.md
+++ b/DEV-GUIDE.md
@@ -391,6 +391,9 @@ The command above adds a version constraint to Gopkg.toml and updates
 Gopkg.lock. Inspect Gopkg.toml to ensure that the package is pinned to the
 correct SHA. _Please pin to COMMIT SHAs instead of branches or tags._
 
+You will need to commit the vendor/ change through a separate PR, please see
+https://github.com/istio/istio/wiki/Vendor-FAQ#how-do-i-add--change-a-dependency
+
 ### About testing
 
 Before sending pull requests you should at least make sure your changes have
@@ -432,7 +435,7 @@ protos in the `istio/api` repo, the Mixer adapter configuration protos, and the 
 template definitions are all examples of this.
 
 - Cobra commands for our CLI docs. The various CLI commands we build generally use the
-Cobra framework to parse our command-lines. Cobra is also used to produce 
+Cobra framework to parse our command-lines. Cobra is also used to produce
 reference documentation for the individual commands.
 
 Here's how this works:
@@ -445,7 +448,7 @@ Here's how this works:
 also produces `.pb.html` files which hold the documentation for the particular proto package.
 
 - Within the `istio/istio.github.io` repo, the script file
-[scripts/grab_reference_docs.sh](https://github.com/istio/istio.github.io/blob/master/scripts/grab_reference_docs.sh) 
+[scripts/grab_reference_docs.sh](https://github.com/istio/istio.github.io/blob/master/scripts/grab_reference_docs.sh)
 does the work necessary to harvest all the generated `.pb.html` files from the `istio/api`
 and `istio/istio` repos and installs them in the right place in the website hierarchy.
 The script also builds and runs the various CLI commands we have in order to extract their
@@ -465,7 +468,7 @@ package pkg;
 
 // This documents the message as a whole
 message MyMsg {
-    // This documents this field 
+    // This documents this field
     // It can contain many lines.
     int32 field1 = 1;
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,18 +5,14 @@
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
-    "iam",
-    "internal",
-    "internal/optional",
     "internal/version",
     "logging",
     "logging/apiv2",
     "logging/internal",
-    "monitoring/apiv3",
-    "storage"
+    "monitoring/apiv3"
   ]
-  revision = "eaddaf6dd7ee35fd3c2420c8d27478db176b0485"
-  version = "v0.15.0"
+  revision = "767c40d6a2e058483c25fa193e963a22da17236d"
+  version = "v0.18.0"
 
 [[projects]]
   name = "code.cloudfoundry.org/copilot"
@@ -130,8 +126,8 @@
     "private/protocol/xml/xmlutil",
     "service/sts"
   ]
-  revision = "bff41fb23b7550368282029f6478819d6a99ae0f"
-  version = "v1.12.79"
+  revision = "adeb60566bc8c9202b0f1be7e3a675beedbc11f0"
+  version = "v1.13.2"
 
 [[projects]]
   branch = "master"
@@ -277,10 +273,9 @@
   revision = "36d33bfe519efae5632669801b180bf1a245da3b"
 
 [[projects]]
-  branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "1de3e0542de65ad8d75452a595886fdd0befb363"
+  revision = "84b5bee7bcb76f3d17bcbaf421bac44bd5709ca6"
 
 [[projects]]
   branch = "master"
@@ -446,7 +441,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "cf2bbaa52ab69d063466a3c46a5918d05d752625"
+  revision = "6c823a6861b8e5dcf93a9a5a6937d592370aacb6"
 
 [[projects]]
   name = "github.com/gorilla/context"
@@ -587,8 +582,8 @@
 [[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "e7c7f3b33712573affdcc7a107218e7926b9a05b"
-  version = "1.0.6"
+  revision = "be70f29b04dea7efb4d82a8989c33aee989b74d1"
+  version = "1.1.0"
 
 [[projects]]
   name = "github.com/juju/ratelimit"
@@ -599,8 +594,8 @@
 [[projects]]
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
-  revision = "8e6aaf55f4954f1ef9d3ee2e8f5a50e79cc04f8f"
-  version = "v0.0.5"
+  revision = "930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc"
+  version = "v0.0.6"
 
 [[projects]]
   branch = "master"
@@ -858,6 +853,15 @@
   version = "v1.3.1"
 
 [[projects]]
+  name = "github.com/v2pro/plz"
+  packages = [
+    "concurrent",
+    "reflect2"
+  ]
+  revision = "571356917fca907b069b7b47a14cd32ba0b340d4"
+  version = "0.9.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/yuin/gopher-lua"
   packages = [
@@ -904,7 +908,7 @@
     "scrypt",
     "ssh/terminal"
   ]
-  revision = "650f4a345ab4e5b245a3034b110ebc7299e68186"
+  revision = "432090b8f568c018896cd8a0fb0345872bbac6ce"
 
 [[projects]]
   branch = "master"
@@ -922,7 +926,7 @@
     "lex/httplex",
     "trace"
   ]
-  revision = "136a25c244d3019482a795d728110278d6ba09a4"
+  revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
 [[projects]]
   branch = "master"
@@ -952,7 +956,6 @@
   revision = "37707fdb30a5b38865cfb95e5aab41707daec7fd"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -983,7 +986,8 @@
     "unicode/rangetable",
     "width"
   ]
-  revision = "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   branch = "master"
@@ -998,7 +1002,7 @@
     "go/ast/astutil",
     "imports"
   ]
-  revision = "ce871d178848e3eea1e8795e5cfb74053dde4bb9"
+  revision = "f8f2f88271bf2c23f28a09d288d26507a9503c97"
 
 [[projects]]
   branch = "master"
@@ -1012,13 +1016,12 @@
     "iterator",
     "option",
     "servicecontrol/v1",
-    "storage/v1",
     "support/bundler",
     "transport",
     "transport/grpc",
     "transport/http"
   ]
-  revision = "c7a403bb5fe12fe4644bb956edd5cd677626120a"
+  revision = "ab90adb3efa287b869ecb698db42f923cc734972"
 
 [[projects]]
   name = "google.golang.org/appengine"
@@ -1048,7 +1051,6 @@
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
-    "googleapis/iam/v1",
     "googleapis/logging/type",
     "googleapis/logging/v2",
     "googleapis/monitoring/v3",
@@ -1156,8 +1158,8 @@
     "ui",
     "version"
   ]
-  revision = "3f6357777a6b5017ae944866ca1abb5c612deb42"
-  version = "v0.7.0"
+  revision = "56d9eab3a9acf6be3546f50d12c31b2c154a02a9"
+  version = "v0.7.1"
 
 [[projects]]
   branch = "master"
@@ -1215,7 +1217,7 @@
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
     "pkg/features"
   ]
-  revision = "4781907d891f76ddacb7f5bef62ad974948d7e6d"
+  revision = "b89f5ce12ce6e022fc3e9d7586d61346e694d56e"
 
 [[projects]]
   branch = "release-1.9"
@@ -1277,7 +1279,7 @@
     "pkg/features",
     "pkg/util/feature"
   ]
-  revision = "43a9f1d3a4f036ddf9965108814e227dd06b42d4"
+  revision = "340af4b1e3bc0849088579387c93cc73ec37f4de"
 
 [[projects]]
   branch = "release-6.0"
@@ -1382,10 +1384,13 @@
   revision = "9389c055a838d4f208b699b3c7c51b70f2368861"
 
 [[projects]]
-  branch = "master"
   name = "k8s.io/cluster-registry"
-  packages = ["pkg/apis/clusterregistry/v1alpha1"]
-  revision = "75c64f7daf2dbdb7756138c3d4b198109858488d"
+  packages = [
+    "pkg/apis/clusterregistry",
+    "pkg/apis/clusterregistry/v1alpha1"
+  ]
+  revision = "a636176fd5730d0638f1dee29307d6073eb0ba72"
+  version = "v0.0.3"
 
 [[projects]]
   name = "k8s.io/helm"
@@ -1444,6 +1449,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6a394f86ba6bebbc277706b5bfe953ecd9e24c222ffb6b613fda4bf70fd43ef8"
+  inputs-digest = "beffe12b8cf5f8de6a15f880ef14da18366914c119e13315e27feb25ebab2184"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ where-is-docker-tar:
 #-----------------------------------------------------------------------------
 # Target: depend
 #-----------------------------------------------------------------------------
-.PHONY: depend depend.status depend.update init
+.PHONY: depend depend.status depend.update depend.cleanlock depend.update.full init
 
 # Parse out the x.y or x.y.z version and output a single value x*10000+y*100+z (e.g., 1.9 is 10900)
 # that allows the three components to be checked in a single comparison.
@@ -215,14 +215,19 @@ $(ISTIO_OUT) $(ISTIO_BIN):
 depend.status: | $(ISTIO_OUT)
 	dep status -dot > $(ISTIO_OUT)/dep.dot
 	dot -T png < $(ISTIO_OUT)/dep.dot > $(ISTIO_OUT)/dep.png
+	@echo "No error means your Gopkg.* are in sync and ok with vendor/"
+	cp Gopkg.* vendor/
 
 # https://github.com/istio/istio/wiki/Vendor-FAQ#how-do-i-add--change-a-dependency
-depend.update:
+depend.update.full: depend.cleanlock depend.update
+
+depend.cleanlock:
 	-rm Gopkg.lock
+
+depend.update:
 	time dep ensure
 	cp Gopkg.* vendor/
 	@echo "now check the diff in vendor/ and make a PR"
-
 
 ${GEN_CERT}:
 	unset GOOS && unset GOARCH && CGO_ENABLED=1 bin/gobuild.sh $@ istio.io/istio/pkg/version ./security/cmd/generate_cert

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ where-is-docker-tar:
 #-----------------------------------------------------------------------------
 # Target: depend
 #-----------------------------------------------------------------------------
-.PHONY: depend depend.ensure depend.status depend.view init
+.PHONY: depend init
 
 # Parse out the x.y or x.y.z version and output a single value x*10000+y*100+z (e.g., 1.9 is 10900)
 # that allows the three components to be checked in a single comparison.
@@ -212,8 +212,6 @@ depend: init | $(ISTIO_OUT)
 
 $(ISTIO_OUT) $(ISTIO_BIN):
 	@mkdir -p $@
-
-depend.ensure: init
 
 # If CGO_ENABLED=0 then go get tries to install in system directories.
 # If -pkgdir <dir> is also used then various additional .a files are present.

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,6 @@ ifeq ($(TAG),)
   $(error "TAG cannot be empty")
 endif
 
-GOLINT   := $(shell which golint 2>/dev/null || echo "${ISTIO_BIN}/golint" )
 GEN_CERT := ${ISTIO_BIN}/generate_cert
 
 # Set Google Storage bucket if not set
@@ -212,11 +211,6 @@ depend: init | $(ISTIO_OUT)
 
 $(ISTIO_OUT) $(ISTIO_BIN):
 	@mkdir -p $@
-
-# If CGO_ENABLED=0 then go get tries to install in system directories.
-# If -pkgdir <dir> is also used then various additional .a files are present.
-${GOLINT}:
-	unset GOOS && CGO_ENABLED=1 go get -u github.com/golang/lint/golint
 
 ${GEN_CERT}:
 	unset GOOS && unset GOARCH && CGO_ENABLED=1 bin/gobuild.sh $@ istio.io/istio/pkg/version ./security/cmd/generate_cert

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -42,29 +42,6 @@ if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
-DEP=${DEP:-$(which dep || echo "${ISTIO_BIN}/dep" )}
-
-# Just in case init.sh is called directly, not from Makefile which has a dependency to dep
-# If CGO_ENABLED=0 then go get tries to install in system directories.
-# If -pkgdir <dir> is also used then various additional .a files are present.
-if [ ! -f ${DEP} ]; then
-    DEP=${ISTIO_BIN}/dep
-    unset GOOS && CGO_ENABLED=1 go get -u github.com/golang/dep/cmd/dep
-fi
-
-# Download dependencies if needed
-if [ ! -d vendor/github.com ]; then
-    ${DEP} ensure -vendor-only
-    cp Gopkg.lock vendor/Gopkg.lock
-elif [ ! -f vendor/Gopkg.lock ]; then
-    ${DEP} ensure -vendor-only
-    cp Gopkg.lock vendor/Gopkg.lock
-else
-    diff Gopkg.lock vendor/Gopkg.lock > /dev/null || \
-            ( ${DEP} ensure -vendor-only ; \
-              cp Gopkg.lock vendor/Gopkg.lock)
-fi
-
 PROXYVERSION=$(grep envoy-debug pilot/docker/Dockerfile.proxy_debug  |cut -d: -f2)
 PROXY=debug-$PROXYVERSION
 


### PR DESCRIPTION
Follow up on having vendor/ checked in (as submodule)

We don't need to run a bunch of dep commands anymore, or build/find dep for that matter

This should shave some time from the build, not counting the simpler Makefile and script

We can later make new targets to automate
https://github.com/istio/istio/wiki/Vendor-FAQ#how-do-i-add--change-a-dependency
(for instance we can follow up with #3679)

