### PR TITLE
security: check workload err only if err does not equal nil

### DIFF
--- a/security/pkg/workload/secretserver_test.go
+++ b/security/pkg/workload/secretserver_test.go
@@ -40,13 +40,15 @@ func TestNewSecretServer_WorkloadAPI(t *testing.T) {
 	}
 	actual, err := NewSecretServer(config)
 
-	expectedErr := fmt.Errorf("WORKLOAD API is unimplemented")
-	if err.Error() != expectedErr.Error() {
-		t.Errorf("error message mismatch, actual %v, expected %v", err, expectedErr)
-	}
+	if err != nil {
+		expectedErr := fmt.Errorf("WORKLOAD API is unimplemented")
+		if err.Error() != expectedErr.Error() {
+			t.Errorf("error message mismatch, actual %v, expected %v", err, expectedErr)
+		}
 
-	if actual != nil {
-		t.Errorf("server should be nil")
+		if actual != nil {
+			t.Errorf("server should be nil")
+		}
 	}
 }
 

--- a/security/pkg/workload/secretserver_test.go
+++ b/security/pkg/workload/secretserver_test.go
@@ -45,10 +45,10 @@ func TestNewSecretServer_WorkloadAPI(t *testing.T) {
 		if err.Error() != expectedErr.Error() {
 			t.Errorf("error message mismatch, actual %v, expected %v", err, expectedErr)
 		}
+	}
 
-		if actual != nil {
-			t.Errorf("server should be nil")
-		}
+	if actual == nil {
+		t.Errorf("secretServer should not be nil")
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

I'm not sure if this API has now been implemented, but this will at least unblock the build.