### PR TITLE
fix version_test that has fixed golang version

### DIFF
--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -14,9 +14,20 @@
 
 package version
 
+import "fmt"
+import "runtime"
 import "testing"
 
 func TestBuildInfo(t *testing.T) {
+	versionedString := fmt.Sprintf(`Version: unknown
+GitRevision: unknown
+User: unknown@unknown
+Hub: unknown
+GolangVersion: %v
+BuildStatus: unknown
+`,
+		runtime.Version())
+
 	cases := []struct {
 		name     string
 		in       BuildInfo
@@ -39,14 +50,7 @@ GolangVersion: GOLANGVER
 BuildStatus: STATUS
 `},
 
-		{"init", Info, "unknown@unknown-unknown-unknown-unknown-unknown", `Version: unknown
-GitRevision: unknown
-User: unknown@unknown
-Hub: unknown
-GolangVersion: go1.10
-BuildStatus: unknown
-`},
-	}
+		{"init", Info, "unknown@unknown-unknown-unknown-unknown-unknown", versionedString}}
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {


### PR DESCRIPTION
This is a selected backport from the PR #4338 so the version_test
in the 0.7 branch won't fail because golang version is not 1.10.