### PR TITLE
Add registry to consume templates and adapters.

### DIFF
--- a/mixer/pkg/config/registry/registry.go
+++ b/mixer/pkg/config/registry/registry.go
@@ -61,7 +61,7 @@ type registry struct {
 // only `templates`, leaving other fields to default empty.
 func New(infos []adapter.Info) (Registry, error) {
 	r := &registry{make(map[string]*AdapterMetadata), make(map[string]*TemplateMetadata)}
-	var resultErr error = nil
+	var resultErr error
 	log.Debugf("registering %#v", infos)
 
 	for _, info := range infos {
@@ -109,7 +109,7 @@ func (r *registry) GetTemplate(name string) *TemplateMetadata {
 }
 
 func (r *registry) ingestTemplates(tmpls []string) ([]string, error) {
-	var resultErr error = nil
+	var resultErr error
 	templates := make([]*TemplateMetadata, 0, len(tmpls))
 	for _, tmpl := range tmpls {
 		tmplMeta, err := r.createTemplateMetadata(tmpl)

--- a/mixer/pkg/config/registry/registry.go
+++ b/mixer/pkg/config/registry/registry.go
@@ -1,0 +1,208 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	"encoding/base64"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/hashicorp/go-multierror"
+
+	adapter "istio.io/api/mixer/adapter/model/v1beta1"
+	tmpl "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/pkg/log"
+)
+
+// TemplateMetadata contains info about a template
+type TemplateMetadata struct {
+	Name          string
+	FileDescSet   *descriptor.FileDescriptorSet
+	FileDescProto *descriptor.FileDescriptorProto
+}
+
+// AdapterMetadata contains info about an adapter
+type AdapterMetadata struct {
+	Info               *adapter.Info
+	SupportedTemplates []string
+}
+
+// Registry to find metadata about templates and adapters
+type Registry interface {
+	GetAdapter(name string) (adapter *AdapterMetadata, found bool)
+	GetTemplate(name string) (template *TemplateMetadata, found bool)
+}
+
+// registry to ingest templates and adapters. It is single threaded.
+type registry struct {
+	adapters  map[string]*AdapterMetadata
+	templates map[string]*TemplateMetadata
+}
+
+// New creates a `Registry` from given adapter infos.
+// Note: For adding built-in templates that are not associated with any adapters, supply the `Info` object with
+// only `templates`, leaving other fields to default empty.
+func New(infos []adapter.Info) (Registry, error) {
+	r := &registry{make(map[string]*AdapterMetadata), make(map[string]*TemplateMetadata)}
+	var resultErr error = nil
+	log.Debugf("registering %#v", infos)
+
+	for _, info := range infos {
+		if old, ok := r.GetAdapter(info.Name); ok {
+			// duplicate entry found
+			resultErr = multierror.Append(resultErr,
+				fmt.Errorf("duplicate registration for adapter '%s' : new = %v old = %v", info.Name, info, old))
+			continue
+		}
+
+		tmplNames, err := r.ingestTemplates(info.Templates)
+		if err != nil {
+			resultErr = multierror.Append(resultErr, err)
+			continue
+		}
+
+		// empty adapter name means just the template needs to be ingested.
+		if len(info.Name) != 0 {
+			r.adapters[info.Name] = &AdapterMetadata{Info: &info, SupportedTemplates: tmplNames}
+		}
+	}
+
+	if resultErr != nil {
+		log.Error(resultErr.Error())
+	}
+
+	return r, resultErr
+}
+
+// GetAdapterInfo returns a AdapterMetadata for a adapter with the given name.
+func (r *registry) GetAdapter(name string) (b *AdapterMetadata, found bool) {
+	if bi, found := r.adapters[name]; found {
+		return bi, true
+	}
+	return nil, false
+}
+
+// GetTemplate returns a TemplateMetadata for a template with the given name.
+func (r *registry) GetTemplate(name string) (b *TemplateMetadata, found bool) {
+	if bi, found := r.templates[name]; found {
+		return bi, true
+	}
+
+	return nil, false
+}
+
+func (r *registry) ingestTemplates(tmpls []string) ([]string, error) {
+	var resultErr error = nil
+	templates := make([]*TemplateMetadata, 0)
+	for _, tmpl := range tmpls {
+		tmplMeta, err := r.createTemplateMetadata(tmpl)
+		if err != nil {
+			resultErr = multierror.Append(resultErr, err)
+			// accumulate all errors
+			continue
+		}
+		templates = append(templates, tmplMeta)
+	}
+	if resultErr != nil {
+		return nil, resultErr
+	}
+
+	// No errors, so we can now safely ingest the templates
+	tmplNames := make([]string, 0)
+	for _, tmplMeta := range templates {
+		r.templates[tmplMeta.Name] = tmplMeta
+		tmplNames = append(tmplNames, tmplMeta.Name)
+	}
+	return tmplNames, resultErr
+}
+
+func (r *registry) createTemplateMetadata(base64Tmpl string) (*TemplateMetadata, error) {
+	var bytes []byte
+	var err error
+
+	reader := strings.NewReader(base64Tmpl)
+	decoder := base64.NewDecoder(base64.StdEncoding, reader)
+
+	if bytes, err = ioutil.ReadAll(decoder); err != nil {
+		return nil, err
+	}
+
+	fds := &descriptor.FileDescriptorSet{}
+	if err = proto.Unmarshal(bytes, fds); err != nil {
+		return nil, err
+	}
+	var tmplDesc *descriptor.FileDescriptorProto
+	if tmplDesc, err = getTmplFileDesc(fds.File); err != nil {
+		return nil, err
+	}
+
+	// TODO: Fix this; Using package name to recreate template name is a hack. Ideally we should put the template name
+	// as an option when generating the augmented proto (we have already computed it during codegen).
+	var lastSeg string
+	if lastSeg, err = getLastSegment(strings.TrimSpace(tmplDesc.GetPackage())); err != nil {
+		return nil, err
+	}
+	tmplName := strings.ToLower(lastSeg)
+
+	// TODO: if given template is already registered, pick the one that is superset. For now just overwrite; last one wins.
+	if _, ok := r.GetTemplate(tmplName); ok {
+		// duplicate entry found TODO: how can we make this error better ??
+		log.Errorf("duplicate registration for template '%s'; picking the last one", tmplName)
+	}
+
+	return &TemplateMetadata{Name: tmplName,
+		FileDescProto: tmplDesc,
+		FileDescSet:   fds}, nil
+}
+
+// Find the file that has the options TemplateVariety. There should only be one such file.
+func getTmplFileDesc(fds []*descriptor.FileDescriptorProto) (*descriptor.FileDescriptorProto, error) {
+	var templateDescriptorProto *descriptor.FileDescriptorProto
+	for _, fd := range fds {
+		if fd.GetOptions() == nil || !proto.HasExtension(fd.GetOptions(), tmpl.E_TemplateVariety) {
+			continue
+		}
+		if templateDescriptorProto != nil {
+			return nil, fmt.Errorf(
+				"proto files %s and %s, both have the option %s. Only one proto file is allowed with this options",
+				fd.GetName(), templateDescriptorProto.GetName(), tmpl.E_TemplateVariety.Name)
+		}
+		templateDescriptorProto = fd
+	}
+
+	if templateDescriptorProto == nil {
+		return nil, fmt.Errorf("there has to be one proto file that has the extension %s", tmpl.E_TemplateVariety.Name)
+	}
+
+	return templateDescriptorProto, nil
+}
+
+var pkgLaskSegRegex = regexp.MustCompile("^[a-zA-Z]+$")
+
+func getLastSegment(pkg string) (string, error) {
+	if len(pkg) != 0 {
+		segs := strings.Split(pkg, ".")
+		last := segs[len(segs)-1]
+		if pkgLaskSegRegex.MatchString(last) {
+			return last, nil
+		}
+	}
+	return "", fmt.Errorf("the last segment of package name '%s' must match the regex '%s'", pkg, "^[a-zA-Z]+$")
+}

--- a/mixer/pkg/config/registry/registry_test.go
+++ b/mixer/pkg/config/registry/registry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Istio Authors.
+// Copyright 2018 Istio Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mixer/pkg/config/registry/registry_test.go
+++ b/mixer/pkg/config/registry/registry_test.go
@@ -1,0 +1,272 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:generate protoc testdata/foo.proto -otestdata/foo.descriptor -I$GOPATH/src/istio.io/api -I.
+//go:generate protoc testdata/bar.proto -otestdata/bar.descriptor -I$GOPATH/src/istio.io/api -I.
+//go:generate protoc testdata/baz.proto -otestdata/baz.descriptor -I$GOPATH/src/istio.io/api -I.
+//go:generate protoc testdata/unsupportedPkgName.proto -otestdata/unsupportedPkgName.descriptor -I$GOPATH/src/istio.io/api -I.
+//go:generate protoc testdata/reqOptionNotFound.proto -otestdata/reqOptionNotFound.descriptor -I$GOPATH/src/istio.io/api -I.
+//go:generate protoc testdata/foo.proto testdata/bar.proto -otestdata/badfoobar.descriptor -I$GOPATH/src/istio.io/api -I.
+
+package registry
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+
+	adapter "istio.io/api/mixer/adapter/model/v1beta1"
+)
+
+type testdata struct {
+	name      string
+	infos     []adapter.Info
+	wantErrs  []string
+	wantInfos map[string][]string
+	wantTmpls []string
+}
+
+func TestNew(t *testing.T) {
+
+	fooTmpl := getFileDescSetBase64("testdata/foo.descriptor")
+	barTmpl := getFileDescSetBase64("testdata/bar.descriptor")
+	bazTmplStr := getFileDescSetBase64("testdata/baz.descriptor")
+	badfoobarTmpl := getFileDescSetBase64("testdata/badfoobar.descriptor")
+	unsupportedPkgNameTmpl := getFileDescSetBase64("testdata/unsupportedPkgName.descriptor")
+	reqOptionNotFoundTmpl := getFileDescSetBase64("testdata/reqOptionNotFound.descriptor")
+	notFileDescriptorSet := getFileDescSetBase64("testdata/foo.proto")
+
+	for _, td := range []testdata{
+		{
+			name: "adapters with varying templates",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{fooTmpl, barTmpl},
+				},
+				{
+					Name:      "a2",
+					Templates: []string{bazTmplStr},
+				},
+				{
+					Name:      "a3",
+					Templates: []string{},
+				},
+			},
+			wantInfos: map[string][]string{"a1": {"foo", "bar"}, "a2": {"baz"}, "a3": {}},
+			wantTmpls: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "adapters with duplicate templates",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{fooTmpl, barTmpl},
+				},
+				{
+					Name:      "a2",
+					Templates: []string{fooTmpl},
+				},
+			},
+			wantInfos: map[string][]string{"a1": {"foo", "bar"}, "a2": {"foo"}},
+			wantTmpls: []string{"foo", "bar"},
+		},
+		{
+			name: "only templates no adapters",
+			infos: []adapter.Info{
+				{
+					Name:      "",
+					Templates: []string{fooTmpl, barTmpl},
+				},
+				{
+					Name:      "",
+					Templates: []string{bazTmplStr},
+				},
+			},
+			wantTmpls: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "adapters with bad templates not registered",
+			infos: []adapter.Info{
+				{
+					Name:      "bad_adapter",
+					Templates: []string{fooTmpl, badfoobarTmpl},
+				},
+				{
+					Name:      "good_adapter",
+					Templates: []string{barTmpl},
+				},
+			},
+			wantInfos: map[string][]string{"good_adapter": {"bar"}},
+			wantTmpls: []string{"bar"},
+			wantErrs:  []string{"Only one proto file is allowed with this options"},
+		},
+		{
+			name: "error duplicate adapters",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{},
+				},
+				{
+					Name:      "a1",
+					Templates: []string{},
+				},
+				{
+					Name:      "a3",
+					Templates: []string{},
+				},
+			},
+			wantInfos: map[string][]string{"a1": {}, "a3": {}},
+			wantErrs:  []string{"duplicate registration for adapter 'a1'"},
+		},
+		{
+			name: "error bad template",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{fooTmpl, barTmpl},
+				},
+				{
+					Name:      "bad_adapter_since_bad_template",
+					Templates: []string{badfoobarTmpl},
+				},
+			},
+			wantInfos: map[string][]string{"a1": {"foo", "bar"}},
+			wantErrs:  []string{"Only one proto file is allowed with this options"},
+			wantTmpls: []string{"foo", "bar"},
+		},
+		{
+			name: "error bad base64 string",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{"error base 64 string"},
+				},
+			},
+			wantErrs: []string{"illegal base64 data at input byte"},
+		},
+		{
+			name: "error bad fds string",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{notFileDescriptorSet},
+				},
+			},
+			wantErrs: []string{"unknown wire type 7"},
+		},
+		{
+			name: "error unsupported template name",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{unsupportedPkgNameTmpl},
+				},
+			},
+			wantErrs: []string{"the last segment of package name 'foo123' must match the regex '^[a-zA-Z]+$'"},
+		},
+		{
+			name: "error required option not found",
+			infos: []adapter.Info{
+				{
+					Name:      "a1",
+					Templates: []string{reqOptionNotFoundTmpl},
+				},
+			},
+			wantErrs: []string{"there has to be one proto file that has the extension"},
+		},
+		{
+			name: "different adapter with mix of good bad templates",
+			infos: []adapter.Info{
+				{
+					Name:      "bad_adapter",
+					Templates: []string{fooTmpl, badfoobarTmpl},
+				},
+				{
+					Name:      "good_adapter",
+					Templates: []string{fooTmpl, barTmpl},
+				},
+			},
+			wantInfos: map[string][]string{"good_adapter": {"foo", "bar"}},
+			wantTmpls: []string{"foo", "bar"},
+			wantErrs:  []string{"Only one proto file is allowed with this options"},
+		},
+	} {
+		t.Run(td.name, func(t *testing.T) {
+			reg, err := New(td.infos)
+			r := reg.(*registry)
+			if len(td.wantErrs) == 0 {
+				if err != nil {
+					t.Fatalf("want no error got '%v;", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("want errors '%v'; got no errors", td.wantErrs)
+				}
+
+				gotErrs := err.(*multierror.Error).Errors
+				wantErrs := td.wantErrs
+				if len(gotErrs) != len(wantErrs) {
+					t.Fatalf("want %d errors as '%v'; got %d as '%v'", len(wantErrs), wantErrs, len(gotErrs), gotErrs)
+				}
+
+				for i, wantErr := range td.wantErrs {
+					gotErr := err.(*multierror.Error).Errors[i]
+					if !strings.Contains(gotErr.Error(), wantErr) {
+						t.Errorf("want error '%s' at location %d; got '%s'", wantErr, i, gotErr.Error())
+					}
+				}
+			}
+
+			// Ensure infos match
+			if len(r.adapters) != len(td.wantInfos) {
+				t.Errorf("want %d infos with names '%v'; got %d as '%v'",
+					len(td.wantInfos), td.wantInfos, len(r.adapters), r.adapters)
+			}
+			for k, wantSupTmpls := range td.wantInfos {
+				if adptMeta, ok := r.adapters[k]; !ok {
+					t.Errorf("want info '%s' to be present; got '%v'", k, r.adapters)
+				} else if !reflect.DeepEqual(wantSupTmpls, adptMeta.SupportedTemplates) {
+					t.Errorf("want supported templates for info '%s' to be '%v'; got '%v'", k, wantSupTmpls, adptMeta.SupportedTemplates)
+				}
+			}
+
+			// Ensure templates match
+			if len(r.templates) != len(td.wantTmpls) {
+				t.Errorf("want %d templates with names '%v'; got %d as '%v'",
+					len(td.wantTmpls), td.wantTmpls, len(r.templates), r.templates)
+			}
+			for _, wantTmpl := range td.wantTmpls {
+				if _, ok := r.templates[wantTmpl]; !ok {
+					t.Errorf("want template '%s' to be present; got '%v'", wantTmpl, r.templates)
+				}
+			}
+		})
+	}
+}
+
+func getFileDescSetBase64(path string) string {
+	byts, _ := ioutil.ReadFile(path)
+	var b bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &b)
+	encoder.Write(byts)
+	encoder.Close()
+	return b.String()
+}

