### PR TITLE
ExternalService bug fix for discovery type DNS

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/config_test.go
+++ b/pilot/pkg/proxy/envoy/v1/config_test.go
@@ -387,6 +387,11 @@ var (
 		file: "testdata/external-service-rule-dns.yaml.golden",
 	}
 
+	externalServiceRuleDNSNoEndpoints = fileConfig{
+		meta: model.ConfigMeta{Type: model.ExternalService.Type, Name: "google"},
+		file: "testdata/external-service-rule-dns-no-endpoints.yaml.golden",
+	}
+
 	externalServiceRuleStatic = fileConfig{
 		meta: model.ConfigMeta{Type: model.ExternalService.Type, Name: "google"},
 		file: "testdata/external-service-rule-static.yaml.golden",

--- a/pilot/pkg/proxy/envoy/v1/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery_test.go
@@ -675,6 +675,7 @@ func TestExternalServicesDiscoveryMode(t *testing.T) {
 	}{
 		{name: "http-none", file: externalServiceRule},
 		{name: "http-dns", file: externalServiceRuleDNS},
+		{name: "http-dns-no-endpoints", file: externalServiceRuleDNSNoEndpoints},
 		{name: "http-static", file: externalServiceRuleStatic},
 		{name: "tcp-none", file: externalServiceRuleTCP},
 		{name: "tcp-dns", file: externalServiceRuleTCPDNS},

--- a/pilot/pkg/proxy/envoy/v1/externalservice.go
+++ b/pilot/pkg/proxy/envoy/v1/externalservice.go
@@ -128,6 +128,12 @@ func buildExternalServiceCluster(mesh *meshconfig.MeshConfig,
 		}
 	}
 
+	// Use host address if discovery type DNS and no endpoints are provided
+	if discovery == routingv2.ExternalService_DNS && len(endpoints) == 0 {
+		url := fmt.Sprintf("tcp://%s:%d", address, port.Port)
+		hosts = append(hosts, Host{URL: url})
+	}
+
 	var clusterType, lbType string
 	switch discovery {
 	case routingv2.ExternalService_NONE:

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns-no-endpoints.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns-no-endpoints.json.golden
@@ -1,0 +1,235 @@
+{
+  "clusters": [
+   {
+    "name": "in.1081",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1081"
+     }
+    ]
+   },
+   {
+    "name": "in.1090",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1090"
+     }
+    ]
+   },
+   {
+    "name": "in.1100",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1100"
+     }
+    ]
+   },
+   {
+    "name": "in.1110",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1110"
+     }
+    ]
+   },
+   {
+    "name": "in.3333",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:3333"
+     }
+    ]
+   },
+   {
+    "name": "in.80",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:80"
+     }
+    ]
+   },
+   {
+    "name": "in.9999",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:9999"
+     }
+    ]
+   },
+   {
+    "name": "out.google.com|external-HTTP-80",
+    "service_name": "google.com|external-HTTP-80",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://google.com:80"
+     }
+    ]
+   },
+   {
+    "name": "out.google.com|external-HTTP-8080",
+    "service_name": "google.com|external-HTTP-8080",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://google.com:8080"
+     }
+    ]
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|custom",
+    "service_name": "hello.default.svc.cluster.local|custom",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|http",
+    "service_name": "hello.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|mongo",
+    "service_name": "hello.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|redis",
+    "service_name": "hello.default.svc.cluster.local|redis",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.httpbin.default.svc.cluster.local|http",
+    "service_name": "httpbin.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://httpbin.default.svc.cluster.local:80"
+     }
+    ]
+   },
+   {
+    "name": "out.httpsbin.default.svc.cluster.local|https",
+    "service_name": "httpsbin.default.svc.cluster.local|https",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://httpsbin.default.svc.cluster.local:443"
+     }
+    ]
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|custom",
+    "service_name": "world.default.svc.cluster.local|custom",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|http",
+    "service_name": "world.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|http-status",
+    "service_name": "world.default.svc.cluster.local|http-status",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|mongo",
+    "service_name": "world.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|redis",
+    "service_name": "world.default.svc.cluster.local|redis",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "mixer_check_server",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://istio-mixer.istio-system:9091"
+     }
+    ],
+    "features": "http2",
+    "circuit_breakers": {
+     "default": {
+      "max_pending_requests": 10000,
+      "max_requests": 10000
+     }
+    }
+   },
+   {
+    "name": "mixer_report_server",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://istio-mixer.istio-system:9091"
+     }
+    ],
+    "features": "http2",
+    "circuit_breakers": {
+     "default": {
+      "max_pending_requests": 10000,
+      "max_requests": 10000
+     }
+    }
+   }
+  ]
+ }

