### PR TITLE
Adding Jwt filter to sidecar listener if it is needed for authentication.

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/types"
+
 	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mccpb "istio.io/api/mixer/v1/config/client"

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -27,11 +27,6 @@ import (
 )
 
 const (
-	// jwtFilterName is the name for the Jwt filter. This should be the same
-	// as the name defined in
-	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
-	jwtFilterName = "jwt-auth"
-
 	// Defautl cache duration for JWT public key.
 	jwtPublicKeyCacheSeconds = 60 * 5
 )
@@ -116,22 +111,24 @@ func ParseJwksURI(jwksURI string) (string, *Port, bool, error) {
 	if err != nil {
 		return "", nil, false, err
 	}
-	if u.Scheme != "https" && u.Scheme != "http" {
+
+	var useSSL bool
+	var portNumber int
+	switch u.Scheme {
+	case "http":
+		useSSL = false
+		portNumber = 80
+	case "https":
+		useSSL = true
+		portNumber = 443
+	default:
 		return "", nil, false, fmt.Errorf("URI scheme %s is not supported", u.Scheme)
 	}
 
-	useSSL := (u.Scheme == "https")
-	var portNumber int
 	if u.Port() != "" {
 		portNumber, err = strconv.Atoi(u.Port())
 		if err != nil {
 			return "", nil, useSSL, err
-		}
-	} else {
-		if useSSL {
-			portNumber = 443
-		} else {
-			portNumber = 80
 		}
 	}
 

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	// Defautl cache duration for JWT public key.
+	// Defautl cache duration for JWT public key. This should be moved to a global config.
 	jwtPublicKeyCacheSeconds = 60 * 5
 )
 
@@ -167,10 +167,8 @@ func CollectJwtSpecs(policy *authn.Policy) []*authn.Jwt {
 			ret = append(ret, method.GetJwt())
 		}
 	}
-	for _, rule := range policy.CredentialRules {
-		for _, method := range rule.Origins {
-			ret = append(ret, method.Jwt)
-		}
+	for _, method := range policy.Origins {
+		ret = append(ret, method.Jwt)
 	}
 	return ret
 }

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -18,8 +18,10 @@ import (
 	"reflect"
 	"testing"
 
+        "github.com/gogo/protobuf/types"
 	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	mccpb "istio.io/api/mixer/v1/config/client"
 )
 
 func TestRequireTls(t *testing.T) {
@@ -59,6 +61,83 @@ func TestRequireTls(t *testing.T) {
 	}
 }
 
