### PR TITLE
Add e2e test for Pilot Dashboard

### DIFF
--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -1236,7 +1236,7 @@
           "expr": "sum(envoy_cluster_rds_membership_healthy)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "rds (healthy)",
+          "legendFormat": "Pilot (healthy)",
           "refId": "E",
           "step": 2
         },
@@ -1244,7 +1244,7 @@
           "expr": "sum(envoy_cluster_rds_membership_total)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "rds (total)",
+          "legendFormat": "Pilot (total)",
           "refId": "F",
           "step": 2
         }

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -1,4 +1,14 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
   "__requires": [
     {
       "type": "grafana",
@@ -698,6 +708,7 @@
       "targets": [
         {
           "expr": "sum(pilot_discovery_cache_size) by (cache_name)",
+          "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ cache_name }}",
           "refId": "A",
@@ -778,6 +789,7 @@
       "targets": [
         {
           "expr": "histogram_quantile(0.5, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
+          "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ method }} -  p50",
           "refId": "A",
@@ -785,6 +797,7 @@
         },
         {
           "expr": "histogram_quantile(0.9, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
+          "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ method }} -  p90",
           "refId": "B",
@@ -792,6 +805,7 @@
         },
         {
           "expr": "histogram_quantile(0.99, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
+          "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ method }} -  p99",
           "refId": "C",
@@ -1191,11 +1205,11 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 27
       },
-      "id": 1,
+      "id": 45,
       "legend": {
         "avg": false,
         "current": false,
@@ -1219,39 +1233,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "envoy_cluster_out_istio_pilot_istio_system_svc_cluster_local_http_discovery_membership_healthy",
+          "expr": "sum(envoy_cluster_rds_membership_healthy)",
           "format": "time_series",
-          "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "Discovery (Healthy)",
-          "refId": "A",
+          "legendFormat": "rds (healthy)",
+          "refId": "E",
           "step": 2
         },
         {
-          "expr": "envoy_cluster_out_istio_pilot_istio_system_svc_cluster_local_http_discovery_membership_total",
+          "expr": "sum(envoy_cluster_rds_membership_total)",
           "format": "time_series",
-          "hide": false,
           "intervalFactor": 2,
-          "legendFormat": "Discovery (Total)",
-          "refId": "B",
-          "step": 2
-        },
-        {
-          "expr": "envoy_cluster_out_istio_pilot_istio_system_svc_cluster_local_admission_webhook_membership_healthy",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Admission Webhook (Healthy)",
-          "refId": "C",
-          "step": 2
-        },
-        {
-          "expr": "envoy_cluster_out_istio_pilot_istio_system_svc_cluster_local_admission_webhook_membership_total",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Admission Webhook (Total)",
-          "refId": "D",
+          "legendFormat": "rds (total)",
+          "refId": "F",
           "step": 2
         }
       ],
@@ -1287,7 +1281,88 @@
           "logBase": 1,
           "max": null,
           "min": null,
+          "show": false
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(envoy_cluster_rds_upstream_rq_time) by (quantile)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{ quantile }}",
+          "refId": "C",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Request Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
           "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ]
     },
@@ -1343,38 +1418,58 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(envoy_cluster_cds_upstream_rq_total[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "cds",
-          "refId": "A",
-          "step": 2
+          "expr": "sum(irate(envoy_cluster_manager_cds_update_attempt[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "CDS Attempts",
+          "refId": "F"
         },
         {
-          "expr": "sum(irate(envoy_cluster_lds_upstream_rq_total[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "lds",
-          "refId": "B",
-          "step": 2
+          "expr": "sum(irate(envoy_cluster_manager_cds_update_success[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "CDS Successes",
+          "refId": "A"
         },
         {
-          "expr": "sum(irate(envoy_cluster_rds_upstream_rq_total[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "rds",
-          "refId": "C",
-          "step": 2
+          "expr": "sum(irate(envoy_listener_manager_lds_update_attempt[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "LDS Attempts",
+          "refId": "E"
         },
         {
-          "expr": "sum(irate(envoy_cluster_sds_upstream_rq_total[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "sds",
-          "refId": "D",
-          "step": 2
+          "expr": "sum(irate(envoy_listener_manager_lds_update_success[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "LDS Successes",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(irate(envoy_cluster_rds_update_attempt[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RDS Attempts",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(irate(envoy_cluster_rds_update_success[1m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "RDS Successes",
+          "refId": "I"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Requests",
+      "title": "Updates",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1444,38 +1539,34 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(envoy_cluster_cds_upstream_rq_4xx[1m]))",
+          "expr": "sum(irate(envoy_cluster_manager_cds_update_failure[1m]))",
+          "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "cds",
+          "legendFormat": "CDS",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(irate(envoy_cluster_lds_upstream_rq_4xx[1m]))",
+          "expr": "sum(irate(envoy_listener_manager_lds_update_failure[1m]))",
+          "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "lds",
+          "legendFormat": "LDS",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(irate(envoy_cluster_rds_upstream_rq_4xx[1m]))",
+          "expr": "sum(irate(envoy_cluster_rds_update_attempt[1m])) - sum(irate(envoy_cluster_rds_update_success[1m]))",
+          "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "rds",
+          "legendFormat": "RDS",
           "refId": "C",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_sds_upstream_rq_4xx[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "sds",
-          "refId": "D",
           "step": 2
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Client Errors (4xxs)",
+      "title": "Failures",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1521,427 +1612,6 @@
         "x": 16,
         "y": 37
       },
-      "id": 43,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(envoy_cluster_cds_upstream_rq_5xx[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "cds",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_lds_upstream_rq_5xx[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "lds",
-          "refId": "B",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_rds_upstream_rq_5xx[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "rds",
-          "refId": "C",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_sds_upstream_rq_5xx[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "sds",
-          "refId": "D",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Server Errors (5xxs)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 43
-      },
-      "id": 44,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_cds_upstream_rq_time) by (quantile)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "CDS Request Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 43
-      },
-      "id": 49,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_lds_upstream_rq_time) by (quantile)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "B",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "LDS Request Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 43
-      },
-      "id": 50,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_rds_upstream_rq_time) by (quantile)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "C",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "RDS Request Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 43
-      },
-      "id": 51,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_sds_upstream_rq_time) by (quantile)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "D",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "SDS Request Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
       "id": 41,
       "legend": {
         "avg": false,
@@ -1966,31 +1636,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_cds_upstream_cx_active)",
-          "intervalFactor": 2,
-          "legendFormat": "cds",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_lds_upstream_cx_active)",
-          "intervalFactor": 2,
-          "legendFormat": "lds",
-          "refId": "B",
-          "step": 2
-        },
-        {
           "expr": "sum(envoy_cluster_rds_upstream_cx_active)",
+          "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "rds",
+          "legendFormat": "Pilot (RDS)",
           "refId": "C",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_sds_upstream_cx_active)",
-          "intervalFactor": 2,
-          "legendFormat": "sds",
-          "refId": "D",
           "step": 2
         }
       ],
