### PR TITLE
Fix bug for external access in ADS v2

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -680,6 +680,9 @@ func buildOutboundHTTPRoutes(node model.Proxy,
 	// outbound connections/requests are directed to service ports; we create a
 	// map for each service port to define filters
 	for _, service := range services {
+		if service.MeshExternal {
+			continue
+		}
 		for _, servicePort := range service.Ports {
 			routes := buildDestinationHTTPRoutes(node, service, servicePort, proxyInstances,
 				config, envoyv2, BuildOutboundCluster)

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -680,9 +680,6 @@ func buildOutboundHTTPRoutes(node model.Proxy,
 	// outbound connections/requests are directed to service ports; we create a
 	// map for each service port to define filters
 	for _, service := range services {
-		if service.MeshExternal {
-			continue
-		}
 		for _, servicePort := range service.Ports {
 			routes := buildDestinationHTTPRoutes(node, service, servicePort, proxyInstances,
 				config, envoyv2, BuildOutboundCluster)

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -62,6 +62,7 @@ type XdsConnection struct {
 	//HttpConnectionManagers map[string]*http_conn.HttpConnectionManager
 
 	HTTPListeners []*xdsapi.Listener
+	HTTPClusters  []*xdsapi.Cluster
 	RouteConfigs  map[string][]*xdsapi.RouteConfiguration
 
 	// current list of clusters monitored by the client

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -47,6 +47,7 @@ func (con *XdsConnection) clusters(response []*xdsapi.Cluster) *xdsapi.Discovery
 func (s *DiscoveryServer) pushCds(node model.Proxy, con *XdsConnection) error {
 	rawClusters, _ := s.ConfigGenerator.BuildClusters(s.env, *con.modelNode)
 
+	con.HTTPClusters = rawClusters
 	response := con.clusters(rawClusters)
 	err := con.stream.Send(response)
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -47,7 +47,6 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 	})
 
 	mux.HandleFunc("/debug/edsz", EDSz)
-
 	mux.HandleFunc("/debug/adsz", adsz)
 	mux.HandleFunc("/debug/cdsz", cdsz)
 

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -49,6 +49,7 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 	mux.HandleFunc("/debug/edsz", EDSz)
 
 	mux.HandleFunc("/debug/adsz", adsz)
+	mux.HandleFunc("/debug/cdsz", cdsz)
 
 	mux.HandleFunc("/debug/registryz", s.registryz)
 	mux.HandleFunc("/debug/endpointz", s.endpointz)
@@ -398,4 +399,43 @@ func adsz(w http.ResponseWriter, req *http.Request) {
 	//}
 	//
 	//_, _ = w.Write(data)
+}
+
+// cdsz implements a status and debug interface for CDS.
+// It is mapped to /debug/cdsz
+func cdsz(w http.ResponseWriter, req *http.Request) {
+	_ = req.ParseForm()
+	adsClientsMutex.RLock()
+
+	fmt.Fprint(w, "[\n")
+	comma2 := false
+	for _, c := range adsClients {
+		if comma2 {
+			fmt.Fprint(w, ",\n")
+		} else {
+			comma2 = true
+		}
+		fmt.Fprintf(w, "\n\n  {\"node\": \"%s\", \"addr\": \"%s\", \"connect\": \"%v\",\"Clusters\":[\n", c.ConID, c.PeerAddr, c.Connect)
+		comma1 := false
+		for _, cl := range c.HTTPClusters {
+			if cl == nil {
+				log.Errorf("INVALID Cluster NIL")
+				continue
+			}
+			if comma1 {
+				fmt.Fprint(w, ",\n")
+			} else {
+				comma1 = true
+			}
+			jsonm := &jsonpb.Marshaler{Indent: "  "}
+			dbgString, _ := jsonm.MarshalToString(cl)
+			if _, err := w.Write([]byte(dbgString)); err != nil {
+				return
+			}
+		}
+		fmt.Fprint(w, "]}\n")
+	}
+	fmt.Fprint(w, "]\n")
+
+	adsClientsMutex.RUnlock()
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -16,8 +16,8 @@ package v2
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -30,6 +30,7 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
@@ -424,14 +425,20 @@ func EDSz(w http.ResponseWriter, req *http.Request) {
 		edsPushAll()
 	}
 	edsClusterMutex.Lock()
-	data, err := json.Marshal(edsClusters)
-	edsClusterMutex.Unlock()
-	if err != nil {
-		_, _ = w.Write([]byte(err.Error()))
-		return
+	comma1 := false
+	for _, eds := range edsClusters {
+		if comma1 {
+			fmt.Fprint(w, ",\n")
+		} else {
+			comma1 = true
+		}
+		jsonm := &jsonpb.Marshaler{Indent: "  "}
+		dbgString, _ := jsonm.MarshalToString(eds.LoadAssignment)
+		if _, err := w.Write([]byte(dbgString)); err != nil {
+			return
+		}
 	}
-
-	_, _ = w.Write(data)
+	edsClusterMutex.Unlock()
 }
 
 // addEdsCon will track the eds connection with clusters, for optimized event-based push and debug


### PR DESCRIPTION
for external access with v1, duplicate entries are created with one using original_dst, the other with sds. The one with sds shouldn't be created.

For v2, if multiple external accesses are configured, then duplicate entries of www and www:80 will be created in the domains, this will confuse envoy and as a result, external access is not possible if more than one external accesses are configured.

Also added support of edsz and cdsz for debugging purpose.