### PR TITLE
Inject ExternalService for jwksUri from authn policy.

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -297,6 +297,9 @@ type IstioConfigStore interface {
 	// one with the same scope, the first one seen will be used (later, we should
 	// have validation at submitting time to prevent this scenario from happening)
 	AuthenticationPolicyByDestination(hostname string, port *Port) *Config
+
+	// AllAuthenticationPolicies retuns all authentication policies.
+	AllAuthenticationPolicies() []Config
 }
 
 const (
@@ -1038,6 +1041,14 @@ func (store *istioConfigStore) QuotaSpecByDestination(instance *ServiceInstance)
 	}
 
 	return out
+}
+
+func (store *istioConfigStore) AllAuthenticationPolicies() []Config {
+	configs, err := store.List(AuthenticationPolicy.Type, NamespaceAll)
+	if err != nil {
+		return nil
+	}
+	return configs
 }
 
 func (store *istioConfigStore) AuthenticationPolicyByDestination(hostname string, port *Port) *Config {

--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -15,6 +15,7 @@
 package external
 
 import (
+	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
@@ -41,7 +42,13 @@ func (d *externalDiscovery) Services() ([]*model.Service, error) {
 
 		services = append(services, convertService(externalService)...)
 	}
-
+	allAuthnConfigs := d.store.AllAuthenticationPolicies()
+	for _, authnPolicyConfig := range allAuthnConfigs {
+		authnPolicy := authnPolicyConfig.Spec.(*authn.Policy)
+		for _, externalService := range extractExternalService(authnPolicy) {
+			services = append(services, convertService(externalService)...)
+		}
+	}
 	return services, nil
 }
 
@@ -69,6 +76,13 @@ func (d *externalDiscovery) getServices() []*model.Service {
 	for _, externalServiceConfig := range configs {
 		externalService := externalServiceConfig.Spec.(*networking.ExternalService)
 		services = append(services, convertService(externalService)...)
+	}
+	allAuthnConfigs := d.store.AllAuthenticationPolicies()
+	for _, authnPolicyConfig := range allAuthnConfigs {
+		authnPolicy := authnPolicyConfig.Spec.(*authn.Policy)
+		for _, externalService := range extractExternalService(authnPolicy) {
+			services = append(services, convertService(externalService)...)
+		}
 	}
 	return services
 }


### PR DESCRIPTION
This is still work in progress. Few concerns:

1. Should ExternalName be set for external services?

1. Is there a way to set SSLContext (and equivalent in v2) without destination rule? Port already has such information (protocol is http or https), can we use it?

1. Can ExternalService have subset labels? In other words, is there a reliable way to construct cluster name for it from host and port? (for more detail, we need to pass this cluster name to the jwt config for envoy)

1. Will externalServices and their clusters be dedupped?