### PR TITLE
Switch CI badge to match style of other badges. [skip ci].

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Istio
 
-[![CircleCI](https://circleci.com/gh/istio/istio.svg?style=svg)](https://circleci.com/gh/istio/istio)
+[![CircleCI](https://circleci.com/gh/istio/istio.svg?style=shield)](https://circleci.com/gh/istio/istio)
 [![Go Report Card](https://goreportcard.com/badge/github.com/istio/istio)](https://goreportcard.com/report/github.com/istio/istio)
 [![GoDoc](https://godoc.org/github.com/istio/istio?status.svg)](https://godoc.org/github.com/istio/istio)
 [![codecov.io](https://codecov.io/github/istio/istio/coverage.svg?branch=master)](https://codecov.io/github/istio/istio?branch=master)


### PR DESCRIPTION
Switches the badge style to make the same style (shield) as the other readme badges.

`[skip ci]` is used since this is a readme fix and doesn't affect any code whatsoever.