### PR TITLE
Stop depending on the evaluator.IL type.

### DIFF
--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -51,9 +51,6 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 		"Max number of goroutines in the API worker pool")
 	serverCmd.PersistentFlags().IntVarP(&sa.AdapterWorkerPoolSize, "adapterWorkerPoolSize", "", sa.AdapterWorkerPoolSize,
 		"Max number of goroutines in the adapter worker pool")
-	// TODO: what is the right default value for expressionEvalCacheSize.
-	serverCmd.PersistentFlags().IntVarP(&sa.ExpressionEvalCacheSize, "expressionEvalCacheSize", "", sa.ExpressionEvalCacheSize,
-		"Number of entries in the expression cache")
 	serverCmd.PersistentFlags().BoolVarP(&sa.UseNewRuntime, "useNewRuntime", "", sa.UseNewRuntime,
 		"Use the new runtime code for processing requests.")
 	serverCmd.PersistentFlags().BoolVarP(&sa.SingleThreaded, "singleThreaded", "", sa.SingleThreaded,

--- a/mixer/cmd/mixs/cmd/validator.go
+++ b/mixer/cmd/mixs/cmd/validator.go
@@ -99,11 +99,8 @@ func newValidator(rvc runtimeValidatorOptions, kinds map[string]proto.Message) (
 	if err != nil {
 		return nil, err
 	}
-	eval, err := evaluator.NewILEvaluator(evaluator.DefaultCacheSize)
-	if err != nil {
-		return nil, err
-	}
-	rv, err := validator.New(eval, rvc.identityAttribute, s, rvc.adapters, rvc.templates)
+	tc := evaluator.NewTypeChecker()
+	rv, err := validator.New(tc, rvc.identityAttribute, s, rvc.adapters, rvc.templates)
 	if err != nil {
 		return nil, err
 	}

--- a/mixer/pkg/runtime2/validator/validator.go
+++ b/mixer/pkg/runtime2/validator/validator.go
@@ -20,13 +20,12 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	cpb "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/mixer/pkg/expr"
-	"istio.io/istio/mixer/pkg/il/evaluator"
 	"istio.io/istio/mixer/pkg/runtime2/config"
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/cache"
@@ -37,7 +36,7 @@ import (
 type Validator struct {
 	handlerBuilders map[string]adapter.HandlerBuilder
 	templates       map[string]*template.Info
-	tc              *evaluator.IL
+	tc              expr.TypeChecker
 	af              expr.AttributeDescriptorFinder
 	c               *validatorCache
 	donec           chan struct{}
@@ -45,7 +44,7 @@ type Validator struct {
 
 // New creates a new store.Validator instance which validates runtime semantics of
 // the configs.
-func New(tc *evaluator.IL, identityAttribute string, s store.Store,
+func New(tc expr.TypeChecker, identityAttribute string, s store.Store,
 	adapterInfo map[string]*adapter.Info, templateInfo map[string]*template.Info) (store.Validator, error) {
 	kinds := config.KindMap(adapterInfo, templateInfo)
 	data, ch, err := store.StartWatch(s, kinds)
@@ -76,7 +75,6 @@ func New(tc *evaluator.IL, identityAttribute string, s store.Store,
 	}
 	go store.WatchChanges(ch, v.donec, time.Second, v.c.applyChanges)
 	v.af = v.newAttributeDescriptorFinder(manifests)
-	v.tc.ChangeVocabulary(v.af)
 	return v, nil
 }
 
@@ -93,7 +91,6 @@ func (v *Validator) refreshTypeChecker() {
 		}
 	})
 	v.af = v.newAttributeDescriptorFinder(manifests)
-	v.tc.ChangeVocabulary(v.af)
 }
 
 func (v *Validator) getKey(value, namespace string) (store.Key, error) {
@@ -258,7 +255,6 @@ func (v *Validator) validateDelete(key store.Key) error {
 			}
 		})
 		af := v.newAttributeDescriptorFinder(manifests)
-		v.tc.ChangeVocabulary(af)
 		if err := v.validateManifests(af); err != nil {
 			return err
 		}
@@ -299,7 +295,6 @@ func (v *Validator) validateUpdate(ev *store.Event) error {
 		})
 		manifests[ev.Key] = manifest
 		af := v.newAttributeDescriptorFinder(manifests)
-		v.tc.ChangeVocabulary(af)
 		if err := v.validateManifests(af); err != nil {
 			return err
 		}

--- a/mixer/pkg/runtime2/validator/validator_test.go
+++ b/mixer/pkg/runtime2/validator/validator_test.go
@@ -80,10 +80,7 @@ func getValidatorForTest() (*Validator, error) {
 	if err != nil {
 		return nil, err
 	}
-	eval, err := evaluator.NewILEvaluator(evaluator.DefaultCacheSize)
-	if err != nil {
-		return nil, err
-	}
+	tc := evaluator.NewTypeChecker()
 	adapterInfo := map[string]*adapter.Info{
 		"listchecker": {
 			DefaultConfig: &types.Struct{},
@@ -110,7 +107,7 @@ func getValidatorForTest() (*Validator, error) {
 			},
 		},
 	}
-	v, err := New(eval, "destination.service", s, adapterInfo, templateInfo)
+	v, err := New(tc, "destination.service", s, adapterInfo, templateInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/config/store"
-	"istio.io/istio/mixer/pkg/il/evaluator"
 	mixerRuntime "istio.io/istio/mixer/pkg/runtime"
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/log"
@@ -47,9 +46,6 @@ type Args struct {
 
 	// Maximum number of goroutines in the adapter worker pool
 	AdapterWorkerPoolSize int
-
-	// Maximum number of entries in the expression cache
-	ExpressionEvalCacheSize int
 
 	// URL of the config store. Use k8s://path_to_kubeconfig or fs:// for file system. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 	// If this is empty (and ConfigStore isn't specified), "k8s://" will be used.
@@ -112,7 +108,6 @@ func DefaultArgs() *Args {
 		MaxConcurrentStreams:          1024,
 		APIWorkerPoolSize:             1024,
 		AdapterWorkerPoolSize:         1024,
-		ExpressionEvalCacheSize:       evaluator.DefaultCacheSize,
 		ConfigDefaultNamespace:        mixerRuntime.DefaultConfigNamespace,
 		ConfigIdentityAttribute:       "destination.service",
 		ConfigIdentityAttributeDomain: "svc.cluster.local",
@@ -134,10 +129,6 @@ func (a *Args) validate() error {
 		return fmt.Errorf("adapter worker pool size must be >= 0 and <= 2^31-1, got pool size %d", a.AdapterWorkerPoolSize)
 	}
 
-	if a.ExpressionEvalCacheSize <= 0 {
-		return fmt.Errorf("expressiion evaluation cache size must be >= 0 and <= 2^31-1, got cache size %d", a.ExpressionEvalCacheSize)
-	}
-
 	return nil
 }
 
@@ -149,7 +140,6 @@ func (a *Args) String() string {
 	fmt.Fprint(buf, "MaxConcurrentStreams: ", a.MaxConcurrentStreams, "\n")
 	fmt.Fprint(buf, "APIWorkerPoolSize: ", a.APIWorkerPoolSize, "\n")
 	fmt.Fprint(buf, "AdapterWorkerPoolSize: ", a.AdapterWorkerPoolSize, "\n")
-	fmt.Fprint(buf, "ExpressionEvalCacheSize: ", a.ExpressionEvalCacheSize, "\n")
 	fmt.Fprint(buf, "APIPort: ", a.APIPort, "\n")
 	fmt.Fprint(buf, "MonitoringPort: ", a.MonitoringPort, "\n")
 	fmt.Fprint(buf, "EnableProfiling: ", a.EnableProfiling, "\n")

--- a/mixer/pkg/server/args_test.go
+++ b/mixer/pkg/server/args_test.go
@@ -35,12 +35,6 @@ func TestValidation(t *testing.T) {
 	if err := a.validate(); err == nil {
 		t.Errorf("Got unexpected success")
 	}
-
-	a = DefaultArgs()
-	a.ExpressionEvalCacheSize = -1
-	if err := a.validate(); err == nil {
-		t.Errorf("Got unexpected success")
-	}
 }
 
 func TestString(t *testing.T) {

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -107,9 +107,9 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 		return nil, err
 	}
 
-	eval, err := p.newILEvaluator(a.ExpressionEvalCacheSize)
+	eval, err := p.newILEvaluator(evaluator.DefaultCacheSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create IL expression evaluator with cache size %d: %v", a.ExpressionEvalCacheSize, err)
+		return nil, fmt.Errorf("failed to create IL expression evaluator with cache size %d: %v", evaluator.DefaultCacheSize, err)
 	}
 
 	apiPoolSize := a.APIWorkerPoolSize


### PR DESCRIPTION
- mixs's validation logic now depends on evaluator.TypeChecker instead
of evaluator.IL. This will let us delete a bunch of stuff when it comes
time to nuke mixer/pkg/runtime in a subsequent PR.

- Delete support for specifying the IL evaluator's default cache size.
This again is in support of soon deleting the IL evaluator as a whole.