### PR TITLE
Add ServiceRole and ServiceRoleBinding to istioctl CRD definition.

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -664,6 +664,8 @@ func newClient() (*crd.Client, error) {
 		model.EndUserAuthenticationPolicySpec,
 		model.EndUserAuthenticationPolicySpecBinding,
 		model.AuthenticationPolicy,
+		model.ServiceRole,
+		model.ServiceRoleBinding,
 	}, "")
 }
 


### PR DESCRIPTION
The CRD definition was added to pilot in #4246.