### PR TITLE
Kubernetes yaml diff tool

### DIFF
--- a/bin/diff_yaml.py
+++ b/bin/diff_yaml.py
@@ -150,7 +150,7 @@ def compare(args):
 
             print datadiff.diff(s0, s1, fromfile=args.orig, tofile=args.new)
 
-    return -1 * (changed + len(added) + len(removed))
+    return changed + len(added) + len(removed)
 
 
 def main(args):

--- a/bin/diff_yaml.py
+++ b/bin/diff_yaml.py
@@ -76,6 +76,8 @@ def normalize_configmap(res):
 def normalize_ports(res):
     try:
         spec = res["spec"]
+        if spec is None:
+            return res
         ports = sorted(spec['ports'], key=lambda x: x["port"])
         spec['ports'] = ports
 

--- a/bin/diff_yaml.py
+++ b/bin/diff_yaml.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+# Compare 2 multi document kubernetes yaml files
+# It ensures that order does not matter
+
+import yaml  # pyyaml
+import datadiff
+import argparse
+
+# returns fully qualified resource name of the k8s resource
+
+
+def byResourceName(res):
+    if res is None:
+        return ""
+
+    return "{}::{}::{}".format(res['apiVersion'],
+                               res['kind'],
+                               res['metadata']['name'])
+
+
+def keydiff(k0, k1):
+    k0s = set(k0)
+    k1s = set(k1)
+    added = k1s - k0s
+    removed = k0s - k1s
+    common = k0s.intersection(k1s)
+
+    return added, removed, common
+
+
+def drop_keys(res, k1, k2):
+    if k2 in res[k1]:
+        del res[k1][k2]
+
+
+def normalize_configmap(res):
+    if res['kind'] != "ConfigMap":
+        return res
+
+    data = res['data']
+
+    # some times keys are yamls...
+    # so parse them
+    for k in data:
+        try:
+            op = yaml.safe_load_all(data[k])
+            data[k] = list(op)
+        except Exception as ex:
+            print ex
+
+    return res
+
+
+def normalize_ports(res):
+    spec = res.get("spec")
+
+    if spec is None:
+        return res
+
+    if 'ports' not in spec:
+        return res
+
+    ports = sorted(spec['ports'], key=lambda x: x["port"])
+    spec['ports'] = ports
+
+    return res
+
+
+def normalize_res(res, args):
+    if not res:
+        return res
+
+    if args.ignore_labels:
+        drop_keys(res, "metadata", "labels")
+
+    if args.ignore_namespace:
+        drop_keys(res, "metadata", "namespace")
+
+    res = normalize_ports(res)
+
+    res = normalize_configmap(res)
+
+    return res
+
+
+def normalize(rl, args):
+    for i in range(len(rl)):
+        rl[i] = normalize_res(rl[i], args)
+
+    return rl
+
+
+def compare(args):
+    j0 = normalize(list(yaml.safe_load_all(open(args.orig))), args)
+    j1 = normalize(list(yaml.safe_load_all(open(args.new))), args)
+
+    q0 = {byResourceName(res): res for res in j0 if res is not None}
+    q1 = {byResourceName(res): res for res in j1 if res is not None}
+
+    added, removed, common = keydiff(q0.keys(), q1.keys())
+
+    changed = 0
+    for k in sorted(common):
+        if q0[k] != q1[k]:
+            changed += 1
+
+    print "## +++ ", args.new
+    print "## --- ", args.orig
+    print "## Added:", len(added)
+    print "## Removed:", len(removed)
+    print "## Updated:", changed
+    print "## Unchanged:", len(common) - changed
+
+    for k in sorted(added):
+        print "+", k
+
+    for k in sorted(removed):
+        print "-", k
+
+    print "## *************************"
+
+    for k in sorted(common):
+        if q0[k] != q1[k]:
+            print "## ", k
+            s0 = yaml.safe_dump(q0[k], default_flow_style=False, indent=2)
+            s1 = yaml.safe_dump(q1[k], default_flow_style=False, indent=2)
+
+            print datadiff.diff(s0, s1, fromfile=args.orig, tofile=args.new)
+
+    return changed + len(added) + len(removed)
+
+
+def main(args):
+    return compare(args)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Compare kubenetes yaml files")
+
+    parser.add_argument("orig")
+    parser.add_argument("new")
+    parser.add_argument("--ignore-namespace", action="store_true", default=False,
+                        help="Ignore namespace during comparison")
+    parser.add_argument("--ignore-labels", action="store_true", default=False,
+                        help="Ignore resource labels during comparison")
+    parser.add_argument("--ignore-annotations", action="store_true", default=False,
+                        help="Ignore annotations during comparison")
+
+    return parser
+
+
+if __name__ == "__main__":
+    import sys
+
+    parser = get_parser()
+    args = parser.parse_args()
+    sys.exit(main(args))


### PR DESCRIPTION
This tool diffs yaml files generated manually / updateVersion.sh or using `helm template`

```
diff_yaml.py --ignore-labels --ignore-namespace orig_istio.yaml istio.yaml

```
It produces the following output.
```diff
## +++  istio.yaml
## ---  orig_istio.yaml
## Added: 1
## Removed: 2
## Updated: 7
## Unchanged: 46
+ autoscaling/v2beta1::HorizontalPodAutoscaler::istio-ingress
- config.istio.io/v1alpha2::attributemanifest::istioproxy
- config.istio.io/v1alpha2::attributemanifest::kubernetes
## *************************
##  extensions/v1beta1::Deployment::istio-ca
--- orig_istio.yaml
+++ istio.yaml
@@ -13,14 +13,12 @@
     spec:
       containers:
       - args:
-        - --istio-ca-storage-namespace=istio-system
         - --grpc-port=8060
         - --grpc-hostname=istio-ca
         - --self-signed-ca=true
-        command:
-        - /usr/local/bin/istio_ca
         image: istio/istio-ca:b4d6b2f704c73c1139fcc549ba836135f717839a
         imagePullPolicy: IfNotPresent
         name: istio-ca
+        resources: {}
       serviceAccountName: istio-ca-service-account

##  extensions/v1beta1::Deployment::istio-ingress
--- orig_istio.yaml
+++ istio.yaml
@@ -3,7 +3,7 @@
 metadata:
   name: istio-ingress
 spec:
-  replicas: 1
+  replicas: null
   template:
     metadata:
       annotations:
@@ -15,8 +15,8 @@
       - args:
         - proxy
         - ingress
-        - --discoveryAddress
-        - istio-pilot:8080
+        - -v
+        - '2'
         - --discoveryRefreshDelay
```