### PR TITLE
Run all tests without early exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 test: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
-	$(MAKE) pilot-test mixer-test security-test broker-test galley-test common-test \
+	$(MAKE) --keep-going pilot-test mixer-test security-test broker-test galley-test common-test \
 	|& tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 
 GOTEST_PARALLEL ?= '-test.parallel=4'

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -46,16 +46,18 @@ endif
 # If set outside, it appears it is not possible to modify the variable.
 E2E_ARGS ?=
 
-EXTRA_E2E_ARGS = ${MINIKUBE_FLAGS}
-EXTRA_E2E_ARGS += --istioctl ${ISTIO_OUT}/istioctl
-EXTRA_E2E_ARGS += --mixer_tag ${TAG}
-EXTRA_E2E_ARGS += --pilot_tag ${TAG}
-EXTRA_E2E_ARGS += --proxy_tag ${TAG}
-EXTRA_E2E_ARGS += --ca_tag ${TAG}
-EXTRA_E2E_ARGS += --mixer_hub ${HUB}
-EXTRA_E2E_ARGS += --pilot_hub ${HUB}
-EXTRA_E2E_ARGS += --proxy_hub ${HUB}
-EXTRA_E2E_ARGS += --ca_hub ${HUB}
+DEFAULT_EXTRA_E2E_ARGS = ${MINIKUBE_FLAGS}
+DEFAULT_EXTRA_E2E_ARGS += --istioctl ${ISTIO_OUT}/istioctl
+DEFAULT_EXTRA_E2E_ARGS += --mixer_tag ${TAG}
+DEFAULT_EXTRA_E2E_ARGS += --pilot_tag ${TAG}
+DEFAULT_EXTRA_E2E_ARGS += --proxy_tag ${TAG}
+DEFAULT_EXTRA_E2E_ARGS += --ca_tag ${TAG}
+DEFAULT_EXTRA_E2E_ARGS += --mixer_hub ${HUB}
+DEFAULT_EXTRA_E2E_ARGS += --pilot_hub ${HUB}
+DEFAULT_EXTRA_E2E_ARGS += --proxy_hub ${HUB}
+DEFAULT_EXTRA_E2E_ARGS += --ca_hub ${HUB}
+
+EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 
 # Simple e2e test using fortio, approx 2 min
 e2e_simple: istioctl generate_yaml
@@ -77,7 +79,7 @@ JUNIT_E2E_XML ?= $(ISTIO_OUT)/junit_e2e-all.xml
 e2e_all: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_E2E_XML))
 	set -o pipefail; \
-	$(MAKE) e2e_simple e2e_mixer e2e_bookinfo \
+	$(MAKE) --keep-going e2e_simple e2e_mixer e2e_bookinfo \
 	|& tee >($(JUNIT_REPORT) > $(JUNIT_E2E_XML))
 
 e2e_pilot: istioctl generate_yaml


### PR DESCRIPTION
After adding junit report to daily release jobs, we see similar issue encountered before such as failures masked by go-junit-report since its exit status is zero. We generate the junit report and handle issue as such in the makefile so the best approach is to call make to trigger the test. I changed `EXTRA_E2E_ARGS` to be configurable so we still have full control on the flags we use for the release.

Also ensure that we finish all the tests without stopping early on nonzero status.