### PR TITLE
Port v1 authentication modules to v2

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/authentication.go
+++ b/pilot/pkg/proxy/envoy/v2/authentication.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"fmt"
+
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/log"
+)
+
+// getConsolidateAuthenticationPolicy returns the authentication policy for
+// service specified by hostname and port, if defined.
+// If not, it generates and output a policy that is equivalent to the legacy flag
+// and/or service annotation. Once these legacy flags/config deprecated,
+// this function can be placed by a call to store.AuthenticationPolicyByDestination
+// directly.
+func getConsolidateAuthenticationPolicy(mesh *meshconfig.MeshConfig, store model.IstioConfigStore, hostname string, port *model.Port) *authn.Policy {
+	config := store.AuthenticationPolicyByDestination(hostname, port)
+	if config == nil {
+		legacyPolicy := consolidateAuthPolicy(mesh, port.AuthenticationPolicy)
+		log.Debugf("No authentication policy found for  %s:%d. Fallback to legacy authentication mode %v\n",
+			hostname, port.Port, legacyPolicy)
+		return legacyAuthenticationPolicyToPolicy(legacyPolicy)
+	}
+
+	return config.Spec.(*authn.Policy)
+}
+
+// consolidateAuthPolicy returns service auth policy, if it's not INHERIT. Else,
+// returns mesh policy.
+func consolidateAuthPolicy(mesh *meshconfig.MeshConfig,
+	serviceAuthPolicy meshconfig.AuthenticationPolicy) meshconfig.AuthenticationPolicy {
+	if serviceAuthPolicy != meshconfig.AuthenticationPolicy_INHERIT {
+		return serviceAuthPolicy
+	}
+	// TODO: use AuthenticationPolicy for mesh policy and remove this conversion
+	switch mesh.AuthPolicy {
+	case meshconfig.MeshConfig_MUTUAL_TLS:
+		return meshconfig.AuthenticationPolicy_MUTUAL_TLS
+	case meshconfig.MeshConfig_NONE:
+		return meshconfig.AuthenticationPolicy_NONE
+	default:
+		// Never get here, there are no other enum value for mesh.AuthPolicy.
+		panic(fmt.Sprintf("Unknown mesh auth policy: %v\n", mesh.AuthPolicy))
+	}
+}
+
+// If input legacy is AuthenticationPolicy_MUTUAL_TLS, return a authentication policy equivalent
+// to it. Else, returns nil (implies no authentication is used)
+func legacyAuthenticationPolicyToPolicy(legacy meshconfig.AuthenticationPolicy) *authn.Policy {
+	if legacy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+		return &authn.Policy{
+			Peers: []*authn.PeerAuthenticationMethod{{
+				Params: &authn.PeerAuthenticationMethod_Mtls{}}},
+		}
+	}
+	return nil
+}
+
+// requireTLS returns true if the policy use mTLS for (peer) authentication.
+func requireTLS(policy *authn.Policy) bool {
+	if policy == nil {
+		return false
+	}
+	if len(policy.Peers) > 0 {
+		for _, method := range policy.Peers {
+			switch method.GetParams().(type) {
+			case *authn.PeerAuthenticationMethod_Mtls:
+				return true
+			default:
+				continue
+			}
+		}
+	}
+	return false
+}

