### PR TITLE
Fix #4215 - change istioctl commands to use default namespace if no n…

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -100,9 +100,8 @@ See https://istio.io/docs/reference/ for an overview of routing rules
 and destination policies.
 
 `,
-		PersistentPreRun: getRealKubeConfig,
-
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			getRealKubeConfig(cmd, args)
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}
@@ -112,10 +111,9 @@ and destination policies.
 	}
 
 	postCmd = &cobra.Command{
-		Use:              "create",
-		Short:            "Create policies and rules",
-		Example:          "istioctl create -f example-routing.yaml",
-		PersistentPreRun: getRealKubeConfig,
+		Use:     "create",
+		Short:   "Create policies and rules",
+		Example: "istioctl create -f example-routing.yaml",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				c.Println(c.UsageString())
@@ -183,10 +181,9 @@ and destination policies.
 	}
 
 	putCmd = &cobra.Command{
-		Use:              "replace",
-		Short:            "Replace existing policies and rules",
-		Example:          "istioctl replace -f example-routing.yaml",
-		PersistentPreRun: getRealKubeConfig,
+		Use:     "replace",
+		Short:   "Replace existing policies and rules",
+		Example: "istioctl replace -f example-routing.yaml",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				c.Println(c.UsageString())
@@ -288,7 +285,6 @@ istioctl get destinationpolicies
 # Get a specific rule named productpage-default
 istioctl get routerule productpage-default
 `,
-		PersistentPreRun: getRealKubeConfig,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, err := newClient()
 			if err != nil {
@@ -349,7 +345,6 @@ istioctl delete -f example-routing.yaml
 # Delete the rule productpage-default
 istioctl delete routerule productpage-default
 `,
-		PersistentPreRun: getRealKubeConfig,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, errs := newClient()
 			if errs != nil {

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -302,15 +302,15 @@ istioctl get routerule productpage-default
 				return err
 			}
 
-			ns, _ := handleNamespaces(v1.NamespaceAll)
 			var configs []model.Config
 			if len(args) > 1 {
+				ns, _ := handleNamespaces(v1.NamespaceAll)
 				config, exists := configClient.Get(typ.Type, args[1], ns)
 				if exists {
 					configs = append(configs, *config)
 				}
 			} else {
-				configs, err = configClient.List(typ.Type, ns)
+				configs, err = configClient.List(typ.Type, namespace)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fix #4215 - change istioctl commands to use default namespace if no namespace provided

The problem was that the `rootCmd` contains the `PersitentPreRunE` function for resolving the default namespace. But this function is executed only if the subcommands do not override it with `PersitentPreRunE` or `PersitentPreRun` functions.
Also for `rootCmd` the `PersitentPreRunE` overrides the `PersitentPreRun` function thus I have merged it into one function.