### PR TITLE
Add e2e tests for Mixer Dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,3 +650,6 @@ workflows:
       - e2e-simple:
           requires:
             - build
+      - e2e-dashboard:
+          requires:
+            - build

--- a/addons/grafana/dashboards/mixer-dashboard.json
+++ b/addons/grafana/dashboards/mixer-dashboard.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "__requires": [
     {
       "type": "grafana",
@@ -42,30 +52,16 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1518735819202,
+  "iteration": 1520470122238,
   "links": [],
   "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 37,
-      "panels": [],
-      "repeat": null,
-      "title": "Resource Usage",
-      "type": "row"
-    },
     {
       "content": "<center><h2>Resource Usage</h2></center>",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "height": "40",
       "id": 29,
@@ -76,31 +72,17 @@
       "type": "text"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 4
-      },
-      "id": 38,
-      "panels": [],
-      "repeat": null,
-      "title": "Resource Usage",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 5
+        "y": 3
       },
       "id": 5,
       "legend": {
@@ -236,13 +218,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 5
+        "y": 3
       },
       "id": 6,
       "legend": {
@@ -333,13 +315,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 5
+        "y": 3
       },
       "id": 7,
       "legend": {
@@ -424,13 +406,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 5
+        "y": 3
       },
       "id": 4,
       "legend": {
@@ -500,26 +482,12 @@
       ]
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 12
-      },
-      "id": 39,
-      "panels": [],
-      "repeat": null,
-      "title": "Mixer Overview",
-      "type": "row"
-    },
-    {
       "content": "<center><h2>Mixer Overview</h2></center>",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 10
       },
       "height": "40px",
       "id": 30,
@@ -530,31 +498,17 @@
       "type": "text"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "id": 40,
-      "panels": [],
-      "repeat": null,
-      "title": "Dashboard Row",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 17
+        "y": 13
       },
       "id": 9,
       "legend": {
@@ -580,24 +534,32 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(envoy_cluster_mixer_server_upstream_rq_total[1m])",
+          "expr": "rate(envoy_cluster_mixer_check_server_upstream_rq_total[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "envoy",
+          "legendFormat": "envoy (Check)",
           "refId": "A"
+        },
+        {
+          "expr": "rate(envoy_cluster_mixer_report_server_upstream_rq_total[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "envoy (Report)",
+          "refId": "D"
         },
         {
           "expr": "sum(rate(grpc_server_handled_total[1m]))",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "mixer",
+          "legendFormat": "mixer (Total)",
           "refId": "B"
         },
         {
           "expr": "rate(grpc_server_handled_total[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "mixer {{ grpc_method }}",
+          "legendFormat": "mixer ({{ grpc_method }})",
           "refId": "C"
         }
       ],
@@ -642,13 +604,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 17
+        "y": 13
       },
       "id": 8,
       "legend": {
@@ -679,11 +641,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "envoy_cluster_mixer_server_upstream_rq_time",
+          "expr": "envoy_cluster_mixer_check_server_upstream_rq_time",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ quantile }} (envoy)",
+          "legendFormat": "{{ quantile }} (envoy Check)",
           "refId": "A"