--- a/pilot/pkg/proxy/envoy/v2/authentication_test.go
+++ b/pilot/pkg/proxy/envoy/v2/authentication_test.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"reflect"
+	"testing"
+
+	authn "istio.io/api/authentication/v1alpha1"
+	meshconfig "istio.io/api/mesh/v1alpha1"
+)
+
+func TestRequireTls(t *testing.T) {
+	cases := []struct {
+		in       authn.Policy
+		expected bool
+	}{
+		{
+			in:       authn.Policy{},
+			expected: false,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+			expected: true,
+		},
+		{
+			in: authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{},
+				},
+					{
+						Params: &authn.PeerAuthenticationMethod_Mtls{},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		if got := requireTLS(&c.in); got != c.expected {
+			t.Errorf("requireTLS(%v): got(%v) != want(%v)\n", c.in, got, c.expected)
+		}
+	}
+}
+
+func TestLegacyAuthenticationPolicyToPolicy(t *testing.T) {
+	cases := []struct {
+		in       meshconfig.AuthenticationPolicy
+		expected *authn.Policy
+	}{
+		{
+			in: meshconfig.AuthenticationPolicy_MUTUAL_TLS,
+			expected: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Mtls{},
+				}},
+			},
+		},
+		{
+			in:       meshconfig.AuthenticationPolicy_NONE,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		if got := legacyAuthenticationPolicyToPolicy(c.in); !reflect.DeepEqual(got, c.expected) {
+			t.Errorf("legacyAuthenticationPolicyToPolicy(%v): got(%#v) != want(%#v)\n", c.in, got, c.expected)
+		}
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/config.go
+++ b/pilot/pkg/proxy/envoy/v2/config.go
@@ -353,7 +353,7 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *xdsapi.Listener {
 func mayApplyInboundAuth(listener *xdsapi.Listener, authenticationPolicy *authn.Policy) {
 	if requireTLS(authenticationPolicy) {
 		// TODO(mostrowski): figure out SSL
-		log.Debugf("Applying authN policy %#v for %#v\n", authenticationPolicy, listener)
+		log.Debugf("TODO Apply authN policy %#v for %#v\n", authenticationPolicy, listener)
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/v2/config.go
+++ b/pilot/pkg/proxy/envoy/v2/config.go
@@ -32,6 +32,7 @@ import (
 
 	"time"
 
+	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/api/routing/v1alpha1"
@@ -348,32 +349,12 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *xdsapi.Listener {
 	}
 }
 
-// consolidateAuthPolicy returns service auth policy, if it's not INHERIT. Else,
-// returns mesh policy.
-func consolidateAuthPolicy(mesh *meshconfig.MeshConfig, serviceAuthPolicy meshconfig.AuthenticationPolicy) meshconfig.AuthenticationPolicy { // nolint
-	if serviceAuthPolicy != meshconfig.AuthenticationPolicy_INHERIT {
-		return serviceAuthPolicy
-	}
-	// TODO: use AuthenticationPolicy for mesh policy and remove this conversion
-	switch mesh.AuthPolicy {
-	case meshconfig.MeshConfig_MUTUAL_TLS:
-		return meshconfig.AuthenticationPolicy_MUTUAL_TLS
-	case meshconfig.MeshConfig_NONE:
-		return meshconfig.AuthenticationPolicy_NONE
-	default:
-		// Never get here, there are no other enum value for mesh.AuthPolicy.
-		panic(fmt.Sprintf("Unknown mesh auth policy: %v\n", mesh.AuthPolicy))
-	}
-}
-
 // mayApplyInboundAuth adds ssl_context to the listener if consolidateAuthPolicy.
-func mayApplyInboundAuth(listener *xdsapi.Listener, mesh *meshconfig.MeshConfig,
-	serviceAuthPolicy meshconfig.AuthenticationPolicy) {
-	// TODO(mostrowski): figure out SSL
-	/*	if consolidateAuthPolicy(mesh, serviceAuthPolicy) == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-			listener.SSLContext = buildListenerSSLContext(model.AuthCertsPath)
-		}
-	*/
+func mayApplyInboundAuth(listener *xdsapi.Listener, authenticationPolicy *authn.Policy) {
+	if requireTLS(authenticationPolicy) {
+		// TODO(mostrowski): figure out SSL
+		log.Debugf("Applying authN policy %#v for %#v\n", authenticationPolicy, listener)
+	}
 }
 
 // buildTCPListener constructs a listener for the TCP proxy
@@ -809,7 +790,8 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 		}
 
 		if l != nil {
-			mayApplyInboundAuth(l, mesh, endpoint.ServicePort.AuthenticationPolicy)
+			authenticationPolicy := getConsolidateAuthenticationPolicy(mesh, config, instance.Service.Hostname, servicePort)
+			mayApplyInboundAuth(l, authenticationPolicy)
 			listeners = append(listeners, l)
 		}
 	}


### PR DESCRIPTION
This ports [PR 4089](https://github.com/istio/istio/pull/4089), which change the logic to also consider authentication policy when configure listener/cluster SSL. The actual configuration is still left open (TODO @mostrowski)

Issue: https://github.com/istio/istio/issues/4337