### PR TITLE
Creates a remote connection for multicluster e2e

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -195,7 +195,7 @@ func (c *CommonConfig) saveLogs(r int) error {
 		log.Errorf("Could not create status file. Error %s", err)
 		return err
 	}
-	return c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace)
+	return c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.KubeConfig)
 }
 
 // RunTest sets up all registered cleanables in FIFO order

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -28,7 +29,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
 
+	"istio.io/istio/pilot/pkg/config/clusterregistry"
+	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/util"
 )
@@ -70,6 +74,7 @@ var (
 	clusterWide         = flag.Bool("cluster_wide", false, "Run cluster wide tests")
 	withMixerValidator  = flag.Bool("with_mixer_validator", false, "Set up mixer validator")
 	imagePullPolicy     = flag.String("image_pull_policy", "", "Specifies an override for the Docker image pull policy to be used")
+	multiClusterDir     = flag.String("cluster_registry_dir", "", "Directory name for the cluster registry config")
 
 	addons = []string{
 		"zipkin",
@@ -108,6 +113,12 @@ type KubeInfo struct {
 	// A map of app label values to the pods for that app
 	appPods      map[string][]string
 	appPodsMutex sync.Mutex
+
+	KubeConfig       string
+	KubeClient       kubernetes.Interface
+	RemoteKubeConfig string
+	RemoteKubeClient kubernetes.Interface
+	RemoteAppManager *AppManager
 }
 
 // newKubeInfo create a new KubeInfo by given temp dir and runID
@@ -125,7 +136,7 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	a := NewAppManager(tmpDir, *namespace, i)
+
 	// Download the base release if baseVersion is specified.
 	var releaseDir string
 	if baseVersion != "" {
@@ -142,6 +153,50 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 	} else {
 		releaseDir = util.GetResourcePath("")
 	}
+	var kubeConfig, remoteKubeConfig string
+	var kubeClient, remoteKubeClient kubernetes.Interface
+	var aRemote *AppManager
+	if *multiClusterDir != "" {
+		// ClusterRegistiresDir indicates the Kubernetes cluster config should come from files versus KUBECONFIG
+		// environmental variable.  The test config can be defined to use either a single cluster or 2 clusters
+		var clusterStore *clusterregistry.ClusterStore
+		clusterStore, err = clusterregistry.ReadClusters(*multiClusterDir)
+		if clusterStore == nil {
+			log.Errorf("Failed to clusters in the ClusterRegistriesDir %s\n", *multiClusterDir)
+			return nil, err
+		}
+		if clusterStore != nil {
+			kubeConfig = clusterStore.GetPilotAccessConfig()
+			kubeConfig = path.Join(*multiClusterDir, kubeConfig)
+			//				kubeConfig = kubeCfgFile
+			if _, kubeClient, err = kube.CreateInterface(kubeConfig); err != nil {
+				return nil, err
+			}
+			// Note only a single remote cluster is currently supported.
+			clusters := clusterStore.GetPilotClusters()
+			for _, cluster := range clusters {
+				kubeconfig := clusterregistry.GetClusterAccessConfig(cluster)
+				remoteKubeConfig = path.Join(*multiClusterDir, kubeconfig)
+				log.Infof("Cluster name: %s, AccessConfigFile: %s", clusterregistry.GetClusterName(cluster), remoteKubeConfig)
+				// Expecting only a single remote cluster so hard code this.  The code won't throw an error
+				// if more than 2 clusters are defined in the config files, but will only use the last cluster parsed.
+				if _, remoteKubeClient, err = kube.CreateInterface(remoteKubeConfig); err != nil {
+					return nil, err
+				}
+			}
+		}
+		aRemote = NewAppManager(tmpDir, *namespace, i, remoteKubeConfig)
+	} else {
+		tmpfile := *namespace + "_kubeconfig"
+		tmpfile = path.Join(tmpDir, tmpfile)
+		if err = util.GetKubeConfig(tmpfile); err != nil {
+			return nil, err
+		}
+		kubeConfig = tmpfile
+	}
+
+	a := NewAppManager(tmpDir, *namespace, i, kubeConfig)
+
 	log.Infof("Using release dir: %s", releaseDir)
 	return &KubeInfo{
 		Namespace:        *namespace,
@@ -151,10 +206,15 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		localCluster:     *localCluster,
 		Istioctl:         i,
 		AppManager:       a,
+		RemoteAppManager: aRemote,
 		AuthEnabled:      *authEnable,
 		RBACEnabled:      *rbacEnable,
 		ReleaseDir:       releaseDir,
 		BaseVersion:      baseVersion,
+		KubeConfig:       kubeConfig,
+		KubeClient:       kubeClient,
+		RemoteKubeConfig: remoteKubeConfig,
+		RemoteKubeClient: remoteKubeClient,
 	}, nil
 }
 
@@ -193,7 +253,7 @@ func (k *KubeInfo) Setup() error {
 		certDir := util.GetResourcePath("./tests/testdata/certs")
 		certFile := filepath.Join(certDir, "cert.crt")
 		keyFile := filepath.Join(certDir, "cert.key")
-		if _, err = util.CreateTLSSecret(ingressCertsName, k.IstioSystemNamespace(), keyFile, certFile); err != nil {
+		if _, err = util.CreateTLSSecret(ingressCertsName, k.IstioSystemNamespace(), keyFile, certFile, k.KubeConfig); err != nil {
 			log.Warn("Secret already exists")
 		}
 		if *withMixerValidator {
@@ -253,9 +313,9 @@ func (k *KubeInfo) Ingress() (string, error) {
 	}
 
 	if k.localCluster {
-		k.ingress, k.ingressErr = util.GetIngressPod(k.Namespace)
+		k.ingress, k.ingressErr = util.GetIngressPod(k.Namespace, k.KubeConfig)
 	} else {
-		k.ingress, k.ingressErr = util.GetIngress(k.Namespace)
+		k.ingress, k.ingressErr = util.GetIngress(k.Namespace, k.KubeConfig)
 	}
 
 	// So far we only do http ingress
@@ -277,7 +337,7 @@ func (k *KubeInfo) Teardown() error {
 	if *useAutomaticInjection {
 		testSidecarInjectorYAML := filepath.Join(k.TmpDir, "yaml", *sidecarInjectorFile)
 
-		if err := util.KubeDelete(k.Namespace, testSidecarInjectorYAML); err != nil {
+		if err := util.KubeDelete(k.Namespace, testSidecarInjectorYAML, k.KubeConfig); err != nil {
 			log.Errorf("Istio sidecar injector %s deletion failed", testSidecarInjectorYAML)
 			return err
 		}
@@ -292,27 +352,33 @@ func (k *KubeInfo) Teardown() error {
 
 		testIstioYaml := filepath.Join(k.TmpDir, "yaml", istioYaml)
 
-		if err := util.KubeDelete(k.Namespace, testIstioYaml); err != nil {
+		if err := util.KubeDelete(k.Namespace, testIstioYaml, k.KubeConfig); err != nil {
 			log.Infof("Safe to ignore resource not found errors in kubectl delete -f %s", testIstioYaml)
 		}
 	} else {
-		if err := util.DeleteNamespace(k.Namespace); err != nil {
+		if err := util.DeleteNamespace(k.Namespace, k.KubeConfig); err != nil {
 			log.Errorf("Failed to delete namespace %s", k.Namespace)
 			return err
 		}
+		if *multiClusterDir != "" {
+			if err := util.DeleteNamespace(k.Namespace, k.RemoteKubeConfig); err != nil {
+				log.Errorf("Failed to delete namespace %s on remote cluster", k.Namespace)
+				return err
+			}
+		}
 
 		// ClusterRoleBindings are not namespaced and need to be deleted separately
-		if _, err := util.Shell("kubectl get clusterrolebinding -o jsonpath={.items[*].metadata.name}"+
-			"|xargs -n 1|fgrep %s|xargs kubectl delete clusterrolebinding",
-			k.Namespace); err != nil {
+		if _, err := util.Shell("kubectl get --kubeconfig=%s clusterrolebinding -o jsonpath={.items[*].metadata.name}"+
+			"|xargs -n 1|fgrep %s|xargs kubectl delete --kubeconfig=%s clusterrolebinding", k.KubeConfig,
+			k.Namespace, k.KubeConfig); err != nil {
 			log.Errorf("Failed to delete clusterrolebindings associated with namespace %s", k.Namespace)
 			return err
 		}
 
 		// ClusterRoles are not namespaced and need to be deleted separately
-		if _, err := util.Shell("kubectl get clusterrole -o jsonpath={.items[*].metadata.name}"+
-			"|xargs -n 1|fgrep %s|xargs kubectl delete clusterrole",
-			k.Namespace); err != nil {
+		if _, err := util.Shell("kubectl get --kubeconfig=%s clusterrole -o jsonpath={.items[*].metadata.name}"+
+			"|xargs -n 1|fgrep %s|xargs kubectl delete --kubeconfig=%s clusterrole", k.KubeConfig,
+			k.Namespace, k.KubeConfig); err != nil {
 			log.Errorf("Failed to delete clusterroles associated with namespace %s", k.Namespace)
 			return err
 		}
@@ -323,7 +389,7 @@ func (k *KubeInfo) Teardown() error {
 	namespaceDeleted := false
 	log.Infof("Deleting namespace %v", k.Namespace)
 	for attempts := 1; attempts <= maxAttempts; attempts++ {
-		namespaceDeleted, _ = util.NamespaceDeleted(k.Namespace)
+		namespaceDeleted, _ = util.NamespaceDeleted(k.Namespace, k.KubeConfig)
 		if namespaceDeleted {
 			break
 		}
@@ -347,7 +413,7 @@ func (k *KubeInfo) GetAppPods() map[string][]string {
 
 	if len(newMap) == 0 {
 		var err error
-		if newMap, err = util.GetAppPods(k.Namespace); err != nil {
+		if newMap, err = util.GetAppPods(k.Namespace, k.KubeConfig); err != nil {
 			log.Errorf("Failed to get retrieve the app pods for namespace %s", k.Namespace)
 		} else {
 			// Copy the new results to the internal map.
@@ -368,7 +434,7 @@ func (k *KubeInfo) GetRoutes(app string) (string, error) {
 	pod := appPods[app][0]
 
 	routesURL := "http://localhost:15000/routes"
-	routes, err := util.PodExec(k.Namespace, pod, "app", fmt.Sprintf("client -url %s", routesURL), true)
+	routes, err := util.PodExec(k.Namespace, pod, "app", fmt.Sprintf("client -url %s", routesURL), true, k.KubeConfig)
 	if err != nil {
 		return "", errors.WithMessage(err, "failed to get routes")
 	}
@@ -420,7 +486,7 @@ func (k *KubeInfo) deployAddons() error {
 			log.Errorf("Cannot write into file %s", yamlFile)
 		}
 
-		if err := util.KubeApply(k.Namespace, yamlFile); err != nil {
+		if err := util.KubeApply(k.Namespace, yamlFile, k.KubeConfig); err != nil {
 			log.Errorf("Kubectl apply %s failed", yamlFile)
 			return err
 		}
@@ -450,12 +516,19 @@ func (k *KubeInfo) deployIstio() error {
 		return err
 	}
 
-	if err := util.CreateNamespace(k.Namespace); err != nil {
+	if err := util.CreateNamespace(k.Namespace, k.KubeConfig); err != nil {
 		log.Errorf("Unable to create namespace %s: %s", k.Namespace, err.Error())
 		return err
 	}
 
-	if err := util.KubeApply(k.Namespace, testIstioYaml); err != nil {
+	if *multiClusterDir != "" {
+		if err := util.CreateNamespace(k.Namespace, k.RemoteKubeConfig); err != nil {
+			log.Errorf("Unable to create namespace %s on remote cluster: %s", k.Namespace, err.Error())
+			return err
+		}
+	}
+
+	if err := util.KubeApply(k.Namespace, testIstioYaml, k.KubeConfig); err != nil {
 		log.Errorf("Istio core %s deployment failed", testIstioYaml)
 		return err
 	}
@@ -472,7 +545,7 @@ func (k *KubeInfo) deployIstio() error {
 				log.Errorf("Generating yaml %s failed", testMixerValidatorYaml)
 				return err
 			}
-			if err := util.KubeApply(k.Namespace, testMixerValidatorYaml); err != nil {
+			if err := util.KubeApply(k.Namespace, testMixerValidatorYaml, k.KubeConfig); err != nil {
 				log.Errorf("Istio mixer validator %s deployment failed", testMixerValidatorYaml)
 				return err
 			}
@@ -486,12 +559,12 @@ func (k *KubeInfo) deployIstio() error {
 			log.Errorf("Generating sidecar injector yaml failed")
 			return err
 		}
-		if err := util.KubeApply(k.Namespace, testSidecarInjectorYAML); err != nil {
+		if err := util.KubeApply(k.Namespace, testSidecarInjectorYAML, k.KubeConfig); err != nil {
 			log.Errorf("Istio sidecar injector %s deployment failed", testSidecarInjectorYAML)
 			return err
 		}
 	}
-	return util.CheckDeployments(k.Namespace, maxDeploymentRolloutTime)
+	return util.CheckDeployments(k.Namespace, maxDeploymentRolloutTime, k.KubeConfig)
 }
 
 func updateInjectImage(name, module, hub, tag string, content []byte) []byte {

--- a/tests/e2e/framework/testInfo.go
+++ b/tests/e2e/framework/testInfo.go
@@ -98,8 +98,8 @@ func (t testInfo) Update(r int) error {
 	return t.createStatusFile(r)
 }
 
-func (t testInfo) FetchAndSaveClusterLogs(namespace string) error {
-	return util.FetchAndSaveClusterLogs(namespace, t.TempDir)
+func (t testInfo) FetchAndSaveClusterLogs(namespace string, kubeconfig string) error {
+	return util.FetchAndSaveClusterLogs(namespace, t.TempDir, kubeconfig)
 }
 
 func (t testInfo) createStatusFile(r int) error {

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -122,7 +122,7 @@ func (t *testConfig) Setup() error {
 
 	}
 
-	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+	if !util.CheckPodsRunning(tc.Kube.Namespace, tc.Kube.KubeConfig) {
 		return fmt.Errorf("can't get all pods running")
 	}
 
@@ -264,7 +264,7 @@ func deleteRules(ruleKeys []string) error {
 	var err error
 	for _, ruleKey := range ruleKeys {
 		rule := filepath.Join(tc.rulesDir, ruleKey+"."+yamlExtension)
-		if e := util.KubeDelete(tc.Kube.Namespace, rule); e != nil {
+		if e := util.KubeDelete(tc.Kube.Namespace, rule, tc.Kube.KubeConfig); e != nil {
 			err = multierror.Append(err, e)
 		}
 	}
@@ -276,7 +276,7 @@ func deleteRules(ruleKeys []string) error {
 func applyRules(ruleKeys []string) error {
 	for _, ruleKey := range ruleKeys {
 		rule := filepath.Join(tc.rulesDir, ruleKey+"."+yamlExtension)
-		if err := util.KubeApply(tc.Kube.Namespace, rule); err != nil {
+		if err := util.KubeApply(tc.Kube.Namespace, rule, tc.Kube.KubeConfig); err != nil {
 			//log.Errorf("Kubectl apply %s failed", rule)
 			return err
 		}

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -309,7 +309,7 @@ func setTestConfig() error {
 }
 
 func (t *testConfig) Setup() (err error) {
-	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+	if !util.CheckPodsRunning(tc.Kube.Namespace, tc.Kube.KubeConfig) {
 		return fmt.Errorf("could not get all pods running")
 	}
 
@@ -381,7 +381,7 @@ func (p *promProxy) portForward(labelSelector string, localPort string, remotePo
 }
 
 func (p *promProxy) Setup() error {
-	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+	if !util.CheckPodsRunning(tc.Kube.Namespace, tc.Kube.KubeConfig) {
 		return errors.New("could not establish port-forward to prometheus: pods not running")
 	}
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -121,7 +121,7 @@ func (t *testConfig) Setup() (err error) {
 
 	err = createDefaultRoutingRules()
 
-	if err = util.WaitForDeploymentsReady(tc.Kube.Namespace, time.Minute*2); err != nil {
+	if err = util.WaitForDeploymentsReady(tc.Kube.Namespace, time.Minute*2, tc.Kube.KubeConfig); err != nil {
 		return fmt.Errorf("pods not ready: %v", err)
 	}
 
@@ -234,7 +234,7 @@ func (p *promProxy) portForward(labelSelector string, localPort string, remotePo
 func (p *promProxy) Setup() error {
 	var err error
 
-	if err = util.WaitForDeploymentsReady(tc.Kube.Namespace, time.Minute*2); err != nil {
+	if err = util.WaitForDeploymentsReady(tc.Kube.Namespace, time.Minute*2, tc.Kube.KubeConfig); err != nil {
 		return fmt.Errorf("could not establish prometheus proxy: pods not ready: %v", err)
 	}
 
@@ -1008,17 +1008,17 @@ func fqdn(service string) string {
 
 func createRouteRule(ruleName string) error {
 	rule := filepath.Join(tc.rulesDir, ruleName+"."+yamlExtension)
-	return util.KubeApply(tc.Kube.Namespace, rule)
+	return util.KubeApply(tc.Kube.Namespace, rule, tc.Kube.KubeConfig)
 }
 
 func replaceRouteRule(ruleName string) error {
 	rule := filepath.Join(tc.rulesDir, ruleName+"."+yamlExtension)
-	return util.KubeApply(tc.Kube.Namespace, rule)
+	return util.KubeApply(tc.Kube.Namespace, rule, tc.Kube.KubeConfig)
 }
 
 func deleteRouteRule(ruleName string) error {
 	rule := filepath.Join(tc.rulesDir, ruleName+"."+yamlExtension)
-	return util.KubeDelete(tc.Kube.Namespace, rule)
+	return util.KubeDelete(tc.Kube.Namespace, rule, tc.Kube.KubeConfig)
 }
 
 func deleteMixerRule(ruleName string) error {
@@ -1029,7 +1029,7 @@ func applyMixerRule(ruleName string) error {
 	return doMixerRule(ruleName, util.KubeApplyContents)
 }
 
-type kubeDo func(namespace string, contents string) error
+type kubeDo func(namespace string, contents string, kubeconfig string) error
 
 // doMixerRule
 // New mixer rules contain fully qualified pointers to other
@@ -1046,7 +1046,7 @@ func doMixerRule(ruleName string, do kubeDo) error {
 		return fmt.Errorf("%s must contain %s so the it can replaced", rule, templateNamespace)
 	}
 	contents = strings.Replace(contents, templateNamespace, tc.Kube.Namespace, -1)
-	return do(tc.Kube.Namespace, contents)
+	return do(tc.Kube.Namespace, contents, tc.Kube.KubeConfig)
 }
 
 func getBookinfoResourcePath(resource string) string {

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -25,8 +25,9 @@ func TestAuthNPolicy(t *testing.T) {
 	}
 
 	cfgs := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{"testdata/v1alpha1/authn-policy.yaml.tmpl"},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{"testdata/v1alpha1/authn-policy.yaml.tmpl"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/egress_rules_test.go
+++ b/tests/e2e/tests/pilot/egress_rules_test.go
@@ -103,8 +103,9 @@ func TestEgress(t *testing.T) {
 
 			// Apply the new rule
 			cfgs = &deployableConfig{
-				Namespace: tc.Kube.Namespace,
-				YamlFiles: []string{ruleYaml},
+				Namespace:  tc.Kube.Namespace,
+				YamlFiles:  []string{ruleYaml},
+				kubeconfig: tc.Kube.KubeConfig,
 			}
 			if err := cfgs.Setup(); err != nil {
 				t.Fatal(err)

--- a/tests/e2e/tests/pilot/ingress_test.go
+++ b/tests/e2e/tests/pilot/ingress_test.go
@@ -36,6 +36,7 @@ func TestIngress(t *testing.T) {
 		YamlFiles: []string{
 			"testdata/ingress.yaml",
 			"testdata/v1alpha1/rule-default-route.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/istio_rbac_test.go
+++ b/tests/e2e/tests/pilot/istio_rbac_test.go
@@ -46,8 +46,9 @@ func TestRBAC(t *testing.T) {
 
 	// Push all of the configs
 	cfgs := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{rbackEnableYaml, rbackRulesYaml},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{rbackEnableYaml, rbackRulesYaml},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/kubernetes_external_name_services_test.go
+++ b/tests/e2e/tests/pilot/kubernetes_external_name_services_test.go
@@ -32,8 +32,9 @@ func TestRewriteExternalService(t *testing.T) {
 
 	// Apply the rule
 	cfgs := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{"testdata/v1alpha1/rule-rewrite-authority-externalbin.yaml"},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{"testdata/v1alpha1/rule-rewrite-authority-externalbin.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	if err := cfgs.Setup(); err != nil {

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -104,6 +104,7 @@ func setTestConfig() error {
 			"testdata/external-wikipedia.yaml",
 			"testdata/externalbin.yaml",
 		},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	return nil
 }
@@ -150,9 +151,10 @@ func runRetriableTest(t *testing.T, testName string, retries int, f func() error
 
 // deployableConfig is a collection of configs that are applied/deleted as a single unit.
 type deployableConfig struct {
-	Namespace string
-	YamlFiles []string
-	applied   []string
+	Namespace  string
+	YamlFiles  []string
+	applied    []string
+	kubeconfig string
 }
 
 // Setup pushes the config and waits for it to propagate to all nodes in the cluster.
@@ -161,7 +163,7 @@ func (c *deployableConfig) Setup() error {
 
 	// Apply the configs.
 	for _, yamlFile := range c.YamlFiles {
-		if err := util.KubeApply(c.Namespace, yamlFile); err != nil {
+		if err := util.KubeApply(c.Namespace, yamlFile, c.kubeconfig); err != nil {
 			// Run the teardown function now and return
 			_ = c.Teardown()
 			return err
@@ -187,7 +189,7 @@ func (c *deployableConfig) Teardown() error {
 func (c *deployableConfig) TeardownNoDelay() error {
 	var err error
 	for _, yamlFile := range c.applied {
-		err = multierr.Append(err, util.KubeDelete(c.Namespace, yamlFile))
+		err = multierr.Append(err, util.KubeDelete(c.Namespace, yamlFile, c.kubeconfig))
 	}
 	c.applied = []string{}
 	return err
@@ -213,7 +215,7 @@ func (t *testConfig) Setup() error {
 	err := t.extraConfig.Setup()
 
 	// Wait for all the pods to be in the running state before starting tests.
-	if err == nil && !util.CheckPodsRunning(t.Kube.Namespace) {
+	if err == nil && !util.CheckPodsRunning(t.Kube.Namespace, t.Kube.KubeConfig) {
 		err = fmt.Errorf("can't get all pods running")
 	}
 
@@ -295,7 +297,7 @@ func ClientRequest(app, url string, count int, extra string) ClientResponse {
 
 	pod := pods[0]
 	cmd := fmt.Sprintf("client -url %s -count %d %s", url, count, extra)
-	request, err := util.PodExec(tc.Kube.Namespace, pod, "app", cmd, true)
+	request, err := util.PodExec(tc.Kube.Namespace, pod, "app", cmd, true, tc.Kube.KubeConfig)
 	if err != nil {
 		log.Errorf("client request error %v for %s in %s", err, url, app)
 		return out
@@ -390,7 +392,7 @@ func (a *accessLogs) checkLogs(t *testing.T) {
 func (a *accessLogs) getAppPods(t *testing.T, app string) []string {
 	if app == ingressAppName {
 		// Ingress is uses the "istio" label, not an "app" label.
-		pods, err := util.GetIngressPodNames(tc.Kube.Namespace)
+		pods, err := util.GetIngressPodNames(tc.Kube.Namespace, tc.Kube.KubeConfig)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -429,7 +431,7 @@ func (a *accessLogs) checkLog(t *testing.T, app string, pods []string) {
 		var logs string
 		for _, pod := range pods {
 			// Retrieve the logs from the service container
-			logs += util.GetPodLogs(tc.Kube.Namespace, pod, container, false, false)
+			logs += util.GetPodLogs(tc.Kube.Namespace, pod, container, false, false, tc.Kube.KubeConfig)
 		}
 
 		for id, want := range counts {

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -42,8 +42,9 @@ func TestRoutes(t *testing.T) {
 
 		// Apply the new rule
 		cfgs = &deployableConfig{
-			Namespace: tc.Kube.Namespace,
-			YamlFiles: []string{ruleYaml},
+			Namespace:  tc.Kube.Namespace,
+			YamlFiles:  []string{ruleYaml},
+			kubeconfig: tc.Kube.KubeConfig,
 		}
 		if err := cfgs.Setup(); err != nil {
 			t.Fatal(err)
@@ -175,8 +176,9 @@ func TestRoutes(t *testing.T) {
 			if version == "v1alpha3" {
 				destRule := "testdata/v1alpha3/destination-rule-c.yaml"
 				cfgs := &deployableConfig{
-					Namespace: tc.Kube.Namespace,
-					YamlFiles: []string{destRule},
+					Namespace:  tc.Kube.Namespace,
+					YamlFiles:  []string{destRule},
+					kubeconfig: tc.Kube.KubeConfig,
 				}
 				if err := cfgs.Setup(); err != nil {
 					t.Fatal(err)
@@ -248,8 +250,9 @@ func TestRouteFaultInjection(t *testing.T) {
 		func() {
 			ruleYaml := fmt.Sprintf("testdata/%s/rule-fault-injection.yaml", version)
 			cfgs := &deployableConfig{
-				Namespace: tc.Kube.Namespace,
-				YamlFiles: []string{ruleYaml},
+				Namespace:  tc.Kube.Namespace,
+				YamlFiles:  []string{ruleYaml},
+				kubeconfig: tc.Kube.KubeConfig,
 			}
 			if err := cfgs.Setup(); err != nil {
 				t.Fatal(err)
@@ -289,8 +292,9 @@ func TestRouteRedirectInjection(t *testing.T) {
 			// Push the rule config.
 			ruleYaml := fmt.Sprintf("testdata/%s/rule-redirect-injection.yaml", version)
 			cfgs := &deployableConfig{
-				Namespace: tc.Kube.Namespace,
-				YamlFiles: []string{ruleYaml},
+				Namespace:  tc.Kube.Namespace,
+				YamlFiles:  []string{ruleYaml},
+				kubeconfig: tc.Kube.KubeConfig,
 			}
 			if err := cfgs.Setup(); err != nil {
 				t.Fatal(err)
@@ -341,8 +345,9 @@ func TestRouteMirroring(t *testing.T) {
 			// Push the rule config.
 			ruleYaml := fmt.Sprintf("testdata/%s/rule-default-route-mirrored.yaml", version)
 			cfgs := &deployableConfig{
-				Namespace: tc.Kube.Namespace,
-				YamlFiles: []string{ruleYaml},
+				Namespace:  tc.Kube.Namespace,
+				YamlFiles:  []string{ruleYaml},
+				kubeconfig: tc.Kube.KubeConfig,
 			}
 			if err := cfgs.Setup(); err != nil {
 				t.Fatal(err)

--- a/tests/e2e/tests/pilot/routing_to_egress_test.go
+++ b/tests/e2e/tests/pilot/routing_to_egress_test.go
@@ -47,8 +47,9 @@ func TestEgressRouteFaultInjection(t *testing.T) {
 
 		// Apply the new rule
 		cfgs = &deployableConfig{
-			Namespace: tc.Kube.Namespace,
-			YamlFiles: yamlFiles,
+			Namespace:  tc.Kube.Namespace,
+			YamlFiles:  yamlFiles,
+			kubeconfig: tc.Kube.KubeConfig,
 		}
 		if err := cfgs.Setup(); err != nil {
 			t.Fatal(err)
@@ -144,6 +145,7 @@ func TestEgressRouteHeaders(t *testing.T) {
 		YamlFiles: []string{
 			"testdata/v1alpha1/egress-rule-httpbin.yaml",
 			"testdata/v1alpha1/rule-route-append-headers-httpbin.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)
@@ -195,8 +197,9 @@ func TestEgressRouteRedirectRewrite(t *testing.T) {
 
 		// Apply the new rule
 		cfgs = &deployableConfig{
-			Namespace: tc.Kube.Namespace,
-			YamlFiles: yamlFiles,
+			Namespace:  tc.Kube.Namespace,
+			YamlFiles:  yamlFiles,
+			kubeconfig: tc.Kube.KubeConfig,
 		}
 		if err := cfgs.Setup(); err != nil {
 			t.Fatal(err)

--- a/tests/e2e/tests/simple/a_simple_1_test.go
+++ b/tests/e2e/tests/simple/a_simple_1_test.go
@@ -70,7 +70,7 @@ func TestSimpleIngress(t *testing.T) {
 	// works, as fortio only replies with "echo debug server ..." on the /debug uri.
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	// Make sure the pods are running:
-	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+	if !util.CheckPodsRunning(tc.Kube.Namespace, tc.Kube.KubeConfig) {
 		t.Fatalf("Pods not ready!")
 	}
 

--- a/tests/e2e/tests/simple/nginx_test.go
+++ b/tests/e2e/tests/simple/nginx_test.go
@@ -188,7 +188,7 @@ func (t *testConfig) SendClientRequest(app, url string, count int, extra string)
 
 	pod := pods[0]
 	cmd := fmt.Sprintf("client -url %s -count %d %s", url, count, extra)
-	request, err := util.PodExec(t.Kube.Namespace, pod, "app", cmd, true)
+	request, err := util.PodExec(t.Kube.Namespace, pod, "app", cmd, true, t.Kube.KubeConfig)
 	if err != nil {
 		log.Errorf("client request error %v for %s in %s", err, url, app)
 		return out

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -80,7 +80,7 @@ func (t *testConfig) Setup() error {
 
 	}
 
-	if !util.CheckPodsRunning(tc.Kube.Namespace) {
+	if !util.CheckPodsRunning(tc.Kube.Namespace, tc.Kube.KubeConfig) {
 		return fmt.Errorf("can't get all pods running")
 	}
 
@@ -210,7 +210,7 @@ func deleteRules(ruleKeys []string) error {
 	var err error
 	for _, ruleKey := range ruleKeys {
 		rule := filepath.Join(tc.rulesDir, ruleKey)
-		if e := util.KubeDelete(tc.Kube.Namespace, rule); e != nil {
+		if e := util.KubeDelete(tc.Kube.Namespace, rule, tc.Kube.KubeConfig); e != nil {
 			err = multierror.Append(err, e)
 		}
 	}
@@ -222,7 +222,7 @@ func deleteRules(ruleKeys []string) error {
 func applyRules(ruleKeys []string) error {
 	for _, ruleKey := range ruleKeys {
 		rule := filepath.Join(tc.rulesDir, ruleKey)
-		if err := util.KubeApply(tc.Kube.Namespace, rule); err != nil {
+		if err := util.KubeApply(tc.Kube.Namespace, rule, tc.Kube.KubeConfig); err != nil {
 			//log.Errorf("Kubectl apply %s failed", rule)
 			return err
 		}
@@ -238,7 +238,7 @@ func upgradeControlPlane() error {
 	if err != nil {
 		return err
 	}
-	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second) {
+	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second, tc.Kube.KubeConfig) {
 		return fmt.Errorf("can't get all pods running when upgrading control plane")
 	}
 	if _, err = util.Shell("kubectl get all -n %s -o wide", targetConfig.Kube.Namespace); err != nil {
@@ -264,7 +264,7 @@ func upgradeSidecars() error {
 	if err != nil {
 		return err
 	}
-	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second) {
+	if !util.CheckPodsRunningWithMaxDuration(targetConfig.Kube.Namespace, 600*time.Second, tc.Kube.KubeConfig) {
 		return fmt.Errorf("can't get all pods running when upgrading sidecar")
 	}
 	// TODO: Check sidecar version.

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -90,8 +90,8 @@ func CreateAndFill(outDir, templateFile string, values interface{}) (string, err
 }
 
 // CreateNamespace create a kubernetes namespace
-func CreateNamespace(n string) error {
-	if _, err := ShellMuteOutput("kubectl create namespace %s", n); err != nil {
+func CreateNamespace(n string, kubeconfig string) error {
+	if _, err := ShellMuteOutput("kubectl create namespace %s --kubeconfig=%s", n, kubeconfig); err != nil {
 		if !strings.Contains(err.Error(), "AlreadyExists") {
 			return err
 		}
@@ -101,14 +101,14 @@ func CreateNamespace(n string) error {
 }
 
 // DeleteNamespace delete a kubernetes namespace
-func DeleteNamespace(n string) error {
-	_, err := Shell("kubectl delete namespace %s", n)
+func DeleteNamespace(n string, kubeconfig string) error {
+	_, err := Shell("kubectl delete namespace %s --kubeconfig=%s", n, kubeconfig)
 	return err
 }
 
 // NamespaceDeleted check if a kubernete namespace is deleted
-func NamespaceDeleted(n string) (bool, error) {
-	output, err := ShellSilent("kubectl get namespace %s -o name", n)
+func NamespaceDeleted(n string, kubeconfig string) (bool, error) {
+	output, err := ShellSilent("kubectl get namespace %s -o name --kubeconfig=%s", n, kubeconfig)
 	if strings.Contains(output, "NotFound") {
 		return true, nil
 	}
@@ -116,29 +116,29 @@ func NamespaceDeleted(n string) (bool, error) {
 }
 
 // KubeApplyContents kubectl apply from contents
-func KubeApplyContents(namespace, yamlContents string) error {
+func KubeApplyContents(namespace, yamlContents string, kubeconfig string) error {
 	tmpfile, err := WriteTempfile(os.TempDir(), "kubeapply", ".yaml", yamlContents)
 	if err != nil {
 		return err
 	}
 	defer removeFile(tmpfile)
-	return KubeApply(namespace, tmpfile)
+	return KubeApply(namespace, tmpfile, kubeconfig)
 }
 
 // KubeApply kubectl apply from file
-func KubeApply(namespace, yamlFileName string) error {
-	_, err := Shell("kubectl apply -n %s -f %s", namespace, yamlFileName)
+func KubeApply(namespace, yamlFileName string, kubeconfig string) error {
+	_, err := Shell("kubectl apply -n %s -f %s --kubeconfig=%s", namespace, yamlFileName, kubeconfig)
 	return err
 }
 
 // KubeDeleteContents kubectl apply from contents
-func KubeDeleteContents(namespace, yamlContents string) error {
+func KubeDeleteContents(namespace, yamlContents string, kubeconfig string) error {
 	tmpfile, err := WriteTempfile(os.TempDir(), "kubedelete", ".yaml", yamlContents)
 	if err != nil {
 		return err
 	}
 	defer removeFile(tmpfile)
-	return KubeDelete(namespace, tmpfile)
+	return KubeDelete(namespace, tmpfile, kubeconfig)
 }
 
 func removeFile(path string) {
@@ -149,12 +149,13 @@ func removeFile(path string) {
 }
 
 // KubeDelete kubectl delete from file
-func KubeDelete(namespace, yamlFileName string) error {
-	_, err := Shell("kubectl delete -n %s -f %s", namespace, yamlFileName)
+func KubeDelete(namespace, yamlFileName string, kubeconfig string) error {
+	_, err := Shell("kubectl delete -n %s -f %s --kubeconfig=%s", namespace, yamlFileName, kubeconfig)
 	return err
 }
 
 // GetKubeMasterIP returns the IP address of the kubernetes master service.
+// TODO update next 2 func to pass in the kubeconfig
 func GetKubeMasterIP() (string, error) {
 	return ShellSilent("kubectl get svc kubernetes -n default -o jsonpath='{.spec.clusterIP}'")
 }
@@ -176,7 +177,7 @@ func GetClusterSubnet() (string, error) {
 }
 
 // GetIngress get istio ingress ip
-func GetIngress(n string) (string, error) {
+func GetIngress(n string, kubeconfig string) (string, error) {
 	retry := Retrier{
 		BaseDelay: 1 * time.Second,
 		MaxDelay:  1 * time.Second,
@@ -186,9 +187,9 @@ func GetIngress(n string) (string, error) {
 	//rp := regexp.MustCompile(`^[0-9]{1,5}$`) # Uncomment for minikube
 	var ingress string
 	retryFn := func(_ context.Context, i int) error {
-		ip, err := ShellSilent("kubectl get svc istio-ingress -n %s -o jsonpath='{.status.loadBalancer.ingress[*].ip}'", n)
+		ip, err := ShellSilent("kubectl get svc istio-ingress -n %s -o jsonpath='{.status.loadBalancer.ingress[*].ip}' --kubeconfig=%s", n, kubeconfig)
 		// For minikube, comment out the previous line and uncomment the following line
-		//ip, err := Shell("kubectl get po -l istio=ingress -n %s -o jsonpath='{.items[0].status.hostIP}'", n)
+		//ip, err := Shell("kubectl get po -l istio=ingress -n %s -o jsonpath='{.items[0].status.hostIP}' --kubeconfig=%s", n, kubeconfig)
 		if err != nil {
 			return err
 		}
@@ -198,7 +199,7 @@ func GetIngress(n string) (string, error) {
 		}
 		ingress = ip
 		// For minikube, comment out the previous line and uncomment the following lines
-		//port, e := Shell("kubectl get svc istio-ingress -n %s -o jsonpath='{.spec.ports[0].nodePort}'", n)
+		//port, e := Shell("kubectl get svc istio-ingress -n %s -o jsonpath='{.spec.ports[0].nodePort}' --kubeconfig=%s", n, kubeconfig)
 		//if e != nil {
 		//	return e
 		//}
@@ -242,7 +243,7 @@ func GetIngress(n string) (string, error) {
 }
 
 // GetIngressPod get istio ingress ip
-func GetIngressPod(n string) (string, error) {
+func GetIngressPod(n string, kubeconfig string) (string, error) {
 	retry := Retrier{
 		BaseDelay: 5 * time.Second,
 		MaxDelay:  5 * time.Minute,
@@ -253,12 +254,12 @@ func GetIngressPod(n string) (string, error) {
 	var ingress string
 	retryFn := func(_ context.Context, i int) error {
 		podIP, err := Shell("kubectl get pod -l istio=ingress "+
-			"-n %s -o jsonpath='{.items[0].status.hostIP}'", n)
+			"-n %s -o jsonpath='{.items[0].status.hostIP}' --kubeconfig=%s", n, kubeconfig)
 		if err != nil {
 			return err
 		}
 		podPort, err := Shell("kubectl get svc istio-ingress "+
-			"-n %s -o jsonpath='{.spec.ports[0].nodePort}'", n)
+			"-n %s -o jsonpath='{.spec.ports[0].nodePort}' --kubeconfig=%s", n, kubeconfig)
 		if err != nil {
 			return err
 		}
@@ -283,8 +284,8 @@ func GetIngressPod(n string) (string, error) {
 }
 
 // GetIngressPodNames get the pod names for the Istio ingress deployment.
-func GetIngressPodNames(n string) ([]string, error) {
-	res, err := Shell("kubectl get pod -l istio=ingress -n %s -o jsonpath='{.items[*].metadata.name}'", n)
+func GetIngressPodNames(n string, kubeconfig string) ([]string, error) {
+	res, err := Shell("kubectl get pod -l istio=ingress -n %s -o jsonpath='{.items[*].metadata.name}' --kubeconfig=%s", n, kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -293,8 +294,8 @@ func GetIngressPodNames(n string) ([]string, error) {
 }
 
 // GetAppPods gets a map of app names to the pods for the app, for the given namespace
-func GetAppPods(n string) (map[string][]string, error) {
-	podLabels, err := GetPodLabelValues(n, "app")
+func GetAppPods(n string, kubeconfig string) (map[string][]string, error) {
+	podLabels, err := GetPodLabelValues(n, "app", kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -307,10 +308,11 @@ func GetAppPods(n string) (map[string][]string, error) {
 }
 
 // GetPodLabelValues gets a map of pod name to label value for the given label and namespace
-func GetPodLabelValues(n, label string) (map[string]string, error) {
+func GetPodLabelValues(n, label string, kubeconfig string) (map[string]string, error) {
 	// This will return a table where c0=pod_name and c1=label_value.
 	// The columns are separated by a space and each result is on a separate line (separated by '\n').
-	res, err := Shell("kubectl -n %s -l=%s get pods -o=jsonpath='{range .items[*]}{.metadata.name}{\" \"}{.metadata.labels.%s}{\"\\n\"}{end}'", n, label, label)
+	res, err := Shell("kubectl -n %s -l=%s get pods -o=jsonpath='{range .items[*]}{.metadata.name}{\" \"}{"+
+		".metadata.labels.%s}{\"\\n\"}{end}' --kubeconfig=%s", n, label, label, kubeconfig)
 	if err != nil {
 		log.Infof("Failed to get pods by label %s in namespace %s: %s", label, n, err)
 		return nil, err
@@ -329,8 +331,8 @@ func GetPodLabelValues(n, label string) (map[string]string, error) {
 }
 
 // GetPodNames gets names of all pods in specific namespace and return in a slice
-func GetPodNames(n string) (pods []string) {
-	res, err := Shell("kubectl -n %s get pods -o jsonpath='{.items[*].metadata.name}'", n)
+func GetPodNames(n string) (pods []string, kubeconfig string) {
+	res, err := Shell("kubectl -n %s get pods -o jsonpath='{.items[*].metadata.name}' --kubeconfig=%s", n, kubeconfig)
 	if err != nil {
 		log.Infof("Failed to get pods name in namespace %s: %s", n, err)
 		return
@@ -345,8 +347,8 @@ func GetPodNames(n string) (pods []string) {
 // Note: It is not enough to check pod phase, which only implies there is at
 // least one container running. Use kubectl CLI to get status so that we can
 // ensure that all containers are running.
-func GetPodStatus(n, pod string) string {
-	status, err := Shell("kubectl -n %s get pods %s --no-headers", n, pod)
+func GetPodStatus(n, pod string, kubeconfig string) string {
+	status, err := Shell("kubectl -n %s get pods %s --no-headers --kubeconfig=%s", n, pod, kubeconfig)
 	if err != nil {
 		log.Infof("Failed to get status of pod %s in namespace %s: %s", pod, n, err)
 		status = podFailedGet
@@ -359,8 +361,8 @@ func GetPodStatus(n, pod string) string {
 }
 
 // GetPodName gets the pod name for the given namespace and label selector
-func GetPodName(n, labelSelector string) (pod string, err error) {
-	pod, err = Shell("kubectl -n %s get pod -l %s -o jsonpath='{.items[0].metadata.name}'", n, labelSelector)
+func GetPodName(n, labelSelector string, kubeconfig string) (pod string, err error) {
+	pod, err = Shell("kubectl -n %s get pod -l %s -o jsonpath='{.items[0].metadata.name}' --kubeconfig=%s", n, labelSelector, kubeconfig)
 	if err != nil {
 		log.Warnf("could not get %s pod: %v", labelSelector, err)
 		return
@@ -371,16 +373,16 @@ func GetPodName(n, labelSelector string) (pod string, err error) {
 }
 
 // GetPodLogsForLabel gets the logs for the given label selector and container
-func GetPodLogsForLabel(n, labelSelector string, container string, tail, alsoShowPreviousPodLogs bool) string {
-	pod, err := GetPodName(n, labelSelector)
+func GetPodLogsForLabel(n, labelSelector string, container string, tail, alsoShowPreviousPodLogs bool, kubeconfig string) string {
+	pod, err := GetPodName(n, labelSelector, kubeconfig)
 	if err != nil {
 		return ""
 	}
-	return GetPodLogs(n, pod, container, tail, alsoShowPreviousPodLogs)
+	return GetPodLogs(n, pod, container, tail, alsoShowPreviousPodLogs, kubeconfig)
 }
 
 // GetPodLogs retrieves the logs for the given namespace, pod and container.
-func GetPodLogs(n, pod, container string, tail, alsoShowPreviousPodLogs bool) string {
+func GetPodLogs(n, pod, container string, tail, alsoShowPreviousPodLogs bool, kubeconfig string) string {
 	tailOption := ""
 	if tail {
 		tailOption = "--tail=40"
@@ -388,38 +390,38 @@ func GetPodLogs(n, pod, container string, tail, alsoShowPreviousPodLogs bool) st
 	o1 := ""
 	if alsoShowPreviousPodLogs {
 		log.Info("Expect and ignore an error getting crash logs when there are no crash (-p invocation)")
-		o1, _ = Shell("kubectl --namespace %s logs %s -c %s %s -p", n, pod, container, tailOption)
+		o1, _ = Shell("kubectl --namespace %s logs %s -c %s %s -p --kubeconfig=%s", n, pod, container, tailOption, kubeconfig)
 		o1 += "\n"
 	}
-	o2, _ := Shell("kubectl --namespace %s logs %s -c %s %s", n, pod, container, tailOption)
+	o2, _ := Shell("kubectl --namespace %s logs %s -c %s %s --kubeconfig=%s", n, pod, container, tailOption, kubeconfig)
 	return o1 + o2
 }
 
 // GetConfigs retrieves the configurations for the list of resources.
-func GetConfigs(names ...string) (string, error) {
-	cmd := fmt.Sprintf("kubectl get %s --all-namespaces -o yaml", strings.Join(names, ","))
+func GetConfigs(kubeconfig string, names ...string) (string, error) {
+	cmd := fmt.Sprintf("kubectl get %s --all-namespaces -o yaml --kubeconfig=%s", strings.Join(names, ","), kubeconfig)
 	return Shell(cmd)
 }
 
 // PodExec runs the specified command on the container for the specified namespace and pod
-func PodExec(n, pod, container, command string, muteOutput bool) (string, error) {
+func PodExec(n, pod, container, command string, muteOutput bool, kubeconfig string) (string, error) {
 	if muteOutput {
-		return ShellMuteOutput("kubectl exec %s -n %s -c %s -- %s", pod, n, container, command)
+		return ShellMuteOutput("kubectl exec --kubeconfig=%s %s -n %s -c %s -- %s", kubeconfig, pod, n, container, command)
 	}
-	return Shell("kubectl exec %s -n %s -c %s -- %s", pod, n, container, command)
+	return Shell("kubectl exec --kubeconfig=%s %s -n %s -c %s -- %s ", kubeconfig, pod, n, container, command)
 }
 
 // CreateTLSSecret creates a secret from the provided cert and key files
-func CreateTLSSecret(secretName, n, keyFile, certFile string) (string, error) {
+func CreateTLSSecret(secretName, n, keyFile, certFile string, kubeconfig string) (string, error) {
 	//cmd := fmt.Sprintf("kubectl create secret tls %s -n %s --key %s --cert %s", secretName, n, keyFile, certFile)
 	//return Shell(cmd)
-	return Shell("kubectl create secret tls %s -n %s --key %s --cert %s", secretName, n, keyFile, certFile)
+	return Shell("kubectl create secret tls %s -n %s --key %s --cert %s --kubeconfig=%s", secretName, n, keyFile, certFile, kubeconfig)
 }
 
 // CheckPodsRunningWithMaxDuration returns if all pods in a namespace are in "Running" status
 // Also check container status to be running.
-func CheckPodsRunningWithMaxDuration(n string, maxDuration time.Duration) (ready bool) {
-	if err := WaitForDeploymentsReady(n, maxDuration); err != nil {
+func CheckPodsRunningWithMaxDuration(n string, maxDuration time.Duration, kubeconfig string) (ready bool) {
+	if err := WaitForDeploymentsReady(n, maxDuration, kubeconfig); err != nil {
 		log.Errorf("CheckPodsRunning: %v", err.Error())
 		return false
 	}
@@ -429,19 +431,19 @@ func CheckPodsRunningWithMaxDuration(n string, maxDuration time.Duration) (ready
 
 // CheckPodsRunning returns readiness of all pods within a namespace. It will wait for upto 2 mins.
 // use WithMaxDuration to specify a duration.
-func CheckPodsRunning(n string) (ready bool) {
-	return CheckPodsRunningWithMaxDuration(n, 2*time.Minute)
+func CheckPodsRunning(n string, kubeconfig string) (ready bool) {
+	return CheckPodsRunningWithMaxDuration(n, 2*time.Minute, kubeconfig)
 }
 
 // CheckDeployment gets status of a deployment from a namespace
-func CheckDeployment(ctx context.Context, namespace, deployment string) error {
+func CheckDeployment(ctx context.Context, namespace, deployment string, kubeconfig string) error {
 	if deployment == "deployments/istio-sidecar-injector" {
 		// This can be deployed by previous tests, but doesn't complete currently, blocking the test.
 		return nil
 	}
 	errc := make(chan error)
 	go func() {
-		if _, err := ShellMuteOutput("kubectl -n %s rollout status %s", namespace, deployment); err != nil {
+		if _, err := ShellMuteOutput("kubectl -n %s rollout status %s --kubeconfig=%s", namespace, deployment, kubeconfig); err != nil {
 			errc <- fmt.Errorf("%s in namespace %s failed", deployment, namespace)
 		}
 		errc <- nil
@@ -455,9 +457,9 @@ func CheckDeployment(ctx context.Context, namespace, deployment string) error {
 }
 
 // CheckDeployments checks whether all deployment in a given namespace
-func CheckDeployments(namespace string, timeout time.Duration) error {
+func CheckDeployments(namespace string, timeout time.Duration, kubeconfig string) error {
 	// wait for istio-system deployments to be fully rolled out before proceeding
-	out, err := Shell("kubectl -n %s get deployment -o name", namespace)
+	out, err := Shell("kubectl -n %s get deployment -o name --kubeconfig=%s", namespace, kubeconfig)
 	if err != nil {
 		return fmt.Errorf("could not list deployments in namespace %q", namespace)
 	}
@@ -467,17 +469,17 @@ func CheckDeployments(namespace string, timeout time.Duration) error {
 	deployments := strings.Fields(out)
 	for i := range deployments {
 		deployment := deployments[i]
-		g.Go(func() error { return CheckDeployment(ctx, namespace, deployment) })
+		g.Go(func() error { return CheckDeployment(ctx, namespace, deployment, kubeconfig) })
 	}
 	return g.Wait()
 }
 
 // FetchAndSaveClusterLogs will dump the logs for a cluster.
-func FetchAndSaveClusterLogs(namespace string, tempDir string) error {
+func FetchAndSaveClusterLogs(namespace string, tempDir string, kubeconfig string) error {
 	var multiErr error
 	fetchAndWrite := func(pod string) error {
 		cmd := fmt.Sprintf(
-			"kubectl get pods -n %s %s -o jsonpath={.spec.containers[*].name}", namespace, pod)
+			"kubectl get pods -n %s %s -o jsonpath={.spec.containers[*].name} --kubeconfig=%s", namespace, pod, kubeconfig)
 		containersString, err := Shell(cmd)
 		if err != nil {
 			return err
@@ -495,7 +497,7 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string) error {
 				}
 			}()
 			dump, err := ShellMuteOutput(
-				fmt.Sprintf("kubectl logs %s -n %s -c %s", pod, namespace, container))
+				fmt.Sprintf("kubectl logs %s -n %s -c %s --kubeconfig=%s", pod, namespace, container, kubeconfig))
 			if err != nil {
 				return err
 			}
@@ -506,11 +508,11 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string) error {
 		return nil
 	}
 
-	_, err := Shell("kubectl get ingress --all-namespaces")
+	_, err := Shell("kubectl get ingress --all-namespaces --kubeconfig=%s", kubeconfig)
 	if err != nil {
 		return err
 	}
-	lines, err := Shell("kubectl get pods -n " + namespace)
+	lines, err := Shell("kubectl get pods -n %s --kubeconfig=%s", namespace, kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -531,7 +533,7 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string) error {
 		log.Info(fmt.Sprintf("Fetching deployment info on %s\n", resrc))
 		filePath := filepath.Join(tempDir, fmt.Sprintf("%s.yaml", resrc))
 		if yaml, err0 := ShellMuteOutput(
-			fmt.Sprintf("kubectl get %s -n %s -o yaml", resrc, namespace)); err0 != nil {
+			fmt.Sprintf("kubectl get %s -n %s -o yaml --kubeconfig=%s", resrc, namespace, kubeconfig)); err0 != nil {
 			multiErr = multierror.Append(multiErr, err0)
 		} else {
 			if f, err1 := os.Create(filePath); err1 != nil {
@@ -548,7 +550,7 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string) error {
 
 // WaitForDeploymentsReady wait up to 'timeout' duration
 // return an error if deployments are not ready
-func WaitForDeploymentsReady(ns string, timeout time.Duration) error {
+func WaitForDeploymentsReady(ns string, timeout time.Duration, kubeconfig string) error {
 	retry := Retrier{
 		BaseDelay:   10 * time.Second,
 		MaxDelay:    10 * time.Second,
@@ -557,7 +559,7 @@ func WaitForDeploymentsReady(ns string, timeout time.Duration) error {
 	}
 
 	_, err := retry.Retry(context.Background(), func(_ context.Context, _ int) error {
-		nr, err := CheckDeploymentsReady(ns)
+		nr, err := CheckDeploymentsReady(ns, kubeconfig)
 		if err != nil {
 			return &Break{err}
 		}
@@ -572,10 +574,10 @@ func WaitForDeploymentsReady(ns string, timeout time.Duration) error {
 
 // CheckDeploymentsReady checks if deployment resources are ready.
 // get podsReady() sometimes gets pods created by the "Job" resource which never reach the "Running" steady state.
-func CheckDeploymentsReady(ns string) (int, error) {
+func CheckDeploymentsReady(ns string, kubeconfig string) (int, error) {
 	CMD := "kubectl -n %s get deployments -ao jsonpath='{range .items[*]}{@.metadata.name}{\" \"}" +
-		"{@.status.availableReplicas}{\"\\n\"}{end}'"
-	out, err := Shell(fmt.Sprintf(CMD, ns))
+		"{@.status.availableReplicas}{\"\\n\"}{end}' --kubeconfig=%s"
+	out, err := Shell(fmt.Sprintf(CMD, ns, kubeconfig))
 
 	if err != nil {
 		return 0, fmt.Errorf("could not list deployments in namespace %q: %v", ns, err)
@@ -596,4 +598,14 @@ func CheckDeploymentsReady(ns string) (int, error) {
 		log.Infof("All deployments are ready")
 	}
 	return notReady, nil
+}
+
+// GetKubeConfig will create a kubeconfig file based on the active environment the test is run in
+func GetKubeConfig(filename string) error {
+	_, err := ShellMuteOutput("kubectl config view --raw=true --minify=true > %s", filename)
+	if err != nil {
+		return err
+	}
+	log.Infof("kubeconfig file %s created\n", filename)
+	return nil
 }


### PR DESCRIPTION
This is the initial change for a series of changes
required to enable multicluster e2e tests. This test
parses the clusterregistry config file to get the
multiple registries and then creates the namespace on
the remote cluster