### PR TITLE
Update perf script and doc - better default run_tests

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -140,8 +140,8 @@ Using istio f2 to f1:
   "ActualQPS": 330.49386695603846,
 ```
 And then you will see:
-![screen shot 2018-03-20 at 8 26 24 pm](https://user-images.githubusercontent.com/3664595/37693480-231ac8c0-2c7d-11e8-9b3a-4e77a06f2d37.png)
-![screen shot 2018-03-20 at 8 26 07 pm](https://user-images.githubusercontent.com/3664595/37693481-232efdf4-2c7d-11e8-92b4-8a6e088d3357.png)
+![Single Graph Screen Shot](https://user-images.githubusercontent.com/3664595/37693480-231ac8c0-2c7d-11e8-9b3a-4e77a06f2d37.png)
+![Multi Graph Screen Shot](https://user-images.githubusercontent.com/3664595/37693481-232efdf4-2c7d-11e8-92b4-8a6e088d3357.png)
 
 
 For comparison and reference you can also run `run_fortio_test1` uses the default loadbalancer and no Istio mesh or Istio Ingress Controller. 

--- a/tools/README.md
+++ b/tools/README.md
@@ -116,12 +116,11 @@ NAME            HOSTS     ADDRESS          PORTS     AGE
 istio-ingress   *         35.188.254.231   80        1m
 ```
 
