### PR TITLE
Increase the lifetime of workload cert to 90 days

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -43,9 +43,9 @@ import (
 const (
 	defaultSelfSignedCACertTTL = 365 * 24 * time.Hour
 
-	defaultMaxWorkloadCertTTL = 7 * 24 * time.Hour
+	defaultMaxWorkloadCertTTL = 60 * 24 * time.Hour
 
-	defaultWorkloadCertTTL = 19 * time.Hour
+	defaultWorkloadCertTTL = 30 * 24 * time.Hour
 
 	// The default length of certificate rotation grace period, configured as
 	// the ratio of the certificate TTL.

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -43,9 +43,9 @@ import (
 const (
 	defaultSelfSignedCACertTTL = 365 * 24 * time.Hour
 
-	defaultMaxWorkloadCertTTL = 60 * 24 * time.Hour
+	defaultMaxWorkloadCertTTL = 90 * 24 * time.Hour
 
-	defaultWorkloadCertTTL = 30 * 24 * time.Hour
+	defaultWorkloadCertTTL = 90 * 24 * time.Hour
 
 	// The default length of certificate rotation grace period, configured as
 	// the ratio of the certificate TTL.

--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -53,7 +53,7 @@ func init() {
 
 	cAClientConfig := &naConfig.CAClientConfig
 	flags.StringVar(&cAClientConfig.Org, "org", "", "Organization for the cert")
-	flags.DurationVar(&cAClientConfig.RequestedCertTTL, "workload-cert-ttl", 30*24*time.Hour,
+	flags.DurationVar(&cAClientConfig.RequestedCertTTL, "workload-cert-ttl", 90*24*time.Hour,
 		"The requested TTL for the workload")
 	flags.IntVar(&cAClientConfig.RSAKeySize, "key-size", 2048, "Size of generated private key")
 	flags.StringVar(&cAClientConfig.CAAddress,

--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -53,7 +53,7 @@ func init() {
 
 	cAClientConfig := &naConfig.CAClientConfig
 	flags.StringVar(&cAClientConfig.Org, "org", "", "Organization for the cert")
-	flags.DurationVar(&cAClientConfig.RequestedCertTTL, "workload-cert-ttl", 19*time.Hour,
+	flags.DurationVar(&cAClientConfig.RequestedCertTTL, "workload-cert-ttl", 30*24*time.Hour,
 		"The requested TTL for the workload")
 	flags.IntVar(&cAClientConfig.RSAKeySize, "key-size", 2048, "Size of generated private key")
 	flags.StringVar(&cAClientConfig.CAAddress,


### PR DESCRIPTION
Discussed with Wencheng, and will change it back once the node agent solution is stable.