### PR TITLE
Ingress failure debug + reduce "flake" in TestSimpleIngress

### DIFF
--- a/tests/e2e/framework/testInfo.go
+++ b/tests/e2e/framework/testInfo.go
@@ -139,6 +139,10 @@ func (t testInfo) FetchAndSaveClusterLogs(namespace string) error {
 		return nil
 	}
 
+	_, err := util.Shell("kubectl get ingress --all-namespaces")
+	if err != nil {
+		return err
+	}
 	lines, err := util.Shell("kubectl get pods -n " + namespace)
 	if err != nil {
 		return err

--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -71,7 +71,7 @@ func TestSimpleIngress(t *testing.T) {
 	// with "echo debug server ..." on the /debug uri.
 	url := "http://" + tc.Kube.Ingress + "/fortio/debug"
 	log.Infof("Fetching '%s'", url)
-	attempts := 7 // should not take more than 70s to be live...
+	attempts := 1 // should not take more than 70s to be live...
 	for i := 1; i <= attempts; i++ {
 		if i > 1 {
 			time.Sleep(10 * time.Second) // wait between retries
@@ -97,7 +97,7 @@ func TestSimpleIngress(t *testing.T) {
 		}
 		return // success
 	}
-	t.Errorf("Unable to find expected output after %d attempts", attempts)
+	t.Errorf("Unable to find expected output after %d attempts - ingress issue", attempts)
 }
 
 func TestSvc2Svc(t *testing.T) {

--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -66,15 +66,17 @@ func TestMain(m *testing.M) {
 	os.Exit(tc.RunTest(m))
 }
 
+// TODO: need an "is cluster ready" before running any tests
+
 func TestSimpleIngress(t *testing.T) {
 	// Tests the rewrite/dropping of the /fortio/ prefix as fortio only replies
 	// with "echo debug server ..." on the /debug uri.
 	url := "http://" + tc.Kube.Ingress + "/fortio/debug"
 	log.Infof("Fetching '%s'", url)
-	attempts := 1 // should not take more than 70s to be live...
+	attempts := 7 // should not take more than 1min45s to be live...
 	for i := 1; i <= attempts; i++ {
 		if i > 1 {
-			time.Sleep(10 * time.Second) // wait between retries
+			time.Sleep(15 * time.Second) // wait between retries
 		}
 		resp, err := http.Get(url)
 		if err != nil {


### PR DESCRIPTION
a) print ingress information when tests fail

b) sleep longer to increase chance of success - but I think we do have a serious problem that even in contained environment it takes >70s for a simple setup to be ready

fixes #2199