### PR TITLE
Add istioctl command document and canonical import path

### DIFF
--- a/istioctl/cmd/istioctl/doc.go
+++ b/istioctl/cmd/istioctl/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command istioctl is a Istio configuration command line utility.
+package main // import "istio.io/istio/istioctl/cmd/istioctl"


### PR DESCRIPTION
Add `istioctl` command document and canonical import path.
I saw `istioctl` package files, but there is no defined canonical import path. so any users can fetch with `go get -u github.com/istio/istio/istioctl/cmd/istioctl`, but also fetch some files into `$GOPATH/istio.io/istio/...`.
It is a bit confusing. I think that it is good to avoid it with canonical import path.