### PR TITLE
Transfer input bag from state to session during dispatch.

### DIFF
--- a/mixer/pkg/runtime2/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher.go
@@ -243,6 +243,7 @@ func (d *Dispatcher) dispatch(session *session) error {
 				state.instance = instance
 				if session.variety == tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR {
 					state.mapper = group.Mappers[j]
+					state.inputBag = session.bag
 				}
 
 				// Dispatch for singleton dispatches

--- a/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime2/dispatcher/dispatcher_test.go
@@ -416,6 +416,10 @@ ident                         : dest.istio-system
 '
 [tapa] InstanceBuilderFn() <= (SUCCESS)
 [tapa] DispatchGenAttrs => instance: '&Empty{}'
+[tapa] DispatchGenAttrs => attrs:    '---
+ident                         : dest.istio-system
+'
+[tapa] DispatchGenAttrs => mapper(exists):   'true'
 [tapa] DispatchGenAttrs <= (SUCCESS)
 `,
 	},
@@ -443,6 +447,10 @@ ident                         : dest.istio-system
 '
 [tapa] InstanceBuilderFn() <= (SUCCESS)
 [tapa] DispatchGenAttrs => instance: '&Empty{}'
+[tapa] DispatchGenAttrs => attrs:    '---
+ident                         : dest.istio-system
+'
+[tapa] DispatchGenAttrs => mapper(exists):   'true'
 [tapa] DispatchGenAttrs <= (ERROR)
 
 `,

--- a/mixer/pkg/runtime2/testing/data/templates.go
+++ b/mixer/pkg/runtime2/testing/data/templates.go
@@ -153,6 +153,8 @@ func createFakeTemplate(name string, s FakeTemplateSettings, l *Logger, variety 
 		DispatchGenAttrs: func(ctx context.Context, handler adapter.Handler, instance interface{},
 			attrs attribute.Bag, mapper template.OutputMapperFn) (*attribute.MutableBag, error) {
 			l.writeFormat(name, "DispatchGenAttrs => instance: '%+v'", instance)
+			l.writeFormat(name, "DispatchGenAttrs => attrs:    '%+v'", attrs.DebugString())
+			l.writeFormat(name, "DispatchGenAttrs => mapper(exists):   '%+v'", mapper != nil)
 
 			signalCallAndWait(s)
 


### PR DESCRIPTION
There is a one-liner bug in the new dispatcher code that is not copying the input bag from session to state objects during an APA session. This causes a panic when generating attributes, when the expression for those attributes depend on "non-$out" expressions.