### PR TITLE
Increase sleep time in pkg/cache tests to avoid timing related flakes

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -229,7 +229,7 @@ func testCacheEvictExpired(c ExpiringCache, t *testing.T) {
 	c.SetWithExpiration("A", "A", 1*time.Millisecond)
 
 	// this is racy, but we're being generous enough that it should be fine
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	_, ok := c.Get("A")
 	if !ok {


### PR DESCRIPTION
Bump up the time allowed to from 10ms to 50ms; this is still short, but should save us this test failing ~once a day.