+        },
+        {
+          "expr": "envoy_cluster_mixer_report_server_upstream_rq_time",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ quantile }} (envoy Report)",
+          "refId": "E"
         },
         {
           "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{}[1m])) by (grpc_method, le)) * 1000",
@@ -748,13 +717,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 17
+        "y": 13
       },
       "id": 11,
       "legend": {
@@ -780,11 +749,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(envoy_cluster_mixer_server_upstream_rq_5xx[1m])",
+          "expr": "rate(envoy_cluster_mixer_check_server_upstream_rq_5xx[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "5xx (envoy)",
+          "legendFormat": "Envoy Check",
           "refId": "A"
+        },
+        {
+          "expr": "rate(envoy_cluster_mixer_report_server_upstream_rq_5xx[1m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Envoy Report",
+          "refId": "C"
         },
         {
           "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|Unimplemented|Internal|DataLoss\"}[1m])) by (grpc_method)",
@@ -835,13 +811,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 17
+        "y": 13
       },
       "id": 12,
       "legend": {
@@ -867,17 +843,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(envoy_cluster_mixer_server_upstream_rq_4xx[1m])",
+          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_4xx[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "envoy",
+          "legendFormat": "Envoy Check",
           "refId": "A"
         },
         {
-          "expr": "sum(irate(grpc_server_handled_total{grpc_code!=\"OK\",grpc_service=~\".*Mixer\"}[1m]))",
+          "expr": "irate(envoy_cluster_mixer_report_server_upstream_rq_4xx[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "mixer grpc",
+          "legendFormat": "Envoy Report",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(irate(grpc_server_handled_total{grpc_code!=\"OK\",grpc_service=~\".*Mixer\"}[1m])) by (grpc_method)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Mixer {{ grpc_method }}",
           "refId": "B"
         }
       ],
@@ -918,31 +901,17 @@
       ]
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 41,
-      "panels": [],
-      "repeat": null,
-      "title": "Dashboard Row",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 24
+        "y": 19
       },
       "id": 10,
       "legend": {
@@ -968,11 +937,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "envoy_cluster_mixer_server_upstream_cx_active",
+          "expr": "envoy_cluster_mixer_check_server_upstream_cx_active",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Active  (envoy)",
+          "legendFormat": "Active  (mixer_check_server)",
           "refId": "B"
+        },
+        {
+          "expr": "envoy_cluster_mixer_report_server_upstream_cx_active",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Active  (mixer_report_server)",
+          "refId": "A"
         }
       ],
       "thresholds": [],
@@ -1016,13 +992,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 24
+        "y": 19
       },
       "id": 1,
       "legend": {
@@ -1048,20 +1024,36 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "envoy_cluster_mixer_server_membership_healthy",
+          "expr": "envoy_cluster_mixer_check_server_membership_healthy",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "Healthy",
+          "legendFormat": "Healthy (mixer_check_server)",
           "refId": "A"
         },
         {
-          "expr": "envoy_cluster_mixer_server_membership_total",
+          "expr": "envoy_cluster_mixer_check_server_membership_total",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "Total",
+          "legendFormat": "Total (mixer_check_server)",
           "refId": "B"
+        },
+        {
+          "expr": "envoy_cluster_mixer_report_server_membership_healthy",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Healthy (mixer_report_server)",
+          "refId": "C"
+        },
+        {
+          "expr": "envoy_cluster_mixer_report_server_membership_total",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Total (mixer_report_server)",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -1105,13 +1097,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 24
+        "y": 19
       },
       "id": 35,
       "legend": {
@@ -1137,28 +1129,52 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(envoy_cluster_mixer_server_outlier_detection_ejections_enforced_total[1m])",
+          "expr": "rate(envoy_cluster_mixer_check_server_outlier_detection_ejections_enforced_total[1m])",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "Total Ejections",
+          "legendFormat": "Total Ejections (mixer_check_server)",
           "refId": "A"
         },
         {
-          "expr": "rate(envoy_cluster_mixer_server_outlier_detection_ejections_overflow[1m])",
+          "expr": "rate(envoy_cluster_mixer_check_server_outlier_detection_ejections_overflow[1m])",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "Overflow Ejections",
+          "legendFormat": "Overflow Ejections (mixer_check_server)",
           "refId": "B"
         },
         {
-          "expr": "envoy_cluster_mixer_server_outlier_detection_ejections_active",
+          "expr": "envoy_cluster_mixer_check_server_outlier_detection_ejections_active",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "Active Ejections",
+          "legendFormat": "Active Ejections (mixer_check_server)",
           "refId": "C"
+        },
+        {
+          "expr": "rate(envoy_cluster_mixer_report_server_outlier_detection_ejections_enforced_total[1m])",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "Total Ejections (mixer_report_server)",
+          "refId": "D"
+        },
+        {
+          "expr": "rate(envoy_cluster_mixer_report_server_outlier_detection_ejections_overflow[1m])",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "Overflow Ejections (mixer_report_server)",
+          "refId": "E"
+        },
+        {
+          "expr": "envoy_cluster_mixer_report_server_outlier_detection_ejections_active",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "Active Ejections (mixer_report_server)",
+          "refId": "F"
         }
       ],
       "thresholds": [],
