### PR TITLE
Set `Resolution` and `MeshExternal` fields of `model.Service`

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -56,6 +56,7 @@ type Service struct {
 	// ExternalName is only set for external services and holds the external
 	// service DNS name.  External services are name-based solution to represent
 	// external service instances as a service inside the cluster.
+	// TODO: this should be deprecated. it is made obsolete by the MeshExternal and Resolution flags.
 	ExternalName string `json:"external"`
 
 	// ServiceAccounts specifies the service accounts that run the service.
@@ -66,6 +67,7 @@ type Service struct {
 	MeshExternal bool
 
 	// LoadBalancingDisabled indicates that no load balancing should be done for this service.
+	// TODO: this should be deprecated. it is made obsolete by the MeshExternal and Resolution flags.
 	LoadBalancingDisabled bool `json:"-"`
 
 	// Resolution indicates how the service instances need to be resolved before routing

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -48,8 +48,10 @@ func (sd *ServiceDiscovery) Services() ([]*model.Service, error) {
 	port := sd.servicePort()
 	for hostname := range resp.Backends {
 		services = append(services, &model.Service{
-			Hostname: hostname,
-			Ports:    []*model.Port{port},
+			Hostname:     hostname,
+			Ports:        []*model.Port{port},
+			MeshExternal: false,
+			Resolution:   model.ClientSideLB,
 		})
 	}
 
@@ -91,8 +93,10 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList 
 				ServicePort: port,
 			},
 			Service: &model.Service{
-				Hostname: hostname,
-				Ports:    []*model.Port{port},
+				Hostname:     hostname,
+				Ports:        []*model.Port{port},
+				MeshExternal: false,
+				Resolution:   model.ClientSideLB,
 			},
 		})
 	}

--- a/pilot/pkg/serviceregistry/eureka/conversion.go
+++ b/pilot/pkg/serviceregistry/eureka/conversion.go
@@ -47,6 +47,8 @@ func convertServices(apps []*application, hostnames map[string]bool) map[string]
 					Address:      "",
 					Ports:        make(model.PortList, 0),
 					ExternalName: "",
+					MeshExternal: false,
+					Resolution:   model.ClientSideLB,
 				}
 				services[instance.Hostname] = service
 			}


### PR DESCRIPTION
Set `Resolution` and `MeshExternal` fields of `model.Service` in k8s, CF, Consul and Eureka.

Does not remove the `ExternalName` and `LoadBalancingDisabled` fields in `model.Service` (which are made obsolete by the new fields) to limit impact on the existing code.