### PR TITLE
RDSv2: Add Virtual hosts and route configs to rds code

### DIFF
--- a/pilot/pkg/networking/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/v1alpha3/httproute.go
@@ -507,7 +507,7 @@ func buildDefaultHTTPRoute(clusterName string) *route.Route {
 
 // buildInboundHTTPRouteConfig builds the route config with a single wildcard virtual host on the inbound path
 // TODO: enable mixer configuration, websockets, trace decorators
-func buildInboundHTTPRouteConfig(instance *model.ServiceInstance) *v2.RouteConfiguration {
+func buildInboundHTTPRouteConfig(instance *model.ServiceInstance) *v2.RouteConfiguration { // nolint: deadcode
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, "",
 		instance.Service.Hostname, instance.Endpoint.ServicePort)
 	defaultRoute := buildDefaultHTTPRoute(clusterName)


### PR DESCRIPTION
This completes some missing functionality in existing RDS code, by generating virtual hosts,
and route configurations per service port. A couple of utility functions have been added to
allow building inbound http connection managers easily.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>