### PR TITLE
Catch mtls zone aware routing failure, inform as currently unsupported

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/watcher.go
+++ b/pilot/pkg/proxy/envoy/v1/watcher.go
@@ -116,6 +116,7 @@ func (w *watcher) Reload() {
 // retrieveAZ will only run once and then exit because AZ won't change over a proxy's lifecycle
 // it has to use a reload due to limitations with envoy (az has to be passed in as a flag)
 func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration, retries int) {
+	// Not currently supported see - https://github.com/istio/istio/issues/2916
 	if w.config.GetControlPlaneAuthPolicy() == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 		log.Infof("Zone aware routing is not currently supported with mutual TLS enabled")
 		return

--- a/pilot/pkg/proxy/envoy/v1/watcher.go
+++ b/pilot/pkg/proxy/envoy/v1/watcher.go
@@ -116,7 +116,10 @@ func (w *watcher) Reload() {
 // retrieveAZ will only run once and then exit because AZ won't change over a proxy's lifecycle
 // it has to use a reload due to limitations with envoy (az has to be passed in as a flag)
 func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration, retries int) {
-	if !model.IsApplicationNodeType(w.role.Type) {
+	if w.config.GetControlPlaneAuthPolicy() == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+		log.Infof("Zone aware routing is not currently supported with mutual TLS enabled")
+		return
+	} else if !model.IsApplicationNodeType(w.role.Type) {
 		log.Infof("Agent is proxy for %v component. This component does not require zone aware routing.", w.role.Type)
 		return
 	}


### PR DESCRIPTION
Currently, zone aware routing does not work for mTLS because pilot-agent can't talk to Pilot. An issue has been raised against Envoy to support zone aware routing as part of the xDS v2 APIs because our current approach will not work via mTLS.

This PR is to inform the user that it is not currently supported and to return gracefully, we currently throw an error due to a timeout.

The issue can be found [here](https://github.com/envoyproxy/envoy/issues/2541) and @cmluciano is looking into it.