### PR TITLE
Use http_destination in HTTP Service Panel as success rate denominator

### DIFF
--- a/addons/grafana/dashboards/istio-dashboard.json
+++ b/addons/grafana/dashboards/istio-dashboard.json
@@ -963,7 +963,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "label_replace(sum(irate(istio_request_count{source_version=~\"$source_version\",destination_service=~\"$http_destination\",source_service=~\"$source\",destination_version=~\"$destination_version\",response_code!~\"5.*\"}[1m])) by (source_service, source_version, destination_version) / sum(irate(istio_request_count{source_version=~\"$source_version\",destination_service=~\"$destination\",source_service=~\"$source\",destination_version=~\"$destination_version\"}[1m])) by (source_service, source_version, destination_version), \"source_service\", \"$1\", \"source_service\", \"(.*).svc.cluster.local\")",
+          "expr": "label_replace(sum(irate(istio_request_count{source_version=~\"$source_version\",destination_service=~\"$http_destination\",source_service=~\"$source\",destination_version=~\"$destination_version\",response_code!~\"5.*\"}[1m])) by (source_service, source_version, destination_version) / sum(irate(istio_request_count{source_version=~\"$source_version\",destination_service=~\"$http_destination\",source_service=~\"$source\",destination_version=~\"$destination_version\"}[1m])) by (source_service, source_version, destination_version), \"source_service\", \"$1\", \"source_service\", \"(.*).svc.cluster.local\")",
           "hide": false,
           "intervalFactor": 1,
           "legendFormat": "{{source_service}}-{{source_version}} -> {{destination_version}}",


### PR DESCRIPTION
The current Grafana dashboard template for Success Rate By Source And Version mixes $http_destination in the numerator and $destination in the denominator. This creates a mismatch in the query making the success rate appear lower than it should be depending on your mix of http or tcp based services. This PR makes both use http_destination which aligns with the HTTP Metric section of the dashboard and accurately reporting the success rate.