### PR TITLE
Fix #4325 - istioctl get list of resources by default must scan all namespaces

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -302,15 +302,15 @@ istioctl get routerule productpage-default
 				return err
 			}
 
-			ns, _ := handleNamespaces(v1.NamespaceAll)
 			var configs []model.Config
 			if len(args) > 1 {
+				ns, _ := handleNamespaces(v1.NamespaceAll)
 				config, exists := configClient.Get(typ.Type, args[1], ns)
 				if exists {
 					configs = append(configs, *config)
 				}
 			} else {
-				configs, err = configClient.List(typ.Type, ns)
+				configs, err = configClient.List(typ.Type, namespace)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fix #4325 - istioctl get list of resources by default must scan all namespaces