@@ -1202,13 +1218,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 24
+        "y": 19
       },
       "id": 36,
       "legend": {
@@ -1234,24 +1250,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(envoy_cluster_mixer_server_upstream_rq_retry[1m])",
+          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Total",
+          "legendFormat": "Total (mixer_check_server)",
           "refId": "A"
         },
         {
-          "expr": "irate(envoy_cluster_mixer_server_upstream_rq_retry_success[1m])",
+          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry_success[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Success",
+          "legendFormat": "Success  (mixer_check_server)",
           "refId": "B"
         },
         {
-          "expr": "irate(envoy_cluster_mixer_server_upstream_rq_retry_overflow[1m])",
+          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry_overflow[1m])",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Overflow",
+          "legendFormat": "Overflow  (mixer_check_server)",
           "refId": "C"
         }
       ],
@@ -1292,26 +1308,12 @@
       ]
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 31
-      },
-      "id": 42,
-      "panels": [],
-      "repeat": null,
-      "title": "Adapters and Config",
-      "type": "row"
-    },
-    {
       "content": "<center><h2>Adapters and Config</h2></center>",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 26
       },
       "id": 28,
       "links": [],
@@ -1321,31 +1323,17 @@
       "type": "text"
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 43,
-      "panels": [],
-      "repeat": null,
-      "title": "Adapter Overview",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 29
       },
       "id": 13,
       "legend": {
@@ -1371,7 +1359,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(mixer_adapter_dispatch_count{adapter=~\"$adapter\"}[1m])) by (adapter)",
+          "expr": "sum(irate(mixer_runtime_dispatch_count{adapter=~\"$adapter\"}[1m])) by (adapter)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ adapter }}",
@@ -1419,13 +1407,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 29
       },
       "id": 14,
       "legend": {
@@ -1451,21 +1439,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
+          "expr": "histogram_quantile(0.5, sum(irate(mixer_runtime_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ adapter }} - p50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.9, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
+          "expr": "histogram_quantile(0.9, sum(irate(mixer_runtime_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ adapter }} - p90 ",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
+          "expr": "histogram_quantile(0.99, sum(irate(mixer_runtime_dispatch_duration_bucket{adapter=~\"$adapter\"}[1m])) by (adapter, le))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ adapter }} - p99",
@@ -1509,33 +1497,19 @@
       ]
     },
     {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 43
-      },
-      "id": 44,
-      "panels": [],
-      "repeat": null,
-      "title": "Config Overview",
-      "type": "row"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 12,
+        "w": 6,
         "x": 0,
-        "y": 44
+        "y": 36
       },
-      "id": 15,
+      "id": 60,
       "legend": {
         "avg": false,
         "current": false,
@@ -1559,111 +1533,38 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(mixer_config_resolve_count[1m])) by (error)",
+          "expr": "scalar(topk(1, max(mixer_config_rule_config_count) by (configID)))",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Total (error: {{ error }})",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Config Resolution Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 44
-      },
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.5, sum(irate(mixer_config_resolve_duration_bucket[1m])) by (error, le))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "p50 (error: {{ error }})",
+          "intervalFactor": 1,
+          "legendFormat": "Rules",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.9, sum(irate(mixer_config_resolve_duration_bucket[1m])) by (error, le))",
+          "expr": "scalar(topk(1, max(mixer_config_rule_config_error_count) by (configID)))",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "p90 (error: {{ error }})",
+          "intervalFactor": 1,
+          "legendFormat": "Config Errors",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(mixer_config_resolve_duration_bucket[1m])) by (error, le))",
+          "expr": "scalar(topk(1, max(mixer_config_rule_config_match_error_count) by (configID)))",
           "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "p99 (error: {{ error }})",
