### PR TITLE
Add service for Istio CA health check probe.

### DIFF
--- a/install/kubernetes/templates/istio-ca-with-health-check.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ca-with-health-check.yaml.tmpl
@@ -8,6 +8,19 @@ metadata:
   name: istio-ca-service-account
   namespace: {ISTIO_NAMESPACE}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ca
+  namespace: istio-system
+  labels:
+    istio: istio-ca
+spec:
+  ports:
+    - port: 8060
+  selector:
+    istio: istio-ca
+---
 # Istio CA watching all namespaces
 apiVersion: v1
 kind: Deployment


### PR DESCRIPTION
With the service "istio-ca", Istio CA health check probe is able to call the Istio CA gRPC service though the service name "istio-ca".