### PR TITLE
Add support for ppc64le architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,24 @@ endif
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
 GOARCH_LOCAL := amd64
+MACH := amd64
 else
 GOARCH_LOCAL := $(LOCAL_ARCH)
+MACH := $(LOCAL_ARCH)
 endif
 export GOARCH ?= $(GOARCH_LOCAL)
+export MACH
+
+# MACH ?= $(shell uname -m)
+
+# ifeq ($(MACH), ppc64le)
+#    export GOARCH ?= ppc64le
+# else ifeq ($(MACH), x86_64)
+#    export GOARCH ?= amd64
+#    export MACH:=amd64
+# else
+#    export GOARCH ?= $(MACH)
+# endif
 
 LOCAL_OS := $(shell uname)
 ifeq ($(LOCAL_OS),Linux)

--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,4 +1,7 @@
-from grafana/grafana:5.0.4
+# starts graphana with Prometheus Datasource pre configured
+# imports dashboard /grafana-dashboard.json from DASHBOARD_URL
+ARG grafana_base
+from ${grafana_base}
 
 COPY grafana.ini /etc/grafana/
 COPY dashboards.yaml /etc/grafana/provisioning/dashboards/

--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -31,8 +31,16 @@ BUILDPATH=${3:?"path to build"}
 
 set -e
 
+ARCH=`uname -m`
+
 GOOS=${GOOS:-linux}
-GOARCH=${GOARCH:-amd64}
+if [ "$ARCH" == "ppc64le" ]; then
+    DEFAULT_ARCH=$ARCH
+else
+    DEFAULT_ARCH="amd64"
+fi
+GOARCH=${GOARCH:-${DEFAULT_ARCH}}
+
 GOBINARY=${GOBINARY:-go}
 GOPKG="$GOPATH/pkg"
 BUILDINFO=${BUILDINFO:-""}

--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -4,6 +4,11 @@ export K8S_VER=${K8S_VER:-v1.9.2}
 export MINIKUBE_VER=${MINIKUBE_VER:-v0.25.0}
 set -x
 
+if [ "$ARCH" == "ppc64le" ]; then
+    echo "Minikube tests not supported on ppc64le, exiting..."
+    exit 1
+fi
+
 if [ ! -f /usr/local/bin/minikube ]; then
    time curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VER}/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 fi

--- a/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
@@ -50,7 +50,11 @@ spec:
     {{- end }}
       containers:
       - name: {{ $statsdname }}
-        image: "{{ $.Values.prometheusStatsdExporter.repository }}:{{ $.Values.prometheusStatsdExporter.tag}}"
+    {{- if eq $.Values.global.platform "amd64" }}
+        image: "{{ $.Values.prometheusStatsdExporter.repository_ppc64le }}:{{ $.Values.prometheusStatsdExporter.tag}}"
+    {{- else }}
+        image: "{{ $.Values.prometheusStatsdExporter.repository_amd64 }}:{{ $.Values.prometheusStatsdExporter.tag}}"
+    {{- end }}
         imagePullPolicy: {{ $.Values.prometheusStatsdExporter.imagePullPolicy }}
         ports:
         - containerPort: 9102

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -26,7 +26,11 @@ spec:
 {{ end }}
       containers:
         - name: prometheus
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      {{- if eq $.Values.global.platform "ppc64le" }}
+          image: "{{ .Values.image.repository_ppc64le }}:{{ .Values.image.tag }}"
+      {{- else }}
+          image: "{{ .Values.image.repository_amd64 }}:{{ .Values.image.tag }}"
+      {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - '--storage.tsdb.retention=6h'

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -19,7 +19,12 @@ spec:
     spec:
       containers:
         - name: zipkin
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      {{- if eq $.Values.global.platform "ppc64le" }}
+          image: "{{ .Values.image.repository_ppc64le }}:{{ .Values.image.tag }}"
+      {{- else }}
+          image: "{{ .Values.image.repository_amd64 }}:{{ .Values.image.tag }}"
+      {{- end }}
+
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -61,6 +61,11 @@ global:
     s390x: 2
     ppc64le: 2
 
+  # Specify the platform arch (amd64, ppc64le) for which the right images
+  # should be pulled.
+  platform: "amd64"
+#  platform: "ppc64le"
+
 # Any customization for istio testing should be here
 istiotesting:
   oneNameSpace: false
@@ -126,7 +131,8 @@ mixer:
   #  memory: 128Mi
 
   prometheusStatsdExporter:
-    repository: prom/statsd-exporter
+    repository_amd64: prom/statsd-exporter
+    repository_ppc64le: ibmcom/statsd-exporter
     tag: latest
     imagePullPolicy: IfNotPresent
     resources: {}
@@ -200,7 +206,8 @@ prometheus:
   enabled: false
   replicaCount: 1
   image:
-    repository: docker.io/prom/prometheus
+    repository_amd64: docker.io/prom/prometheus
+    repository_ppc64le: ibmcom/prometheus
     tag: latest
     pullPolicy: IfNotPresent
   ingress:
@@ -264,7 +271,8 @@ zipkin:
   enabled: false
   replicaCount: 1
   image:
-    repository: docker.io/openzipkin/zipkin
+    repository_amd64: docker.io/openzipkin/zipkin
+    repository_ppc64le: ibmcom/zipkin
     tag: latest
     pullPolicy: IfNotPresent
   service:

--- a/install/kubernetes/templates/addons/prometheus.yaml.tmpl
+++ b/install/kubernetes/templates/addons/prometheus.yaml.tmpl
@@ -222,7 +222,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: docker.io/prom/prometheus:v2.0.0
+        image: {PROM_HUB}/prometheus:{PROM_TAG}
         imagePullPolicy: IfNotPresent
         args:
           - '--storage.tsdb.retention=6h'

--- a/install/kubernetes/templates/addons/zipkin-to-stackdriver.yaml.tmpl
+++ b/install/kubernetes/templates/addons/zipkin-to-stackdriver.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: zipkin-to-stackdriver
-        image: gcr.io/stackdriver-trace-docker/zipkin-collector
+        image: {ZIPKIN_COLLECTOR_HUB}/zipkin-collector:{ZIPKIN_COLLECTOR_TAG}
         imagePullPolicy: IfNotPresent
 #        env:
 #        - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/install/kubernetes/templates/addons/zipkin.yaml.tmpl
+++ b/install/kubernetes/templates/addons/zipkin.yaml.tmpl
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: zipkin
-        image: docker.io/openzipkin/zipkin:latest
+        image: {ZIPKIN_HUB}/zipkin:{ZIPKIN_TAG}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9411

--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
       serviceAccountName: istio-mixer-service-account
       containers:
       - name: statsd-to-prometheus
-        image: prom/statsd-exporter:v0.5.0
+        image: {STATSD_HUB}/statsd-exporter:{STATSD_TAG}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9102


### PR DESCRIPTION
Sets the GOARCH according to the current architecture. Modifies the
yaml.tmpl files to add images and tags for zipkin, prometheus,
statsd-exporter, stackdriver/zipkin-collector, etc. Adds 3 dockerfiles
for mixer_debug, servicegraph_debug and graphana, since, no debug
images for ppc64le in istio-testing/ubuntu_xenial_debug. Modifies the
tools/istio-docker.mk accordingly. The tests with minikube need to
be disabled for ppc64le, since minikube binary is not publically
available on github for ppc64le.