--- a/mixer/pkg/config/registry/registry_test.go
+++ b/mixer/pkg/config/registry/registry_test.go
@@ -266,7 +266,7 @@ func getFileDescSetBase64(path string) string {
 	byts, _ := ioutil.ReadFile(path)
 	var b bytes.Buffer
 	encoder := base64.NewEncoder(base64.StdEncoding, &b)
-	encoder.Write(byts)
-	encoder.Close()
+	_, _ = encoder.Write(byts)
+	_ = encoder.Close()
 	return b.String()
 }

--- a/mixer/pkg/config/registry/testdata/badfoobar.descriptor
+++ b/mixer/pkg/config/registry/testdata/badfoobar.descriptor
@@ -1,0 +1,5 @@
+
+W
+testdata/foo.protofoo,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3
+W
+testdata/bar.protobar,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3

--- a/mixer/pkg/config/registry/testdata/bar.descriptor
+++ b/mixer/pkg/config/registry/testdata/bar.descriptor
@@ -1,0 +1,3 @@
+
+W
+testdata/bar.protobar,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3

--- a/mixer/pkg/config/registry/testdata/bar.proto
+++ b/mixer/pkg/config/registry/testdata/bar.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package bar;
+
+import "mixer/adapter/model/v1beta1/extensions.proto";
+
+option (istio.mixer.adapter.model.v1beta1.template_variety) = TEMPLATE_VARIETY_REPORT;

