### PR TITLE
Update gcsweb URL to include HTTPS

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -29,8 +29,7 @@ bugs.
 
 Every day, a new release is automatically built and made available at 
 https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/
-after it passes the automatic daily release tests. You can find more details about daily releases at
-https://github.com/istio/istio/wiki/Daily-builds.
+after it passes the automatic daily release tests. These are not meant for developer testing, but not general consumption.
 
 ## Weekly Releases
 

--- a/release/README.md
+++ b/release/README.md
@@ -27,7 +27,8 @@ bugs.
 
 ## Daily Releases
 
-Every day, a new release is automatically built and made available at http://gcsweb.istio.io/gcs/istio-prerelease/daily-build/
+Every day, a new release is automatically built and made available at 
+https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/
 after it passes the automatic daily release tests. You can find more details about daily releases at
 https://github.com/istio/istio/wiki/Daily-builds.
 

--- a/release/README.md
+++ b/release/README.md
@@ -29,7 +29,7 @@ bugs.
 
 Every day, a new release is automatically built and made available at 
 https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/
-after it passes the automatic daily release tests. These are not meant for developer testing, but not general consumption.
+after it passes the automatic daily release tests. These are meant for developer testing, but not general consumption.
 
 ## Weekly Releases
 


### PR DESCRIPTION
Update gcsweb to use HTTPS in the release process doc.

And I plan to remove https://github.com/istio/istio/wiki/Daily-builds after this is merged.