### PR TITLE
[wip] convert ingress into v1alpha3 gateway+virt service

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -160,7 +160,15 @@ const (
 
 	// DiscoveryPlainAddress discovery IP address:port with plain text
 	DiscoveryPlainAddress = "istio-pilot:15007"
+
+	// IstioIngressGatewayName is the internal gateway name assigned to ingress
+	IstioIngressGatewayName = "istio-k8s-ingress-gateway"
+
+	// IstioIngressNamespace is the namespace where Istio ingress controller is deployed
+	IstioIngressNamespace = "istio-system"
 )
+
+var IstioIngressWorkloadLabels = map[string]string{"istio": "ingress"}
 
 // DefaultProxyConfig for individual proxies
 func DefaultProxyConfig() meshconfig.ProxyConfig {


### PR DESCRIPTION
No merging with other gateways for the moment.
I have added the conversion function. Would appreciate some help in plumbing
this into the config system in pilot/pkg/kube/. I can add the gateway code.
cc @ijsnellf @GregHanson @ZackButcher

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>