### PR TITLE
Integrate circle CI with Testgrid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,49 @@ integrationDefaults: &integrationDefaults
     TAG: dontpush
     GOPATH: /go
 
+# Common procedure to initialize working directory
+initWorkingDir: &initWorkingDir
+  type: shell
+  name: Initialize Working Directory
+  pwd: /
+  command: |
+    sudo mkdir -p /go/src/istio.io/istio
+    sudo chown -R circleci /go
+    mkdir -p /go/out/tests
+    mkdir -p /home/circleci/logs
+
+recordZeroExitCodeIfTestPassed: &recordZeroExitCodeIfTestPassed
+  run:
+    when: on_success
+    name: Record zero exit code as test passed
+    command: echo 0 > exit_code
+
+recordNonzeroExitCodeIfTestFailed: &recordNonzeroExitCodeIfTestFailed
+  run:
+    when: on_fail
+    name: Record nonzero exit code as test failed
+    command: echo 1 > exit_code
+
+markJobStartsOnGCS: &markJobStartsOnGCS
+  run:
+    when: always
+    command: bin/ci2gubernator.sh --job_starts
+
+markJobFinishesOnGCS: &markJobFinishesOnGCS
+  run:
+    when: always
+    command: bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
+
+dumpsysNonPilot: &dumpsysNonPilot
+  run:
+    name: dumpsys
+    when: always
+    command: |
+      /go/bin/go-junit-report </go/out/tests/build-log.txt > /go/out/tests/junit.xml
+      kubectl get all -o wide --all-namespaces
+      kubectl cluster-info dump > /go/out/tests/cluster-info.dump.txt
+      kubectl describe pods -n istio-system > /go/out/tests/pods-system.txt
+
 jobs:
   e2e-simple:
     <<: *integrationDefaults
@@ -32,17 +75,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - type: shell
-        name: Initialize Working Directory
-        pwd: /
-        command: |
-          sudo mkdir -p /go/src/istio.io/istio
-          sudo chown -R circleci /go
-          mkdir -p /go/out
-          mkdir /home/circleci/logs
+      - <<: *initWorkingDir
       - checkout
       - attach_workspace:
           at:  /go
+      - <<: *markJobStartsOnGCS
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -54,17 +91,11 @@ jobs:
             make docker.all generate_yaml
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
-      - run: make test/minikube/auth/e2e_simple
-      - run:
-          name: dumpsys
-          when: always
-          command: |
-            mkdir -p /go/out/logs
-            # TODO: move to a make target 'dumpsys'.
-            kubectl get all -o wide --all-namespaces
-            kubectl cluster-info dump > /go/out/logs/cluster-info.dump.txt
-            kubectl describe pods -n istio-system > /go/out/logs/pods-system.txt
-            /go/bin/go-junit-report </go/out/tests/test-report-auth-simple.raw > /go/out/tests/test-report-auth-simple.xml
+      - run: make test/minikube/noauth/e2e_simple | tee -a /go/out/tests/build-log.txt
+      - <<: *recordZeroExitCodeIfTestPassed
+      - <<: *recordNonzeroExitCodeIfTestFailed
+      - <<: *dumpsysNonPilot
+      - <<: *markJobFinishesOnGCS
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -118,17 +149,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - type: shell
-        name: Initialize Working Directory
-        pwd: /
-        command: |
-          sudo mkdir -p /go/src/istio.io/istio
-          sudo chown -R circleci /go
-          mkdir -p /go/out
-          mkdir /home/circleci/logs
+      - <<: *initWorkingDir
       - checkout
       - attach_workspace:
           at:  /go
+      - <<: *markJobStartsOnGCS
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -141,15 +166,23 @@ jobs:
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
       - run:
