### PR TITLE
Always Use .Release.Namespace in the ClusterRoleBinding Name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -600,56 +600,15 @@ generate_yaml:
 $(HELM):
 	bin/init_helm.sh
 
-istio.yaml: $(HELM)
+
+# creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml
+# Ensure that values-$filename is present in install/kubernetes/helm/istio
+isti%.yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
-				  --namespace=istio-system \
+		  --namespace=istio-system \
                   --set global.hub=${HUB} \
-                  --set global.controlPlaneSecurityEnabled=false \
-		  --set global.refreshInterval=1s \
-                  --set global.mtls.enabled=false \
-		  --set global.rbacEnabled=true \
-		  --set istiotesting.oneNamespace=false \
-                  --set prometheus.enabled=true \
-				install/kubernetes/helm/istio > install/kubernetes/istio.yaml
-
-istio-one-namespace.yaml: $(HELM)
-	$(HELM) template --set global.tag=${TAG} \
-				  --namespace=istio-system \
-                  --set global.hub=${HUB} \
-                  --set global.controlPlaneSecurityEnabled=false \
-		  --set global.refreshInterval=1s \
-                  --set global.mtls.enabled=false \
-		  --set global.rbacEnabled=true \
-		  --set istiotesting.oneNamespace=true \
-                  --set prometheus.enabled=true \
-				install/kubernetes/helm/istio > install/kubernetes/istio-one-namespace.yaml
-
-
-istio-auth.yaml: $(HELM)
-	$(HELM) template --set global.tag=${TAG} \
-				  --namespace=istio-system \
-                  --set global.hub=${HUB} \
-                  --set global.controlPlaneSecurityEnabled=true \
-		  --set global.refreshInterval=1s \
-                  --set global.mtls.enabled=true \
-		  --set global.rbacEnabled=true \
-		  --set istiotesting.oneNamespace=false \
-                  --set prometheus.enabled=true \
-				install/kubernetes/helm/istio > install/kubernetes/istio-auth.yaml
-
-istio-one-namespace-auth.yaml: $(HELM)
-	$(HELM) template --set global.tag=${TAG} \
-				  --namespace=istio-system \
-                  --set global.hub=${HUB} \
-                  --set global.controlPlaneSecurityEnabled=true \
-		  --set global.refreshInterval=1s \
-                  --set global.mtls.enabled=true \
-		  --set global.rbacEnabled=true \
-		  --set istiotesting.oneNamespace=true \
-                  --set prometheus.enabled=true \
-				install/kubernetes/helm/istio > install/kubernetes/istio-one-namespace-auth.yaml
-
-
+		  --values install/kubernetes/helm/istio/values-$@ \
+		  install/kubernetes/helm/istio > install/kubernetes/$@
 
 deploy/all: $(HELM)
 	kubectl create ns istio-system > /dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -597,7 +597,10 @@ generate_yaml:
 	./install/updateVersion.sh -a ${HUB},${TAG} 
 
 
-istio.yaml:
+$(HELM):
+	bin/init_helm.sh
+
+istio.yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
 				  --namespace=istio-system \
                   --set global.hub=${HUB} \
@@ -609,7 +612,7 @@ istio.yaml:
                   --set prometheus.enabled=true \
 				install/kubernetes/helm/istio > install/kubernetes/istio.yaml
 
-istio-one-namespace.yaml:
+istio-one-namespace.yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
 				  --namespace=istio-system \
                   --set global.hub=${HUB} \
@@ -622,7 +625,7 @@ istio-one-namespace.yaml:
 				install/kubernetes/helm/istio > install/kubernetes/istio-one-namespace.yaml
 
 
-istio-auth.yaml:
+istio-auth.yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
 				  --namespace=istio-system \
                   --set global.hub=${HUB} \
@@ -634,7 +637,7 @@ istio-auth.yaml:
                   --set prometheus.enabled=true \
 				install/kubernetes/helm/istio > install/kubernetes/istio-auth.yaml
 
-istio-one-namespace-auth.yaml:
+istio-one-namespace-auth.yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
 				  --namespace=istio-system \
                   --set global.hub=${HUB} \
@@ -648,7 +651,7 @@ istio-one-namespace-auth.yaml:
 
 
 