@@ -2027,135 +1677,6 @@
           "max": null,
           "min": null,
           "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 50
-      },
-      "id": 45,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_cds_membership_healthy)",
-          "intervalFactor": 2,
-          "legendFormat": "cds (healthy)",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_cds_membership_total)",
-          "intervalFactor": 2,
-          "legendFormat": "cds (total)",
-          "refId": "B",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_lds_membership_healthy)",
-          "intervalFactor": 2,
-          "legendFormat": "lds (healthy)",
-          "refId": "C",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_lds_membership_total)",
-          "intervalFactor": 2,
-          "legendFormat": "lds (total)",
-          "refId": "D",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_rds_membership_healthy)",
-          "intervalFactor": 2,
-          "legendFormat": "rds (healthy)",
-          "refId": "E",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_rds_membership_total)",
-          "intervalFactor": 2,
-          "legendFormat": "rds (total)",
-          "refId": "F",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_sds_membership_healthy)",
-          "intervalFactor": 2,
-          "legendFormat": "sds (healthy)",
-          "refId": "G",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_sds_membership_total)",
-          "intervalFactor": 2,
-          "legendFormat": "sds (total)",
-          "refId": "H",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Cluster Membership",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
         }
       ]
     }
@@ -2199,5 +1720,5 @@
   "timezone": "browser",
   "title": "Pilot Dashboard",
   "uid": "3",
