### PR TITLE
fix broken proxy docker build

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -118,6 +118,9 @@ ISTIO_ENVOY_RELEASE_PATH=${ISTIO_ENVOY_RELEASE_PATH:-"$ISTIO_ENVOY_RELEASE_DIR/$
 
 # Save envoy in $ISTIO_ENVOY_DIR
 if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; then
+    # Clear out any old versions of Envoy.
+    rm -f ${ISTIO_OUT}/envoy ${ROOT}/pilot/pkg/proxy/envoy/envoy ${ISTIO_BIN}/envoy
+
     # Set the value of DOWNLOAD_COMMAND (either curl or wget)
     set_download_command
 
@@ -138,9 +141,6 @@ if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; 
     cp usr/local/bin/envoy $ISTIO_ENVOY_RELEASE_PATH
     rm -rf usr
     popd
-
-    # Clear out any old versions of Envoy.
-    rm -f ${ISTIO_OUT}/envoy ${ROOT}/pilot/pkg/proxy/envoy/envoy ${ISTIO_BIN}/envoy
 fi
 
 # TODO(nmittler): Remove once tests no longer use the envoy binary directly.

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -88,16 +88,18 @@ docker.eurekamirror: $(ISTIO_DOCKER)/pilot-test-eurekamirror
 docker.proxy_init: $(ISTIO_DOCKER)/prepare_proxy.sh
 docker.sidecar_injector: $(ISTIO_DOCKER)/sidecar-injector
 
-docker.proxy: tools/deb/envoy_bootstrap_tmpl.json ${PROXY_JSON_FILES}
-docker.proxy: $(ISTIO_OUT)/envoy
-docker.proxy: $(ISTIO_OUT)/pilot-agent
+docker.proxy: tools/deb/envoy_bootstrap_tmpl.json
+docker.proxy: ${ISTIO_ENVOY_RELEASE_PATH}
+docker.proxy: $(ISTIO_OUT)/pilot-agent ${PROXY_JSON_FILES}
 docker.proxy: pilot/docker/Dockerfile.proxy pilot/docker/Dockerfile.proxy_debug
 	mkdir -p $(ISTIO_DOCKER)/proxy
 	cp $^ $(ISTIO_DOCKER)/proxy/
 ifeq ($(DEBUG_IMAGE),1)
+	cp ${ISTIO_ENVOY_DEBUG_PATH} $(ISTIO_DOCKER)/proxyd/envoy
 	time (cd $(ISTIO_DOCKER)/proxy && \
 		docker build -t $(HUB)/proxy:$(TAG) -f Dockerfile.proxy_debug .)
 else
+	cp ${ISTIO_ENVOY_RELEASE_PATH} $(ISTIO_DOCKER)/proxy/envoy
 	time (cd $(ISTIO_DOCKER)/proxy && \
 		docker build -t $(HUB)/proxy:$(TAG) -f Dockerfile.proxy .)
 endif
@@ -107,8 +109,8 @@ docker.proxy_debug: ${ISTIO_ENVOY_DEBUG_PATH}
 docker.proxy_debug: $(ISTIO_OUT)/pilot-agent ${PROXY_JSON_FILES}
 docker.proxy_debug: pilot/docker/Dockerfile.proxy_debug
 	mkdir -p $(ISTIO_DOCKER)/proxyd
-	cp  ${ISTIO_ENVOY_DEBUG_PATH} $(ISTIO_DOCKER)/proxyd/envoy
-	cp  tools/deb/envoy_bootstrap_tmpl.json ${PROXY_JSON_FILES} $(ISTIO_OUT)/pilot-agent pilot/docker/Dockerfile.proxy_debug $(ISTIO_DOCKER)/proxyd/
+	cp ${ISTIO_ENVOY_DEBUG_PATH} $(ISTIO_DOCKER)/proxyd/envoy
+	cp $^ $(ISTIO_DOCKER)/proxyd/
 	time (cd $(ISTIO_DOCKER)/proxyd && \
 		docker build -t $(HUB)/proxy_debug:$(TAG) -f Dockerfile.proxy_debug .)
 

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -5,9 +5,6 @@
 # Notes:
 # * Make sure istioctl in your path is the one matching your release/crd/...
 # * You need to update istio-auth.yaml or run from a release directory:
-# For instance in ~/tmp/istio-0.3.0/ run
-#   ln -s ~/go/src/istio.io/istio/tools .
-# then
 #   source tools/setup_perf_cluster.sh
 #   setup_all
 # (inside google you may need to rerun setup_vm_firewall multiple times)


### PR DESCRIPTION
for regular (non debug) builds envoy should come from ISTIO_ENVOY_RELEASE_PATH
instead it was dependent on $ISTIO_OUT/envoy which is wrong.

Cleaned up proxy_debug target to make it similar to proxy. Makes it easier to fix, if we need changes in the future.

fixes #4266 