### PR TITLE
WIP: Add a dockerized Api-Server based test framework for Galley

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,8 @@ jobs:
       KUBECONFIG: /go/src/istio.io/istio/.circleci/config
       ISTIO_BIN: /go/bin
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
       - run: make submodule-sync
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,8 @@ jobs:
       KUBECONFIG: /go/src/istio.io/istio/.circleci/config
     resource_class: xlarge
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
       - attach_workspace:
           at:  /go
 #      - restore_cache:

--- a/Makefile
+++ b/Makefile
@@ -404,6 +404,7 @@ istioctl-install:
 .PHONY: test localTestEnv test-bins
 
 JUNIT_REPORT := $(shell which go-junit-report 2> /dev/null || echo "${ISTIO_BIN}/go-junit-report")
+JUNIT_REPORT := $(shell which go-junit-report 2> /dev/null || echo "${ISTIO_BIN}/go-junit-report")
 
 ${ISTIO_BIN}/go-junit-report:
 	@echo "go-junit-report not found. Installing it now..."

--- a/galley/docker/testing/Dockerfile
+++ b/galley/docker/testing/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:xenial
+
+ADD init.sh /
+RUN chmod +x /init.sh
+
+ADD bin/etcd /bin/etcd
+ADD bin/kubectl /bin/kubectl
+ADD bin/kube-apiserver /bin/kube-apiserver
+
+# All the temporary data will be stored in /app.
+RUN mkdir /app
+VOLUME /app
+
+# Expose the API Server at 8080
+EXPOSE 8080
+
+CMD ["/init.sh"]

--- a/galley/docker/testing/build.sh
+++ b/galley/docker/testing/build.sh
@@ -15,8 +15,8 @@ ETCD_VER="${ETCD_VER:-v3.2.15}"
 TAG="v1"
 
 # TODO: A better location to publish the images.
-#HUB="docker.io/ozevren/galley-testing"
-HUB="gcr.io/oztest-mixer/galley-testing"
+HUB="docker.io/ozevren/galley-testing"
+#HUB="gcr.io/oztest-mixer/galley-testing"
 
 rm -rf "${SCRATCH_DIR}"
 mkdir -p "${SCRATCH_DIR}"

--- a/galley/docker/testing/build.sh
+++ b/galley/docker/testing/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+#
+# To test/run the image manually, use this command-line:
+# docker run -it --mount type=tmpfs,target=/app,tmpfs-mode=1770 --expose=8080  -p 8080:8080 <imageid>
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+SCRATCH_DIR="/tmp/galley/test/docker"
+
+K8S_VER="${K8S_VER:-v1.9.2}"
+ETCD_VER="${ETCD_VER:-v3.2.15}"
+
+# The tag is used to keep a consistent set of images, aligned with code-changes.
+TAG="v1"
+
+# TODO: A better location to publish the images.
+HUB="docker.io/ozevren/galley-testing"
+
+rm -rf "${SCRATCH_DIR}"
+mkdir -p "${SCRATCH_DIR}"
+mkdir "${SCRATCH_DIR}/bin"
+
+curl -Lo ${SCRATCH_DIR}/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubectl && chmod +x ${SCRATCH_DIR}/bin/kubectl
+curl -Lo ${SCRATCH_DIR}/bin/kube-apiserver https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kube-apiserver && chmod +x ${SCRATCH_DIR}/bin/kube-apiserver
+curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-linux-amd64.tar.gz | tar xz -O etcd-${ETCD_VER}-linux-amd64/etcd > ${SCRATCH_DIR}/bin/etcd && chmod +x ${SCRATCH_DIR}/bin/etcd
+
+cp "${SCRIPT_DIR}/Dockerfile" "${SCRATCH_DIR}/Dockerfile"
+cp "${SCRIPT_DIR}/init.sh" "${SCRATCH_DIR}/init.sh"
+
+docker build "${SCRATCH_DIR}" --tag "${TAG}"
+
+docker image push ${HUB}:${TAG}

