### PR TITLE
make ingress autoscalar scale to 1 by default

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -62,8 +62,8 @@ ingress:
   enabled: true
   serviceAccountName: default
   imagePullPolicy: IfNotPresent
-  autoscaleMin: 2
-  autoscaleMax: 8
+  autoscaleMin: 1
+  autoscaleMax: 1
   resources: {}
 # limits:
 #  cpu: 100m


### PR DESCRIPTION
In order to ensure that we need least amount of resources for base case, set autoscalar to scale to 1.