### PR TITLE
fix zipkin service name from istio-zipkin to zipkin

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           - --serviceCluster
           - istio-ingress
           - --zipkinAddress
-          - istio-zipkin:9411
+          - zipkin:9411
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
           - --proxyAdminPort

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -69,7 +69,7 @@ data:
       proxyAdminPort: 15000
       #
       # Zipkin trace collector
-      zipkinAddress: istio-zipkin.{{ .Release.Namespace }}:9411
+      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
       statsdUdpAddress: istio-statsd-prom-bridge.{{ .Release.Namespace }}:9125


### PR DESCRIPTION
Name of the zipkin service is `zipkin`, not `istio-zipkin`.
This fixes the ingress and sidecar configuration to use `zipkin:9411`