### PR TITLE
fixing os detection in init_helm

### DIFF
--- a/bin/init_helm.sh
+++ b/bin/init_helm.sh
@@ -45,12 +45,12 @@ export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 export GOARCH=${GOARCH:-'amd64'}
 
 # Determine the OS. Matches logic in the Makefile.
-LOCAL_OS="`uname`"
+LOCAL_OS=${OSTYPE}
 case $LOCAL_OS in
-  'Linux')
+  "linux"*)
     LOCAL_OS='linux'
     ;;
-  'Darwin')
+  "darwin"*)
     LOCAL_OS='darwin'
     ;;
   *)


### PR DESCRIPTION
Fixing OSTYPE detection in order to retrieve correct helm binary.