-            no_output_timeout: 20m
-            # Run the test even if previous failed
-            when: always
-            command: |
-                  make e2e_mixer E2E_ARGS="--skip_cleanup -use_local_cluster -cluster_wide -test.v"
+          no_output_timeout: 20m
+          # Run the test even if previous failed
+          when: always
+          name: make e2e_mixer
+          command: |
+            E2E_ARGS="--skip_cleanup -use_local_cluster -cluster_wide -test.v" \
+            make e2e_mixer | tee -a /go/out/tests/build-log.txt
+      - <<: *recordZeroExitCodeIfTestPassed
+      - <<: *recordNonzeroExitCodeIfTestFailed
+      - <<: *dumpsysNonPilot
+      - <<: *markJobFinishesOnGCS
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
           path: /tmp
+      - store_test_results:
+          path: /go/out/tests
 
   e2e-bookinfo:
     <<: *integrationDefaults

--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+# set -x
+
+SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
+ROOTDIR="$(dirname ${SCRIPTPATH})"
+
+if [ -z "$GCS_BUCKET_TOKEN" ]; then
+	echo "GCS_BUCKET_TOKEN unavailible"
+	exit 0
+fi
+
+# The GCP service account for circle ci is only authorized to edit gs://istio-circleci bucket
+TMP_SA_JSON=$(mktemp /tmp/XXXXX.json)
+ENCRYPTED_SA_JSON="${ROOTDIR}/.circleci/accounts/istio-circle-ci.gcp.serviceaccount"
+openssl aes-256-cbc -d -in "${ENCRYPTED_SA_JSON}" -out "${TMP_SA_JSON}" -k "${GCS_BUCKET_TOKEN}" -md sha256
+
+go get -u istio.io/test-infra/toolbox/ci2gubernator
+
+/go/bin/ci2gubernator ${@} \
+--service_account="${TMP_SA_JSON}" \
+--sha=${CIRCLE_SHA1} \
+--org=${CIRCLE_PROJECT_USERNAME} \
+--repo=${CIRCLE_PROJECT_REPONAME} \
+--job=${CIRCLE_JOB} \
+--build_number=${CIRCLE_BUILD_NUM} \
+--pr_number=${CIRCLE_PR_NUMBER}

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -104,7 +104,7 @@ if [[ -n "${CIRCLE_BUILD_NUM:-}" ]]; then
   if [[ -z "${CIRCLE_PR_NUMBER:-}" ]]; then
     TMP_SA_JSON=$(mktemp /tmp/XXXXX.json)
     ENCRYPTED_SA_JSON="${ROOTDIR}/.circleci/accounts/istio-circle-ci.gcp.serviceaccount"
-    openssl aes-256-cbc -d -in "${ENCRYPTED_SA_JSON}" -out "${TMP_SA_JSON}" -k "${GCS_BUCKET_TOKEN}"
+    openssl aes-256-cbc -d -in "${ENCRYPTED_SA_JSON}" -out "${TMP_SA_JSON}" -k "${GCS_BUCKET_TOKEN}" -md sha256
     # only pushing data on post submit
     PKG_CHECK_ARGS=( --build_id="${CIRCLE_BUILD_NUM}"
       --job_name="istio/${CIRCLE_JOB}_${CIRCLE_BRANCH}"

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -194,4 +194,4 @@ dumpsys:
 	kubectl cluster-info dump > ${OUT_DIR}/logs/cluster-info.dump.txt
 	kubectl describe pods -n istio-system > ${OUT_DIR}/logs/pods-system.txt
 	kubectl logs -n istio-system -listio=pilot -c discovery
-	$(JUNIT_REPORT) <${OUT_DIR}/logs/test-report.raw >${OUT_DIR}/tests/test-report.xml
+	$(JUNIT_REPORT) <${OUT_DIR}/logs/test-report.raw >${OUT_DIR}/tests/junit.xml


### PR DESCRIPTION
The integration will start with mixer and simple e2e tests. Will expand to other jobs in subsequent PRs.

Results are now available on
https://k8s-testgrid.appspot.com/istio#circleci-e2e-mixer
https://k8s-testgrid.appspot.com/istio#circleci-e2e-simple

Those are test results from this PR exclusively. After this is merged, the results will be more interesting.

The `ci_to_gubernator` binary is built from https://github.com/istio/test-infra/pull/769. Feel free to also take a look.