### PR TITLE
Backports certificate expiry bugfix from master to release-0.5

### DIFF
--- a/security/pkg/pki/ca/controller/secret.go
+++ b/security/pkg/pki/ca/controller/secret.go
@@ -280,7 +280,8 @@ func (sc *SecretController) scrtUpdated(oldObj, newObj interface{}) {
 	certLifeTimeLeft := time.Until(cert.NotAfter)
 	certLifeTime := cert.NotAfter.Sub(cert.NotBefore)
 	// TODO(myidpt): we may introduce a minimum gracePeriod, without making the config too complex.
-	gracePeriod := time.Duration(sc.gracePeriodRatio) * certLifeTime
+	// Because time.Duration only takes int type, multiply gracePeriodRatio by 1000 and then divide it.
+	gracePeriod := time.Duration(sc.gracePeriodRatio*1000) * certLifeTime / 1000
 	rootCertificate := sc.ca.GetRootCertificate()
 
 	// Refresh the secret if 1) the certificate contained in the secret is about


### PR DESCRIPTION
As `time.Duration()` expectes integer arguments but is given a float, the graceperiod is truncated to 0, causing the Istio CA to only issue new certificates _after_ the certificates have expired, causing unwanted expired certificates to be used. By default instead of replacing the certificates every 30 minutes (0.5 of 1 hour), it issues new certificates every 60 minutes + cache trigger time.

This bug is fixed in master, but should also be fixed in 0.5.x, hence this pull request.

See also: https://github.com/istio/issues/issues/248
Fixed in master: https://github.com/istio/istio/blob/master/security/pkg/pki/ca/controller/secret.go#L316