### PR TITLE
Enable istio work offline.

### DIFF
--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -70,7 +70,7 @@ initContainers:
     unlimited
   command:
   - /bin/sh
-  image: alpine
+  image: {{ .InitImage }}
   imagePullPolicy: IfNotPresent
   name: enable-core-dump
   resources: {}

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"17e7cb1b97c141c3a724ec5e66a230817f3772e81c1cce9e438713d24c27c79f","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
+        sidecar.istio.io/status: '{"version":"0df13cbba48820e26f4142b1397351f6cbdcaa91d012da025bcdf405302b5913","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"]}'
       creationTimestamp: null
       labels:
         app: hello
@@ -105,7 +105,7 @@ spec:
           unlimited
         command:
         - /bin/sh
-        image: alpine
+        image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}


### PR DESCRIPTION
Use `proxy_init` to set system parameters, this can make sure
the image can be customized if the customer env do not have
external internet access.

Fixed https://github.com/istio/istio/issues/4729