### PR TITLE
make TestOddballs of log module robust

### DIFF
--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -232,14 +232,15 @@ func TestOddballs(t *testing.T) {
 	}
 
 	o = DefaultOptions()
-	o.OutputPaths = []string{"/JUNK"}
+	//using invalid filename
+	o.OutputPaths = []string{"//"}
 	err = Configure(o)
 	if err == nil {
 		t.Errorf("Got success, expecting error")
 	}
 
 	o = DefaultOptions()
-	o.ErrorOutputPaths = []string{"/JUNK"}
+	o.ErrorOutputPaths = []string{"//"}
 	err = Configure(o)
 	if err == nil {
 		t.Errorf("Got success, expecting error")


### PR DESCRIPTION
As in Configure() function, although the path "/JUNK" does not exist, the code `f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)`  will create the file and do not return err, so the test cases will be fail always, i thinks it's useless, should remove