--- a/galley/docker/testing/build.sh
+++ b/galley/docker/testing/build.sh
@@ -15,7 +15,8 @@ ETCD_VER="${ETCD_VER:-v3.2.15}"
 TAG="v1"
 
 # TODO: A better location to publish the images.
-HUB="docker.io/ozevren/galley-testing"
+#HUB="docker.io/ozevren/galley-testing"
+HUB="gcr.io/oztest-mixer/galley-testing"
 
 rm -rf "${SCRATCH_DIR}"
 mkdir -p "${SCRATCH_DIR}"
@@ -28,6 +29,6 @@ curl -L https://github.com/coreos/etcd/releases/download/${ETCD_VER}/etcd-${ETCD
 cp "${SCRIPT_DIR}/Dockerfile" "${SCRATCH_DIR}/Dockerfile"
 cp "${SCRIPT_DIR}/init.sh" "${SCRATCH_DIR}/init.sh"
 
-docker build "${SCRATCH_DIR}" --tag "${TAG}"
+docker build "${SCRATCH_DIR}" --tag "${HUB}:${TAG}"
 
 docker image push ${HUB}:${TAG}

--- a/galley/docker/testing/init.sh
+++ b/galley/docker/testing/init.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Base directory definitions
+BASE_DIR=/app
+DATA_DIR=${BASE_DIR}/data
+
+# The in-container port for the API Server to listen on. This needs to be exposed/mapped from the container.
+APISERVER_PORT=8080
+
+# Lifecycle check frequency and iterations. Even though the tests will try to do graceful cleanup of the
+# containers, there is a good chance that they won't be able to do so. We don't want the containers to linger
+# indefinitely.
+#
+# The script performs health checks at the frequency defined by LIFECYCLE_CHECK_FREQUENCY_SECS. After doing
+# this for the number of iterations defined with LIFECYCLE_CHECK_ITERATIONS, the scripts will simply exit.
+#
+LIFECYCLE_CHECK_FREQUENCY_SECS=3
+LIFECYCLE_CHECK_ITERATIONS=10
+
+mkdir -p ${DATA_DIR}
+
+# Start Etcd
+bin/etcd --data-dir "${DATA_DIR}" &
+STATUS=$?
+echo "Etcd status: ${STATUS}"
+if [[ "${STATUS}" -ne 0 ]]; then
+  echo "Failed to start etcd: ${STATUS}"
+  exit "${STATUS}"
+fi
+
+# Start Api Server
+/bin/kube-apiserver --etcd-servers http://127.0.0.1:2379 \
+        --insecure-port "${APISERVER_PORT}" \
+        -v 2 \
+        --insecure-bind-address 0.0.0.0 &
+STATUS=$?
+echo "Api Server status: ${STATUS}"
+if [[ "${STATUS}" -ne 0 ]]; then
+  echo "Failed to start api server: ${STATUS}"
+  exit "${STATUS}"
+fi
+
+ITERATION="0"
+
+while sleep "${LIFECYCLE_CHECK_FREQUENCY}"; do
+  ps aux |grep etcd |grep -q -v grep
+  PROCESS_1_STATUS=$?
+  ps aux |grep kube-apiserver |grep -q -v grep
+  PROCESS_2_STATUS=$?
+
+  # If the greps above find anything, they exit with 0 status
+  # If they are not both 0, then something is wrong
+  if [ $PROCESS_1_STATUS -ne 0 -o $PROCESS_2_STATUS -ne 0 ]; then
+    echo "One of the processes has already exited."
+    exit 1
+  fi
+
+  # Don't run indefinitely. Exit after a set number of iterations.
+  if [ "${ITERATION}" -eq "${LIFECYCLE_CHECK_ITERATIONS}" ]; then
+    exit 2
+  fi
+
+  echo "Completed iteration: ${ITERATION}"
+  let ITERATION++
+
+done
+

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	//apiServerRepository = "docker.io/ozevren/galley-testing"
-	apiServerRepository = "gcr.io/oztest-mixer/galley-testing"
+	apiServerRepository = "docker.io/ozevren/galley-testing"
+	//apiServerRepository = "gcr.io/oztest-mixer/galley-testing"
 	apiServerTag        = "v1"
 	connectionRetries   = 10
 	retryBackoff        = time.Second * 3
