### PR TITLE
Helm/injection with template

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (not .Release.IsInstall) -}}
+{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (and (not .Release.IsInstall) .Values.useAdmissionRegistration) -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (and (not .Release.IsInstall) .Values.useAdmissionRegistration) -}}
+{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (not .Release.IsInstall) -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -16,7 +16,7 @@ webhooks:
         name: {{ .Release.Name }}-sidecar-injector
         namespace: {{ .Release.Namespace }}
         path: "/inject"
-      caBundle: ${CA_BUNDLE}
+      caBundle: {{ $.Values.CA | quote }}
     rules:
       - operations: [ "CREATE" ]
         apiGroups: [""]

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1" -}}
+{{- if or (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1beta1") (not .Release.IsInstall) -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -92,6 +92,11 @@ sidecar-injector:
   # be allowed by the sidecar
   includeIPRanges: {}
 
+  # Force admission registration webhook when using `helm template`
+  # This capability is automatically populated as a cluster capability when using `helm install`
+  # or `helm upgrade` but must be manually specified if using `helm template`
+  useAdmissionRegistration: false
+
 #
 # mixer configuration
 #

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -94,7 +94,7 @@ sidecar-injector:
 
   # Base64-encoded CA Bundle 
   # The default cA bundle can be retrieved for a given cluster with the following command
-  # `  kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n'`
+  # `kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n'`
   CA: ""
 
 #

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -95,7 +95,7 @@ sidecar-injector:
   # Base64-encoded CA Bundle 
   # The default cA bundle can be retrieved for a given cluster with the following command
   # `kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n'`
-  CA: ""
+  CA: "${CA_BUNDLE}"
 
 #
 # mixer configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -92,10 +92,10 @@ sidecar-injector:
   # be allowed by the sidecar
   includeIPRanges: {}
 
-  # Force admission registration webhook when using `helm template`
-  # This capability is automatically populated as a cluster capability when using `helm install`
-  # or `helm upgrade` but must be manually specified if using `helm template`
-  useAdmissionRegistration: false
+  # Base64-encoded CA Bundle 
+  # The default cA bundle can be retrieved for a given cluster with the following command
+  # `  kubectl get configmap -n kube-system extension-apiserver-authentication -o=jsonpath='{.data.client-ca-file}' | base64 | tr -d '\n'`
+  CA: ""
 
 #
 # mixer configuration


### PR DESCRIPTION
The mutating webhook config could not be generated when running helm template as it relied on a condition only available during helm install or upgrade. This adds an explicit option when not installing or upgrading istio.

New PR to clean up from #3785 