-You can now run the performance tests, either from the command line or interactively using the UIs (see next section). For command lines there are a couple of examples in the `run_tests` function:
-
+You can now run the performance tests, either from the command line or interactively using the UIs (see next section). 
+For command lines there are a couple of examples in the `run_tests` functions, it will run 4 tests 
+and start fortio report so you can graph the result on [http://localhost:8080/](http://localhost:8080/)
 
 ```
-# will run 4 tests and start fortio report so you can graph the result on [http://localhost:8080/](http://localhost:8080/)
-
 $ run_tests
 +++ VM Ip is 35.199.55.254 - visit (http on port 443 is not a typo:) http://35.199.55.254:443/fortio/
 +++ In k8s fortio external ip: http://35.199.37.178:8080/fortio/

--- a/tools/README.md
+++ b/tools/README.md
@@ -118,15 +118,39 @@ istio-ingress   *         35.188.254.231   80        1m
 
 You can now run the performance tests, either from the command line or interactively using the UIs (see next section). For command lines there are a couple of examples in the `run_tests` function:
 
-```
-$ run_tests
-# will run 4 tests and start fortio report so you can graph the result on [http://localhost:8080/](http://localhost:8080/)
-```
 
-The first test case uses the default loadbalancer and no Istio mesh or Istio Ingress Controller. The following command tells
+```
+# will run 4 tests and start fortio report so you can graph the result on [http://localhost:8080/](http://localhost:8080/)
+
+$ run_tests
++++ VM Ip is 35.199.55.254 - visit (http on port 443 is not a typo:) http://35.199.55.254:443/fortio/
++++ In k8s fortio external ip: http://35.199.37.178:8080/fortio/
++++ In k8s non istio ingress: http://35.227.201.148/fortio/
++++ In k8s istio ingress: http://35.188.241.231/fortio1/fortio/ and fortio2
+Using istio ingress to fortio1:
+### Running: curl -s http://35.199.55.254:443/fortio/?labels=ingress+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://35.188.241.231/fortio1/echo | tee ing-to-f1.json | grep ActualQPS
+  "ActualQPS": 439.8723210634554,
+Using istio ingress to fortio2:
+### Running: curl -s http://35.199.55.254:443/fortio/?labels=ingress+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://35.188.241.231/fortio2/echo | tee ing-to-f2.json | grep ActualQPS
+  "ActualQPS": 540.2583184971915,
+Using istio f1 to f2:
+### Running: curl -s http://35.188.241.231/fortio1/fortio/?labels=f1+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv2:8080/echo | tee f1-to-f2.json | grep ActualQPS
+  "ActualQPS": 439.5027107832303,
+Using istio f2 to f1:
+### Running: curl -s http://35.188.241.231/fortio2/fortio/?labels=f2+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv1:8080/echo | tee f2-to-f1.json | grep ActualQPS
+  "ActualQPS": 330.49386695603846,
+```
+And then you will see:
+![screen shot 2018-03-20 at 8 26 24 pm](https://user-images.githubusercontent.com/3664595/37693480-231ac8c0-2c7d-11e8-9b3a-4e77a06f2d37.png)
+![screen shot 2018-03-20 at 8 26 07 pm](https://user-images.githubusercontent.com/3664595/37693481-232efdf4-2c7d-11e8-92b4-8a6e088d3357.png)
+
+
+For comparison and reference you can also run `run_fortio_test1` uses the default loadbalancer and no Istio mesh or Istio Ingress Controller. 
+
+The following command tells
 Fortio on the VM to run a load test against the Fortio echo server running in the Kubernetes cluster:
 ```
-### Running: curl http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_FORTIO_EXT_IP:8080/echo
+### Running: curl http://$VM_URL/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_FORTIO_EXT_IP:8080/echo
 ```
 The following arguments are passed to the Fortio server running on the GCE VM:
 
@@ -140,15 +164,15 @@ The following arguments are passed to the Fortio server running on the GCE VM:
 | load=Start                              | Tells Fortio to be a load generator     |
 | url=http://$K8S_FORTIO_EXT_IP:8080/echo | The target to load test                 |
 
-The second test case uses the Fortio Ingress with no Istio mesh and the same arguments as the first test:
+You can also run `run_fortio_test2` which uses the Fortio Ingress with no Istio mesh and the same arguments as the first test:
 ```
-### Running: curl http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$NON_ISTIO_INGRESS/echo
+### Running: curl http://$VM_URL/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$NON_ISTIO_INGRESS/echo
 ```
 
-The third test case uses the Istio Ingress with the same arguments as the first test. This is the test that performs load testing
+The tests from `run_tests` uses the Istio Ingress with the same arguments. This is the test that performs load testing
 of the Istio service mesh:
 ```
-### Running: curl http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$ISTIO_INGRESS/fortio1/echo
+### Running: curl http://$VM_URL/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$ISTIO_INGRESS/fortio1/echo
 ```
 Compare the test results to understand the load differential between the 3 test cases.
 
@@ -158,7 +182,7 @@ Fortio provides a [Web UI](https://github.com/istio/fortio#webgraphical-ui) that
 can be used to perform load testing. You can call the `get_ips` function to obtain Fortio endpoint information for further load testing:
 ```
 $ get_ips
-+++ VM Ip is $VM_IP - visit http://$VM_IP/fortio/
++++ VM Ip is $VM_IP - visit http://$VM_URL/
 +++ In k8s fortio external ip: http://$EXTERNAL_IP:8080/fortio/
 +++ In k8s non istio ingress: http://$NON_ISTIO_INGRESS_IP/fortio/
 +++ In k8s istio ingress: http://$ISTIO_INGRESS_IP/fortio1/fortio/ and fortio2

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -233,7 +233,7 @@ function run_fortio_test_istio_ingress1() {
 }
 function run_fortio_test_istio_ingress2() {
   echo "Using istio ingress to fortio2:"
-  ExecuteEval curl -s "$VM_URL?labels=ingress+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://$ISTIO_INGRESS_IP/fortio2/echo" \| tee ing-to-f2.json \| grep ActualQPS
+  ExecuteEval curl -s "$VM_URL?labels=ingress+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://$ISTIO_INGRESS_IP/fortio2/echo" \| tee ing-to-f2.json \| grep ActualQPS
 }
 function run_fortio_test_istio_1_2() {
   echo "Using istio f1 to f2:"

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -114,7 +114,7 @@ function delete_vm_firewall() {
 }
 
 function update_fortio_on_vm() {
-  run_on_vm 'go get istio.io/fortio && cd go/src/istio.io/fortio && git fetch && git checkout latest_release && make submodule-sync && go install -ldflags "-X istio.io/fortio/version.tag=$(git describe --tag --match v\*) -X istio.io/fortio/version.buildInfo=$(git rev-parse HEAD)" . && sudo setcap 'cap_net_bind_service=+ep' `which fortio` && fortio version'
+  run_on_vm 'go get istio.io/fortio && cd go/src/istio.io/fortio && git fetch && git checkout latest_release && make submodule-sync && go build -o ~/go/bin/fortio -ldflags "-X istio.io/fortio/version.tag=$(git describe --tag --match v\*) -X istio.io/fortio/version.buildInfo=$(git rev-parse HEAD)" . && sudo setcap 'cap_net_bind_service=+ep' `which fortio` && fortio version'
 }
 
 function run_fortio_on_vm() {

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -3,6 +3,7 @@
 # Sets up a cluster for perf testing - GCP/GKE
 #   tools/setup_perf_cluster.sh
 # Notes:
+# * See README.md
 # * Make sure istioctl in your path is the one matching your release/crd/...
 # * You need to update istio-auth.yaml or run from a release directory:
 # For instance in ~/tmp/istio-0.3.0/ run
@@ -14,7 +15,8 @@
 #
 # This can be used as a script or sourced and functions called interactively
 #
-
+# The script must be run/sourced from the parent of the tools/ directory
+#
 PROJECT=${PROJECT:-$(gcloud config list --format 'value(core.project)' 2>/dev/null)}
 ZONE=${ZONE:-us-east4-b}
 CLUSTER_NAME=${CLUSTER_NAME:-istio-perf}
@@ -59,9 +61,15 @@ function update_gcp_opts() {
 }
 
 function Execute() {
-  echo "### Running:" "$@"
+  echo "### Running:" "$@" 1>&2
   "$@"
 }
+
+function ExecuteEval() {
+  echo "### Running:" "$@" 1>&2
+  eval "$@"
+}
+
 
 function create_cluster() {
   Execute gcloud container clusters create $CLUSTER_NAME $GCP_OPTS --machine-type=$MACHINE_TYPE --num-nodes=$NUM_NODES --no-enable-legacy-authorization
@@ -88,23 +96,21 @@ function delete_vm() {
 }
 
 function run_on_vm() {
-  echo "*** Remote run: \"$1\""
+  echo "*** Remote run: \"$1\"" 1>&2
   Execute gcloud compute ssh $VM_NAME $GCP_OPTS --command "$1"
 }
 
 function setup_vm() {
-  Execute gcloud compute instances add-tags $VM_NAME $GCP_OPTS --tags http-server,allow-8080
+  Execute gcloud compute instances add-tags $VM_NAME $GCP_OPTS --tags https-server
   run_on_vm '(sudo add-apt-repository ppa:gophers/archive > /dev/null && sudo apt-get update > /dev/null && sudo apt-get upgrade --no-install-recommends -y && sudo apt-get install --no-install-recommends -y golang-1.9-go make && mv .bashrc .bashrc.orig && (echo "export PATH=/usr/lib/go-1.9/bin:\$PATH:~/go/bin"; cat .bashrc.orig) > ~/.bashrc ) < /dev/null'
 }
 
 function setup_vm_firewall() {
-  Execute gcloud compute --project=$PROJECT firewall-rules create default-allow-http --network=default --action=ALLOW --rules=tcp:80 --source-ranges=0.0.0.0/0 --target-tags=http-server || true
-  Execute gcloud compute --project $PROJECT firewall-rules create allow-8080 --direction=INGRESS --action=ALLOW --rules=tcp:8080 --target-tags=port8080 || true
+  Execute gcloud compute --project=$PROJECT firewall-rules create default-allow-https --network=default --action=ALLOW --rules=tcp:443 --source-ranges=0.0.0.0/0 --target-tags=https-server || true
 }
 
 function delete_vm_firewall() {
-  Execute gcloud compute --project=$PROJECT firewall-rules delete default-allow-http -q
-  Execute gcloud compute --project $PROJECT firewall-rules delete allow-8080 -q
+  Execute gcloud compute --project=$PROJECT firewall-rules delete default-allow-https -q
 }
 
 function update_fortio_on_vm() {
@@ -112,12 +118,13 @@ function update_fortio_on_vm() {
 }
 
 function run_fortio_on_vm() {
-  run_on_vm 'pkill fortio; nohup fortio server -http-port 80 > ~/fortio.log 2>&1 &'
+  run_on_vm 'pkill fortio; nohup fortio server -http-port 443 > ~/fortio.log 2>&1 &'
 }
 
 function get_vm_ip() {
   VM_IP=$(gcloud compute instances describe $VM_NAME $GCP_OPTS |grep natIP|awk -F": " '{print $2}')
-  echo "+++ VM Ip is $VM_IP - visit http://$VM_IP/fortio/"
+  VM_URL="http://$VM_IP:443/fortio/"
+  echo "+++ VM Ip is $VM_IP - visit (http on port 443 is not a typo:) $VM_URL"
 }
 
 # assumes run from istio/ (or release) directory
@@ -217,16 +224,29 @@ function get_istio_ingress_ip() {
 
 function run_fortio_test1() {
   echo "Using default loadbalancer, no istio:"
-  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO_K8S_IP:8080/echo"
+  Execute curl "$VM_URL?json=on&save=on&qps=-1&t=30s&c=48&load=Start&url=http://$FORTIO_K8S_IP:8080/echo"
 }
 function run_fortio_test2() {
   echo "Using default ingress, no istio:"
-  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP/echo"
+  Execute curl "$VM_URL?json=on&save=on&qps=-1&t=30s&c=48&load=Start&url=http://$K8S_INGRESS_IP/echo"
 }
-function run_fortio_test3() {
-  echo "Using istio ingress:"
-  Execute curl "http://$VM_IP/fortio/?json=on&qps=-1&t=30s&c=48&load=Start&url=http://$ISTIO_INGRESS_IP/fortio1/echo"
+function run_fortio_test_istio_ingress1() {
+  echo "Using istio ingress to fortio1:"
+  ExecuteEval curl -s "$VM_URL?labels=ingress+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://$ISTIO_INGRESS_IP/fortio1/echo" \| tee ing-to-f1.json \| grep ActualQPS
 }
+function run_fortio_test_istio_ingress2() {
+  echo "Using istio ingress to fortio2:"
+  ExecuteEval curl -s "$VM_URL?labels=ingress+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://$ISTIO_INGRESS_IP/fortio2/echo" \| tee ing-to-f2.json \| grep ActualQPS
+}
+function run_fortio_test_istio_1_2() {
+  echo "Using istio f1 to f2:"
+  ExecuteEval curl -s "http://$ISTIO_INGRESS_IP/fortio1/fortio/?labels=f1+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv2:8080/echo" \| tee f1-to-f2.json \| grep ActualQPS
+}
+function run_fortio_test_istio_2_1() {
+  echo "Using istio f2 to f1:"
+  ExecuteEval curl -s "http://$ISTIO_INGRESS_IP/fortio2/fortio/?labels=f1+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv1:8080/echo" \| tee f2-to-f1.json \| grep ActualQPS
+}
+
 
 # Run canonical perf tests.
 # The following parameters can be supplied:
@@ -297,7 +317,6 @@ function run_canonical_perf_test() {
             ;;
     esac
 
-    PERCENTILES="50%2C+75%2C+90%2C+99%2C+99.9"
     GRANULARITY="0.001"
 
     LABELS="${LABEL}+${DRIVER}+${TARGET}+Q${QPS}+T${DURATION}+C${CLIENTS}"
@@ -311,7 +330,7 @@ function run_canonical_perf_test() {
 
     echo "Running '${LABELS}' and storing results in ${OUT_FILE}"
 
-    URL="${DRIVER_URL}/?labels=${LABELS}&url=${TARGET_URL}&qps=${QPS}&t=${DURATION}&c=${CLIENTS}&p=${PERCENTILES}&r=${GRANULARITY}&json=on&save=on&load=Start"
+    URL="${DRIVER_URL}/?labels=${LABELS}&url=${TARGET_URL}&qps=${QPS}&t=${DURATION}&c=${CLIENTS}&r=${GRANULARITY}&json=on&save=on&load=Start"
     #echo "URL: ${URL}"
 
     curl -s "${URL}" -o "${OUT_FILE}"
@@ -369,9 +388,14 @@ function get_ips() {
 function run_tests() {
   update_gcp_opts
   get_ips
-  run_fortio_test1
-  run_fortio_test2
-  run_fortio_test3
+#  run_fortio_test1
+#  run_fortio_test2
+  run_fortio_test_istio_ingress1
+  run_fortio_test_istio_ingress2
+  run_fortio_test_istio_1_2
+  run_fortio_test_istio_2_1
+  echo "Graph the results:"
+  fortio report &
 }
 
 
@@ -400,5 +424,5 @@ if [[ $SOURCED == 0 ]]; then
 #setup_vm_firewall
 #get_ips
 #install_istio_svc
-  delete_all
+#delete_all
 fi

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -244,7 +244,7 @@ function run_fortio_test_istio_1_2() {
 }
 function run_fortio_test_istio_2_1() {
   echo "Using istio f2 to f1:"
-  ExecuteEval curl -s "http://$ISTIO_INGRESS_IP/fortio2/fortio/?labels=f1+to+f2\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv1:8080/echo" \| tee f2-to-f1.json \| grep ActualQPS
+  ExecuteEval curl -s "http://$ISTIO_INGRESS_IP/fortio2/fortio/?labels=f2+to+f1\&json=on\&save=on\&qps=-1\&t=30s\&c=48\&load=Start\&url=http://echosrv1:8080/echo" \| tee f2-to-f1.json \| grep ActualQPS
 }
 
 


### PR DESCRIPTION
run_tests now run ing->f1 ing->f2 f1->f2 f2->f1 and saves the json and
starts report ui (if fortio is installed)

Simplify some of the setup and doc

Use 443 as the http port on the VM (should not get auto cleaned up)

Only run the through istio ingress test by default

Don’t delete everything by default (when not sourcing)

Fortio 0.8.x doesn’t need percentiles passed