### PR TITLE
Update cd to be relative to script

### DIFF
--- a/tests/e2e_istio_preinstalled.sh
+++ b/tests/e2e_istio_preinstalled.sh
@@ -33,7 +33,7 @@ declare -a tests
 
 HUB=gcr.io/istio-release
 
-cd ${WORKSPACE}/istio.io/istio
+cd $(dirname ${BASH_SOURCE[0]})/..
 git checkout ${TAG}
 make submodule-sync
 make init


### PR DESCRIPTION
Now istio is being checked out to a different path relative to $WORKSPACE - so removing that and making root path relative to script itself.