--- a/mixer/pkg/config/registry/testdata/baz.descriptor
+++ b/mixer/pkg/config/registry/testdata/baz.descriptor
@@ -1,0 +1,3 @@
+
+W
+testdata/baz.protobaz,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3

--- a/mixer/pkg/config/registry/testdata/baz.proto
+++ b/mixer/pkg/config/registry/testdata/baz.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package baz;
+
+import "mixer/adapter/model/v1beta1/extensions.proto";
+
+option (istio.mixer.adapter.model.v1beta1.template_variety) = TEMPLATE_VARIETY_REPORT;

--- a/mixer/pkg/config/registry/testdata/foo.descriptor
+++ b/mixer/pkg/config/registry/testdata/foo.descriptor
@@ -1,0 +1,3 @@
+
+W
+testdata/foo.protofoo,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3

--- a/mixer/pkg/config/registry/testdata/foo.proto
+++ b/mixer/pkg/config/registry/testdata/foo.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package foo;
+
+import "mixer/adapter/model/v1beta1/extensions.proto";
+
+option (istio.mixer.adapter.model.v1beta1.template_variety) = TEMPLATE_VARIETY_REPORT;

--- a/mixer/pkg/config/registry/testdata/reqOptionNotFound.descriptor
+++ b/mixer/pkg/config/registry/testdata/reqOptionNotFound.descriptor
@@ -1,0 +1,3 @@
+
+]
+ testdata/reqOptionNotFound.protoabc,mixer/adapter/model/v1beta1/extensions.protobproto3

