### PR TITLE
Lazily evaluate Ingress address

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+	"testing"
 	"time"
 
 	"istio.io/istio/pkg/log"
@@ -72,7 +74,9 @@ type KubeInfo struct {
 	TmpDir  string
 	yamlDir string
 
-	Ingress string
+	inglock    sync.Mutex
+	ingress    string
+	ingressErr error
 
 	localCluster     bool
 	namespaceCreated bool
@@ -156,17 +160,6 @@ func (k *KubeInfo) Setup() error {
 		}
 	}
 
-	var in string
-	if k.localCluster {
-		in, err = util.GetIngressPod(k.Namespace)
-	} else {
-		in, err = util.GetIngress(k.Namespace)
-	}
-	if err != nil {
-		return err
-	}
-	k.Ingress = in
-
 	if *withMixerValidator {
 		// Run the script to set up the certificate.
 		certGenerator := util.GetResourcePath("./install/kubernetes/webhook-create-signed-cert.sh")
@@ -176,6 +169,39 @@ func (k *KubeInfo) Setup() error {
 
 	}
 	return nil
+}
+
+// IngressOrFail lazily initialize ingress and fail test if not found.
+func (k *KubeInfo) IngressOrFail(t *testing.T) string {
+	gw, err := k.Ingress()
+	if err != nil {
+		t.Fatalf("Unable to get ingress: %v", err)
+	}
+	return gw
+}
+
+// Ingress lazily initialize ingress
+func (k *KubeInfo) Ingress() (string, error) {
+	k.inglock.Lock()
+	defer k.inglock.Unlock()
+
+	// Previously fetched ingress or failed.
+	if k.ingressErr != nil || len(k.ingress) != 0 {
+		return k.ingress, k.ingressErr
+	}
+
+	if k.localCluster {
+		k.ingress, k.ingressErr = util.GetIngressPod(k.Namespace)
+	} else {
+		k.ingress, k.ingressErr = util.GetIngress(k.Namespace)
+	}
+
+	// So far we only do http ingress
+	if len(k.ingress) > 0 {
+		k.ingress = "http://" + k.ingress
+	}
+
+	return k.ingress, k.ingressErr
 }
 
 // Teardown clean up everything created by setup

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -63,7 +63,6 @@ var (
 
 type testConfig struct {
 	*framework.CommonConfig
-	gateway  string
 	rulesDir string
 }
 
@@ -90,7 +89,6 @@ func closeResponseBody(r *http.Response) {
 }
 
 func (t *testConfig) Setup() error {
-	t.gateway = "http://" + tc.Kube.Ingress
 	//generate rule yaml files, replace "jason" with actual user
 	for _, rule := range []string{allRule, delayRule, fiftyRule, testRule, testDbRule, testMysqlRule,
 		detailsExternalServiceRouteRule, detailsExternalServiceEgressRule} {
@@ -152,7 +150,11 @@ func setUpDefaultRouting() error {
 	standby := 0
 	for i := 0; i <= testRetryTimes; i++ {
 		time.Sleep(time.Duration(standby) * time.Second)
-		resp, err := http.Get(fmt.Sprintf("%s/productpage", tc.gateway))
+		gateway, errGw := tc.Kube.Ingress()
+		if errGw != nil {
+			return errGw
+		}
+		resp, err := http.Get(fmt.Sprintf("%s/productpage", gateway))
 		if err != nil {
 			log.Infof("Error talking to productpage: %s", err)
 		} else {
@@ -207,7 +209,7 @@ func checkRoutingResponse(user, version, gateway, modelFile string) (int, error)
 }
 
 func checkHTTPResponse(user, gateway, expr string, count int) (int, error) {
-	resp, err := http.Get(fmt.Sprintf("%s/productpage", tc.gateway))
+	resp, err := http.Get(fmt.Sprintf("%s/productpage", gateway))
 	if err != nil {
 		return -1, err
 	}
@@ -282,11 +284,11 @@ func TestVersionRouting(t *testing.T) {
 	v1File := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
 	v2File := util.GetResourcePath(filepath.Join(modelDir, "productpage-test-user-v2.html"))
 
-	_, err = checkRoutingResponse(u1, "v1", tc.gateway, v1File)
+	_, err = checkRoutingResponse(u1, "v1", tc.Kube.IngressOrFail(t), v1File)
 	inspect(
 		err, fmt.Sprintf("Failed version routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s in v1", u1), t)
-	_, err = checkRoutingResponse(u2, "v2", tc.gateway, v2File)
+	_, err = checkRoutingResponse(u2, "v2", tc.Kube.IngressOrFail(t), v2File)
 	inspect(
 		err, fmt.Sprintf("Failed version routing! %s in v2", u2),
 		fmt.Sprintf("Success! Response matches with expected! %s in v2", u2), t)
@@ -305,7 +307,7 @@ func TestFaultDelay(t *testing.T) {
 		filepath.Join(modelDir, "productpage-test-user-v1-review-timeout.html"))
 	for i := 0; i < testRetryTimes; i++ {
 		duration, err := checkRoutingResponse(
-			u2, "v1-timeout", tc.gateway,
+			u2, "v1-timeout", tc.Kube.IngressOrFail(t),
 			testModel)
 		log.Infof("Get response in %d second", duration)
 		if err == nil && duration >= minDuration && duration <= maxDuration {
@@ -352,7 +354,7 @@ func TestVersionMigration(t *testing.T) {
 	for i := 0; i < testRetryTimes; i++ {
 		c1, c3 := 0, 0
 		for c := 0; c < totalShot; c++ {
-			resp, err := getWithCookie(fmt.Sprintf("%s/productpage", tc.gateway), cookies)
+			resp, err := getWithCookie(fmt.Sprintf("%s/productpage", tc.Kube.IngressOrFail(t)), cookies)
 			inspect(err, "Failed to record", "", t)
 			if resp.StatusCode != http.StatusOK {
 				log.Errorf("unexpected response status %d", resp.StatusCode)
@@ -434,7 +436,7 @@ func TestDbRoutingMongo(t *testing.T) {
 
 	respExpr := "glyphicon-star" // not great test for v2 or v3 being alive
 
-	_, err = checkHTTPResponse(u1, tc.gateway, respExpr, 10)
+	_, err = checkHTTPResponse(u1, tc.Kube.IngressOrFail(t), respExpr, 10)
 	inspect(
 		err, fmt.Sprintf("Failed database routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", respExpr), t)
@@ -452,7 +454,7 @@ func TestDbRoutingMysql(t *testing.T) {
 
 	respExpr := "glyphicon-star" // not great test for v2 or v3 being alive
 
-	_, err = checkHTTPResponse(u1, tc.gateway, respExpr, 10)
+	_, err = checkHTTPResponse(u1, tc.Kube.IngressOrFail(t), respExpr, 10)
 	inspect(
 		err, fmt.Sprintf("Failed database routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", respExpr), t)
@@ -487,7 +489,7 @@ func TestExternalDetailsService(t *testing.T) {
 
 	isbnFetchedFromExternalService := "0486424618"
 
-	_, err = checkHTTPResponse(u1, tc.gateway, isbnFetchedFromExternalService, 1)
+	_, err = checkHTTPResponse(u1, tc.Kube.IngressOrFail(t), isbnFetchedFromExternalService, 1)
 	inspect(
 		err, fmt.Sprintf("Failed external details routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", isbnFetchedFromExternalService), t)

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -69,7 +69,7 @@ const (
 
 type testConfig struct {
 	*framework.CommonConfig
-	gateway  string
+
 	rulesDir string
 }
 
@@ -87,7 +87,6 @@ func (t *testConfig) Setup() (err error) {
 		}
 	}()
 
-	t.gateway = "http://" + tc.Kube.Ingress
 	var srcBytes []byte
 	for _, rule := range rules {
 		src := util.GetResourcePath(filepath.Join(rulesDir, rule))
@@ -516,7 +515,7 @@ func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {
 
 	t.Log("Sending traffic...")
 
-	url := fmt.Sprintf("%s/productpage", tc.gateway)
+	url := fmt.Sprintf("%s/productpage", tc.Kube.IngressOrFail(t))
 
 	// run at a high enough QPS (here 10) to ensure that enough
 	// traffic is generated to trigger 429s from the 1 QPS rate limit rule
@@ -734,7 +733,13 @@ func visitProductPage(timeout time.Duration, wantStatus int, headers ...*header)
 	clnt := &http.Client{
 		Timeout: 1 * time.Minute,
 	}
-	url := tc.gateway + "/productpage"
+
+	gateway, err := tc.Kube.Ingress()
+	if err != nil {
+		return err
+	}
+
+	url := gateway + "/productpage"
 
 	for {
 		status, _, err := get(clnt, url, headers...)

--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 func TestSimpleIngress(t *testing.T) {
 	// Tests the rewrite/dropping of the /fortio/ prefix as fortio only replies
 	// with "echo debug server ..." on the /debug uri.
-	url := "http://" + tc.Kube.Ingress + "/fortio/debug"
+	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	log.Infof("Fetching '%s'", url)
 	attempts := 7 // should not take more than 1min45s to be live...
 	for i := 1; i <= attempts; i++ {

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -65,7 +65,6 @@ type testConfig struct {
 }
 
 func (t *testConfig) Setup() error {
-	t.gateway = "http://" + tc.Kube.Ingress
 	//generate rule yaml files, replace "jason" with actual user
 	for _, rule := range defaultRules {
 		src := util.GetResourcePath(filepath.Join(rulesDir, rule))
@@ -88,6 +87,13 @@ func (t *testConfig) Setup() error {
 	if !util.CheckPodsRunning(tc.Kube.Namespace) {
 		return fmt.Errorf("can't get all pods running")
 	}
+
+	gateway, errGw := tc.Kube.Ingress()
+	if errGw != nil {
+		return errGw
+	}
+
+	t.gateway = gateway
 
 	return setUpDefaultRouting()
 }
@@ -262,7 +268,12 @@ func upgradeControlPlane() error {
 	}
 	// TODO: Check control plane version.
 	// Update gateway address
-	tc.gateway = "http://" + targetConfig.Kube.Ingress
+	gateway, errGw := targetConfig.Kube.Ingress()
+	if errGw != nil {
+		return errGw
+	}
+
+	tc.gateway = gateway
 	return nil
 }
 


### PR DESCRIPTION
Ingress takes up to 2 minutes to get an address.
We could be doing other work during that time.

This PR updates code to wait for ingress address only when the code is about to use that address.