### PR TITLE
should not create k8s client if config dir is provided

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -327,6 +327,7 @@ func (s *Server) getKubeCfgFile(args *PilotArgs) (kubeCfgFile string) {
 // initKubeClient creates the k8s client if running in an k8s environment.
 func (s *Server) initKubeClient(args *PilotArgs) error {
 	needToCreateClient := false
+	// FIXME: in the case of multiple registries, we are currently only checking needToCreateClient for the last one
 	for _, r := range args.Service.Registries {
 		switch ServiceRegistry(r) {
 		case KubernetesRegistry:
@@ -335,10 +336,11 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			needToCreateClient = true
 		case EurekaRegistry:
 			needToCreateClient = true
-		}
+		case CloudFoundryRegistry:
+			needToCreateClient = false
 	}
 
-	if needToCreateClient {
+	if needToCreateClient && args.Config.FileDir == "" {
 		var client kubernetes.Interface
 		var kuberr error
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -327,7 +327,6 @@ func (s *Server) getKubeCfgFile(args *PilotArgs) (kubeCfgFile string) {
 // initKubeClient creates the k8s client if running in an k8s environment.
 func (s *Server) initKubeClient(args *PilotArgs) error {
 	needToCreateClient := false
-	var errs error
 	for _, r := range args.Service.Registries {
 		switch ServiceRegistry(r) {
 		case KubernetesRegistry:
@@ -336,16 +335,7 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 			needToCreateClient = true
 		case EurekaRegistry:
 			needToCreateClient = true
-		case CloudFoundryRegistry:
-			//valid registry, but does not need to create client
-			continue
-		default:
-			errs = multierror.Append(errs, fmt.Errorf("Service registry %s is not supported.", r))
 		}
-	}
-
-	if errs != nil {
-		return errs
 	}
 
 	if needToCreateClient && args.Config.FileDir == "" {


### PR DESCRIPTION
in response to istio-users question here: https://groups.google.com/forum/#!topic/istio-users/52SiQkkTq2A

pilot should not need to create a k8s client (and therefor provide a kubeconfig file) when the `--configDir` flag is provided.  This is currently blocking the use of pilot's filewatcher adapter.  The way we are currently checking for whether a k8s client needs to be created has a bug and needs to be corrected - this will be addressed in an additional PR