### PR TITLE
Fixing gRPC EDS - server shutdown

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -475,7 +475,7 @@ func (ds *DiscoveryService) Start(stop chan struct{}) (net.Addr, error) {
 		// Wait for the stop notification and shutdown the server.
 		<-stop
 		if envoyv2.Enabled() {
-			ds.serverV2.Start()
+			ds.serverV2.Stop()
 		}
 		err := ds.server.Close()
 		if err != nil {


### PR DESCRIPTION
Envoy v2 (grpc) discovery  server ought to be shutdown not started during Pilot's shutdown sequence.  