### PR TITLE
Add local proxy debug functionality to proxy-debug command

### DIFF
--- a/istioctl/cmd/istioctl/deregister.go
+++ b/istioctl/cmd/istioctl/deregister.go
@@ -23,10 +23,9 @@ import (
 
 var (
 	deregisterCmd = &cobra.Command{
-		Use:              "deregister <svcname> <ip>",
-		Short:            "De-registers a service instance",
-		Args:             cobra.MinimumNArgs(2),
-		PersistentPreRun: getRealKubeConfig,
+		Use:   "deregister <svcname> <ip>",
+		Short: "De-registers a service instance",
+		Args:  cobra.MinimumNArgs(2),
 		RunE: func(c *cobra.Command, args []string) error {
 			svcName := args[0]
 			ip := args[1]

--- a/istioctl/cmd/istioctl/inject.go
+++ b/istioctl/cmd/istioctl/inject.go
@@ -150,7 +150,6 @@ kubectl get deployment -o yaml | istioctl kube-inject -f - | kubectl apply -f -
 # injected configuration from kubernetes configmap 'istio-inject'
 istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConfigMapName istio-inject
 `,
-		PersistentPreRun: getRealKubeConfig,
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			switch {
 			case inFilename != "" && emitTemplate:

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -100,14 +100,7 @@ See https://istio.io/docs/reference/ for an overview of routing rules
 and destination policies.
 
 `,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := log.Configure(loggingOptions); err != nil {
-				return err
-			}
-			getRealKubeConfig(cmd, args)
-			defaultNamespace = getDefaultNamespace(kubeconfig)
-			return nil
-		},
+		PersistentPreRunE: istioPersistentPreRunE,
 	}
 
 	postCmd = &cobra.Command{
@@ -497,7 +490,16 @@ istioctl context-create --api-server http://127.0.0.1:8080
 
 const defaultKubeConfigText = "$KUBECONFIG else $HOME/.kube/config"
 
-func getRealKubeConfig(c *cobra.Command, args []string) {
+func istioPersistentPreRunE(c *cobra.Command, args []string) error {
+	if err := log.Configure(loggingOptions); err != nil {
+		return err
+	}
+	defaultNamespace = getDefaultNamespace(kubeconfig)
+	getRealKubeConfig()
+	return nil
+}
+
+func getRealKubeConfig() {
 	// if the user didn't supply a specific value for kubeconfig, derive it from the environment
 	if kubeconfig == defaultKubeConfigText {
 		kubeconfig = path.Join(homedir.HomeDir(), ".kube/config")

--- a/istioctl/cmd/istioctl/register.go
+++ b/istioctl/cmd/istioctl/register.go
@@ -25,10 +25,9 @@ import (
 
 var (
 	registerCmd = &cobra.Command{
-		Use:              "register <svcname> <ip> [name1:]port1 [name2:]port2 ...",
-		Short:            "Registers a service instance (e.g. VM) joining the mesh",
-		Args:             cobra.MinimumNArgs(3),
-		PersistentPreRun: getRealKubeConfig,
+		Use:   "register <svcname> <ip> [name1:]port1 [name2:]port2 ...",
+		Short: "Registers a service instance (e.g. VM) joining the mesh",
+		Args:  cobra.MinimumNArgs(3),
 		RunE: func(c *cobra.Command, args []string) error {
 			svcName := args[0]
 			ip := args[1]

--- a/pilot/cmd/pilot-agent/debug.go
+++ b/pilot/cmd/pilot-agent/debug.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+
+	"istio.io/istio/pkg/log"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	configTypes = map[string]struct{}{
+		"all":       {},
+		"clusters":  {},
+		"listeners": {},
+		"routes":    {},
+		"static":    {},
+	}
+
+	debugCmd = &cobra.Command{
+		Use:   "debug <configuration-type>",
+		Short: "Debug local envoy",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			configType := args[0]
+			if err := validateConfigType(configType); err != nil {
+				return err
+			}
+
+			if configType == "static" {
+				return printStaticConfig()
+			} else if configType == "all" {
+				for ct := range configTypes {
+					switch ct {
+					case "clusters", "listeners", "routes":
+						if err := printDynamicConfig(ct); err != nil {
+							return err
+						}
+					case "static":
+						return printStaticConfig()
+					}
+				}
+				return nil
+			}
+			return printDynamicConfig(configType)
+		},
+	}
+)
+
+func printStaticConfig() error {
+	dir := "/etc/istio/proxy"
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("error reading default config directory: %v", err)
+	}
+	for _, f := range files {
+		filePath := filepath.Join(dir, f.Name())
+		contents, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("error reading config file %q: %v", filePath, err)
+		}
+		fmt.Println(string(contents))
+	}
+	return nil
+}
+
+func printDynamicConfig(typ string) error {
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:15000/%s", typ))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Errorf("Error closing response body: %v", err)
+		}
+	}()
+	bytes, _ := ioutil.ReadAll(resp.Body)
+	fmt.Println(string(bytes))
+	return nil
+}
+
+func validateConfigType(typ string) error {
+	if _, ok := configTypes[typ]; !ok {
+		return fmt.Errorf("%q is not a supported debugging config type", typ)
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(debugCmd)
+}

--- a/pilot/cmd/pilot-agent/debug_test.go
+++ b/pilot/cmd/pilot-agent/debug_test.go
@@ -1,0 +1,175 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+type envoyStubHandler struct {
+	sync.Mutex
+	States []envoyStubState
+}
+
+type envoyStubState struct {
+	StatusCode int
+	Response   string
+}
+
+func (p *envoyStubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.Lock()
+	switch r.URL.Path {
+	case "/clusters", "/listeners", "/routes":
+		w.WriteHeader(p.States[0].StatusCode)
+		_, _ = w.Write([]byte(p.States[0].Response))
+		p.States = p.States[1:]
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(fmt.Sprintf("%q is not a valid path", r.URL.Path)))
+	}
+	p.Unlock()
+}
+
+func TestDebug_Run(t *testing.T) {
+	tests := []struct {
+		name                 string
+		args                 []string
+		staticConfigLocation string
+		envoyNotReachable    bool
+		envoyStates          []envoyStubState
+		wantError            bool
+	}{
+		{
+			name:                 "debug with all configType does not error",
+			args:                 []string{"all"},
+			staticConfigLocation: "./testdata",
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 200, Response: "fine"},
+			},
+		},
+		{
+			name:                 "debug with all configType errors when unable to reach to envoy",
+			args:                 []string{"all"},
+			staticConfigLocation: "./testdata",
+			envoyNotReachable:    true,
+			wantError:            true,
+		},
+		{
+			name:                 "debug with all configType errors when unable to find static config",
+			args:                 []string{"all"},
+			staticConfigLocation: "",
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 200, Response: "fine"},
+			},
+			wantError: true,
+		},
+		{
+			name:                 "debug with all configType errors when one request to envoy returns a non 200 response",
+			args:                 []string{"all"},
+			staticConfigLocation: "./testdata",
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 200, Response: "fine"},
+				{StatusCode: 404, Response: "not fine"},
+			},
+			wantError: true,
+		},
+		{
+			name:                 "debug with static configType does not error",
+			args:                 []string{"static"},
+			staticConfigLocation: "./testdata",
+		},
+		{
+			name:                 "debug with static configType and no config returns an error",
+			args:                 []string{"static"},
+			staticConfigLocation: "",
+			wantError:            true,
+		},
+		{
+			name: "debug with listeners configType does not error",
+			args: []string{"listeners"},
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+			},
+		},
+		{
+			name:              "debug with listeners configType errors if envoy unreachable",
+			args:              []string{"listeners"},
+			envoyNotReachable: true,
+			wantError:         true,
+		},
+		{
+			name: "debug with clusters configType does not error",
+			args: []string{"routes"},
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+			},
+		},
+		{
+			name:              "debug with clusters configType errors if envoy unreachable",
+			args:              []string{"clusters"},
+			envoyNotReachable: true,
+			wantError:         true,
+		},
+		{
+			name: "debug with routes configType does not error",
+			args: []string{"routes"},
+			envoyStates: []envoyStubState{
+				{StatusCode: 200, Response: "fine"},
+			},
+		},
+		{
+			name:              "debug with routes configType errors if envoy unreachable",
+			args:              []string{"routes"},
+			envoyNotReachable: true,
+			wantError:         true,
+		},
+		{
+			name:      "debug with invalid configType returns an error",
+			args:      []string{"not-a-config-type"},
+			wantError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envoyStub := httptest.NewServer(
+				&envoyStubHandler{States: tt.envoyStates},
+			)
+			stubURL, _ := url.Parse(envoyStub.URL)
+			if tt.envoyNotReachable {
+				stubURL, _ = url.Parse("http://notenvoy")
+			}
+			d := &debug{
+				envoyAdminAddress:    stubURL.Host,
+				staticConfigLocation: tt.staticConfigLocation,
+			}
+			err := d.run(tt.args)
+			if (err == nil) && tt.wantError {
+				t.Errorf("Expected an error but received none")
+			} else if (err != nil) && !tt.wantError {
+				t.Errorf("Unexpected err: %v", err)
+			}
+		})
+	}
+}

