### PR TITLE
Setup default passthrough TCP route in proxy

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -271,12 +271,26 @@ func buildSidecarListenersClusters(
 		}
 
 		// add an extra listener that binds to the port that is the recipient of the iptables redirect
+		// Setup a default pass through cluster in this listener so that traffic for ports that do not match
+		// will be forwarded to their original destination as is.
+		// TODO: add mixer in this listener as well.
+		passthruCluster := BuildOriginalDSTCluster("default-passthrough", mesh.ConnectTimeout)
+		passthruTCPRouteConfig := &TCPRouteConfig{Routes: []*TCPRoute{BuildTCPRoute(passthruCluster, nil)}}
+		passthruTCPFilters := &NetworkFilter{
+			Type: read,
+			Name: TCPProxyFilter,
+			Config: &TCPProxyFilterConfig{
+				StatPrefix:  "tcp",
+				RouteConfig: passthruTCPRouteConfig,
+			},
+		}
+
 		listeners = append(listeners, &Listener{
 			Name:           VirtualListenerName,
 			Address:        fmt.Sprintf("tcp://%s:%d", WildcardAddress, mesh.ProxyListenPort),
 			BindToPort:     true,
 			UseOriginalDst: true,
-			Filters:        make([]*NetworkFilter, 0),
+			Filters:        []*NetworkFilter{passthruTCPFilters},
 		})
 	}
 

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -292,6 +292,8 @@ func buildSidecarListenersClusters(
 			UseOriginalDst: true,
 			Filters:        []*NetworkFilter{passthruTCPFilters},
 		})
+
+		clusters = append(clusters, passthruCluster)
 	}
 
 	// enable HTTP PROXY port if necessary; this will add an RDS route for this port

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-circuit-breaker-v1alpha3.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-circuit-breaker-v1alpha3.json.golden
@@ -123,6 +123,12 @@
     }
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-circuit-breaker.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-circuit-breaker.json.golden
@@ -146,6 +146,12 @@
     }
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-mixer-check-report-config.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-mixer-check-report-config.json.golden
@@ -78,6 +78,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-mixerclient-filter.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-mixerclient-filter.json.golden
@@ -78,6 +78,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-redirect-egress.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-redirect-egress.json.golden
@@ -101,6 +101,12 @@
     "ssl_context": {}
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optin.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optin.json.golden
@@ -78,6 +78,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optout.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context-optout.json.golden
@@ -101,6 +101,12 @@
     "ssl_context": {}
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-ssl-context.json.golden
@@ -101,6 +101,12 @@
     "ssl_context": {}
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns-no-endpoints.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns-no-endpoints.json.golden
@@ -78,6 +78,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.google.com|external-HTTP-80",
     "service_name": "google.com|external-HTTP-80",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-dns.json.golden
@@ -114,6 +114,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-none.json.golden
@@ -93,6 +93,12 @@
     "features": "http2"
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-static.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-http-static.json.golden
@@ -114,6 +114,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-dns.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-dns.json.golden
@@ -93,6 +93,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-none.json.golden
@@ -85,6 +85,12 @@
     "lb_type": "original_dst_lb"
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-static.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-tcp-static.json.golden
@@ -93,6 +93,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-weighted-external-service.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds-v0-weighted-external-service.json.golden
@@ -168,6 +168,12 @@
     }
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/cds.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/cds.json.golden
@@ -78,6 +78,12 @@
     ]
    },
    {
+    "name": "out.default-passthrough",
+    "connect_timeout_ms": 1000,
+    "type": "original_dst",
+    "lb_type": "original_dst_lb"
+   },
+   {
     "name": "out.hello.default.svc.cluster.local|custom",
     "service_name": "hello.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-mixer-check-report-config.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-mixer-check-report-config.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-mixerclient-filter.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-mixerclient-filter.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns-no-endpoints.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns-no-endpoints.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-dns.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-none.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-static.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-http-static.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-multi-match-fault.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optin.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optin.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optout.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optout.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-dns.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-dns.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-none.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-static.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-tcp-static.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-external-service.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-external-service.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-multi-match-fault.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-auth.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-nomixer.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-nomixer.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-websocket.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-websocket.json.golden
@@ -3,7 +3,22 @@
    {
     "address": "tcp://0.0.0.0:15001",
     "name": "virtual",
-    "filters": [],
+    "filters": [
+     {
+      "type": "read",
+      "name": "tcp_proxy",
+      "config": {
+       "stat_prefix": "tcp",
+       "route_config": {
+        "routes": [
+         {
+          "cluster": "out.default-passthrough"
+         }
+        ]
+       }
+      }
+     }
+    ],
     "bind_to_port": true,
     "use_original_dst": true
    },


### PR DESCRIPTION
This will allow traffic to unknown egress destinations to pass through as is, for any port that does not match the listeners.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>