--- a/mixer/pkg/config/registry/testdata/reqOptionNotFound.proto
+++ b/mixer/pkg/config/registry/testdata/reqOptionNotFound.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package abc;
+
+import "mixer/adapter/model/v1beta1/extensions.proto";
+
+// Below option is required.
+// option (istio.mixer.adapter.model.v1beta1.template_variety) = TEMPLATE_VARIETY_REPORT;

--- a/mixer/pkg/config/registry/testdata/unsupportedPkgName.descriptor
+++ b/mixer/pkg/config/registry/testdata/unsupportedPkgName.descriptor
@@ -1,0 +1,3 @@
+
+i
+!testdata/unsupportedPkgName.protofoo123,mixer/adapter/model/v1beta1/extensions.protoBøÒä“bproto3

--- a/mixer/pkg/config/registry/testdata/unsupportedPkgName.proto
+++ b/mixer/pkg/config/registry/testdata/unsupportedPkgName.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package foo123;
+
+import "mixer/adapter/model/v1beta1/extensions.proto";
+
+option (istio.mixer.adapter.model.v1beta1.template_variety) = TEMPLATE_VARIETY_REPORT;


### PR DESCRIPTION
Creates a single registry for ingestion of adapter info and base64 encoded template descriptors. PR also contains provision for ingesting template descriptors that are not tied to any adapters (example: all the core built-in templates).

This PR provides the wiring needed for next work of taking descriptor and yaml config to generate bytes.

**NOTE:** This PR depend on [new Info proto pr](https://github.com/istio/api/pull/426) 

100% codecoverage woohoo!!

