### PR TITLE
Fix race test failures for mix client tests.

### DIFF
--- a/mixer/test/client/check_cache/check_cache_test.go
+++ b/mixer/test/client/check_cache/check_cache_test.go
@@ -62,9 +62,9 @@ func TestCheckCache(t *testing.T) {
 		if _, _, err := env.HTTPGet(url); err != nil {
 			t.Errorf("Failed in request %s: %v", tag, err)
 		}
-		// Only the first check is called.
-		s.VerifyCheckCount(tag, 1)
 	}
+	// Only the first check is called.
+	s.VerifyCheckCount(tag, 1)
 
 	// Check stats for Check, Quota and report calls.
 	if respStats, err := s.WaitForStatsUpdateAndGetStats(2); err == nil {

--- a/mixer/test/client/env/mixer_server.go
+++ b/mixer/test/client/env/mixer_server.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -33,6 +34,7 @@ type Handler struct {
 	stress  bool
 	ch      chan *attribute.MutableBag
 	count   int
+	mutex   *sync.Mutex
 	rStatus rpc.Status
 }
 
@@ -40,6 +42,7 @@ func newHandler(stress bool) *Handler {
 	h := &Handler{
 		stress:  stress,
 		count:   0,
+		mutex:   &sync.Mutex{},
 		rStatus: rpc.Status{},
 	}
 	if !stress {
@@ -50,10 +53,19 @@ func newHandler(stress bool) *Handler {
 
 func (h *Handler) run(bag attribute.Bag) rpc.Status {
 	if !h.stress {
+		h.mutex.Lock()
+		h.count++
+		h.mutex.Unlock()
 		h.ch <- attribute.CopyBag(bag)
 	}
-	h.count++
 	return h.rStatus
+}
+
+func (h *Handler) Count() int {
+	h.mutex.Lock()
+	c := h.count
+	h.mutex.Unlock()
+	return c
 }
 
 // MixerServer stores data for a mock Mixer server.
@@ -92,7 +104,10 @@ func (ts *MixerServer) Report(bag attribute.Bag) rpc.Status {
 
 // Quota is called by the mock mixer api
 func (ts *MixerServer) Quota(bag attribute.Bag, qma mockapi.QuotaArgs) (mockapi.QuotaResponse, rpc.Status) {
-	ts.qma = qma
+	if !ts.quota.stress {
+		// In non-stress case, saved for test verification
+		ts.qma = qma
+	}
 	status := ts.quota.run(bag)
 	qmr := mockapi.QuotaResponse{}
 	if status.Code == 0 {

--- a/mixer/test/client/env/mixer_server.go
+++ b/mixer/test/client/env/mixer_server.go
@@ -61,6 +61,7 @@ func (h *Handler) run(bag attribute.Bag) rpc.Status {
 	return h.rStatus
 }
 
+// Count get the called counter
 func (h *Handler) Count() int {
 	h.mutex.Lock()
 	c := h.count

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -86,7 +86,7 @@ func (s *TestSetup) SetMixerQuotaLimit(limit int64) {
 
 // GetMixerQuotaCount get the number of Quota calls.
 func (s *TestSetup) GetMixerQuotaCount() int {
-	return s.mixer.quota.count
+	return s.mixer.quota.Count()
 }
 
 // SetStress set the stress flag
@@ -155,17 +155,17 @@ func (s *TestSetup) ReStartEnvoy() {
 
 // VerifyCheckCount verifies the number of Check calls.
 func (s *TestSetup) VerifyCheckCount(tag string, expected int) {
-	if s.mixer.check.count != expected {
+	if s.mixer.check.Count() != expected {
 		s.t.Fatalf("%s check count doesn't match: %v\n, expected: %+v",
-			tag, s.mixer.check.count, expected)
+			tag, s.mixer.check.Count(), expected)
 	}
 }
 
 // VerifyReportCount verifies the number of Report calls.
 func (s *TestSetup) VerifyReportCount(tag string, expected int) {
-	if s.mixer.report.count != expected {
+	if s.mixer.report.Count() != expected {
 		s.t.Fatalf("%s report count doesn't match: %v\n, expected: %+v",
-			tag, s.mixer.report.count, expected)
+			tag, s.mixer.report.Count(), expected)
 	}
 }
 


### PR DESCRIPTION

Fixed two race conditions
1) during stress tests,  saved qma,  mixer_server save,  test client read. not protected.
   fix:  not to save qma during stress test.

2) count is not protected,  mixer_server write, test_client read.
   fix use mutex to protect count.

