### PR TITLE
WIP: Enable 1% trace sampling by default.

### DIFF
--- a/pilot/docker/Dockerfile.proxy
+++ b/pilot/docker/Dockerfile.proxy
@@ -11,5 +11,8 @@ COPY envoy_mixer.json      /etc/istio/proxy/envoy_mixer.json
 COPY envoy_mixer_auth.json /etc/istio/proxy/envoy_mixer_auth.json
 COPY envoy_bootstrap_tmpl.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 
+# Control tracing using legacy runtime API
+COPY random_sampling /etc/istio/proxy/runtime/tracing/random_sampling
+
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -36,5 +36,8 @@ RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
     chown -R istio-proxy /var/lib/istio
 
+# Control tracing using legacy runtime API
+COPY random_sampling /etc/istio/proxy/runtime/tracing/random_sampling
+
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/random_sampling
+++ b/pilot/docker/random_sampling
@@ -1,5 +1,6 @@
-# per 10000 of requests that will be randomly traced.
-# See here for more information. 
+# per 10000 of requests that are randomly traced.
+# For more information see:
+# https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sampling
 # This runtime control is specified in the range 0-10000 and defaults to 10000.
 # Thus, trace sampling can be specified in 0.01% increments.
 100

--- a/pilot/docker/random_sampling
+++ b/pilot/docker/random_sampling
@@ -1,0 +1,5 @@
+# per 10000 of requests that will be randomly traced.
+# See here for more information. 
+# This runtime control is specified in the range 0-10000 and defaults to 10000.
+# Thus, trace sampling can be specified in 0.01% increments.
+100

--- a/pilot/docker/random_sampling
+++ b/pilot/docker/random_sampling
@@ -3,4 +3,4 @@
 # https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/runtime.html?highlight=sampling
 # This runtime control is specified in the range 0-10000 and defaults to 10000.
 # Thus, trace sampling can be specified in 0.01% increments.
-100
+0

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -14,6 +14,7 @@
 package bootstrap
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/test/util"
 )
 
 func TestGolden(t *testing.T) {
@@ -60,13 +62,14 @@ func TestGolden(t *testing.T) {
 				t.Error("Error reading generated file ", err)
 				return
 			}
-			golden, err := ioutil.ReadFile("testdata/" + c.base + "_golden.json")
-			if err != nil {
-				golden = []byte{}
+			golden := "testdata/" + c.base + "_golden.json"
+
+			var dat map[string]interface{}
+			if err = json.Unmarshal(real, &dat); err != nil {
+				t.Fatalf("Invalid json: %s\n%s", err.Error(), string(real))
 			}
-			if string(real) != string(golden) {
-				t.Error("Generated incorrect config, want:\n" + string(golden) + "\ngot:\n" + string(real))
-			}
+
+			util.CompareContent(real, golden, t)
 		})
 	}
 

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -116,6 +116,9 @@
         }
       }
     }
-  ]
+  ],
 
+  "runtime": {
+    "symlink_root": "/etc/istio/proxy/runtime"
+  }
 }

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -83,4 +83,7 @@
   },
   
   
+  "runtime": {
+    "symlink_root": "/etc/istio/proxy/runtime"
+  }
 }

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -62,4 +62,7 @@
   },
   
   
+  "runtime": {
+    "symlink_root": "/etc/istio/proxy/runtime"
+  }
 }

--- a/tools/deb/envoy_bootstrap_tmpl.json
+++ b/tools/deb/envoy_bootstrap_tmpl.json
@@ -118,6 +118,9 @@
         }
       }
     }
-  ]
+  ],
 {{ end }}
+  "runtime": {
+    "symlink_root": "/etc/istio/proxy/runtime"
+  }
 }

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -26,7 +26,8 @@ $(ISTIO_DOCKER) $(ISTIO_DOCKER_TAR):
 PROXY_JSON_FILES:=pilot/docker/envoy_pilot.json \
                   pilot/docker/envoy_pilot_auth.json \
                   pilot/docker/envoy_mixer.json \
-                  pilot/docker/envoy_mixer_auth.json
+                  pilot/docker/envoy_mixer_auth.json \
+                  pilot/docker/random_sampling
 
 NODE_AGENT_TEST_FILES:=security/docker/start_app.sh \
                        security/docker/app.js


### PR DESCRIPTION
1. Enable 1% trace sampling.
2. This PR uses a deprecated method of setting these parameters until this is supported thru xDS.