+func TestParseJwksURI(t *testing.T) {
+	cases := []struct {
+		in                   string
+		expectedHostname     string
+		expectedPort         *Port
+		expectedUseSSL       bool
+		expectedErrorMessage string
+	}{
+		{
+			in:                   "foo.bar.com",
+			expectedErrorMessage: "URI scheme  is not supported",
+		},
+		{
+			in:                   "tcp://foo.bar.com:abc",
+			expectedErrorMessage: "URI scheme tcp is not supported",
+		},
+		{
+			in:                   "http://foo.bar.com:abc",
+			expectedErrorMessage: `strconv.Atoi: parsing "abc": invalid syntax`,
+		},
+		{
+			in:               "http://foo.bar.com",
+			expectedHostname: "foo.bar.com",
+			expectedPort:     &Port{Name: "http", Port: 80},
+			expectedUseSSL:   false,
+		},
+		{
+			in:               "https://foo.bar.com",
+			expectedHostname: "foo.bar.com",
+			expectedPort:     &Port{Name: "https", Port: 443},
+			expectedUseSSL:   true,
+		},
+		{
+			in:               "http://foo.bar.com:1234",
+			expectedHostname: "foo.bar.com",
+			expectedPort:     &Port{Name: "http", Port: 1234},
+			expectedUseSSL:   false,
+		},
+	}
+	for _, c := range cases {
+		host, port, useSSL, err := ParseJwksURI(c.in)
+		if err != nil {
+			if c.expectedErrorMessage != err.Error() {
+				t.Errorf("ParseJwksURI(%s): expected error (%s), got (%v)", c.in, c.expectedErrorMessage, err)
+			}
+		} else {
+			if c.expectedErrorMessage != "" {
+				t.Errorf("ParseJwksURI(%s): expected error (%s), got no error", c.in, c.expectedErrorMessage)
+			}
+			if c.expectedHostname != host || !reflect.DeepEqual(c.expectedPort, port) || c.expectedUseSSL != useSSL {
+				t.Errorf("ParseJwksURI(%s): expected (%s, %#v, %v), got (%s, %#v, %v)",
+					c.in, c.expectedHostname, c.expectedPort, c.expectedUseSSL,
+					host, port, useSSL)
+			}
+		}
+	}
+}
+
+func TestJwksURIClusterName(t *testing.T) {
+	cases := []struct {
+		hostname string
+		port     *Port
+		expected string
+	}{
+		{
+			hostname: "foo.bar.com",
+			port:     &Port{Name: "http", Port: 80},
+			expected: "jwks.foo.bar.com|http",
+		},
+	}
+	for _, c := range cases {
+		if got := JwksURIClusterName(c.hostname, c.port); c.expected != got {
+			t.Errorf("JwksURIClusterName(%s, %#v): expected (%s), got (%s)", c.hostname, c.port, c.expected, got)
+		}
+	}
+}
+
 func TestLegacyAuthenticationPolicyToPolicy(t *testing.T) {
 	cases := []struct {
 		in       meshconfig.AuthenticationPolicy
@@ -81,6 +160,282 @@ func TestLegacyAuthenticationPolicyToPolicy(t *testing.T) {
 	for _, c := range cases {
 		if got := legacyAuthenticationPolicyToPolicy(c.in); !reflect.DeepEqual(got, c.expected) {
 			t.Errorf("legacyAuthenticationPolicyToPolicy(%v): got(%#v) != want(%#v)\n", c.in, got, c.expected)
+		}
+	}
+}
+
+func TestCollectJwtSpecs(t *testing.T) {
+	cases := []struct {
+		in           authn.Policy
+		expectedSize int
+	}{
+		{
+			in:           authn.Policy{},
+			expectedSize: 0,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+			expectedSize: 0,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+			expectedSize: 1,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+				CredentialRules: []*authn.CredentialRule{{
+					Origins: []*authn.OriginAuthenticationMethod{{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://xyz.com",
+						},
+					}},
+				}},
+			},
+			expectedSize: 2,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+				CredentialRules: []*authn.CredentialRule{{
+					Origins: []*authn.OriginAuthenticationMethod{
+						{
+							Jwt: &authn.Jwt{
+								JwksUri: "http://xyz.com",
+							},
+						},
+						{
+							Jwt: &authn.Jwt{
+								JwksUri: "http://abc.com",
+							},
+						}},
+				}},
+			},
+			expectedSize: 3,
+		},
+	}
+	for _, c := range cases {
+		if got := CollectJwtSpecs(&c.in); len(got) != c.expectedSize {
+			t.Errorf("CollectJwtSpecs(%#v): return map of size (%d) != want(%d)\n", c.in, len(got), c.expectedSize)
+		}
+	}
+}
+
+func TestConvertPolicyToJwtConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       authn.Policy
+		expected *mccpb.EndUserAuthenticationPolicySpec
+	}{
+		{
+			name:     "empty policy",
+			in:       authn.Policy{},
+			expected: nil,
+		},
+		{
+			name: "no jwt policy",
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+			expected: nil,
+		},
+		{
+			name: "one jwt policy",
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Jwt{
+							Jwt: &authn.Jwt{
+								Issuer:     "foo",
+								Audiences:  []string{"dead", "beef"},
+								JwksUri:    "http://abc.com",
+								JwtHeaders: []string{"x-jwt-foo", "x-jwt-foo-another"},
+							},
+						},
+					},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+			expected: &mccpb.EndUserAuthenticationPolicySpec{
+				Jwts: []*mccpb.JWT{
+					{
+						Issuer:                 "foo",
+						Audiences:              []string{"dead", "beef"},
+						JwksUri:                "http://abc.com",
+						JwksUriEnvoyCluster:    "jwks.abc.com|http",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+						Locations: []*mccpb.JWT_Location{
+							{
+								Scheme: &mccpb.JWT_Location_Header{Header: "x-jwt-foo"},
+							},
+							{
+								Scheme: &mccpb.JWT_Location_Header{Header: "x-jwt-foo-another"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two jwt policy",
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Jwt{
+							Jwt: &authn.Jwt{
+								Issuer:     "foo",
+								Audiences:  []string{"dead", "beef"},
+								JwksUri:    "http://abc.com",
+								JwtHeaders: []string{"x-jwt-foo", "x-jwt-foo-another"},
+							},
+						},
+					},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+				CredentialRules: []*authn.CredentialRule{{
+					Origins: []*authn.OriginAuthenticationMethod{
+						{
+							Jwt: &authn.Jwt{
+								Issuer:    "bar",
+								JwksUri:   "https://xyz.com",
+								JwtParams: []string{"x-jwt-bar"},
+							},
+						},
+					},
+				}},
+			},
+			expected: &mccpb.EndUserAuthenticationPolicySpec{
+				Jwts: []*mccpb.JWT{
+					{
+						Issuer:                 "foo",
+						Audiences:              []string{"dead", "beef"},
+						JwksUri:                "http://abc.com",
+						JwksUriEnvoyCluster:    "jwks.abc.com|http",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+						Locations: []*mccpb.JWT_Location{
+							{
+								Scheme: &mccpb.JWT_Location_Header{Header: "x-jwt-foo"},
+							},
+							{
+								Scheme: &mccpb.JWT_Location_Header{Header: "x-jwt-foo-another"},
+							},
+						},
+					},
+					{
+						Issuer:                 "bar",
+						Audiences:              nil,
+						JwksUri:                "https://xyz.com",
+						JwksUriEnvoyCluster:    "jwks.xyz.com|https",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+						Locations: []*mccpb.JWT_Location{
+							{
+								Scheme: &mccpb.JWT_Location_Query{Query: "x-jwt-bar"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate jwt policy",
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+				CredentialRules: []*authn.CredentialRule{{
+					Origins: []*authn.OriginAuthenticationMethod{
+						{
+							Jwt: &authn.Jwt{
+								JwksUri: "https://xyz.com",
+							},
+						},
+						{
+							Jwt: &authn.Jwt{
+								JwksUri: "http://abc.com",
+							},
+						}},
+				}},
+			},
+			expected: &mccpb.EndUserAuthenticationPolicySpec{
+				Jwts: []*mccpb.JWT{
+					{
+						JwksUri:                "http://abc.com",
+						JwksUriEnvoyCluster:    "jwks.abc.com|http",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+					},
+					{
+						JwksUri:                "https://xyz.com",
+						JwksUriEnvoyCluster:    "jwks.xyz.com|https",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+					},
+					{
+						JwksUri:                "http://abc.com",
+						JwksUriEnvoyCluster:    "jwks.abc.com|http",
+						ForwardJwt:             true,
+						PublicKeyCacheDuration: &types.Duration{Seconds: 300},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		if got := ConvertPolicyToJwtConfig(&c.in); !reflect.DeepEqual(c.expected, got) {
+			t.Errorf("Test case %s: expected\n%#v\n, got\n%#v", c.name, c.expected.String(), got.String())
 		}
 	}
 }

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/types"
+
 	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mccpb "istio.io/api/mixer/v1/config/client"

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -16,6 +16,7 @@ package model
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
         "github.com/gogo/protobuf/types"
@@ -129,6 +130,13 @@ func TestJwksURIClusterName(t *testing.T) {
 			hostname: "foo.bar.com",
 			port:     &Port{Name: "http", Port: 80},
 			expected: "jwks.foo.bar.com|http",
+		},
+		{
+			hostname: "very.l" + strings.Repeat("o", 180) + "ng.hostname.com",
+			port:     &Port{Name: "http", Port: 80},
+			expected: "jwks.very.loooooooooooooooooooooooooooooooooooooooooooooooooo" +
+				"oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo" +
+				"ooooooooooooooooooooooooa96644bbd2fd09d9b6f9f0114d6c4dc792fa7efe",
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"testing"
 
-        "github.com/gogo/protobuf/types"
+	"github.com/gogo/protobuf/types"
 	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mccpb "istio.io/api/mixer/v1/config/client"
@@ -218,13 +218,13 @@ func TestCollectJwtSpecs(t *testing.T) {
 						Params: &authn.PeerAuthenticationMethod_Mtls{},
 					},
 				},
-				CredentialRules: []*authn.CredentialRule{{
-					Origins: []*authn.OriginAuthenticationMethod{{
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
 						Jwt: &authn.Jwt{
 							JwksUri: "http://xyz.com",
 						},
-					}},
-				}},
+					},
+				},
 			},
 			expectedSize: 2,
 		},
@@ -241,19 +241,18 @@ func TestCollectJwtSpecs(t *testing.T) {
 						Params: &authn.PeerAuthenticationMethod_Mtls{},
 					},
 				},
-				CredentialRules: []*authn.CredentialRule{{
-					Origins: []*authn.OriginAuthenticationMethod{
-						{
-							Jwt: &authn.Jwt{
-								JwksUri: "http://xyz.com",
-							},
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://xyz.com",
 						},
-						{
-							Jwt: &authn.Jwt{
-								JwksUri: "http://abc.com",
-							},
-						}},
-				}},
+					},
+					{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
 			},
 			expectedSize: 3,
 		},
@@ -343,17 +342,15 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 						Params: &authn.PeerAuthenticationMethod_Mtls{},
 					},
 				},
-				CredentialRules: []*authn.CredentialRule{{
-					Origins: []*authn.OriginAuthenticationMethod{
-						{
-							Jwt: &authn.Jwt{
-								Issuer:    "bar",
-								JwksUri:   "https://xyz.com",
-								JwtParams: []string{"x-jwt-bar"},
-							},
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							Issuer:    "bar",
+							JwksUri:   "https://xyz.com",
+							JwtParams: []string{"x-jwt-bar"},
 						},
 					},
-				}},
+				},
 			},
 			expected: &mccpb.EndUserAuthenticationPolicySpec{
 				Jwts: []*mccpb.JWT{
@@ -403,19 +400,18 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 						Params: &authn.PeerAuthenticationMethod_Mtls{},
 					},
 				},