+          "intervalFactor": 1,
+          "legendFormat": "Match Errors",
           "refId": "C"
+        },
+        {
+          "expr": "scalar(topk(1, max(mixer_config_unsatisfied_action_handler_count) by (configID)))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Unsatisfied Actions",
+          "refId": "D"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Config Resolution Duration",
+      "title": "Rules",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1679,7 +1580,7 @@
       },
       "yaxes": [
         {
-          "format": "s",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1692,23 +1593,250 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": false
+          "show": true
         }
       ]
     },
     {
-      "collapsed": false,
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
       "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 51
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 36
       },
-      "id": 45,
-      "panels": [],
-      "repeat": null,
-      "title": "Individual Adapters",
-      "type": "row"
+      "id": 56,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "scalar(topk(1, max(mixer_config_instance_config_count) by (configID)))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Instances",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Instances in Latest Config",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 36
+      },
+      "id": 54,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "scalar(topk(1, max(mixer_config_handler_config_count) by (configID)))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Handlers",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Handlers in Latest Config",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 36
+      },
+      "id": 58,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "scalar(topk(1, max(mixer_config_attribute_count) by (configID)))",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "Attributes",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Attributes in Latest Config",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
     },
     {
       "content": "<center><h2>Individual Adapters</h2></center>",
@@ -1716,7 +1844,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 43
       },
       "id": 23,
       "links": [],
@@ -1731,7 +1859,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 46
       },
       "id": 46,
       "panels": [],
@@ -1744,13 +1872,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 47
       },
       "id": 17,
       "legend": {
@@ -1776,10 +1904,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(mixer_adapter_dispatch_count{adapter=\"$adapter\"}[1m])",
+          "expr": "label_replace(irate(mixer_runtime_dispatch_count{adapter=\"$adapter\"}[1m]),\"handler\", \"$1 ($3)\", \"handler\", \"(.*)\\\\.(.*)\\\\.(.*)\")",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{ handler }} ({{ response_code }})",
+          "legendFormat": "{{ handler }} (error: {{  error }})",
           "refId": "A"
         }
       ],
@@ -1824,13 +1952,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus",
+      "datasource": "${DS_PROMETHEUS}",
       "fill": 1,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 56
+        "y": 47
       },
       "id": 18,
       "legend": {
@@ -1856,25 +1984,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, response_code, le))",
+          "expr": "label_replace(histogram_quantile(0.5, sum(rate(mixer_runtime_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, error, le)),  \"handler_short\", \"$1 ($3)\", \"handler\", \"(.*)\\\\.(.*)\\\\.(.*)\")",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "p50 - {{ handler }} ({{ response_code }})",
+          "legendFormat": "p50 - {{ handler_short }} (error: {{ error }})",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.9, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, response_code, le))",
+          "expr": "label_replace(histogram_quantile(0.9, sum(irate(mixer_runtime_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, error, le)),  \"handler_short\", \"$1 ($3)\", \"handler\", \"(.*)\\\\.(.*)\\\\.(.*)\")",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "p90 - {{ handler }} ({{ response_code }})",
-          "refId": "B"
+          "legendFormat": "p90 - {{ handler_short }} (error: {{ error }})",
+          "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(mixer_adapter_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, response_code, le))",
+          "expr": "label_replace(histogram_quantile(0.99, sum(irate(mixer_runtime_dispatch_duration_bucket{adapter=\"$adapter\"}[1m])) by (handler, error, le)),  \"handler_short\", \"$1 ($3)\", \"handler\", \"(.*)\\\\.(.*)\\\\.(.*)\")",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "p99 - {{ handler }} ({{ response_code }})",
-          "refId": "C"
+          "legendFormat": "p99 - {{ handler_short }} (error: {{ error }})",
+          "refId": "E"
         }
       ],
       "thresholds": [],
