### PR TITLE
remove unnecessary code in registryAuthorizor

### DIFF
--- a/security/pkg/server/grpc/authorizer.go
+++ b/security/pkg/server/grpc/authorizer.go
@@ -17,7 +17,6 @@ package grpc
 import (
 	"fmt"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/registry"
 )
 
@@ -70,14 +69,6 @@ func (authZ *registryAuthorizor) authorize(requestor *caller, requestedIDs []str
 		}
 		if !valid {
 			return fmt.Errorf("the requestor (%v) is not registered", requestor)
-		}
-
-		// add the requestedIDs to the registry
-		for _, requestedID := range requestedIDs {
-			err := authZ.reg.AddMapping(requestedID, requestedID)
-			if err != nil {
-				log.Warnf("cannot add mapping %q -> %q to registry: %s", requestedID, requestedID, err.Error())
-			}
 		}
 		return nil
 	}

--- a/security/pkg/server/grpc/authorizer_test.go
+++ b/security/pkg/server/grpc/authorizer_test.go
@@ -58,10 +58,6 @@ func TestRegistryAuthorizerWithJWT(t *testing.T) {
 		authSource: authSourceIDToken,
 		identities: []string{"id"},
 	}
-	certRequestor := &caller{
-		authSource: authSourceClientCertificate,
-		identities: []string{"spiffe://id", "spiffe://id2"},
-	}
 	requestedIDs := []string{"spiffe://id", "spiffe://id2"}
 
 	testCases := map[string]struct {
@@ -82,17 +78,6 @@ func TestRegistryAuthorizerWithJWT(t *testing.T) {
 			authorizor: &registryAuthorizor{&registry.IdentityRegistry{
 				Map: map[string]string{"id": "id"},
 			}},
-		},
-		"Authorized cert with one mapping": {
-			requestor:    certRequestor,
-			requestedIDs: requestedIDs,
-			authorizor: func() *registryAuthorizor {
-				authz := &registryAuthorizor{&registry.IdentityRegistry{
-					Map: map[string]string{"id": "id"},
-				}}
-				_ = authz.authorize(idRequestor, requestedIDs)
-				return authz
-			}(),
 		},
 	}
 


### PR DESCRIPTION
When I wrote `registryAuthorizor`, I thought that for GCE VM expansion the node agent will only use JWT for the first CSR. Since it's not the case (node agent sends the same request every time), the registry no longer needs to record the requested ID.