### PR TITLE
Add secret "delete" permission to Istio CA.

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/clusterrole.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["get", "watch", "list"]

--- a/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
+++ b/install/kubernetes/templates/istio-rbac-beta.yaml.tmpl
@@ -92,7 +92,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "watch", "list", "update"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["get", "watch", "list"]


### PR DESCRIPTION
Partially fixes https://github.com/istio/istio/issues/4256.
Istio CA needs the secret "delete" permission to delete the secret when the corresponding service account is deleted.