### PR TITLE
Pilot e2e test support for local docker registry

### DIFF
--- a/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
       containers:
       - name: app
         image: {{.Hub}}/app:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         args:
           - --port
           - "{{.port1}}"

--- a/tests/e2e/tests/pilot/testdata/ca.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/ca.yaml.tmpl
@@ -21,4 +21,4 @@ spec:
       containers:
       - name: istio-ca-container
         image: {{.Hub}}/istio-ca:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}

--- a/tests/e2e/tests/pilot/testdata/eureka.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/eureka.yaml.tmpl
@@ -24,12 +24,12 @@ spec:
       containers:
       - name: eureka
         image: netflixoss/eureka:1.3.1
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 8080
       - name: mirror
         image: {{.Hub}}/eurekamirror:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - -url
         - http://localhost:8080

--- a/tests/e2e/tests/pilot/testdata/ingress-proxy.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/ingress-proxy.yaml.tmpl
@@ -50,7 +50,7 @@ spec:
 {{end}}
         - --controlPlaneAuthPolicy
         - "{{.ControlPlaneAuthPolicy.String}}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 443
         - containerPort: 80

--- a/tests/e2e/tests/pilot/testdata/mixer.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/mixer.yaml.tmpl
@@ -47,7 +47,7 @@ spec:
       containers:
       - name: mixer
         image: {{.Hub}}/mixer_debug:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 9091
         - containerPort: 9093
@@ -61,7 +61,7 @@ spec:
         - debug # pilot verification required debug output
       - name: istio-proxy
         image: {{.Hub}}/proxy_debug:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 15004
         args:

--- a/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/pilot.yaml.tmpl
@@ -81,7 +81,7 @@ spec:
       containers:
       - name: discovery
         image: {{.Hub}}/pilot:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         args:
         - discovery
         - -a
@@ -126,7 +126,7 @@ spec:
 {{end}}
       - name: istio-proxy
         image: {{.Hub}}/proxy_debug:{{.Tag}}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 15003
         - containerPort: 15005