-  "version": 1
+  "version": 2
 }

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -41,6 +41,7 @@ import (
 const (
 	istioDashboard = "addons/grafana/dashboards/istio-dashboard.json"
 	mixerDashboard = "addons/grafana/dashboards/mixer-dashboard.json"
+	pilotDashboard = "addons/grafana/dashboards/pilot-dashboard.json"
 	fortioYaml     = "tests/e2e/tests/dashboard/fortio-rules.yaml"
 	netcatYaml     = "tests/e2e/tests/dashboard/netcat-rules.yaml"
 
@@ -82,6 +83,7 @@ func TestDashboards(t *testing.T) {
 	}{
 		{"Istio", istioDashboard, func(queries []string) []string { return queries }},
 		{"Mixer", mixerDashboard, mixerQueryFilterFn},
+		{"Pilot", pilotDashboard, pilotQueryFilterFn},
 	}
 
 	for _, testCase := range cases {
@@ -201,6 +203,28 @@ func mixerQueryFilterFn(queries []string) []string {
 			continue
 		}
 		if strings.Contains(query, "grpc_code!=") {
+			continue
+		}
+		filtered = append(filtered, query)
+	}
+	return filtered
+}
+
+// There currently is no good way to inject failures into a running Pilot,
+// nor to cause Pilots to become unhealthy and drop out of cluster membership.
+// For now, we will filter out the queries related to those metrics.
+//
+// Issue: https://github.com/istio/istio/issues/4155
+func pilotQueryFilterFn(queries []string) []string {
+	filtered := make([]string, 0, len(queries))
+	for _, query := range queries {
+		if strings.Contains(query, "_rq_5xx") {
+			continue
+		}
+		if strings.Contains(query, "_rq_4xx") {
+			continue
+		}
+		if strings.Contains(query, "_membership_") {
 			continue
 		}
 		filtered = append(filtered, query)

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -55,6 +55,8 @@ var (
 		"$http_destination", "echosrv.*",
 		"$destination_version", "v1.*",
 		"$adapter", "kubernetesenv",
+		`connection_mtls=\"true\"`, "",
+		`connection_mtls=\"false\"`, "",
 		`\`, "",
 	)
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -82,7 +82,7 @@ JUNIT_E2E_XML ?= $(ISTIO_OUT)/junit_e2e-all.xml
 e2e_all: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_E2E_XML))
 	set -o pipefail; \
-	$(MAKE) --keep-going e2e_simple e2e_mixer e2e_bookinfo \
+	$(MAKE) --keep-going e2e_simple e2e_mixer e2e_bookinfo e2e_dashboard \
 	|& tee >($(JUNIT_REPORT) > $(JUNIT_E2E_XML))
 
 # Run the e2e tests, with auth enabled. A separate target is used for non-auth.


### PR DESCRIPTION
This PR adds e2e tests (in e2e_dashboard) for the Pilot grafana dashboard. This
is part of the larger effort to move these dashboards from dev versions out to
stable versions.

As part of this work, the Pilot dashboard was updated to reflect the new reality
of cluster naming, etc. (all Pilot traffic appears now in the `rds` cluster).

This PR also updates the `istio.mk` file to ensure that e2e_dashboard tests are
run in Prow as well as in CircleCI.

![pilotdash](https://user-images.githubusercontent.com/21148125/37235581-8c71ea32-23b4-11e8-99db-e15b673bc6e2.png)

Fixes: https://github.com/istio/istio/issues/4161, https://github.com/istio/istio/issues/4178