### PR TITLE
Conform to Testgrid Regex on Junit Reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ ${ISTIO_BIN}/go-junit-report:
 	unset GOOS && CGO_ENABLED=1 go get -u github.com/jstemmer/go-junit-report
 
 # Run coverage tests
-JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit_tests.xml
+JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 test: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -106,6 +106,6 @@ else
     echo "Executing e2e test suite"
     time ISTIO_DOCKER_HUB=$HUB \
       E2E_ARGS="${E2E_ARGS[@]}" \
-      JUNIT_E2E_XML="${ARTIFACTS_DIR}/junit_e2e_all.xml" \
+      JUNIT_E2E_XML="${ARTIFACTS_DIR}/junit_e2e-all.xml" \
       make e2e_all
 fi

--- a/prow/istio-postsubmit.sh
+++ b/prow/istio-postsubmit.sh
@@ -36,7 +36,7 @@ cd $ROOT
 make init
 
 echo 'Running Unit Tests'
-time JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit_tests.xml" \
+time JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
 T="-v" \
 make localTestEnv test
 

--- a/prow/istio-unit-tests.sh
+++ b/prow/istio-unit-tests.sh
@@ -31,6 +31,6 @@ cd ${ROOT}
 
 # Unit tests are run against a local apiserver and etcd.
 # Integration/e2e tests in the other scripts are run against GKE or real clusters.
-JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit_tests.xml" \
+JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
 T="-v" \
 make build localTestEnv test

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -73,7 +73,7 @@ e2e_bookinfo: istioctl generate_yaml
 e2e_upgrade: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
-JUNIT_E2E_XML ?= $(ISTIO_OUT)/junit_e2e_all.xml
+JUNIT_E2E_XML ?= $(ISTIO_OUT)/junit_e2e-all.xml
 e2e_all: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_E2E_XML))
 	set -o pipefail; \


### PR DESCRIPTION
This PR fixes the issue where the junit reports are only recognized by Prow but not Testgird. The reason is that Testgrid requires the reports the match `junit(_[^_]+)?(_\d+-\d+)?(_\d+)?.xml`.

fixes https://github.com/istio/istio/issues/3975