### PR TITLE
Check earlier if Istio source code is in the right place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,16 @@ ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
                  then printf "go version $(GO_VERSION_REQUIRED)+ required, found: "; $(GO) version; exit 1; fi
 	@touch ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
 
+# Ensure expected GOPATH setup
+.PHONY: check-tree
+check-tree:
+	@if [ "$(ISTIO_GO)" != "$(GO_TOP)/src/istio.io/istio" ]; then \
+       echo Istio not found in GOPATH/src/istio.io. Make sure to clone Istio on that path. ; \
+       exit 1; fi
+
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
 # Will also check vendor, based on Gopkg.lock
-init: submodule vendor.check check-go-version $(ISTIO_OUT)/istio_is_init
+init: check-tree submodule vendor.check check-go-version $(ISTIO_OUT)/istio_is_init
 
 # Marker for whether vendor submodule is here or not already
 GRPC_DIR:=./vendor/google.golang.org/grpc

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -63,12 +63,6 @@ export GOOS=${GOOS:-${LOCAL_OS}}
 # test scripts seem to like to run this script directly rather than use make
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
 
-# Ensure expected GOPATH setup
-if [ ${ROOT} != "${GO_TOP:-$HOME/go}/src/istio.io/istio" ]; then
-       echo "Istio not found in GOPATH/src/istio.io/"
-       exit 1
-fi
-
 # Download Envoy debug and release binaries for Linux x86_64. They will be included in the
 # docker images created by Dockerfile.proxy and Dockerfile.proxy_debug.
 


### PR DESCRIPTION
Thus we get a more informative error message. For example,
if one clones Istio in their $HOME and try to run make:

Before:
```sh
$ make
Checking that Gopkg.* are in sync with vendor/ submodule:
if this fails, 'make pull' and/or seek on-call help
diff Gopkg.toml vendor/
diff Gopkg.lock vendor/
mkdir: cannot create directory ‘//out’: Permission denied
make: *** [//out/linux_amd64/release] Error 1
```

After this patch:
```sh
$ make
Istio not found in GOPATH/src/istio.io. Make sure to clone Istio on that path.
make: *** [Makefile:185: check-tree] Error 1
```