### PR TITLE
[vendor-change] Fortio update to 0.8.0 - with semver not need to specify the tag, dep picks up the latest release tag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1232,7 +1232,7 @@
     "ui",
     "version"
   ]
-  revision = "latest_release"
+  revision = "v0.8.0"
 
 [[projects]]
   branch = "release-1.9"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1513,6 +1513,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4d7140ff09e65a21b5bcfb52300d27fbb7d044fc7fbd2d0d0a1c1c7e3dab7daf"
+  inputs-digest = "69d4f0b300945d3929b747bf5fde5fb8ed31ddcf9343b70d485530383971d706"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -130,11 +130,9 @@ required = [
  name = "github.com/apache/thrift"
  version = ">=0.9.3, <0.11.0"
 
-[[constraint]]
-  name = "istio.io/fortio"
-  revision = "latest_release"
+# Default behavior of dep is to get the latest tagged version for fortio
+# which is what we want.
 
-# TODO replace with master as api/master should be tracked in istio/master
 [[constraint]]
   name = "istio.io/api"
   branch = "master"


### PR DESCRIPTION
2 phase commit needed when tests pass

changes/release notes:
https://github.com/istio/fortio/releases/tag/v0.8.0