### PR TITLE
Compare handlers names, instead of the interfaces during routing build.

### DIFF
--- a/mixer/pkg/runtime2/routing/builder_test.go
+++ b/mixer/pkg/runtime2/routing/builder_test.go
@@ -15,8 +15,11 @@
 package routing
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/il/compiled"
@@ -67,7 +70,7 @@ ID: 1
 	},
 
 	{
-		Name:          "multiple-instances",
+		Name:          "multiple-instances-check",
 		ServiceConfig: data.ServiceConfig,
 		Configs: []string{
 			data.HandlerACheck1,
@@ -89,7 +92,29 @@ ID: 1
 	},
 
 	{
-		Name:          "instance-with-conditional",
+		Name:          "multiple-instances-report",
+		ServiceConfig: data.ServiceConfig,
+		Configs: []string{
+			data.HandlerAReport1,
+			data.InstanceReport1,
+			data.InstanceReport2,
+			data.RuleReport1And2,
+		},
+		ExpectedTable: `
+[Routing ExpectedTable]
+ID: 1
+[#0] TEMPLATE_VARIETY_REPORT {V}
+  [#0] istio-system {NS}
+    [#0] hreport1.areport.istio-system {H}
+      [#0]
+        Condition: <NONE>
+        [#0] ireport1.treport.istio-system {I}
+        [#1] ireport2.treport.istio-system {I}
+`,
+	},
+
+	{
+		Name:          "check-instance-with-conditional",
 		ServiceConfig: data.ServiceConfig,
 		Configs: []string{
 			data.HandlerACheck1,
@@ -541,4 +566,74 @@ func buildTableWithTemplatesAndAdapters(templates map[string]*template.Info, ada
 	expb := compiled.NewBuilder(s.Attributes)
 
 	return BuildTable(ht, s, expb, "istio-system", debugInfo), s
+}
+
+func TestNonPointerAdapter(t *testing.T) {
+
+	templates := data.BuildTemplates(nil)
+
+	adapters := map[string]*adapter.Info{
+		"acheck": {
+			Name:               "acheck",
+			SupportedTemplates: []string{"tcheck", "thalt"},
+			DefaultConfig:      &types.Struct{},
+			NewBuilder: func() adapter.HandlerBuilder {
+				return nonPointerBuilder{}
+			},
+		},
+	}
+
+	globalConfigs := []string{
+		data.HandlerACheck1,
+		data.InstanceCheck1,
+		data.InstanceCheck2,
+		data.RuleCheck1WithInstance1And2,
+	}
+
+	expected := `
+[Routing ExpectedTable]
+ID: 1
+[#0] TEMPLATE_VARIETY_CHECK {V}
+  [#0] istio-system {NS}
+    [#0] hcheck1.acheck.istio-system {H}
+      [#0]
+        Condition: <NONE>
+        [#0] icheck1.tcheck.istio-system {I}
+        [#1] icheck2.tcheck.istio-system {I}
+`
+
+	table, _ := buildTableWithTemplatesAndAdapters(templates, adapters, data.ServiceConfig, globalConfigs, true)
+
+	actual := table.String()
+
+	if normalize(actual) != normalize(expected) {
+		t.Fatalf("got:\n%v\nwant:\n%v\n", actual, expected)
+	}
+}
+
+type nonPointerBuilder struct{}
+
+var _ adapter.HandlerBuilder = nonPointerBuilder{}
+
+func (n nonPointerBuilder) SetAdapterConfig(adapter.Config) {
+}
+
+func (n nonPointerBuilder) Validate() *adapter.ConfigErrors {
+	return nil
+}
+
+func (n nonPointerBuilder) Build(context.Context, adapter.Env) (adapter.Handler, error) {
+	return nonPointerHandler{fn: func() {}}, nil
+}
+
+type nonPointerHandler struct {
+	// Make handler non-comparable.
+	fn func()
+}
+
+var _ adapter.Handler = nonPointerHandler{}
+
+func (h nonPointerHandler) Close() error {
+	h.fn()
+	return nil
 }

--- a/mixer/pkg/runtime2/testing/data/data.go
+++ b/mixer/pkg/runtime2/testing/data/data.go
@@ -127,6 +127,16 @@ spec:
   foo: attr.string
 `
 
+// InstanceReport2 is a standard testing instance for template treport.
+var InstanceReport2 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: treport
+metadata:
+  name: ireport2
+  namespace: istio-system
+spec:
+`
+
 // InstanceQuota1 is a standard testing instance for template tquota.
 var InstanceQuota1 = `
 apiVersion: "config.istio.io/v1alpha2"
@@ -469,6 +479,21 @@ spec:
   - handler: hreport1.areport
     instances:
     - ireport1.treport.istio-system
+`
+
+// RuleReport1And2 is a standard testing instance config with name rreport1.
+var RuleReport1And2 = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: rreport1
+  namespace: istio-system
+spec:
+  actions:
+  - handler: hreport1.areport
+    instances:
+    - ireport1.treport.istio-system
+    - ireport2.treport.istio-system
 `
 
 // RuleQuota1 is a standard testing instance config with name rquota1. It references I1 and H1.


### PR DESCRIPTION
Comparing the interfaces are problematic, as it causes panics when the underlying type is a struct{} (and has non-comparable members). instead of &struct{}.
