### PR TITLE
Read configMap from the good ns in shared env

### DIFF
--- a/tests/e2e/tests/pilot/util/environment.go
+++ b/tests/e2e/tests/pilot/util/environment.go
@@ -230,7 +230,7 @@ func (e *Environment) Setup() error {
 		return err
 	}
 
-	if _, e.meshConfig, err = bootstrap.GetMeshConfig(e.KubeClient, kube.IstioNamespace, kube.IstioConfigMap); err != nil {
+	if _, e.meshConfig, err = bootstrap.GetMeshConfig(e.KubeClient, e.Config.IstioNamespace, kube.IstioConfigMap); err != nil {
 		return err
 	}
 	debugMode := e.Config.DebugImagesAndMode


### PR DESCRIPTION
PR #4024 broke e2e-pilot in shared env because it read the config map from "istio-system" instead of the generated ns.