### PR TITLE
Use iptables TPROXY instead of REDIRECT for inbound traffic

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -21,6 +21,8 @@ data:
         - {{ "[[ .MeshConfig.ProxyListenPort ]]" }}
         - "-u"
         - 1337
+        - "-m"
+        - {{ "[[ .ProxyConfig.InterceptionMode.String ]]" }}
         - "-i"
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\") -]]" }}
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"  ]]\"" }}
@@ -107,11 +109,19 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: {{ "[[ .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: IfNotPresent
         securityContext:
             privileged: false
             readOnlyRootFilesystem: true
+            {{ "[[ if eq .ProxyConfig.InterceptionMode.String \"TPROXY\" -]]" }}
+            capabilities:
+              add:
+              - NET_ADMIN
+            {{ "[[ else -]]" }}
             runAsUser: 1337
+            {{ "[[ end -]]" }}
         restartPolicy: Always
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
         - "-u"
         - 1337
         - "-m"
-        - {{ "[[ .ProxyConfig.InterceptionMode.String ]]" }}
+        - {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         - "-i"
         {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\") -]]" }}
         {{ "- \"[[ index .ObjectMeta.Annotations \"traffic.sidecar.istio.io/includeOutboundIPRanges\"  ]]\"" }}
@@ -110,12 +110,12 @@ data:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
-          value: {{ "[[ .ProxyConfig.InterceptionMode.String ]]" }}
+          value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: IfNotPresent
         securityContext:
             privileged: false
             readOnlyRootFilesystem: true
-            {{ "[[ if eq .ProxyConfig.InterceptionMode.String \"TPROXY\" -]]" }}
+            {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
             capabilities:
               add:
               - NET_ADMIN

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -61,6 +61,19 @@ data:
       drainDuration: 45s
       parentShutdownDuration: 1m0s
       #
+      # The mode used to redirect inbound connections to Envoy. This setting
+      # has no effect on outbound traffic: iptables REDIRECT is always used for
+      # outbound connections.
+      # If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+      # The "REDIRECT" mode loses source addresses during redirection.
+      # If "TPROXY", use iptables TPROXY to redirect to Envoy.
+      # The "TPROXY" mode preserves both the source and destination IP
+      # addresses and ports, so that they can be used for advanced filtering
+      # and manipulation.
+      # The "TPROXY" mode also configures the sidecar to run with the
+      # CAP_NET_ADMIN capability, which is required to use TPROXY.
+      interceptionMode: REDIRECT
+      #
       # Port where Envoy listens (on local host) for admin commands
       # You can exec into the istio-proxy container in a pod and
       # curl the admin port (curl http://localhost:15000/) to obtain

--- a/install/kubernetes/templates/istio-config.yaml.tmpl
+++ b/install/kubernetes/templates/istio-config.yaml.tmpl
@@ -56,6 +56,19 @@ data:
       drainDuration: 45s
       parentShutdownDuration: 1m0s
       #
+      # The mode used to redirect inbound connections to Envoy. This setting
+      # has no effect on outbound traffic: iptables REDIRECT is always used for
+      # outbound connections.
+      # If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+      # The "REDIRECT" mode loses source addresses during redirection.
+      # If "TPROXY", use iptables TPROXY to redirect to Envoy.
+      # The "TPROXY" mode preserves both the source and destination IP
+      # addresses and ports, so that they can be used for advanced filtering
+      # and manipulation.
+      # The "TPROXY" mode also configures the sidecar to run with the
+      # CAP_NET_ADMIN capability, which is required to use TPROXY.
+      interceptionMode: REDIRECT
+      #
       # Port where Envoy listens (on local host) for admin commands
       # You can exec into the istio-proxy container in a pod and
       # curl the admin port (curl http://localhost:15000/) to obtain

--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
@@ -15,6 +15,8 @@ data:
         - {{ .MeshConfig.ProxyListenPort }}
         - "-u"
         - 1337
+        - "-m"
+        - {{ .ProxyConfig.InterceptionMode.String }}
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
@@ -81,11 +83,19 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: {{ .ProxyConfig.InterceptionMode.String }}
         imagePullPolicy: IfNotPresent
         securityContext:
-            privileged: true
-            readOnlyRootFilesystem: false
-            runAsUser: 1337
+          privileged: true
+          readOnlyRootFilesystem: false
+          {{ if ne .ProxyConfig.InterceptionMode.String "TPROXY" -}}
+          runAsUser: 1337
+          {{ end -}}
         restartPolicy: Always
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-release.yaml.tmpl
@@ -15,6 +15,8 @@ data:
         - {{ .MeshConfig.ProxyListenPort }}
         - "-u"
         - 1337
+        - "-m"
+        - {{ .ProxyConfig.InterceptionMode.String }}
         imagePullPolicy: IfNotPresent
         securityContext:
           capabilities:
@@ -68,11 +70,23 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: {{ .ProxyConfig.InterceptionMode.String }}
         imagePullPolicy: IfNotPresent
         securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
+          privileged: false
+          readOnlyRootFilesystem: true
+          {{ if eq .ProxyConfig.InterceptionMode.String "TPROXY" -}}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {{ else -}}
+          runAsUser: 1337
+          {{ end -}}
         restartPolicy: Always
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/docker/Dockerfile.proxy
+++ b/pilot/docker/Dockerfile.proxy
@@ -5,14 +5,20 @@ ADD envoy /usr/local/bin/envoy
 
 ADD pilot-agent /usr/local/bin/pilot-agent
 
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+RUN \
+chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 
 COPY envoy_bootstrap_tmpl.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
-
-# Allow non-root user to run envoy.
-RUN chmod 755 /usr/local/bin/envoy
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -5,6 +5,15 @@ ADD envoy /usr/local/bin/envoy
 
 ADD pilot-agent /usr/local/bin/pilot-agent
 
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+RUN \
+chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
@@ -15,9 +24,6 @@ COPY envoy_bootstrap_tmpl.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
     chown -R istio-proxy /var/lib/istio
-
-# Allow non-root user to run envoy.
-RUN chmod 755 /usr/local/bin/envoy
 
 # The pilot-agent will bootstrap Envoy.
 ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/pilot/docker/Dockerfile.proxy_init
+++ b/pilot/docker/Dockerfile.proxy_init
@@ -1,5 +1,6 @@
 FROM ubuntu:xenial
 RUN apt-get update && apt-get install -y \
+    iproute2 \
     iptables \
  && rm -rf /var/lib/apt/lists/*
 

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -67,6 +67,7 @@ func TestIntoResourceFile(t *testing.T) {
 		excludeIPRanges     string
 		includeInboundPorts string
 		excludeInboundPorts string
+		tproxy              bool
 	}{
 		// "testdata/hello.yaml" is tested in http_test.go (with debug)
 		{
@@ -82,6 +83,17 @@ func TestIntoResourceFile(t *testing.T) {
 			debugMode:           true,
 			includeIPRanges:     DefaultIncludeIPRanges,
 			includeInboundPorts: DefaultIncludeInboundPorts,
+		},
+		{
+			in:     "testdata/hello.yaml",
+			want:   "testdata/hello-tproxy.yaml.injected",
+			tproxy: true,
+		},
+		{
+			in:        "testdata/hello.yaml",
+			want:      "testdata/hello-tproxy-debug.yaml.injected",
+			debugMode: true,
+			tproxy:    true,
 		},
 		{
 			in:                  "testdata/hello-probes.yaml",
@@ -292,6 +304,11 @@ func TestIntoResourceFile(t *testing.T) {
 				mesh.DefaultConfig.ParentShutdownDuration = ptypes.DurationProto(c.duration)
 				mesh.DefaultConfig.DiscoveryRefreshDelay = ptypes.DurationProto(c.duration)
 				mesh.DefaultConfig.ConnectTimeout = ptypes.DurationProto(c.duration)
+			}
+			if c.tproxy {
+				mesh.DefaultConfig.InterceptionMode = meshconfig.ProxyConfig_TPROXY
+			} else {
+				mesh.DefaultConfig.InterceptionMode = meshconfig.ProxyConfig_REDIRECT
 			}
 
 			params := &Params{

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -27,7 +27,7 @@ initContainers:
   - "-u"
   - {{ .SidecarProxyUID }}
   - "-m"
-  - [[ .ProxyConfig.InterceptionMode.String ]]
+  - [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
   - "-i"
   [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges") -]]
   - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges"]]"
@@ -134,7 +134,7 @@ containers:
       fieldRef:
         fieldPath: metadata.name
   - name: ISTIO_META_INTERCEPTION_MODE
-    value: [[ .ProxyConfig.InterceptionMode.String ]]
+    value: [[ or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String ]]
   {{ if eq .ImagePullPolicy "" -}}
   imagePullPolicy: IfNotPresent
   {{ else -}}
@@ -147,13 +147,13 @@ containers:
     {{ else -}}
     privileged: false
     readOnlyRootFilesystem: true
-    [[ if eq .ProxyConfig.InterceptionMode.String "TPROXY" -]]
+    [[ if eq (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
     capabilities:
       add:
       - NET_ADMIN
     [[ end -]]
     {{ end -}}
-    [[ if ne .ProxyConfig.InterceptionMode.String "TPROXY" -]]
+    [[ if ne (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
     runAsUser: 1337
     [[ end -]]
   restartPolicy: Always

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -26,6 +26,8 @@ initContainers:
   - [[ .MeshConfig.ProxyListenPort ]]
   - "-u"
   - {{ .SidecarProxyUID }}
+  - "-m"
+  - [[ .ProxyConfig.InterceptionMode.String ]]
   - "-i"
   [[ if (isset .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges") -]]
   - "[[ index .ObjectMeta.Annotations "traffic.sidecar.istio.io/includeOutboundIPRanges"]]"
@@ -127,20 +129,33 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: status.podIP
+  - name: ISTIO_META_POD_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.name
+  - name: ISTIO_META_INTERCEPTION_MODE
+    value: [[ .ProxyConfig.InterceptionMode.String ]]
   {{ if eq .ImagePullPolicy "" -}}
   imagePullPolicy: IfNotPresent
   {{ else -}}
   imagePullPolicy: {{ .ImagePullPolicy }}
   {{ end -}}
   securityContext:
-      {{ if eq .DebugMode true -}}
-      privileged: true
-      readOnlyRootFilesystem: false
-      {{ else -}}
-      privileged: false
-      readOnlyRootFilesystem: true
-      {{ end -}}
-      runAsUser: 1337
+    {{ if eq .DebugMode true -}}
+    privileged: true
+    readOnlyRootFilesystem: false
+    {{ else -}}
+    privileged: false
+    readOnlyRootFilesystem: true
+    [[ if eq .ProxyConfig.InterceptionMode.String "TPROXY" -]]
+    capabilities:
+      add:
+      - NET_ADMIN
+    [[ end -]]
+    {{ end -}}
+    [[ if ne .ProxyConfig.InterceptionMode.String "TPROXY" -]]
+    runAsUser: 1337
+    [[ end -]]
   restartPolicy: Always
   volumeMounts:
   - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
     spec:
       template:
@@ -62,6 +62,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: ISTIO_META_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ISTIO_META_INTERCEPTION_MODE
+              value: REDIRECT
             image: docker.io/istio/proxy:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy
@@ -82,6 +88,8 @@ spec:
             - "15001"
             - -u
             - "1337"
+            - -m
+            - REDIRECT
             - -i
             - '*'
             - -x

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -61,6 +61,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -81,6 +87,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -81,6 +81,12 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ISTIO_META_INTERCEPTION_MODE
+            value: REDIRECT
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -101,6 +107,8 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -m
+          - REDIRECT
           - -i
           - '*'
           - -x

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -66,6 +66,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -86,6 +92,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"b73fb7cb0a8183dc1b3879160a7f910b75454732ec02f1b1d78b5bee7bba464e","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e3fc365121585192ba107ab789ff28562e4e0ae05f84df1eb1566f0fb88f3e09","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"4e9fe7a43cc419179f296c017339937af3c8d61ccb6d2a02809ff5bf6f4cf407","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"a60733221abaab8cfdb244d1b9af6f03c3dfe1390b55382c779e2ff39de86c33","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: Always
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -64,6 +64,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -84,6 +90,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -64,6 +64,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -84,6 +90,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x
@@ -121,7 +129,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -176,6 +184,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -196,6 +210,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"ea1e25c398b7973ca4afc818481bc7d81868cfa166b7bb66997b60f1b7cf1d1c","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"e99e072f5c58bed639a20a8a425d2b88139ad459430995d869050f8a9664d9bd","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: Never
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -103,6 +109,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-proxy-override.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"version":"3d26eb0ae6bfe33a4819a33dc0b087c52d8670a5527789f2c85ba3368a161881","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c1e1ad3ae924828c3779f965516178e10676993a4dcf46d5b63eaeeb5067d15c","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -64,6 +64,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -84,6 +90,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-tproxy-debug.yaml.injected
@@ -1,45 +1,27 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: frontend
-spec:
-  selector:
-    app: hello
-    tier: frontend
-  ports:
-    - protocol: "TCP"
-      port: 80
-      targetPort: 80
-  type: LoadBalancer
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   creationTimestamp: null
-  name: frontend
+  name: hello
 spec:
-  replicas: 1
+  replicas: 7
   strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"eb03b36543150e0ef0ff3ddd7d588a6246eaa73dbca4ab9a329c1d1d750e85b0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
-        tier: frontend
+        tier: backend
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-frontend:1.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /usr/sbin/nginx
-              - -s
-              - quit
-        name: nginx
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
         resources: {}
       - args:
         - proxy
@@ -86,15 +68,14 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
-          value: REDIRECT
-        image: docker.io/istio/proxy:unittest
+          value: TPROXY
+        image: docker.io/istio/proxy_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         resources: {}
         securityContext:
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsUser: 1337
+          privileged: true
+          readOnlyRootFilesystem: false
         volumeMounts:
         - mountPath: /etc/istio/proxy
           name: istio-envoy
@@ -108,13 +89,13 @@ spec:
         - -u
         - "1337"
         - -m
-        - REDIRECT
+        - TPROXY
         - -i
-        - '*'
+        - ""
         - -x
         - ""
         - -b
-        - '*'
+        - ""
         - -d
         - ""
         image: docker.io/istio/proxy_init:unittest
@@ -125,6 +106,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-tproxy.yaml.injected
@@ -1,45 +1,27 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: frontend
-spec:
-  selector:
-    app: hello
-    tier: frontend
-  ports:
-    - protocol: "TCP"
-      port: 80
-      targetPort: 80
-  type: LoadBalancer
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   creationTimestamp: null
-  name: frontend
+  name: hello
 spec:
-  replicas: 1
+  replicas: 7
   strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c5e9e7eff3a6126c26458f0d0a06815689dbb328c0c34f9df7ff00b85f322ef0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
-        tier: frontend
+        tier: backend
         track: stable
     spec:
       containers:
-      - image: fake.docker.io/google-samples/hello-frontend:1.0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /usr/sbin/nginx
-              - -s
-              - quit
-        name: nginx
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
         resources: {}
       - args:
         - proxy
@@ -86,15 +68,17 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
-          value: REDIRECT
+          value: TPROXY
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         resources: {}
         securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
           privileged: false
           readOnlyRootFilesystem: true
-          runAsUser: 1337
         volumeMounts:
         - mountPath: /etc/istio/proxy
           name: istio-envoy
@@ -108,13 +92,13 @@ spec:
         - -u
         - "1337"
         - -m
-        - REDIRECT
+        - TPROXY
         - -i
-        - '*'
+        - ""
         - -x
         - ""
         - -b
-        - '*'
+        - ""
         - -d
         - ""
         image: docker.io/istio/proxy_init:unittest

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"3d26eb0ae6bfe33a4819a33dc0b087c52d8670a5527789f2c85ba3368a161881","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c1e1ad3ae924828c3779f965516178e10676993a4dcf46d5b63eaeeb5067d15c","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -83,6 +89,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:
@@ -60,6 +60,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -80,6 +86,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -82,6 +82,12 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ISTIO_META_INTERCEPTION_MODE
+            value: REDIRECT
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -102,6 +108,8 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -m
+          - REDIRECT
           - -i
           - '*'
           - -x

--- a/pilot/pkg/kube/inject/testdata/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -66,6 +66,12 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ISTIO_META_INTERCEPTION_MODE
+            value: REDIRECT
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -86,6 +92,8 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -m
+          - REDIRECT
           - -i
           - '*'
           - -x
@@ -122,7 +130,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -177,6 +185,12 @@ items:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ISTIO_META_INTERCEPTION_MODE
+            value: REDIRECT
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
@@ -197,6 +211,8 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -m
+          - REDIRECT
           - -i
           - '*'
           - -x

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -63,6 +63,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -97,6 +103,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -60,6 +60,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -80,6 +86,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -62,6 +62,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -82,6 +88,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -66,6 +66,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -86,6 +92,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""
@@ -65,6 +65,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -85,6 +91,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - ""
         - -x

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'
@@ -65,6 +65,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -85,6 +91,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - '*'
         - -x

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"6664c7ccc4d37fcb43512dd10fb86c20f045a3eae116a994acdb8cfd78cb0945","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0aa4004dced33479c4e63a337aa661a447bc3d3c3e325e024208076d385ff2f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
@@ -65,6 +65,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -85,6 +91,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - 127.0.0.1/24,10.96.0.1/24
         - -x

--- a/pilot/pkg/kube/inject/testdata/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-params-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"56e98a691c5224e5c499ba1cb58447e8a840971934785c702f7179912bc2d7d5","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c5e9e7eff3a6126c26458f0d0a06815689dbb328c0c34f9df7ff00b85f322ef0","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -61,6 +61,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -81,6 +87,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - ""
         - -x

--- a/pilot/pkg/kube/inject/testdata/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-params.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"8c32c804c5ab6ffd0d714cb1904252b71b95c8422aa751d0bfb8cb17a998a5d3","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"7399025ecc3a86cba89c48d040cc087605b50df3d0e588031d49e3b2cf969e1a","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -61,6 +61,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
@@ -81,6 +87,8 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -m
+        - REDIRECT
         - -i
         - 127.0.0.1/24,10.96.0.1/24
         - -x

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -688,10 +688,10 @@ func compareDeployments(got, want *extv1beta1.Deployment, t *testing.T) {
 	gotIstioProxy.TerminationMessagePolicy = wantIstioProxy.TerminationMessagePolicy
 	envVars := []corev1.EnvVar{}
 	for _, env := range gotIstioProxy.Env {
-		if env.Name != "ISTIO_META_POD_NAME" {
+		if env.ValueFrom != nil {
 			env.ValueFrom.FieldRef.APIVersion = ""
-			envVars = append(envVars, env)
 		}
+		envVars = append(envVars, env)
 	}
 	gotIstioProxy.Env = envVars
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -135,10 +135,16 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env model.Environmen
 			Cluster:    "Dummy",
 		}
 
+		var transparent *google_protobuf.BoolValue
+		if mode := node.Metadata["INTERCEPTION_MODE"]; mode == "TPROXY" {
+			transparent = &google_protobuf.BoolValue{true}
+		}
+
 		// add an extra listener that binds to the port that is the recipient of the iptables redirect
 		listeners = append(listeners, &xdsapi.Listener{
 			Name:           VirtualListenerName,
 			Address:        util.BuildAddress(WildcardAddress, uint32(mesh.ProxyListenPort)),
+			Transparent:    transparent,
 			UseOriginalDst: &google_protobuf.BoolValue{true},
 			FilterChains: []listener.FilterChain{
 				{

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -165,6 +165,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 			if err != nil {
 				return err
 			}
+			nt.Metadata = model.ParseMetadata(discReq.Node.Metadata)
 			con.modelNode = &nt
 			if con.ConID == "" {
 				// first request

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -192,7 +192,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	meta := map[string]string{}
 	for _, env := range os.Environ() {
 		if strings.HasPrefix(env, "ISTIO_META_") {
-			v := env[len("ISTIO_META"):]
+			v := env[len("ISTIO_META_"):]
 			parts := strings.SplitN(v, "=", 2)
 			if len(parts) == 2 {
 				meta[parts[0]] = parts[1]

--- a/tools/deb/Dockerfile
+++ b/tools/deb/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:xenial
 
 ADD istio.deb /tmp
 RUN apt-get update && apt-get install -y \
+    iproute2 \
     iptables \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -198,6 +198,7 @@ for uid in ${PROXY_UID}; do
   # Avoid infinite loops. Don't redirect Envoy traffic directly back to
   # Envoy for non-loopback traffic.
   iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner ${uid} -j RETURN
+  iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner ${uid} -j RETURN
 done
 
 # Skip redirection for Envoy-aware applications and

--- a/tools/deb/istio.mk
+++ b/tools/deb/istio.mk
@@ -64,6 +64,7 @@ deb/fpm:
 		--config-files /var/lib/istio/envoy/envoy_bootstrap_tmpl.json \
 		--config-files /var/lib/istio/envoy/sidecar.env \
 		--description "Istio" \
+		--depends iptables \
 		$(SIDECAR_FILES)
 
 .PHONY: deb/docker

--- a/tools/deb/istio.mk
+++ b/tools/deb/istio.mk
@@ -64,6 +64,7 @@ deb/fpm:
 		--config-files /var/lib/istio/envoy/envoy_bootstrap_tmpl.json \
 		--config-files /var/lib/istio/envoy/sidecar.env \
 		--description "Istio" \
+		--depends iproute2 \
 		--depends iptables \
 		$(SIDECAR_FILES)
 

--- a/tools/deb/postinst.sh
+++ b/tools/deb/postinst.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 Istio Authors. All Rights Reserved.
+# Copyright 2017, 2018 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,3 +41,10 @@ touch /var/lib/istio/config/mesh
 
 chown istio-proxy.istio-proxy /var/lib/istio/envoy /var/lib/istio/config /var/log/istio /var/lib/istio/config/mesh /var/lib/istio/proxy
 chmod o+rx /usr/local/bin/{envoy,istioctl,pilot-agent,node_agent,mixs,pilot-discovery}
+
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+chmod 2755 /usr/local/bin/{envoy,pilot-agent}

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -8,6 +8,31 @@
 # Name of the service exposed by the machine.
 # ISTIO_SERVICE=myservice
 
+# The mode used to redirect inbound connections to Envoy. This setting
+# has no effect on outbound traffic: iptables REDIRECT is always used for
+# outbound connections.
+# If "REDIRECT", use iptables REDIRECT to NAT and redirect to Envoy.
+# The "REDIRECT" mode loses source addresses during redirection.
+# If "TPROXY", use iptables TPROXY to redirect to Envoy.
+# The "TPROXY" mode preserves both the source and destination IP
+# addresses and ports, so that they can be used for advanced filtering
+# and manipulation.
+# The "TPROXY" mode also configures the sidecar to run with the
+# CAP_NET_ADMIN capability, which is required to use TPROXY.
+# If not set, defaults to "REDIRECT".
+# ISTIO_INBOUND_INTERCEPTION_MODE=REDIRECT
+
+# When the interception mode is "TPROXY", the iptables skb mark that is set on
+# every inbound packet to be redirected to Envoy.
+# If not set, defaults to "1337".
+# ISTIO_INBOUND_TPROXY_MARK=1337
+
+# When the interception mode is "TPROXY", the number of the routing table that
+# is configured and used to route inbound connections to the loopback interface
+# in order to be redirected to Envoy.
+# If not set, defaults to "133".
+# ISTIO_INBOUND_TPROXY_ROUTE_TABLE=133
+
 # Comma separated list of local ports that will use Istio sidecar for inbound services.
 # If set, iptables rules will be configured to intercept inbound traffic and redirect to sidecar.
 # If not set, no rules will be enabled


### PR DESCRIPTION
Modify proxy containers to use TPROXY to redirect inbound connections to Envoy. Contrary to REDIRECT, TPROXY doesn't perform NAT, and therefore preserves both source and destination IP addresses and ports of inbound connections. One benefit is that the `source.ip` attributes reported by Mixer for inbound connections will always be correct, unlike when using REDIRECT.

Keep using REDIRECT for outbound traffic, since TPROXY can only be used in PREROUTING.

The support for TPROXY in Envoy was implemented in https://github.com/envoyproxy/envoy/pull/2719 and pulled into Istio in https://github.com/istio/istio/pull/4651 and https://github.com/istio/proxy/pull/1338.

Modify the `proxy` images and Debian package to support running envoy with CAP_NET_ADMIN to enable setting the IP_TRANSPARENT option on listen sockets.
Support setting the inbound traffic interception mode (`"REDIRECT"` or `"TPROXY"`) in `ProxySettings` config maps.
Send the interception mode to `pilot-discovery` in the `INTERCEPTION_MODE` Node metadata to set the listener socket `transparent` setting for that proxy.

Add `iptables` anbd `iproute2` as dependencies to the istio.deb package. `iptables` was already required but was missing.
Install `iproute2` into the `proxy_init` Docker image.

Fix the `deb/*` Makefile targets.

Requires: https://github.com/istio/istio/pull/4651 (to update `go-control-plane` vendor dep), https://github.com/istio/proxy/pull/1338 (to support `transparent` listener option in Envoy)

Signed-off-by: Romain Lenglet <romain@covalent.io>