### PR TITLE
Enforce authentication policy validation.

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -113,7 +113,6 @@ func ParseJwksURI(jwksURI string) (string, *Port, bool, error) {
 	if err != nil {
 		return "", nil, false, err
 	}
-
 	var useSSL bool
 	var portNumber int
 	switch u.Scheme {
@@ -124,7 +123,7 @@ func ParseJwksURI(jwksURI string) (string, *Port, bool, error) {
 		useSSL = true
 		portNumber = 443
 	default:
-		return "", nil, false, fmt.Errorf("URI scheme %s is not supported", u.Scheme)
+		return "", nil, false, fmt.Errorf("URI scheme %q is not supported", u.Scheme)
 	}
 
 	if u.Port() != "" {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -73,11 +73,11 @@ func TestParseJwksURI(t *testing.T) {
 	}{
 		{
 			in:                   "foo.bar.com",
-			expectedErrorMessage: "URI scheme  is not supported",
+			expectedErrorMessage: `URI scheme "" is not supported`,
 		},
 		{
 			in:                   "tcp://foo.bar.com:abc",
-			expectedErrorMessage: "URI scheme tcp is not supported",
+			expectedErrorMessage: `URI scheme "tcp" is not supported`,
 		},
 		{
 			in:                   "http://foo.bar.com:abc",
@@ -100,6 +100,12 @@ func TestParseJwksURI(t *testing.T) {
 			expectedHostname: "foo.bar.com",
 			expectedPort:     &Port{Name: "http", Port: 1234},
 			expectedUseSSL:   false,
+		},
+		{
+			in:               "https://foo.bar.com:1234/secure/key",
+			expectedHostname: "foo.bar.com",
+			expectedPort:     &Port{Name: "https", Port: 1234},
+			expectedUseSSL:   true,
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1699,7 +1699,7 @@ func ValidateAuthenticationPolicy(msg proto.Message) error {
 	for _, method := range in.Peers {
 		if jwt := method.GetJwt(); jwt != nil {
 			if _, jwtExist := jwtIssuers[jwt.Issuer]; jwtExist {
-				errs = appendErrors(errs, fmt.Errorf("Jwt with issuer %q already defined", jwt.Issuer))
+				errs = appendErrors(errs, fmt.Errorf("jwt with issuer %q already defined", jwt.Issuer))
 			} else {
 				jwtIssuers[jwt.Issuer] = true
 			}
@@ -1708,7 +1708,7 @@ func ValidateAuthenticationPolicy(msg proto.Message) error {
 	}
 	for _, method := range in.Origins {
 		if _, jwtExist := jwtIssuers[method.Jwt.Issuer]; jwtExist {
-			errs = appendErrors(errs, fmt.Errorf("Jwt with issuer %q already defined", method.Jwt.Issuer))
+			errs = appendErrors(errs, fmt.Errorf("jwt with issuer %q already defined", method.Jwt.Issuer))
 		} else {
 			jwtIssuers[method.Jwt.Issuer] = true
 		}
@@ -1817,7 +1817,7 @@ func validateAuthNPolicyTarget(target *authn.TargetSelector) (errs error) {
 
 	// AuthN policy target (host)name must be a shortname
 	if !IsDNS1123Label(target.Name) {
-		errs = multierror.Append(errs, fmt.Errorf("Taget name %q must be a valid label", target.Name))
+		errs = multierror.Append(errs, fmt.Errorf("taget name %q must be a valid label", target.Name))
 	}
 
 	if target.Subset != "" {

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1695,10 +1695,23 @@ func ValidateAuthenticationPolicy(msg proto.Message) error {
 		errs = appendErrors(errs, validateAuthNPolicyTarget(target))
 	}
 
+	jwtIssuers := make(map[string]bool)
 	for _, method := range in.Peers {
-		errs = appendErrors(errs, validateJwt(method.GetJwt()))
+		if jwt := method.GetJwt(); jwt != nil {
+			if _, jwtExist := jwtIssuers[jwt.Issuer]; jwtExist {
+				errs = appendErrors(errs, fmt.Errorf("Jwt with issuer %q already defined", jwt.Issuer))
+			} else {
+				jwtIssuers[jwt.Issuer] = true
+			}
+			errs = appendErrors(errs, validateJwt(jwt))
+		}
 	}
 	for _, method := range in.Origins {
+		if _, jwtExist := jwtIssuers[method.Jwt.Issuer]; jwtExist {
+			errs = appendErrors(errs, fmt.Errorf("Jwt with issuer %q already defined", method.Jwt.Issuer))
+		} else {
+			jwtIssuers[method.Jwt.Issuer] = true
+		}
 		errs = appendErrors(errs, validateJwt(method.Jwt))
 	}
 
@@ -1779,11 +1792,8 @@ func validateJwt(jwt *authn.Jwt) (errs error) {
 	if jwt.JwksUri == "" {
 		errs = multierror.Append(errs, errors.New("jwks_uri must be set"))
 	}
-	if !strings.HasPrefix(jwt.JwksUri, "http://") && !strings.HasPrefix(jwt.JwksUri, "https://") {
-		errs = multierror.Append(errs, errors.New("jwks_uri must have http:// or https:// scheme"))
-	}
-	if _, err := url.Parse(jwt.JwksUri); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("%q is not a valid url: %v", jwt.JwksUri, err))
+	if _, _, _, err := ParseJwksURI(jwt.JwksUri); err != nil {
+		errs = multierror.Append(errs, err)
 	}
 
 	for _, location := range jwt.JwtHeaders {
@@ -1805,7 +1815,11 @@ func validateAuthNPolicyTarget(target *authn.TargetSelector) (errs error) {
 		return
 	}
 
-	errs = appendErrors(errs, validateHost(target.Name))
+	// AuthN policy target (host)name must be a shortname
+	if !IsDNS1123Label(target.Name) {
+		errs = multierror.Append(errs, fmt.Errorf("Taget name %q must be a valid label", target.Name))
+	}
+
 	if target.Subset != "" {
 		errs = appendErrors(errs, validateSubsetName(target.Subset))
 	}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3058,9 +3058,85 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "Bad JkwsURI",
+			in: &authn.Policy{
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							Issuer:     "istio.io",
+							JwksUri:    "secure.istio.io/oauth/v1/certs",
+							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "Bad JkwsURI Port",
+			in: &authn.Policy{
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							Issuer:     "istio.io",
+							JwksUri:    "https://secure.istio.io:not-a-number/oauth/v1/certs",
+							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "Duplicate Jwt issuers",
+			in: &authn.Policy{
+				Peers: []*authn.PeerAuthenticationMethod{{
+					Params: &authn.PeerAuthenticationMethod_Jwt{
+						Jwt: &authn.Jwt{
+							Issuer:     "istio.io",
+							JwksUri:    "https://secure.istio.io/oauth/v1/certs",
+							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+						},
+					},
+				}},
+				Origins: []*authn.OriginAuthenticationMethod{
+					{
+						Jwt: &authn.Jwt{
+							Issuer:     "istio.io",
+							JwksUri:    "https://secure.istio.io/oauth/v1/certs",
+							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+						},
+					},
+				},
+			},
+			valid: false,
+		},
+		{
 			name: "Just binding",
 			in: &authn.Policy{
 				PrincipalBinding: authn.PrincipalBinding_USE_ORIGIN,
+			},
+			valid: true,
+		},
+		{
+			name: "Bad target name",
+			in: &authn.Policy{
+				Targets: []*authn.TargetSelector{
+					{
+						Name: "foo.bar",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			name: "Good target name",
+			in: &authn.Policy{
+				Targets: []*authn.TargetSelector{
+					{
+						Name: "good-service-name",
+					},
+				},
 			},
 			valid: true,
 		},


### PR DESCRIPTION
- Fully parse JwksURI to make sure both hostname and port are valid.
- Add addition check to prohibit JWTs with the same issuer.