### PR TITLE
Expose two ports for pilot envoy

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           - {{ .Release.Name }}-pilot:15005
         {{- else }}
           - --controlPlaneAuthPolicy
-          - NONE
+          - NONE #--controlPlaneAuthPolicy
           - --discoveryAddress
           - {{ .Release.Name }}-pilot:15007
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -32,8 +32,6 @@ spec:
           - ingress
           - -v
           - "2"
-          - --discoveryAddress
-          - {{ .Release.Name }}-pilot:15003
           - --discoveryRefreshDelay
           - '1s' #discoveryRefreshDelay
           - --drainDuration
@@ -50,11 +48,16 @@ spec:
           - {{ .Release.Name }}-mixer:9125
           - --proxyAdminPort
           - "15000"
-          - --controlPlaneAuthPolicy
         {{- if .Values.global.securityEnabled }}
+          - --controlPlaneAuthPolicy
           - MUTUAL_TLS
+          - --discoveryAddress
+          - {{ .Release.Name }}-pilot:15005
         {{- else }}
-          - NONE #--controlPlaneAuthPolicy
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - {{ .Release.Name }}-pilot:15007
         {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -59,22 +59,27 @@ spec:
           imagePullPolicy: {{ .Values.global.proxy.imagePullPolicy }}
           ports:
           - containerPort: 15003
+          - containerPort: 15005
+          - containerPort: 15007
           args:
           - proxy
           - pilot
           - -v
           - "2"
-          - --discoveryAddress
-          - {{ template "pilot.fullname" . }}:15003
-          - --controlPlaneAuthPolicy
         {{- if .Values.global.securityEnabled }}
+          - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --customConfigFile
           - /etc/istio/proxy/envoy_pilot_auth.json
+          - --discoveryAddress
+          - {{ template "pilot.fullname" . }}:15005
         {{- else }}
+          - --controlPlaneAuthPolicy
           - NONE #--controlPlaneAuthPolicy
           - --customConfigFile
           - /etc/istio/proxy/envoy_pilot.json
+          - --discoveryAddress
+          - {{ template "pilot.fullname" . }}:15007
         {{- end }}
           resources:
 {{ toYaml .Values.global.proxy.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -75,13 +75,17 @@ data:
       # to collect and convert statsd metrics into Prometheus metrics.
       statsdUdpAddress: {{ .Release.Name }}-mixer.{{ .Release.Namespace }}:9125
     {{- if .Values.global.securityEnabled }}
+      #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: MUTUAL_TLS
+      #
       # Address where istio Pilot service is running
       discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15005
     {{- else }}
+      #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
+      #
       # Address where istio Pilot service is running
       discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15007
     {{- end }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -68,9 +68,6 @@ data:
       # for more details
       proxyAdminPort: 15000
       #
-      # Address where istio Pilot service is running
-      discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15003
-      #
       # Zipkin trace collector
       zipkinAddress: {{ .Release.Name}}-zipkin.{{ .Release.Namespace }}:9411
       #
@@ -78,7 +75,13 @@ data:
       # to collect and convert statsd metrics into Prometheus metrics.
       statsdUdpAddress: {{ .Release.Name }}-mixer.{{ .Release.Namespace }}:9125
     {{- if .Values.global.securityEnabled }}
-      #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: MUTUAL_TLS
+      # Address where istio Pilot service is running
+      discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15005
+    {{- else }}
+      # Mutual TLS authentication between sidecars and istio control plane.
+      controlPlaneAuthPolicy: NONE
+      # Address where istio Pilot service is running
+      discoveryAddress: {{ .Release.Name }}-pilot.{{ .Release.Namespace }}:15007
     {{- end }}

--- a/install/kubernetes/templates/istio-config.yaml.tmpl
+++ b/install/kubernetes/templates/istio-config.yaml.tmpl
@@ -65,7 +65,7 @@ data:
       proxyAdminPort: 15000
       #
       # Address where Istio Pilot service is running
-      discoveryAddress: istio-pilot.{ISTIO_NAMESPACE}:15003
+      discoveryAddress: istio-pilot.{ISTIO_NAMESPACE}:15007
       #
       # Zipkin trace collector
       zipkinAddress: zipkin.{ISTIO_NAMESPACE}:9411

--- a/install/kubernetes/templates/istio-ingress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ingress.yaml.tmpl
@@ -49,7 +49,7 @@ spec:
         - -v
         - "2"
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - '1s' #discoveryRefreshDelay
         - --drainDuration

--- a/install/kubernetes/templates/istio-pilot.yaml.tmpl
+++ b/install/kubernetes/templates/istio-pilot.yaml.tmpl
@@ -96,7 +96,7 @@ metadata:
     istio: pilot
 spec:
   ports:
-  - port: 15003
+  - port: 15007
     name: http-discovery
   - port: 8080
     name: http-legacy-discovery
@@ -156,14 +156,14 @@ spec:
         image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 15003
+        - containerPort: 15007
         args:
         - proxy
         - pilot
         - -v
         - "2"
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --controlPlaneAuthPolicy
         - NONE #--controlPlaneAuthPolicy
         - --customConfigFile

--- a/install/kubernetes/templates/istio-pilot.yaml.tmpl
+++ b/install/kubernetes/templates/istio-pilot.yaml.tmpl
@@ -96,6 +96,10 @@ metadata:
     istio: pilot
 spec:
   ports:
+  - port: 15003
+    name: discovery
+  - port: 15005
+    name: https-discovery
   - port: 15007
     name: http-discovery
   - port: 8080
@@ -156,6 +160,8 @@ spec:
         image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}
         imagePullPolicy: IfNotPresent
         ports:
+        - containerPort: 15003
+        - containerPort: 15005
         - containerPort: 15007
         args:
         - proxy

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -167,6 +167,7 @@ function merge_files() {
   cat $SRC/istio-ca.yaml.tmpl >> $ISTIO
 
   cp $ISTIO $ISTIO_AUTH
+  execute_sed "s/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15007/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15005/" $ISTIO_AUTH
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_AUTH
@@ -178,6 +179,7 @@ function merge_files() {
   cat $SRC/istio-ca-one-namespace.yaml.tmpl >> $ISTIO_ONE_NAMESPACE
 
   cp $ISTIO_ONE_NAMESPACE $ISTIO_ONE_NAMESPACE_AUTH
+  execute_sed "s/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15007/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15005/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -168,6 +168,7 @@ function merge_files() {
 
   cp $ISTIO $ISTIO_AUTH
   execute_sed "s/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15007/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15005/" $ISTIO_AUTH
+  execute_sed "s/- istio-pilot:15007/- istio-pilot:15005/" $ISTIO_AUTH
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_AUTH
@@ -180,6 +181,7 @@ function merge_files() {
 
   cp $ISTIO_ONE_NAMESPACE $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15007/discoveryAddress: istio-pilot.${ISTIO_NAMESPACE}:15005/" $ISTIO_ONE_NAMESPACE_AUTH
+  execute_sed "s/- istio-pilot:15007/- istio-pilot:15005/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH

--- a/pilot/docker/envoy_pilot.json
+++ b/pilot/docker/envoy_pilot.json
@@ -20,6 +20,54 @@
      }
     ],
     "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:15005",
+    "name": "tcp_0.0.0.0_15005",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.8080"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:15007",
+    "name": "tcp_0.0.0.0_15007",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.8080"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
    }
   ],
   "admin": {

--- a/pilot/docker/envoy_pilot_auth.json
+++ b/pilot/docker/envoy_pilot_auth.json
@@ -26,6 +26,54 @@
      "require_client_certificate": true
     },
     "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:15005",
+    "name": "tcp_0.0.0.0_15005",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.8080"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "require_client_certificate": true
+    },
+    "bind_to_port": true
+   },
+   {
+    "address": "tcp://0.0.0.0:15007",
+    "name": "tcp_0.0.0.0_15007",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.8080"
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": true
    }
   ],
   "admin": {

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -36,7 +36,7 @@ spec:
             - --parentShutdownDuration
             - 3s
             - --discoveryAddress
-            - istio-pilot:15003
+            - istio-pilot:15007
             - --discoveryRefreshDelay
             - 1s
             - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -35,7 +35,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
@@ -55,7 +55,7 @@ items:
           - --parentShutdownDuration
           - 3s
           - --discoveryAddress
-          - istio-pilot:15003
+          - istio-pilot:15007
           - --discoveryRefreshDelay
           - 1s
           - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
@@ -40,7 +40,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 42s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 42s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
@@ -55,7 +55,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -38,7 +38,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -38,7 +38,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress
@@ -142,7 +142,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -57,7 +57,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -34,7 +34,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
@@ -56,7 +56,7 @@ items:
           - --parentShutdownDuration
           - 3s
           - --discoveryAddress
-          - istio-pilot:15003
+          - istio-pilot:15007
           - --discoveryRefreshDelay
           - 1s
           - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list.yaml.injected
@@ -40,7 +40,7 @@ items:
           - --parentShutdownDuration
           - 3s
           - --discoveryAddress
-          - istio-pilot:15003
+          - istio-pilot:15007
           - --discoveryRefreshDelay
           - 1s
           - --zipkinAddress
@@ -143,7 +143,7 @@ items:
           - --parentShutdownDuration
           - 3s
           - --discoveryAddress
-          - istio-pilot:15003
+          - istio-pilot:15007
           - --discoveryRefreshDelay
           - 1s
           - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -37,7 +37,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -34,7 +34,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -36,7 +36,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -40,7 +40,7 @@ spec:
         - --parentShutdownDuration
         - 3s
         - --discoveryAddress
-        - istio-pilot:15003
+        - istio-pilot:15007
         - --discoveryRefreshDelay
         - 1s
         - --zipkinAddress

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -159,8 +159,8 @@ const (
 	// ServiceClusterName service cluster name used in xDS calls
 	ServiceClusterName = "istio-proxy"
 
-	// DiscoveryServerAddress discovery IP address:port
-	DiscoveryServerAddress = "istio-pilot:15003"
+	// DiscoveryPlainAddress discovery IP address:port with plain text
+	DiscoveryPlainAddress = "istio-pilot:15007"
 )
 
 // DefaultProxyConfig for individual proxies
@@ -172,7 +172,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		AvailabilityZone:       "", //no service zone by default, i.e. AZ-aware routing is disabled
 		DrainDuration:          ptypes.DurationProto(2 * time.Second),
 		ParentShutdownDuration: ptypes.DurationProto(3 * time.Second),
-		DiscoveryAddress:       DiscoveryServerAddress,
+		DiscoveryAddress:       DiscoveryPlainAddress,
 		DiscoveryRefreshDelay:  ptypes.DurationProto(1 * time.Second),
 		ZipkinAddress:          "",
 		ConnectTimeout:         ptypes.DurationProto(1 * time.Second),

--- a/tests/e2e/tests/pilot/testdata/config.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/config.yaml.tmpl
@@ -10,7 +10,11 @@ data:
       serviceCluster:         istio-proxy
       drainDuration:          2s
       parentShutdownDuration: 3s
-      discoveryAddress:       istio-pilot.{{.IstioNamespace}}:15003
+{{if eq .Auth.String "NONE"}}
+      discoveryAddress:       istio-pilot.{{.IstioNamespace}}:15007
+{{else}}
+      discoveryAddress:       istio-pilot.{{.IstioNamespace}}:15005
+{{end}}
       discoveryRefreshDelay:  1s
       connectTimeout:         1s
       proxyAdminPort:         15000

--- a/tests/e2e/tests/pilot/testdata/ingress-proxy.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/ingress-proxy.yaml.tmpl
@@ -41,7 +41,11 @@ spec:
         - -v
         - "{{.Verbosity}}"
         - --discoveryAddress
-        - istio-pilot:15003
+{{if eq .ControlPlaneAuthPolicy.String "NONE" }}
+        - istio-pilot:15007
+{{else}}
+        - istio-pilot:15005
+{{end}}
 {{if .Zipkin}}
         - --zipkinAddress
         - zipkin:9411

--- a/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
@@ -42,6 +42,10 @@ spec:
   type: LoadBalancer
 {{end}}
   ports:
+  - port: 15003
+    name: discovery
+  - port: 15005
+    name: https-discovery
   - port: 15007
     name: http-discovery
 {{if .DebugPort}}
@@ -124,8 +128,8 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 15003
-        - containerPort: 15007
         - containerPort: 15005
+        - containerPort: 15007
         args:
         - proxy
         - pilot

--- a/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
@@ -44,6 +44,10 @@ spec:
   ports:
   - port: 15003
     name: http-discovery
+  - port: 15005
+    name: http-discovery
+  - port: 15007
+    name: http-discovery
 {{if .DebugPort}}
   - port: {{.DebugPort}}
     name: tcp-debug
@@ -124,13 +128,19 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 15003
+        - containerPort: 15007
+        - containerPort: 15005
         args:
         - proxy
         - pilot
         - -v
         - "{{.Verbosity}}"
         - "--discoveryAddress"
-        - "istio-pilot:15003"
+{{if eq .ControlPlaneAuthPolicy.String "NONE"}}
+        - "istio-pilot:15007"
+{{else}}
+        - "istio-pilot:15005"
+{{end}}
         - "--controlPlaneAuthPolicy"
         - "{{.ControlPlaneAuthPolicy.String}}"
         - --customConfigFile

--- a/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
@@ -42,10 +42,6 @@ spec:
   type: LoadBalancer
 {{end}}
   ports:
-  - port: 15003
-    name: http-discovery
-  - port: 15005
-    name: http-discovery
   - port: 15007
     name: http-discovery
 {{if .DebugPort}}

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -26,7 +26,7 @@
 
 # If istio-pilot is configured with mTLS authentication (--controlPlaneAuthPolicy MUTUAL_TLS ) you must
 # also configure the mesh expansion machines:
-# ISTIO_PILOT_PORT=15003
+# ISTIO_PILOT_PORT=15005
 # ISTIO_CP_AUTH=MUTUAL_TLS
 
 # Fine tunning - useful if installing/building binaries instead of using the .deb file, or running
@@ -53,4 +53,3 @@
 
 # Location of istio configs.
 # ISTIO_CFG=/var/lib/istio
-


### PR DESCRIPTION
Pilot envoy has two new ports: 15007 for http and 15005 for https. This fixes the bug that when pilot ControlPlaneAuthPolicy changes, others won't be able to talk to it.