@@ -1923,7 +2051,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "Prometheus",
+        "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
         "includeAll": true,
         "label": "Adapter",
@@ -1974,5 +2102,5 @@
   "timezone": "",
   "title": "Mixer Dashboard",
   "uid": "2",
-  "version": 1
+  "version": 9
 }

--- a/addons/grafana/dashboards/mixer-dashboard.json
+++ b/addons/grafana/dashboards/mixer-dashboard.json
@@ -76,7 +76,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -218,7 +218,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -315,7 +315,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -406,7 +406,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -502,7 +502,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -604,7 +604,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -717,7 +717,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -811,7 +811,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 6,
@@ -905,7 +905,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -992,7 +992,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1097,7 +1097,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1218,7 +1218,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1327,7 +1327,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1407,7 +1407,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1501,7 +1501,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1602,7 +1602,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1682,7 +1682,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1762,7 +1762,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1872,7 +1872,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -1952,7 +1952,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 7,
@@ -2051,7 +2051,7 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMETHEUS}",
+        "datasource": "Prometheus",
         "hide": 0,
         "includeAll": true,
         "label": "Adapter",

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -19,6 +19,7 @@ package dashboard
 import (
 	"bufio"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -323,6 +324,10 @@ func (p *promProxy) portForward(labelSelector string, localPort string, remotePo
 }
 
 func (p *promProxy) Setup() error {
+	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+		return errors.New("could not establish port-forward to prometheus: pods not running")
+	}
+
 	return p.portForward("app=prometheus", prometheusPort, prometheusPort)
 }
 
@@ -357,5 +362,5 @@ func getPodList(namespace string, selector string) ([]string, error) {
 }
 
 func allowPrometheusSync() {
-	time.Sleep(30 * time.Second)
+	time.Sleep(1 * time.Minute)
 }

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	istioDashboard = "addons/grafana/dashboards/istio-dashboard.json"
+	mixerDashboard = "addons/grafana/dashboards/mixer-dashboard.json"
 	fortioYaml     = "tests/e2e/tests/dashboard/fortio-rules.yaml"
 	netcatYaml     = "tests/e2e/tests/dashboard/netcat-rules.yaml"
 
