### PR TITLE
Add a Helm chart for remote Kubernetes clusters

### DIFF
--- a/install/kubernetes/helm/istio-remote/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: istio-remote
+version: 0.8.0
+description: Helm chart for Istio remote components
+keywords:
+  - remote
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/install/kubernetes/helm/istio-remote/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio-remote
 version: 0.8.0
-description: Helm chart for Istio remote components
+description: Helm chart needed for remote Kubernetes clusters to join the main Istio control plane
 keywords:
   - remote
 sources:

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: istio-mixer
+  namespace: istio-system
+subsets:
+- addresses:
+  - ip: {{ .Values.global.mixerIp }}
+  ports:
+  - name: tcp-plain
+    port: 9091
+  - name: tcp-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  - name: configapi
+    port: 9094
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
+  - name: prometheus
+    port: 42422
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: istio-pilot
+  namespace: istio-system
+subsets:
+- addresses:
+  - ip: {{ .Values.global.pilotIp }}
+  ports:
+  - port: 15003
+    name: discovery
+  - port: 15005
+    name: https-discovery
+  - port: 15007
+    name: http-discovery
+  - port: 15010
+    name: grpc-discovery
+  - port: 8080
+    name: http-legacy-discovery
+  - port: 9093
+    name: http-monitoring
+  - port: 443
+    name: admission-webhook
+---

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -1,0 +1,51 @@
+# Pilot service for discovery
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  namespace: istio-system
+  labels:
+    istio: pilot
+spec:
+  ports:
+  - port: 15003
+    name: discovery
+  - port: 15005
+    name: https-discovery
+  - port: 15007
+    name: http-discovery
+  - port: 15010
+    name: grpc-discovery
+  - port: 8080
+    name: http-legacy-discovery
+  - port: 9093
+    name: http-monitoring
+  - port: 443
+    name: admission-webhook
+---
+# Mixer service for discovery
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-mixer
+  namespace: istio-system
+  labels:
+    istio: mixer
+spec:
+  ports:
+  - name: tcp-plain
+    port: 9091
+  - name: tcp-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  - name: configapi
+    port: 9094
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
+  - name: prometheus
+    port: 42422
+---

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -1,0 +1,7 @@
+# Use --set to specify the pilot and mixer IPs on the main Istio control plane
+global:
+  # The Istio control plane Pilot IP address
+  pilotIp: none
+
+  # The Istio control plane Mixer IP address
+  mixerIp: none


### PR DESCRIPTION
This Helm chart enables remote Kubernetes clusters running envoy
to discover and communicate with Pilot and Mixer.  --set must
be used to override the pilotIp and mixerIp.  This work will be
iterated upon prior to 1.0 to remove the various problems that
reviewers may see with specifying a static IP that could potentially
change on a pilot or mixer pod restart.