### PR TITLE
Fix flaky mixer/test/client tests

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -29,7 +29,7 @@ type Envoy struct {
 }
 
 // NewEnvoy creates a new Envoy struct.
-func NewEnvoy(stress, faultInject bool, v2 *V2Conf, ports *Ports) (*Envoy, error) {
+func NewEnvoy(stress, faultInject bool, v2 *V2Conf, ports *Ports, epoch int) (*Envoy, error) {
 	// Asssume test environment has copied latest envoy to $HOME/go/bin in bin/init.sh
 	envoyPath := "envoy"
 	confPath := fmt.Sprintf("/tmp/config.conf.%v", ports.AdminPort)
@@ -38,7 +38,9 @@ func NewEnvoy(stress, faultInject bool, v2 *V2Conf, ports *Ports) (*Envoy, error
 		return nil, err
 	}
 
-	args := []string{"-c", confPath, "--base-id", strconv.Itoa(int(ports.AdminPort))}
+	// Don't use hot-start, each Envoy re-start use different base-id
+	args := []string{"-c", confPath,
+		"--base-id", strconv.Itoa(int(ports.AdminPort) + epoch)}
 	if stress {
 		args = append(args, "--concurrency", "10")
 	} else {

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -146,7 +146,7 @@ func (s *TestSetup) TearDown() {
 func (s *TestSetup) ReStartEnvoy() {
 	_ = s.envoy.Stop()
 	var err error
-	s.epoch += 1
+	s.epoch++
 	s.envoy, err = NewEnvoy(s.stress, s.faultInject, s.v2, s.ports, s.epoch)
 	if err != nil {
 		s.t.Errorf("unable to re-start Envoy %v", err)

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -37,6 +37,7 @@ type TestSetup struct {
 	envoy   *Envoy
 	mixer   *MixerServer
 	backend *HTTPServer
+	epoch   int
 }
 
 // NewTestSetup creates a new test setup
@@ -107,7 +108,7 @@ func (s *TestSetup) SetFaultInject(f bool) {
 // SetUp setups Envoy, Mixer, and Backend server for test.
 func (s *TestSetup) SetUp() error {
 	var err error
-	s.envoy, err = NewEnvoy(s.stress, s.faultInject, s.v2, s.ports)
+	s.envoy, err = NewEnvoy(s.stress, s.faultInject, s.v2, s.ports, s.epoch)
 	if err != nil {
 		log.Printf("unable to create Envoy %v", err)
 	} else {
@@ -145,7 +146,8 @@ func (s *TestSetup) TearDown() {
 func (s *TestSetup) ReStartEnvoy() {
 	_ = s.envoy.Stop()
 	var err error
-	s.envoy, err = NewEnvoy(s.stress, s.faultInject, s.v2, s.ports)
+	s.epoch += 1
+	s.envoy, err = NewEnvoy(s.stress, s.faultInject, s.v2, s.ports, s.epoch)
 	if err != nil {
 		s.t.Errorf("unable to re-start Envoy %v", err)
 	} else {

--- a/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
+++ b/mixer/test/client/mixer_internal_fail/mixer_internal_fail_test.go
@@ -24,7 +24,6 @@ import (
 
 // Mixer server returns INTERNAL failure.
 func TestMixerInternalFail(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4264")
 	s := env.NewTestSetup(env.MixerInternalFailTest, t)
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)


### PR DESCRIPTION
Use different base-id for each Envoy restart in the test. 

Tried to use hot_start with restart_epoh flag,but  the tests still fails.  