### PR TITLE
fix readme example to show how to add jaeger

### DIFF
--- a/install/ansible/README.md
+++ b/install/ansible/README.md
@@ -60,7 +60,7 @@ The full list of configurable parameters is as follows:
 
 An example of an invocation where we want to deploy Jaeger instead of Zipkin would be:
 ```bash
-ansible-playbook main.yml -e '{"istio": {"jaeger": true}}'
+ansible-playbook main.yml -e '{"istio": {"addon": ["grafana","prometheus","jaeger","servicegraph"]}}'
 ```
 
 


### PR DESCRIPTION
This is simply a change to README.md - no code changes at all.
This addresses issue #4044 