### PR TITLE
IPv6: Generate error, if no address provided for resolution

### DIFF
--- a/pilot/pkg/proxy/resolve_test.go
+++ b/pilot/pkg/proxy/resolve_test.go
@@ -85,7 +85,7 @@ func TestResolveAddr(t *testing.T) {
 			name:     "Empty host",
 			input:    "",
 			expected: "",
-			errStr:   "",
+			errStr:   ErrResolveNoAddress.Error(),
 		},
 		{
 			name:     "IPv6 missing brackets",


### PR DESCRIPTION
Not an IPv6 specific item, but doing as cleanup to PR4369. First change is
to return an error, if no address is specified for IP resolution. Previously,
the code would not return an error, but instead, just return an empty string
as the result. However, the ONLY place that currently uses this, is for statsd
UDP address, where the caller checks for empty strying first.  Changing to
raise an error (which makes more sense), and if future callers need to ignore
this case, they can check against the new error definition.

The second change is to remove duplication in lookup of IP address.
Follow-up PR for Issue #4096 
/area networking
