### PR TITLE
Update custom mixer deployment instructions

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -34,4 +34,4 @@ spec:
         - name: tmp-configmap-mixer
           configMap:
             name: istio-mixer-custom-resources
-      restartPolicy: Never # CRD might take some time till they are available to comsume
+      restartPolicy: Never # CRD might take some time till they are available to consume


### PR DESCRIPTION
This PR removes the `bazel`-based instructions and attempts to match
the current `make` and `helm` build and deployment regimes.

Fixes: https://github.com/istio/istio/issues/4530