### PR TITLE
Fix flakyness of TestPersistBatches

### DIFF
--- a/mixer/adapter/solarwinds/internal/appoptics/batching.go
+++ b/mixer/adapter/solarwinds/internal/appoptics/batching.go
@@ -49,8 +49,6 @@ func BatchMeasurements(prepChan <-chan []*Measurement,
 			}
 		case <-stopChan:
 			return
-		default:
-			continue
 		}
 	}
 }

--- a/mixer/adapter/solarwinds/internal/appoptics/batching_test.go
+++ b/mixer/adapter/solarwinds/internal/appoptics/batching_test.go
@@ -15,13 +15,13 @@
 package appoptics
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"fmt"
 	test2 "istio.io/istio/mixer/pkg/adapter/test"
 )
 

--- a/mixer/adapter/solarwinds/internal/appoptics/batching_test.go
+++ b/mixer/adapter/solarwinds/internal/appoptics/batching_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	test2 "istio.io/istio/mixer/pkg/adapter/test"
 )
 
@@ -114,6 +115,13 @@ func TestPersistBatches(t *testing.T) {
 			sendOnStopChan: false,
 		},
 		{
+			name:           "Persist with error",
+			expectedCount:  0,
+			response:       nil,
+			error:          fmt.Errorf("metrics empty"),
+			sendOnStopChan: false,
+		},
+		{
 			name:           "Stop chan test",
 			expectedCount:  0,
 			response:       nil,
@@ -140,7 +148,9 @@ func TestPersistBatches(t *testing.T) {
 					MockMeasurementsService: func() MeasurementsCommunicator {
 						return &MockMeasurementsService{
 							OnCreate: func(measurements []*Measurement) (*http.Response, error) {
-								atomic.AddInt32(&count, 1)
+								if test.error == nil {
+									atomic.AddInt32(&count, 1)
+								}
 								action.Done()
 								return test.response, test.error
 							},


### PR DESCRIPTION
make sure the request is processed before tearing down.  
added more tests for coverage.
addressed #3209 