### PR TITLE
Add unit test for GenCertFomCSR.

### DIFF
--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -15,7 +15,11 @@
 package util
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"math/big"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -188,7 +192,72 @@ func TestGenCertKeyFromOptions(t *testing.T) {
 	}
 }
 
-// TODO(myidpt): Add test cases for GenCertFromCSR.
+func TestGenCertFromCSR(t *testing.T) {
+	// First Creates a self-signed CA cert.
+	caPK, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Errorf("failed to generate ca's key pair %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(-1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caPK.PublicKey, caPK)
+	if err != nil {
+		t.Errorf("failed to Create self signed ca cert %v", err)
+	}
+	caCert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Errorf("failed to parse generated ca certificate %v", err)
+	}
+
+	// Then generates signee's key pairs.
+	signeePK, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Errorf("failed to generate signee key pair %v", err)
+	}
+
+	tmpl := &x509.CertificateRequest{
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		DNSNames:           []string{"test.example.com"},
+		Version:            3,
+	}
+	derBytes, err := x509.CreateCertificateRequest(rand.Reader, tmpl, signeePK)
+	if err != nil {
+		t.Error("failed to create certificate request")
+	}
+	csr, err := x509.ParseCertificateRequest(derBytes)
+	if err != nil {
+		t.Errorf("failed to parse certificate request %v", err)
+	}
+
+	derBytes, err = GenCertFromCSR(csr, caCert, &signeePK.PublicKey, caPK, time.Hour, false)
+	if err != nil {
+		t.Errorf("failed to GenCertFromCSR, error %v", err)
+	}
+
+	// Verifies the certificate.
+	out, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Errorf("failed to parse generated certificate %v", err)
+	}
+	if !reflect.DeepEqual(out.DNSNames, tmpl.DNSNames) {
+		t.Errorf("generated cert dns name is unexpected, got %v, want %v", out.DNSNames, tmpl.DNSNames)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	vo := x509.VerifyOptions{
+		Roots: pool,
+	}
+	if _, err := out.Verify(vo); err != nil {
+		t.Errorf("verification of the signed certificate failed %v", err)
+	}
+}
 
 func TestLoadSignerCredsFromFiles(t *testing.T) {
 	testCases := map[string]struct {


### PR DESCRIPTION
The test works as follow:
- Generate self-signed CA cert first.
- Generate key pair for signee & prepare the template, generate the CSR.
- Call util.GenCertFromCSR.
- Verify the generated signee's cert based on CA's cert.