### PR TITLE
Add check for Grafana dashboards to bin/linters.sh.

### DIFF
--- a/bin/check_dashboards.sh
+++ b/bin/check_dashboards.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+ROOTDIR=$SCRIPTPATH/..
+pushd $ROOTDIR
+
+git diff --quiet addons/grafana/dashboards/
+if [[ $? -ne 0 ]]; then
+    echo "Grafana dashboards have unstaged changes, please stage before linting."
+    popd
+    exit 1
+fi
+
+addons/grafana/fix_datasources.sh
+
+git diff --quiet addons/grafana/dashboards/
+if [[ $? -ne 0 ]]; then
+    echo "Grafana dashboards' datasources fixed, please add to commit."
+    popd
+    exit 1
+fi
+
+popd

--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -35,3 +35,7 @@ popd
 
 $gometalinter --config=./mixer/tools/adapterlinter/gometalinter.json ./mixer/adapter/...
 echo 'gometalinter on adapters OK'
+
+echo 'Checking Grafana dashboards'
+bin/check_dashboards.sh
+echo 'dashboards OK'


### PR DESCRIPTION
Grafana dashboards need to have the datasources set correctly. The
script addons/grafana/fix_datasources.sh does this. This commit adds a
check to bin/linters.sh and therefore "make lint" to ensure that this
script has been run.