### PR TITLE
Check running pods after istio and apps deployments

### DIFF
--- a/tests/e2e/framework/appManager.go
+++ b/tests/e2e/framework/appManager.go
@@ -105,6 +105,7 @@ func (am *AppManager) Setup() error {
 			return err
 		}
 	}
+	util.CheckPodsRunning(am.namespace)
 	return nil
 }
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -154,6 +154,7 @@ func (k *KubeInfo) Setup() error {
 			log.Error("Failed to deploy istio addons")
 			return err
 		}
+		util.CheckPodsRunning(k.Namespace)
 	}
 
 	var in string


### PR DESCRIPTION
Noticed that some pod were not running when the test started. Let's see if that helps. In a different PR I would like to start using timeout context in all the function that wait to cleanup the code, to expand what @ayj started. 