### PR TITLE
Add multicluster flag enablement to Helm charts

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.global.multicluster.enabled }}
+          - "--clusterRegistriesDir"
+          - "/etc/istio/multicluster"
+{{- end }}
           ports:
           - containerPort: 8080
           - containerPort: 15010
@@ -64,6 +68,10 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
+{{- if .Values.global.multicluster.enabled }}
+          - name: multicluster-volume
+            mountPath: /etc/istio/multicluster
+{{- end }}
         - name: istio-proxy
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.proxy.imagePullPolicy }}
@@ -97,6 +105,11 @@ spec:
       - name: config-volume
         configMap:
           name: istio
+{{- if .Values.global.multicluster.enabled }}
+      - name: multicluster-volume
+        configMap:
+          name: multicluster
+{{- end }}
       - name: istio-certs
         secret:
           secretName: "istio.istio-pilot-service-account"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -46,7 +46,11 @@ global:
   # Default is 1 second
   refreshInterval: 10s
   
- 
+  # Enable multicluster operation.  Must be set to true if multicluster operation
+  # is desired.
+  multicluster:
+    enabled: false
+
 # Any customization for istio testing should be here
 istiotesting:
   oneNameSpace: false


### PR DESCRIPTION
Add a multicluster.enabled flag to values.yaml and the associated
implementation to the pilot deployment template in the Helm
templates.

I have tested helm template with and without the flag enabled.
Without the flag set to true, there is no delta between the
templates.  With the flag, the appropriate config options are set
in pilot's deployment.

I didn't bother with the legacy templates as those are going away,
and would need to add a new flag to updateVersion.sh to enable
multicluster.  Seemed simpler to just let that go away naturally
with the changes @mandarjog is working on.