### PR TITLE
Upgrade test: increase retry times and add more check

### DIFF
--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    cat <<EOF
+Generate certificate suitable for use with an Istio webhook service.
+
+This script uses k8s' CertificateSigningRequest API to a generate a
+certificate signed by k8s CA suitable for use with Istio webhook
+services. This requires permissions to create and approve CSR. See
+https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+detailed explantion and additional instructions.
+
+The server key/cert k8s CA cert are stored in a k8s secret.
+
+usage: ${0} [OPTIONS]
+
+The following flags are required.
+
+       --service          Service name of webhook.
+       --namespace        Namespace where webhook service and secret reside.
+       --secret           Secret name for CA certificate and server certificate/key pair.
+EOF
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case ${1} in
+        --service)
+            service="$2"
+            shift
+            ;;
+        --secret)
+            secret="$2"
+            shift
+            ;;
+        --namespace)
+            namespace="$2"
+            shift
+            ;;
+        *)
+            usage
+            ;;
+    esac
+    shift
+done
+
+[ -z ${service} ] && service=istio-sidecar-injector
+[ -z ${secret} ] && secret=sidecar-injector-certs
+[ -z ${namespace} ] && namespace=istio-system
+
+if [ ! -x "$(command -v openssl)" ]; then
+    echo "openssl not found"
+    exit 1
+fi
+
+csrName=${service}.${namespace}
+tmpdir=$(mktemp -d)
+echo "creating certs in tmpdir ${tmpdir} "
+
+cat <<EOF >> ${tmpdir}/csr.conf
+[req]
+req_extensions = v3_req
+distinguished_name = req_distinguished_name
+[req_distinguished_name]
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${service}
+DNS.2 = ${service}.${namespace}
+DNS.3 = ${service}.${namespace}.svc
+EOF
+
+openssl genrsa -out ${tmpdir}/server-key.pem 2048
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+# clean-up any previously created CSR for our service. Ignore errors if not present.
+kubectl delete csr ${csrName} 2>/dev/null || true
+
+# create  server cert/key CSR and  send to k8s API
+cat <<EOF | kubectl create -f -
+apiVersion: certificates.k8s.io/v1beta1
+kind: CertificateSigningRequest
+metadata:
+  name: ${csrName}
+spec:
+  groups:
+  - system:authenticated
+  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+EOF
+
+# verify CSR has been created
+while true; do
+    kubectl get csr ${csrName}
+    if [ "$?" -eq 0 ]; then
+        break
+    fi
+done
+
+# approve and fetch the signed certificate
+kubectl certificate approve ${csrName}
+# verify certificate has been signed
+for x in $(seq 10); do
+    serverCert=$(kubectl get csr ${csrName} -o jsonpath='{.status.certificate}')
+    if [[ ${serverCert} != '' ]]; then
+        break
+    fi
+    sleep 1
+done
+if [[ ${serverCert} == '' ]]; then
+    echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 10 attempts." >&2
+    echo "See https://istio.io/docs/setup/kubernetes/sidecar-injection.html for more details on troubleshooting." >&2
+    exit 1
+fi
+echo ${serverCert} | openssl base64 -d -A -out ${tmpdir}/server-cert.pem
+
+
+# create the secret with CA cert and server cert/key
+kubectl create secret generic ${secret} \
+        --from-file=key.pem=${tmpdir}/server-key.pem \
+        --from-file=cert.pem=${tmpdir}/server-cert.pem \
+        --dry-run -o yaml |
+    kubectl -n ${namespace} apply -f -

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -296,7 +296,7 @@ func (k *KubeInfo) Teardown() error {
 	}
 
 	// confirm the namespace is deleted as it will cause future creation to fail
