### PR TITLE
Simplify and make e2e simple simple again/more readable

### DIFF
--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -69,6 +69,10 @@ func TestSimpleIngress(t *testing.T) {
 	// Tests that a simple ingress with rewrite/dropping of the /fortio/ prefix
 	// works, as fortio only replies with "echo debug server ..." on the /debug uri.
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
+	// Make sure the pods are running:
+	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+		t.Fatalf("Pods not ready!")
+	}
 
 	// This checks until all of those 3 things become ready:
 	// 1) ingress pod is up (that done by IngressOrFail above)
@@ -114,7 +118,8 @@ func TestSvc2Svc(t *testing.T) {
 	if len(podList) != 2 {
 		t.Fatalf("Unexpected to get %d pods when expecting 2. got %v", len(podList), podList)
 	}
-	// Check that both pods are ready before doing a (small) load test
+	// Check that both pods are ready (can talk to each other through envoy) before doing a (small) load test
+	// (despite the CheckPodsRunning in previous test, envoy rules may not have reached the 2 pods envoy yet)
 	log.Infof("Configuration readiness pre-check from %v to http://echosrv:8080/echo", podList)
 	timeout := time.Now().Add(timeToWaitForPods)
 	var res string

--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -88,7 +88,7 @@ func TestSimpleIngress(t *testing.T) {
 			continue
 		}
 		if !bytes.Contains(data, needle) {
-			log.Errorf("Iter %d : unexpected content despite 200: %s", i)
+			log.Errorf("Iter %d : unexpected content despite 200: %s", i, data)
 		}
 		// Test success:
 		log.Infof("Iter %d : ingress->Svc is up! Found %s", i, dataDebug)
@@ -113,7 +113,7 @@ func TestSvc2Svc(t *testing.T) {
 	start := time.Now()
 	timeout := start.Add(20 * time.Second)
 	var res string
-	for true {
+	for {
 		if start.After(timeout) {
 			t.Fatalf("Pod readyness failed - last error: %s", res)
 		}

--- a/tests/util/kubeUtils.go
+++ b/tests/util/kubeUtils.go
@@ -279,9 +279,9 @@ func GetPodStatus(n, pod string) string {
 // Also check container status to be running.
 func CheckPodsRunning(n string) (ready bool) {
 	retry := Retrier{
-		BaseDelay: 30 * time.Second,
-		MaxDelay:  30 * time.Second,
-		Retries:   6,
+		BaseDelay:   1 * time.Second,
+		MaxDelay:    30 * time.Second,
+		MaxDuration: 90 * time.Second,
 	}
 
 	retryFn := func(_ context.Context, i int) error {


### PR DESCRIPTION
I find the shiny retry/context way too verbose and not obvious to read

going back to a simpler/straightforward approach

use the new simple `fhttp.Fetch`