### PR TITLE
Remove leftover uses of glog from our code base.

### DIFF
--- a/mixer/adapter/redisquota/redisquota_test.go
+++ b/mixer/adapter/redisquota/redisquota_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/alicebob/miniredis"
 	"github.com/alicebob/miniredis/server"
-	"github.com/golang/glog"
 
 	"istio.io/istio/mixer/adapter/redisquota/config"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -46,7 +45,7 @@ type (
 func TestBuilderValidate(t *testing.T) {
 	mockRedis, err := miniredis.Run()
 	if err != nil {
-		glog.Fatalf("Unable to start mock redis server: %v", err)
+		t.Fatalf("Unable to start mock redis server: %v", err)
 		return
 	}
 	defer mockRedis.Close()
@@ -270,7 +269,7 @@ func TestBuilderValidate(t *testing.T) {
 func TestHandleQuota(t *testing.T) {
 	mockRedis, err := miniredis.Run()
 	if err != nil {
-		glog.Fatalf("Unable to start mock redis server: %v", err)
+		t.Fatalf("Unable to start mock redis server: %v", err)
 		return
 	}
 	defer mockRedis.Close()
@@ -636,7 +635,7 @@ func TestHandleQuotaErrorMsg(t *testing.T) {
 		})
 
 		if err != nil {
-			glog.Errorf("%v: unexpected error: %v", id, err.Error())
+			t.Errorf("%v: unexpected error: %v", id, err.Error())
 			continue
 		}
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -25,6 +25,11 @@ import (
 var logger = zap.NewNop()
 var sugar = logger.Sugar()
 
+func init() {
+	// use our defaults for starters so that logging works even before everything is fully configured
+	_ = Configure(NewOptions())
+}
+
 func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
 	t = t.UTC()
 	year, month, day := t.Date()

--- a/security/tests/integration/certificateRotationTest/certificate_rotation_test.go
+++ b/security/tests/integration/certificateRotationTest/certificate_rotation_test.go
@@ -21,8 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
-
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/ca/controller"
 	"istio.io/istio/security/tests/integration"
 	"istio.io/istio/tests/integration/framework"
@@ -59,7 +58,7 @@ func TestCertificateRotation(t *testing.T) {
 	term := certValidationInterval
 	for i := 0; i < certValidateRetry; i++ {
 		if i > 0 {
-			glog.Infof("checking certificate rotation in %v seconds", term)
+			t.Logf("checking certificate rotation in %v seconds", term)
 			time.Sleep(time.Duration(term) * time.Second)
 			term = term * 2
 		}
@@ -80,7 +79,7 @@ func TestCertificateRotation(t *testing.T) {
 
 		if !bytes.Equal(initialSecret.Data[controller.PrivateKeyID], secret.Data[controller.PrivateKeyID]) &&
 			!bytes.Equal(initialSecret.Data[controller.CertChainID], secret.Data[controller.CertChainID]) {
-			glog.Infof("certificates were successfully rotated")
+			t.Logf("certificates were successfully rotated")
 
 			return
 		}
@@ -98,14 +97,14 @@ func TestMain(m *testing.M) {
 	testEnv = integration.NewCertRotationTestEnv(testEnvName, *kubeconfig, *hub, *tag)
 
 	if testEnv == nil {
-		glog.Error("test environment creation failure")
+		log.Error("test environment creation failure")
 		// There is no cleanup needed at this point.
 		os.Exit(1)
 	}
 
 	res := framework.NewTestEnvManager(testEnv, testID).RunTest(m)
 
-	glog.Infof("Test result %d in env %s", res, testEnvName)
+	log.Infof("Test result %d in env %s", res, testEnvName)
 
 	os.Exit(res)
 }

--- a/security/tests/integration/istio_ca_cert_rotation_env.go
+++ b/security/tests/integration/istio_ca_cert_rotation_env.go
@@ -17,9 +17,9 @@ package integration
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/integration/framework"
 )
 
@@ -44,13 +44,13 @@ const (
 func NewCertRotationTestEnv(name, kubeConfig, hub, tag string) *CertRotationTestEnv {
 	clientset, err := CreateClientset(kubeConfig)
 	if err != nil {
-		glog.Errorf("failed to initialize K8s client: %v", err)
+		log.Errorf("failed to initialize K8s client: %v", err)
 		return nil
 	}
 
 	namespace, err := createTestNamespace(clientset, testNamespacePrefix)
 	if err != nil {
-		glog.Errorf("failed to create test namespace: %v", err)
+		log.Errorf("failed to create test namespace: %v", err)
 		return nil
 	}
 
@@ -101,11 +101,11 @@ func (env *CertRotationTestEnv) Bringup() error {
 // Cleanup clean everything created by this test environment, not component level
 // Cleanup() is being called in framework.TearDown()
 func (env *CertRotationTestEnv) Cleanup() error {
-	glog.Infof("cleaning up environment...")
+	log.Infof("cleaning up environment...")
 	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete the namespace: %v error: %v", env.NameSpace, err)
-		glog.Error(retErr)
+		log.Errorf("%v", retErr)
 		return retErr
 	}
 	return nil

--- a/security/tests/integration/istio_ca_node_agent_env.go
+++ b/security/tests/integration/istio_ca_node_agent_env.go
@@ -17,11 +17,11 @@ package integration
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/integration/framework"
 )
 
@@ -49,13 +49,13 @@ const (
 func NewNodeAgentTestEnv(name, kubeConfig, hub, tag string) *NodeAgentTestEnv {
 	clientset, err := CreateClientset(kubeConfig)
 	if err != nil {
-		glog.Errorf("failed to initialize K8s client: %v", err)
+		log.Errorf("failed to initialize K8s client: %v", err)
 		return nil
 	}
 
 	namespace, err := createTestNamespace(clientset, testNamespacePrefix)
 	if err != nil {
-		glog.Errorf("failed to create test namespace: %v", err)
+		log.Errorf("failed to create test namespace: %v", err)
 		return nil
 	}
 
@@ -133,11 +133,11 @@ func (env *NodeAgentTestEnv) Bringup() error {
 // Cleanup clean everything created by this test environment, not component level
 // Cleanup() is being called in framework.TearDown()
 func (env *NodeAgentTestEnv) Cleanup() error {
-	glog.Infof("cleaning up environment...")
+	log.Infof("cleaning up environment...")
 	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.NameSpace, err)
-		glog.Error(retErr)
+		log.Errorf("%v", retErr)
 		return retErr
 	}
 	return nil

--- a/security/tests/integration/istio_ca_secret_env.go
+++ b/security/tests/integration/istio_ca_secret_env.go
@@ -17,9 +17,9 @@ package integration
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/integration/framework"
 )
 
@@ -44,13 +44,13 @@ type (
 func NewSecretTestEnv(name, kubeConfig, hub, tag string) *SecretTestEnv {
 	clientset, err := CreateClientset(kubeConfig)
 	if err != nil {
-		glog.Errorf("failed to initialize K8s client: %v", err)
+		log.Errorf("failed to initialize K8s client: %v", err)
 		return nil
 	}
 
 	namespace, err := createTestNamespace(clientset, testNamespacePrefix)
 	if err != nil {
-		glog.Errorf("failed to create test namespace: %v", err)
+		log.Errorf("failed to create test namespace: %v", err)
 		return nil
 	}
 
@@ -100,11 +100,11 @@ func (env *SecretTestEnv) Bringup() error {
 // Cleanup clean everything created by this test environment, not component level
 // Cleanup() is being called in framework.TearDown()
 func (env *SecretTestEnv) Cleanup() error {
-	glog.Infof("cleaning up environment...")
+	log.Infof("cleaning up environment...")
 	err := deleteTestNamespace(env.ClientSet, env.NameSpace)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete namespace: %v error: %v", env.NameSpace, err)
-		glog.Error(retErr)
+		log.Errorf("%v", retErr)
 		return retErr
 	}
 	return nil

--- a/security/tests/integration/kubernetes_pod.go
+++ b/security/tests/integration/kubernetes_pod.go
@@ -17,10 +17,10 @@ package integration
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/integration/framework"
 )
 
@@ -66,7 +66,7 @@ func (c *KubernetesPod) Start() (err error) {
 	}
 
 	if _, err = createPod(c.clientset, c.namespace, c.image, c.name, labels, c.cmds, c.args); err != nil {
-		glog.Errorf("failed to create a pod: %v", c.name)
+		log.Errorf("failed to create a pod: %v", c.name)
 	}
 	return err
 }
@@ -74,14 +74,14 @@ func (c *KubernetesPod) Start() (err error) {
 // Stop stop this component
 // Stop is being called in framework.TearDown()
 func (c *KubernetesPod) Stop() (err error) {
-	glog.Infof("deleting the pod: %v", c.name)
+	log.Infof("deleting the pod: %v", c.name)
 	return deletePod(c.clientset, c.namespace, c.name)
 }
 
 // IsAlive check if component is alive/running
 func (c *KubernetesPod) IsAlive() (bool, error) {
 	if err := waitForPodRunning(c.clientset, c.namespace, c.uuid, kubernetesWaitTimeout); err != nil {
-		glog.Errorf("failed to create a pod: %v err: %v", c.name, err)
+		log.Errorf("failed to create a pod: %v err: %v", c.name, err)
 		return false, err
 	}
 

--- a/security/tests/integration/kubernetes_service.go
+++ b/security/tests/integration/kubernetes_service.go
@@ -17,11 +17,11 @@ package integration
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/integration/framework"
 )
 
@@ -77,7 +77,7 @@ func (c *KubernetesService) Start() (err error) {
 		c.selector,
 		c.annotation)
 	if err != nil {
-		glog.Errorf("failed to create a service %v", c.name)
+		log.Errorf("failed to create a service %v", c.name)
 	}
 
 	return err
@@ -86,14 +86,14 @@ func (c *KubernetesService) Start() (err error) {
 // Stop stop this component
 // Stop is being called in framework.TearDown()
 func (c *KubernetesService) Stop() (err error) {
-	glog.Infof("deleting the service: %v", c.name)
+	log.Infof("deleting the service: %v", c.name)
 	return deleteService(c.clientset, c.namespace, c.name)
 }
 
 // IsAlive checks if the component is alive/running
 func (c *KubernetesService) IsAlive() (bool, error) {
 	if c.serviceType == v1.ServiceTypeLoadBalancer {
-		glog.Infof("waiting for the load balancer to be ready...")
+		log.Infof("waiting for the load balancer to be ready...")
 		if err := waitForServiceExternalIPAddress(c.clientset, c.namespace, c.uuid, kubernetesWaitTimeout); err != nil {
 			return false, fmt.Errorf("failed to get the external IP adddress of %v service: %v", c.name, err)
 		}

--- a/security/tests/integration/kubernetes_utils.go
+++ b/security/tests/integration/kubernetes_utils.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // to avoid 'No Auth Provider found for name "gcp"'
 	"k8s.io/client-go/tools/clientcmd"
 
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/pki/ca/controller"
 	"istio.io/istio/security/pkg/pki/util"
 )
@@ -69,7 +69,7 @@ func createTestNamespace(clientset kubernetes.Interface, prefix string) (string,
 		return "", fmt.Errorf("failed to create a namespace (error: %v)", err)
 	}
 
-	glog.Infof("namespace %v is created", namespace.GetName())
+	log.Infof("namespace %v is created", namespace.GetName())
 
 	// Create Role
 	err = createIstioCARole(clientset, namespace.GetName())
@@ -93,7 +93,7 @@ func deleteTestNamespace(clientset kubernetes.Interface, namespace string) error
 	if err := clientset.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{GracePeriodSeconds: &immediate}); err != nil {
 		return fmt.Errorf("failed to delete namespace %q (error: %v)", namespace, err)
 	}
-	glog.Infof("namespace %v is deleted", namespace)
+	log.Infof("namespace %v is deleted", namespace)
 	return nil
 }
 
@@ -257,7 +257,7 @@ func waitForServiceExternalIPAddress(clientset kubernetes.Interface, namespace s
 		case event := <-events:
 			svc := event.Object.(*v1.Service)
 			if len(svc.Status.LoadBalancer.Ingress) > 0 {
-				glog.Infof("LoadBalancer for %v/%v is ready. IP: %v", namespace, svc.GetName(),
+				log.Infof("LoadBalancer for %v/%v is ready. IP: %v", namespace, svc.GetName(),
 					svc.Status.LoadBalancer.Ingress[0].IP)
 				return nil
 			}
@@ -285,7 +285,7 @@ func waitForPodRunning(clientset kubernetes.Interface, namespace string, uuid st
 		case event := <-events:
 			pod := event.Object.(*v1.Pod)
 			if pod.Status.Phase == v1.PodRunning {
-				glog.Infof("pod %v/%v is in Running phase", namespace, pod.GetName())
+				log.Infof("pod %v/%v is in Running phase", namespace, pod.GetName())
 				return nil
 			}
 		case <-time.After(timeToWait - time.Since(startTime)):

--- a/security/tests/integration/nodeAgentTest/node_agent_test.go
+++ b/security/tests/integration/nodeAgentTest/node_agent_test.go
@@ -25,8 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
-
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/tests/integration"
 	"istio.io/istio/tests/integration/framework"
 )
@@ -97,20 +96,20 @@ func TestNodeAgent(t *testing.T) {
 	term := certValidationInterval
 	for i := 0; i < certValidateRetry; i++ {
 		if i > 0 {
-			glog.Infof("retry checking certificate update and validation in %v seconds", term)
+			t.Logf("retry checking certificate update and validation in %v seconds", term)
 			time.Sleep(time.Duration(term) * time.Second)
 			term = term * 2
 		}
 
 		retrievedCertChain, err := readURI(fmt.Sprintf("http://%v:8080/cert", nodeAgentIPAddress))
 		if err != nil {
-			glog.Errorf("failed to read the certificate of NodeAgent: %v", err)
+			t.Errorf("failed to read the certificate of NodeAgent: %v", err)
 			continue
 		}
 
 		retrievedRootCert, err := readURI(fmt.Sprintf("http://%v:8080/root", nodeAgentIPAddress))
 		if err != nil {
-			glog.Errorf("failed to read the root certificate of NodeAgent: %v", err)
+			t.Errorf("failed to read the root certificate of NodeAgent: %v", err)
 			continue
 		}
 
@@ -119,7 +118,7 @@ func TestNodeAgent(t *testing.T) {
 		}
 
 		if initialCertChain == retrievedCertChain {
-			glog.Warning("certificate chain is not updated yet")
+			t.Log("certificate chain is not updated yet")
 			continue
 		}
 
@@ -167,19 +166,19 @@ func TestMain(m *testing.M) {
 		certChain: *certChain,
 	}
 
-	glog.Errorf("%v", config)
+	log.Errorf("%v", config)
 
 	testEnv = integration.NewNodeAgentTestEnv(testEnvName, *kubeconfig, *hub, *tag)
 
 	if testEnv == nil {
-		glog.Error("test environment creation failure")
+		log.Error("test environment creation failure")
 		// There is no cleanup needed at this point.
 		os.Exit(1)
 	}
 
 	res := framework.NewTestEnvManager(testEnv, testID).RunTest(m)
 
-	glog.Infof("Test result %d in env %s", res, testEnvName)
+	log.Infof("Test result %d in env %s", res, testEnvName)
 
 	os.Exit(res)
 }

--- a/security/tests/integration/secretCreationTest/secret_creation_test.go
+++ b/security/tests/integration/secretCreationTest/secret_creation_test.go
@@ -20,8 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
-
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/tests/integration"
 	"istio.io/istio/tests/integration/framework"
 )
@@ -44,7 +43,7 @@ func TestSecretCreation(t *testing.T) {
 		t.Error(err)
 	}
 
-	glog.Info(`checking secret "istio.default" is correctly created`)
+	t.Log(`checking secret "istio.default" is correctly created`)
 	if err := integration.ExamineSecret(s); err != nil {
 		t.Error(err)
 	}
@@ -53,14 +52,14 @@ func TestSecretCreation(t *testing.T) {
 	if err := integration.DeleteSecret(testEnv.ClientSet, testEnv.NameSpace, "istio.default"); err != nil {
 		t.Error(err)
 	}
-	glog.Info(`secret "istio.default" has been deleted`)
+	t.Log(`secret "istio.default" has been deleted`)
 
 	// Test that the deleted secret is re-created properly.
 	if _, err := integration.WaitForSecretExist(testEnv.ClientSet, testEnv.NameSpace, "istio.default",
 		secretWaitTime); err != nil {
 		t.Error(err)
 	}
-	glog.Info(`checking secret "istio.default" is correctly re-created`)
+	t.Log(`checking secret "istio.default" is correctly re-created`)
 }
 
 func TestMain(m *testing.M) {
@@ -73,14 +72,14 @@ func TestMain(m *testing.M) {
 	testEnv = integration.NewSecretTestEnv(testEnvName, *kubeconfig, *hub, *tag)
 
 	if testEnv == nil {
-		glog.Error("test environment creation failure")
+		log.Error("test environment creation failure")
 		// There is no cleanup needed at this point.
 		os.Exit(1)
 	}
 
 	res := framework.NewTestEnvManager(testEnv, testID).RunTest(m)
 
-	glog.Infof("Test result %d in env %s", res, testEnvName)
+	log.Infof("Test result %d in env %s", res, testEnvName)
 
 	os.Exit(res)
 }


### PR DESCRIPTION
Also, configure pkg/log to default values such that you can log using defaults
without having to call pkg/log.Configure() first.
