### PR TITLE
Use consul node address as a backup when filtering service instances

### DIFF
--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -163,7 +163,11 @@ func (c *Controller) GetProxyServiceInstances(node model.Proxy) ([]*model.Servic
 			return nil, err
 		}
 		for _, endpoint := range endpoints {
-			if node.IPAddress == endpoint.ServiceAddress {
+			addr := endpoint.ServiceAddress
+			if addr == "" {
+				addr = endpoint.Address
+			}
+			if node.IPAddress == addr {
 				out = append(out, convertInstance(endpoint))
 			}
 		}


### PR DESCRIPTION
Otherwise, when `ServiceAddress` is not specified during consul registration (which is valid use case), istio fails to find any services for the node.