### PR TITLE
[helm] Mixer Service Selectors Do Not Match Pod Spec 

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -26,6 +26,4 @@ spec:
   - name: prometheus
     port: 42422
   selector:
-    app: istio-mixer
-    release: {{ .Release.Name }}
     istio: mixer


### PR DESCRIPTION
When using the latest helm chart on master the mixer Service [pod selectors](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml#L28-L31) don't match the mixer [pod spec](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml#L17-L18) in the deployment.

Other services only select based on the [`istio` label](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml#L27-L28) so I changed the mixer service to match.

### Example yaml from `helm template`

```yaml
---
# Source: istio/charts/mixer/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-mixer
  labels:
    app: mixer
    chart: mixer-0.5.0
    release: test-template
    heritage: Tiller
    istio: mixer
spec:
  ports:
  - name: tcp-plain
    port: 9091
  - name: tcp-mtls
    port: 15004
  - name: http-health
    port: 9093
  - name: configapi
    port: 9094
  - name: statsd-prom
    port: 9102
  - name: statsd-udp
    port: 9125
    protocol: UDP
  - name: prometheus
    port: 42422
  selector:
    app: istio-mixer
    release: test-template
    istio: mixer

---
# Source: istio/charts/mixer/templates/deployment.yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: istio-mixer
  labels:
    app: mixer
    chart: mixer-0.5.0
    release: test-template
    heritage: Tiller
    istio: mixer
  annotations:
    checksum/config-volume: aa9a748156816384e60a0e3a3ed8ac8f8fa44a41fe50127558bcd09379cc03b5
spec:
  replicas: 1
  template:
    metadata:
      labels:
        istio: mixer
      annotations:
        sidecar.istio.io/inject: "false"
    spec:
      serviceAccountName: istio-mixer-service-account
      containers:
        - name: statsd-to-prometheus
          image: "prom/statsd-exporter:latest"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 9102
          - containerPort: 9125
            protocol: UDP
          args:
          - '-statsd.mapping-config=/etc/statsd/mapping.conf'
          resources:
            {}

          volumeMounts:
          - name: config-volume
            mountPath: /etc/statsd
        - name: mixer
          image: "docker.io/istionightly/mixer:circleci-nightly"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 9091
          - containerPort: 9093
          - containerPort: 9094
          - containerPort: 42422
          args:
            - --configStoreURL=k8s://
            - --configDefaultNamespace=istio-system
            - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
            - --logtostderr
          resources:
            {}

        - name: mixer-proxy
          image: "docker.io/istionightly/proxy:circleci-nightly"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 15004
          args:
          - proxy
          - mixer
          - --controlPlaneAuthPolicy
          - NONE #--controlPlaneAuthPolicy
          - --customConfigFile
          - /etc/istio/proxy/envoy_mixer.json
          resources:
            null

          volumeMounts:
          - name: istio-certs
            mountPath: /etc/certs
            readOnly: true
      volumes:
      - name: istio-certs
        secret:
          secretName: istio.istio-mixer-service-account
          optional: true
      - name: config-volume
        configMap:
          name: istio-mixer
```

### New example output

```yaml
---
# Source: istio/charts/mixer/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: istio-mixer
  labels:
    app: mixer
    chart: mixer-0.5.0
    release: test-template
    heritage: Tiller
    istio: mixer
spec:
  ports:
  - name: tcp-plain
    port: 9091
  - name: tcp-mtls
    port: 15004
  - name: http-health
    port: 9093
  - name: configapi
    port: 9094
  - name: statsd-prom
    port: 9102
  - name: statsd-udp
    port: 9125
    protocol: UDP
  - name: prometheus
    port: 42422
  selector:
    istio: mixer

---
# Source: istio/charts/mixer/templates/deployment.yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: istio-mixer
  labels:
    app: mixer
    chart: mixer-0.5.0
    release: test-template
    heritage: Tiller
    istio: mixer
  annotations:
    checksum/config-volume: f9d584221ded283afeff3543a3a561485717933e34482cbc719f6d94a2b8b10a
spec:
  replicas: 1
  template:
    metadata:
      labels:
        istio: mixer
      annotations:
        sidecar.istio.io/inject: "false"
    spec:
      serviceAccountName: istio-mixer-service-account
      containers:
        - name: statsd-to-prometheus
          image: "prom/statsd-exporter:latest"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 9102
          - containerPort: 9125
            protocol: UDP
          args:
          - '-statsd.mapping-config=/etc/statsd/mapping.conf'
          resources:
            {}

          volumeMounts:
          - name: config-volume
            mountPath: /etc/statsd
        - name: mixer
          image: "docker.io/istionightly/mixer:circleci-nightly"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 9091
          - containerPort: 9093
          - containerPort: 9094
          - containerPort: 42422
          args:
            - --configStoreURL=k8s://
            - --configDefaultNamespace=istio-system
            - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
            - --logtostderr
          resources:
            {}

        - name: mixer-proxy
          image: "docker.io/istionightly/proxy:circleci-nightly"
          imagePullPolicy: IfNotPresent
          ports:
          - containerPort: 15004
          args:
          - proxy
          - mixer
          - --controlPlaneAuthPolicy
          - NONE #--controlPlaneAuthPolicy
          - --customConfigFile
          - /etc/istio/proxy/envoy_mixer.json
          resources:
            null

          volumeMounts:
          - name: istio-certs
            mountPath: /etc/certs
            readOnly: true
      volumes:
      - name: istio-certs
        secret:
          secretName: istio.istio-mixer-service-account
          optional: true
      - name: config-volume
        configMap:
          name: istio-mixer

---
```