-	maxAttempts := 120
+	maxAttempts := 600
 	namespaceDeleted := false
 	log.Infof("Deleting namespace %v", k.Namespace)
 	for attempts := 1; attempts <= maxAttempts; attempts++ {

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 const (
-	u1           = "normal-user"
-	u2           = "test-user"
-	bookinfoYaml = "samples/bookinfo/kube/bookinfo.yaml"
-	modelDir     = "tests/apps/bookinfo/output"
-	rulesDir     = "samples/bookinfo/kube"
-	allRule      = "route-rule-all-v1.yaml"
-	testRule     = "route-rule-reviews-test-v2.yaml"
+	u1             = "normal-user"
+	u2             = "test-user"
+	bookinfoYaml   = "samples/bookinfo/kube/bookinfo.yaml"
+	modelDir       = "tests/apps/bookinfo/output"
+	rulesDir       = "samples/bookinfo/kube"
+	allRule        = "route-rule-all-v1.yaml"
+	testRule       = "route-rule-reviews-test-v2.yaml"
+	testRetryTimes = 10
 )
 
 var (
@@ -141,18 +142,27 @@ func inspect(err error, fMsg, sMsg string, t *testing.T) {
 	}
 }
 
-func probeGateway(retryTimes int, modelFile string) error {
+func probeGateway(retryTimes int) error {
+	var err1, err2 error
 	standby := 0
 	v1File := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
+	v2File := util.GetResourcePath(filepath.Join(modelDir, "productpage-test-user-v2.html"))
 	for i := 0; i <= retryTimes; i++ {
 		time.Sleep(time.Duration(standby) * time.Second)
-		_, err := checkRoutingResponse(u1, "v1", tc.gateway, v1File)
-		if err == nil {
+		_, err1 = checkRoutingResponse(u1, "v1", tc.gateway, v1File)
+		_, err2 = checkRoutingResponse(u2, "v2", tc.gateway, v2File)
+		if err1 == nil && err2 == nil {
 			log.Infof("Successfully getting response from gateway.")
 			return nil
 		}
 		standby += 5
 		log.Warnf("Couldn't get to the bookinfo product page, trying again in %d second", standby)
+	}
+	if err1 != nil {
+		log.Errorf("Failed version routing! %s in v1: %s", u1, err1)
+	}
+	if err2 != nil {
+		log.Errorf("Failed version routing! %s in v2: %s", u2, err2)
 	}
 	return errors.New("unable to get valid response from gateway")
 }
@@ -161,8 +171,7 @@ func setUpDefaultRouting() error {
 	if err := applyRules(defaultRules); err != nil {
 		return fmt.Errorf("could not apply rule '%s': %v", allRule, err)
 	}
-	v1File := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
-	return probeGateway(5, v1File)
+	return probeGateway(testRetryTimes)
 }
 
 func checkRoutingResponse(user, version, gateway, modelFile string) (int, error) {
@@ -223,30 +232,13 @@ func applyRules(ruleKeys []string) error {
 	return nil
 }
 
-func checkTraffic(t *testing.T) {
-	v1File := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
-	v2File := util.GetResourcePath(filepath.Join(modelDir, "productpage-test-user-v2.html"))
-	// Check whether gateway is reachable
-	err := probeGateway(5, v1File)
-	inspect(err, "Failed to reach Gateway after upgrade", "", t)
-	// Check whether routes are correct.
-	_, err = checkRoutingResponse(u1, "v1", tc.gateway, v1File)
-	inspect(
-		err, fmt.Sprintf("Failed version routing! %s in v1", u1),
-		fmt.Sprintf("Success! Response matches with expected! %s in v1", u1), t)
-	_, err = checkRoutingResponse(u2, "v2", tc.gateway, v2File)
-	inspect(
-		err, fmt.Sprintf("Failed version routing! %s in v2", u2),
-		fmt.Sprintf("Success! Response matches with expected! %s in v2", u2), t)
-}
-
 func upgradeControlPlane() error {
 	// Generate and deploy Isito yaml files.
 	err := targetConfig.Kube.Setup()
 	if err != nil {
 		return err
 	}
-	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 300*time.Second) {
+	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second) {
 		return fmt.Errorf("can't get all pods running when upgrading control plane")
 	}
 	if _, err = util.Shell("kubectl get all -n %s -o wide", targetConfig.Kube.Namespace); err != nil {
@@ -272,7 +264,7 @@ func upgradeSidecars() error {
 	if err != nil {
 		return err
 	}
-	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 300*time.Second) {
+	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second) {
 		return fmt.Errorf("can't get all pods running when upgrading sidecar")
 	}
 	// TODO: Check sidecar version.
@@ -280,18 +272,22 @@ func upgradeSidecars() error {
 }
 
 func TestUpgrade(t *testing.T) {
-	checkTraffic(t)
 	err := upgradeControlPlane()
 	inspect(err, "Failed to upgrade control plane", "Control plane upgraded.", t)
 	if err != nil {
 		return
 	}
 	if *flagSmoothCheck {
-		checkTraffic(t)
+		err = probeGateway(testRetryTimes)
+		inspect(err, "Probing Gateway failed after control plane upgraded.", "", t)
 	}
 	err = upgradeSidecars()
 	inspect(err, "Failed to upgrade sidecars.", "Sidecar upgraded.", t)
-	checkTraffic(t)
+	if err != nil {
+		return
+	}
+	err = probeGateway(testRetryTimes)
+	inspect(err, "Probing Gateway failed after sidecar upgraded.", "", t)
 }
 
 func setTestConfig() error {


### PR DESCRIPTION
Fix the flakiness of some e2e tests:
(1) Increase the deadline for deleting namespace. Some tests take more than 120s to delete all jobs and it caused the test cluster not to be completely clean after the test exits. It affects all the cluster-wide tests, where the subsequent tests are sharing the same namespace with previous ones.
(2) Restore a deleted script which is being used by mixer validator e2e test when the flag with_mixer_validation is set.
(3) Add more routing check in upgrade tests. Increase the retry times and merge some duplicate code.