### PR TITLE
Restore defaults for istio-iptables.sh

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -21,17 +21,21 @@ data:
         - {{ "{{ .MeshConfig.ProxyListenPort }}" }}
         - "-u"
         - 1337
-        {{ if .Values.includeIPRanges -}}
         - "-i"
+        {{ if .Values.includeIPRanges -}}
         - {{ .Values.includeIPRanges | quote }}
+        {{ else -}}
+        - "*"
         {{ end -}}
         {{ if .Values.excludeIPRanges -}}
         - "-x"
         - {{ .Values.excludeIPRanges | quote }}
         {{ end -}}
-        {{ if .Values.includeInboundPorts -}}
         - "-b"
+        {{ if .Values.includeInboundPorts -}}
         - {{ .Values.includeInboundPorts | quote }}
+        {{ else -}}
+        - "*"
         {{ end -}}
         {{ if .Values.excludeInboundPorts -}}
         - "-d"

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -26,9 +26,25 @@ initContainers:
   - {{ .MeshConfig.ProxyListenPort }}
   - "-u"
   - [[ .SidecarProxyUID ]]
-  [[ if ne .IncludeIPRanges "" -]]
   - "-i"
+  [[ if ne .IncludeIPRanges "" -]]
   - [[ .IncludeIPRanges ]]
+  [[ else -]]
+  - "*"
+  [[ end -]]
+  [[ if ne .ExcludeIPRanges "" -]]
+  - "-x"
+  - [[ .ExcludeIPRanges ]]
+  [[ end -]]
+  - "-b"
+  [[ if ne .IncludeInboundPorts "" -]]
+  - [[ .IncludeInboundPorts ]]
+  [[ else -]]
+  - "*"
+  [[ end -]]
+  [[ if ne .ExcludeInboundPorts "" -]]
+  - "-d"
+  - [[ .ExcludeInboundPorts ]]
   [[ end -]]
   [[ if eq .ImagePullPolicy "" -]]
   imagePullPolicy: IfNotPresent

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
     spec:
       template:
@@ -82,6 +82,10 @@ spec:
             - "15001"
             - -u
             - "1337"
+            - -i
+            - '*'
+            - -b
+            - '*'
             image: docker.io/istio/proxy_init:unittest
             imagePullPolicy: IfNotPresent
             name: istio-init

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -81,6 +81,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+          sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
         creationTimestamp: null
         labels:
           app: hello
@@ -101,6 +101,10 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -i
+          - '*'
+          - -b
+          - '*'
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -86,6 +86,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"25deea1217623062e710353911374f1ffeb8da83b918662b426fe87016d57dcd","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"9efe21c481264f20398c59b5d888f015a209d63e085dedbacd1d3ce652cb7609","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -101,6 +101,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"e30df2d2e39539e99b157bccd4b26fd5c62a4e290e36480b56af53d71a3507bf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"1bcafd7ef80851e2cec859d52071d8acfe1a8e5f6447a2d9199b2a2346fdba4a","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: Always
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -84,6 +84,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -84,6 +84,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init
@@ -113,7 +117,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -188,6 +192,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"f28aff3e90d1fdcd31901bd59ce8bb370d9806d7588c869545362c3b5536d1a7","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"4f97a34e20fd9faedcd0a1a0d1c37d496d604a7bd56504689e60ec103a59b50d","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: Never
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -103,6 +103,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"4a0d7e2d9d8613a6385098b0f0bf9fa25a85a23c29c876f05baa6731086cd356","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"02b0ca9b0c55be33c3770f39b52964d1c4a88be95b2cef2f9438be0e502733ec","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -83,6 +83,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       name: pi
     spec:
@@ -80,6 +80,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+          sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
         creationTimestamp: null
         labels:
           app: hello
@@ -102,6 +102,10 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -i
+          - '*'
+          - -b
+          - '*'
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/pilot/pkg/kube/inject/testdata/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+          sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
         creationTimestamp: null
         labels:
           app: hello
@@ -86,6 +86,10 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -i
+          - '*'
+          - -b
+          - '*'
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init
@@ -114,7 +118,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+          sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
         creationTimestamp: null
         labels:
           app: hello
@@ -189,6 +193,10 @@ items:
           - "15001"
           - -u
           - "1337"
+          - -i
+          - '*'
+          - -b
+          - '*'
           image: docker.io/istio/proxy_init:unittest
           imagePullPolicy: IfNotPresent
           name: istio-init

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -97,6 +97,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -80,6 +80,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -82,6 +82,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/single-initializer.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/single-initializer.yaml.injected
@@ -59,6 +59,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0fd4ba601a8387ce4a6317d83dd1d8af037d3a5f59512824113a5a0fce04e9b8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"2331371530cc3939de97204ee548e1e7dd9d69f9e589d0fe59ec2a538eeb99cf","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -86,6 +86,10 @@ spec:
         - "15001"
         - -u
         - "1337"
+        - -i
+        - '*'
+        - -b
+        - '*'
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init

--- a/tests/e2e/tests/simple/testdata/nginx/nginx-injected.yaml.tmpl
+++ b/tests/e2e/tests/simple/testdata/nginx/nginx-injected.yaml.tmpl
@@ -261,6 +261,12 @@ spec:
         - "15001"
         - -u
         - "1337"
+        # Redirect all outbound traffic to Envoy.
+        - -i
+        - "*"
+        # Redirect all inbound traffic to Envoy.
+        - -b
+        - "*"
         image: {{.ProxyHub}}/proxy_init:{{.ProxyTag}}
         imagePullPolicy: {{.ImagePullPolicy}}
         name: istio-init
@@ -440,13 +446,16 @@ spec:
         - "15001"
         - -u
         - "1337"
-        # Do not redirect inbound traffic to Envoy.
-        - -b
-        - ""
+        # By default, redirect all outbound traffic to Envoy.
+        - -i
+        - "*"
         # Exclude outbound traffic to kubernetes master from redirection.
         # This is required in order to support single-namespace Istio configurations.
         - -x
         - {{.KubeMasterCIDR}}
+        # Do not redirect inbound traffic to Envoy.
+        - -b
+        - ""
         image: {{.ProxyHub}}/proxy_init:{{.ProxyTag}}
         imagePullPolicy: {{.ImagePullPolicy}}
         name: istio-init


### PR DESCRIPTION
By default, VMs should not redirect any traffic to Envoy. When merging
this script with the old proxy script, the defaults were swapped to
redirect all traffic.

The one wrinkle is that the old script was supposed to be symmetrical in that by default neither inbound nor outbound traffic would be redirected to Envoy.  However, it seems that the [original script](https://github.com/istio/istio/blob/90987fca376fa5148760f538443fb632cf8c116f/tools/deb/istio-iptables.sh#L179) redirected all outbound traffic to Envoy by default.  This PR will correctly do nothing by default.