### PR TITLE
Export required v1 symbols to implement LDS v2

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/gateway.go
+++ b/pilot/pkg/proxy/envoy/v1/gateway.go
@@ -161,8 +161,8 @@ func buildGatewayVirtualHosts(configStore model.IstioConfigStore, node model.Pro
 				}
 				for _, rh := range allRulesWithHosts {
 					rule := rh.Rule
-					routesForThisVirtualHost := buildHTTPRoutes(configStore, rule, pseudoService,
-						pseudoServicePort, nil, node.Domain, buildOutboundCluster)
+					routesForThisVirtualHost := BuildHTTPRoutes(configStore, rule, pseudoService,
+						pseudoServicePort, nil, node.Domain, BuildOutboundCluster)
 
 					for _, host := range rh.Hosts {
 						virtualHosts = append(virtualHosts, &VirtualHost{
@@ -176,7 +176,7 @@ func buildGatewayVirtualHosts(configStore model.IstioConfigStore, node model.Pro
 		}
 	}
 
-	configs := (&HTTPRouteConfig{VirtualHosts: virtualHosts}).normalize()
+	configs := (&HTTPRouteConfig{VirtualHosts: virtualHosts}).Normalize()
 	return configs, nil
 }
 

--- a/pilot/pkg/proxy/envoy/v1/header.go
+++ b/pilot/pkg/proxy/envoy/v1/header.go
@@ -91,15 +91,15 @@ func buildHTTPRouteMatchV2(match *networking.HTTPMatchRequest) *HTTPRoute {
 	}
 
 	if match.Method != nil {
-		route.Headers = append(route.Headers, buildHeaderV2(headerMethod, match.Method))
+		route.Headers = append(route.Headers, buildHeaderV2(HeaderMethod, match.Method))
 	}
 
 	if match.Authority != nil {
-		route.Headers = append(route.Headers, buildHeaderV2(headerAuthority, match.Authority))
+		route.Headers = append(route.Headers, buildHeaderV2(HeaderAuthority, match.Authority))
 	}
 
 	if match.Scheme != nil {
-		route.Headers = append(route.Headers, buildHeaderV2(headerScheme, match.Scheme))
+		route.Headers = append(route.Headers, buildHeaderV2(HeaderScheme, match.Scheme))
 	}
 
 	// TODO: match.DestinationPorts

--- a/pilot/pkg/proxy/envoy/v1/ingress.go
+++ b/pilot/pkg/proxy/envoy/v1/ingress.go
@@ -49,7 +49,7 @@ func buildIngressListeners(mesh *meshconfig.MeshConfig, proxyInstances []*model.
 
 	// lack of SNI in Envoy implies that TLS secrets are attached to listeners
 	// therefore, we should first check that TLS endpoint is needed before shipping TLS listener
-	_, secret := buildIngressRoutes(mesh, ingress, proxyInstances, discovery, config)
+	_, secret := BuildIngressRoutes(mesh, ingress, proxyInstances, discovery, config)
 	if secret != "" {
 		opts.port = 443
 		opts.rds = "443"
@@ -65,7 +65,8 @@ func buildIngressListeners(mesh *meshconfig.MeshConfig, proxyInstances []*model.
 	return listeners
 }
 
-func buildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
+// BuildIngressRoutes builds ingress routes.
+func BuildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
 	proxyInstances []*model.ServiceInstance,
 	discovery model.ServiceDiscovery,
 	config model.IstioConfigStore) (HTTPRouteConfigs, string) {
@@ -110,7 +111,7 @@ func buildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
 		}
 	}
 
-	// normalize config
+	// Normalize config
 	rc := &HTTPRouteConfig{VirtualHosts: make([]*VirtualHost, 0)}
 	for host, routes := range vhosts {
 		sort.Sort(RoutesByPath(routes))
@@ -132,7 +133,7 @@ func buildIngressRoutes(mesh *meshconfig.MeshConfig, node model.Proxy,
 	}
 
 	configs := HTTPRouteConfigs{80: rc, 443: rcTLS}
-	return configs.normalize(), tlsAll
+	return configs.Normalize(), tlsAll
 }
 
 // buildIngressVhostDomains returns an array of domain strings with the port attached
@@ -171,14 +172,14 @@ func buildIngressRoute(mesh *meshconfig.MeshConfig, node model.Proxy,
 	}
 
 	// unfold the rules for the destination port
-	routes := buildDestinationHTTPRoutes(node, service, servicePort, proxyInstances, config, buildOutboundCluster)
+	routes := buildDestinationHTTPRoutes(node, service, servicePort, proxyInstances, config, BuildOutboundCluster)
 
 	// filter by path, prefix from the ingress
 	ingressRoute := buildHTTPRouteMatch(ingress.Match)
 
 	// TODO: not handling header match in ingress apart from uri and authority (uri must not be regex)
 	if len(ingressRoute.Headers) > 0 {
-		if len(ingressRoute.Headers) > 1 || ingressRoute.Headers[0].Name != headerAuthority {
+		if len(ingressRoute.Headers) > 1 || ingressRoute.Headers[0].Name != HeaderAuthority {
 			return nil, "", errors.New("header matches in ingress rule not supported")
 		}
 	}
@@ -196,7 +197,7 @@ func buildIngressRoute(mesh *meshconfig.MeshConfig, node model.Proxy,
 
 		// enable mixer check on the route
 		if mesh.MixerCheckServer != "" || mesh.MixerReportServer != "" {
-			route.OpaqueConfig = buildMixerOpaqueConfig(!mesh.DisablePolicyChecks, true, service.Hostname)
+			route.OpaqueConfig = BuildMixerOpaqueConfig(!mesh.DisablePolicyChecks, true, service.Hostname)
 		}
 
 		if applied := route.CombinePathPrefix(ingressRoute.Path, ingressRoute.Prefix); applied != nil {

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -152,8 +152,8 @@ func buildMixerCluster(mesh *meshconfig.MeshConfig, mixerSAN []string, server, c
 	return cluster
 }
 
-// buildMixerClusters builds an outbound mixer cluster with configured check/report clusters
-func buildMixerClusters(mesh *meshconfig.MeshConfig, role model.Proxy, mixerSAN []string) []*Cluster {
+// BuildMixerClusters builds an outbound mixer cluster with configured check/report clusters
+func BuildMixerClusters(mesh *meshconfig.MeshConfig, role model.Proxy, mixerSAN []string) []*Cluster {
 	mixerClusters := make([]*Cluster, 0)
 
 	if mesh.MixerCheckServer != "" {
@@ -167,9 +167,9 @@ func buildMixerClusters(mesh *meshconfig.MeshConfig, role model.Proxy, mixerSAN 
 	return mixerClusters
 }
 
-// buildMixerConfig build per route mixer config to be deployed at the `model.Proxy` workload
+// BuildMixerConfig build per route mixer config to be deployed at the `model.Proxy` workload
 // with destination of Service `dest` and `destName` as the service name
-func buildMixerConfig(source model.Proxy, destName string, dest *model.Service, instances []*model.ServiceInstance, config model.IstioConfigStore,
+func BuildMixerConfig(source model.Proxy, destName string, dest *model.Service, instances []*model.ServiceInstance, config model.IstioConfigStore,
 	disableCheck bool, disableReport bool) map[string]string {
 	sc := serviceConfig(destName, &model.ServiceInstance{Service: dest}, config, disableCheck, disableReport)
 	var labels map[string]string
@@ -198,7 +198,8 @@ func buildMixerConfig(source model.Proxy, destName string, dest *model.Service, 
 	return oc
 }
 
-func buildMixerOpaqueConfig(check, forward bool, destinationService string) map[string]string {
+// BuildMixerOpaqueConfig builds a mixer opaque config.
+func BuildMixerOpaqueConfig(check, forward bool, destinationService string) map[string]string {
 	keys := map[bool]string{true: "on", false: "off"}
 	m := map[string]string{
 		MixerReport:  "on",
@@ -211,9 +212,9 @@ func buildMixerOpaqueConfig(check, forward bool, destinationService string) map[
 	return m
 }
 
-// Mixer filter uses outbound configuration by default (forward attributes,
-// but not invoke check calls)  ServiceInstances belong to the Node.
-func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *FilterMixerConfig { // nolint: lll
+// BuildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
+// (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.
+func BuildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *FilterMixerConfig { // nolint: lll
 	transport := &mccpb.TransportConfig{
 		CheckCluster:  MixerCheckClusterName,
 		ReportCluster: MixerReportClusterName,
@@ -348,8 +349,8 @@ func serviceConfig(serviceName string, dest *model.ServiceInstance, config model
 	return sc
 }
 
-// Mixer TCP filter config for inbound requests.
-func buildTCPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, instance *model.ServiceInstance) *FilterMixerConfig {
+// BuildTCPMixerFilterConfig builds a TCP filter config for inbound requests.
+func BuildTCPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, instance *model.ServiceInstance) *FilterMixerConfig {
 	filter := &FilterMixerConfig{
 		MixerAttributes: map[string]string{
 			AttrDestinationIP:  role.IPAddress,
@@ -424,9 +425,9 @@ func buildJWKSURIClusterNameAndAddress(raw string) (string, string, bool, error)
 	return TruncateClusterName(OutboundJWTURIClusterPrefix + name), address, useSSL, nil
 }
 
-// buildMixerAuthFilterClusters builds the necessary clusters for the
+// BuildMixerAuthFilterClusters builds the necessary clusters for the
 // JWT auth filter to fetch public keys from the specified jwks_uri.
-func buildMixerAuthFilterClusters(config model.IstioConfigStore, mesh *meshconfig.MeshConfig, proxyInstances []*model.ServiceInstance) Clusters {
+func BuildMixerAuthFilterClusters(config model.IstioConfigStore, mesh *meshconfig.MeshConfig, proxyInstances []*model.ServiceInstance) Clusters {
 	type authCluster struct {
 		name   string
 		useSSL bool

--- a/pilot/pkg/proxy/envoy/v1/policy.go
+++ b/pilot/pkg/proxy/envoy/v1/policy.go
@@ -35,8 +35,8 @@ func isDestinationExcludedForMTLS(serviceName string, mtlsExcludedServices []str
 	return false
 }
 
-// applyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
-func applyClusterPolicy(cluster *Cluster,
+// ApplyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
+func ApplyClusterPolicy(cluster *Cluster,
 	proxyInstances []*model.ServiceInstance,
 	config model.IstioConfigStore,
 	mesh *meshconfig.MeshConfig,
@@ -54,16 +54,16 @@ func applyClusterPolicy(cluster *Cluster,
 	// where Istio auth does not apply.
 	if cluster.Type != ClusterTypeOriginalDST {
 		if !isDestinationExcludedForMTLS(cluster.ServiceName, mesh.MtlsExcludedServices) &&
-			consolidateAuthPolicy(mesh, cluster.port.AuthenticationPolicy) == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+			consolidateAuthPolicy(mesh, cluster.Port.AuthenticationPolicy) == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 			// apply auth policies
-			ports := model.PortList{cluster.port}.GetNames()
-			serviceAccounts := accounts.GetIstioServiceAccounts(cluster.hostname, ports)
+			ports := model.PortList{cluster.Port}.GetNames()
+			serviceAccounts := accounts.GetIstioServiceAccounts(cluster.Hostname, ports)
 			cluster.SSLContext = buildClusterSSLContext(model.AuthCertsPath, serviceAccounts)
 		}
 	}
 
 	// apply destination policies
-	policyConfig := config.Policy(proxyInstances, cluster.hostname, cluster.labels)
+	policyConfig := config.Policy(proxyInstances, cluster.Hostname, cluster.labels)
 
 	// if no policy is configured apply destination rule if one exists
 	if policyConfig == nil {
@@ -236,7 +236,7 @@ func applyTrafficPolicy(cluster *Cluster, policy *networking.TrafficPolicy) {
 }
 
 func applyDestinationRule(config model.IstioConfigStore, cluster *Cluster, domain string) {
-	destinationRuleConfig := config.DestinationRule(cluster.hostname, domain)
+	destinationRuleConfig := config.DestinationRule(cluster.Hostname, domain)
 	if destinationRuleConfig != nil {
 		destinationRule := destinationRuleConfig.Spec.(*networking.DestinationRule)
 

--- a/pilot/pkg/proxy/envoy/v1/resources.go
+++ b/pilot/pkg/proxy/envoy/v1/resources.go
@@ -129,10 +129,14 @@ const (
 	// MaxClusterNameLength is the maximum cluster name length
 	MaxClusterNameLength = 189 // TODO: use MeshConfig.StatNameLength instead
 
-	// headers with special meaning in Envoy
-	headerMethod    = ":method"
-	headerAuthority = ":authority"
-	headerScheme    = ":scheme"
+	// Headers with special meaning in Envoy
+
+	// HeaderMethod is the method header.
+	HeaderMethod = ":method"
+	// HeaderAuthority is the authority header.
+	HeaderAuthority = ":authority"
+	// HeaderScheme is the scheme header.
+	HeaderScheme = ":scheme"
 
 	router  = "router"
 	auto    = "auto"
@@ -298,7 +302,7 @@ type HTTPRoute struct {
 
 	// clusters contains the set of referenced clusters in the route; the field is special
 	// and used only to aggregate cluster information after composing routes
-	clusters Clusters
+	Clusters Clusters `json:"-"`
 
 	// faults contains the set of referenced faults in the route; the field is special
 	// and used only to aggregate fault filter information after composing routes
@@ -395,7 +399,7 @@ type VirtualHost struct {
 func (host *VirtualHost) clusters() Clusters {
 	out := make(Clusters, 0)
 	for _, route := range host.Routes {
-		out = append(out, route.clusters...)
+		out = append(out, route.Clusters...)
 	}
 	return out
 }
@@ -418,29 +422,31 @@ func (routes HTTPRouteConfigs) EnsurePort(port int) *HTTPRouteConfig {
 	return config
 }
 
-func (routes HTTPRouteConfigs) clusters() Clusters {
+// Clusters returns the clusters corresponding to the given routes.
+func (routes HTTPRouteConfigs) Clusters() Clusters {
 	out := make(Clusters, 0)
 	for _, config := range routes {
-		out = append(out, config.clusters()...)
+		out = append(out, config.Clusters()...)
 	}
 	return out
 }
 
-func (routes HTTPRouteConfigs) normalize() HTTPRouteConfigs {
+// Normalize normalizes the route configs.
+func (routes HTTPRouteConfigs) Normalize() HTTPRouteConfigs {
 	out := make(HTTPRouteConfigs)
 
 	// sort HTTP routes by virtual hosts, rest should be deterministic
 	for port, routeConfig := range routes {
-		out[port] = routeConfig.normalize()
+		out[port] = routeConfig.Normalize()
 	}
 
 	return out
 }
 
-// combine creates a new route config that is the union of all HTTP routes.
+// Combine creates a new route config that is the union of all HTTP routes.
 // note that the virtual hosts without an explicit port suffix (IP:PORT) are stripped
 // for all routes except the route for port 80.
-func (routes HTTPRouteConfigs) combine() *HTTPRouteConfig {
+func (routes HTTPRouteConfigs) Combine() *HTTPRouteConfig {
 	out := &HTTPRouteConfig{}
 	for port, config := range routes {
 		for _, host := range config.VirtualHosts {
@@ -459,7 +465,7 @@ func (routes HTTPRouteConfigs) combine() *HTTPRouteConfig {
 			}
 		}
 	}
-	return out.normalize()
+	return out.Normalize()
 }
 
 // faults aggregates fault filters across virtual hosts in single http_conn_man
@@ -473,7 +479,8 @@ func (rc *HTTPRouteConfig) faults() []*HTTPFilter {
 	return out
 }
 
-func (rc *HTTPRouteConfig) clusters() Clusters {
+// Clusters returns the clusters for the given route config.
+func (rc *HTTPRouteConfig) Clusters() Clusters {
 	out := make(Clusters, 0)
 	for _, host := range rc.VirtualHosts {
 		out = append(out, host.clusters()...)
@@ -481,7 +488,8 @@ func (rc *HTTPRouteConfig) clusters() Clusters {
 	return out
 }
 
-func (rc *HTTPRouteConfig) normalize() *HTTPRouteConfig {
+// Normalize normalizes the route config.
+func (rc *HTTPRouteConfig) Normalize() *HTTPRouteConfig {
 	hosts := make([]*VirtualHost, len(rc.VirtualHosts))
 	copy(hosts, rc.VirtualHosts)
 	sort.Slice(hosts, func(i, j int) bool { return hosts[i].Name < hosts[j].Name })
@@ -693,7 +701,7 @@ type Listener struct {
 // Listeners is a collection of listeners
 type Listeners []*Listener
 
-// normalize sorts and de-duplicates listeners by address
+// Normalize sorts and de-duplicates listeners by address
 func (listeners Listeners) normalize() Listeners {
 	out := make(Listeners, 0, len(listeners))
 	set := make(map[string]bool)
@@ -766,8 +774,8 @@ type Cluster struct {
 
 	// special values used by the post-processing passes for outbound mesh-local clusters
 	outbound bool
-	hostname string
-	port     *model.Port
+	Hostname string      `json:"-"`
+	Port     *model.Port `json:"-"`
 	labels   model.Labels
 }
 
@@ -797,8 +805,8 @@ type OutlierDetection struct {
 // Clusters is a collection of clusters
 type Clusters []*Cluster
 
-// normalize deduplicates and sorts clusters by name
-func (clusters Clusters) normalize() Clusters {
+// Normalize deduplicates and sorts clusters by name
+func (clusters Clusters) Normalize() Clusters {
 	out := make(Clusters, 0, len(clusters))
 	set := make(map[string]bool)
 	for _, cluster := range clusters {


### PR DESCRIPTION
First part of LDS v2 implementation. In initial implementation, building Listener proto requires some v1 functions (mainly for computing Clusters and Routes). This PR exposes those functions, with the aim of gradually removing all v1 dependencies and dealing purely with v2 structs.