### PR TITLE
Cache k8s API object conversions

### DIFF
--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -22,8 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-multierror"
-
+	multierror "github.com/hashicorp/go-multierror"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pilot/pkg/config/kube/crd/controller.go
+++ b/pilot/pkg/config/kube/crd/controller.go
@@ -118,7 +118,7 @@ func (c *controller) createInformer(
 	wf cache.WatchFunc) cacheHandler {
 	handler := &kube.ChainHandler{}
 	handler.Append(c.notify)
-	// Write up cache eviction as a handler function
+	// Wire up cache eviction as a handler function
 	handler.Append(func(obj interface{}, event model.Event) error {
 		switch event {
 		// We don't care about Add events since we're doing cache eviction

--- a/pilot/pkg/config/kube/crd/conversion_cache.go
+++ b/pilot/pkg/config/kube/crd/conversion_cache.go
@@ -30,10 +30,10 @@ type CachingConverter struct {
 	inner ObjectConverter
 }
 
-// Accepts an objects name and returns its key; produced by calling newKeyFunc.
+// keyFunc accepts an objects name and returns its key; produced by calling newKeyFunc.
 type keyFunc func(string) string
 
-// KeyFunc curries the application of model.Key by accepting the object type and domain. The returned function accepts
+// newKeyFunc curries the application of model.Key by accepting the object type and domain. The returned function accepts
 // the `name` of an object of type `typ` in config domain `domain` and returns its full key.
 func newKeyFunc(typ, domain string) keyFunc {
 	return func(name string) string {
@@ -41,8 +41,9 @@ func newKeyFunc(typ, domain string) keyFunc {
 	}
 }
 
-// Returns a CachingConverter: an ObjectConverter wrapped in a cache. The cache is not bounded in size, nor does it
-// implement cache size based eviction. Instead, it relies on the underlying store calling Evict.
+// NewCachingConverter returns a CachingConverter: an ObjectConverter wrapped in a cache. The cache is not bounded in
+// size, nor does it implement cache size based eviction. Instead, it relies on the underlying store calling Evict as
+// objects change.
 func NewCachingConverter(converter ObjectConverter) *CachingConverter {
 	return &CachingConverter{
 		cache: sync.Map{},
@@ -50,7 +51,7 @@ func NewCachingConverter(converter ObjectConverter) *CachingConverter {
 	}
 }
 
-// ConvertObjects consults a cache of model.Config objects before deferring to c's underlying ObjectConverter.
+// ConvertObject consults a cache of model.Config objects before deferring to c's underlying ObjectConverter.
 func (c *CachingConverter) ConvertObject(schema model.ProtoSchema, object IstioObject, domain string) (*model.Config, error) {
 	key := model.Key(schema.Type, object.GetObjectMeta().Name, domain)
 	if item, exists := c.get(key); exists {

--- a/pilot/pkg/config/kube/crd/conversion_cache.go
+++ b/pilot/pkg/config/kube/crd/conversion_cache.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	"sync"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// ObjectConverter describes a function that can convert a k8s API object into an Istio model object.
+type ObjectConverter func(schema model.ProtoSchema, object IstioObject, domain string) (*model.Config, error)
+
+// CachingConverter implements an ObjectConverter that consults a cache before performing (expensive) marshalling.
+// This struct is threadsafe, but cannot be copied.
+type CachingConverter struct {
+	cache sync.Map
+	inner ObjectConverter
+}
+
+// Accepts an objects name and returns its key; produced by calling newKeyFunc.
+type keyFunc func(string) string
+
+// KeyFunc curries the application of model.Key by accepting the object type and domain. The returned function accepts
+// the `name` of an object of type `typ` in config domain `domain` and returns its full key.
+func newKeyFunc(typ, domain string) keyFunc {
+	return func(name string) string {
+		return model.Key(typ, name, domain)
+	}
+}
+
+// Returns a CachingConverter: an ObjectConverter wrapped in a cache. The cache is not bounded in size, nor does it
+// implement cache size based eviction. Instead, it relies on the underlying store calling Evict.
+func NewCachingConverter(converter ObjectConverter) *CachingConverter {
+	return &CachingConverter{
+		cache: sync.Map{},
+		inner: converter,
+	}
+}
+
+// ConvertObjects consults a cache of model.Config objects before deferring to c's underlying ObjectConverter.
+func (c *CachingConverter) ConvertObject(schema model.ProtoSchema, object IstioObject, domain string) (*model.Config, error) {
+	key := model.Key(schema.Type, object.GetObjectMeta().Name, domain)
+	if item, exists := c.get(key); exists {
+		return item, nil
+	}
+
+	item, err := c.inner(schema, object, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	// NB: we don't cache negative results (i.e. we don't cache the result when c.inner returns an err).
+	// We should evaluate if that's worthwhile, given we implement evictions and a conversion should fail consistently
+	// until the resource is updated.
+	c.cache.Store(key, item)
+	return item, nil
+}
+
+// Evict removes an entry from the cache.
+func (c *CachingConverter) Evict(key string) {
+	c.cache.Delete(key)
+}
+
+// returns the cached config object and whether the object was found; if !found, the returned config is nil
+func (c *CachingConverter) get(key string) (*model.Config, bool) {
+	item, found := c.cache.Load(key)
+	if !found {
+		return nil, false
+	}
+	return item.(*model.Config), true
+}

--- a/pilot/pkg/config/kube/crd/conversion_cache.go
+++ b/pilot/pkg/config/kube/crd/conversion_cache.go
@@ -19,7 +19,7 @@ import (
 	"istio.io/istio/pkg/cache"
 )
 
-const LRU_NUM_ENTRIES = 3000
+const cacheSize = 3000
 
 // ObjectConverter describes a function that can convert a k8s API object into an Istio model object.
 type ObjectConverter func(schema model.ProtoSchema, object IstioObject, domain string) (*model.Config, error)
@@ -47,7 +47,7 @@ func newKeyFunc(typ, domain string) keyFunc {
 // objects change.
 func NewCachingConverter(converter ObjectConverter) *CachingConverter {
 	return &CachingConverter{
-		cache: cache.SimpleLRU(LRU_NUM_ENTRIES),
+		cache: cache.SimpleLRU(cacheSize),
 		inner: converter,
 	}
 }

--- a/pilot/pkg/config/kube/crd/conversion_cache_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_cache_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func oneCallConversion(key string, out *model.Config) ObjectConverter {
+	called := false
+	return func(schema model.ProtoSchema, object IstioObject, domain string) (*model.Config, error) {
+		if model.Key(schema.Type, object.GetObjectMeta().Name, domain) != key {
+			return nil, fmt.Errorf("wrong key")
+		}
+		if !called {
+			called = true
+			return out, nil
+		}
+		panic("can only be called once")
+	}
+}
+
+func TestConversionCache(t *testing.T) {
+	schema := model.Gateway
+	obj := &Gateway{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "bar",
+		},
+		Spec: map[string]interface{}{
+			"servers": []interface{}{v1alpha3.Server{
+				Port:  &v1alpha3.Port{Number: 7},
+				Hosts: []string{"host"},
+			}},
+		},
+	}
+	// call the real conversion method to get our expected output
+	want, _ := ConvertObject(schema, obj, "bar")
+
+	key := model.Key(schema.Type, obj.GetObjectMeta().Name, obj.GetObjectMeta().Namespace)
+	underTest := NewCachingConverter(oneCallConversion(key, want))
+
+	// attempt to convert obj the first time
+	out, err := underTest.ConvertObject(schema, obj, "bar")
+	if err != nil || !reflect.DeepEqual(out, want) {
+		t.Fatalf("underTest.ConvertObject(%v, %v, %q) = %v, %v, wanted %v", schema, obj, "bar", out, err, want)
+	}
+	// verify we get the same object a second time, without calling the underlying converter (which will panic if called a second time)
+	out2, err := underTest.ConvertObject(schema, obj, "bar")
+	if err != nil || !reflect.DeepEqual(out2, out) {
+		t.Fatalf("underTest.ConvertObject(%v, %v, %q) = %v, %v, wanted %v", schema, obj, "bar", out2, err, out)
+	}
+
+	// finally, verify that the cache does call the underlying converter after an eviction
+	underTest.Evict(key)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("Should have panic'd after evicting %q from cache and attempting to convert a third time", key)
+		}
+	}()
+	_, _ = underTest.ConvertObject(schema, obj, "bar")
+	t.Fatalf("unreachable")
+}

--- a/pilot/pkg/config/kube/crd/conversion_cache_test.go
+++ b/pilot/pkg/config/kube/crd/conversion_cache_test.go
@@ -19,9 +19,10 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func oneCallConversion(key string, out *model.Config) ObjectConverter {

--- a/pkg/cache/lruCache.go
+++ b/pkg/cache/lruCache.go
@@ -156,6 +156,12 @@ func NewLRU(defaultExpiration time.Duration, evictionInterval time.Duration, max
 	return c
 }
 
+// SimpleLRU returns a cache with an LRU eviction model. It differs from NewLRU in that it does not perform
+// time based evictions.
+func SimpleLRU(maxEntries int32) Cache {
+	return NewLRU(time.Duration(0), time.Duration(0), maxEntries)
+}
+
 func (c *lruCache) evicter(evictionInterval time.Duration) {
 	// Wake up once in a while and evict stale items
 	ticker := time.NewTicker(evictionInterval)


### PR DESCRIPTION
Add a simple cache around k8s API object conversion to reduce allocs from JSON unmarshalling due to converting the same objects repeatedly.

Fixes https://github.com/istio/istio/issues/3965