--- a/tests/e2e/tests/pilot/testdata/sidecar-injector.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/sidecar-injector.yaml.tmpl
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: webhook
           image: {{.Hub}}/sidecar_injector:{{.Tag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           args:
             - --tlsCertFile=/etc/istio/certs/cert.pem
             - --tlsKeyFile=/etc/istio/certs/key.pem

--- a/tests/e2e/tests/pilot/testdata/zipkin.yaml
+++ b/tests/e2e/tests/pilot/testdata/zipkin.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: zipkin
         image: docker.io/openzipkin/zipkin
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{.ImagePullPolicy}}
         ports:
         - containerPort: 9411
         env:

--- a/tests/e2e/tests/pilot/util/config.go
+++ b/tests/e2e/tests/pilot/util/config.go
@@ -32,13 +32,13 @@ type Config struct {
 	KubeConfig            string
 	Hub                   string
 	Tag                   string
+	ImagePullPolicy       string
 	Namespace             string
 	IstioNamespace        string
 	Registry              string
 	ErrorLogsDir          string
 	CoreFilesDir          string
 	SelectedTest          string
-	SidecarTemplate       string
 	AdmissionServiceName  string
 	Verbosity             int
 	DebugPort             int
@@ -66,6 +66,7 @@ func NewConfig() *Config {
 		KubeConfig:            os.Getenv("KUBECONFIG"),
 		Hub:                   defaultHub,
 		Tag:                   "",
+		ImagePullPolicy:       "IfNotPresent",
 		Namespace:             "",
 		IstioNamespace:        "",
 		Registry:              defaultRegistry,

--- a/tests/util/localregistry/README.md
+++ b/tests/util/localregistry/README.md
@@ -40,7 +40,7 @@ $ make docker push HUB=localhost:5000 TAG=latest
 If you're running e2e tests, you can set the test flags:
 
 ```shell
-$ go test <TEST_PATH> -hub=localhost:5001 -tag=latest
+$ go test <TEST_PATH> -hub=localhost:5000 -tag=latest
 ```
 
 #### Hard-coding the Image URL
@@ -48,6 +48,6 @@ $ go test <TEST_PATH> -hub=localhost:5001 -tag=latest
 You can also modify the image URLs in your deployment yaml files directly:
 
 ```yaml
-image: localhost:50001/<APP_NAME>:latest
+image: localhost:5000/<APP_NAME>:latest
 ```
 

--- a/tests/util/localregistry/README.md
+++ b/tests/util/localregistry/README.md
@@ -1,0 +1,53 @@
+# Using a Local Docker Registry
+
+`localregistry.yaml` is a copy of Kubernete's local registry addon, and is included to make it easier to test
+Istio by allowing a developer to push docker images locally rather than to some remote registry.
+
+### Run the registry
+To run the local registry in your kubernetes cluster:
+
+```shell
+$ kubectl apply -f ./tests/util/localregistry/localregistry.yaml
+```
+
+### Expose the Registry
+
+After the registry server is running, expose it locally by executing:
+
+```shell
+$ kubectl port-forward --namespace kube-system $POD 5000:5000
+```
+
+If you're testing locally with minikube, `$POD` can be set with:
+
+```shell
+$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+  -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
+  | grep Running | head -1 | cut -f1 -d' ')
+```
+
+### Push Local Images
+
+Build and push the Istio docker images to the local registry, by running:
+
+```shell
+$ make docker push HUB=localhost:5000 TAG=latest
+```
+
+### Run with Local Images
+
+#### Running E2E Tests
+If you're running e2e tests, you can set the test flags:
+
+```shell
+$ go test <TEST_PATH> -hub=localhost:5001 -tag=latest
+```
+
+#### Hard-coding the Image URL
+
+You can also modify the image URLs in your deployment yaml files directly:
+
+```yaml
+image: localhost:50001/<APP_NAME>:latest
+```
+

--- a/tests/util/localregistry/localregistry.yaml
+++ b/tests/util/localregistry/localregistry.yaml
@@ -1,0 +1,88 @@
+# after creating the local registry, to push images to it you need to open up a port to the pod's registry:
+# $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+#               -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
+#               | grep Running | head -1 | cut -f1 -d' ')
+# $ kubectl port-forward --namespace kube-system $POD 5000:5000
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-registry-v0
+  namespace: kube-system
+  labels:
+    k8s-app: kube-registry
+    version: v0
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-registry
+    version: v0
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-registry
+        version: v0
+    spec:
+      containers:
+      - name: registry
+        image: registry:2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+          value: /var/lib/registry
+        volumeMounts:
+        - name: image-store
+          mountPath: /var/lib/registry
+        ports:
+        - containerPort: 5000
+          name: registry
+          protocol: TCP
+      volumes:
+      - name: image-store
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-registry
+  namespace: kube-system
+  labels:
+    k8s-app: kube-registry
+    kubernetes.io/name: "KubeRegistry"
+spec:
+  selector:
+    k8s-app: kube-registry
+  ports:
+  - name: registry
+    port: 5000
+    protocol: TCP
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-registry-proxy
+  namespace: kube-system
+spec:
+  containers:
+  - name: kube-registry-proxy
+    image: gcr.io/google_containers/kube-registry-proxy:0.3
+    resources:
+      limits:
+        cpu: 100m
+        memory: 50Mi
+    env:
+    - name: REGISTRY_HOST
+      value: kube-registry.kube-system.svc.cluster.local
+    - name: REGISTRY_PORT
+      value: "5000"
+    - name: FORWARD_PORT
+      value: "5000"
+    ports:
+    - name: registry
+      containerPort: 5000
+      hostPort: 5000


### PR DESCRIPTION
- Various changes to the e2e tests
- Re-introducing old mixer docs (with many changes) for
running a local docker registry in k8s.