### PR TITLE
Remove races from cache tests

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -242,12 +242,15 @@ func testCacheEvictExpired(c ExpiringCache, t *testing.T) {
 func testCacheEvicter(c ExpiringCache, t *testing.T) {
 	c.SetWithExpiration("A", "A", 1*time.Millisecond)
 
-	// this is racy, but we're being generous enough that it should be fine
-	time.Sleep(10 * time.Millisecond)
+	// loop until eviction happens. If eviction doesn't happen, this loop will get stuck forever which is fine
+	for {
+		time.Sleep(10 * time.Millisecond)
 
-	_, ok := c.Get("A")
-	if ok {
-		t.Error("Got entry, expecting it to have been evicted")
+		_, ok := c.Get("A")
+		if !ok {
+			// item disappeared, we're done
+			return
+		}
 	}
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !race
-
 package cache
 
 import (
@@ -168,7 +166,6 @@ func testCacheConcurrent(c Cache, t *testing.T) {
 
 // WARNING: This test expects the cache to have been created with a long expiration time.
 func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	now := time.Now()
 
 	c.SetWithExpiration("EARLY", "123", 10*time.Millisecond)
@@ -227,11 +224,7 @@ func testCacheExpiration(c ExpiringCache, evictExpired func(time.Time), t *testi
 }
 
 func testCacheEvictExpired(c ExpiringCache, t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	c.SetWithExpiration("A", "A", 1*time.Millisecond)
-
-	// this is racy, but we're being generous enough that it should be fine
-	time.Sleep(50 * time.Millisecond)
 
 	_, ok := c.Get("A")
 	if !ok {
@@ -247,7 +240,6 @@ func testCacheEvictExpired(c ExpiringCache, t *testing.T) {
 }
 
 func testCacheEvicter(c ExpiringCache, t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	c.SetWithExpiration("A", "A", 1*time.Millisecond)
 
 	// this is racy, but we're being generous enough that it should be fine
@@ -259,18 +251,9 @@ func testCacheEvicter(c ExpiringCache, t *testing.T) {
 	}
 }
 
-func testCacheFinalizer(gate *bool, t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
-	for i := 0; i < 100; i++ {
-		runtime.GC()
-		if *gate {
-			return
-		}
-
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	t.Errorf("Expecting eviction loop to have been terminated")
+func testCacheFinalizer(gate *sync.WaitGroup, t *testing.T) {
+	runtime.GC()
+	gate.Wait()
 }
 
 func benchmarkCacheGet(c Cache, b *testing.B) {

--- a/pkg/cache/lruCache_test.go
+++ b/pkg/cache/lruCache_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !race
-
 package cache
 
 import (
@@ -22,45 +20,36 @@ import (
 )
 
 func TestLRUBasic(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	lru := NewLRU(5*time.Minute, 1*time.Millisecond, 500)
 	testCacheBasic(lru, t)
 }
 
 func TestLRUConcurrent(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	lru := NewLRU(5*time.Minute, 1*time.Minute, 500)
 	testCacheConcurrent(lru, t)
 }
 
 func TestLRUExpiration(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	lru := NewLRU(5*time.Second, 100*time.Second, 500).(*lruWrapper)
 	testCacheExpiration(lru, lru.evictExpired, t)
 }
 
 func TestLRUEvicter(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	lru := NewLRU(5*time.Second, 1*time.Millisecond, 500)
 	testCacheEvicter(lru, t)
 }
 
 func TestLRUEvictExpired(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
-	lru := NewLRU(5*time.Second, 0, 500)
+	lru := NewLRU(5*time.Second, 0, 500).(*lruCache)
 	testCacheEvictExpired(lru, t)
 }
 
 func TestLRUFinalizer(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
-	c := NewLRU(5*time.Second, 1*time.Millisecond, 500).(*lruWrapper)
-	gate := &c.evicterTerminated
-
-	testCacheFinalizer(gate, t)
+	lru := NewLRU(5*time.Second, 1*time.Millisecond, 500).(*lruWrapper)
+	testCacheFinalizer(&lru.evicterTerminated, t)
 }
 
 func TestLRUBehavior(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	lru := NewLRU(5*time.Minute, 1*time.Millisecond, 3)
 
 	lru.Set("1", "1")

--- a/pkg/cache/ttlCache_test.go
+++ b/pkg/cache/ttlCache_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !race
-
 package cache
 
 import (
@@ -22,40 +20,33 @@ import (
 )
 
 func TestTTLBasic(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	ttl := NewTTL(5*time.Second, 1*time.Millisecond)
 	testCacheBasic(ttl, t)
 }
 
 func TestTTLConcurrent(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	ttl := NewTTL(5*time.Second, 1*time.Second)
 	testCacheConcurrent(ttl, t)
 }
 
 func TestTTLExpiration(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	ttl := NewTTL(5*time.Second, 100*time.Second).(*ttlWrapper)
 	testCacheExpiration(ttl, ttl.evictExpired, t)
 }
 
 func TestTTLEvicter(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
 	ttl := NewTTL(5*time.Second, 1*time.Millisecond)
 	testCacheEvicter(ttl, t)
 }
 
 func TestTTLEvictExpired(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
-	ttl := NewTTL(5*time.Second, 0)
+	ttl := NewTTL(5*time.Second, 0).(*ttlCache)
 	testCacheEvictExpired(ttl, t)
 }
 
 func TestTTLFinalizer(t *testing.T) {
-	t.Skip("issue https://github.com/istio/istio/issues/4304")
-	c := NewTTL(5*time.Second, 1*time.Millisecond).(*ttlWrapper)
-	gate := &c.evicterTerminated
-	testCacheFinalizer(gate, t)
+	ttl := NewTTL(5*time.Second, 1*time.Millisecond).(*ttlWrapper)
+	testCacheFinalizer(&ttl.evicterTerminated, t)
 }
 
 func BenchmarkTTLGet(b *testing.B) {


### PR DESCRIPTION
This expands the scope of a lock in the async evicter to satisfy the race test logic. It's not
strictly necessary, but it's better to keep the tools happy.