--- a/pilot/pkg/proxy/envoy/v1/testdata/external-service-rule-dns-no-endpoints.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/external-service-rule-dns-no-endpoints.yaml.golden
@@ -1,0 +1,10 @@
+hosts:
+  - "google.com"
+ports:
+  - number: 80
+    name: http-port
+    protocol: http
+  - number: 8080
+    name: http-alt-port
+    protocol: http
+discovery: DNS

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns-no-endpoints.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns-no-endpoints.json.golden
@@ -1,0 +1,979 @@
+{
+  "listeners": [
+   {
+    "address": "tcp://0.0.0.0:15001",
+    "name": "virtual",
+    "filters": [],
+    "bind_to_port": true,
+    "use_original_dst": true
+   },
+   {
+    "address": "tcp://0.0.0.0:443",
+    "name": "http_0.0.0.0_443",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "443",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://0.0.0.0:80",
+    "name": "http_0.0.0.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "80",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://0.0.0.0:8080",
+    "name": "http_0.0.0.0_8080",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "8080",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://0.0.0.0:81",
+    "name": "http_0.0.0.0_81",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "81",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|mongo",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:110",
+    "name": "tcp_10.1.0.0_110",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:90",
+    "name": "tcp_10.1.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|custom",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1081",
+    "name": "http_10.1.1.0_1081",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "route_config": {
+        "virtual_hosts": [
+         {
+          "name": "inbound|1081",
+          "domains": [
+           "*"
+          ],
+          "routes": [
+           {
+            "prefix": "/",
+            "cluster": "in.1081",
+            "timeout_ms": 0,
+            "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
+            }
+           }
+          ]
+         }
+        ]
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1090",
+    "name": "tcp_10.1.1.0_1090",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1110",
+    "name": "tcp_10.1.1.0_1110",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "stringValue": "10.1.1.0"
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:3333",
+    "name": "tcp_10.1.1.0_3333",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.3333",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:80",
+    "name": "http_10.1.1.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "route_config": {
+        "virtual_hosts": [
+         {
+          "name": "inbound|80",
+          "domains": [
+           "*"
+          ],
+          "routes": [
+           {
+            "prefix": "/",
+            "cluster": "in.80",
+            "timeout_ms": 0,
+            "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
+            }
+           }
+          ]
+         }
+        ]
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:9999",
+    "name": "tcp_10.1.1.0_9999",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.9999",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|mongo",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:110",
+    "name": "tcp_10.2.0.0_110",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:90",
+    "name": "tcp_10.2.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|custom",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   }
+  ]
+ }

--- a/pilot/pkg/proxy/envoy/v1/testdata/rds-v0-http-dns-no-endpoints.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/rds-v0-http-dns-no-endpoints.json.golden
@@ -1,0 +1,105 @@
+{
+  "virtual_hosts": [
+   {
+    "name": "google.com:80",
+    "domains": [
+     "google.com",
+     "google.com:80"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.google.com|external-HTTP-80",
+      "timeout_ms": 0,
+      "opaque_config": {
+       "destination.service": "google.default.cluster.local",
+       "mixer": "eyJtaXhlckF0dHJpYnV0ZXMiOnsiYXR0cmlidXRlcyI6eyJkZXN0aW5hdGlvbi5zZXJ2aWNlIjp7InN0cmluZ1ZhbHVlIjoiZ29vZ2xlLmRlZmF1bHQuY2x1c3Rlci5sb2NhbCJ9LCJkZXN0aW5hdGlvbi51aWQiOnsic3RyaW5nVmFsdWUiOiJrdWJlcm5ldGVzOi8vZ29vZ2xlLmRlZmF1bHQuY2x1c3Rlci5sb2NhbCJ9LCJzb3VyY2UuaXAiOnsiYnl0ZXNWYWx1ZSI6IkFBQUFBQUFBQUFBQUFQLy9DZ0VCQUE9PSJ9LCJzb3VyY2UubGFiZWxzIjp7InN0cmluZ01hcFZhbHVlIjp7ImVudHJpZXMiOnsidmVyc2lvbiI6InYwIn19fSwic291cmNlLnVpZCI6eyJzdHJpbmdWYWx1ZSI6Imt1YmVybmV0ZXM6Ly92MC5kZWZhdWx0In19fX0=",
+       "mixer_sha": "z4SXhcppGgGvSDYk9lW36WG0uIQ/68+N2Zq/ueFb5tg="
+      },
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   },
+   {
+    "name": "hello.default.svc.cluster.local|http",
+    "domains": [
+     "hello:80",
+     "hello",
+     "hello.default:80",
+     "hello.default",
+     "hello.default.svc:80",
+     "hello.default.svc",
+     "hello.default.svc.cluster:80",
+     "hello.default.svc.cluster",
+     "hello.default.svc.cluster.local:80",
+     "hello.default.svc.cluster.local",
+     "10.1.0.0:80",
+     "10.1.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.hello.default.svc.cluster.local|http",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   },
+   {
+    "name": "httpbin.default.svc.cluster.local|http",
+    "domains": [
+     "httpbin:80",
+     "httpbin",
+     "httpbin.default:80",
+     "httpbin.default",
+     "httpbin.default.svc:80",
+     "httpbin.default.svc",
+     "httpbin.default.svc.cluster:80",
+     "httpbin.default.svc.cluster",
+     "httpbin.default.svc.cluster.local:80",
+     "httpbin.default.svc.cluster.local"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.httpbin.default.svc.cluster.local|http",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   },
+   {
+    "name": "world.default.svc.cluster.local|http",
+    "domains": [
+     "world:80",
+     "world",
+     "world.default:80",
+     "world.default",
+     "world.default.svc:80",
+     "world.default.svc",
+     "world.default.svc.cluster:80",
+     "world.default.svc.cluster",
+     "world.default.svc.cluster.local:80",
+     "world.default.svc.cluster.local",
+     "10.2.0.0:80",
+     "10.2.0.0"
+    ],
+    "routes": [
+     {
+      "prefix": "/",
+      "cluster": "out.world.default.svc.cluster.local|http",
+      "timeout_ms": 0,
+      "decorator": {
+       "operation": "default-route"
+      }
+     }
+    ]
+   }
+  ]
+ }


### PR DESCRIPTION
If no hosts are provided for an ExternalService of discovery type DNS, the `hosts` field should be used to populate the `hosts` field for CDS