### PR TITLE
Webhook status code check

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -823,7 +823,12 @@ func (ds *DiscoveryService) invokeWebhook(path string, payload []byte, methodNam
 		incWebhookErrors(methodName)
 		return nil, err
 	}
-
+	
+	if resp.StatusCode != 200 {
+		incWebhookErrors(methodName)
+		return nil, fmt.Errorf("statusCode: %v - %v", resp.StatusCode, resp.Status)
+	}
+	
 	defer resp.Body.Close() // nolint: errcheck
 
 	out, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
If the webhook does not return a happy status i think it would be a good idea to return an error and allow pilot to return the generated output it created.