### PR TITLE
Again tee messes up with the exit code

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -93,17 +93,17 @@ e2e_pilot_noauth: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} -hub ${HUB} -tag ${TAG} --skip-cleanup -mixer=true -auth=disable -use-sidecar-injector=false
 
 test/minikube/auth/e2e_simple:
-	go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=true \
+	set -o pipefail; go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=true \
 	  --skip_cleanup  -use_local_cluster -cluster_wide -test.v \
 	  ${E2E_ARGS} ${EXTRA_E2E_ARGS} \
-           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-simple.raw
+           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-simple.raw
 
 test/minikube/noauth/e2e_simple:
 	mkdir -p ${OUT_DIR}/tests
-	go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=false \
+	set -o pipefail; go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=false \
 	  --skip_cleanup  -use_local_cluster -cluster_wide -test.v \
 	  ${E2E_ARGS} ${EXTRA_E2E_ARGS} \
-           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-noauth-simple.raw
+           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-noauth-simple.raw
 
 # Target for running e2e pilot in a minikube env. Used by CI
 test/minikube/auth/e2e_pilot: istioctl
@@ -111,7 +111,7 @@ test/minikube/auth/e2e_pilot: istioctl
 	mkdir -p ${OUT_DIR}/tests
 	kubectl create ns pilot-auth-system || true
 	kubectl create ns pilot-auth-test || true
-	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
+	set -o pipefail; go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
 		--skip-cleanup --mixer=true --auth_enable=true \
 		-errorlogsdir=${OUT_DIR}/logs \
@@ -121,7 +121,7 @@ test/minikube/auth/e2e_pilot: istioctl
 		--auth_enable=true \
 		--ns pilot-auth-system \
 		-n pilot-auth-test \
-		   ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-pilot.raw
+		   ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-pilot.raw
 
 
 # Target for running e2e pilot in a minikube env. Used by CI
@@ -131,7 +131,7 @@ test/minikube/noauth/e2e_pilot: istioctl
 	# istio-system and pilot system are not compatible. Once we merge the setup it should work.
 	kubectl create ns pilot-noauth-system || true
 	kubectl create ns pilot-noauth || true
-	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
+	set -o pipefail; go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
 		--skip-cleanup --mixer=true \
 		-errorlogsdir=${OUT_DIR}/logs \
@@ -141,7 +141,7 @@ test/minikube/noauth/e2e_pilot: istioctl
 		--core-files-dir=${OUT_DIR}/logs \
         	--ns pilot-noauth-system \
         	-n pilot-noauth \
-           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-noauth-pilot.raw
+           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-noauth-pilot.raw
 
 # Target for running e2e pilot in a minikube env. Used by CI
 test/minikube/auth/e2e_pilot_alpha1: istioctl
@@ -150,7 +150,7 @@ test/minikube/auth/e2e_pilot_alpha1: istioctl
 	# istio-system and pilot system are not compatible. Once we merge the setup it should work.
 	kubectl create ns pilot-auth-system || true
 	kubectl create ns pilot-test || true
-	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
+	set -o pipefail; go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
 		--skip-cleanup --mixer=true \
 		-errorlogsdir=${OUT_DIR}/logs \
@@ -160,4 +160,4 @@ test/minikube/auth/e2e_pilot_alpha1: istioctl
 		--core-files-dir=${OUT_DIR}/logs \
         --ns pilot-auth-system \
         -n pilot-test \
-           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-pilot-v1.raw
+           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-pilot-v1.raw

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -96,14 +96,14 @@ test/minikube/auth/e2e_simple:
 	go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=true \
 	  --skip_cleanup  -use_local_cluster -cluster_wide -test.v \
 	  ${E2E_ARGS} ${EXTRA_E2E_ARGS} \
-           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-simple.raw
+           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-simple.raw
 
 test/minikube/noauth/e2e_simple:
 	mkdir -p ${OUT_DIR}/tests
 	go test -v -timeout 20m ./tests/e2e/tests/simple -args --auth_enable=false \
 	  --skip_cleanup  -use_local_cluster -cluster_wide -test.v \
 	  ${E2E_ARGS} ${EXTRA_E2E_ARGS} \
-           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-noauth-simple.raw
+           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-noauth-simple.raw
 
 # Target for running e2e pilot in a minikube env. Used by CI
 test/minikube/auth/e2e_pilot: istioctl
@@ -121,7 +121,7 @@ test/minikube/auth/e2e_pilot: istioctl
 		--auth_enable=true \
 		--ns pilot-auth-system \
 		-n pilot-auth-test \
-		   ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-pilot.raw
+		   ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-pilot.raw
 
 
 # Target for running e2e pilot in a minikube env. Used by CI
@@ -129,8 +129,8 @@ test/minikube/noauth/e2e_pilot: istioctl
 	mkdir -p ${OUT_DIR}/logs
 	mkdir -p ${OUT_DIR}/tests
 	# istio-system and pilot system are not compatible. Once we merge the setup it should work.
-	kubectl create ns pilot-system-test || true
-	kubectl create ns pilot-test || true
+	kubectl create ns pilot-noauth-system || true
+	kubectl create ns pilot-noauth || true
 	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
 		--skip-cleanup --mixer=true \
@@ -141,14 +141,14 @@ test/minikube/noauth/e2e_pilot: istioctl
 		--core-files-dir=${OUT_DIR}/logs \
         	--ns pilot-noauth-system \
         	-n pilot-noauth \
-           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-noauth-pilot.raw
+           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-noauth-pilot.raw
 
 # Target for running e2e pilot in a minikube env. Used by CI
 test/minikube/auth/e2e_pilot_alpha1: istioctl
 	mkdir -p ${OUT_DIR}/logs
 	mkdir -p ${OUT_DIR}/tests
 	# istio-system and pilot system are not compatible. Once we merge the setup it should work.
-	kubectl create ns pilot-system-test || true
+	kubectl create ns pilot-auth-system || true
 	kubectl create ns pilot-test || true
 	go test -test.v -timeout 20m ./tests/e2e/tests/pilot -args \
 		-hub ${HUB} -tag ${TAG} \
@@ -160,4 +160,4 @@ test/minikube/auth/e2e_pilot_alpha1: istioctl
 		--core-files-dir=${OUT_DIR}/logs \
         --ns pilot-auth-system \
         -n pilot-test \
-           ${TESTOPTS} | tee ${OUT_DIR}/tests/test-report-auth-pilot-v1.raw
+           ${TESTOPTS} > ${OUT_DIR}/tests/test-report-auth-pilot-v1.raw


### PR DESCRIPTION
This prevents the test from turning red.

Alternative is to disable the generation of the report, or find a better way to report exit status - but 
will try to do it in separate PR, for now things are really broken.