### PR TITLE
Fix Pilot port number config for Ingress and ConfigMap

### DIFF
--- a/install/kubernetes/templates/istio-config.yaml.tmpl
+++ b/install/kubernetes/templates/istio-config.yaml.tmpl
@@ -65,7 +65,7 @@ data:
       proxyAdminPort: 15000
       #
       # Address where Istio Pilot service is running
-      discoveryAddress: istio-pilot.{ISTIO_NAMESPACE}:8080
+      discoveryAddress: istio-pilot.{ISTIO_NAMESPACE}:8080 #--controlPlaneAuthPolicy
       #
       # Zipkin trace collector
       zipkinAddress: zipkin.{ISTIO_NAMESPACE}:9411

--- a/install/kubernetes/templates/istio-ingress.yaml.tmpl
+++ b/install/kubernetes/templates/istio-ingress.yaml.tmpl
@@ -47,7 +47,7 @@ spec:
         - proxy
         - ingress
         - --discoveryAddress
-        - istio-pilot:8080
+        - istio-pilot:8080 #--controlPlaneAuthPolicy
         - --discoveryRefreshDelay
         - '1s' #discoveryRefreshDelay
         - --drainDuration

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -173,6 +173,7 @@ function merge_files() {
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_AUTH
+  execute_sed "s/8080 #--controlPlaneAuthPolicy/15005/" $ISTIO_AUTH
   execute_sed "s/envoy_mixer.json/envoy_mixer_auth.json/" $ISTIO_AUTH
   execute_sed "s/envoy_pilot.json/envoy_pilot_auth.json/" $ISTIO_AUTH
 
@@ -186,6 +187,7 @@ function merge_files() {
   execute_sed "s/# authPolicy: MUTUAL_TLS/authPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/# controlPlaneAuthPolicy: MUTUAL_TLS/controlPlaneAuthPolicy: MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/NONE #--controlPlaneAuthPolicy/MUTUAL_TLS/" $ISTIO_ONE_NAMESPACE_AUTH
+  execute_sed "s/8080 #--controlPlaneAuthPolicy/15005/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/envoy_mixer.json/envoy_mixer_auth.json/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/envoy_pilot.json/envoy_pilot_auth.json/" $ISTIO_ONE_NAMESPACE_AUTH
 


### PR DESCRIPTION
Partially fixes https://github.com/istio/istio/issues/3757.
Pilot starts without cert ready in auth tests caused Envoy unable to connect to Pilot. This fixes the issue for prow e2e tests. Also need to fix the same issue on other tests not using istio-auth.yaml.