### PR TITLE
Reintroduce --logtostderr option until such a point as we switch to the do-nothing glog.

### DIFF
--- a/install/kubernetes/templates/istio-mixer.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer.yaml.tmpl
@@ -80,6 +80,7 @@ spec:
           - --configStoreURL=k8s://
           - --configDefaultNamespace={ISTIO_NAMESPACE}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+          - --logtostderr
       - name: istio-proxy
         image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Without this option, glog tries to open a tmp log file somewhere which doesn't always work.