### PR TITLE
IPv6: Proxy address validation

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1222,22 +1222,21 @@ func ValidateDestinationPolicy(msg proto.Message) error {
 
 // ValidateProxyAddress checks that a network address is well-formed
 func ValidateProxyAddress(hostAddr string) error {
-	colon := strings.Index(hostAddr, ":")
-	if colon < 0 {
-		return fmt.Errorf("':' separator not found in %q, host address must be of the form <DNS name>:<port> or <IP>:<port>",
-			hostAddr)
-	}
-	port, err := strconv.Atoi(hostAddr[colon+1:])
+	host, p, err := net.SplitHostPort(hostAddr)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to split %q: %v", hostAddr, err)
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return fmt.Errorf("port (%s) is not a number: %v", p, err)
 	}
 	if err = ValidatePort(port); err != nil {
 		return err
 	}
-	host := hostAddr[:colon]
 	if err = ValidateFQDN(host); err != nil {
-		if err = ValidateIPv4Address(host); err != nil {
-			return fmt.Errorf("%q is not a valid hostname or an IPv4 address", host)
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("%q is not a valid hostname or an IP address", host)
 		}
 	}
 
@@ -1425,7 +1424,7 @@ func ValidateProxyConfig(config *meshconfig.ProxyConfig) (errs error) {
 
 	if config.StatsdUdpAddress != "" {
 		if err := ValidateProxyAddress(config.StatsdUdpAddress); err != nil {
-			errs = multierror.Append(errs, multierror.Prefix(err, "invalid statsd udp address:"))
+			errs = multierror.Append(errs, multierror.Prefix(err, fmt.Sprintf("invalid statsd udp address %q:", config.StatsdUdpAddress)))
 		}
 	}
 

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -828,13 +828,18 @@ func TestValidatePort(t *testing.T) {
 
 func TestValidateProxyAddress(t *testing.T) {
 	addresses := map[string]bool{
-		"istio-pilot:80":     true,
-		"istio-pilot":        false,
-		"isti..:80":          false,
-		"10.0.0.100:9090":    true,
-		"10.0.0.100":         false,
-		"istio-pilot:port":   false,
-		"istio-pilot:100000": false,
+		"istio-pilot:80":        true,
+		"istio-pilot":           false,
+		"isti..:80":             false,
+		"10.0.0.100:9090":       true,
+		"10.0.0.100":            false,
+		"istio-pilot:port":      false,
+		"istio-pilot:100000":    false,
+		"[2001:db8::100]:80":    true,
+		"[2001:db8::10::20]:80": false,
+		"[2001:db8::100]":       false,
+		"[2001:db8::100]:port":  false,
+		"2001:db8::100:80":      false,
 	}
 	for addr, valid := range addresses {
 		if got := ValidateProxyAddress(addr); (got == nil) != valid {


### PR DESCRIPTION
Modified logic to allow validation of IPv6 addresses, which will have the IP
address enclosed in square brackets.