### PR TITLE
Change apiversion for destination policies sample in bookinfo

### DIFF
--- a/samples/bookinfo/kube/destination-policy-reviews.yaml
+++ b/samples/bookinfo/kube/destination-policy-reviews.yaml
@@ -1,4 +1,4 @@
-apiVersion: config.istio.io/v1beta1
+apiVersion: config.istio.io/v1alpha2
 kind: DestinationPolicy
 metadata:
   name: reviews-random


### PR DESCRIPTION
In Bookinfo sample, there is an example of definition of a DestinationPolicy (`/samples/bookinfo/kube/destination-policy-reviews.yaml`). 

When creating it into a Open Shift cluster using:

`oc create -f samples/bookinfo/kube/destination-policy-reviews.yaml`

it prompts the following error:

> Error from server (BadRequest): error when creating "samples/bookinfo/kube/destination-policy-reviews.yaml": the API version in the data (config.istio.io/v1beta1) does not match the expected API version (config.istio.io/v1alpha2)

Changing the DestinationPolicy apiVersion from `v1beta1` to `v1alpha2` just fix this issue.