### PR TITLE
Fix badly defined v1alpha3 test rule

### DIFF
--- a/tests/e2e/tests/pilot/testdata/v1alpha3/rule-regex-route.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/rule-regex-route.yaml.tmpl
@@ -20,5 +20,5 @@ spec:
     - route:
       - destination:
           name: c
-          subset: v2
+          subset: v1
         weight: 100

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/rule-regex-route.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/rule-regex-route.yaml.tmpl
@@ -19,5 +19,6 @@ spec:
         weight: 100
     - route:
       - destination:
-          name: v2
+          name: c
+          subset: v2
         weight: 100


### PR DESCRIPTION
Fixes a badly defined v1alpha3 config diagnosed by @costinm: https://github.com/istio/istio/issues/4314

Handling poorly defined configs may need further work, but this should fix the broken test in the meantime.