### PR TITLE
Mixer filter fixes

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
 )

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -38,5 +38,5 @@ type ConfigGenerator interface {
 
 // NewConfigGenerator creates a new instance of the dataplane configuration generator
 func NewConfigGenerator() ConfigGenerator {
-	return v1alpha3.NewConfigGenerator(registry.NewPlugins())
+	return v1alpha3.NewConfigGenerator(registry.NewDefaultPlugins())
 }

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -193,6 +193,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env model.Environmen
 // configuration for co-located service proxyInstances.
 func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Environment, node model.Proxy,
 	proxyInstances []*model.ServiceInstance) []*xdsapi.Listener {
+
 	listeners := make([]*xdsapi.Listener, 0, len(proxyInstances))
 
 	mesh := env.Mesh
@@ -223,8 +224,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 			// TODO move to plugin
 			tlsContext: buildSidecarListenerTLSContext(authenticationPolicy),
 		}
+		var listenerType plugin.ListenerType
 		switch protocol {
 		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC:
+			listenerType = plugin.ListenerTypeHTTP
 			listenerOpts.httpOpts = &httpListenerOpts{
 				routeConfig:      configgen.buildSidecarInboundHTTPRouteConfig(env, node, instance),
 				rds:              "",
@@ -233,6 +236,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 				authnPolicy:      authenticationPolicy,
 			}
 		case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMongo, model.ProtocolRedis:
+			listenerType = plugin.ListenerTypeTCP
 			listenerOpts.networkFilters = buildInboundNetworkFilters(instance)
 
 		default:
@@ -242,17 +246,19 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 		// call plugins
 		for _, p := range configgen.Plugins {
 			params := &plugin.CallbackListenerInputParams{
+				ListenerType:    listenerType,
 				Env:             &env,
 				Node:            &node,
 				ServiceInstance: instance,
 			}
-			mutable := &plugin.CallbackListenerMutableObjects{
-				TCPFilters:  listenerOpts.networkFilters,
-				HTTPFilters: listenerOpts.hTTPFilters,
-			}
-			if err := p.OnInboundListener(params, mutable); err != nil {
+
+			nf, hf, err := p.OnInboundListener(params, nil)
+			if err != nil {
 				log.Error(err.Error())
 			}
+
+			listenerOpts.networkFilters = append(listenerOpts.networkFilters, nf...)
+			listenerOpts.hTTPFilters = append(listenerOpts.hTTPFilters, hf...)
 
 			listeners = append(listeners, buildListener(listenerOpts))
 		}
@@ -298,8 +304,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 				protocol:       servicePort.Protocol,
 			}
 
+			var listenerType plugin.ListenerType
 			switch servicePort.Protocol {
 			case model.ProtocolTCP, model.ProtocolHTTPS, model.ProtocolMongo, model.ProtocolRedis:
+				listenerType = plugin.ListenerTypeTCP
 				if service.Resolution != model.Passthrough {
 					listenAddress = service.Address
 					addresses = []string{service.Address}
@@ -314,6 +322,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 				listenerOpts.networkFilters = buildOutboundNetworkFilters(clusterName, addresses, servicePort)
 				// TODO: Set SNI for HTTPS
 			case model.ProtocolHTTP2, model.ProtocolHTTP, model.ProtocolGRPC:
+				listenerType = plugin.ListenerTypeHTTP
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
 				if l, exists := listenerMap[listenerMapKey]; exists {
 					if !strings.HasPrefix(l.Name, "http") {
@@ -346,17 +355,18 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 			// call plugins
 
 			params := &plugin.CallbackListenerInputParams{
-				Env:  &env,
-				Node: &node,
-			}
-			mutable := &plugin.CallbackListenerMutableObjects{
-				TCPFilters:  listenerOpts.networkFilters,
-				HTTPFilters: listenerOpts.hTTPFilters,
+				ListenerType: listenerType,
+				Env:          &env,
+				Node:         &node,
+				Service:      service,
 			}
 			for _, p := range configgen.Plugins {
-				if err := p.OnOutboundListener(params, mutable); err != nil {
+				nf, hf, err := p.OnOutboundListener(params, nil)
+				if err != nil {
 					log.Error(err.Error())
 				}
+				listenerOpts.networkFilters = append(listenerOpts.networkFilters, nf...)
+				listenerOpts.hTTPFilters = append(listenerOpts.hTTPFilters, hf...)
 			}
 
 			listenerOpts.ip = listenAddress
@@ -498,9 +508,7 @@ type buildListenerOpts struct {
 
 func buildHTTPConnectionManager(opts buildListenerOpts) *http_conn.HttpConnectionManager {
 	mesh := opts.env.Mesh
-	var filters []*http_conn.HttpFilter
-
-	filters = append(filters, opts.hTTPFilters...)
+	filters := opts.hTTPFilters
 
 	filters = append(filters, &http_conn.HttpFilter{
 		Name: xdsutil.CORS,

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -18,6 +18,7 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
 	authn "istio.io/api/authentication/v1alpha1"
@@ -55,15 +56,15 @@ func BuildJwtFilter(policy *authn.Policy) *http_conn.HttpFilter {
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service
 // Can be used to add additional filters on the outbound path
-func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
-	return nil
+func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, listener *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error) {
+	return nil, nil, nil
 }
 
 // OnInboundListener is called whenever a new listener is added to the LDS output for a given service
 // Can be used to add additional filters (e.g., mixer filter) or add more stuff to the HTTP connection manager
 // on the inbound path
-func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
-	return nil
+func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, listener *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error) {
+	return nil, nil, nil
 }
 
 // OnInboundCluster is called whenever a new cluster is added to the CDS output

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -15,12 +15,15 @@
 package mixer
 
 import (
-	"errors"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 
+	"fmt"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	mpb "istio.io/api/mixer/v1"
+	mccpb "istio.io/api/mixer/v1/config/client"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -30,13 +33,15 @@ import (
 // Plugin is a mixer plugin.
 type Plugin struct{}
 
+// NewPlugin returns an ptr to an initialized mixer.Plugin.
+func NewPlugin() *Plugin {
+	return &Plugin{}
+}
+
 // OnOutboundListener implements the Callbacks interface method.
-func (m *Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
-	if in.ServiceInstance == nil || in.ServiceInstance.Service == nil {
-		return errors.New("mixer.Plugin#OnOutboundListener: in.ServiceInstance.Service must be non-nil")
-	}
-	if !in.ServiceInstance.Service.MeshExternal {
-		return nil
+func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, _ *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error) {
+	if in.Service == nil || !in.Service.MeshExternal {
+		return nil, nil, nil
 	}
 
 	env := in.Env
@@ -45,16 +50,16 @@ func (m *Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, muta
 
 	switch in.ListenerType {
 	case plugin.ListenerTypeHTTP:
-		mutable.HTTPFilters = append(mutable.HTTPFilters, buildMixerHTTPFilter(env, node, proxyInstances, true))
+		return nil, []*http_conn.HttpFilter{buildMixerHTTPFilter(env, node, proxyInstances, true)}, nil
 	case plugin.ListenerTypeTCP:
-		mutable.TCPFilters = append(mutable.TCPFilters, buildMixerOutboundTCPFilter(env, node))
+		return []listener.Filter{buildMixerOutboundTCPFilter(env, node)}, nil, nil
 	}
 
-	return nil
+	return nil, nil, fmt.Errorf("unknown listener type %v in mixer.OnOutboundListener", in.ListenerType)
 }
 
 // OnInboundListener implements the Callbacks interface method.
-func (m *Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
+func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, _ *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error) {
 	env := in.Env
 	node := in.Node
 	proxyInstances := in.ProxyInstances
@@ -62,29 +67,29 @@ func (m *Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutab
 
 	switch in.ListenerType {
 	case plugin.ListenerTypeHTTP:
-		mutable.HTTPFilters = append(mutable.HTTPFilters, buildMixerHTTPFilter(env, node, proxyInstances, false))
+		return nil, []*http_conn.HttpFilter{buildMixerHTTPFilter(env, node, proxyInstances, false)}, nil
 
 	case plugin.ListenerTypeTCP:
-		mutable.TCPFilters = append(mutable.TCPFilters, buildMixerInboundTCPFilter(env, node, instance))
+		return []listener.Filter{buildMixerInboundTCPFilter(env, node, instance)}, nil, nil
 	}
 
-	return nil
+	return nil, nil, fmt.Errorf("unknown listener type %v in mixer.OnOutboundListener", in.ListenerType)
 }
 
 // OnOutboundCluster implements the Callbacks interface method.
-func (m *Plugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
+func (*Plugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
 }
 
 // OnInboundCluster implements the Callbacks interface method.
-func (m *Plugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
+func (*Plugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
 }
 
 // OnOutboundRoute implements the Callbacks interface method.
-func (m *Plugin) OnOutboundRoute(env model.Environment, node model.Proxy, route *xdsapi.RouteConfiguration) {
+func (*Plugin) OnOutboundRoute(env model.Environment, node model.Proxy, route *xdsapi.RouteConfiguration) {
 }
 
 // OnInboundRoute implements the Callbacks interface method.
-func (m *Plugin) OnInboundRoute(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
+func (*Plugin) OnInboundRoute(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
 	route *xdsapi.RouteConfiguration) {
 }
 
@@ -97,10 +102,10 @@ func buildMixerHTTPFilter(env *model.Environment, node *model.Proxy,
 		return &http_conn.HttpFilter{}
 	}
 
-	c := v1.BuildHTTPMixerFilterConfig(mesh, *node, proxyInstances, outbound, config)
+	c := buildHTTPMixerFilterConfig(mesh, *node, proxyInstances, outbound, config)
 	return &http_conn.HttpFilter{
 		Name:   v1.MixerFilter,
-		Config: util.BuildProtoStruct(*c),
+		Config: util.MessageToStruct(c),
 	}
 }
 
@@ -111,9 +116,10 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 		return listener.Filter{}
 	}
 
-	c := v1.BuildTCPMixerFilterConfig(mesh, *node, instance)
+	c := buildTCPMixerFilterConfig(mesh, *node, instance)
 	return listener.Filter{
-		Config: util.BuildProtoStruct(*c),
+		Name:   v1.MixerFilter,
+		Config: util.MessageToStruct(c),
 	}
 }
 
@@ -121,4 +127,70 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 func buildMixerOutboundTCPFilter(env *model.Environment, node *model.Proxy) listener.Filter {
 	// TODO(mostrowski): implementation
 	return listener.Filter{}
+}
+
+// BuildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
+// (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.
+func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *mccpb.HttpClientConfig { // nolint: lll
+	transport := &mccpb.TransportConfig{
+		CheckCluster:  v1.MixerCheckClusterName,
+		ReportCluster: v1.MixerReportClusterName,
+	}
+
+	mxConfig := &mccpb.HttpClientConfig{
+		MixerAttributes: &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{},
+		},
+		ServiceConfigs: map[string]*mccpb.ServiceConfig{},
+		Transport:      transport,
+	}
+
+	var labels map[string]string
+	// Note: instances are all running on mode.Node named 'role'
+	// So instance labels are the workload / Node labels.
+	if len(nodeInstances) > 0 {
+		labels = nodeInstances[0].Labels
+		mxConfig.DefaultDestinationService = nodeInstances[0].Service.Hostname
+	}
+
+	if !outboundRoute {
+		// for outboundRoutes there are no default MixerAttributes
+		// specific MixerAttributes are in per route configuration.
+		v1.AddStandardNodeAttributes(mxConfig.MixerAttributes.Attributes, v1.AttrDestinationPrefix, role.IPAddress, role.ID, labels)
+	}
+
+	if role.Type == model.Sidecar && !outboundRoute {
+		// Don't forward mixer attributes to the app from inbound sidecar routes
+	} else {
+		mxConfig.ForwardAttributes = &mpb.Attributes{
+			Attributes: map[string]*mpb.Attributes_AttributeValue{},
+		}
+		v1.AddStandardNodeAttributes(mxConfig.ForwardAttributes.Attributes, v1.AttrSourcePrefix, role.IPAddress, role.ID, labels)
+	}
+
+	for _, instance := range nodeInstances {
+		mxConfig.ServiceConfigs[instance.Service.Hostname] = v1.ServiceConfig(instance.Service.Hostname, instance, config,
+			outboundRoute || mesh.DisablePolicyChecks, outboundRoute)
+	}
+
+	return mxConfig
+}
+
+// buildTCPMixerFilterConfig builds a TCP filter config for inbound requests.
+func buildTCPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, instance *model.ServiceInstance) *mccpb.TcpClientConfig {
+	attrs := v1.StandardNodeAttributes(v1.AttrDestinationPrefix, role.IPAddress, role.ID, nil)
+	attrs[v1.AttrDestinationService] = &mpb.Attributes_AttributeValue{Value: &mpb.Attributes_AttributeValue_StringValue{instance.Service.Hostname}}
+
+	mxConfig := &mccpb.TcpClientConfig{
+		MixerAttributes: &mpb.Attributes{
+			Attributes: attrs,
+		},
+		Transport: &mccpb.TransportConfig{
+			CheckCluster:  v1.MixerCheckClusterName,
+			ReportCluster: v1.MixerReportClusterName,
+		},
+		DisableCheckCalls: mesh.DisablePolicyChecks,
+	}
+
+	return mxConfig
 }

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -26,8 +26,10 @@ import (
 type ListenerType int
 
 const (
+	// ListenerTypeUnknown is an unknown type of listener.
+	ListenerTypeUnknown = iota
 	// ListenerTypeTCP is a TCP listener.
-	ListenerTypeTCP = iota
+	ListenerTypeTCP
 	// ListenerTypeHTTP is an HTTP listener.
 	ListenerTypeHTTP
 )
@@ -46,33 +48,23 @@ type CallbackListenerInputParams struct {
 	ProxyInstances []*model.ServiceInstance
 	// ServiceInstance is the service instance colocated with the listener (applies to sidecar).
 	ServiceInstance *model.ServiceInstance
-}
-
-// CallbackListenerMutableObjects is a set of objects passed to On*Listener callbacks. Fields may be nil or empty.
-// Any lists should not be overridden, but rather only appended to.
-// Non-list fields may be mutated; however it's not recommended to do this since it can affect other plugins in the
-// chain in unpredictable ways.
-type CallbackListenerMutableObjects struct {
-	// HTTPFilters is the slice of HTTP filters for the Listener. Append to only.
-	HTTPFilters []*http_conn.HttpFilter
-	// TCPFilters is the slice of TCP filters for the Listener. Append to only.
-	TCPFilters []listener.Filter
-	// Listener is the listener being built. Any field may be modified, but changing other than appending to slices
-	// is discouraged.
-	Listener *xdsapi.Listener
+	// Service is the service colocated with the listener (applies to sidecar).
+	Service *model.Service
 }
 
 // Plugin is called during the construction of a xdsapi.Listener which may alter the Listener in any
 // way. Examples include AuthenticationPlugin that sets up mTLS authentication on the inbound Listener
 // and outbound Cluster, the mixer plugin that sets up policy checks on the inbound listener, etc.
 type Plugin interface {
-	// OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service
+	// OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service.
+	// It returns a slice of network or HTTP filters that should be appended to the listener filter list.
 	// Can be used to add additional filters on the outbound path.
-	OnOutboundListener(in *CallbackListenerInputParams, mutable *CallbackListenerMutableObjects) error
+	OnOutboundListener(in *CallbackListenerInputParams, listener *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error)
 
 	// OnInboundListener is called whenever a new listener is added to the LDS output for a given service
+	// It returns a slice of network or HTTP filters that should be appended to the listener filter list.
 	// Can be used to add additional filters.
-	OnInboundListener(in *CallbackListenerInputParams, mutable *CallbackListenerMutableObjects) error
+	OnInboundListener(in *CallbackListenerInputParams, listener *xdsapi.Listener) ([]listener.Filter, []*http_conn.HttpFilter, error)
 
 	// OnOutboundCluster is called whenever a new cluster is added to the CDS output
 	// Typically used by AuthN plugin to add mTLS settings

--- a/pilot/pkg/networking/plugin/registry/registry.go
+++ b/pilot/pkg/networking/plugin/registry/registry.go
@@ -20,13 +20,38 @@ package registry
 import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/plugin/authn"
+	"istio.io/istio/pilot/pkg/networking/plugin/mixer"
 )
 
-// NewPlugins returns a list of plugin instance handles. Each plugin implements the plugin.Callbacks interfaces
-func NewPlugins() []plugin.Plugin {
-	plugins := make([]plugin.Plugin, 0)
+// PluginType is a type of filter plugin.
+type PluginType string
+
+const (
+	// AuthnPlugin is an authn plugin.
+	AuthnPlugin PluginType = "authn_plugin"
+	// MixerPlugin is a mixer plugin.
+	MixerPlugin PluginType = "mixer_plugin"
+)
+
+// NewDefaultPlugins returns a slice of default Plugins.
+func NewDefaultPlugins() []plugin.Plugin {
+	var plugins []plugin.Plugin
 	plugins = append(plugins, authn.NewPlugin())
-	// plugins = append(plugins, mixer.NewPlugin())
+	plugins = append(plugins, mixer.NewPlugin())
 	// plugins = append(plugins, apim.NewPlugin())
+	return plugins
+}
+
+// NewPlugins returns a slice of plugins corresponding ot the provided names.
+func NewPlugins(names ...PluginType) []plugin.Plugin {
+	var plugins []plugin.Plugin
+	for _, name := range names {
+		switch name {
+		case AuthnPlugin:
+			plugins = append(plugins, authn.NewPlugin())
+		case MixerPlugin:
+			plugins = append(plugins, mixer.NewPlugin())
+		}
+	}
 	return plugins
 }

--- a/tests/e2e/tests/pilot/a_zipkin_test.go
+++ b/tests/e2e/tests/pilot/a_zipkin_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 const (


### PR DESCRIPTION
This PR includes the following changes:
1. Import some v1 mixer filter code and rewrite in terms of expected v2 envoy format (proto rather than JSON)
2. API change to OnOutboundListener and OnInboundListener. Rather than bundling the filters in a struct, return the filters as a plugin slice. This is more convenient for appending.
3. Various fixes.