### PR TITLE
Update Grafana to 5.0.2

### DIFF
--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,4 +1,4 @@
-from grafana/grafana:5.0.2
+from grafana/grafana:5.0.4
 
 COPY grafana.ini /etc/grafana/
 COPY dashboards.yaml /etc/grafana/provisioning/dashboards/

--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,4 +1,4 @@
-from grafana/grafana:5.0.0-beta2
+from grafana/grafana:5.0.2
 
 COPY grafana.ini /etc/grafana/
 COPY dashboards.yaml /etc/grafana/provisioning/dashboards/

--- a/addons/grafana/dashboards.yaml
+++ b/addons/grafana/dashboards.yaml
@@ -1,6 +1,9 @@
+apiVersion: 1
+
+providers:
 - name: 'default'
-  org_id: 1
+  orgId: 1
   folder: ''
   type: file
   options:
-    folder: /var/lib/grafana/dashboards
+    path: /var/lib/grafana/dashboards

--- a/addons/grafana/datasources.yaml
+++ b/addons/grafana/datasources.yaml
@@ -1,3 +1,6 @@
+# config file version
+apiVersion: 1
+
 # list of datasources to insert/update depending
 # whats available in the datbase
 datasources:
@@ -8,13 +11,13 @@ datasources:
     # <string, required> access mode. direct or proxy. Required
     access: proxy
     # <int> org id. will default to org_id 1 if not specified
-    org_id: 1
+    orgId: 1
     # <string> url
     url: http://prometheus:9090
     # <bool> mark as default datasource. Max one per org
-    is_default: true
+    isDefault: true
     # <map> fields that will be converted to json and stored in json_data
-    json_data:
+    jsonData:
       timeInterval: 5s
     # <bool> allow users to edit datasources from the UI.
     editable: true


### PR DESCRIPTION
Updating from beta 5.0 to released 5.0. Also update provisioning config to v1 spec.

See http://docs.grafana.org/administration/provisioning for docs on latest provisioning config spec. There should be no noticeable changes in Grafana.