### PR TITLE
Use docker image for envoy extraction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,8 @@ jobs:
   depupdate:
     <<: *defaults
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
       - run: make submodule-sync
       - run: make depend.status # check before any change
@@ -290,6 +292,8 @@ jobs:
   dependencies:
     <<: *defaults
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
       - run: make git.pullmaster
       - run: make submodule-sync

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -43,8 +43,8 @@ if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
        exit 1
 fi
 
-# Get the debug istio.io/proxy docker image. We'll use this image to extract the envoy executable used by
-# some of our tests.
+# Get the envoy binary (the same one used by our docker images). Some of our
+# tests use the envoy binary directly.
 PROXY_DOCKERFILE="pilot/docker/Dockerfile.proxy_debug"
 ENVOY_IMAGE=$(grep envoy-debug $PROXY_DOCKERFILE  |cut -d ' ' -f2)
 ENVOY_IMAGE_VERSION=$(grep envoy-debug $PROXY_DOCKERFILE  |cut -d: -f2)
@@ -58,8 +58,9 @@ if [ ! -f $OUT/$ENVOY_BIN_NAME ] ; then
     echo "Downloading envoy docker image..."
     docker pull $ENVOY_IMAGE
 
-    # Run the image and pull out the envoy executable. Need to override the entrypoint so
-    # avoid attempting to update iptables, which requires root access.
+    # Run the image and pull out the envoy executable. Need to override the
+    # entrypoint to avoid attempting to update iptables, which requires
+    # root access.
     echo "Extracting envoy from docker image..."
     docker run --entrypoint cat $ENVOY_IMAGE /usr/local/bin/envoy > $ENVOY_BIN_NAME
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -58,9 +58,10 @@ if [ ! -f $OUT/$ENVOY_BIN_NAME ] ; then
     echo "Downloading envoy docker image..."
     docker pull $ENVOY_IMAGE
 
-    # Run the image and pull out the envoy executable
+    # Run the image and pull out the envoy executable. Need to override the entrypoint so
+    # avoid attempting to update iptables, which requires root access.
     echo "Extracting envoy from docker image..."
-    docker run $ENVOY_IMAGE cat /usr/local/bin/envoy > $ENVOY_BIN_NAME
+    docker run --entrypoint cat $ENVOY_IMAGE /usr/local/bin/envoy > $ENVOY_BIN_NAME
 
     # Set executable permissions on the binary.
     chmod +x $ENVOY_BIN_NAME


### PR DESCRIPTION
The `init.sh` script currently relies on a separately pushed
envoy `tar.gz`, which does not seem to be pushed by our
standard build process. This makes it difficult to update the
proxy base image (in istio/proxy) and use it within istio/istio (for example, to try out an experimental version of the proxy image).

This PR changes `init.sh` to run the proxy image used by `Dockerfile.proxy_debug` and to extract the envoy binary from it directly.

With this change in place, istio/istio can use any
proxy base image by simply updating `Dockerfile.proxy` and `Dockerfile.proxy_debug`.

This does introduce the need for the build environment to have docker installed and running in order for `init.sh` to run successfully.