### PR TITLE
add mixer-validator webhook optionally as a part of e2e test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ install/kubernetes/addons/zipkin-to-stackdriver.yaml
 install/kubernetes/addons/zipkin.yaml
 install/kubernetes/istio-auth.yaml
 install/kubernetes/istio-mixer-with-health-check.yaml
+install/kubernetes/istio-mixer-validator.yaml
 install/kubernetes/istio-ca-plugin-certs.yaml
 install/kubernetes/istio-ca-with-health-check.yaml
 install/kubernetes/istio-one-namespace-auth.yaml

--- a/Makefile
+++ b/Makefile
@@ -619,9 +619,11 @@ FILES_TO_CLEAN+=install/consul/istio.yaml \
                 install/kubernetes/addons/servicegraph.yaml \
                 install/kubernetes/addons/zipkin-to-stackdriver.yaml \
                 install/kubernetes/addons/zipkin.yaml \
-                install/kubernetes/helm/istio/values.yaml \
                 install/kubernetes/istio-auth.yaml \
                 install/kubernetes/istio-ca-plugin-certs.yaml \
+                install/kubernetes/istio-ca-with-health-check.yaml \
+                install/kubernetes/istio-mixer-validator.yaml \
+                install/kubernetes/istio-mixer-with-health-check.yaml \
                 install/kubernetes/istio-one-namespace-auth.yaml \
                 install/kubernetes/istio-one-namespace.yaml \
                 install/kubernetes/istio-sidecar-injector-configmap-debug.yaml \

--- a/install/kubernetes/templates/istio-mixer-validator.yaml.tmpl
+++ b/install/kubernetes/templates/istio-mixer-validator.yaml.tmpl
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-mixer-validator
+  namespace: {ISTIO_NAMESPACE}
+  labels:
+    istio: mixer-validator
+spec:
+  ports:
+  - name: webhook
+    port: 443
+  selector:
+    istio: mixer-validator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-mixer-validator-service-account
+  namespace: {ISTIO_NAMESPACE}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-mixer-validator
+  namespace: {ISTIO_NAMESPACE}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: mixer-validator
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-mixer-validator-service-account
+      containers:
+      - name: validator
+        image: {MIXER_HUB}/mixer:{MIXER_TAG}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 443
+        command:
+        - /usr/local/bin/mixs
+        - validator
+        - --webhook-name=istio-mixer-validator
+        - --namespace={ISTIO_NAMESPACE}
+        - --port=443
+        - --secret-name=istio-mixer-validator
+---

--- a/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
+++ b/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
@@ -30,7 +30,7 @@ rules:
   resources: ["namespaces", "nodes", "secrets"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["externaladmissionhookconfigurations"]
+  resources: ["validatingwebhookconfigurations"]
   verbs: ["create", "update", "delete"]
 ---
 kind: ClusterRole
@@ -59,6 +59,25 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
   verbs: ["get", "list", "watch"]
+---
+# Mixer validator: CRD, configmaps, and secrets need to be watched.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-mixer-validator-{ISTIO_NAMESPACE}
+rules:
+- apiGroups: ["config.istio.io"] # Istio CRD watcher
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["create", "update", "delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -172,5 +191,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: istio-mixer-{ISTIO_NAMESPACE}
+  apiGroup: rbac.authorization.k8s.io
+---
+# Grant permissions to Mixer validator.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-mixer-validator-admin-role-binding-{ISTIO_NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: istio-mixer-validator-service-account
+  namespace: {ISTIO_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: istio-mixer-validator-{ISTIO_NAMESPACE}
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -139,6 +139,7 @@ function merge_files() {
   ISTIO_CA_PLUGIN_CERTS=$DEST/istio-ca-plugin-certs.yaml
   ISTIO_CA_HEALTH_CHECK=$DEST/istio-ca-with-health-check.yaml
   ISTIO_MIXER_HEALTH_CHECK=$DEST/istio-mixer-with-health-check.yaml
+  ISTIO_MIXER_VALIDATOR=$DEST/istio-mixer-validator.yaml
 
 
   if [ "$COMPONENT_FILES" = true ]; then
@@ -212,6 +213,10 @@ function merge_files() {
   echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_MIXER_HEALTH_CHECK
   echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_MIXER_HEALTH_CHECK
   cat $SRC/istio-mixer-with-health-check.yaml.tmpl >> $ISTIO_MIXER_HEALTH_CHECK
+
+  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_MIXER_VALIDATOR
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_MIXER_VALIDATOR
+  cat $SRC/istio-mixer-validator.yaml.tmpl >> $ISTIO_MIXER_VALIDATOR
 }
 
 function update_version_file() {
@@ -257,6 +262,7 @@ function update_istio_install() {
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ingress.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-mixer.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-mixer-with-health-check.yaml.tmpl
+  execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-mixer-validator.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ca.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ca-one-namespace.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-ca-plugin-certs.yaml.tmpl
@@ -269,6 +275,7 @@ function update_istio_install() {
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PILOT_HUB}/${PROXY_IMAGE}:${PILOT_TAG}|" istio-pilot.yaml.tmpl
   execute_sed "s|image: {MIXER_HUB}/\(.*\):{MIXER_TAG}|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" istio-mixer.yaml.tmpl
   execute_sed "s|image: {MIXER_HUB}/\(.*\):{MIXER_TAG}|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" istio-mixer-with-health-check.yaml.tmpl
+  execute_sed "s|image: {MIXER_HUB}/\(.*\):{MIXER_TAG}|image: ${MIXER_HUB}/\1:${MIXER_TAG}|" istio-mixer-validator.yaml.tmpl
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PILOT_HUB}/${PROXY_IMAGE}:${PILOT_TAG}|" istio-mixer.yaml.tmpl
   execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-ca.yaml.tmpl
   execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-ca-one-namespace.yaml.tmpl

--- a/prow/e2e-cluster_wide-auth.sh
+++ b/prow/e2e-cluster_wide-auth.sh
@@ -31,4 +31,4 @@ set -x
 ROOT=$(cd $(dirname $0)/..; pwd)
 
 echo 'Running cluster-wide e2e rbac, auth Tests'
-${ROOT}/prow/e2e-suite.sh --test_vm --auth_enable --cluster_wide "$@"
+${ROOT}/prow/e2e-suite.sh --test_vm --auth_enable --cluster_wide --with_mixer_validator "$@"


### PR DESCRIPTION
The e2e test starts and sets up the mixer-validator webhook
with --with_mixer_validator flag (which is off by default).

This PR also fixes the stale code in admit.go which does not
work well with the current scheme.