### PR TITLE
Add make init and switch test version

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -34,6 +34,9 @@ declare -a tests
 HUB=gcr.io/istio-release
 
 cd ${WORKSPACE}/istio.io/istio
+git checkout ${TAG}
+make submodule-sync
+make init
 
 for t in ${tests[@]}; do
   make e2e_${t} E2E_ARGS="--skip_setup --namespace=istio-system --istioctl_url=https://storage.googleapis.com/istio-artifacts/pilot/${TAG}/artifacts/istioctl"


### PR DESCRIPTION
make e2e_ doesn't work without init and vendor being in sync. 
Also checking out previous version of tests to make sure running test version is aligned with TAG.