### PR TITLE
Make prow e2e test failure actually fail

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -85,8 +85,7 @@ e2e_upgrade: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
 e2e_all:
-	set -o pipefail
-	$(MAKE) e2e_simple e2e_mixer e2e_bookinfo |& tee >(go-junit-report > junit.xml)
+	set -o pipefail; $(MAKE) e2e_simple e2e_mixer e2e_bookinfo |& tee >(go-junit-report > junit.xml)
 
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${TESTOPTS} -hub ${HUB} -tag ${TAG}

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -85,6 +85,7 @@ e2e_upgrade: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
 e2e_all:
+	set -o pipefail
 	$(MAKE) e2e_simple e2e_mixer e2e_bookinfo |& tee >(go-junit-report > junit.xml)
 
 e2e_pilot: istioctl generate_yaml


### PR DESCRIPTION
Fixes issue introduced by istio/istio#3542, which returns the exit code of tee instead of the exit code of make.