### PR TITLE
Update proxy sha to use Envoy 1.6.0

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -12,6 +12,6 @@
 		"repoName": "proxy",
 		"prodBranch": "master",
 		"file": "",
-		"lastStableSHA": "0a539af8a637d42679c6a014f62f9b45c1a9eafa"
+		"lastStableSHA": "f6942b938d230a33200eae7784e5be1d294a5fb7"
 	}
 ]


### PR DESCRIPTION
Update to use the latest proxy sha which uses Envoy 1.6.0.

Signed-off-by: Gary Brown <gary@brownuk.com>