### PR TITLE
Missed a change for prometheus.

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingress/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/autoscale.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.autoscaleMin }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+    name: istio-ingress
+spec:
+    maxReplicas: {{ .Values.autoscaleMax }}
+    minReplicas: {{ .Values.autoscaleMin }}
+    scaleTargetRef:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+      name: istio-ingress
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          targetAverageUtilization: 80
+{{ end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/NOTES.txt
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/NOTES.txt
@@ -3,17 +3,12 @@
 {{- range .Values.ingress.hosts }}
   http://{{ . }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus.fullname" . }})
+{{- else if .Values.service.nodePort.enabled }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services prometheus)
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- else }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app=prometheus" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:9090 to use your application"
+  kubectl port-forward $POD_NAME 9090:9090
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
@@ -10,7 +10,25 @@ spec:
   selector:
     app: prometheus
   ports:
-  - name: prometheus
+  - name: http-prometheus
     protocol: TCP
     port: 9090
 
+{{- if .Values.service.nodePort.enabled }}
+# Using separate ingress for nodeport, to avoid conflict with pilot e2e test configs.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-nodeport
+  labels:
+    name: prometheus
+spec:
+  type: NodePort
+  ports:
+  - port: 9090
+    nodePort: {{ .Values.service.nodePort.port }}
+    name: http-prometheus
+  selector:
+    app: prometheus
+{{- end }}

--- a/install/kubernetes/helm/istio/values-istiotest.yaml
+++ b/install/kubernetes/helm/istio/values-istiotest.yaml
@@ -9,12 +9,25 @@ ingress:
   service:
     nodePort:
       enabled: true
+  autoscaleMin: 1
+  autoscaleMax: 8
+  meshExpansion:
+    enabled: true
+
+  zvpn:
+    enabled: true
+    apps:
+    - externalPort: 9999
+      portName: http-9999
 
 
 prometheus:
   enabled: true
   ingress:
     enabled: true
+  service:
+    nodePort:
+      enabled: true
 
 grafana:
   enabled: true

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -50,6 +50,8 @@ ingress:
   enabled: true
   serviceAccountName: default
   imagePullPolicy: IfNotPresent
+  autoscaleMin: 2
+  autoscaleMax: 8
   resources: {}
 # limits:
 #  cpu: 100m
@@ -58,10 +60,7 @@ ingress:
 #  cpu: 100m
 #  memory: 128Mi
   nodeSelector: {}
-# istio ingress configuration
   service:
-  # By default istio ingress uses LoadBalancer type of service
-  # to use NodePort, it needs to be enabled and desired port specified
     nodePort:
       enabled: false
       port: 32000
@@ -171,6 +170,9 @@ grafana:
       # - secretName: grafana-tls
       #   hosts:
       #     - grafana.local
+  zvpn:
+    enabled: false
+
   resources: {}
     # limits:
     #  cpu: 100m
@@ -208,6 +210,10 @@ prometheus:
     #  cpu: 100m
     #  memory: 128Mi
   nodeSelector: {}
+  service:
+    nodePort:
+      enabled: false
+      port: 9090
 
 servicegraph:
   enabled: false

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -170,8 +170,6 @@ grafana:
       # - secretName: grafana-tls
       #   hosts:
       #     - grafana.local
-  zvpn:
-    enabled: false
 
   resources: {}
     # limits:
@@ -213,7 +211,7 @@ prometheus:
   service:
     nodePort:
       enabled: false
-      port: 9090
+      port: 32090
 
 servicegraph:
   enabled: false


### PR DESCRIPTION
Added nodeport in a style consistent with ingress. This is useful for
minikube. Right now it is not recommended to create an external address
for prom, since external auth is missing, so removed the option. We may add
it later in a consistent way for all internal services. 