### PR TITLE
Refactor cluster registry to use Secret to store kubeconf

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -82,8 +82,10 @@ func init() {
 			serviceregistry.CloudFoundryRegistry, serviceregistry.MockRegistry))
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.CFConfig, "cfConfig", "",
 		"Cloud Foundry config file")
-	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesDir, "clusterRegistriesDir", "",
-		"Directory for a file-based cluster config store")
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesConfigmap, "clusterRegistriesConfigMap", "",
+		"ConfigMap map for clusters config store")
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesNamespace, "clusterRegistriesNamespace", "",
+		"Namespace for ConfigMap which stores clusters configs")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.KubeConfig, "kubeconfig", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Mesh.ConfigFile, "meshConfig", "/etc/istio/config/mesh",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"strconv"
 	"time"
 
@@ -102,11 +101,12 @@ type MeshArgs struct {
 // be monitored for CRD yaml files and will update the controller as those files change (This is used for testing
 // purposes). Otherwise, a CRD client is created based on the configuration.
 type ConfigArgs struct {
-	ClusterRegistriesDir string
-	KubeConfig           string
-	CFConfig             string
-	ControllerOptions    kube.ControllerOptions
-	FileDir              string
+	ClusterRegistriesConfigmap string
+	ClusterRegistriesNamespace string
+	KubeConfig                 string
+	CFConfig                   string
+	ControllerOptions          kube.ControllerOptions
+	FileDir                    string
 }
 
 // ConsulArgs provides configuration for the Consul service registry.
@@ -210,10 +210,10 @@ func NewServer(args PilotArgs) (*Server, error) {
 	s := &Server{}
 
 	// Apply the arguments to the configuration.
-	if err := s.initClusterRegistries(&args); err != nil {
+	if err := s.initKubeClient(&args); err != nil {
 		return nil, err
 	}
-	if err := s.initKubeClient(&args); err != nil {
+	if err := s.initClusterRegistries(&args); err != nil {
 		return nil, err
 	}
 	if err := s.initMesh(&args); err != nil {
@@ -278,8 +278,10 @@ func (s *Server) initMonitor(args *PilotArgs) error {
 }
 
 func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
-	if args.Config.ClusterRegistriesDir != "" {
-		s.clusterStore, err = clusterregistry.ReadClusters(args.Config.ClusterRegistriesDir)
+	if args.Config.ClusterRegistriesConfigmap != "" {
+		s.clusterStore, err = clusterregistry.ReadClusters(s.kubeClient,
+			args.Config.ClusterRegistriesConfigmap,
+			args.Config.ClusterRegistriesNamespace)
 		if s.clusterStore != nil {
 			log.Infof("clusters configuration %s", spew.Sdump(s.clusterStore))
 		}
@@ -365,12 +367,6 @@ func (s *Server) initMixerSan(args *PilotArgs) error {
 }
 
 func (s *Server) getKubeCfgFile(args *PilotArgs) (kubeCfgFile string) {
-	// If the cluster store is configured, get pilot's kubeconfig from there
-	if s.clusterStore != nil {
-		if kubeCfgFile = s.clusterStore.GetPilotAccessConfig(); kubeCfgFile != "" {
-			kubeCfgFile = path.Join(args.Config.ClusterRegistriesDir, kubeCfgFile)
-		}
-	}
 	if kubeCfgFile == "" {
 		kubeCfgFile = args.Config.KubeConfig
 	}
@@ -525,13 +521,13 @@ func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Contr
 	// Add clusters under the same pilot
 	if s.clusterStore != nil {
 		clusters := s.clusterStore.GetPilotClusters()
+		clientAccessConfigs := s.clusterStore.GetClientAccessConfigs()
 		for _, cluster := range clusters {
-			kubeconfig := clusterregistry.GetClusterAccessConfig(cluster)
-			kubeCfgFile := path.Join(args.Config.ClusterRegistriesDir, kubeconfig)
-			log.Infof("Cluster name: %s, AccessConfigFile: %s", clusterregistry.GetClusterName(cluster), kubeCfgFile)
-			_, client, kuberr := kube.CreateInterface(kubeCfgFile)
+			log.Infof("Cluster name: %s, AccessConfigFile: %s", clusterregistry.GetClusterName(cluster))
+			clusterClient := clientAccessConfigs[cluster.ObjectMeta.Name]
+			_, client, kuberr := kube.CreateInterfaceFromClusterConfig(&clusterClient)
 			if kuberr != nil {
-				err = multierror.Append(err, multierror.Prefix(kuberr, fmt.Sprintf("failed to connect to Access API with accessconfig: %s", kubeCfgFile)))
+				err = multierror.Append(err, multierror.Prefix(kuberr, fmt.Sprintf("failed to connect to Access API with access config: %s", cluster.ObjectMeta.Name)))
 			}
 
 			kubectl := kube.NewController(client, args.Config.ControllerOptions)

--- a/pilot/pkg/config/clusterregistry/clusterconfig.gotmpl
+++ b/pilot/pkg/config/clusterregistry/clusterconfig.gotmpl
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+	certificate-authority-data: {{.CertificateAuthorityData}}
+    server: {{.ClusterIP}}:6443
+  name: {{.ClusterName}}
+contexts:
+- context:
+    cluster: {{.ClusterName}}
+    user: {{.ClusterUserName}}
+  name: {{.ClusterUserName}}@{{.ClusterName}}
+current-context: {{.ClusterUserName}}@{{.ClusterName}}
+kind: Config
+preferences: {}
+users:
+- name: {{.ClusterUserName}}
+  user:
+	client-certificate-data: {{.ClientCertificateData}}
+	client-key-data: {{.ClientKeyData}}

--- a/pilot/pkg/config/clusterregistry/clusterregistry.gotmpl
+++ b/pilot/pkg/config/clusterregistry/clusterregistry.gotmpl
@@ -1,0 +1,16 @@
+apiVersion: clusterregistry.k8s.io/v1alpha1
+kind: {{.Kind}}
+metadata:
+  name: {{.Name}}
+  annotations:
+    config.istio.io/pilotEndpoint: "{{.PilotIP}}:9080"
+    config.istio.io/platform: "{{if .Platform}}{{.Platform}}{{else}}Kubernetes{{end}}"
+    {{if .PilotCfgStore}}config.istio.io/pilotCfgStore: "{{.PilotCfgStore}}"
+    {{end -}}
+    config.istio.io/accessConfigSecret: "{{.AccessConfigSecret}}"
+    config.istio.io/accessConfigSecretNamespace: "{{.AccessConfigNamespace}}"
+spec:
+  kubernetesApiEndpoints:
+    serverEndpoints:
+    - clientCIDR: "{{.ClientCidr}}"
+      serverAddress: "{{.ServerEndpointIP}}"

--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -15,30 +15,21 @@
 package clusterregistry
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
-	"reflect"
 	"strconv"
+	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"go.uber.org/multierr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/log"
-)
-
-var (
-	supportedExtensions = map[string]bool{
-		".yaml": true,
-		".yml":  true,
-	}
 )
 
 // annotations for a Cluster
@@ -49,9 +40,10 @@ const (
 	// The cluster's platform: Kubernetes, Consul, Eureka, CloudFoundry
 	ClusterPlatform = "config.istio.io/platform"
 
-	// The cluster's access configuration file
+	// The cluster's access configuration stored in k8s Secret object
 	// E.g., on kubenetes, this file can be usually copied from .kube/config
-	ClusterAccessConfigFile = "config.istio.io/accessConfigFile"
+	ClusterAccessConfigSecret          = "config.istio.io/accessConfigSecret"
+	ClusterAccessConfigSecretNamespace = "config.istio.io/accessConfigSecretNamespace"
 
 	// For the time being, assume that ClusterPilotCfgStore is only set for one cluster only.
 	// If set to be true, this cluster will be used as the pilot's config store.
@@ -60,24 +52,32 @@ const (
 
 // ClusterStore is a collection of clusters
 type ClusterStore struct {
-	clusters []*k8s_cr.Cluster
-	cfgStore *k8s_cr.Cluster
+	clusters      []*k8s_cr.Cluster
+	cfgStore      *k8s_cr.Cluster
+	clientConfigs map[string]clientcmdapi.Config
 }
 
 // GetPilotAccessConfig returns this pilot's access config file name
-func (cs *ClusterStore) GetPilotAccessConfig() string {
+func (cs *ClusterStore) GetPilotAccessConfig() *clientcmdapi.Config {
 	if cs.cfgStore == nil {
-		return ""
+		return nil
 	}
-	return cs.cfgStore.ObjectMeta.Annotations[ClusterAccessConfigFile]
+	pilotAccessConfig := cs.clientConfigs[cs.cfgStore.ObjectMeta.Name]
+	return &pilotAccessConfig
+}
+
+// GetClientAccessConfigs returns map of collected client configs
+func (cs *ClusterStore) GetClientAccessConfigs() map[string]clientcmdapi.Config {
+	return cs.clientConfigs
 }
 
 // GetClusterAccessConfig returns the access config file of a cluster
-func GetClusterAccessConfig(cluster *k8s_cr.Cluster) string {
+func (cs *ClusterStore) GetClusterAccessConfig(cluster *k8s_cr.Cluster) *clientcmdapi.Config {
 	if cluster == nil {
-		return ""
+		return nil
 	}
-	return cluster.ObjectMeta.Annotations[ClusterAccessConfigFile]
+	clusterAccessConfig := cs.clientConfigs[cluster.ObjectMeta.Name]
+	return &clusterAccessConfig
 }
 
 // GetClusterName returns a cluster's name
@@ -101,62 +101,114 @@ func (cs *ClusterStore) GetPilotClusters() (clusters []*k8s_cr.Cluster) {
 	return
 }
 
-// ReadClusters reads multiple clusters from files in a directory
-func ReadClusters(crPath string) (cs *ClusterStore, err error) {
-	cs = &ClusterStore{
-		clusters: []*k8s_cr.Cluster{},
-		cfgStore: nil,
-	}
-
-	var clusters []*k8s_cr.Cluster
-	err = filepath.Walk(crPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !supportedExtensions[filepath.Ext(path)] || (info.Mode()&os.ModeType) != 0 {
-			return nil
-		}
-		data, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Warnf("Failed to read %s: %v", path, err)
-			return err
-		}
-		result, err := parseClusters(crPath, data)
-		if err != nil {
-			log.Warnf("Failed to parse cluster file %s: %v", path, err)
-			return err
-		}
-		clusters = append(clusters, result...)
-		return nil
-	})
-
-	if err == nil {
-		// For the time being, assume that ClusterPilotCfgStore is only set for one cluster only.
-		// This cluster will be used as the pilot's config store.
-		for _, cluster := range clusters {
-			log.Infof("ClusterPilotCfgStore: %s", cluster.ObjectMeta.Annotations[ClusterPilotCfgStore])
-			if isCfgStore, _ := strconv.ParseBool(cluster.ObjectMeta.Annotations[ClusterPilotCfgStore]); isCfgStore {
-				if cs.cfgStore != nil {
-					err = fmt.Errorf("multiple cluster config stores are defined")
-					log.Warnf("%v", err)
-					return nil, err
-				}
-				cs.cfgStore = cluster
-			} else {
-				cs.clusters = append(cs.clusters, cluster)
+func setCfgStore(cs *ClusterStore) error {
+	for _, cluster := range cs.clusters {
+		log.Infof("ClusterPilotCfgStore: %s", cluster.ObjectMeta.Annotations[ClusterPilotCfgStore])
+		if isCfgStore, _ := strconv.ParseBool(cluster.ObjectMeta.Annotations[ClusterPilotCfgStore]); isCfgStore {
+			if cs.cfgStore != nil {
+				return fmt.Errorf("multiple cluster config stores are defined")
 			}
-		}
-		if cs.cfgStore == nil {
-			log.Warnf("no config store is defined in the cluster registries")
-			return nil, nil
+			cs.cfgStore = cluster
 		}
 	}
+	if cs.cfgStore == nil {
+		return fmt.Errorf("no config store is defined in the cluster registries")
+	}
 
-	return
+	return nil
+}
+
+// ReadClusters reads multiple clusters from a ConfigMap
+func ReadClusters(k8s kubernetes.Interface, configMapName string, configMapNamespace string) (*ClusterStore, error) {
+
+	// getClustersConfigs
+	cs, err := getClustersConfigs(k8s, configMapName, configMapNamespace)
+	if err != nil {
+		return nil, err
+	}
+	if len(cs.clusters) == 0 {
+		return nil, fmt.Errorf("no kubeconf found in provided ConfigMap: %s/%s", configMapNamespace, configMapName)
+	}
+	if err := setCfgStore(cs); err != nil {
+		log.Errorf("%s", err.Error())
+		return nil, err
+	}
+
+	return cs, nil
+}
+
+// getClustersConfigs(configMapName,configMapNamespace)
+func getClustersConfigs(k8s kubernetes.Interface, configMapName, configMapNamespace string) (*ClusterStore, error) {
+	cs := &ClusterStore{
+		clusters:      []*k8s_cr.Cluster{},
+		cfgStore:      nil,
+		clientConfigs: map[string]clientcmdapi.Config{},
+	}
+
+	clusterRegistry, err := k8s.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
+	if err != nil {
+		return &ClusterStore{}, err
+	}
+	cluster := k8s_cr.Cluster{}
+
+	for key, data := range clusterRegistry.Data {
+		decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(data), 4096)
+		if err = decoder.Decode(&cluster); err != nil {
+			log.Errorf("failed to decode cluster definition for: %s error: %v", key, err)
+			return &ClusterStore{}, err
+		}
+		if err := validateCluster(&cluster); err != nil {
+			log.Errorf("failed to validate cluster: %s error: %v", key, err)
+			return &ClusterStore{}, err
+		}
+		secretName := cluster.ObjectMeta.Annotations[ClusterAccessConfigSecret]
+		secretNamespace := cluster.ObjectMeta.Annotations[ClusterAccessConfigSecretNamespace]
+		if len(secretName) == 0 {
+			log.Errorf("cluster %s does not have annotation for Secret", key)
+			return &ClusterStore{}, nil
+		}
+		if len(secretNamespace) == 0 {
+			secretNamespace = "istio-system"
+		}
+		kubeconfig, err := getClusterConfigFromSecret(k8s, secretName, secretNamespace, key)
+		if err != nil {
+			log.Errorf("failed to get Secret %s in namespace %s for cluster %s with error: %v",
+				secretName, secretNamespace, key, err)
+			return &ClusterStore{}, nil
+		}
+		clientConfig, err := clientcmd.Load(kubeconfig)
+		if err != nil {
+			log.Errorf("failed to load client config from secret %s in namespace %s for cluster %s with error: %v",
+				secretName, secretNamespace, key, err)
+			return &ClusterStore{}, nil
+		}
+		cs.clientConfigs[cluster.ObjectMeta.Name] = *clientConfig
+	}
+
+	return cs, nil
+}
+
+func getClusterConfigFromSecret(k8s kubernetes.Interface,
+	secretName string,
+	secretNamespace string,
+	clusterName string) ([]byte, error) {
+
+	secret, err := k8s.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
+	if err == nil {
+		val, ok := secret.Data[clusterName]
+		if !ok {
+			log.Errorf("cluster name %s is not found in the secret object: %s/%s",
+				clusterName, secret.Name, secret.Namespace)
+			return []byte{}, fmt.Errorf("cluster name %s is not found in the secret object: %s/%s",
+				clusterName, secret.Name, secret.Namespace)
+		}
+		return val, nil
+	}
+	return []byte{}, err
 }
 
 // validateCluster validate a cluster
-func validateCluster(crPath string, cluster *k8s_cr.Cluster) (err error) {
+func validateCluster(cluster *k8s_cr.Cluster) (err error) {
 	if cluster.TypeMeta.Kind != "Cluster" {
 		err = multierr.Append(err, fmt.Errorf("bad kind in configuration: `%s` != 'Cluster'", cluster.TypeMeta.Kind))
 	}
@@ -180,44 +232,11 @@ func validateCluster(crPath string, cluster *k8s_cr.Cluster) (err error) {
 			err = multierror.Append(err, err1)
 		}
 	}
-
-	if cluster.ObjectMeta.Annotations[ClusterAccessConfigFile] == "" {
-		err = multierror.Append(err, fmt.Errorf("cluster %s doesn't have a valid config file", cluster.ObjectMeta.Name))
+	if cluster.ObjectMeta.Annotations[ClusterAccessConfigSecret] == "" {
+		err = multierror.Append(err, fmt.Errorf("cluster %s doesn't have a valid config secret", cluster.ObjectMeta.Name))
 	} else {
-		cfgFile := path.Join(crPath, cluster.ObjectMeta.Annotations[ClusterAccessConfigFile])
-		if _, err1 := os.Stat(cfgFile); err1 != nil {
-			err = multierror.Append(err, err1)
-		}
-	}
-	return
-}
-
-// parseClusters reads multiple clusters from a single file
-func parseClusters(crPath string, clusterData []byte) (clusters []*k8s_cr.Cluster, err error) {
-	reader := bytes.NewReader(clusterData)
-	var empty = k8s_cr.Cluster{}
-
-	// We store configs as a YaML stream; there may be more than one decoder.
-	yamlDecoder := yaml.NewYAMLOrJSONDecoder(reader, 512*1024)
-	for {
-		obj := k8s_cr.Cluster{}
-		err1 := yamlDecoder.Decode(&obj)
-		if err1 == io.EOF {
-			break
-		}
-		if err1 != nil {
-			err = multierror.Append(err, err1)
-			return nil, err
-		}
-		if reflect.DeepEqual(obj, empty) {
-			continue
-		}
-
-		err1 = validateCluster(crPath, &obj)
-		if err1 == nil {
-			clusters = append(clusters, &obj)
-		} else {
-			err = multierror.Append(err, err1)
+		if cluster.ObjectMeta.Annotations[ClusterAccessConfigSecretNamespace] == "" {
+			cluster.ObjectMeta.Annotations[ClusterAccessConfigSecretNamespace] = "istio-system"
 		}
 	}
 


### PR DESCRIPTION
4th attempt to resolve Circle CI stuck on Waiting for status to be reported issue.

This PR refactors cluster registry to use k8s Secret object to store kubeconf files of member clusters.

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: clusterregistry
  namespace: istio-system
data:
  kube-3.yaml: |-
    apiVersion: clusterregistry.k8s.io/v1alpha1
    kind: Cluster
    metadata:
      name: "kube-3"
      annotations:
        config.istio.io/pilotEndpoint: "192.168.80.234:9080"
        config.istio.io/platform: "Kubernetes"
        config.istio.io/pilotCfgStore: True
        config.istio.io/accessConfigSecret: "kube-3.conf"   < ---   Name of Secret which stores kube-3 kubeconf config 
        config.istio.io/accessConfigSecretNamespace: "istio-system"   < ---   Namespace where secrets will be stored. 
```