### PR TITLE
v1alpha3 cleanup: util and authn package

### DIFF
--- a/mixer/template/sample/createinstance_test.go
+++ b/mixer/template/sample/createinstance_test.go
@@ -687,7 +687,7 @@ func generateReportTests() []createInstanceTest {
 	emptyFieldsParam := sample_report.InstanceParam{
 		// missing all fields
 		Res1: &sample_report.Res1InstanceParam{
-		// missing all fields
+			// missing all fields
 		},
 	}
 	t = createInstanceTest{

--- a/pilot/pkg/networking/plugins/authn/authentication.go
+++ b/pilot/pkg/networking/plugins/authn/authentication.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha3
+package authn
 
 import (
 	"time"
@@ -28,6 +28,7 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/log"
 )
 
@@ -38,21 +39,21 @@ const (
 	jwtFilterName = "jwt-auth"
 )
 
-// buildJwtFilter returns a Jwt filter for all Jwt specs in the policy.
-func buildJwtFilter(policy *authn.Policy) *http_conn.HttpFilter {
+// BuildJwtFilter returns a Jwt filter for all Jwt specs in the policy.
+func BuildJwtFilter(policy *authn.Policy) *http_conn.HttpFilter {
 	filterConfigProto := model.ConvertPolicyToJwtConfig(policy)
 	if filterConfigProto == nil {
 		return nil
 	}
 	return &http_conn.HttpFilter{
 		Name:   jwtFilterName,
-		Config: messageToStruct(filterConfigProto),
+		Config: util.MessageToStruct(filterConfigProto),
 	}
 }
 
-// buildJwksURIClustersForProxyInstances checks the authentication policy for the
+// BuildJwksURIClustersForProxyInstances checks the authentication policy for the
 // input proxyInstances, and generates (outbound) clusters for all JwksURIs.
-func buildJwksURIClustersForProxyInstances(mesh *meshconfig.MeshConfig,
+func BuildJwksURIClustersForProxyInstances(mesh *meshconfig.MeshConfig,
 	store model.IstioConfigStore, proxyInstances []*model.ServiceInstance) []*v2.Cluster {
 	if len(proxyInstances) == 0 {
 		return nil

--- a/pilot/pkg/networking/plugins/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugins/authn/authentication_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha3
+package authn
 
 import (
 	"fmt"
@@ -98,7 +98,7 @@ func TestBuildJwtFilter(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if got := buildJwtFilter(c.in); !reflect.DeepEqual(c.expected, got) {
+		if got := BuildJwtFilter(c.in); !reflect.DeepEqual(c.expected, got) {
 			t.Errorf("buildJwtFilter(%#v), got:\n%#v\nwanted:\n%#v\n", c.in, got, c.expected)
 		}
 	}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha3
+package util
 
 import (
 	"sort"
@@ -37,12 +37,13 @@ import (
 //
 //	cidrList := make([]*core.CidrRange, 0)
 //	for _, addr := range addresses {
-//		cidrList = append(cidrList, convertAddressToCidr(addr))
+//		cidrList = append(cidrList, ConvertAddressToCidr(addr))
 //	}
 //	return cidrList
 //}
 
-func convertAddressToCidr(addr string) *core.CidrRange {
+// ConvertAddressToCidr converts from string to CIDR proto
+func ConvertAddressToCidr(addr string) *core.CidrRange {
 	cidr := &core.CidrRange{
 		AddressPrefix: addr,
 		PrefixLen: &types.UInt32Value{
@@ -59,8 +60,8 @@ func convertAddressToCidr(addr string) *core.CidrRange {
 	return cidr
 }
 
-// normalizeListeners sorts and de-duplicates listeners by address
-func normalizeListeners(listeners []*xdsapi.Listener) []*xdsapi.Listener {
+// NormalizeListeners sorts and de-duplicates listeners by address
+func NormalizeListeners(listeners []*xdsapi.Listener) []*xdsapi.Listener {
 	out := make([]*xdsapi.Listener, 0, len(listeners))
 	set := make(map[string]bool)
 	for _, listener := range listeners {
@@ -73,8 +74,8 @@ func normalizeListeners(listeners []*xdsapi.Listener) []*xdsapi.Listener {
 	return out
 }
 
-// buildAddress returns a SocketAddress with the given ip and port.
-func buildAddress(ip string, port uint32) core.Address {
+// BuildAddress returns a SocketAddress with the given ip and port.
+func BuildAddress(ip string, port uint32) core.Address {
 	return core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
@@ -87,9 +88,9 @@ func buildAddress(ip string, port uint32) core.Address {
 	}
 }
 
-// getByAddress returns a listener by its address
+// GetByAddress returns a listener by its address
 // TODO(mostrowski): consider passing map around to save iteration.
-func getByAddress(listeners []*xdsapi.Listener, addr string) *xdsapi.Listener {
+func GetByAddress(listeners []*xdsapi.Listener, addr string) *xdsapi.Listener {
 	for _, listener := range listeners {
 		if listener.Address.String() == addr {
 			return listener
@@ -126,7 +127,8 @@ func getByAddress(listeners []*xdsapi.Listener, addr string) *xdsapi.Listener {
 //	}
 //}
 
-func messageToStruct(msg proto.Message) *types.Struct {
+// MessageToStruct converts from proto message to proto Struct
+func MessageToStruct(msg proto.Message) *types.Struct {
 	s, err := util.MessageToStruct(msg)
 	if err != nil {
 		log.Error(err.Error())
@@ -135,7 +137,8 @@ func messageToStruct(msg proto.Message) *types.Struct {
 	return s
 }
 
-func convertGogoDurationToDuration(d *types.Duration) time.Duration {
+// ConvertGogoDurationToDuration converts from gogo proto duration to time.duration
+func ConvertGogoDurationToDuration(d *types.Duration) time.Duration {
 	if d == nil {
 		return 0
 	}

--- a/pilot/pkg/networking/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/v1alpha3/networkfilter.go
@@ -15,23 +15,22 @@
 package v1alpha3
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/types"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	mongo_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mongo_proxy/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
 
 	"istio.io/istio/pilot/pkg/model"
-
-	"bytes"
-
-	"k8s.io/apimachinery/pkg/util/json"
+	"istio.io/istio/pilot/pkg/networking/util"
 )
 
 // buildInboundNetworkFilters generates a TCP proxy network filter on the inbound path
@@ -45,8 +44,8 @@ func buildInboundNetworkFilters(instance *model.ServiceInstance) []listener.Filt
 
 	return []listener.Filter{
 		{
-			Name:   util.TCPProxy,
-			Config: messageToStruct(config),
+			Name:   xdsutil.TCPProxy,
+			Config: util.MessageToStruct(config),
 		},
 	}
 
@@ -114,7 +113,7 @@ func buildOutboundNetworkFilters(clusterName string, addresses []string, port *m
 
 	// FIXME
 	tcpFilter := listener.Filter{
-		Name: util.TCPProxy,
+		Name: xdsutil.TCPProxy,
 		Config: &types.Struct{Fields: map[string]*types.Value{
 			"deprecated_v1": &trueValue,
 			"value":         &structValue,
@@ -144,8 +143,8 @@ func buildOutboundMongoFilter() listener.Filter {
 	}
 
 	return listener.Filter{
-		Name:   util.MongoProxy,
-		Config: messageToStruct(config),
+		Name:   xdsutil.MongoProxy,
+		Config: util.MessageToStruct(config),
 	}
 }
 


### PR DESCRIPTION
Move util to its own package under networking so that it can be used by mixer/authn filters.
Minor cleanups of the JWK... code. More to come.
Setting up the base for adding mixer filter.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>