### PR TITLE
Enhance MutableBag to support attribute deletion

### DIFF
--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -792,6 +792,53 @@ func TestGlobalList(t *testing.T) {
 	t.Error("Did not find destination.service")
 }
 
+func TestReset(t *testing.T) {
+	mb := GetMutableBag(nil)
+	defer mb.Done()
+
+	mb.Set("some", "value")
+	mb.Reset()
+
+	if len(mb.Names()) != 0 {
+		t.Errorf("Got %v, expected %v", mb.Names(), []string{})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	parent := GetMutableBag(nil)
+	defer parent.Done()
+	child := GetMutableBag(parent)
+	defer child.Done()
+
+	parent.Set("parent", true)
+	child.Set("parent", false)
+
+	if len(child.Names()) != 1 {
+		t.Errorf("Got %v, expected %v", len(child.Names()), 1)
+	}
+
+	v, found := child.Get("parent")
+	if !found {
+		t.Error("Failed to retrieve attribute")
+	}
+	isParent, isBool := v.(bool)
+	if !isBool || isParent {
+		t.Error("Failed to retrieve bool attribute from child")
+	}
+
+	child.Delete("parent")
+
+	v, found = child.Get("parent")
+	if !found {
+		t.Error("Failed to retrieve attribute after Delete")
+	}
+	isParent, isBool = v.(bool)
+	if !isBool || !isParent {
+		t.Error("Failed to retrieve bool attribute from parent after Delete")
+	}
+
+}
+
 func init() {
 	// bump up the log level so log-only logic runs during the tests, for correctness and coverage.
 	o := log.DefaultOptions()

--- a/mixer/pkg/attribute/mutableBag.go
+++ b/mixer/pkg/attribute/mutableBag.go
@@ -166,6 +166,12 @@ func (mb *MutableBag) Set(name string, value interface{}) {
 	mb.values[name] = value
 }
 
+// Delete removes a named item from the local state.
+// The item may still be present higher in the hierarchy
+func (mb *MutableBag) Delete(name string) {
+	delete(mb.values, name)
+}
+
 // Reset removes all local state.
 func (mb *MutableBag) Reset() {
 	mb.values = make(map[string]interface{})

--- a/mixer/pkg/attribute/mutableBag.go
+++ b/mixer/pkg/attribute/mutableBag.go
@@ -168,10 +168,7 @@ func (mb *MutableBag) Set(name string, value interface{}) {
 
 // Reset removes all local state.
 func (mb *MutableBag) Reset() {
-	// my kingdom for a clear method on maps!
-	for k := range mb.values {
-		delete(mb.values, k)
-	}
+	mb.values = make(map[string]interface{})
 }
 
 // Merge combines an array of bags into the current bag. If the current bag already defines


### PR DESCRIPTION
This PR adds a way to clear attributes from MutableBag and changes how Reset() is handled.

Trying to use the MutableBag hierarchy to support attribute extension (i.e., each layer inherits the upper layer, which is fixed for the life time of the lower layer):
request-attributes -> session-attributes -> server-attribute

I needed a way to clear transient attributes from the request MutableBag (such as time, method, ...) instead of creating a new bag on each request-respone iteration.
