### PR TITLE
update nodeSelector to affinity for chart to support multiple architecture

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -44,10 +44,8 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data/grafana
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       volumes:
       - name: data
         emptyDir: {}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -86,7 +86,5 @@ spec:
         secret:
           secretName: istio-ingress-certs
           optional: true
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -84,7 +84,5 @@ spec:
       - name: config-volume
         configMap:
           name: istio-mixer
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -93,7 +93,5 @@ spec:
         secret:
           secretName: "istio.istio-pilot-service-account"
           optional: true
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -50,7 +50,5 @@ spec:
       - name: config-volume
         configMap:
           name: prometheus
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/security/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/security/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -29,7 +29,5 @@ spec:
             - --self-signed-ca=true
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -34,7 +34,5 @@ spec:
 #              port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/deployment.yaml
@@ -71,7 +71,5 @@ spec:
           items:
           - key: config
             path: config
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -38,7 +38,5 @@ spec:
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -59,11 +59,20 @@ ingress:
 # requests:
 #  cpu: 100m
 #  memory: 128Mi
-  nodeSelector: {}
   service:
     nodePort:
       enabled: false
       port: 32000
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
 #
 # sidecar-injector configuration
@@ -80,7 +89,16 @@ sidecar-injector:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
-  nodeSelector: {}
+
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
   # istio egress capture whitelist
   # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly
@@ -104,7 +122,16 @@ mixer:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
   prometheusStatsdExporter:
     repository: prom/statsd-exporter
@@ -127,7 +154,16 @@ pilot:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
 #
 # security configuration
@@ -143,7 +179,16 @@ security:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
 #
 # addons configuration
@@ -178,7 +223,16 @@ grafana:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
 prometheus:
   enabled: false
@@ -207,11 +261,20 @@ prometheus:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-  nodeSelector: {}
   service:
     nodePort:
       enabled: false
       port: 32090
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
 
 servicegraph:
   enabled: false
@@ -242,7 +305,16 @@ servicegraph:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
   # prometheus addres
   prometheusAddr: http://prometheus:9090
 
@@ -278,4 +350,13 @@ zipkin:
     # requests:
     #  cpu: 100m
     #  memory: 128Mi
-  nodeSelector: {}
+  
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2


### PR DESCRIPTION
Update node selector to node affinity to support multiple architecture(amd64, ppc64le, s390x) for chart. Because
> nodeSelector continues to work as usual, but will eventually be deprecated, as node affinity can express everything that nodeSelector can express.

When install istio chart, specify pod scheduling arch(amd64, ppc64le, s390x) preference and weight as follows:
 - 0(Never scheduled)
 - 1(Least preferred)
 - 2(No preference)
 - 3(Most preferred)

default value:
```
  arch:
    amd64: 2
    s390x: 2
    ppc64le: 2
```

