### PR TITLE
Add multicluster DNS discovery example for the ratings service

### DIFF
--- a/samples/bookinfo/kube/bookinfo-ratings-discovery.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-discovery.yaml
@@ -1,0 +1,30 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Ratings service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratings
+  labels:
+    app: ratings
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: ratings
+---


### PR DESCRIPTION
When reviews-v3 is run on the "remote" multicluster Kubernetes,
reviews-v3 Java code will crash if it cannot find the ratings service
via DNS discovery.

In a non-multicluster environment, the existing code is not a prob lem,
however, in a multicluster environment, the "remote" reviews-v3 service
must be aware of the DNS mapping (e.g. Kubernetes Service definition)
to find the ratings service on the Istio control plane.

Proper documentation is in progress to enable a bookinfo multicluster
setup task.  This work is part of that documentation, however, the
documentation will land in the github.istio.io repo.