### PR TITLE
Rerun generate_config_crd_types.go to update ServiceRole and ServiceRoleBinding types.

### DIFF
--- a/pilot/pkg/config/kube/crd/types.go
+++ b/pilot/pkg/config/kube/crd/types.go
@@ -199,7 +199,7 @@ var knownTypes = map[string]schemaType{
 		schema: model.ServiceRole,
 		object: &ServiceRole{
 			TypeMeta: meta_v1.TypeMeta{
-				Kind:       model.ServiceRole.Type,
+				Kind:       "ServiceRole",
 				APIVersion: apiVersion(&model.ServiceRole),
 			},
 		},
@@ -209,7 +209,7 @@ var knownTypes = map[string]schemaType{
 		schema: model.ServiceRoleBinding,
 		object: &ServiceRoleBinding{
 			TypeMeta: meta_v1.TypeMeta{
-				Kind:       model.ServiceRoleBinding.Type,
+				Kind:       "ServiceRoleBinding",
 				APIVersion: apiVersion(&model.ServiceRoleBinding),
 			},
 		},


### PR DESCRIPTION
Change https://github.com/istio/istio/pull/4246 might use the old script when generate types for the new CRDs.