### PR TITLE
Use dynamically assigned port for Prometheus integration tests

### DIFF
--- a/mixer/adapter/prometheus/prometheus.go
+++ b/mixer/adapter/prometheus/prometheus.go
@@ -72,13 +72,10 @@ const (
 	namespace = "istio"
 )
 
-// GetInfo returns the Info associated with this adapter.
-func GetInfo() adapter.Info {
-	// prometheus uses a singleton http port, so we make the
-	// builder itself a singleton, when defaultAddr become configurable
-	// srv will be a map[string]server
+// getInfo returns the Info associated with this adapter.
+func getInfo(addr string) (adapter.Info, server) {
 	singletonBuilder := &builder{
-		srv: newServer(defaultAddr),
+		srv: newServer(addr),
 	}
 	singletonBuilder.clearState()
 	return adapter.Info{
@@ -90,7 +87,16 @@ func GetInfo() adapter.Info {
 		},
 		NewBuilder:    func() adapter.HandlerBuilder { return singletonBuilder },
 		DefaultConfig: &config.Params{},
-	}
+	}, singletonBuilder.srv
+}
+
+// GetInfo returns the Info associated with this adapter.
+func GetInfo() adapter.Info {
+	// prometheus uses a singleton http port, so we make the
+	// builder itself a singleton, when defaultAddr become configurable
+	// srv will be a map[string]server
+	ii, _ := getInfo(defaultAddr)
+	return ii
 }
 
 func (b *builder) clearState() {

--- a/mixer/adapter/prometheus/prometheus_test.go
+++ b/mixer/adapter/prometheus/prometheus_test.go
@@ -44,6 +44,7 @@ func (t testServer) Start(adapter.Env, http.Handler) error {
 	return nil
 }
 
+func (testServer) Port() int    { return 0 }
 func (testServer) Close() error { return nil }
 
 func newBuilder(s server) *builder {


### PR DESCRIPTION
fixes #4309 