@@ -48,6 +48,15 @@ func InitAPIServer() (err error) {
 	defer lock.Unlock()
 
 	if singleton != nil {
+		return
+	}
+
+	cmd := exec.Command(
+		"docker",
+		"pull",
+		apiServerRepository + ":" + apiServerTag)
+	if err = cmd.Run(); err != nil {
+		log.Errorf("Unable to pull docker image: %v", err)
 		return
 	}
 

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -1,0 +1,157 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"sync"
+
+	"gopkg.in/ory-am/dockertest.v3"
+	"istio.io/istio/pkg/log"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+)
+
+const (
+	apiServerRepository = "docker.io/ozevren/galley-testing"
+	apiServerTag        = "v1"
+	apiServerPort       = "8080/tcp"
+)
+
+var singleton *apiServer
+var lock sync.Mutex
+
+// InitApiServer starts a container with API server. The handle is kept in a package-internal singleton.
+// This should be called from a test main to do one-time initialization of the API Server.
+func InitApiServer() (err error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if singleton != nil {
+		return
+	}
+
+	if singleton, err = newApiServer(); err != nil {
+		singleton = nil
+	}
+
+	return
+}
+
+// ShutdownApiServer gracefully cleans up the container with the API server. The container is resilient
+// to non-graceful terminations: it will self-terminate eventually.
+func ShutdownApiServer() (err error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if singleton == nil {
+		return
+	}
+
+	err = singleton.close()
+	singleton = nil
+	return
+}
+
+// GetBaseApiServerConfig returns a base configuration that can be used to connect to the API server that
+// is running within the container.
+func GetBaseApiServerConfig() *rest.Config {
+	lock.Lock()
+	defer lock.Unlock()
+
+	if singleton == nil {
+		return nil
+	}
+
+	return rest.CopyConfig(singleton.baseConfig)
+}
+
+// apiServer represents a Kubernetes Api Server that is launched within a container.
+type apiServer struct {
+	dockerPool *dockertest.Pool
+	container  *dockertest.Resource
+	baseConfig *rest.Config
+}
+
+// newApiServer returns a new apiServer instance.
+func newApiServer() (*apiServer, error) {
+
+	// uses a sensible default on windows (tcp/http) and linux/osx (socket)
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Errorf("Could not connect to docker: %s", err)
+		return nil, err
+	}
+
+	// pulls an image, creates a container based on it and runs it
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: apiServerRepository,
+		Tag: apiServerTag,
+	})
+	if err != nil {
+		log.Errorf("Could not start container: %s", err)
+		return nil, err
+	}
+
+	port := container.GetPort(apiServerPort)
+	log.Debugf("apiServer container port is: %s", port)
+
+	baseConfig := &rest.Config{
+		APIPath:       "/apis",
+		ContentConfig: rest.ContentConfig{ContentType: runtime.ContentTypeJSON},
+		Host:          "localhost:" + port,
+	}
+
+	err = pool.Retry(func() error {
+		log.Debugf("Attempting to connect to the apiServer...")
+
+		// Try connecting to the custom resource definitions.
+		var client *v1beta1.ApiextensionsV1beta1Client
+		if client, err = v1beta1.NewForConfig(baseConfig); err != nil {
+			log.Debugf("apiServer connection failure: %v", err)
+			return err
+		}
+
+		if _, err = client.CustomResourceDefinitions().List(v1.ListOptions{}); err != nil {
+			log.Debugf("List CustomResourceDefinitions failure: %v", err)
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		log.Errorf("Could not connect to docker: %s", err)
+		return nil, err
+	}
+
+	return &apiServer{
+		dockerPool: pool,
+		container:  container,
+		baseConfig: baseConfig,
+	}, nil
+}
+
+// Close purges the container from docker.
+func (s *apiServer) close() error {
+	if err := s.dockerPool.Purge(s.container); err != nil {
+		log.Errorf("Could not purge resource: %s", err)
+		return err
+	}
+
+	return nil
+}

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -116,6 +116,12 @@ func newApiServer() (*apiServer, error) {
 		Host:          "localhost:" + port,
 	}
 
+	s := &apiServer{
+		dockerPool: pool,
+		container:  container,
+		baseConfig: baseConfig,
+	}
+
 	err = pool.Retry(func() error {
 		log.Debugf("Attempting to connect to the apiServer...")
 
@@ -135,15 +141,12 @@ func newApiServer() (*apiServer, error) {
 	})
 
 	if err != nil {
+		_ = s.close() // retry error takes precedence
 		log.Errorf("Could not connect to docker: %s", err)
 		return nil, err
 	}
 
-	return &apiServer{
-		dockerPool: pool,
-		container:  container,
-		baseConfig: baseConfig,
-	}, nil
+	return s, nil
 }
 
 // Close purges the container from docker.

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -127,7 +127,7 @@ func newAPIServer() (s *apiServer, err error) {
 		Publish: "8080",
 		Image:   apiServerRepository + ":" + apiServerTag,
 	}); err != nil {
-		log.Errorf("Could not start docker: vs", err)
+		log.Errorf("Could not start docker: %v", err)
 		return nil, err
 	}
 

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -15,6 +15,7 @@
 package testing
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -111,7 +112,8 @@ func newAPIServer() (*apiServer, error) {
 		"--expose=8080", "-p", "8080:"+localPort,
 		apiServerRepository+":"+apiServerTag)
 
