### PR TITLE
Include pem file in build package for better user experience

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -113,6 +113,7 @@ find samples install -type f \( \
   -name "*.yaml" \
   -o -name "cleanup*" \
   -o -name "*.md" \
+  -o -name "*.pem" \
   -o -name "kubeconfig" \
   -o -name "*.jinja*" \
   -o -name "webhook-create-signed-cert.sh" \


### PR DESCRIPTION
Currently we need to download the key/cert example files in this demo https://istio.io/docs/tasks/security/plugin-ca-cert.html, we should include it for better user experience.

