### PR TITLE
Use authentication policy to service-to-service mTLS.

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -25,11 +25,6 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-const (
-	// AuthenticationFilterName is the name for filter
-	AuthenticationFilterName = "isiot_authn"
-)
-
 // getConsolidateAuthenticationPolicy returns the authentication policy for
 // service specified by hostname and port, if defined.
 // If not, it generates and output a policy that is equivalent to the legacy flag

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -79,16 +79,6 @@ func legacyAuthenticationPolicyToPolicy(legacy meshconfig.AuthenticationPolicy) 
 	return nil
 }
 
-// isJwtMechanism returns true if the (peer) authentication method is using JWT.
-func isJwtMechanism(mechanism *authn.PeerAuthenticationMethod) bool {
-	switch mechanism.Params.(type) {
-	case *authn.PeerAuthenticationMethod_Jwt:
-		return true
-	default:
-		return false
-	}
-}
-
 // requireTLS returns true if the policy use mTLS for (peer) authentication.
 func requireTLS(policy *authn.Policy) bool {
 	if policy == nil {

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -1,0 +1,108 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AuthN filter configuration
+
+package v1
+
+import (
+	"fmt"
+
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	// AuthenticationFilterName is the name for filter
+	AuthenticationFilterName = "isiot_authn"
+)
+
+// getConsolidateAuthenticationPolicy returns the authentication policy for
+// service specified by hostname and port, if defined.
+// If not, it generates and output a policy that is equivalent to the legacy flag
+// and/or service annotation. Once these legacy flags/config deprecated,
+// this function can be placed by a call to store.AuthenticationPolicyByDestination
+// directly.
+func getConsolidateAuthenticationPolicy(mesh *meshconfig.MeshConfig, store model.IstioConfigStore, hostname string, port *model.Port) *authn.Policy {
+	config := store.AuthenticationPolicyByDestination(hostname, port)
+	if config == nil {
+		legacyPolicy := consolidateAuthPolicy(mesh, port.AuthenticationPolicy)
+		log.Debugf("No authentication policy found for  %s:%d. Fallback to legacy authentication mode %v\n",
+			hostname, port.Port, legacyPolicy)
+		return legacyAuthenticationPolicyToPolicy(legacyPolicy)
+	}
+
+	return config.Spec.(*authn.Policy)
+}
+
+// consolidateAuthPolicy returns service auth policy, if it's not INHERIT. Else,
+// returns mesh policy.
+func consolidateAuthPolicy(mesh *meshconfig.MeshConfig,
+	serviceAuthPolicy meshconfig.AuthenticationPolicy) meshconfig.AuthenticationPolicy {
+	if serviceAuthPolicy != meshconfig.AuthenticationPolicy_INHERIT {
+		return serviceAuthPolicy
+	}
+	// TODO: use AuthenticationPolicy for mesh policy and remove this conversion
+	switch mesh.AuthPolicy {
+	case meshconfig.MeshConfig_MUTUAL_TLS:
+		return meshconfig.AuthenticationPolicy_MUTUAL_TLS
+	case meshconfig.MeshConfig_NONE:
+		return meshconfig.AuthenticationPolicy_NONE
+	default:
+		// Never get here, there are no other enum value for mesh.AuthPolicy.
+		panic(fmt.Sprintf("Unknown mesh auth policy: %v\n", mesh.AuthPolicy))
+	}
+}
+
+// If input legacy is AuthenticationPolicy_MUTUAL_TLS, return a authentication policy equivalent
+// to it. Else, returns nil (implies no authentication is used)
+func legacyAuthenticationPolicyToPolicy(legacy meshconfig.AuthenticationPolicy) *authn.Policy {
+	if legacy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+		return &authn.Policy{
+			Peers: []*authn.PeerAuthenticationMethod{&authn.PeerAuthenticationMethod{
+				Params: &authn.PeerAuthenticationMethod_Mtls{}}},
+		}
+	}
+	return nil
+}
+
+// isJwtMechanism returns true if the (peer) authentication method is using JWT.
+func isJwtMechanism(mechanism *authn.PeerAuthenticationMethod) bool {
+	switch mechanism.Params.(type) {
+	case *authn.PeerAuthenticationMethod_Jwt:
+		return true
+	default:
+		return false
+	}
+}
+
+// requireTLS returns true if the policy use mTLS for (peer) authentication.
+func requireTLS(policy *authn.Policy) bool {
+	if policy == nil {
+		return false
+	}
+	if len(policy.Peers) > 0 {
+		for _, method := range policy.Peers {
+			switch method.GetParams().(type) {
+			case *authn.PeerAuthenticationMethod_Mtls:
+				return true
+			default:
+				continue
+			}
+		}
+	}
+	return false
+}

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -72,7 +72,7 @@ func consolidateAuthPolicy(mesh *meshconfig.MeshConfig,
 func legacyAuthenticationPolicyToPolicy(legacy meshconfig.AuthenticationPolicy) *authn.Policy {
 	if legacy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 		return &authn.Policy{
-			Peers: []*authn.PeerAuthenticationMethod{&authn.PeerAuthenticationMethod{
+			Peers: []*authn.PeerAuthenticationMethod{{
 				Params: &authn.PeerAuthenticationMethod_Mtls{}}},
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v1/authentication_test.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication_test.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"reflect"
+	"testing"
+
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+)
+
+func TestRequireTls(t *testing.T) {
+	cases := []struct {
+		in       authn.Policy
+		expected bool
+	}{
+		{
+			in:       authn.Policy{},
+			expected: false,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+			expected: true,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		if got := requireTLS(&c.in); got != c.expected {
+			t.Errorf("requireTLS(%v): got(%v) != want(%v)\n", c.in, got, c.expected)
+		}
+	}
+}
+
+func TestLegacyAuthenticationPolicyToPolicy(t *testing.T) {
+	cases := []struct {
+		in       meshconfig.AuthenticationPolicy
+		expected *authn.Policy
+	}{
+		{
+			in: meshconfig.AuthenticationPolicy_MUTUAL_TLS,
+			expected: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+		},
+		{
+			in:       meshconfig.AuthenticationPolicy_NONE,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		if got := legacyAuthenticationPolicyToPolicy(c.in); !reflect.DeepEqual(got, c.expected) {
+			t.Errorf("legacyAuthenticationPolicyToPolicy(%v): got(%#v) != want(%#v)\n", c.in, got, c.expected)
+		}
+	}
+}

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -298,18 +298,17 @@ func buildSidecarListenersClusters(
 		httpOutbound = BuildExternalServiceHTTPRoutes(mesh, node, proxyInstances, config, httpOutbound)
 		clusters = append(clusters, httpOutbound.Clusters()...)
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
-			mesh:                 mesh,
-			proxy:                node,
-			proxyInstances:       proxyInstances,
-			routeConfig:          nil,
-			ip:                   listenAddress,
-			port:                 int(mesh.ProxyHttpPort),
-			rds:                  RDSAll,
-			useRemoteAddress:     useRemoteAddress,
-			direction:            traceOperation,
-			outboundListener:     true,
-			store:                config,
-			authenticationPolicy: nil, /* authN policy is not needed for outbout listener */
+			mesh:             mesh,
+			proxy:            node,
+			proxyInstances:   proxyInstances,
+			routeConfig:      nil,
+			ip:               listenAddress,
+			port:             int(mesh.ProxyHttpPort),
+			rds:              RDSAll,
+			useRemoteAddress: useRemoteAddress,
+			direction:        traceOperation,
+			outboundListener: true,
+			store:            config,
 		}))
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
@@ -368,18 +367,17 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 
 // options required to build an HTTPListener
 type buildHTTPListenerOpts struct { // nolint: maligned
-	mesh                 *meshconfig.MeshConfig
-	proxy                model.Proxy
-	proxyInstances       []*model.ServiceInstance
-	routeConfig          *HTTPRouteConfig
-	ip                   string
-	port                 int
-	rds                  string
-	useRemoteAddress     bool
-	direction            string
-	outboundListener     bool
-	store                model.IstioConfigStore
-	authenticationPolicy *authn.Policy
+	mesh             *meshconfig.MeshConfig
+	proxy            model.Proxy
+	proxyInstances   []*model.ServiceInstance
+	routeConfig      *HTTPRouteConfig
+	ip               string
+	port             int
+	rds              string
+	useRemoteAddress bool
+	direction        string
+	outboundListener bool
+	store            model.IstioConfigStore
 }
 
 // buildHTTPListener constructs a listener for the network interface address and port.

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -298,17 +298,18 @@ func buildSidecarListenersClusters(
 		httpOutbound = BuildExternalServiceHTTPRoutes(mesh, node, proxyInstances, config, httpOutbound)
 		clusters = append(clusters, httpOutbound.Clusters()...)
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
-			mesh:             mesh,
-			proxy:            node,
-			proxyInstances:   proxyInstances,
-			routeConfig:      nil,
-			ip:               listenAddress,
-			port:             int(mesh.ProxyHttpPort),
-			rds:              RDSAll,
-			useRemoteAddress: useRemoteAddress,
-			direction:        traceOperation,
-			outboundListener: true,
-			store:            config,
+			mesh:                 mesh,
+			proxy:                node,
+			proxyInstances:       proxyInstances,
+			routeConfig:          nil,
+			ip:                   listenAddress,
+			port:                 int(mesh.ProxyHttpPort),
+			rds:                  RDSAll,
+			useRemoteAddress:     useRemoteAddress,
+			direction:            traceOperation,
+			outboundListener:     true,
+			store:                config,
+			authenticationPolicy: nil, /* authN policy is not needed for outbout listener */
 		}))
 		// TODO: need inbound listeners in HTTP_PROXY case, with dedicated ingress listener.
 	}
@@ -367,17 +368,18 @@ func buildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 
 // options required to build an HTTPListener
 type buildHTTPListenerOpts struct { // nolint: maligned
-	mesh             *meshconfig.MeshConfig
-	proxy            model.Proxy
-	proxyInstances   []*model.ServiceInstance
-	routeConfig      *HTTPRouteConfig
-	ip               string
-	port             int
-	rds              string
-	useRemoteAddress bool
-	direction        string
-	outboundListener bool
-	store            model.IstioConfigStore
+	mesh                 *meshconfig.MeshConfig
+	proxy                model.Proxy
+	proxyInstances       []*model.ServiceInstance
+	routeConfig          *HTTPRouteConfig
+	ip                   string
+	port                 int
+	rds                  string
+	useRemoteAddress     bool
+	direction            string
+	outboundListener     bool
+	store                model.IstioConfigStore
+	authenticationPolicy *authn.Policy
 }
 
 // buildHTTPListener constructs a listener for the network interface address and port.

--- a/pilot/pkg/proxy/envoy/v1/config_test.go
+++ b/pilot/pkg/proxy/envoy/v1/config_test.go
@@ -507,6 +507,26 @@ var (
 		meta: model.ConfigMeta{Type: model.EndUserAuthenticationPolicySpecBinding.Type, Name: "auth-spec-binding"},
 		file: "testdata/auth-spec-binding.yaml.golden",
 	}
+
+	authnPolicyNamespaceMTlsOff = fileConfig{
+		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-namespace-mtls-off"},
+		file: "testdata/authn-namespace-mtls-off.yaml.golden",
+	}
+
+	authnPolicyNamespaceMTlsOn = fileConfig{
+		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-namespace-mtls-on"},
+		file: "testdata/authn-namespace-mtls-on.yaml.golden",
+	}
+
+	authnPolicyHelloMTlsOff = fileConfig{
+		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-hello-mtls-off"},
+		file: "testdata/authn-hello-mtls-off.yaml.golden",
+	}
+
+	authnPolicyWorldMTlsOff = fileConfig{
+		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-world-mtls-on"},
+		file: "testdata/authn-world-mtls-off.yaml.golden",
+	}
 )
 
 func addConfig(r model.ConfigStore, config fileConfig, t *testing.T) {

--- a/pilot/pkg/proxy/envoy/v1/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery_test.go
@@ -343,7 +343,7 @@ func TestClusterDiscoveryWithSecurityOnByByAuthenticationPolicy(t *testing.T) {
 }
 
 func TestClusterDiscoveryWithSecurityOffByByAuthenticationPolicy(t *testing.T) {
-	// This test shows mesh config AuthPolicy will be overriden by policy. The
+	// This test shows mesh config AuthPolicy will be overridden by policy. The
 	// test will enable mTLS via mesh flag, but then disable with authn policy. The
 	// end result should be equivalent to mesh's auth policy is disable in the
 	// first place (i.e TestClusterDiscovery)

--- a/pilot/pkg/proxy/envoy/v1/policy.go
+++ b/pilot/pkg/proxy/envoy/v1/policy.go
@@ -54,7 +54,7 @@ func ApplyClusterPolicy(cluster *Cluster,
 	// where Istio auth does not apply.
 	if cluster.Type != ClusterTypeOriginalDST {
 		if !isDestinationExcludedForMTLS(cluster.ServiceName, mesh.MtlsExcludedServices) &&
-			consolidateAuthPolicy(mesh, cluster.Port.AuthenticationPolicy) == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+			requireTLS(getConsolidateAuthenticationPolicy(mesh, config, cluster.Hostname, cluster.Port)) {
 			// apply auth policies
 			ports := model.PortList{cluster.Port}.GetNames()
 			serviceAccounts := accounts.GetIstioServiceAccounts(cluster.Hostname, ports)

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-mtls-off.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-mtls-off.yaml.golden
@@ -1,0 +1,6 @@
+destinations:
+- name: hello
+  port:
+    name: "http"
+peers:
+- none: null

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-namespace-mtls-off.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-namespace-mtls-off.yaml.golden
@@ -1,0 +1,2 @@
+peers:
+- none: null

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-namespace-mtls-on.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-namespace-mtls-on.yaml.golden
@@ -1,0 +1,2 @@
+peers:
+- mtls: null

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-world-mtls-off.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-world-mtls-off.yaml.golden
@@ -1,0 +1,6 @@
+destinations:
+- name: world
+  port:
+    name: "http"
+peers:
+- none: null

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Routing tests
+
+package pilot
+
+import (
+	"fmt"
+
+	tutil "istio.io/istio/tests/e2e/tests/pilot/util"
+)
+
+type authnPolicy struct {
+	*tutil.Environment
+}
+
+func (r *authnPolicy) String() string {
+	return "authn-policy"
+}
+
+func (r *authnPolicy) Setup() error {
+	return nil
+}
+
+func (r *authnPolicy) Teardown() {}
+
+func (r *authnPolicy) Run() error {
+	// This authentication policy will:
+	// - Enable mTLS for the whole namespace.
+	// - But disable mTLS for service c (all ports) and d port 80.
+	if err := r.ApplyConfig("v1alpha1/authn-policy.yaml.tmpl", nil); err != nil {
+		return err
+	}
+	return r.makeRequests()
+}
+
+// makeRequests executes requests in pods and collects request ids per pod to check against access logs
+func (r *authnPolicy) makeRequests() error {
+	srcPods := []string{"a", "t"}
+	dstPods := []string{"b", "c", "d"}
+	funcs := make(map[string]func() tutil.Status)
+	// Given the policy, the expected behavior is:
+	// - a (with proxy) can talk to all destination that also have proxy, as mTLS will be
+	// configured matchingly between them.
+	// - t (without proxy) can NOT talk to b and d port 80 as mTLS is on for those destinations.
+	// - However, t can still talk to c and d:8080 as mTLS is off for those.
+	for _, src := range srcPods {
+		for _, dst := range dstPods {
+			for _, port := range []string{"", ":80", ":8080"} {
+				for _, domain := range []string{"", "." + r.Config.Namespace} {
+					name := fmt.Sprintf("Request from %s to %s%s%s", src, dst, domain, port)
+					funcs[name] = (func(src, dst, port, domain string) func() tutil.Status {
+						url := fmt.Sprintf("http://%s%s%s/%s", dst, domain, port, src)
+						return func() tutil.Status {
+							resp := r.ClientRequest(src, url, 1, "")
+							if src == "t" && (dst == "b" || (dst == "d" && port == ":8080")) {
+								if len(resp.ID) == 0 {
+									// t cannot talk to b nor d:80
+									return nil
+								}
+								return tutil.ErrAgain
+							}
+							// Request should return successfully (status 200)
+							if resp.IsHTTPOk() {
+								return nil
+							}
+							return tutil.ErrAgain
+						}
+					})(src, dst, port, domain)
+				}
+			}
+		}
+	}
+	return tutil.Parallel(funcs)
+}

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -128,6 +128,7 @@ func TestPilot(t *testing.T) {
 		&zipkin{Environment: env},
 		&authExclusion{Environment: env},
 		&kubernetesExternalNameServices{Environment: env},
+		&authnPolicy{Environment: env},
 	}
 
 	for _, test := range tests {

--- a/tests/e2e/tests/pilot/testdata/v1alpha1/authn-policy.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/v1alpha1/authn-policy.yaml.tmpl
@@ -1,0 +1,20 @@
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "global-enable-mtls"
+spec:
+  peers:
+  - mtls:
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "per-service-disable-mtls"
+spec:
+  destinations:
+  - name: "c"
+  - name: "d"
+    port:
+      number: 80
+  peers:
+  - none:


### PR DESCRIPTION
This is the first of the changes to start using authentication policy (CRD based). In this PR, we simply use the policy, if available, to overwrite mTLS settings that were set previously by mesh config and/or service annotation.