-	if b, err := cmd.Output(); err != nil {
+	var b []byte
+	if b, err = cmd.Output(); err != nil {
 		stderr := ""
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			stderr = string(exitErr.Stderr)

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -15,7 +15,6 @@
 package testing
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -32,7 +31,8 @@ import (
 )
 
 const (
-	apiServerRepository = "docker.io/ozevren/galley-testing"
+	//apiServerRepository = "docker.io/ozevren/galley-testing"
+	apiServerRepository = "gcr.io/oztest-mixer/galley-testing"
 	apiServerTag        = "v1"
 	connectionRetries   = 10
 	retryBackoff        = time.Second * 3

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/log"
+
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-
-	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 )
 
 const (
@@ -39,15 +39,9 @@ const (
 var singleton *apiServer
 var lock sync.Mutex
 
-func init() {
-	o := log.DefaultOptions()
-	o.SetOutputLevel(log.DebugLevel)
-	log.Configure(o)
-}
-
-// InitApiServer starts a container with API server. The handle is kept in a package-internal singleton.
+// InitAPIServer starts a container with API server. The handle is kept in a package-internal singleton.
 // This should be called from a test main to do one-time initialization of the API Server.
-func InitApiServer() (err error) {
+func InitAPIServer() (err error) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -55,16 +49,16 @@ func InitApiServer() (err error) {
 		return
 	}
 
-	if singleton, err = newApiServer(); err != nil {
+	if singleton, err = newAPIServer(); err != nil {
 		singleton = nil
 	}
 
 	return
 }
 
-// ShutdownApiServer gracefully cleans up the container with the API server. The container is resilient
+// ShutdownAPIServer gracefully cleans up the container with the API server. The container is resilient
 // to non-graceful terminations: it will self-terminate eventually.
-func ShutdownApiServer() (err error) {
+func ShutdownAPIServer() (err error) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -77,9 +71,9 @@ func ShutdownApiServer() (err error) {
 	return
 }
 
-// GetBaseApiServerConfig returns a base configuration that can be used to connect to the API server that
+// GetBaseAPIServerConfig returns a base configuration that can be used to connect to the API server that
 // is running within the container.
-func GetBaseApiServerConfig() *rest.Config {
+func GetBaseAPIServerConfig() *rest.Config {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -96,8 +90,8 @@ type apiServer struct {
 	baseConfig    *rest.Config
 }
 
-// newApiServer returns a new apiServer instance.
-func newApiServer() (*apiServer, error) {
+// newAPIServer returns a new apiServer instance.
+func newAPIServer() (*apiServer, error) {
 	containerName := fmt.Sprintf("galley-testing-%d", time.Now().UnixNano())
 
 	// TODO: Auto-calculate a free local port.

--- a/galley/pkg/testing/apiserver.go
+++ b/galley/pkg/testing/apiserver.go
@@ -112,7 +112,11 @@ func newAPIServer() (*apiServer, error) {
 		apiServerRepository+":"+apiServerTag)
 
 	if b, err := cmd.Output(); err != nil {
-		log.Errorf("Could not start docker: %s\n %s", err, string(b))
+		stderr := ""
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr = string(exitErr.Stderr)
+		}
+		log.Errorf("Could not start docker: %s\n out:\n%s\nerr:\n%s\n", err, string(b), stderr)
 		return nil, err
 	}
 

--- a/galley/pkg/testing/apiserver_test.go
+++ b/galley/pkg/testing/apiserver_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func TestApiServer(t *testing.T) {
-	a, err := newApiServer()
+	a, err := newAPIServer()
 	if err != nil {
-		t.Fatalf("newApiServer error: %v", err)
+		t.Fatalf("newAPIServer error: %v", err)
 	}
 
 	if err = a.close(); err != nil {
@@ -30,57 +30,57 @@ func TestApiServer(t *testing.T) {
 }
 
 func TestSingleton(t *testing.T) {
-	cfg := GetBaseApiServerConfig()
+	cfg := GetBaseAPIServerConfig()
 	if cfg != nil {
 		t.Fatalf("non-nil base config before init")
 	}
 
-	if err := InitApiServer(); err != nil {
-		t.Fatalf("InitApiServer error: %v", err)
+	if err := InitAPIServer(); err != nil {
+		t.Fatalf("InitAPIServer error: %v", err)
 	}
 
-	if cfg = GetBaseApiServerConfig(); cfg == nil {
+	if cfg = GetBaseAPIServerConfig(); cfg == nil {
 		t.Fatalf("nil base config after init")
 	}
 
-	if err := ShutdownApiServer(); err != nil {
-		t.Fatalf("ShutdownApiServer error: %v", err)
+	if err := ShutdownAPIServer(); err != nil {
+		t.Fatalf("ShutdownAPIServer error: %v", err)
 	}
 
-	if cfg = GetBaseApiServerConfig(); cfg != nil {
+	if cfg = GetBaseAPIServerConfig(); cfg != nil {
 		t.Fatalf("non-nil base config after shutdown")
 	}
 }
 
 func TestSingleton_DoubleInit(t *testing.T) {
-	if err := InitApiServer(); err != nil {
-		t.Fatalf("InitApiServer error: %v", err)
+	if err := InitAPIServer(); err != nil {
+		t.Fatalf("InitAPIServer error: %v", err)
 	}
 
-	if err := InitApiServer(); err != nil {
-		t.Fatalf("InitApiServer error during second invocation: %v", err)
+	if err := InitAPIServer(); err != nil {
+		t.Fatalf("InitAPIServer error during second invocation: %v", err)
 	}
 
-	if err := ShutdownApiServer(); err != nil {
-		t.Fatalf("ShutdownApiServer error: %v", err)
+	if err := ShutdownAPIServer(); err != nil {
+		t.Fatalf("ShutdownAPIServer error: %v", err)
 	}
 
 	// use config as a way to check for shutdown detection.
-	if cfg := GetBaseApiServerConfig(); cfg != nil {
+	if cfg := GetBaseAPIServerConfig(); cfg != nil {
 		t.Fatalf("non-nil base config after shutdown")
 	}
 }
 
 func TestSingleton_DoubleShutdown(t *testing.T) {
-	if err := InitApiServer(); err != nil {
-		t.Fatalf("InitApiServer error: %v", err)
+	if err := InitAPIServer(); err != nil {
+		t.Fatalf("InitAPIServer error: %v", err)
 	}
 
-	if err := ShutdownApiServer(); err != nil {
-		t.Fatalf("ShutdownApiServer error: %v", err)
+	if err := ShutdownAPIServer(); err != nil {
+		t.Fatalf("ShutdownAPIServer error: %v", err)
 	}
 
-	if err := ShutdownApiServer(); err != nil {
-		t.Fatalf("ShutdownApiServer error during second invocation: %v", err)
+	if err := ShutdownAPIServer(); err != nil {
+		t.Fatalf("ShutdownAPIServer error during second invocation: %v", err)
 	}
 }

--- a/galley/pkg/testing/apiserver_test.go
+++ b/galley/pkg/testing/apiserver_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"testing"
+)
+
+func TestApiServer(t *testing.T) {
+	a, err := newApiServer()
+	if err != nil {
+		t.Fatalf("newApiServer error: %v", err)
+	}
+
+	if err = a.close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+}
+
+func TestSingleton(t *testing.T) {
+	if err := InitApiServer(); err != nil {
+		t.Fatalf("InitApiServer error: %v", err)
+	}
+
+	if err := ShutdownApiServer(); err != nil {
+		t.Fatalf("ShutdownApiServer error: %v", err)
+	}
+}

--- a/galley/pkg/testing/apiserver_test.go
+++ b/galley/pkg/testing/apiserver_test.go
@@ -71,7 +71,6 @@ func TestSingleton_DoubleInit(t *testing.T) {
 	}
 }
 
-
 func TestSingleton_DoubleShutdown(t *testing.T) {
 	if err := InitApiServer(); err != nil {
 		t.Fatalf("InitApiServer error: %v", err)

--- a/galley/pkg/testing/apiserver_test.go
+++ b/galley/pkg/testing/apiserver_test.go
@@ -30,11 +30,58 @@ func TestApiServer(t *testing.T) {
 }
 
 func TestSingleton(t *testing.T) {
+	cfg := GetBaseApiServerConfig()
+	if cfg != nil {
+		t.Fatalf("non-nil base config before init")
+	}
+
+	if err := InitApiServer(); err != nil {
+		t.Fatalf("InitApiServer error: %v", err)
+	}
+
+	if cfg = GetBaseApiServerConfig(); cfg == nil {
+		t.Fatalf("nil base config after init")
+	}
+
+	if err := ShutdownApiServer(); err != nil {
+		t.Fatalf("ShutdownApiServer error: %v", err)
+	}
+
+	if cfg = GetBaseApiServerConfig(); cfg != nil {
+		t.Fatalf("non-nil base config after shutdown")
+	}
+}
+
+func TestSingleton_DoubleInit(t *testing.T) {
+	if err := InitApiServer(); err != nil {
+		t.Fatalf("InitApiServer error: %v", err)
+	}
+
+	if err := InitApiServer(); err != nil {
+		t.Fatalf("InitApiServer error during second invocation: %v", err)
+	}
+
+	if err := ShutdownApiServer(); err != nil {
+		t.Fatalf("ShutdownApiServer error: %v", err)
+	}
+
+	// use config as a way to check for shutdown detection.
+	if cfg := GetBaseApiServerConfig(); cfg != nil {
+		t.Fatalf("non-nil base config after shutdown")
+	}
+}
+
+
+func TestSingleton_DoubleShutdown(t *testing.T) {
 	if err := InitApiServer(); err != nil {
 		t.Fatalf("InitApiServer error: %v", err)
 	}
 
 	if err := ShutdownApiServer(); err != nil {
 		t.Fatalf("ShutdownApiServer error: %v", err)
+	}
+
+	if err := ShutdownApiServer(); err != nil {
+		t.Fatalf("ShutdownApiServer error during second invocation: %v", err)
 	}
 }

--- a/galley/pkg/testing/docker/run.go
+++ b/galley/pkg/testing/docker/run.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+// RunArgs are arguments to supply to "docker run".
+type RunArgs struct {
+	Name    string
+	Mount   string
+	Expose  string
+	Publish string
+	Image   string
+}
+
+// Instance of a running "docker run" process.
+type Instance struct {
+	cmd *exec.Cmd
+}
+
+// Start a "docker run" process, with the given args.
+func Start(a RunArgs) (*Instance, error) {
+
+	if a.Image == "" {
+		return nil, errors.New("args.Image cannot be empty")
+	}
+
+	args := []string{"run"}
+
+	if a.Name != "" {
+		args = append(args, "--name="+a.Name)
+	}
+
+	if a.Mount != "" {
+		args = append(args, "--mount="+a.Mount)
+	}
+
+	if a.Expose != "" {
+		args = append(args, "--expose="+a.Expose)
+	}
+
+	if a.Publish != "" {
+		args = append(args, "--publish="+a.Publish)
+	}
+
+	args = append(args, a.Image)
+
+	c := exec.Command("docker", args...)
+
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+
+	return &Instance{c}, nil
+}
+
+// Kill a running "docker run" process.
+func (i *Instance) Kill() (out string, err error) {
+	err = i.cmd.Process.Kill()
+	i.cmd.Process.Wait()
+
+	out = (i.cmd.Stderr).(*bytes.Buffer).String()
+	return
+}

--- a/galley/pkg/testing/docker/run.go
+++ b/galley/pkg/testing/docker/run.go
@@ -18,6 +18,9 @@ import (
 	"bytes"
 	"errors"
 	"os/exec"
+	"strings"
+
+	"istio.io/istio/pkg/log"
 )
 
 // RunArgs are arguments to supply to "docker run".
@@ -71,13 +74,18 @@ func Start(a RunArgs) (*Instance, error) {
 		return nil, err
 	}
 
+	log.Infof("docker %s", strings.Join(args, " "))
+
 	return &Instance{c}, nil
 }
 
 // Kill a running "docker run" process.
 func (i *Instance) Kill() (out string, err error) {
 	err = i.cmd.Process.Kill()
-	i.cmd.Process.Wait()
+	_, err2 := i.cmd.Process.Wait()
+	if err == nil { // Kill's error takes precedence
+		err = err2
+	}
 
 	out = (i.cmd.Stderr).(*bytes.Buffer).String()
 	return

--- a/galley/pkg/testing/docker/shell.go
+++ b/galley/pkg/testing/docker/shell.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"fmt"
+	"strings"
+
+	"istio.io/istio/pilot/test/util"
+)
+
+var shell = util.Shell
+
+func dockerErr(op string, out string, err error) error {
+	return fmt.Errorf("[docker/%s] err:'%v', out: '%s'", op, out, err)
+}
+
+// Pull executes "docker pull <imageName>"
+func Pull(imageName string) error {
+	if s, err := shell(fmt.Sprintf("docker pull %s", imageName)); err != nil {
+		return dockerErr("pull", s, err)
+	}
+
+	return nil
+}
+
+// Kill executes "docker kill <containerName>"
+func Kill(containerName string) error {
+	if s, err := shell(fmt.Sprintf("docker kill %s", containerName)); err != nil {
+		return dockerErr("pull", s, err)
+	}
+
+	return nil
+}
+
+// Port executes "docker port <containerName>"
+func Port(containerName string) (s string, err error) {
+	if s, err = shell(fmt.Sprintf("docker port %s", containerName)); err != nil {
+		s = ""
+		err = dockerErr("port", s, err)
+	}
+	return
+}
+
+// GetExternalPort finds the matching external port for the given internal port.
+func GetExternalPort(containerName string, internalPort string) (string, error) {
+	ports, err := Port(containerName)
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(ports, "\n") {
+		parts := strings.Split(line, "->")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("unrecognized port line: '%s'", line)
+		}
+
+		if strings.Contains(parts[0], internalPort) {
+			idx := strings.LastIndex(parts[1], ":")
+			if idx == -1 {
+				return "", fmt.Errorf("unrecognized port line: '%s'", line)
+			}
+			return parts[1][idx+1:], nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find the port: internal:'%s', ports:'%s'", internalPort, ports)
+}


### PR DESCRIPTION
This is a framework for bringing up a dockerized ApiServer for testing purposes.

+ Introduces a Dockerfile, build scripts for creating an image that contains etcd and the ApiServer.
+ Introduce a testing framework that utilizes the local Docker daemon and the apiserver docker image to start/stop the ApiServer as part of go test flow.
+ The framework takes care of creating the appropriate rest.Config for accessing the dockerized ApiServer.

NOTE: This is work-in-progress. We need to update the vendor files to get some of the depencies checked in first. I am sending this ahead to capture early feedback.
