### PR TITLE
Fix updateVersion - Expand args when running updateVersion_orig

### DIFF
--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -23,7 +23,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.."
 cd ${ROOT}
 
 # just run the old version
-${ROOT}/install/updateVersion_orig.sh "$*"
+${ROOT}/install/updateVersion_orig.sh "$@"
 
 
 function gen_file() {


### PR DESCRIPTION
Replace "$*" with "$@".
When using "$*", updateVersion_orig.sh sees one single arg.

For a reference, see here: https://stackoverflow.com/a/14247867/2749989

For example, when running:
`./updateVersion.sh -D true -a "<hub>,<tag>"`
there would  be an unexpected behavior: the hub and tag won't be specified.