### PR TITLE
Finally get rid of the dependencies and cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,12 @@ jobs:
           mkdir -p /go/out
           mkdir /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
-            ls -l /go/bin
             if [ ! -f /go/out/linux_amd64/release/pilot-discovery ]; then
               # Should only happen when re-running a job, and the workspace is gone
               time make build test-bins
@@ -91,13 +90,12 @@ jobs:
           mkdir -p /go/out
           mkdir /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
-            ls -l /go/bin
             if [ ! -f /go/out/linux_amd64/release/pilot-discovery ]; then
               # Should only happen when re-running a job, and the workspace is gone
               time make build test-bins
@@ -129,10 +127,9 @@ jobs:
           mkdir -p /go/out
           mkdir /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
-      - run: ls -R /go # Debug attach_workspace, pkg must be restored.
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -169,9 +166,9 @@ jobs:
           sudo chown -R circleci /go
           mkdir -p /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -210,10 +207,9 @@ jobs:
           sudo chown -R circleci /go
           mkdir -p /home/circleci/logs
       - checkout
-      - run: make git.pullmaster
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -262,10 +258,9 @@ jobs:
           sudo chown -R circleci /go
           mkdir -p /home/circleci/logs
       - checkout
-      - run: make git.pullmaster
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -314,9 +309,9 @@ jobs:
           sudo chown -R circleci /go
           mkdir -p /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -370,9 +365,9 @@ jobs:
           sudo chown -R circleci /go
           mkdir -p /home/circleci/logs
       - checkout
-      - run: make submodule-sync
       - attach_workspace:
           at:  /go
+      - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
           command: |
@@ -421,26 +416,6 @@ jobs:
       - store_artifacts:
           path: /go/out/dep.dot
       # TODO: auto-commit Gopkg.lock if test is successful
-
-  # Runs first, will download any dependencies - currently envoy, and do any work
-  # that can be shared between build/test/lint.
-  dependencies:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: make git.pullmaster
-      - run: make submodule-sync
-      - run: make init
-      - run:
-            command: |
-              date '+%Y-%W-%D' > /go/out/cache.stamp
-
-      - persist_to_workspace:
-          root: /go
-          paths:
-            - src
-            - bin
-            - out
 
   codecov:
     <<: *defaults
@@ -590,41 +565,52 @@ workflows:
                  - master
     jobs: #daisy chained steps ending with docker push
       - depupdate
-      - dependencies
       - build
       - test
       - e2e-simple:
           requires:
             - test
+            - build
       - e2e-bookinfo:
           requires:
             - test
+            - build
       - e2e-dashboard:
           requires:
             - test
+            - build
       - e2e-mixer:
           requires:
             - test
+            - build
       - e2e-pilot:
           requires:
             - test
+            - build
+      - e2e-pilot-alpha3:
+          requires:
+            - test
+            - build
       - e2e-pilot-auth:
           requires:
             - test
+            - build
       - benchcheck:
           requires:
             - test
+            - build
       # Compile for mac and arm
       - goxbuild:
           requires:
             - test
+            - build
       # Nightly release
       - nightly:
           context: org-global
           requires:
             - e2e-simple
             - e2e-pilot
-            - e2e-pilot-auth
+            - e2e-pilot-alpha3
 
   periodic:
     triggers:
@@ -636,7 +622,6 @@ workflows:
                  - master
     jobs:
       - depupdate
-      - dependencies
       - build
       - test
       - e2e-simple:
@@ -660,6 +645,7 @@ workflows:
       - benchcheck:
           requires:
             - test
+            - build
       - e2e-mixer:
           requires:
             - build
@@ -673,12 +659,8 @@ workflows:
                only:
                  - master
     jobs:
-      - depupdate
-      - dependencies
       - build
-      - racetest:
-          requires:
-            - dependencies
+      - racetest
       - e2e-pilot-auth-egress:
           requires:
             - build
@@ -686,7 +668,6 @@ workflows:
 
   all:
     jobs:
-      - dependencies
       - lint
       - build
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,6 +457,10 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
+  dependencies:
+    steps:
+      - run: echo "Placeholder until an admin removes the required job"
+
   racetest:
     <<: *defaults
     environment:
@@ -668,6 +672,7 @@ workflows:
 
   all:
     jobs:
+      - dependencies
       - lint
       - build
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,6 +458,7 @@ jobs:
           path: /go/out/tests
 
   dependencies:
+    <<: *defaults
     steps:
       - run: echo "Placeholder until an admin removes the required job"
 


### PR DESCRIPTION
- consistent checkout: checkout, attach workspace ( for binaries can cached stuff from build ), make sync
(make sync combines the previous submodules steps and init)
 
- depend on test and build ( nightly was failing and probably slower than needed)

- remove the debug statements for attach workspace

- remove dependencies target, thanks to vendor no longer needed.