@@ -51,6 +52,7 @@ var (
 		"$source", "istio-ingress.*",
 		"$http_destination", "echosrv.*",
 		"$destination_version", "v1.*",
+		"$adapter", "kubernetesenv",
 		`\`, "",
 	)
 
@@ -71,53 +73,53 @@ func TestMain(m *testing.M) {
 	os.Exit(tc.RunTest(m))
 }
 
-func TestIstioDashboard(t *testing.T) {
-	promAPI, err := promAPI()
-	if err != nil {
-		t.Fatalf("Could not build prometheus API client: %v", err)
+func TestDashboards(t *testing.T) {
+	// dashboards := map[string]string{"Istio": istioDashboard, "Mixer": mixerDashboard}
+
+	cases := []struct {
+		name      string
+		dashboard string
+		filter    func([]string) []string
+	}{
+		{"Istio", istioDashboard, func(queries []string) []string { return queries }},
+		{"Mixer", mixerDashboard, mixerQueryFilterFn},
 	}
 
-	t.Log("Generating TCP traffic...")
-	if err = sendTCPTrafficToCluster(t); err != nil {
-		t.Fatalf("Generating traffic failed: %v", err)
-	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			queries, err := extractQueries(testCase.dashboard)
+			if err != nil {
+				t.Fatalf("Could not extract queries from dashboard: %v", err)
+			}
 
-	t.Log("Generating HTTP traffic...")
-	_, err = sendTrafficToCluster()
-	if err != nil {
-		t.Fatalf("Generating traffic failed: %v", err)
-	}
+			queries = testCase.filter(queries)
 
-	t.Log("Sleep to allow prometheus scraping to happen...")
-	allowPrometheusSync()
+			t.Logf("For %s, checking %d queries.", testCase.name, len(queries))
 
-	queries, err := extractQueries()
-	if err != nil {
-		t.Fatalf("Could not extract queries from dashboard: %v", err)
-	}
-
-	for _, query := range queries {
-		modified := replaceGrafanaTemplates(query)
-		value, err := promAPI.Query(context.Background(), modified, time.Now())
-		if err != nil {
-			t.Errorf("Failure executing query (%s): %v", modified, err)
-		}
-		if value == nil {
-			t.Errorf("Returned value should not be nil for '%s'", modified)
-			continue
-		}
-		numSamples := 0
-		switch v := value.(type) {
-		case model.Vector:
-			numSamples = v.Len()
-		case *model.Scalar:
-			numSamples = 1
-		default:
-			t.Logf("unknown metric value type: %T", v)
-		}
-		if numSamples == 0 {
-			t.Errorf("Expected a metric value for '%s', found no samples: %#v", modified, value)
-		}
+			for _, query := range queries {
+				modified := replaceGrafanaTemplates(query)
+				value, err := tc.promAPI.Query(context.Background(), modified, time.Now())
+				if err != nil {
+					t.Errorf("Failure executing query (%s): %v", modified, err)
+				}
+				if value == nil {
+					t.Errorf("Returned value should not be nil for '%s'", modified)
+					continue
+				}
+				numSamples := 0
+				switch v := value.(type) {
+				case model.Vector:
+					numSamples = v.Len()
+				case *model.Scalar:
+					numSamples = 1
+				default:
+					t.Logf("unknown metric value type: %T", v)
+				}
+				if numSamples == 0 {
+					t.Errorf("Expected a metric value for '%s', found no samples: %#v", modified, value)
+				}
+			}
+		})
 	}
 }
 
@@ -137,7 +139,7 @@ func sendTrafficToCluster() (*fhttp.HTTPRunnerResults, error) {
 	return fhttp.RunHTTPTest(&opts)
 }
 
-func sendTCPTrafficToCluster(t *testing.T) error {
+func sendTCPTrafficToCluster() error {
 	ns := tc.Kube.Namespace
 	ncPods, err := getPodList(ns, "app=netcat-client")
 	if err != nil {
@@ -147,14 +149,13 @@ func sendTCPTrafficToCluster(t *testing.T) error {
 		return fmt.Errorf("bad number of pods returned for netcat client: %d", len(ncPods))
 	}
 	clientPod := ncPods[0]
-	res, err := util.Shell("kubectl -n %s exec %s -c netcat -- sh -c \"echo 'test' | nc -vv -w5 -vv netcat-srv 44444\"", ns, clientPod)
-	t.Logf("TCP Traffic Response: %v", res)
+	_, err = util.Shell("kubectl -n %s exec %s -c netcat -- sh -c \"echo 'test' | nc -vv -w5 -vv netcat-srv 44444\"", ns, clientPod)
 	return err
 }
 
-func extractQueries() ([]string, error) {
+func extractQueries(dashFile string) ([]string, error) {
 	var queries []string
-	dash, err := os.Open(util.GetResourcePath(istioDashboard))
+	dash, err := os.Open(util.GetResourcePath(dashFile))
 	if err != nil {
 		return queries, fmt.Errorf("could not open dashboard file: %v", err)
 	}
@@ -177,6 +178,37 @@ func replaceGrafanaTemplates(orig string) string {
 	return out
 }
 
+// There currently is no good way to inject failures into a running Mixer,
+// nor to cause Mixers to become unhealthy and drop out of cluster membership.
+// For now, we will filter out the queries related to those metrics.
+//
+// Issue: https://github.com/istio/istio/issues/4070
+func mixerQueryFilterFn(queries []string) []string {
+	filtered := make([]string, 0, len(queries))
+	for _, query := range queries {
+		if strings.Contains(query, "_rq_5xx") {
+			continue
+		}
+		if strings.Contains(query, "_rq_4xx") {
+			continue
+		}
+		if strings.Contains(query, "ejections") {
+			continue
+		}
+		if strings.Contains(query, "retry") {
+			continue
+		}
+		if strings.Contains(query, "DataLoss") {
+			continue
+		}
+		if strings.Contains(query, "grpc_code!=") {
+			continue
+		}
+		filtered = append(filtered, query)
+	}
+	return filtered
+}
+
 func promAPI() (v1.API, error) {
 	client, err := api.NewClient(api.Config{Address: fmt.Sprintf("http://localhost:%s", prometheusPort)})
 	if err != nil {
@@ -188,6 +220,7 @@ func promAPI() (v1.API, error) {
 type testConfig struct {
 	*framework.CommonConfig
 	gateway string
+	promAPI v1.API
 }
 
 func (t *testConfig) Teardown() error {
@@ -229,12 +262,29 @@ func setTestConfig() error {
 	return nil
 }
 
-func (t *testConfig) Setup() (err error) {
+func (t *testConfig) Setup() error {
 	t.gateway = "http://" + tc.Kube.Ingress
 	if !util.CheckPodsRunning(tc.Kube.Namespace) {
-		return fmt.Errorf("can't get all pods running")
+		return fmt.Errorf("could not get all pods running")
 	}
-	return
+
+	pAPI, err := promAPI()
+	if err != nil {
+		return fmt.Errorf("could not build prometheus API client: %v", err)
+	}
+	t.promAPI = pAPI
+
+	if err := sendTCPTrafficToCluster(); err != nil {
+		return fmt.Errorf("generating TCP traffic failed: %v", err)
+	}
+
+	if _, err := sendTrafficToCluster(); err != nil {
+		return fmt.Errorf("generating HTTP traffic failed: %v", err)
+	}
+
+	allowPrometheusSync()
+
+	return nil
 }
 
 type promProxy struct {

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -75,8 +75,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestDashboards(t *testing.T) {
-	// dashboards := map[string]string{"Istio": istioDashboard, "Mixer": mixerDashboard}
-
 	cases := []struct {
 		name      string
 		dashboard string
@@ -140,7 +138,7 @@ func sendTrafficToCluster() (*fhttp.HTTPRunnerResults, error) {
 	return fhttp.RunHTTPTest(&opts)
 }
 
-func sendTCPTrafficToCluster() error {
+func generateTCPInCluster() error {
 	ns := tc.Kube.Namespace
 	ncPods, err := getPodList(ns, "app=netcat-client")
 	if err != nil {
@@ -275,7 +273,7 @@ func (t *testConfig) Setup() error {
 	}
 	t.promAPI = pAPI
 
-	if err := sendTCPTrafficToCluster(); err != nil {
+	if err := generateTCPInCluster(); err != nil {
 		return fmt.Errorf("generating TCP traffic failed: %v", err)
 	}
 


### PR DESCRIPTION
This PR follows-on the PR that setup e2e testing for the Istio grafana dashboard. It
establishes a set of baseline tests that verify that some data is available for each
of the queries in the Mixer dashboard.

This work is part of the effort to move the Mixer dashboard status from dev into alpha (and
eventually beta and stable) status.

As part of this effort, the existing Mixer dashboard components that referenced the old runtime
metrics were updated to match the new runtime2 metrics, and the barely supported rows feature
of grafana were removed where applicable.

![mixerdashboard](https://user-images.githubusercontent.com/21148125/37167302-652cc3c4-22b6-11e8-960c-d94366bd10ab.png)

Fixes: #2163 