### PR TITLE
Create namespace before running tests

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -330,7 +330,7 @@ func (k *KubeInfo) deployIstio() error {
 	}
 
 	if err := util.CreateNamespace(k.Namespace); err != nil {
-		log.Errorf("Unable to create namespace %s", k.Namespace)
+		log.Errorf("Unable to create namespace %s: %s", k.Namespace, err.Error())
 		return err
 	}
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -328,6 +328,12 @@ func (k *KubeInfo) deployIstio() error {
 		log.Errorf("Generating yaml %s failed", testIstioYaml)
 		return err
 	}
+
+	if err := util.CreateNamespace(k.Namespace); err != nil {
+		log.Errorf("Unable to create namespace %s", k.Namespace)
+		return err
+	}
+
 	if err := util.KubeApply(k.Namespace, testIstioYaml); err != nil {
 		log.Errorf("Istio core %s deployment failed", testIstioYaml)
 		return err

--- a/tests/util/kubeUtils.go
+++ b/tests/util/kubeUtils.go
@@ -76,8 +76,10 @@ func Fill(outFile, inFile string, values interface{}) error {
 
 // CreateNamespace create a kubernetes namespace
 func CreateNamespace(n string) error {
-	if _, err := Shell("kubectl create namespace %s", n); err != nil {
-		return err
+	if _, err := ShellMuteOutput("kubectl create namespace %s", n); err != nil {
+		if !strings.Contains(err.Error(), "AlreadyExists") {
+			return err
+		}
 	}
 	log.Infof("namespace %s created\n", n)
 	return nil


### PR DESCRIPTION
Helm does not guarantee that namespace resource will be placed at the top of the file. Create namespace before installing istio using `kubectl apply`.