### PR TITLE
Change the Infof to Debugf in KindMap() to fix #3835.

### DIFF
--- a/mixer/pkg/runtime/init.go
+++ b/mixer/pkg/runtime/init.go
@@ -66,17 +66,17 @@ func KindMap(adapterInfo map[string]*adapter.Info,
 	// typed instances
 	for kind, info := range templateInfo {
 		kindMap[kind] = info.CtrCfg
-		log.Infof("template Kind: %s, %v", kind, info.CtrCfg)
+		log.Debugf("template Kind: %s, %v", kind, info.CtrCfg)
 	}
 	// typed handlers
 	for kind, info := range adapterInfo {
 		kindMap[kind] = info.DefaultConfig
-		log.Infof("adapter Kind: %s, %v", kind, info.DefaultConfig)
+		log.Debugf("adapter Kind: %s, %v", kind, info.DefaultConfig)
 	}
 	kindMap[RulesKind] = &cpb.Rule{}
-	log.Infof("template Kind: %s", RulesKind)
+	log.Debugf("template Kind: %s", RulesKind)
 	kindMap[AttributeManifestKind] = &cpb.AttributeManifest{}
-	log.Infof("template Kind: %s", AttributeManifestKind)
+	log.Debugf("template Kind: %s", AttributeManifestKind)
 
 	return kindMap
 }

--- a/mixer/pkg/runtime2/config/kinds.go
+++ b/mixer/pkg/runtime2/config/kinds.go
@@ -29,17 +29,17 @@ func KindMap(adapterInfo map[string]*adapter.Info, templateInfo map[string]*temp
 	// typed instances
 	for kind, info := range templateInfo {
 		kindMap[kind] = info.CtrCfg
-		log.Infof("template Kind: %s, %v", kind, info.CtrCfg)
+		log.Debugf("template Kind: %s, %v", kind, info.CtrCfg)
 	}
 	// typed handlers
 	for kind, info := range adapterInfo {
 		kindMap[kind] = info.DefaultConfig
-		log.Infof("adapter Kind: %s, %v", kind, info.DefaultConfig)
+		log.Debugf("adapter Kind: %s, %v", kind, info.DefaultConfig)
 	}
 	kindMap[RulesKind] = &configpb.Rule{}
-	log.Infof("template Kind: %s", RulesKind)
+	log.Debugf("template Kind: %s", RulesKind)
 	kindMap[AttributeManifestKind] = &configpb.AttributeManifest{}
-	log.Infof("template Kind: %s", AttributeManifestKind)
+	log.Debugf("template Kind: %s", AttributeManifestKind)
 
 	return kindMap
 }


### PR DESCRIPTION
In #3759, it changed pkg/log/log.go to use default logging options which sets to InfoLevel by default.