### PR TITLE
Add name param to test helper function

### DIFF
--- a/pilot/pkg/config/kube/ingress/controller_test.go
+++ b/pilot/pkg/config/kube/ingress/controller_test.go
@@ -170,7 +170,7 @@ func TestConfig(t *testing.T) {
 		t.Errorf("Delete should not be allowed")
 	}
 
-	util.Eventually(ctl.HasSynced, t)
+	util.Eventually("HasSynced", ctl.HasSynced, t)
 }
 
 func TestIngressController(t *testing.T) {

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -70,7 +70,7 @@ func TestServices(t *testing.T) {
 
 	var sds model.ServiceDiscovery = ctl
 	makeService(testService, ns, cl, t)
-	util.Eventually(func() bool {
+	util.Eventually("successfully list services", func() bool {
 		out, clientErr := sds.Services()
 		if clientErr != nil {
 			return false

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -596,7 +596,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 		t.Error(err)
 	}
 
-	util.Eventually(func() bool {
+	util.Eventually("successfully set done", func() bool {
 		doneMu.Lock()
 		defer doneMu.Unlock()
 		return done
@@ -619,7 +619,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	stop := make(chan struct{})
 	defer close(stop)
 	go cache.Run(stop)
-	util.Eventually(func() bool { return cache.HasSynced() }, t)
+	util.Eventually("HasSynced", cache.HasSynced, t)
 	os, _ := cache.List(model.MockConfig.Type, namespace)
 	if len(os) != n {
 		t.Errorf("cache.List => Got %d, expected %d", len(os), n)
@@ -633,7 +633,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	}
 
 	// check again in the controller cache
-	util.Eventually(func() bool {
+	util.Eventually("no elements in cache", func() bool {
 		os, _ = cache.List(model.MockConfig.Type, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(os), 0)
 		return len(os) == 0
@@ -647,7 +647,7 @@ func CheckCacheSync(store model.ConfigStore, cache model.ConfigStoreCache, names
 	}
 
 	// check directly through the client
-	util.Eventually(func() bool {
+	util.Eventually("cache and backing store match", func() bool {
 		cs, _ := cache.List(model.MockConfig.Type, namespace)
 		os, _ := store.List(model.MockConfig.Type, namespace)
 		log.Infof("cache.List => Got %d, expected %d", len(cs), n)

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -212,7 +212,7 @@ func FetchLogs(cl kubernetes.Interface, name, namespace string, container string
 }
 
 // Eventually retries until f() returns true, or it times out in error
-func Eventually(f func() bool, t *testing.T) {
+func Eventually(name string, f func() bool, t *testing.T) {
 	interval := 64 * time.Millisecond
 	for i := 0; i < 10; i++ {
 		if f() {
@@ -222,5 +222,5 @@ func Eventually(f func() bool, t *testing.T) {
 		time.Sleep(interval)
 		interval = 2 * interval
 	}
-	t.Errorf("Failed to satisfy function")
+	t.Errorf("Failed to satisfy function %q", name)
 }

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -213,6 +213,7 @@ func FetchLogs(cl kubernetes.Interface, name, namespace string, container string
 
 // Eventually retries until f() returns true, or it times out in error
 func Eventually(name string, f func() bool, t *testing.T) {
+	t.Helper()
 	interval := 64 * time.Millisecond
 	for i := 0; i < 10; i++ {
 		if f() {


### PR DESCRIPTION
These tests fail in post-submit but it's hard to tell why, add a function name param to help identify the call site, and mark the method as a helper method so that the failure is reported in the caller instead of in this util.

Example message today:

> I0309 01:03:56.940] --- FAIL: TestControllerEvents (89.99s)
> I0309 01:03:56.940] 	kubernetes.go:225: Failed to satisfy function
> I0309 01:03:56.940] FAIL

And full failure logs: https://k8s-gubernator.appspot.com/build/istio-prow/istio-postsubmit/1116