-deploy/all:
+deploy/all: $(HELM)
 	kubectl create ns istio-system > /dev/null || true
 	$(HELM) template --set global.tag=${TAG} \
 		          --namespace=istio-system \

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -110,6 +110,7 @@ ISTIO_ENVOY_RELEASE_DIR=${ISTIO_ENVOY_RELEASE_DIR:-"${OUT_DIR}/${GOOS}_${GOARCH}
 ISTIO_ENVOY_RELEASE_NAME=${ISTIO_ENVOY_RELEASE_NAME:-"envoy-$ISTIO_ENVOY_VERSION"}
 ISTIO_ENVOY_RELEASE_PATH=${ISTIO_ENVOY_RELEASE_PATH:-"$ISTIO_ENVOY_RELEASE_DIR/$ISTIO_ENVOY_RELEASE_NAME"}
 
+
 # Save envoy in $ISTIO_ENVOY_DIR
 if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; then
     # Clear out any old versions of Envoy.
@@ -144,14 +145,7 @@ if [ ! -f ${ISTIO_OUT}/envoy ] ; then
     cp ${ISTIO_ENVOY_DEBUG_PATH} ${ISTIO_OUT}/envoy
 fi
 
-if [ ! -f ${ISTIO_OUT}/helm ] ; then
-    # Install helm. Please keep it in sync with .circleci
-    cd /tmp && \
-        curl -Lo /tmp/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VER}-linux-amd64.tar.gz && \
-        tar xfz helm.tgz && \
-        mv linux-amd64/helm ${ISTIO_OUT}/helm && \
-        rm -rf helm.tgz linux-amd64
-fi
+${ROOT}/bin/init_helm.sh
 
 # TODO(nmittler): Remove once tests no longer use the envoy binary directly.
 # circleCI expects this in the bin directory

--- a/bin/init_helm.sh
+++ b/bin/init_helm.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Copyright 2017,2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Init script downloads or updates envoy and the go dependencies. Called from Makefile, which sets
+# the needed environment variables.
+
+ROOT=$(cd $(dirname $0)/..; pwd)
+ISTIO_GO=$ROOT
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(nmittler): Remove before merging.
+set -x # echo on
+
+# TODO(nmittler): Remove these variables and require that this script be run from the Makefile
+
+# Set GOPATH to match the expected layout
+GO_TOP=$(cd $(dirname $0)/../../../..; pwd)
+
+export OUT_DIR=${OUT_DIR:-${GO_TOP}/out}
+
+HELM_VER=v2.7.2
+
+export GOPATH=${GOPATH:-$GO_TOP}
+# Normally set by Makefile
+export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
+
+# Set the architecture. Matches logic in the Makefile.
+export GOARCH=${GOARCH:-'amd64'}
+
+# Determine the OS. Matches logic in the Makefile.
+LOCAL_OS="`uname`"
+case $LOCAL_OS in
+  'Linux')
+    LOCAL_OS='linux'
+    ;;
+  'Darwin')
+    LOCAL_OS='darwin'
+    ;;
+  *)
+    echo "This system's OS ${LOCAL_OS} isn't recognized/supported"
+    exit 1
+    ;;
+esac
+export GOOS=${GOOS:-${LOCAL_OS}}
+
+# test scripts seem to like to run this script directly rather than use make
+export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
+
+# install helm if not present, it must be the local version.
+if [ ! -f ${ISTIO_OUT}/helm ] ; then
+    TD=$(mktemp -d)
+    # Install helm. Please keep it in sync with .circleci
+    cd ${TD} && \
+        curl -Lo ${TD}/helm.tgz https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VER}-${LOCAL_OS}-amd64.tar.gz && \
+        tar xfz helm.tgz && \
+        mv ${LOCAL_OS}-amd64/helm ${ISTIO_OUT}/helm && \
+        rm -rf ${TD}
+fi

--- a/install/kubernetes/helm/istio/charts/ingress/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-ingress-admin-role-binding-{{ .Release.Namespace }}
+  name: istio-ingress-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-pilot
+  name: istio-pilot-{{ .Release.Namespace }}
   labels:
     app: istio-pilot
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: prometheus
+  name: prometheus-{{ .Release.Namespace }}
 rules:
 - apiGroups: [""]
   resources:
@@ -23,11 +23,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus
+  name: prometheus-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus
+  name: prometheus-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: prometheus

--- a/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
+  name: istio-ca-{{ .Release.Namespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-  name: istio-ca-role-binding-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/helm/istio/values-istio-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth.yaml
@@ -1,0 +1,22 @@
+# This is used to generate istio.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: true
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: true
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+istiotesting:
+  oneNameSpace: false
+
+prometheus:
+  enabled: true

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
@@ -1,0 +1,22 @@
+# This is used to generate istio.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: true
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: true
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+istiotesting:
+  oneNameSpace: true
+
+prometheus:
+  enabled: true

--- a/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
@@ -1,0 +1,22 @@
+# This is used to generate istio.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: false
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+istiotesting:
+  oneNameSpace: true
+
+prometheus:
+  enabled: true

--- a/install/kubernetes/helm/istio/values-istio.yaml
+++ b/install/kubernetes/helm/istio/values-istio.yaml
@@ -1,0 +1,22 @@
+# This is used to generate istio.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: false
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+istiotesting:
+  oneNameSpace: false
+
+prometheus:
+  enabled: true


### PR DESCRIPTION
Ensures that all clusterRoleBinding has name of namespace encoded in it.

This is needed for one-namespace testing.