### PR TITLE
Ansible installer needs to create proper service account names for 0.6.0

### DIFF
--- a/install/ansible/istio/tasks/add_serviceaccount_to_addon.yml
+++ b/install/ansible/istio/tasks/add_serviceaccount_to_addon.yml
@@ -9,22 +9,56 @@
   register: go
   ignore_errors: true
 
-- name: Add ServiceAccount to {{ add_on_name }} add-on
+- name: Add ServiceAccount to {{ add_on_name }} add-on for istio prior to version 0.6
   replace:
     path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
     regexp: '^(\s*)containers:\s*$'
     replace: '\1serviceAccountName: istio-{{ add_on_name }}-service-account\n\1containers:'
     backup: yes
-  when: go.stdout_lines | length == 0
+  when:
+    - go.stdout_lines | length == 0
+    - istio_version_to_use.split(".")[0] | int == 0
+    - istio_version_to_use.split(".")[1] | int < 6
+
+- name: Add ServiceAccount to {{ add_on_name }} add-on
+  replace:
+    path: "{{ istio_dir }}/install/kubernetes/addons/{{ add_on_name }}.yaml"
+    regexp: '^(\s*)containers:\s*$'
+    replace: '\1serviceAccountName: {{ add_on_name }}\n\1containers:'
+    backup: yes
+  when:
+    - go.stdout_lines | length == 0
+    - (istio_version_to_use.split(".")[0] | int > 0) or
+      (istio_version_to_use.split(".")[1] | int >= 6)
 
 - set_fact:
     add_on_definition_path: /tmp/{{ add_on_name }}-service-account
 
-- name: Apply ServiceAccount from template for {{ add_on_name }}
+- name: Apply ServiceAccount from template for {{ add_on_name }} for istio prior to version 0.6
   command: "{{ cmd_path }} create serviceaccount istio-{{ add_on_name }}-service-account -n istio-system"
   ignore_errors: true
+  when:
+    - istio_version_to_use.split(".")[0] | int == 0
+    - istio_version_to_use.split(".")[1] | int < 6
+
+- name: Apply ServiceAccount from template for {{ add_on_name }}
+  command: "{{ cmd_path }} create serviceaccount {{ add_on_name }} -n istio-system"
+  ignore_errors: true
+  when:
+    - (istio_version_to_use.split(".")[0] | int > 0) or
+      (istio_version_to_use.split(".")[1] | int >= 6)
+
+- name: Define SCC rules to enable containers running with UID zero for Addon service accounts for {{ add_on_name }} for istio prior to version 0.6
+  command: "{{ cmd_path }} adm policy add-scc-to-user anyuid -z istio-{{ add_on_name }}-service-account -n istio-system"
+  when:
+    - cluster_flavour == 'ocp'
+    - istio_version_to_use.split(".")[0] | int == 0
+    - istio_version_to_use.split(".")[1] | int < 6
 
 - name: Define SCC rules to enable containers running with UID zero for Addon service accounts for {{ add_on_name }}
-  command: "{{ cmd_path }} adm policy add-scc-to-user anyuid -z istio-{{ add_on_name }}-service-account -n istio-system"
-  when: cluster_flavour == 'ocp'
+  command: "{{ cmd_path }} adm policy add-scc-to-user anyuid -z {{ add_on_name }} -n istio-system"
+  when:
+    - cluster_flavour == 'ocp'
+    - (istio_version_to_use.split(".")[0] | int > 0) or
+      (istio_version_to_use.split(".")[1] | int >= 6)
 


### PR DESCRIPTION
In 0.6.0, it seems the names of the addon service accounts are explicitly

defined and no longer are prefixed/suffixed with "istio-" and
"-service-account". The names of the addon service accounts are now simply
just the addon names themselves (i.e. "grafana" and "prometheus").

This PR makes this change so when installing 0.6.0+ the service
accounts are named properly, however, this PR also maintains
backward compatibility by ensuring the service accounts names
are those used in the past (i.e. istio-grafana-service-account
and istio-prometheus-service-account) when installing 0.5.1 and under.