### PR TITLE
Update sample/bookinfo/kube ratelimit configs

### DIFF
--- a/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
@@ -12,19 +12,19 @@ spec:
     # A requestcount instance is checked against override dimensions.
     overrides:
     # The following override applies to 'ratings' when
-    # the source is 'reviews'.
+    # the source is 'reviews' and sourceVersion is 'v2'.
     - dimensions:
         destination: ratings
         source: reviews
+        sourceVersion: v3
       maxAmount: 1
-      validDuration: 1s
+      validDuration: 5s
     # The following override applies to 'ratings' regardless
     # of the source.
     - dimensions:
         destination: ratings
-      maxAmount: 100
-      validDuration: 1s
-
+      maxAmount: 5
+      validDuration: 10s
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: quota
@@ -37,7 +37,6 @@ spec:
     sourceVersion: source.labels["version"] | "unknown"
     destination: destination.labels["app"] | destination.service | "unknown"
     destinationVersion: destination.labels["version"] | "unknown"
-
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -53,28 +52,32 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpec
 metadata:
-  creationTimestamp: null
-  name: request-count
+  name: requestcount
   namespace: istio-system
 spec:
   rules:
   - quotas:
     - charge: 1
-      quota: RequestCount
+      quota: requestcount
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpecBinding
 metadata:
-  creationTimestamp: null
-  name: request-count
+  name: requestcount
   namespace: istio-system
 spec:
   quotaSpecs:
-  - name: request-count
+  - name: requestcount
     namespace: istio-system
   services:
+  # Must include namespace if the services are in a
+  # different namespace than this QuotaSpecBinding resource
   - name: ratings
+    namespace: default
   - name: reviews
+    namespace: default
   - name: details
+    namespace: default
   - name: productpage
+    namespace: default
 


### PR DESCRIPTION
This example does not work as is when following the docs. I updated it to work with current documentation. 

* Added namespace to `QuotaSpecBinding` `service` definitions because it is needed if `bookinfo` is deployed into `default` namespace (which it is following current docs)
* Updated names to `requestcount` to be consistent within the file
* Updated rate-limit amounts so that it can be tested and viewed by hand in a reasonable timeframe without having to run a load script 

Addresses: https://github.com/istio/issues/issues/257
Docs change: https://github.com/istio/istio.github.io/pull/1109