### PR TITLE
Improve generated docs for commands.

### DIFF
--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -120,6 +120,9 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 	addAttributeFlags(cc, rootArgs)
 	addAttributeFlags(rc, rootArgs)
 
+	rootArgs.tracingOptions.AttachCobraFlags(cc)
+	rootArgs.tracingOptions.AttachCobraFlags(rc)
+
 	rootCmd.AddCommand(cc)
 	rootCmd.AddCommand(rc)
 	rootCmd.AddCommand(version.CobraCommand())
@@ -128,8 +131,6 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 		Section: "mixc CLI",
 		Manual:  "Istio Mixer Client",
 	}))
-
-	rootArgs.tracingOptions.AttachCobraFlags(rootCmd)
 
 	return rootCmd
 }


### PR DESCRIPTION
- Don't output a flag table if there are no flags for a command.

- Don't output a Shorthand column in a flag table if there are no shorthands defined for the
command.

- Attach mixc's tracing flags to the check and report commands instead of at the top since
that's where they apply.