### PR TITLE
Add istioctl path in e2e script

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -36,6 +36,6 @@ HUB=gcr.io/istio-release
 cd ${WORKSPACE}/istio.io/istio
 
 for t in ${tests[@]}; do
-  make e2e_${t} E2E_ARGS="--skip_setup --namespace=istio-system"
+  make e2e_${t} E2E_ARGS="--skip_setup --namespace=istio-system --istioctl_url=https://storage.googleapis.com/istio-artifacts/pilot/${TAG}/artifacts/istioctl"
 done
 


### PR DESCRIPTION
Test was failing from k8s test-infra caller because istioctl was not available.
