### PR TITLE
Move package node_agent_k8s/nodeagentmgmt to node_agent/management.

### DIFF
--- a/security/cmd/flexvolume/driver/driver.go
+++ b/security/cmd/flexvolume/driver/driver.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
-	nagent "istio.io/istio/security/cmd/node_agent_k8s/nodeagentmgmt"
+	nagent "istio.io/istio/security/cmd/node_agent/management"
 	pb "istio.io/istio/security/proto"
 )
 

--- a/security/cmd/node_agent/management/client.go
+++ b/security/cmd/node_agent/management/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodeagentmgmt
+package management
 
 import (
 	"net"

--- a/security/cmd/node_agent/management/client_test.go
+++ b/security/cmd/node_agent/management/client_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodeagentmgmt
+package management
 
 import (
 	"net"

--- a/security/cmd/node_agent/management/server.go
+++ b/security/cmd/node_agent/management/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodeagentmgmt
+package management
 
 import (
 	"net"

--- a/security/cmd/node_agent/management/server_test.go
+++ b/security/cmd/node_agent/management/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodeagentmgmt
+package management
 
 import (
 	"testing"

--- a/security/cmd/node_agent_k8s/nodeagent/main.go
+++ b/security/cmd/node_agent_k8s/nodeagent/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	mwi "istio.io/istio/security/cmd/node_agent_k8s/mgmtwlhintf"
-	nam "istio.io/istio/security/cmd/node_agent_k8s/nodeagentmgmt"
+	nam "istio.io/istio/security/cmd/node_agent/management"
 	wlapi "istio.io/istio/security/cmd/node_agent_k8s/workloadapi"
 	wlh "istio.io/istio/security/cmd/node_agent_k8s/workloadhandler"
 )

--- a/security/cmd/node_agent_k8s/nodeagent/main.go
+++ b/security/cmd/node_agent_k8s/nodeagent/main.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	mwi "istio.io/istio/security/cmd/node_agent_k8s/mgmtwlhintf"
 	nam "istio.io/istio/security/cmd/node_agent/management"
+	mwi "istio.io/istio/security/cmd/node_agent_k8s/mgmtwlhintf"
 	wlapi "istio.io/istio/security/cmd/node_agent_k8s/workloadapi"
 	wlh "istio.io/istio/security/cmd/node_agent_k8s/workloadhandler"
 )


### PR DESCRIPTION
The next step is to use the same package to implement --platform="k8s" case. For more details, see #4190 