-				CredentialRules: []*authn.CredentialRule{{
-					Origins: []*authn.OriginAuthenticationMethod{
-						{
-							Jwt: &authn.Jwt{
-								JwksUri: "https://xyz.com",
-							},
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							JwksUri: "https://xyz.com",
 						},
-						{
-							Jwt: &authn.Jwt{
-								JwksUri: "http://abc.com",
-							},
-						}},
-				}},
+					},
+					{
+						Jwt: &authn.Jwt{
+							JwksUri: "http://abc.com",
+						},
+					},
+				},
 			},
 			expected: &mccpb.EndUserAuthenticationPolicySpec{
 				Jwts: []*mccpb.JWT{

--- a/pilot/pkg/networking/v1alpha3/authentication.go
+++ b/pilot/pkg/networking/v1alpha3/authentication.go
@@ -18,7 +18,7 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/golang/protobuf/ptypes/duration"
 
-	authn "istio.io/api/authentication/v1alpha1"
+	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
@@ -38,8 +38,10 @@ func buildJwtFilter(policy *authn.Policy) *http_conn.HttpFilter {
 	if filterConfigProto == nil {
 		return nil
 	}
-	// TODO(diemtvu): check what is the right way to set config using proto.
-	return buildHTTPFilterConfig(jwtFilterName, filterConfigProto.String())
+	return &http_conn.HttpFilter{
+		Name:   jwtFilterName,
+		Config: messageToStruct(filterConfigProto),
+	}
 }
 
 // buildJwksURIClustersForProxyInstances checks the authentication policy for the

--- a/pilot/pkg/networking/v1alpha3/authentication.go
+++ b/pilot/pkg/networking/v1alpha3/authentication.go
@@ -30,9 +30,6 @@ const (
 	// as the name defined in
 	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
 	jwtFilterName = "jwt-auth"
-
-	// Defautl cache duration for JWT public key.
-	jwtPublicKeyCacheSeconds = 60 * 5
 )
 
 // buildJwtFilter returns a Jwt filter for all Jwt specs in the policy.

--- a/pilot/pkg/networking/v1alpha3/authentication.go
+++ b/pilot/pkg/networking/v1alpha3/authentication.go
@@ -1,0 +1,104 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/golang/protobuf/ptypes/duration"
+
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	// jwtFilterName is the name for the Jwt filter. This should be the same
+	// as the name defined in
+	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
+	jwtFilterName = "jwt-auth"
+
+	// Defautl cache duration for JWT public key.
+	jwtPublicKeyCacheSeconds = 60 * 5
+)
+
+// buildJwtFilter returns a Jwt filter for all Jwt specs in the policy.
+func buildJwtFilter(policy *authn.Policy) *http_conn.HttpFilter {
+	filterConfigProto := model.ConvertPolicyToJwtConfig(policy)
+	if filterConfigProto == nil {
+		return nil
+	}
+	// TODO(diemtvu): check what is the right way to set config using proto.
+	return buildHTTPFilterConfig(jwtFilterName, filterConfigProto.String())
+}
+
+// buildJwksURIClustersForProxyInstances checks the authentication policy for the
+// input proxyInstances, and generates (outbound) clusters for all JwksURIs.
+func buildJwksURIClustersForProxyInstances(mesh *meshconfig.MeshConfig,
+	store model.IstioConfigStore, proxyInstances []*model.ServiceInstance) v1.Clusters {
+	if len(proxyInstances) == 0 {
+		return nil
+	}
+	var jwtSpecs []*authn.Jwt
+	for _, instance := range proxyInstances {
+		authnPolicy := model.GetConsolidateAuthenticationPolicy(mesh, store, instance.Service.Hostname, instance.Endpoint.ServicePort)
+		jwtSpecs = append(jwtSpecs, model.CollectJwtSpecs(authnPolicy)...)
+	}
+
+	return buildJwksURIClusters(jwtSpecs, mesh.ConnectTimeout)
+}
+
+// buildJwksURIClusters returns a list of clusters for each unique JwksUri from
+// the input list of Jwt specs. This function is to support
+// buildJwksURIClustersForProxyInstances above.
+func buildJwksURIClusters(jwtSpecs []*authn.Jwt, timeout *duration.Duration) v1.Clusters {
+	type jwksCluster struct {
+		hostname string
+		port     *model.Port
+		useSSL   bool
+	}
+	jwksClusters := map[string]jwksCluster{}
+	for _, jwt := range jwtSpecs {
+		if _, exist := jwksClusters[jwt.JwksUri]; exist {
+			continue
+		}
+		if hostname, port, ssl, err := model.ParseJwksURI(jwt.JwksUri); err != nil {
+			log.Warnf("Could not build envoy cluster and address from jwks_uri %q: %v",
+				jwt.JwksUri, err)
+		} else {
+			jwksClusters[jwt.JwksUri] = jwksCluster{hostname, port, ssl}
+		}
+	}
+
+	var clusters v1.Clusters
+	for _, auth := range jwksClusters {
+		cluster := v1.BuildOutboundCluster(auth.hostname, auth.port, nil /* labels */, true /* external */)
+		cluster.Name = model.JwksURIClusterName(auth.hostname, auth.port)
+		cluster.CircuitBreaker = &v1.CircuitBreaker{
+			Default: v1.DefaultCBPriority{
+				MaxPendingRequests: 10000,
+				MaxRequests:        10000,
+			},
+		}
+		cluster.ConnectTimeoutMs = timeout.GetSeconds() * 1000
+		if auth.useSSL {
+			cluster.SSLContext = &v1.SSLContextExternal{}
+		}
+
+		clusters = append(clusters, cluster)
+	}
+	return clusters
+}

--- a/pilot/pkg/networking/v1alpha3/authentication_test.go
+++ b/pilot/pkg/networking/v1alpha3/authentication_test.go
@@ -21,6 +21,7 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/ptypes/duration"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
@@ -55,7 +56,7 @@ func TestBuildJwtFilter(t *testing.T) {
 				Name: "jwt-auth",
 				Config: &types.Struct{
 					Fields: map[string]*types.Value{
-						"jwt-auth": &types.Value{
+						"jwt-auth": {
 							Kind: &types.Value_StringValue{
 								StringValue: `&EndUserAuthenticationPolicySpec{Jwts:[&JWT{Issuer:,Audiences:[],JwksUri:http://abc.com,ForwardJwt:true,PublicKeyCacheDuration:5m0s,Locations:[],JwksUriEnvoyCluster:jwks.abc.com|http,}],}`,
 							},
@@ -107,7 +108,7 @@ func makeGoldenCluster(mode int) *v1.Cluster {
 		LbType:           "round_robin",
 		MaxRequestsPerConnection: 0,
 		Hosts: []v1.Host{
-			v1.Host{URL: host},
+			{URL: host},
 		},
 		SSLContext: ssl,
 		Features:   "",

--- a/pilot/pkg/networking/v1alpha3/authentication_test.go
+++ b/pilot/pkg/networking/v1alpha3/authentication_test.go
@@ -1,0 +1,202 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"reflect"
+	"testing"
+
+	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/protobuf/ptypes/duration"
+	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
+)
+
+func TestBuildJwtFilter(t *testing.T) {
+	cases := []struct {
+		in       *authn.Policy
+		expected *http_conn.HttpFilter
+	}{
+		{
+			in:       nil,
+			expected: nil,
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+		{
+			in: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Jwt{
+							Jwt: &authn.Jwt{
+								JwksUri: "http://abc.com",
+							},
+						},
+					},
+				},
+			},
+			expected: &http_conn.HttpFilter{
+				Name: "jwt-auth",
+				Config: &types.Struct{
+					Fields: map[string]*types.Value{
+						"jwt-auth": &types.Value{
+							Kind: &types.Value_StringValue{
+								StringValue: `&EndUserAuthenticationPolicySpec{Jwts:[&JWT{Issuer:,Audiences:[],JwksUri:http://abc.com,ForwardJwt:true,PublicKeyCacheDuration:5m0s,Locations:[],JwksUriEnvoyCluster:jwks.abc.com|http,}],}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		if got := buildJwtFilter(c.in); !reflect.DeepEqual(c.expected, got) {
+			t.Errorf("buildJwtFilter(%#v), got:\n%#v\nwanted:\n%#v\n", c.in, got, c.expected)
+		}
+	}
+}
+
+func makeGoldenCluster(mode int) *v1.Cluster {
+	var name, host, serviceName, hostname string
+	var port *model.Port
+	var ssl interface{}
+
+	if mode == 0 {
+		name = "jwks.abc.com|http"
+		serviceName = "abc.com|http"
+		host = "tcp://abc.com:80"
+		hostname = "abc.com"
+		port = &model.Port{
+			Name: "http",
+			Port: 80,
+		}
+	} else {
+		name = "jwks.xyz.com|https"
+		serviceName = "xyz.com|https"
+		host = "tcp://xyz.com:443"
+		hostname = "xyz.com"
+		port = &model.Port{
+			Name: "https",
+			Port: 443,
+		}
+		ssl = &v1.SSLContextExternal{CaCertFile: ""}
+	}
+
+	return &v1.Cluster{
+		Name:             name,
+		ServiceName:      serviceName,
+		ConnectTimeoutMs: 42000,
+		Type:             "strict_dns",
+		LbType:           "round_robin",
+		MaxRequestsPerConnection: 0,
+		Hosts: []v1.Host{
+			v1.Host{URL: host},
+		},
+		SSLContext: ssl,
+		Features:   "",
+		CircuitBreaker: &v1.CircuitBreaker{
+			Default: v1.DefaultCBPriority{
+				MaxConnections:     0,
+				MaxPendingRequests: 10000,
+				MaxRequests:        10000,
+				MaxRetries:         0,
+			},
+		},
+		OutlierDetection: nil,
+		Hostname:         hostname,
+		Port:             port,
+	}
+}
+
+func TestBuildJwksURIClusters(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       []*authn.Jwt
+		expected map[string]*v1.Cluster
+	}{
+		{
+			name:     "nil list",
+			in:       nil,
+			expected: map[string]*v1.Cluster{},
+		},
+		{
+			name:     "empty list",
+			in:       []*authn.Jwt{},
+			expected: map[string]*v1.Cluster{},
+		},
+		{
+			name: "one jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+			},
+			expected: map[string]*v1.Cluster{
+				"jwks.abc.com|http": makeGoldenCluster(0),
+			},
+		},
+		{
+			name: "two jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+				{
+					JwksUri: "https://xyz.com",
+				},
+			},
+			expected: map[string]*v1.Cluster{
+				"jwks.abc.com|http":  makeGoldenCluster(0),
+				"jwks.xyz.com|https": makeGoldenCluster(1),
+			},
+		},
+		{
+			name: "duplicate jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+				{
+					JwksUri: "https://xyz.com",
+				},
+				{
+					JwksUri: "http://abc.com",
+				},
+			},
+			expected: map[string]*v1.Cluster{
+				"jwks.abc.com|http":  makeGoldenCluster(0),
+				"jwks.xyz.com|https": makeGoldenCluster(1),
+			},
+		},
+	}
+	for _, c := range cases {
+		got := buildJwksURIClusters(c.in, &duration.Duration{Seconds: 42})
+		if len(got) != len(c.expected) {
+			t.Errorf("collectJwtSpecs(%#v): return (%d) != want(%d)\n", c.in, len(got), len(c.expected))
+		}
+		for _, cluster := range got {
+			expectedCluster := c.expected[cluster.Name]
+			if !reflect.DeepEqual(expectedCluster, cluster) {
+				t.Errorf("Test case %s: expected\n%#v\n, got\n%#v", c.name, expectedCluster, cluster)
+
+			}
+		}
+	}
+}

--- a/pilot/pkg/networking/v1alpha3/authentication_test.go
+++ b/pilot/pkg/networking/v1alpha3/authentication_test.go
@@ -57,28 +57,28 @@ func TestBuildJwtFilter(t *testing.T) {
 				Name: "jwt-auth",
 				Config: &types.Struct{
 					Fields: map[string]*types.Value{
-						"jwts": &types.Value{
+						"jwts": {
 							Kind: &types.Value_ListValue{
 								ListValue: &types.ListValue{
 									Values: []*types.Value{
-										&types.Value{
+										{
 											Kind: &types.Value_StructValue{
 												StructValue: &types.Struct{
 													Fields: map[string]*types.Value{
-														"forward_jwt": &types.Value{
+														"forward_jwt": {
 															Kind: &types.Value_BoolValue{BoolValue: true},
 														},
-														"jwks_uri": &types.Value{
+														"jwks_uri": {
 															Kind: &types.Value_StringValue{
 																StringValue: "http://abc.com",
 															},
 														},
-														"jwks_uri_envoy_cluster": &types.Value{
+														"jwks_uri_envoy_cluster": {
 															Kind: &types.Value_StringValue{
 																StringValue: "jwks.abc.com|http",
 															},
 														},
-														"public_key_cache_duration": &types.Value{
+														"public_key_cache_duration": {
 															Kind: &types.Value_StringValue{
 																StringValue: "300.000s",
 															},

--- a/pilot/pkg/networking/v1alpha3/authentication_test.go
+++ b/pilot/pkg/networking/v1alpha3/authentication_test.go
@@ -58,7 +58,13 @@ func TestBuildJwtFilter(t *testing.T) {
 					Fields: map[string]*types.Value{
 						"jwt-auth": {
 							Kind: &types.Value_StringValue{
-								StringValue: `&EndUserAuthenticationPolicySpec{Jwts:[&JWT{Issuer:,Audiences:[],JwksUri:http://abc.com,ForwardJwt:true,PublicKeyCacheDuration:5m0s,Locations:[],JwksUriEnvoyCluster:jwks.abc.com|http,}],}`,
+								StringValue: "&EndUserAuthenticationPolicySpec{" +
+									"Jwts:[&JWT{Issuer:,Audiences:[]," +
+									"JwksUri:http://abc.com," +
+									"ForwardJwt:true," +
+									"PublicKeyCacheDuration:5m0s," +
+									"Locations:[]," +
+									"JwksUriEnvoyCluster:jwks.abc.com|http,}],}",
 							},
 						},
 					},

--- a/pilot/pkg/networking/v1alpha3/authentication_test.go
+++ b/pilot/pkg/networking/v1alpha3/authentication_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/ptypes/duration"
 
-	authn "istio.io/api/authentication/v1alpha1"
+	authn "istio.io/api/authentication/v1alpha2"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
 )
@@ -56,15 +56,38 @@ func TestBuildJwtFilter(t *testing.T) {
 				Name: "jwt-auth",
 				Config: &types.Struct{
 					Fields: map[string]*types.Value{
-						"jwt-auth": {
-							Kind: &types.Value_StringValue{
-								StringValue: "&EndUserAuthenticationPolicySpec{" +
-									"Jwts:[&JWT{Issuer:,Audiences:[]," +
-									"JwksUri:http://abc.com," +
-									"ForwardJwt:true," +
-									"PublicKeyCacheDuration:5m0s," +
-									"Locations:[]," +
-									"JwksUriEnvoyCluster:jwks.abc.com|http,}],}",
+						"jwts": &types.Value{
+							Kind: &types.Value_ListValue{
+								ListValue: &types.ListValue{
+									Values: []*types.Value{
+										&types.Value{
+											Kind: &types.Value_StructValue{
+												StructValue: &types.Struct{
+													Fields: map[string]*types.Value{
+														"forward_jwt": &types.Value{
+															Kind: &types.Value_BoolValue{BoolValue: true},
+														},
+														"jwks_uri": &types.Value{
+															Kind: &types.Value_StringValue{
+																StringValue: "http://abc.com",
+															},
+														},
+														"jwks_uri_envoy_cluster": &types.Value{
+															Kind: &types.Value_StringValue{
+																StringValue: "jwks.abc.com|http",
+															},
+														},
+														"public_key_cache_duration": &types.Value{
+															Kind: &types.Value_StringValue{
+																StringValue: "300.000s",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/pilot/pkg/networking/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/v1alpha3/cluster.go
@@ -110,6 +110,10 @@ func BuildClusters(env model.Environment, proxy model.Proxy) []*v2.Cluster {
 		clusters = append(clusters, BuildInboundCluster(instance.Endpoint.Port))
 	}
 
+	// append cluster for JwksUri (for Jwt authentication) if necessary.
+	clusters = append(clusters, buildJwksURIClustersForProxyInstances(
+		env.Mesh, env.IstioConfigStore, instances)...)
+
 	// TODO add original dst cluster
 
 	return clusters // TODO: guaranteed ordering?

--- a/pilot/pkg/networking/v1alpha3/config.go
+++ b/pilot/pkg/networking/v1alpha3/config.go
@@ -134,6 +134,7 @@ func buildSidecarListeners(
 			listenAddress = v1.WildcardAddress
 		}
 
+
 		listeners = append(listeners, buildHTTPListener(buildHTTPListenerOpts{
 			mesh:             mesh,
 			proxy:            node,
@@ -175,6 +176,10 @@ func buildHTTPConnectionManager(opts buildHTTPListenerOpts) *http_conn.HttpConne
 		}
 	*/
 	refresh := time.Duration(opts.mesh.RdsRefreshDelay.Seconds) * time.Second
+
+	if filter := buildJwtFilter(opts.authnPolicy); filter != nil {
+		filters = append([]*http_conn.HttpFilter{filter}, filters...)
+	}
 
 	var rds *http_conn.HttpConnectionManager_Rds
 	if opts.rds != "" {

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -30,9 +30,6 @@ const (
 	// as the name defined in
 	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
 	jwtFilterName = "jwt-auth"
-
-	// Defautl cache duration for JWT public key.
-	jwtPublicKeyCacheSeconds = 60 * 5
 )
 
 // BuildJwtFilter returns a Jwt filter for all Jwt specs in the policy.

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"github.com/golang/protobuf/ptypes/duration"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -19,7 +19,7 @@ package v1
 import (
 	"github.com/golang/protobuf/ptypes/duration"
 
-	authn "istio.io/api/authentication/v1alpha1"
+	authn "istio.io/api/authentication/v1alpha2"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"

--- a/pilot/pkg/proxy/envoy/v1/authentication.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication.go
@@ -1,0 +1,111 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AuthN filter configuration
+
+package v1
+
+import (
+	"github.com/golang/protobuf/ptypes/duration"
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	// jwtFilterName is the name for the Jwt filter. This should be the same
+	// as the name defined in
+	// https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/http_filter_factory.cc#L50
+	jwtFilterName = "jwt-auth"
+
+	// Defautl cache duration for JWT public key.
+	jwtPublicKeyCacheSeconds = 60 * 5
+)
+
+// BuildJwtFilter returns a Jwt filter for all Jwt specs in the policy.
+func buildJwtFilter(policy *authn.Policy) *HTTPFilter {
+	filterConfigProto := model.ConvertPolicyToJwtConfig(policy)
+	if filterConfigProto == nil {
+		return nil
+	}
+	config, err := model.ToJSONMap(filterConfigProto)
+	if err != nil {
+		log.Errorf("Unable to convert Jwt filter config proto: %v", err)
+		return nil
+	}
+	return &HTTPFilter{
+		Type:   decoder,
+		Name:   jwtFilterName,
+		Config: config,
+	}
+}
+
+// buildJwksURIClustersForProxyInstances checks the authentication policy for the
+// input proxyInstances, and generates (outbound) clusters for all JwksURIs.
+func buildJwksURIClustersForProxyInstances(mesh *meshconfig.MeshConfig,
+	store model.IstioConfigStore, proxyInstances []*model.ServiceInstance) Clusters {
+	if len(proxyInstances) == 0 {
+		return nil
+	}
+	var jwtSpecs []*authn.Jwt
+	for _, instance := range proxyInstances {
+		authnPolicy := model.GetConsolidateAuthenticationPolicy(mesh, store, instance.Service.Hostname, instance.Endpoint.ServicePort)
+		jwtSpecs = append(jwtSpecs, model.CollectJwtSpecs(authnPolicy)...)
+	}
+
+	return buildJwksURIClusters(jwtSpecs, mesh.ConnectTimeout)
+}
+
+// buildJwksURIClusters returns a list of clusters for each unique JwksUri from
+// the input list of Jwt specs. This function is to support
+// buildJwksURIClustersForProxyInstances above.
+func buildJwksURIClusters(jwtSpecs []*authn.Jwt, timeout *duration.Duration) Clusters {
+	type jwksCluster struct {
+		hostname string
+		port     *model.Port
+		useSSL   bool
+	}
+	jwksClusters := map[string]jwksCluster{}
+	for _, jwt := range jwtSpecs {
+		if _, exist := jwksClusters[jwt.JwksUri]; exist {
+			continue
+		}
+		if hostname, port, ssl, err := model.ParseJwksURI(jwt.JwksUri); err != nil {
+			log.Warnf("Could not build envoy cluster and address from jwks_uri %q: %v",
+				jwt.JwksUri, err)
+		} else {
+			jwksClusters[jwt.JwksUri] = jwksCluster{hostname, port, ssl}
+		}
+	}
+
+	var clusters Clusters
+	for _, auth := range jwksClusters {
+		cluster := BuildOutboundCluster(auth.hostname, auth.port, nil /* labels */, true /* external */)
+		cluster.Name = model.JwksURIClusterName(auth.hostname, auth.port)
+		cluster.CircuitBreaker = &CircuitBreaker{
+			Default: DefaultCBPriority{
+				MaxPendingRequests: 10000,
+				MaxRequests:        10000,
+			},
+		}
+		cluster.ConnectTimeoutMs = timeout.GetSeconds() * 1000
+		if auth.useSSL {
+			cluster.SSLContext = &SSLContextExternal{}
+		}
+
+		clusters = append(clusters, cluster)
+	}
+	return clusters
+}

--- a/pilot/pkg/proxy/envoy/v1/authentication_test.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication_test.go
@@ -1,0 +1,203 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/duration"
+	authn "istio.io/api/authentication/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestBuildJwksFilter(t *testing.T) {
+	cases := []struct {
+		in       *authn.Policy
+		expected *HTTPFilter
+	}{
+		{
+			in:       nil,
+			expected: nil,
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+		{
+			in: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{
+					{
+						Params: &authn.PeerAuthenticationMethod_Jwt{
+							Jwt: &authn.Jwt{
+								JwksUri: "http://abc.com",
+							},
+						},
+					},
+				},
+			},
+			expected: &HTTPFilter{
+				Type: "decoder",
+				Name: "jwt-auth",
+				Config: map[string]interface{}{
+					"jwts": []interface{}{
+						map[string]interface{}{
+							"jwksUri":                "http://abc.com",
+							"forwardJwt":             true,
+							"publicKeyCacheDuration": "300.000s",
+							"jwksUriEnvoyCluster":    "jwks.abc.com|http",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		if got := buildJwtFilter(c.in); !reflect.DeepEqual(c.expected, got) {
+			t.Errorf("buildJwtFilter(%#v), got:\n%#v\nwanted:\n%#v\n", c.in, got, c.expected)
+		}
+	}
+}
+
+func makeGoldenCluster(mode int) *Cluster {
+	var name, host, serviceName, hostname string
+	var port *model.Port
+	var ssl interface{}
+
+	if mode == 0 {
+		name = "jwks.abc.com|http"
+		serviceName = "abc.com|http"
+		host = "tcp://abc.com:80"
+		hostname = "abc.com"
+		port = &model.Port{
+			Name: "http",
+			Port: 80,
+		}
+	} else {
+		name = "jwks.xyz.com|https"
+		serviceName = "xyz.com|https"
+		host = "tcp://xyz.com:443"
+		hostname = "xyz.com"
+		port = &model.Port{
+			Name: "https",
+			Port: 443,
+		}
+		ssl = &SSLContextExternal{CaCertFile: ""}
+	}
+
+	return &Cluster{
+		Name:             name,
+		ServiceName:      serviceName,
+		ConnectTimeoutMs: 42000,
+		Type:             "strict_dns",
+		LbType:           "round_robin",
+		MaxRequestsPerConnection: 0,
+		Hosts: []Host{
+			Host{URL: host},
+		},
+		SSLContext: ssl,
+		Features:   "",
+		CircuitBreaker: &CircuitBreaker{
+			Default: DefaultCBPriority{
+				MaxConnections:     0,
+				MaxPendingRequests: 10000,
+				MaxRequests:        10000,
+				MaxRetries:         0,
+			},
+		},
+		OutlierDetection: nil,
+		outbound:         false,
+		Hostname:         hostname,
+		Port:             port,
+		labels:           nil,
+	}
+}
+
+func TestBuildJwksURIClusters(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       []*authn.Jwt
+		expected map[string]*Cluster
+	}{
+		{
+			name:     "nil list",
+			in:       nil,
+			expected: map[string]*Cluster{},
+		},
+		{
+			name:     "empty list",
+			in:       []*authn.Jwt{},
+			expected: map[string]*Cluster{},
+		},
+		{
+			name: "one jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+			},
+			expected: map[string]*Cluster{
+				"jwks.abc.com|http": makeGoldenCluster(0),
+			},
+		},
+		{
+			name: "two jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+				{
+					JwksUri: "https://xyz.com",
+				},
+			},
+			expected: map[string]*Cluster{
+				"jwks.abc.com|http":  makeGoldenCluster(0),
+				"jwks.xyz.com|https": makeGoldenCluster(1),
+			},
+		},
+		{
+			name: "duplicate jwt policy",
+			in: []*authn.Jwt{
+				{
+					JwksUri: "http://abc.com",
+				},
+				{
+					JwksUri: "https://xyz.com",
+				},
+				{
+					JwksUri: "http://abc.com",
+				},
+			},
+			expected: map[string]*Cluster{
+				"jwks.abc.com|http":  makeGoldenCluster(0),
+				"jwks.xyz.com|https": makeGoldenCluster(1),
+			},
+		},
+	}
+	for _, c := range cases {
+		got := buildJwksURIClusters(c.in, &duration.Duration{Seconds: 42})
+		if len(got) != len(c.expected) {
+			t.Errorf("collectJwtSpecs(%#v): return (%d) != want(%d)\n", c.in, len(got), len(c.expected))
+		}
+		for _, cluster := range got {
+			expectedCluster := c.expected[cluster.Name]
+			if !reflect.DeepEqual(expectedCluster, cluster) {
+				t.Errorf("Test case %s: expected\n%#v\n, got\n%#v", c.name, expectedCluster, cluster)
+
+			}
+		}
+	}
+}

--- a/pilot/pkg/proxy/envoy/v1/authentication_test.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/duration"
 
-	authn "istio.io/api/authentication/v1alpha1"
+	authn "istio.io/api/authentication/v1alpha2"
 	"istio.io/istio/pilot/pkg/model"
 )
 

--- a/pilot/pkg/proxy/envoy/v1/authentication_test.go
+++ b/pilot/pkg/proxy/envoy/v1/authentication_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/duration"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -106,7 +107,7 @@ func makeGoldenCluster(mode int) *Cluster {
 		LbType:           "round_robin",
 		MaxRequestsPerConnection: 0,
 		Hosts: []Host{
-			Host{URL: host},
+			{URL: host},
 		},
 		SSLContext: ssl,
 		Features:   "",

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -787,11 +787,11 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 		protocol := servicePort.Protocol
 		cluster := BuildInboundCluster(endpoint.Port, protocol, mesh.ConnectTimeout)
 		clusters = append(clusters, cluster)
+		authenticationPolicy := model.GetConsolidateAuthenticationPolicy(mesh,
+			config, instance.Service.Hostname, endpoint.ServicePort)
 
 		var listener *Listener
 
-		authenticationPolicy := model.GetConsolidateAuthenticationPolicy(mesh,
-			config, instance.Service.Hostname, endpoint.ServicePort)
 		// Local service instances can be accessed through one of three
 		// addresses: localhost, endpoint IP, and service
 		// VIP. Localhost bypasses the proxy and doesn't need any TCP

--- a/pilot/pkg/proxy/envoy/v1/config_test.go
+++ b/pilot/pkg/proxy/envoy/v1/config_test.go
@@ -527,6 +527,11 @@ var (
 		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-world-mtls-on"},
 		file: "testdata/authn-world-mtls-off.yaml.golden",
 	}
+
+	authnPolicyHelloJwt = fileConfig{
+		meta: model.ConfigMeta{Type: model.AuthenticationPolicy.Type, Name: "authn-hello-jwt"},
+		file: "testdata/authn-hello-jwt.yaml.golden",
+	}
 )
 
 func addConfig(r model.ConfigStore, config fileConfig, t *testing.T) {

--- a/pilot/pkg/proxy/envoy/v1/discovery_test.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery_test.go
@@ -1178,3 +1178,17 @@ func TestSeparateCheckReportClusters(t *testing.T) {
 	response = makeDiscoveryRequest(ds, "GET", url, t)
 	compareResponse(response, "testdata/cds-mixer-check-report-config.json", t)
 }
+
+func TestAuthNJwtFilter(t *testing.T) {
+	_, registry, ds := commonSetup(t)
+
+	addConfig(registry, authnPolicyHelloJwt, t)
+
+	url := fmt.Sprintf("/v1/listeners/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
+	response := makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/lds-authn-jwt.json", t)
+
+	url = fmt.Sprintf("/v1/clusters/%s/%s", "istio-proxy", mock.HelloProxyV0.ServiceNode())
+	response = makeDiscoveryRequest(ds, "GET", url, t)
+	compareResponse(response, "testdata/cds-authn-jwt.json", t)
+}

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-jwt.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-jwt.yaml.golden
@@ -1,0 +1,12 @@
+destinations:
+- name: hello
+  port:
+    name: "http"
+credentialRules:
+- binding: USE_ORIGIN
+  origins:
+  - jwt:
+      issuer: "https://securetoken.google.com"
+      jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
+      jwt_headers:
+      - "x-goog-iap-jwt-assertion"

--- a/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-jwt.yaml.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/authn-hello-jwt.yaml.golden
@@ -1,12 +1,11 @@
-destinations:
+targets:
 - name: hello
-  port:
-    name: "http"
-credentialRules:
-- binding: USE_ORIGIN
-  origins:
-  - jwt:
-      issuer: "https://securetoken.google.com"
-      jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
-      jwt_headers:
-      - "x-goog-iap-jwt-assertion"
+  ports:
+  - name: "http"
+origins:
+- jwt:
+    issuer: "https://securetoken.google.com"
+    jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
+    jwt_headers:
+    - "x-goog-iap-jwt-assertion"
+principalBinding: USE_ORIGIN

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-authn-jwt.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-authn-jwt.json.golden
@@ -1,0 +1,230 @@
+{
+  "clusters": [
+   {
+    "name": "in.1081",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1081"
+     }
+    ]
+   },
+   {
+    "name": "in.1090",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1090"
+     }
+    ]
+   },
+   {
+    "name": "in.1100",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1100"
+     }
+    ]
+   },
+   {
+    "name": "in.1110",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:1110"
+     }
+    ]
+   },
+   {
+    "name": "in.3333",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:3333"
+     }
+    ]
+   },
+   {
+    "name": "in.80",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:80"
+     }
+    ]
+   },
+   {
+    "name": "in.9999",
+    "connect_timeout_ms": 1000,
+    "type": "static",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://127.0.0.1:9999"
+     }
+    ]
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|custom",
+    "service_name": "hello.default.svc.cluster.local|custom",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|http",
+    "service_name": "hello.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|mongo",
+    "service_name": "hello.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.hello.default.svc.cluster.local|redis",
+    "service_name": "hello.default.svc.cluster.local|redis",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.httpbin.default.svc.cluster.local|http",
+    "service_name": "httpbin.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://httpbin.default.svc.cluster.local:80"
+     }
+    ]
+   },
+   {
+    "name": "out.httpsbin.default.svc.cluster.local|https",
+    "service_name": "httpsbin.default.svc.cluster.local|https",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://httpsbin.default.svc.cluster.local:443"
+     }
+    ]
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|custom",
+    "service_name": "world.default.svc.cluster.local|custom",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|http",
+    "service_name": "world.default.svc.cluster.local|http",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|http-status",
+    "service_name": "world.default.svc.cluster.local|http-status",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|mongo",
+    "service_name": "world.default.svc.cluster.local|mongo",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "out.world.default.svc.cluster.local|redis",
+    "service_name": "world.default.svc.cluster.local|redis",
+    "connect_timeout_ms": 1000,
+    "type": "sds",
+    "lb_type": "round_robin"
+   },
+   {
+    "name": "mixer_check_server",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://istio-mixer.istio-system:9091"
+     }
+    ],
+    "features": "http2",
+    "circuit_breakers": {
+     "default": {
+      "max_pending_requests": 10000,
+      "max_requests": 10000
+     }
+    }
+   },
+   {
+    "name": "mixer_report_server",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://istio-mixer.istio-system:9091"
+     }
+    ],
+    "features": "http2",
+    "circuit_breakers": {
+     "default": {
+      "max_pending_requests": 10000,
+      "max_requests": 10000
+     }
+    }
+   },
+   {
+    "name": "jwks.www.googleapis.com|https",
+    "service_name": "www.googleapis.com|https",
+    "connect_timeout_ms": 1000,
+    "type": "strict_dns",
+    "lb_type": "round_robin",
+    "hosts": [
+     {
+      "url": "tcp://www.googleapis.com:443"
+     }
+    ],
+    "ssl_context": {},
+    "circuit_breakers": {
+     "default": {
+      "max_pending_requests": 10000,
+      "max_requests": 10000
+     }
+    }
+   }
+  ]
+ }

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-authn-jwt.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-authn-jwt.json.golden
@@ -1,0 +1,907 @@
+{
+  "listeners": [
+   {
+    "address": "tcp://0.0.0.0:15001",
+    "name": "virtual",
+    "filters": [],
+    "bind_to_port": true,
+    "use_original_dst": true
+   },
+   {
+    "address": "tcp://0.0.0.0:443",
+    "name": "http_0.0.0.0_443",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "443",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://0.0.0.0:80",
+    "name": "http_0.0.0.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "80",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://0.0.0.0:81",
+    "name": "http_0.0.0.0_81",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "egress"
+       },
+       "rds": {
+        "cluster": "rds",
+        "route_config_name": "81",
+        "refresh_delay_ms": 10
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "forwardAttributes": {
+            "attributes": {
+             "source.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "source.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "source.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "mixerAttributes": {
+            "attributes": {}
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "disableCheckCalls": true,
+             "disableReportCalls": true,
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:100",
+    "name": "mongo_10.1.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|mongo",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:110",
+    "name": "tcp_10.1.0.0_110",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.0.0:90",
+    "name": "tcp_10.1.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.hello.default.svc.cluster.local|custom",
+          "destination_ip_list": [
+           "10.1.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1081",
+    "name": "http_10.1.1.0_1081",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "route_config": {
+        "validate_clusters": true,
+        "virtual_hosts": [
+         {
+          "name": "inbound|1081",
+          "domains": [
+           "*"
+          ],
+          "routes": [
+           {
+            "prefix": "/",
+            "cluster": "in.1081",
+            "timeout_ms": 0,
+            "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
+            }
+           }
+          ]
+         }
+        ]
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1090",
+    "name": "tcp_10.1.1.0_1090",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1090",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1100",
+    "name": "mongo_10.1.1.0_1100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1100",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:1110",
+    "name": "tcp_10.1.1.0_1110",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mixer",
+      "config": {
+       "mixer_attributes": {
+        "destination.ip": "10.1.1.0",
+        "destination.uid": "kubernetes://v0.default"
+       },
+       "v2": {
+        "mixerAttributes": {
+         "attributes": {
+          "destination.ip": {
+           "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+          },
+          "destination.service": {
+           "stringValue": "hello.default.svc.cluster.local"
+          },
+          "destination.uid": {
+           "stringValue": "kubernetes://v0.default"
+          }
+         }
+        },
+        "transport": {
+         "checkCluster": "mixer_check_server",
+         "reportCluster": "mixer_report_server"
+        }
+       }
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.1110",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:3333",
+    "name": "tcp_10.1.1.0_3333",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.3333",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:80",
+    "name": "http_10.1.1.0_80",
+    "filters": [
+     {
+      "type": "read",
+      "name": "http_connection_manager",
+      "config": {
+       "codec_type": "auto",
+       "stat_prefix": "http",
+       "generate_request_id": true,
+       "tracing": {
+        "operation_name": "ingress"
+       },
+       "route_config": {
+        "validate_clusters": true,
+        "virtual_hosts": [
+         {
+          "name": "inbound|80",
+          "domains": [
+           "*"
+          ],
+          "routes": [
+           {
+            "prefix": "/",
+            "cluster": "in.80",
+            "timeout_ms": 0,
+            "opaque_config": {
+             "destination.service": "hello.default.svc.cluster.local",
+             "mixer_check": "on",
+             "mixer_forward": "off",
+             "mixer_report": "on"
+            },
+            "decorator": {
+             "operation": "default-route"
+            }
+           }
+          ]
+         }
+        ]
+       },
+       "filters": [
+        {
+         "type": "decoder",
+         "name": "jwt-auth",
+         "config": {
+          "jwts": [
+           {
+            "forwardJwt": true,
+            "issuer": "https://securetoken.google.com",
+            "jwksUri": "https://www.googleapis.com/oauth2/v1/certs",
+            "jwksUriEnvoyCluster": "jwks.www.googleapis.com|https",
+            "locations": [
+             {
+              "header": "x-goog-iap-jwt-assertion"
+             }
+            ],
+            "publicKeyCacheDuration": "300.000s"
+           }
+          ]
+         }
+        },
+        {
+         "type": "decoder",
+         "name": "mixer",
+         "config": {
+          "v2": {
+           "defaultDestinationService": "hello.default.svc.cluster.local",
+           "mixerAttributes": {
+            "attributes": {
+             "destination.ip": {
+              "bytesValue": "AAAAAAAAAAAAAP//CgEBAA=="
+             },
+             "destination.labels": {
+              "stringMapValue": {
+               "entries": {
+                "version": "v0"
+               }
+              }
+             },
+             "destination.uid": {
+              "stringValue": "kubernetes://v0.default"
+             }
+            }
+           },
+           "serviceConfigs": {
+            "hello.default.svc.cluster.local": {
+             "mixerAttributes": {
+              "attributes": {
+               "destination.labels": {
+                "stringMapValue": {
+                 "entries": {
+                  "version": "v0"
+                 }
+                }
+               },
+               "destination.service": {
+                "stringValue": "hello.default.svc.cluster.local"
+               }
+              }
+             }
+            }
+           },
+           "transport": {
+            "checkCluster": "mixer_check_server",
+            "reportCluster": "mixer_report_server"
+           }
+          }
+         }
+        },
+        {
+         "type": "",
+         "name": "cors",
+         "config": {}
+        },
+        {
+         "type": "decoder",
+         "name": "router",
+         "config": {}
+        }
+       ],
+       "access_log": [
+        {
+         "path": "/dev/stdout"
+        }
+       ]
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.1.1.0:9999",
+    "name": "tcp_10.1.1.0_9999",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "in.9999",
+          "destination_ip_list": [
+           "10.1.1.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:100",
+    "name": "mongo_10.2.0.0_100",
+    "filters": [
+     {
+      "type": "both",
+      "name": "mongo_proxy",
+      "config": {
+       "stat_prefix": "mongo"
+      }
+     },
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|mongo",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:110",
+    "name": "tcp_10.2.0.0_110",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|redis",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   },
+   {
+    "address": "tcp://10.2.0.0:90",
+    "name": "tcp_10.2.0.0_90",
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.world.default.svc.cluster.local|custom",
+          "destination_ip_list": [
+           "10.2.0.0/32"
+          ]
+         }
+        ]
+       }
+      }
+     }
+    ],
+    "bind_to_port": false
+   }
+  ]
+ }


### PR DESCRIPTION
Pilot will add Jwt filter to listener if it detect that Jwt is required by authentication policy. It also add the corresponding cluster for JwksURI (so that Jwt filter can make request to fetch public key for validation).

This PR use the existing Jwt filter implementation in Istio proxy. It may need to change to the upstream version when https://github.com/envoyproxy/envoy/issues/2514 complete.

Issue: https://github.com/istio/istio/issues/4337
Related: https://github.com/istio/istio/issues/1090