### PR TITLE
Improve dashboard test robustness

### DIFF
--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -422,7 +422,7 @@ func waitForMixerConfigResolution() error {
 	configQuery := `sum(mixer_config_handler_config_count)`
 	handlers := 0.0
 	for _, duration := range waitDurations {
-		fmt.Printf("waiting for Mixer to be configured with correct handlers: %v\n", duration)
+		log.Infof("waiting for Mixer to be configured with correct handlers: %v", duration)
 		time.Sleep(duration)
 		val, err := getMetricValue(configQuery)
 		if err == nil && val >= 3.0 {
@@ -443,7 +443,7 @@ func waitForMetricsInPrometheus(t *testing.T) error {
 	}
 
 	for _, duration := range waitDurations {
-		t.Logf("waiting for prometheus metrics: %v", duration)
+		t.Logf("Waiting for prometheus metrics: %v", duration)
 		time.Sleep(duration)
 
 		i := 0

--- a/tests/e2e/tests/dashboard/fortio-rules.yaml
+++ b/tests/e2e/tests/dashboard/fortio-rules.yaml
@@ -48,7 +48,7 @@ kind: Deployment
 metadata:
   name: echosrv-deployment
 spec:
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR is an attempt to improve the stability of the dashboard tests, which
have demonstrated a bit of flakiness (especially in rbac-auth tests). 

There appear to be two possible explanations for test flakiness:
1. Mixer configuration for handlers is not received before traffic is handled by Mixer.
1. Metrics exposed by Mixer have not been processed by Prometheus in time for test.

This PR adds two wait-loops to address these issues:
1. in `Setup()`, the test now checks a Mixer metric to confirm that Mixer has the expected number of handlers configured (kubernetesenv, stdio, prometheus).
1. in `TestDashboard`, a set of sentinel queries are executed to confirm that Mixer scraping is working as expected.

Together, these polling operations should significantly reduce (if not fully eliminate) observed flakes in the dashboard tests caused by timing issues.

cc: @xiaolanz (oncall)

Fixes: #4420 