### PR TITLE
Add a bookinfo-reviews-v3 example for multicluster

### DIFF
--- a/samples/bookinfo/kube/bookinfo-reviews-v3.yaml
+++ b/samples/bookinfo/kube/bookinfo-reviews-v3.yaml
@@ -1,0 +1,35 @@
+##################################################################################################
+# Reviews-v3 multicluster service example
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  labels:
+    app: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: reviews-v3
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      containers:
+      - name: reviews
+        image: istio/examples-bookinfo-reviews-v3:1.5.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9080
+---


### PR DESCRIPTION
This is intended to be used with route-rule-reviews-v3.yaml, coupled
with documentation to be submitted via PR to the github.istio.io repository
to demonstrate how to deploy bookinfo in a multicluster scenario.  This
file must be sidecar injected and run on the "remote" cluster independently
after bookinfo-reviews-v3 deployment is removed from the Istio control plane.

Documentation should hit the PR queue by EOD Friday.

While the multicluster solution now is imperfect, the general idea is to get
the basics documented and exampled so others in the community can eval it,
provide feedback, and hopefully improve the implementation incrementally.

This may or may not be a long lived file in the repository.  I am hopeful it
is not long-lived, but will be necessary to achieve the incremental development
approach described above.