### PR TITLE
Move CA client config to pkg.

### DIFF
--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -51,22 +51,22 @@ func init() {
 
 	flags := rootCmd.Flags()
 
-	flags.StringVar(&naConfig.ServiceIdentityOrg, "org", "", "Organization for the cert")
-	flags.DurationVar(&naConfig.WorkloadCertTTL, "workload-cert-ttl", 19*time.Hour,
+	flags.StringVar(&naConfig.CAClientConfig.Org, "org", "", "Organization for the cert")
+	flags.DurationVar(&naConfig.CAClientConfig.RequestedCertTTL, "workload-cert-ttl", 19*time.Hour,
 		"The requested TTL for the workload")
-	flags.IntVar(&naConfig.RSAKeySize, "key-size", 2048, "Size of generated private key")
-	flags.StringVar(&naConfig.IstioCAAddress,
+	flags.IntVar(&naConfig.CAClientConfig.RSAKeySize, "key-size", 2048, "Size of generated private key")
+	flags.StringVar(&naConfig.CAClientConfig.CAAddress,
 		"ca-address", "istio-ca:8060", "Istio CA address")
 
-	flags.StringVar(&naConfig.Env, "env", "unspecified",
+	flags.StringVar(&naConfig.CAClientConfig.Env, "env", "unspecified",
 		"Node Environment : unspecified | onprem | gcp | aws")
-	flags.StringVar(&naConfig.Platform, "platform", "vm", "The platform istio runs on: vm | k8s")
+	flags.StringVar(&naConfig.CAClientConfig.Platform, "platform", "vm", "The platform istio runs on: vm | k8s")
 
-	flags.StringVar(&naConfig.CertChainFile, "cert-chain",
+	flags.StringVar(&naConfig.CAClientConfig.CertChainFile, "cert-chain",
 		"/etc/certs/cert-chain.pem", "Node Agent identity cert file")
-	flags.StringVar(&naConfig.KeyFile,
+	flags.StringVar(&naConfig.CAClientConfig.KeyFile,
 		"key", "/etc/certs/key.pem", "Node Agent private key file")
-	flags.StringVar(&naConfig.RootCertFile, "root-cert",
+	flags.StringVar(&naConfig.CAClientConfig.RootCertFile, "root-cert",
 		"/etc/certs/root-cert.pem", "Root Certificate file")
 
 	naConfig.LoggingOptions.AttachCobraFlags(rootCmd)
@@ -74,16 +74,16 @@ func init() {
 }
 
 func main() {
-	if naConfig.Platform == "vm" {
+	if naConfig.CAClientConfig.Platform == "vm" {
 		if err := rootCmd.Execute(); err != nil {
 			log.Errora(err)
 			os.Exit(-1)
 		}
-	} else if naConfig.Platform == "k8s" {
+	} else if naConfig.CAClientConfig.Platform == "k8s" {
 		log.Errorf("WIP for support on k8s...")
 		os.Exit(-1)
 	} else {
-		log.Errorf("node agent on %v is not supported yet", naConfig.Platform)
+		log.Errorf("node agent on %v is not supported yet", naConfig.CAClientConfig.Platform)
 		os.Exit(-1)
 	}
 }

--- a/security/cmd/node_agent/na/config.go
+++ b/security/cmd/node_agent/na/config.go
@@ -19,6 +19,7 @@ import (
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
+	"istio.io/istio/security/pkg/caclient"
 )
 
 const (
@@ -32,44 +33,11 @@ const (
 
 // Config is Node agent configuration.
 type Config struct {
-	// Istio CA grpc server
-	IstioCAAddress string
-
-	// Organization of service, presented in the certificates
-	ServiceIdentityOrg string
-
-	// Requested TTL of the workload certificates
-	WorkloadCertTTL time.Duration
-
-	RSAKeySize int
-
-	// The environment this node agent is running on.
-	Env string
-
-	// The cluster management platform this ndoe agent is running on, e.g k8s.
-	Platform string
-
-	// CSRInitialRetrialInterval is the retrial interval for certificate requests.
-	CSRInitialRetrialInterval time.Duration
-
-	// CSRMaxRetries is the number of retries for certificate requests.
-	CSRMaxRetries int
-
-	// CSRGracePeriodPercentage indicates the length of the grace period in the
-	// percentage of the entire certificate TTL.
-	CSRGracePeriodPercentage int
+	// Config for CA Client
+	CAClientConfig caclient.Config
 
 	// LoggingOptions is the options for Istio logging.
 	LoggingOptions *log.Options
-
-	// CertChainFile defines the cert chain file of node agent.
-	CertChainFile string
-
-	// KeyFile defines the private key of node agent.
-	KeyFile string
-
-	// RootCertFile defines the root cert of node agent.
-	RootCertFile string
 
 	// WorkloadOpts configures how to create handler for each workload api.
 	WorkloadOpts handler.Options
@@ -78,9 +46,11 @@ type Config struct {
 // NewConfig creates a new Config instance with default values.
 func NewConfig() *Config {
 	return &Config{
-		CSRInitialRetrialInterval: defaultCSRInitialRetrialInterval,
-		CSRMaxRetries:             defaultCSRMaxRetries,
-		CSRGracePeriodPercentage:  defaultCSRGracePeriodPercentage,
-		LoggingOptions:            log.DefaultOptions(),
+		CAClientConfig: caclient.Config{
+			CSRInitialRetrialInterval: defaultCSRInitialRetrialInterval,
+			CSRMaxRetries:             defaultCSRMaxRetries,
+			CSRGracePeriodPercentage:  defaultCSRGracePeriodPercentage,
+		},
+		LoggingOptions: log.DefaultOptions(),
 	}
 }

--- a/security/cmd/node_agent/na/config_test.go
+++ b/security/cmd/node_agent/na/config_test.go
@@ -21,16 +21,16 @@ import (
 func TestInitializeConfig(t *testing.T) {
 	config := NewConfig()
 
-	if config.CSRInitialRetrialInterval != defaultCSRInitialRetrialInterval {
-		t.Errorf("Unexpected config.CSRInitialRetrialInterval: %v", config.CSRInitialRetrialInterval)
+	if config.CAClientConfig.CSRInitialRetrialInterval != defaultCSRInitialRetrialInterval {
+		t.Errorf("Unexpected config.CSRInitialRetrialInterval: %v", config.CAClientConfig.CSRInitialRetrialInterval)
 	}
 
-	if config.CSRMaxRetries != defaultCSRMaxRetries {
-		t.Errorf("Unexpected config.CSRMaxRetries: %v", config.CSRMaxRetries)
+	if config.CAClientConfig.CSRMaxRetries != defaultCSRMaxRetries {
+		t.Errorf("Unexpected config.CSRMaxRetries: %v", config.CAClientConfig.CSRMaxRetries)
 	}
 
-	if config.CSRGracePeriodPercentage != defaultCSRGracePeriodPercentage {
-		t.Errorf("Unexpected config.CSRGracePeriodPercentage: %v", config.CSRGracePeriodPercentage)
+	if config.CAClientConfig.CSRGracePeriodPercentage != defaultCSRGracePeriodPercentage {
+		t.Errorf("Unexpected config.CSRGracePeriodPercentage: %v", config.CAClientConfig.CSRGracePeriodPercentage)
 	}
 
 }

--- a/security/cmd/node_agent/na/nafactory.go
+++ b/security/cmd/node_agent/na/nafactory.go
@@ -40,12 +40,12 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 	}
 	na := &nodeAgentInternal{
 		config:   cfg,
-		certUtil: util.NewCertUtil(cfg.CSRGracePeriodPercentage),
+		certUtil: util.NewCertUtil(cfg.CAClientConfig.CSRGracePeriodPercentage),
 	}
 
 	env := DetermineEnv(cfg)
-	pc, err := platform.NewClient(env, cfg.RootCertFile, cfg.KeyFile,
-		cfg.CertChainFile, cfg.IstioCAAddress)
+	pc, err := platform.NewClient(env, cfg.CAClientConfig.RootCertFile, cfg.CAClientConfig.KeyFile,
+		cfg.CAClientConfig.CertChainFile, cfg.CAClientConfig.CAAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 
 	// TODO: Specify files for service identity cert/key instead of node agent files.
 	secretServer, err := workload.NewSecretServer(
-		workload.NewSecretFileServerConfig(cfg.CertChainFile, cfg.KeyFile))
+		workload.NewSecretFileServerConfig(cfg.CAClientConfig.CertChainFile, cfg.CAClientConfig.KeyFile))
 	if err != nil {
 		log.Errorf("Workload IO creation error: %v", err)
 		os.Exit(-1)
@@ -68,8 +68,8 @@ func NewNodeAgent(cfg *Config) (NodeAgent, error) {
 // DetermineEnv choose the right environment. If the env is specified in cfg.Env,
 // then we will use it. Otherwise nodeagent will detect the platform for you.
 func DetermineEnv(cfg *Config) string {
-	if cfg.Env != "unspecified" {
-		return cfg.Env
+	if cfg.CAClientConfig.Env != "unspecified" {
+		return cfg.CAClientConfig.Env
 	}
 	if metadata.OnGCE() {
 		return "gcp"

--- a/security/cmd/node_agent/na/nafactory_test.go
+++ b/security/cmd/node_agent/na/nafactory_test.go
@@ -16,6 +16,8 @@ package na
 
 import (
 	"testing"
+
+	"istio.io/istio/security/pkg/caclient"
 )
 
 func TestNewNodeAgent(t *testing.T) {
@@ -30,25 +32,33 @@ func TestNewNodeAgent(t *testing.T) {
 		},
 		"onprem env test": {
 			config: &Config{
-				Env: "onprem",
+				CAClientConfig: caclient.Config{
+					Env: "onprem",
+				},
 			},
 			expectedErr: "",
 		},
 		"gcp env test": {
 			config: &Config{
-				Env: "gcp",
+				CAClientConfig: caclient.Config{
+					Env: "gcp",
+				},
 			},
 			expectedErr: "",
 		},
 		"unspecified env test": {
 			config: &Config{
-				Env: "unspecified",
+				CAClientConfig: caclient.Config{
+					Env: "unspecified",
+				},
 			},
 			expectedErr: "",
 		},
 		"Unsupported env test": {
 			config: &Config{
-				Env: "somethig else",
+				CAClientConfig: caclient.Config{
+					Env: "somethig else",
+				},
 			},
 			expectedErr: "invalid env somethig else specified",
 		},

--- a/security/cmd/node_agent/na/nodeagent_test.go
+++ b/security/cmd/node_agent/na/nodeagent_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/pkg/caclient"
 	mockclient "istio.io/istio/security/pkg/caclient/grpc/mock"
 	"istio.io/istio/security/pkg/platform"
 	mockpc "istio.io/istio/security/pkg/platform/mock"
@@ -32,17 +33,19 @@ import (
 
 func TestStartWithArgs(t *testing.T) {
 	generalConfig := Config{
-		IstioCAAddress:     "ca_addr",
-		ServiceIdentityOrg: "Google Inc.",
-		RSAKeySize:         512,
-		Env:                "onprem",
-		CSRInitialRetrialInterval: time.Millisecond,
-		CSRMaxRetries:             3,
-		CSRGracePeriodPercentage:  50,
-		LoggingOptions:            log.DefaultOptions(),
-		RootCertFile:              "ca_file",
-		KeyFile:                   "pkey",
-		CertChainFile:             "cert_file",
+		CAClientConfig: caclient.Config{
+			CAAddress:  "ca_addr",
+			Org:        "Google Inc.",
+			RSAKeySize: 512,
+			Env:        "onprem",
+			CSRInitialRetrialInterval: time.Millisecond,
+			CSRMaxRetries:             3,
+			CSRGracePeriodPercentage:  50,
+			RootCertFile:              "ca_file",
+			KeyFile:                   "pkey",
+			CertChainFile:             "cert_file",
+		},
+		LoggingOptions: log.DefaultOptions(),
 	}
 	signedCert := []byte(`TESTCERT`)
 	certChain := []byte(`CERTCHAIN`)
@@ -82,17 +85,19 @@ func TestStartWithArgs(t *testing.T) {
 			// 128 is too small for a RSA private key. GenCSR will return error.
 
 			config: &Config{
-				IstioCAAddress:     "ca_addr",
-				ServiceIdentityOrg: "Google Inc.",
-				RSAKeySize:         128,
-				Env:                "onprem",
-				CSRInitialRetrialInterval: time.Millisecond,
-				CSRMaxRetries:             3,
-				CSRGracePeriodPercentage:  50,
-				RootCertFile:              "ca_file",
-				KeyFile:                   "pkey",
-				CertChainFile:             "cert_file",
-				LoggingOptions:            log.DefaultOptions(),
+				CAClientConfig: caclient.Config{
+					CAAddress:  "ca_addr",
+					Org:        "Google Inc.",
+					RSAKeySize: 128,
+					Env:        "onprem",
+					CSRInitialRetrialInterval: time.Millisecond,
+					CSRMaxRetries:             3,
+					CSRGracePeriodPercentage:  50,
+					RootCertFile:              "ca_file",
+					KeyFile:                   "pkey",
+					CertChainFile:             "cert_file",
+				},
+				LoggingOptions: log.DefaultOptions(),
 			},
 			pc:          mockpc.FakeClient{nil, "", "service1", "", []byte{}, "", true},
 			cAClient:    &mockclient.FakeCAClient{0, nil, nil},

--- a/security/pkg/caclient/config.go
+++ b/security/pkg/caclient/config.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caclient
+
+import (
+	"time"
+)
+
+// Config is configuration for the CA client.
+type Config struct {
+	// Address of the CA which the CA client calls to
+	CAAddress string
+
+	// Organization presented in the certificates
+	Org string
+
+	// Requested TTL of the certificates
+	RequestedCertTTL time.Duration
+
+	// Size of RSA private key
+	RSAKeySize int
+
+	// The environment this CA client is running on.
+	Env string
+
+	// The cluster management platform this ndoe agent is running on.
+	Platform string
+
+	// Whether the certificate is for CA
+	ForCA bool
+
+	// CSRInitialRetrialInterval is the retrial interval for certificate requests.
+	CSRInitialRetrialInterval time.Duration
+
+	// CSRMaxRetries is the number of retries for certificate requests.
+	CSRMaxRetries int
+
+	// CSRGracePeriodPercentage indicates the length of the grace period in the
+	// percentage of the entire certificate TTL.
+	CSRGracePeriodPercentage int
+
+	// CertFile defines the cert of the CA client.
+	CertFile string
+
+	// CertChainFile defines the cert chain file of the CA client, including the client's cert.
+	CertChainFile string
+
+	// KeyFile defines the private key of the CA client.
+	KeyFile string
+
+	// RootCertFile defines the root cert of the CA client.
+	RootCertFile string
+}


### PR DESCRIPTION
Over the time, we plan to move the logic in cmd/ to pkg/. This is part of the effort to migrate the CA client code.