### PR TITLE
Fix istio-proxy imagePullPolicy setting in pilot's helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
 {{- end }}
         - name: istio-proxy
           image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
-          imagePullPolicy: {{ .Values.global.proxy.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
           - containerPort: 15003
           - containerPort: 15005


### PR DESCRIPTION
There is no setting for _.Values.global.proxy.imagePullPolicy_ in values.yaml
https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/values.yaml#L16
(But there is a setting for _.Values.global.imagePullPolicy_ 3 lines ahead.)

I compared this setting with other places where proxy's pull policy is used:
ingress
https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml#L25

Mixer
https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml#L29
https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml#L103
