### PR TITLE
Hook up jwt and authn filter for v2. Move tls context code to authn plugin.

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -277,8 +277,8 @@ func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutabl
 // Can be used to add additional filters (e.g., mixer filter) or add more stuff to the HTTP connection manager
 // on the inbound path
 func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
-	if in.Node.Type != model.Router {
-		// Only care about Router nodes.
+	if in.Node.Type != model.Sidecar {
+		// Only care about sidecar.
 		return nil
 	}
 	authnPolicy := model.GetConsolidateAuthenticationPolicy(

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -255,7 +255,7 @@ func buildSidecarListenerTLSContext(authenticationPolicy *authn.Policy) *auth.Do
 				AlpnProtocols: []string{"h2", "http/1.1"},
 			},
 			RequireClientCertificate: &types.BoolValue{
-				Value: !mTLSParams.AllowTls,
+				Value: !(mTLSParams != nil && mTLSParams.AllowTls),
 			},
 		}
 	}

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -285,7 +285,7 @@ func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable
 		in.Env.Mesh, in.Env.IstioConfigStore, in.ServiceInstance.Service.Hostname, in.ServiceInstance.Endpoint.ServicePort)
 
 	if mutable.Listener == nil || len(mutable.Listener.FilterChains) != 1 {
-		return fmt.Errorf("Expect lister has exactly one filter chain")
+		return fmt.Errorf("expect lister has exactly one filter chain")
 	}
 	mutable.Listener.FilterChains[0].TlsContext = buildSidecarListenerTLSContext(authnPolicy)
 

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -778,7 +778,7 @@ func TestBuildSidecarListenerTLSContex(t *testing.T) {
 			expected: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsCertificates: []*auth.TlsCertificate{
-						&auth.TlsCertificate{
+						{
 							CertificateChain: &core.DataSource{
 								Specifier: &core.DataSource_Filename{
 									Filename: "cert-chain.pem",
@@ -819,7 +819,7 @@ func TestBuildSidecarListenerTLSContex(t *testing.T) {
 			expected: &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
 					TlsCertificates: []*auth.TlsCertificate{
-						&auth.TlsCertificate{
+						{
 							CertificateChain: &core.DataSource{
 								Specifier: &core.DataSource_Filename{
 									Filename: "cert-chain.pem",


### PR DESCRIPTION
- Move buildSidecarListenerTLSContext to authn plugin, add unit test.
- Hook up Jwt and Authn filter to OnInboundListener