### PR TITLE
Remove serial execution contraint on postsubmit unit tests

### DIFF
--- a/prow/istio-postsubmit.sh
+++ b/prow/istio-postsubmit.sh
@@ -36,11 +36,8 @@ cd $ROOT
 make init
 
 echo 'Running Unit Tests'
-GOTEST_FLAG="-p 1 -parallel 1 -v"
 time JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
-T="${GOTEST_FLAG}" \
-PILOT_TEST_T="${GOTEST_FLAG}" \
-MIXER_TEST_T="${GOTEST_FLAG}" \
+T="-v" \
 make localTestEnv test
 
 HUB="gcr.io/istio-testing"


### PR DESCRIPTION
Such constaints were imposed due to a bug from go-junit-report. Remove them now that bug has been resolved.

fixes https://github.com/istio/istio/issues/4230