### PR TITLE
Update external k8s e2e test to work with 0.6.0

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -31,15 +31,11 @@ set -o pipefail
 declare -a tests
 [[  $1 == "all" ]] && tests=("bookinfo" "mixer" "simple") || tests=($1)
 
-HUB=gcr.io/istio-testing
+HUB=gcr.io/istio-release
 
-cd ${WORKSPACE}/github.com/istio/istio
-TAG=`git rev-parse HEAD`
+cd ${WORKSPACE}/istio.io/istio
 
 for t in ${tests[@]}; do
-  go test -v -timeout 20m ./tests/e2e/tests/${t} -args \
-  --skip_setup --namespace istio-system \
-  --mixer_tag ${TAG} --pilot_tag ${TAG} --proxy_tag ${TAG} --ca_tag ${TAG} \
-  --mixer_hub ${HUB} --pilot_hub ${HUB} --proxy_hub ${HUB} --ca_hub ${HUB} \
-  --istioctl_url https://storage.googleapis.com/istio-artifacts/pilot/${TAG}/artifacts/istioctl
+  make e2e_${t} E2E_ARGS="--skip_setup --namespace=istio-system"
 done
+


### PR DESCRIPTION
This script is called externally from test-infra k8s prow testing. It is used to verify the istio.yaml used to install Istio as a k8s addon (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/istio).