### PR TITLE
Fix config error when running with minikube

### DIFF
--- a/.circleci/config
+++ b/.circleci/config
@@ -9,3 +9,4 @@ contexts:
     user: ""
   name: istio
 current-context: istio
+kind: Config


### PR DESCRIPTION
There will be error like this if this field is missing:
Object 'Kind' is missing in ...