### PR TITLE
tcp proxy support in a multi-cluster environment.

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -478,10 +478,13 @@ func (s *Server) makeCopilotMonitor(args *PilotArgs, configController model.Conf
 
 // createK8sServiceControllers creates all the k8s service controllers under this pilot
 func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
+	clusterID := string(serviceregistry.KubernetesRegistry)
+	log.Infof("Primary Cluster name: %s", clusterID)
 	kubectl := kube.NewController(s.kubeClient, args.Config.ControllerOptions)
 	serviceControllers.AddRegistry(
 		aggregate.Registry{
-			Name:             serviceregistry.KubernetesRegistry,
+			Name:             serviceregistry.ServiceRegistry(serviceregistry.KubernetesRegistry),
+			ClusterID:        clusterID,
 			ServiceDiscovery: kubectl,
 			ServiceAccounts:  kubectl,
 			Controller:       kubectl,
@@ -492,7 +495,7 @@ func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Contr
 		clusters := s.clusterStore.GetPilotClusters()
 		clientAccessConfigs := s.clusterStore.GetClientAccessConfigs()
 		for _, cluster := range clusters {
-			log.Infof("Cluster name: %s, AccessConfigFile: %s", clusterregistry.GetClusterName(cluster))
+			log.Infof("Cluster name: %s", clusterregistry.GetClusterID(cluster))
 			clusterClient := clientAccessConfigs[cluster.ObjectMeta.Name]
 			_, client, kuberr := kube.CreateInterfaceFromClusterConfig(&clusterClient)
 			if kuberr != nil {
@@ -503,7 +506,7 @@ func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Contr
 			serviceControllers.AddRegistry(
 				aggregate.Registry{
 					Name:             serviceregistry.KubernetesRegistry,
-					ClusterName:      clusterregistry.GetClusterName(cluster),
+					ClusterID:        clusterregistry.GetClusterID(cluster),
 					ServiceDiscovery: kubectl,
 					ServiceAccounts:  kubectl,
 					Controller:       kubectl,
@@ -564,7 +567,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			}
 			serviceControllers.AddRegistry(
 				aggregate.Registry{
-					Name:             serviceRegistry,
+					Name:             serviceregistry.ServiceRegistry(r),
+					ClusterID:        string(serviceregistry.ConsulRegistry),
 					ServiceDiscovery: conctl,
 					ServiceAccounts:  conctl,
 					Controller:       conctl,
@@ -574,7 +578,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			eurekaClient := eureka.NewClient(args.Service.Eureka.ServerURL)
 			serviceControllers.AddRegistry(
 				aggregate.Registry{
-					Name:             serviceRegistry,
+					Name:             serviceregistry.ServiceRegistry(r),
+					ClusterID:        string(serviceregistry.EurekaRegistry),
 					Controller:       eureka.NewController(eurekaClient, args.Service.Eureka.Interval),
 					ServiceDiscovery: eureka.NewServiceDiscovery(eurekaClient),
 					ServiceAccounts:  eureka.NewServiceAccounts(),
@@ -594,7 +599,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 				return multierror.Prefix(err, "creating cloud foundry client")
 			}
 			serviceControllers.AddRegistry(aggregate.Registry{
-				Name: serviceRegistry,
+				Name:      serviceregistry.ServiceRegistry(r),
+				ClusterID: string(serviceregistry.CloudFoundryRegistry),
 				Controller: &cloudfoundry.Controller{
 					Ticker: cloudfoundry.NewTicker(cfConfig.Copilot.PollInterval),
 					Client: client,
@@ -616,6 +622,7 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 	serviceControllers.AddRegistry(
 		aggregate.Registry{
 			Name:             "ExternalServices",
+			ClusterID:        "ExternalServices",
 			Controller:       external.NewController(s.configController),
 			ServiceDiscovery: external.NewServiceDiscovery(configStore),
 			ServiceAccounts:  external.NewServiceAccounts(),
@@ -645,6 +652,7 @@ func initMemoryRegistry(s *Server, serviceControllers *aggregate.Controller) {
 
 	registry1 := aggregate.Registry{
 		Name:             serviceregistry.ServiceRegistry("mockAdapter1"),
+		ClusterID:        "mockAdapter1",
 		ServiceDiscovery: discovery1,
 		ServiceAccounts:  discovery1,
 		Controller:       &mockController{},
@@ -652,6 +660,7 @@ func initMemoryRegistry(s *Server, serviceControllers *aggregate.Controller) {
 
 	registry2 := aggregate.Registry{
 		Name:             serviceregistry.ServiceRegistry("mockAdapter2"),
+		ClusterID:        "mockAdapter2",
 		ServiceDiscovery: discovery2,
 		ServiceAccounts:  discovery2,
 		Controller:       &mockController{},

--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -61,8 +61,8 @@ func (cs *ClusterStore) GetClusterAccessConfig(cluster *k8s_cr.Cluster) *clientc
 	return &clusterAccessConfig
 }
 
-// GetClusterName returns a cluster's name
-func GetClusterName(cluster *k8s_cr.Cluster) string {
+// GetClusterID returns a cluster's ID
+func GetClusterID(cluster *k8s_cr.Cluster) string {
 	if cluster == nil {
 		return ""
 	}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -48,6 +48,9 @@ type Environment struct {
 
 // Proxy defines the proxy attributes used by xDS identification
 type Proxy struct {
+	// ClusterID specifies the cluster where the proxy resides
+	ClusterID string
+
 	// Type specifies the node type
 	Type NodeType
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -49,6 +49,10 @@ type Service struct {
 	// Address specifies the service IPv4 address of the load balancer
 	Address string `json:"address,omitempty"`
 
+	// Addresses specifies the service address of the load balancer
+	// in each of the clusters where the service resides
+	Addresses map[string]string `json:"addresses,omitempty"`
+
 	// Ports is the set of network ports where the service is listening for
 	// connections
 	Ports PortList `json:"ports,omitempty"`
@@ -322,7 +326,7 @@ type ServiceDiscovery interface {
 	// though with a different ServicePort and NetworkEndpoint for each.  If any of these overlapping
 	// services are not HTTP or H2-based, behavior is undefined, since the listener may not be able to
 	// determine the intended destination of a connection without a Host header on the request.
-	GetProxyServiceInstances(Proxy) ([]*ServiceInstance, error)
+	GetProxyServiceInstances(*Proxy) ([]*ServiceInstance, error)
 
 	// ManagementPorts lists set of management ports associated with an IPv4 address.
 	// These management ports are typically used by the platform for out of band management
@@ -581,4 +585,12 @@ func ParseLabelsString(s string) Labels {
 		}
 	}
 	return tag
+}
+
+// GetServiceAddressForProxy returns a Service's IP address specific to the cluster where the node resides
+func (s Service) GetServiceAddressForProxy(node *Proxy) string {
+	if node.ClusterID != "" && s.Addresses[node.ClusterID] != "" {
+		return s.Addresses[node.ClusterID]
+	}
+	return s.Address
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -62,7 +62,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env model.Environment, proxy
 		}
 	}
 	if proxy.Type == model.Sidecar {
-		instances, err := env.GetProxyServiceInstances(proxy)
+		instances, err := env.GetProxyServiceInstances(&proxy)
 		if err != nil {
 			log.Errorf("failed to get service proxy service instances: %v", err)
 			return nil, err
@@ -92,6 +92,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env model.Environmen
 			for _, p := range configgen.Plugins {
 				p.OnOutboundCluster(env, proxy, service, port, defaultCluster)
 			}
+
 			clusters = append(clusters, defaultCluster)
 
 			if config != nil {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -48,7 +48,7 @@ var (
 
 func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environment, node model.Proxy) ([]*xdsapi.Listener, error) {
 	// collect workload labels
-	workloadInstances, err := env.GetProxyServiceInstances(node)
+	workloadInstances, err := env.GetProxyServiceInstances(&node)
 	if err != nil {
 		log.Errora("Failed to get gateway instances for router ", node.ID, err)
 		return nil, err

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -86,6 +86,7 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 				nameToServiceMap[svc.Hostname] = &model.Service{
 					Hostname:     svc.Hostname,
 					Address:      svc.Address,
+					Addresses:    svc.Addresses,
 					MeshExternal: svc.MeshExternal,
 					Ports:        []*model.Port{svcPort},
 				}
@@ -164,11 +165,12 @@ func buildVirtualHostDomains(service *model.Service, port int, node model.Proxy)
 	domains = append(domains, generateAltVirtualHosts(service.Hostname, port, node.Domain)...)
 
 	if len(service.Address) > 0 {
+		svcAddr := service.GetServiceAddressForProxy(&node)
 		// add a vhost match for the IP (if its non CIDR)
-		cidr := util.ConvertAddressToCidr(service.Address)
+		cidr := util.ConvertAddressToCidr(svcAddr)
 		if cidr.PrefixLen.Value == 32 {
-			domains = append(domains, service.Address)
-			domains = append(domains, fmt.Sprintf("%s:%d", service.Address, port))
+			domains = append(domains, svcAddr)
+			domains = append(domains, fmt.Sprintf("%s:%d", svcAddr, port))
 		}
 	}
 	return domains

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -91,7 +91,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env model.Environmen
 	mesh := env.Mesh
 	managementPorts := env.ManagementPorts(node.IPAddress)
 
-	proxyInstances, err := env.GetProxyServiceInstances(node)
+	proxyInstances, err := env.GetProxyServiceInstances(&node)
 	if err != nil {
 		return nil, err
 	}
@@ -353,8 +353,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 				fallthrough
 			case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMongo, model.ProtocolRedis:
 				if service.Resolution != model.Passthrough {
-					listenAddress = service.Address
-					addresses = []string{service.Address}
+					listenAddress = service.GetServiceAddressForProxy(&node)
+					addresses = []string{listenAddress}
 				}
 
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -143,7 +143,7 @@ func BuildConfig(config meshconfig.ProxyConfig, pilotSAN []string) *Config {
 func buildListeners(env model.Environment, node model.Proxy) (Listeners, error) {
 	switch node.Type {
 	case model.Sidecar:
-		proxyInstances, err := env.GetProxyServiceInstances(node)
+		proxyInstances, err := env.GetProxyServiceInstances(&node)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +181,7 @@ func buildClusters(env model.Environment, node model.Proxy) (Clusters, error) {
 	var err error
 	switch node.Type {
 	case model.Sidecar, model.Router:
-		proxyInstances, err = env.GetProxyServiceInstances(node)
+		proxyInstances, err = env.GetProxyServiceInstances(&node)
 		if err != nil {
 			return clusters, err
 		}
@@ -328,7 +328,7 @@ func BuildRDSRoute(mesh *meshconfig.MeshConfig, node model.Proxy, routeName stri
 	case model.Ingress:
 		httpConfigs, _ = buildIngressRoutes(mesh, nil, discovery, config, envoyV2)
 	case model.Sidecar:
-		proxyInstances, err := discovery.GetProxyServiceInstances(node)
+		proxyInstances, err := discovery.GetProxyServiceInstances(&node)
 		if err != nil {
 			return nil, err
 		}

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -618,7 +618,7 @@ func (ds *DiscoveryService) AvailabilityZone(request *restful.Request, response 
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return
 	}
-	proxyInstances, err := ds.GetProxyServiceInstances(svcNode)
+	proxyInstances, err := ds.GetProxyServiceInstances(&svcNode)
 	if err != nil {
 		errorResponse(methodName, response, http.StatusNotFound, "AvailabilityZone "+err.Error())
 		return

--- a/pilot/pkg/proxy/envoy/v1/mock/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/mock/discovery.go
@@ -257,7 +257,7 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string,
 }
 
 // GetProxyServiceInstances implements discovery interface
-func (sd *ServiceDiscovery) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) GetProxyServiceInstances(node *model.Proxy) ([]*model.ServiceInstance, error) {
 	if sd.GetProxyServiceInstancesError != nil {
 		return nil, sd.GetProxyServiceInstancesError
 	}

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -390,7 +390,7 @@ func (s *DiscoveryServer) pushRoute(con *XdsConnection) error {
 	services = s.services
 	s.modelMutex.RUnlock()
 
-	proxyInstances, err := s.env.GetProxyServiceInstances(*con.modelNode)
+	proxyInstances, err := s.env.GetProxyServiceInstances(con.modelNode)
 	if err != nil {
 		log.Warnf("ADS: RDS: Failed to retrieve proxy service instances %v", err)
 		return err

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -42,6 +42,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 		}, 2)
 
 	sctl.AddRegistry(aggregate.Registry{
+		ClusterID:        "v2-debug",
 		Name:             serviceregistry.ServiceRegistry("memAdapter"),
 		ServiceDiscovery: s.MemRegistry,
 		ServiceAccounts:  s.MemRegistry,
@@ -210,7 +211,7 @@ func (sd *MemServiceDiscovery) Instances(hostname string, ports []string,
 
 // GetProxyServiceInstances returns service instances associated with a node, resulting in
 // 'in' services.
-func (sd *MemServiceDiscovery) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+func (sd *MemServiceDiscovery) GetProxyServiceInstances(node *model.Proxy) ([]*model.ServiceInstance, error) {
 	sd.mutex.Lock()
 	defer sd.mutex.Unlock()
 	if sd.GetProxyServiceInstancesError != nil {

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -107,7 +107,7 @@ func (sd *ServiceDiscovery) Instances(hostname string, ports []string, tagsList 
 // GetProxyServiceInstances returns all service instances running on a particular proxy
 // Cloud Foundry integration is currently ingress-only -- there is no sidecar support yet.
 // So this function always returns an empty slice.
-func (sd *ServiceDiscovery) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
+func (sd *ServiceDiscovery) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
 	return nil, nil
 }
 

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -227,7 +227,7 @@ func TestServiceDiscovery_GetProxyServiceInstances(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	state := newSDTestState()
 
-	instances, err := state.serviceDiscovery.GetProxyServiceInstances(model.Proxy{IPAddress: "not-checked"})
+	instances, err := state.serviceDiscovery.GetProxyServiceInstances(&model.Proxy{IPAddress: "not-checked"})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(instances).To(gomega.BeEmpty())
 }

--- a/pilot/pkg/serviceregistry/consul/controller.go
+++ b/pilot/pkg/serviceregistry/consul/controller.go
@@ -151,7 +151,7 @@ func portMatch(instance *model.ServiceInstance, portMap map[string]bool) bool {
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
-func (c *Controller) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.ServiceInstance, error) {
 	data, err := c.getServices()
 	if err != nil {
 		return nil, err

--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -357,7 +357,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 		t.Errorf("could not create Consul Controller: %v", err)
 	}
 
-	services, err := controller.GetProxyServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
+	services, err := controller.GetProxyServiceInstances(&model.Proxy{IPAddress: "172.19.0.11"})
 	if err != nil {
 		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
 	}
@@ -380,7 +380,7 @@ func TestGetProxyServiceInstancesError(t *testing.T) {
 	}
 
 	ts.Server.Close()
-	instances, err := controller.GetProxyServiceInstances(model.Proxy{IPAddress: "172.19.0.11"})
+	instances, err := controller.GetProxyServiceInstances(&model.Proxy{IPAddress: "172.19.0.11"})
 	if err == nil {
 		t.Error("GetProxyServiceInstances() should return error when client experiences connection problem")
 	}

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery.go
@@ -90,7 +90,7 @@ func (sd *serviceDiscovery) Instances(hostname string, ports []string,
 }
 
 // GetProxyServiceInstances returns service instances co-located with a proxy
-func (sd *serviceDiscovery) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
+func (sd *serviceDiscovery) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
 	apps, err := sd.client.Applications()
 	if err != nil {
 		log.Warnf("could not list Eureka instances: %v", err)
@@ -104,6 +104,7 @@ func (sd *serviceDiscovery) GetProxyServiceInstances(proxy model.Proxy) ([]*mode
 			out = append(out, instance)
 		}
 	}
+
 	return out, nil
 }
 

--- a/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/eureka/servicediscovery_test.go
@@ -92,7 +92,7 @@ func TestServiceDiscoveryClientError(t *testing.T) {
 		t.Error("Instances() should return nil on error")
 	}
 
-	hostInstances, err := sd.GetProxyServiceInstances(model.Proxy{})
+	hostInstances, err := sd.GetProxyServiceInstances(&model.Proxy{})
 	if err == nil {
 		t.Error("GetProxyServiceInstances() should return error")
 	}
@@ -171,7 +171,7 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	}
 
 	for _, tt := range instanceTests {
-		instances, err := sd.GetProxyServiceInstances(tt.node)
+		instances, err := sd.GetProxyServiceInstances(&tt.node)
 		if err != nil {
 			t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 		}

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -99,7 +99,7 @@ func portMatch(instance *model.ServiceInstance, portMap map[string]bool) bool {
 }
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
-func (d *externalDiscovery) GetProxyServiceInstances(node model.Proxy) ([]*model.ServiceInstance, error) {
+func (d *externalDiscovery) GetProxyServiceInstances(node *model.Proxy) ([]*model.ServiceInstance, error) {
 	// There is no proxy sitting next to google.com.  If supplied, istio will end up generating a full envoy
 	// configuration with routes to internal services, (listeners, etc.) for the external service
 	// (which does not exist in the cluster).

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -108,7 +108,7 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 
 	createExternalServices([]*networking.ExternalService{httpStatic, tcpStatic}, store, t)
 
-	instances, err := sd.GetProxyServiceInstances(model.Proxy{IPAddress: "2.2.2.2"})
+	instances, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddress: "2.2.2.2"})
 	if err != nil {
 		t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -353,7 +353,7 @@ func (c *Controller) Instances(hostname string, ports []string,
 }
 
 // GetProxyServiceInstances returns service instances co-located with a given proxy
-func (c *Controller) GetProxyServiceInstances(proxy model.Proxy) ([]*model.ServiceInstance, error) {
+func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {
@@ -362,7 +362,7 @@ func (c *Controller) GetProxyServiceInstances(proxy model.Proxy) ([]*model.Servi
 			for _, ea := range ss.Addresses {
 				if proxy.IPAddress == ea.IP {
 					if kubeNodes[ea.IP] == nil {
-						err := parseKubeServiceNode(ea.IP, &proxy, kubeNodes)
+						err := parseKubeServiceNode(ea.IP, proxy, kubeNodes)
 						if err != nil {
 							return out, err
 						}

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -244,7 +244,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	svcNode.IPAddress = "128.0.0.1"
 	svcNode.ID = "pod1.nsA"
 	svcNode.Domain = "nsA.svc.cluster.local"
-	services, err := controller.GetProxyServiceInstances(svcNode)
+	services, err := controller.GetProxyServiceInstances(&svcNode)
 	if err != nil {
 		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)
 	}
@@ -260,7 +260,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	}
 
 	svcNode.Domain = "nsWRONG.svc.cluster.local"
-	_, err = controller.GetProxyServiceInstances(svcNode)
+	_, err = controller.GetProxyServiceInstances(&svcNode)
 	if err == nil {
 		t.Errorf("GetProxyServiceInstances() should have returned error for unknown domain.")
 	}


### PR DESCRIPTION
Services need to maintain per cluster service IPs.  For sidecars running in a cluster, cluster-specific service IPs should be used to build destination_ip_list for envoy listeners.