### PR TITLE
Support `helm template` generation of MutatingWebhookConfiguration

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (not .Release.IsInstall) -}}
+{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (and (not .Release.IsInstall) .Values.useAdmissionRegistration) -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1" -}}
+{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (not .Release.IsInstall) -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -92,6 +92,11 @@ sidecar-injector:
   # be allowed by the sidecar
   includeIPRanges: {}
 
+  # Force admission registration webhook when using `helm template`
+  # This capability is automatically populated as a cluster capability when using `helm install`
+  # or `helm upgrade` but must be manually specified if using `helm template`
+  useAdmissionRegistration: false
+
 #
 # mixer configuration
 #


### PR DESCRIPTION
The mutating webhook config could not be generated when running `helm template` as it relied on a condition only available during helm install or upgrade. This adds an explicit option when not installing or upgrading istio.