--- a/pilot/cmd/pilot-agent/testdata/envoy-rev0.json
+++ b/pilot/cmd/pilot-agent/testdata/envoy-rev0.json
@@ -1,0 +1,113 @@
+{
+    "stats_config": {
+      "use_all_default_tags": false
+    },
+    "admin": {
+      "access_log_path": "/dev/stdout",
+      "address": {
+        "socket_address": {
+          "address": "127.0.0.1",
+          "port_value": 15000
+        }
+      }
+    },
+    "dynamic_resources": {
+      "lds_config": {
+        "api_config_source": {
+          "api_type": "REST_LEGACY",
+          "refresh_delay": {"seconds": 1, "nanos": 0},
+          "cluster_names": [
+            "rds"
+          ]
+        }
+      },
+      "cds_config": {
+        "api_config_source": {
+          "api_type": "REST_LEGACY",
+          "refresh_delay": {"seconds": 1, "nanos": 0},
+          "cluster_names": [
+            "rds"
+          ]
+        }
+      },
+      "deprecated_v1": {
+        "sds_config": {
+          "api_config_source": {
+            "api_type": "REST_LEGACY",
+            "refresh_delay": {"seconds": 1, "nanos": 0},
+            "cluster_names": [
+              "rds"
+            ]
+          }
+        }
+      }
+    },
+    "static_resources": {
+      "clusters": [
+        {
+          "name": "rds",
+          "type": "STRICT_DNS",
+          "connect_timeout": {"seconds": 10, "nanos": 0},
+          "lb_policy": "ROUND_ROBIN",
+  
+        "hosts": [
+            {
+              "socket_address": {"address": "istio-pilot.istio-system", "port_value": 15003}
+            }
+          ]
+  
+      },
+      {
+      "name": "xds-grpc",
+      "type": "STRICT_DNS",
+      "connect_timeout": {"seconds": 10, "nanos": 0},
+      "lb_policy": "ROUND_ROBIN",
+      "hosts": [
+      {
+      "socket_address": {"address": "istio-pilot.istio-system", "port_value": 15010}
+      }
+      ],
+      "http2_protocol_options": { }
+      }
+  
+  
+      ,
+        {
+          "name": "zipkin",
+          "type": "STRICT_DNS",
+          "connect_timeout": {
+            "seconds": 1
+          },
+          "lb_policy": "ROUND_ROBIN",
+          "hosts": [
+            {
+              "socket_address": {"address": "zipkin.istio-system", "port_value": 9411}
+            }
+          ]
+        }
+  
+      ]
+    },
+  
+    "tracing": {
+      "http": {
+        "name": "envoy.zipkin",
+        "config": {
+          "collector_cluster": "zipkin"
+        }
+      }
+    },
+  
+  
+    "stats_sinks": [
+      {
+        "name": "envoy.statsd",
+        "config": {
+          "address": {
+            "socket_address": {"address": "172.21.59.178", "port_value": 9125}
+          }
+        }
+      }
+    ]
+  
+  }


### PR DESCRIPTION
The local phase of the functionality discussed [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/istio-networking/H0p8GycQbDo/Uy855Ny7AgAJ).

Also fixes an issue where the kubeconfig, default namespace and logging configuration was not being inherited from the root command due to the value being overwritten