### PR TITLE
Fix for istio-proxy-cfg.py backtrace when pod has no labels

### DIFF
--- a/bin/istio-proxy-cfg.py
+++ b/bin/istio-proxy-cfg.py
@@ -160,7 +160,7 @@ def pod_info():
     o = json.loads(op)
     return {i['metadata']['name'] + "." + i['metadata']['namespace']:
             POD(i['metadata']['name'], i['metadata']['namespace'],
-                i['status']['podIP'], i['metadata']['labels']) for i in o['items']}
+                i['status']['podIP'], i['metadata'].get('labels', {})) for i in o['items']}
 
 
 def searchpod(pi, searchstr):


### PR DESCRIPTION
See https://github.com/istio/issues/issues/199
