### PR TITLE
Jaeger cleanup in Ansible installation

### DIFF
--- a/install/ansible/istio/defaults/main.yml
+++ b/install/ansible/istio/defaults/main.yml
@@ -26,9 +26,6 @@ istio:
 
   addon: "{{ istio_all_addons }}"
 
-  # Whether or not Jaeger should be installed as well
-  jaeger: false
-
   # The names of the samples that should be installed as well.
   # The available samples are in the istio_simple_samples variable
   # In addition to the values in istio_simple_samples, 'bookinfo' can also be specified

--- a/install/ansible/istio/tasks/install_istio_addons.yml
+++ b/install/ansible/istio/tasks/install_istio_addons.yml
@@ -2,5 +2,5 @@
   shell: |
     {{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/addons/{{ item }}.yaml
     {{ cmd_path }} expose svc {{ item }} -n istio-system
-  with_items: "{{ istio.addon | difference(disabled_addons) }}"
+  with_items: "{{ istio.addon | difference(disabled_addons) | difference('jaeger') }}"
   ignore_errors: true


### PR DESCRIPTION
This PR is needed to prevent confusion of how the Jaeger addon is installed which was caused by left overs from https://github.com/istio/istio/pull/3603