### PR TITLE
Implement a spy IBP backend

### DIFF
--- a/mixer/pkg/adapter/test/integration.go
+++ b/mixer/pkg/adapter/test/integration.go
@@ -163,7 +163,11 @@ func RunTest(
 	// Start Mixer
 	var args *server.Args
 	var env *server.Server
-	if args, err = getServerArgs(scenario.Templates, []adapter.InfoFn{adapterInfo}, scenario.Configs); err != nil {
+	adapterInfos := []adapter.InfoFn{}
+	if adapterInfo != nil {
+		adapterInfos = append(adapterInfos, adapterInfo)
+	}
+	if args, err = getServerArgs(scenario.Templates, adapterInfos, scenario.Configs); err != nil {
 		t.Fatalf("fail to create mixer args: %v", err)
 	}
 
@@ -201,7 +205,11 @@ func RunTest(
 	// the baseline json. Without this, deep equality on un-marshalled baseline AdapterState would defer
 	// from the rich object returned by getState function.
 	if scenario.GetState != nil {
-		adptState, _ := scenario.GetState(ctx)
+		var adptState interface{}
+		adptState, err = scenario.GetState(ctx)
+		if err != nil {
+			t.Fatalf("getting state from adapter failed; %v", err)
+		}
 		var adptStateBytes []byte
 		if adptStateBytes, err = json.Marshal(adptState); err != nil {
 			t.Fatalf("Unable to convert %v into json: %v", adptState, err)

--- a/mixer/test/spybackend/args.go
+++ b/mixer/test/spybackend/args.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spybackend
+
+import (
+	adptModel "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/mixer/template/listentry"
+	"istio.io/istio/mixer/template/metric"
+	"istio.io/istio/mixer/template/quota"
+)
+
+type (
+	args struct {
+		// manipulate the behavior of the backend.
+		behavior *behavior
+
+		// observed inputs by the backend
+		requests *requests
+	}
+
+	behavior struct {
+		validateResponse *adptModel.ValidateResponse
+		validateError    error
+
+		createSessionResponse *adptModel.CreateSessionResponse
+		createSessionError    error
+
+		closeSessionResponse *adptModel.CloseSessionResponse
+		closeSessionError    error
+
+		// report metric IBP
+		handleMetricResult *adptModel.ReportResult
+		handleMetricError  error
+
+		// check listEntry IBP
+		handleListEntryResult *adptModel.CheckResult
+		handleListEntryError  error
+
+		// quota IBP
+		handleQuotaResult *adptModel.QuotaResult
+		handleQuotaError  error
+	}
+
+	requests struct {
+		validateRequest []*adptModel.ValidateRequest
+
+		createSessionRequest []*adptModel.CreateSessionRequest
+
+		closeSessionRequest []*adptModel.CloseSessionRequest
+
+		handleMetricRequest    []*metric.HandleMetricRequest
+		handleListEntryRequest []*listentry.HandleListEntryRequest
+		handleQuotaRequest     []*quota.HandleQuotaRequest
+	}
+)
+
+// nolint:deadcode
+func defaultArgs() *args {
+	return &args{
+		behavior: &behavior{},
+		requests: &requests{},
+	}
+}

--- a/mixer/test/spybackend/nosession.go
+++ b/mixer/test/spybackend/nosession.go
@@ -1,0 +1,117 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spybackend
+
+import (
+	"context"
+
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc"
+
+	adptModel "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/mixer/template/listentry"
+	"istio.io/istio/mixer/template/metric"
+	"istio.io/istio/mixer/template/quota"
+)
+
+type (
+	server interface {
+		Addr() net.Addr
+		Close() error
+		Run()
+	}
+
+	noSessionServer struct {
+		listener net.Listener
+		shutdown chan error
+		server   *grpc.Server
+		behavior *behavior
+		requests *requests
+	}
+)
+
+var _ metric.HandleMetricServiceServer = &noSessionServer{}
+var _ listentry.HandleListEntryServiceServer = &noSessionServer{}
+var _ quota.HandleQuotaServiceServer = &noSessionServer{}
+
+func (s *noSessionServer) HandleMetric(c context.Context, r *metric.HandleMetricRequest) (*adptModel.ReportResult, error) {
+	s.requests.handleMetricRequest = append(s.requests.handleMetricRequest, r)
+	return s.behavior.handleMetricResult, s.behavior.handleMetricError
+}
+func (s *noSessionServer) HandleListEntry(c context.Context, r *listentry.HandleListEntryRequest) (*adptModel.CheckResult, error) {
+	s.requests.handleListEntryRequest = append(s.requests.handleListEntryRequest, r)
+	return s.behavior.handleListEntryResult, s.behavior.handleListEntryError
+}
+func (s *noSessionServer) HandleQuota(c context.Context, r *quota.HandleQuotaRequest) (*adptModel.QuotaResult, error) {
+	s.requests.handleQuotaRequest = append(s.requests.handleQuotaRequest, r)
+	return s.behavior.handleQuotaResult, s.behavior.handleQuotaError
+}
+
+func (s *noSessionServer) Addr() net.Addr {
+	return s.listener.Addr()
+}
+
+func (s *noSessionServer) Run() {
+	s.shutdown = make(chan error, 1)
+	go func() {
+		err := s.server.Serve(s.listener)
+
+		// notify closer we're done
+		s.shutdown <- err
+	}()
+}
+
+func (s *noSessionServer) Wait() error {
+	if s.shutdown == nil {
+		return fmt.Errorf("server not running")
+	}
+
+	err := <-s.shutdown
+	s.shutdown = nil
+	return err
+}
+
+func (s *noSessionServer) Close() error {
+	if s.shutdown != nil {
+		s.server.GracefulStop()
+		_ = s.Wait()
+	}
+
+	if s.listener != nil {
+		_ = s.listener.Close()
+	}
+
+	return nil
+}
+
+// nolint:deadcode
+func newNoSessionServer(a *args) (server, error) {
+	s := &noSessionServer{behavior: a.behavior, requests: a.requests}
+	var err error
+
+	if s.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", 0)); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("unable to listen on socket: %v", err)
+	}
+
+	s.server = grpc.NewServer()
+	metric.RegisterHandleMetricServiceServer(s.server, s)
+	listentry.RegisterHandleListEntryServiceServer(s.server, s)
+	quota.RegisterHandleQuotaServiceServer(s.server, s)
+
+	return s, nil
+}

--- a/mixer/test/spybackend/nosession.go
+++ b/mixer/test/spybackend/nosession.go
@@ -16,7 +16,6 @@ package spybackend
 
 import (
 	"context"
-
 	"fmt"
 	"net"
 

--- a/mixer/test/spybackend/nosession_integration_test.go
+++ b/mixer/test/spybackend/nosession_integration_test.go
@@ -15,12 +15,11 @@
 package spybackend
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"google.golang.org/grpc"
-
-	"context"
-	"fmt"
 
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	adapter_integration "istio.io/istio/mixer/pkg/adapter/test"

--- a/mixer/test/spybackend/nosession_integration_test.go
+++ b/mixer/test/spybackend/nosession_integration_test.go
@@ -1,0 +1,113 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spybackend
+
+import (
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"context"
+	"fmt"
+
+	"istio.io/api/mixer/adapter/model/v1beta1"
+	adapter_integration "istio.io/istio/mixer/pkg/adapter/test"
+	"istio.io/istio/mixer/template/listentry"
+	"istio.io/istio/mixer/template/metric"
+	"istio.io/istio/mixer/template/quota"
+)
+
+// This test for now just validates the backend can be started and tested against. This is will be used to verify
+// the OOP adapter work. As various features start lighting up, this test will grow.
+
+func TestNoSessionBackend(t *testing.T) {
+	adapter_integration.RunTest(
+		t,
+		nil,
+		adapter_integration.Scenario{
+			Setup: func() (interface{}, error) {
+				args := defaultArgs()
+				args.behavior.handleMetricResult = &v1beta1.ReportResult{}
+				args.behavior.handleListEntryResult = &v1beta1.CheckResult{ValidUseCount: 31}
+				args.behavior.handleQuotaResult = &v1beta1.QuotaResult{Quotas: map[string]v1beta1.QuotaResult_Result{"key1": {GrantedAmount: 32}}}
+
+				var s server
+				var err error
+				if s, err = newNoSessionServer(args); err != nil {
+					return nil, err
+				}
+				s.Run()
+				return s, nil
+			},
+			Teardown: func(ctx interface{}) {
+				_ = ctx.(server).Close()
+			},
+			GetState: func(ctx interface{}) (interface{}, error) {
+				return nil, validateNoSessionBackend(ctx, t)
+			},
+			ParallelCalls: []adapter_integration.Call{},
+			Configs:       []string{},
+			Want: `{
+              "AdapterState": null,
+		      "Returns": []
+            }`,
+		},
+	)
+}
+
+func validateNoSessionBackend(ctx interface{}, t *testing.T) error {
+	s := ctx.(*noSessionServer)
+	req := s.requests
+	// Connect the client to Mixer
+	conn, err := grpc.Dial(s.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Unable to connect to gRPC server: %v", err)
+	}
+	defer closeHelper(conn)
+
+	return validateHandleCalls(
+		metric.NewHandleMetricServiceClient(conn),
+		listentry.NewHandleListEntryServiceClient(conn),
+		quota.NewHandleQuotaServiceClient(conn),
+		req)
+}
+
+func validateHandleCalls(metricClt metric.HandleMetricServiceClient,
+	listentryClt listentry.HandleListEntryServiceClient, quotaClt quota.HandleQuotaServiceClient, req *requests) error {
+	if _, err := metricClt.HandleMetric(context.Background(), &metric.HandleMetricRequest{}); err != nil {
+		return err
+	}
+	if le, err := listentryClt.HandleListEntry(context.Background(), &listentry.HandleListEntryRequest{}); err != nil {
+		return err
+	} else if le.ValidUseCount != 31 {
+		return fmt.Errorf("got listentry.ValidUseCount %v; want %v", le.ValidUseCount, 31)
+	}
+	if qr, err := quotaClt.HandleQuota(context.Background(), &quota.HandleQuotaRequest{}); err != nil {
+		return err
+	} else if qr.Quotas["key1"].GrantedAmount != 32 {
+		return fmt.Errorf("got quota.GrantedAmount %v; want %v", qr.Quotas["key1"].GrantedAmount, 31)
+	}
+
+	if len(req.handleQuotaRequest) != 1 {
+		return fmt.Errorf("got quota calls %d; want %d", len(req.handleQuotaRequest), 1)
+	}
+	if len(req.handleMetricRequest) != 1 {
+		return fmt.Errorf("got metric calls %d; want %d", len(req.handleMetricRequest), 1)
+	}
+	if len(req.handleListEntryRequest) != 1 {
+		return fmt.Errorf("got listentry calls %d; want %d", len(req.handleListEntryRequest), 1)
+	}
+	return nil
+}

--- a/mixer/test/spybackend/session.go
+++ b/mixer/test/spybackend/session.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spybackend
+
+import (
+	"context"
+
+	"fmt"
+	"net"
+
+	"google.golang.org/grpc"
+
+	adptModel "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/mixer/template/listentry"
+	"istio.io/istio/mixer/template/metric"
+	"istio.io/istio/mixer/template/quota"
+)
+
+type sessionServer struct {
+	noSessionServer
+}
+
+var _ adptModel.InfrastructureBackendServer = &sessionServer{}
+var _ metric.HandleMetricServiceServer = &sessionServer{}
+var _ listentry.HandleListEntryServiceServer = &sessionServer{}
+var _ quota.HandleQuotaServiceServer = &sessionServer{}
+
+// Non request time rpcs
+func (s *sessionServer) Validate(c context.Context, r *adptModel.ValidateRequest) (*adptModel.ValidateResponse, error) {
+	s.requests.validateRequest = append(s.requests.validateRequest, r)
+	return s.behavior.validateResponse, s.behavior.validateError
+}
+func (s *sessionServer) CreateSession(c context.Context, r *adptModel.CreateSessionRequest) (*adptModel.CreateSessionResponse, error) {
+	s.requests.createSessionRequest = append(s.requests.createSessionRequest, r)
+	return s.behavior.createSessionResponse, s.behavior.createSessionError
+}
+func (s *sessionServer) CloseSession(c context.Context, r *adptModel.CloseSessionRequest) (*adptModel.CloseSessionResponse, error) {
+	s.requests.closeSessionRequest = append(s.requests.closeSessionRequest, r)
+	return s.behavior.closeSessionResponse, s.behavior.closeSessionError
+}
+
+// nolint:deadcode
+func newSessionServer(a *args) (server, error) {
+	s := &sessionServer{noSessionServer{behavior: a.behavior, requests: a.requests}}
+	s.server = grpc.NewServer()
+	var err error
+
+	if s.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", 0)); err != nil {
+		_ = s.Close()
+		return nil, fmt.Errorf("unable to listen on socket: %v", err)
+	}
+
+	adptModel.RegisterInfrastructureBackendServer(s.server, s)
+	metric.RegisterHandleMetricServiceServer(s.server, s)
+	listentry.RegisterHandleListEntryServiceServer(s.server, s)
+	quota.RegisterHandleQuotaServiceServer(s.server, s)
+
+	return s, nil
+}

--- a/mixer/test/spybackend/session.go
+++ b/mixer/test/spybackend/session.go
@@ -16,7 +16,6 @@ package spybackend
 
 import (
 	"context"
-
 	"fmt"
 	"net"
 

--- a/mixer/test/spybackend/session_integration_test.go
+++ b/mixer/test/spybackend/session_integration_test.go
@@ -1,0 +1,116 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spybackend
+
+import (
+	"testing"
+
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gogo/googleapis/google/rpc"
+	"google.golang.org/grpc"
+
+	"istio.io/api/mixer/adapter/model/v1beta1"
+	adapter_integration "istio.io/istio/mixer/pkg/adapter/test"
+	"istio.io/istio/mixer/template/listentry"
+	"istio.io/istio/mixer/template/metric"
+	"istio.io/istio/mixer/template/quota"
+)
+
+// This test for now just validates the backend can be started and tested against. This is will be used to verify
+// the OOP adapter work. As various features start lighting up, this test will grow.
+
+const (
+	sessionID = "1234"
+)
+
+func TestSessionBackend(t *testing.T) {
+	adapter_integration.RunTest(
+		t,
+		nil,
+		adapter_integration.Scenario{
+			Setup: func() (interface{}, error) {
+				args := defaultArgs()
+				args.behavior.validateResponse = &v1beta1.ValidateResponse{Status: &rpc.Status{Code: 0}}
+				args.behavior.createSessionResponse = &v1beta1.CreateSessionResponse{Status: &rpc.Status{Code: 0}, SessionId: "1234"}
+				args.behavior.closeSessionResponse = &v1beta1.CloseSessionResponse{Status: &rpc.Status{Code: 0}}
+				args.behavior.handleMetricResult = &v1beta1.ReportResult{}
+				args.behavior.handleListEntryResult = &v1beta1.CheckResult{ValidUseCount: 31}
+				args.behavior.handleQuotaResult = &v1beta1.QuotaResult{Quotas: map[string]v1beta1.QuotaResult_Result{"key1": {GrantedAmount: 32}}}
+
+				var s server
+				var err error
+				if s, err = newSessionServer(args); err != nil {
+					return nil, err
+				}
+				s.Run()
+				return s, nil
+			},
+			Teardown: func(ctx interface{}) {
+				_ = ctx.(server).Close()
+			},
+			GetState: func(ctx interface{}) (interface{}, error) {
+				return nil, validateSessionBackend(ctx, t)
+			},
+			ParallelCalls: []adapter_integration.Call{},
+			Configs:       []string{},
+			Want: `{
+              "AdapterState": null,
+		      "Returns": []
+            }`,
+		},
+	)
+}
+
+func closeHelper(c io.Closer) {
+	_ = c.Close()
+}
+
+func validateSessionBackend(ctx interface{}, t *testing.T) error {
+	s := ctx.(*sessionServer)
+	// Connect the client to Mixer
+	conn, err := grpc.Dial(s.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Unable to connect to gRPC server: %v", err)
+	}
+	client := v1beta1.NewInfrastructureBackendClient(conn)
+	defer closeHelper(conn)
+
+	if createSessionResponse, err := client.CreateSession(context.Background(), &v1beta1.CreateSessionRequest{}); err != nil {
+		return err
+	} else if createSessionResponse.SessionId != sessionID {
+		return fmt.Errorf("got SessionId %s; want %s", createSessionResponse.SessionId, sessionID)
+	}
+
+	if createSessionResponse, err := client.CloseSession(context.Background(), &v1beta1.CloseSessionRequest{sessionID}); err != nil {
+		return err
+	} else if createSessionResponse.Status.Code != int32(rpc.OK) {
+		return fmt.Errorf("got CloseSession code %v; want %v", createSessionResponse.Status.Code, rpc.OK)
+	}
+
+	if validateResponse, err := client.Validate(context.Background(), &v1beta1.ValidateRequest{}); err != nil {
+		return err
+	} else if validateResponse.Status.Code != int32(rpc.OK) {
+		return fmt.Errorf("got Validate code %v; want %v", validateResponse.Status.Code, rpc.OK)
+	}
+
+	return validateHandleCalls(
+		metric.NewHandleMetricServiceClient(conn),
+		listentry.NewHandleListEntryServiceClient(conn),
+		quota.NewHandleQuotaServiceClient(conn),
+		s.requests)
+}

--- a/mixer/test/spybackend/session_integration_test.go
+++ b/mixer/test/spybackend/session_integration_test.go
@@ -15,11 +15,10 @@
 package spybackend
 
 import (
-	"testing"
-
 	"context"
 	"fmt"
 	"io"
+	"testing"
 
 	"github.com/gogo/googleapis/google/rpc"
 	"google.golang.org/grpc"


### PR DESCRIPTION
This will help in easy testing of our OOOP adapter implementation.

Currently, this spy backend only implements static IBP interface. After my template specific IBP Handle service PR goes in, I will enhance this spy backend to have two flavors, session plan and no-session plan.