### PR TITLE
Update to latest supported GKE version

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -8,7 +8,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ properties['gkeClusterName'] }}
-      initialClusterVersion: 1.9.2-gke.1
+      initialClusterVersion: 1.9.6-gke.0
       legacyAbac:
         enabled: false
       initialNodeCount: {{ properties['initialNodeCount'] }}


### PR DESCRIPTION
According to https://cloud.google.com/kubernetes-engine/release-notes, the current version used is no longer supported; here we update to the next available 1.9 version.

Related to https://github.com/istio/issues/issues/262

/cc @ayj 