### PR TITLE
Mixer route config

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -230,7 +230,7 @@ func applyConnectionPool(cluster *v2.Cluster, settings *networking.ConnectionPoo
 
 	if settings.Tcp != nil {
 		if settings.Tcp.ConnectTimeout != nil {
-			cluster.ConnectTimeout = util.ConvertGogoDurationToDuration(settings.Tcp.ConnectTimeout)
+			cluster.ConnectTimeout = util.GogoDurationToDuration(settings.Tcp.ConnectTimeout)
 		}
 
 		if settings.Tcp.MaxConnections > 0 {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -27,6 +27,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
+	istio_route "istio.io/istio/pilot/pkg/networking/route"
 	"istio.io/istio/pkg/log"
 )
 
@@ -129,12 +130,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 		newListener := buildListener(opts)
 
 		for _, p := range configgen.Plugins {
-			params := &plugin.CallbackListenerInputParams{
+			params := &plugin.InputParams{
 				ListenerType: listenerType,
 				Env:          &env,
 				Node:         &node,
 			}
-			mutable := &plugin.CallbackListenerMutableObjects{
+			mutable := &plugin.MutableObjects{
 				Listener:    newListener,
 				TCPFilters:  &networkFilters,
 				HTTPFilters: &hTTPFilters,
@@ -215,7 +216,7 @@ func buildGatewayInboundHTTPRouteConfig(env model.Environment, gatewayName strin
 
 	virtualHosts := make([]route.VirtualHost, 0)
 	for _, v := range virtualServices {
-		routes := translateRoutes(v, nameF, int(server.Port.Number), nil, gatewayName)
+		routes := istio_route.TranslateRoutes(v, nameF, int(server.Port.Number), nil, gatewayName)
 		domains := v.Spec.(*networking.VirtualService).Hosts
 
 		virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -212,7 +212,7 @@ func buildGatewayInboundHTTPRouteConfig(env model.Environment, gatewayName strin
 		nameToServiceMap[svc.Hostname] = svc
 	}
 
-	nameF := convertDestinationToCluster(nameToServiceMap, int(server.Port.Number))
+	nameF := istio_route.ConvertDestinationToCluster(nameToServiceMap, int(server.Port.Number))
 
 	virtualHosts := make([]route.VirtualHost, 0)
 	for _, v := range virtualServices {

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -16,461 +16,16 @@ package v1alpha3
 
 import (
 	"fmt"
-	"regexp"
-	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 
-	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
-	"istio.io/istio/pkg/log"
 )
-
-// Headers with special meaning in Envoy
-const (
-	HeaderMethod    = ":method"
-	HeaderAuthority = ":authority"
-	HeaderScheme    = ":scheme"
-)
-
-const (
-	// UnresolvedCluster for destinations pointing to unknown clusters.
-	UnresolvedCluster = "unresolved-cluster"
-
-	// DefaultRoute is the default decorator
-	DefaultRoute = "default-route"
-)
-
-// GuardedHost is a context-dependent virtual host entry with guarded routes.
-type GuardedHost struct {
-	// Port is the capture port (e.g. service port)
-	Port int
-
-	// Services are the services matching the virtual host.
-	// The service host names need to be contextualized by the source.
-	Services []*model.Service
-
-	// Hosts is a list of alternative literal host names for the host.
-	Hosts []string
-
-	// Routes in the virtual host
-	Routes []route.Route
-}
-
-// translateVirtualHosts creates the entire routing table for Istio v1alpha3 configs.
-// Services are indexed by FQDN hostnames.
-// Cluster domain is used to resolve short service names (e.g. "svc.cluster.local").
-func translateVirtualHosts(
-	serviceConfigs []model.Config,
-	services map[string]*model.Service,
-	proxyLabels model.LabelsCollection,
-	gatewayName string) []GuardedHost {
-	out := make([]GuardedHost, 0)
-
-	// translate all virtual service configs
-	for _, config := range serviceConfigs {
-		out = append(out, translateVirtualHost(config, services, proxyLabels, gatewayName)...)
-	}
-
-	// compute services missing service configs
-	missing := make(map[string]bool)
-	for fqdn := range services {
-		missing[fqdn] = true
-	}
-	for _, host := range out {
-		for _, service := range host.Services {
-			delete(missing, service.Hostname)
-		}
-	}
-
-	// append default hosts for the service missing virtual services
-	for fqdn := range missing {
-		svc := services[fqdn]
-		for _, port := range svc.Ports {
-			if port.Protocol.IsHTTP() {
-				cluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", svc.Hostname, port)
-				out = append(out, GuardedHost{
-					Port:     port.Port,
-					Services: []*model.Service{svc},
-					Routes:   []route.Route{*buildDefaultHTTPRoute(cluster)},
-				})
-			}
-		}
-	}
-
-	return out
-}
-
-// matchServiceHosts splits the virtual service hosts into services and literal hosts
-func matchServiceHosts(in model.Config, serviceIndex map[string]*model.Service) ([]string, []*model.Service) {
-	rule := in.Spec.(*networking.VirtualService)
-	hosts := make([]string, 0)
-	services := make([]*model.Service, 0)
-	for _, host := range rule.Hosts {
-		if svc := serviceIndex[host]; svc != nil {
-			services = append(services, svc)
-		} else {
-			hosts = append(hosts, host)
-		}
-	}
-	return hosts, services
-}
-
-// translateVirtualHost creates virtual hosts corresponding to a virtual service.
-func translateVirtualHost(in model.Config, serviceIndex map[string]*model.Service,
-	proxyLabels model.LabelsCollection, gatewayName string) []GuardedHost {
-	hosts, services := matchServiceHosts(in, serviceIndex)
-	serviceByPort := make(map[int][]*model.Service)
-	for _, svc := range services {
-		for _, port := range svc.Ports {
-			if port.Protocol.IsHTTP() {
-				serviceByPort[port.Port] = append(serviceByPort[port.Port], svc)
-			}
-		}
-	}
-
-	// if no services matched, then we have no port information -- default to 80 for now
-	if len(serviceByPort) == 0 {
-		serviceByPort[80] = nil
-	}
-
-	out := make([]GuardedHost, len(serviceByPort))
-	for port, services := range serviceByPort {
-		clusterNameGenerator := convertDestinationToCluster(serviceIndex, port)
-		routes := translateRoutes(in, clusterNameGenerator, port, proxyLabels, gatewayName)
-		if len(routes) == 0 {
-			continue
-		}
-		out = append(out, GuardedHost{
-			Port:     port,
-			Services: services,
-			Hosts:    hosts,
-			Routes:   routes,
-		})
-	}
-
-	return out
-}
-
-// convertDestinationToCluster produces a cluster naming function using the config context.
-func convertDestinationToCluster(
-	serviceIndex map[string]*model.Service,
-	defaultPort int) ClusterNameGenerator {
-	return func(destination *networking.Destination) string {
-		// detect if it is a service
-		svc := serviceIndex[destination.Host]
-
-		// TODO: create clusters for non-service hostnames/IPs
-		if svc == nil {
-			return UnresolvedCluster
-		}
-
-		// default port uses port number
-		svcPort, _ := svc.Ports.GetByPort(defaultPort)
-		if destination.Port != nil {
-			switch selector := destination.Port.Port.(type) {
-			case *networking.PortSelector_Name:
-				svcPort, _ = svc.Ports.Get(selector.Name)
-			case *networking.PortSelector_Number:
-				svcPort, _ = svc.Ports.GetByPort(int(selector.Number))
-			}
-		}
-
-		if svcPort == nil {
-			return UnresolvedCluster
-		}
-
-		// use subsets if it is a service
-		return model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, svc.Hostname, svcPort)
-	}
-}
-
-// ClusterNameGenerator specifies cluster name for a destination
-type ClusterNameGenerator func(*networking.Destination) string
-
-// translateRoutes creates virtual host routes from the v1alpha3 config.
-// The rule should be adapted to destination names (outbound clusters).
-// Each rule is guarded by source labels.
-func translateRoutes(in model.Config, nameF ClusterNameGenerator, port int,
-	proxyLabels model.LabelsCollection, gatewayName string) []route.Route {
-	rule, ok := in.Spec.(*networking.VirtualService)
-	if !ok {
-		return nil
-	}
-
-	operation := in.ConfigMeta.Name
-
-	out := make([]route.Route, 0)
-	for _, http := range rule.Http {
-		if len(http.Match) == 0 {
-			if r := translateRoute(http, nil, port, operation, nameF, proxyLabels, gatewayName); r != nil {
-				// this cannot be nil
-				out = append(out, *r)
-			}
-			break // we have a rule with catch all match prefix: /. Other rules are of no use
-		} else {
-			// TODO: https://github.com/istio/istio/issues/4239
-			for _, match := range http.Match {
-				if r := translateRoute(http, match, port, operation, nameF, proxyLabels, gatewayName); r != nil {
-					out = append(out, *r)
-				}
-			}
-		}
-	}
-
-	return out
-}
-
-// sourceMatchHttp checks if the sourceLabels or the gateways in a match condition match with the
-// labels for the proxy or the gateway name for which we are generating a route
-func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels model.LabelsCollection, gatewayName string) bool {
-	if match == nil {
-		return true
-	}
-
-	// Trim by source labels or mesh gateway
-	if len(match.Gateways) > 0 {
-		for _, g := range match.Gateways {
-			if g == gatewayName {
-				return true
-			}
-		}
-	} else if proxyLabels.IsSupersetOf(match.GetSourceLabels()) {
-		return true
-	}
-
-	return false
-}
-
-// translateRoute translates HTTP routes
-// TODO: fault filters -- issue https://github.com/istio/api/issues/388
-func translateRoute(in *networking.HTTPRoute,
-	match *networking.HTTPMatchRequest, port int,
-	operation string,
-	nameF ClusterNameGenerator,
-	proxyLabels model.LabelsCollection,
-	gatewayName string) *route.Route {
-
-	// Match by source labels/gateway names inside the match condition
-	if !sourceMatchHTTP(match, proxyLabels, gatewayName) {
-		return nil
-	}
-
-	// Match by the destination port specified in the match condition
-	if match != nil && match.Port != nil && match.Port.GetNumber() != uint32(port) {
-		return nil
-	}
-
-	out := &route.Route{
-		Match: translateRouteMatch(match),
-		Decorator: &route.Decorator{
-			Operation: operation,
-		},
-	}
-
-	if redirect := in.Redirect; redirect != nil {
-		out.Action = &route.Route_Redirect{
-			Redirect: &route.RedirectAction{
-				HostRedirect: redirect.Authority,
-				PathRewriteSpecifier: &route.RedirectAction_PathRedirect{
-					PathRedirect: redirect.Uri,
-				},
-			}}
-	} else {
-		action := &route.RouteAction{
-			Cors:         translateCORSPolicy(in.CorsPolicy),
-			RetryPolicy:  translateRetryPolicy(in.Retries),
-			Timeout:      translateTime(in.Timeout),
-			UseWebsocket: &types.BoolValue{Value: in.WebsocketUpgrade},
-		}
-		out.Action = &route.Route_Route{Route: action}
-
-		if rewrite := in.Rewrite; rewrite != nil {
-			action.PrefixRewrite = rewrite.Uri
-			action.HostRewriteSpecifier = &route.RouteAction_HostRewrite{
-				HostRewrite: rewrite.Authority,
-			}
-		}
-
-		if len(in.AppendHeaders) > 0 {
-			action.RequestHeadersToAdd = make([]*core.HeaderValueOption, 0)
-			for key, value := range in.AppendHeaders {
-				action.RequestHeadersToAdd = append(action.RequestHeadersToAdd, &core.HeaderValueOption{
-					Header: &core.HeaderValue{
-						Key:   key,
-						Value: value,
-					},
-				})
-			}
-		}
-
-		if in.Mirror != nil {
-			action.RequestMirrorPolicy = &route.RouteAction_RequestMirrorPolicy{Cluster: nameF(in.Mirror)}
-		}
-
-		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
-		for _, dst := range in.Route {
-			weight := &types.UInt32Value{Value: uint32(dst.Weight)}
-			if dst.Weight == 0 {
-				weight.Value = uint32(100)
-			}
-			weighted = append(weighted, &route.WeightedCluster_ClusterWeight{
-				Name:   nameF(dst.Destination),
-				Weight: weight,
-			})
-		}
-
-		// rewrite to a single cluster if there is only weighted cluster
-		if len(weighted) == 1 {
-			action.ClusterSpecifier = &route.RouteAction_Cluster{Cluster: weighted[0].Name}
-		} else {
-			action.ClusterSpecifier = &route.RouteAction_WeightedClusters{
-				WeightedClusters: &route.WeightedCluster{
-					Clusters: weighted,
-				},
-			}
-		}
-	}
-
-	return out
-}
-
-// translateRouteMatch translates match condition
-func translateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
-	out := route.RouteMatch{PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"}}
-	if in == nil {
-		return out
-	}
-
-	for name, stringMatch := range in.Headers {
-		matcher := translateHeaderMatch(name, stringMatch)
-		out.Headers = append(out.Headers, &matcher)
-	}
-
-	// guarantee ordering of headers
-	sort.Slice(out.Headers, func(i, j int) bool {
-		if out.Headers[i].Name == out.Headers[j].Name {
-			return out.Headers[i].Value < out.Headers[j].Value
-		}
-		return out.Headers[i].Name < out.Headers[j].Name
-	})
-
-	if in.Uri != nil {
-		switch m := in.Uri.MatchType.(type) {
-		case *networking.StringMatch_Exact:
-			out.PathSpecifier = &route.RouteMatch_Path{Path: m.Exact}
-		case *networking.StringMatch_Prefix:
-			out.PathSpecifier = &route.RouteMatch_Prefix{Prefix: m.Prefix}
-		case *networking.StringMatch_Regex:
-			out.PathSpecifier = &route.RouteMatch_Regex{Regex: m.Regex}
-		}
-	}
-
-	if in.Method != nil {
-		matcher := translateHeaderMatch(HeaderMethod, in.Method)
-		out.Headers = append(out.Headers, &matcher)
-	}
-
-	if in.Authority != nil {
-		matcher := translateHeaderMatch(HeaderAuthority, in.Authority)
-		out.Headers = append(out.Headers, &matcher)
-	}
-
-	if in.Scheme != nil {
-		matcher := translateHeaderMatch(HeaderScheme, in.Scheme)
-		out.Headers = append(out.Headers, &matcher)
-	}
-
-	return out
-}
-
-// translateHeaderMatch translates to HeaderMatcher
-func translateHeaderMatch(name string, in *networking.StringMatch) route.HeaderMatcher {
-	out := route.HeaderMatcher{
-		Name: name,
-	}
-
-	switch m := in.MatchType.(type) {
-	case *networking.StringMatch_Exact:
-		out.Value = m.Exact
-	case *networking.StringMatch_Prefix:
-		// Envoy regex grammar is ECMA-262 (http://en.cppreference.com/w/cpp/regex/ecmascript)
-		// Golang has a slightly different regex grammar
-		out.Value = fmt.Sprintf("^%s.*", regexp.QuoteMeta(m.Prefix))
-		out.Regex = &types.BoolValue{Value: true}
-	case *networking.StringMatch_Regex:
-		out.Value = m.Regex
-		out.Regex = &types.BoolValue{Value: true}
-	}
-
-	return out
-}
-
-// translateRetryPolicy translates retry policy
-func translateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
-	if in != nil && in.Attempts > 0 {
-		return &route.RouteAction_RetryPolicy{
-			NumRetries:    &types.UInt32Value{Value: uint32(in.GetAttempts())},
-			RetryOn:       "5xx,connect-failure,refused-stream",
-			PerTryTimeout: translateTime(in.PerTryTimeout),
-		}
-	}
-	return nil
-}
-
-// translateCORSPolicy translates CORS policy
-func translateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
-	if in == nil {
-		return nil
-	}
-
-	out := route.CorsPolicy{
-		AllowOrigin: in.AllowOrigin,
-		Enabled:     &types.BoolValue{Value: true},
-	}
-	out.AllowCredentials = in.AllowCredentials
-	out.AllowHeaders = strings.Join(in.AllowHeaders, ",")
-	out.AllowMethods = strings.Join(in.AllowMethods, ",")
-	out.ExposeHeaders = strings.Join(in.ExposeHeaders, ",")
-	if in.MaxAge != nil {
-		out.MaxAge = in.MaxAge.String()
-	}
-	return &out
-}
-
-// translateTime converts time protos.
-func translateTime(in *types.Duration) *time.Duration {
-	if in == nil {
-		return nil
-	}
-	out, err := types.DurationFromProto(in)
-	if err != nil {
-		log.Warnf("error converting duration %#v, using 0: %v", in, err)
-	}
-	return &out
-}
-
-// buildDefaultHTTPRoute builds a default route.
-func buildDefaultHTTPRoute(clusterName string) *route.Route {
-	return &route.Route{
-		Match: translateRouteMatch(nil),
-		Decorator: &route.Decorator{
-			Operation: DefaultRoute,
-		},
-		Action: &route.Route_Route{
-			Route: &route.RouteAction{
-				ClusterSpecifier: &route.RouteAction_Cluster{Cluster: clusterName},
-			},
-		},
-	}
-}
 
 // buildSidecarInboundHTTPRouteConfig builds the route config with a single wildcard virtual host on the inbound path
 // TODO: enable websockets, trace decorators
@@ -479,7 +34,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env mod
 
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, "",
 		instance.Service.Hostname, instance.Endpoint.ServicePort)
-	defaultRoute := buildDefaultHTTPRoute(clusterName)
+	defaultRoute := istio_route.BuildDefaultHTTPRoute(clusterName)
 
 	inboundVHost := route.VirtualHost{
 		Name:    fmt.Sprintf("%s|http|%d", model.TrafficDirectionInbound, instance.Endpoint.ServicePort.Port),
@@ -493,14 +48,21 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env mod
 		ValidateClusters: &types.BoolValue{Value: false},
 	}
 
-	// call plugins
 	for _, p := range configgen.Plugins {
-		p.OnInboundRoute(env, node, instance.Service, instance.Endpoint.ServicePort, r)
+		in := &plugin.InputParams{
+			ListenerType:    plugin.ListenerTypeHTTP,
+			Env:             &env,
+			Node:            &node,
+			ServiceInstance: instance,
+			Service:         instance.Service,
+		}
+		p.OnInboundRouteConfiguration(in, r)
 	}
+
 	return r
 }
 
-// BuildSidecarOutboundHTTPRouteConfig generates outbound routes
+// BuildSidecarOutboundHTTPRouteConfig builds an outbound HTTP Route for sidecar.
 func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env model.Environment, node model.Proxy,
 	proxyInstances []*model.ServiceInstance, services []*model.Service, routeName string) *xdsapi.RouteConfiguration {
 
@@ -537,7 +99,7 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 
 	// Get list of virtual services bound to the mesh gateway
 	virtualServices := env.VirtualServices([]string{model.IstioMeshGateway})
-	guardedHosts := translateVirtualHosts(virtualServices, nameToServiceMap, proxyLabels, model.IstioMeshGateway)
+	guardedHosts := istio_route.TranslateVirtualHosts(virtualServices, nameToServiceMap, proxyLabels, model.IstioMeshGateway)
 	vHostPortMap := make(map[int][]route.VirtualHost)
 
 	for _, guardedHost := range guardedHosts {
@@ -593,7 +155,12 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 
 	// call plugins
 	for _, p := range configgen.Plugins {
-		p.OnOutboundRoute(env, node, out)
+		in := &plugin.InputParams{
+			ListenerType: plugin.ListenerTypeHTTP,
+			Env:          &env,
+			Node:         &node,
+		}
+		p.OnOutboundRouteConfiguration(in, out)
 	}
 
 	return out

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	istio_route "istio.io/istio/pilot/pkg/networking/route"
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -238,13 +238,13 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 		newListener := buildListener(listenerOpts)
 		// call plugins
 		for _, p := range configgen.Plugins {
-			params := &plugin.CallbackListenerInputParams{
+			params := &plugin.InputParams{
 				ListenerType:    listenerType,
 				Env:             &env,
 				Node:            &node,
 				ServiceInstance: instance,
 			}
-			mutable := &plugin.CallbackListenerMutableObjects{
+			mutable := &plugin.MutableObjects{
 				Listener:    newListener,
 				TCPFilters:  &networkFilters,
 				HTTPFilters: &httpFilters,
@@ -357,13 +357,13 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 			newListener := buildListener(listenerOpts)
 
 			for _, p := range configgen.Plugins {
-				params := &plugin.CallbackListenerInputParams{
+				params := &plugin.InputParams{
 					ListenerType: listenerType,
 					Env:          &env,
 					Node:         &node,
 					Service:      service,
 				}
-				mutable := &plugin.CallbackListenerMutableObjects{
+				mutable := &plugin.MutableObjects{
 					Listener:    newListener,
 					TCPFilters:  &networkFilters,
 					HTTPFilters: &httpFilters,

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -53,8 +53,8 @@ const (
 type Plugin struct{}
 
 // NewPlugin returns an instance of the authn plugin
-func NewPlugin() *Plugin {
-	return &Plugin{}
+func NewPlugin() plugin.Plugin {
+	return Plugin{}
 }
 
 // RequireTLS returns true and pointer to mTLS params if the policy use mTLS for (peer) authentication.
@@ -264,11 +264,7 @@ func buildSidecarListenerTLSContext(authenticationPolicy *authn.Policy) *auth.Do
 
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service
 // Can be used to add additional filters on the outbound path
-func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
-	if in.Node.Type != model.Router {
-		// Only care about Router nodes.
-		return nil
-	}
+func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	// TODO: implementation
 	return nil
 }
@@ -276,7 +272,7 @@ func (*Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutabl
 // OnInboundListener is called whenever a new listener is added to the LDS output for a given service
 // Can be used to add additional filters (e.g., mixer filter) or add more stuff to the HTTP connection manager
 // on the inbound path
-func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
+func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	if in.Node.Type != model.Sidecar {
 		// Only care about sidecar.
 		return nil
@@ -299,27 +295,21 @@ func (*Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable
 	return nil
 }
 
-// OnInboundCluster is called whenever a new cluster is added to the CDS output
-// Not used typically
-func (*Plugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service,
+// OnInboundCluster implements the Plugin interface method.
+func (Plugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service,
 	servicePort *model.Port, cluster *xdsapi.Cluster) {
 }
 
-// OnOutboundRoute is called whenever a new set of virtual hosts (a set of virtual hosts with routes) is added to
-// RDS in the outbound path. Can be used to add route specific metadata or additional headers to forward
-func (*Plugin) OnOutboundRoute(env model.Environment, node model.Proxy,
-	route *xdsapi.RouteConfiguration) {
+// OnOutboundRouteConfiguration implements the Plugin interface method.
+func (Plugin) OnOutboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.RouteConfiguration) {
 }
 
-// OnInboundRoute is called whenever a new set of virtual hosts are added to the inbound path.
-// Can be used to enable route specific stuff like Lua filters or other metadata.
-func (*Plugin) OnInboundRoute(env model.Environment, node model.Proxy, service *model.Service,
-	servicePort *model.Port, route *xdsapi.RouteConfiguration) {
+// OnInboundRouteConfiguration implements the Plugin interface method.
+func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, route *xdsapi.RouteConfiguration) {
 }
 
-// OnOutboundCluster is called whenever a new cluster is added to the CDS output
-// Typically used by AuthN plugin to add mTLS settings
-func (*Plugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service,
+// OnOutboundCluster implements the Plugin interface method.
+func (Plugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service,
 	servicePort *model.Port, cluster *xdsapi.Cluster) {
 	mesh := env.Mesh
 	config := env.IstioConfigStore

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -19,8 +19,12 @@ import (
 	"net"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/gogo/protobuf/types"
+	"github.com/prometheus/common/log"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
@@ -40,7 +44,7 @@ func NewPlugin() plugin.Plugin {
 }
 
 // OnOutboundListener implements the Callbacks interface method.
-func (Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
+func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	if in.Service == nil || !in.Service.MeshExternal {
 		return nil
 	}
@@ -62,7 +66,7 @@ func (Plugin) OnOutboundListener(in *plugin.CallbackListenerInputParams, mutable
 }
 
 // OnInboundListener implements the Callbacks interface method.
-func (Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable *plugin.CallbackListenerMutableObjects) error {
+func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	env := in.Env
 	node := in.Node
 	proxyInstances := in.ProxyInstances
@@ -80,21 +84,57 @@ func (Plugin) OnInboundListener(in *plugin.CallbackListenerInputParams, mutable 
 	return fmt.Errorf("unknown listener type %v in mixer.OnOutboundListener", in.ListenerType)
 }
 
-// OnOutboundCluster implements the Callbacks interface method.
+// OnOutboundCluster implements the Plugin interface method.
 func (Plugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
 }
 
-// OnInboundCluster implements the Callbacks interface method.
+// OnInboundCluster implements the Plugin interface method.
 func (Plugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
 }
 
-// OnOutboundRoute implements the Callbacks interface method.
-func (Plugin) OnOutboundRoute(env model.Environment, node model.Proxy, route *xdsapi.RouteConfiguration) {
+// OnOutboundRouteConfiguration implements the Plugin interface method.
+func (Plugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
 }
 
-// OnInboundRoute implements the Callbacks interface method.
-func (Plugin) OnInboundRoute(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
-	route *xdsapi.RouteConfiguration) {
+// oc := BuildMixerConfig(node, serviceName, dest, proxyInstances, config, mesh.DisablePolicyChecks, false)
+// func BuildMixerConfig(source model.Proxy, destName string, dest *model.Service, instances []*model.ServiceInstance, config model.IstioConfigStore,
+
+// OnInboundRouteConfiguration implements the Plugin interface method.
+func (Plugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+	forward := false
+	if in.Node.Type == model.Ingress {
+		forward = true
+	}
+
+	switch in.ListenerType {
+	case plugin.ListenerTypeHTTP:
+		var nvhs []route.VirtualHost
+		for _, vh := range routeConfiguration.VirtualHosts {
+			nvh := vh
+			var nrs []route.Route
+			for _, r := range vh.Routes {
+				nr := r
+				if nr.Metadata == nil {
+					nr.Metadata = &core.Metadata{}
+				}
+				if nr.Metadata.FilterMetadata == nil {
+					nr.Metadata.FilterMetadata = make(map[string]*types.Struct)
+				}
+				nr.Metadata.FilterMetadata[v1.MixerFilter] =
+					util.BuildProtoStruct(v1.BuildMixerOpaqueConfig(!in.Env.Mesh.DisablePolicyChecks, forward, in.ServiceInstance.Service.Hostname))
+				nrs = append(nrs, nr)
+			}
+			nvh.Routes = nrs
+			nvhs = append(nvhs, nvh)
+		}
+		routeConfiguration.VirtualHosts = nvhs
+
+	case plugin.ListenerTypeTCP:
+		// TODO: implement
+	default:
+		log.Warn("Unknown listener type in mixer#OnOutboundRouteConfiguration")
+	}
+
 }
 
 // buildMixerHTTPFilter builds a filter with a v1 mixer config encapsulated as JSON in a proto.Struct for v2 consumption.

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -34,15 +34,15 @@ const (
 	ListenerTypeHTTP
 )
 
-// CallbackListenerInputParams is a set of values passed to On*Listener callbacks. Not all fields are guaranteed to
+// InputParams is a set of values passed to Plugin callback methods. Not all fields are guaranteed to
 // be set, it's up to the callee to validate required fields are set and emit error if they are not.
 // These are for reading only and should not be modified.
-type CallbackListenerInputParams struct {
-	// ListenerType is the type of listener (TCP, HTTP etc.)
+type InputParams struct {
+	// ListenerType is the type of listener (TCP, HTTP etc.). Must be set.
 	ListenerType ListenerType
-	// Env is the model environment.
+	// Env is the model environment. Must be set.
 	Env *model.Environment
-	// Node is the node the listener is for.
+	// Node is the node the response is for.
 	Node *model.Proxy
 	// ProxyInstances is a slice of all proxy service instances in the mesh.
 	ProxyInstances []*model.ServiceInstance
@@ -52,18 +52,17 @@ type CallbackListenerInputParams struct {
 	Service *model.Service
 }
 
-// CallbackListenerMutableObjects is a set of objects passed to On*Listener callbacks. Fields may be nil or empty.
+// MutableObjects is a set of objects passed to On*Listener callbacks. Fields may be nil or empty.
 // Any lists should not be overridden, but rather only appended to.
 // Non-list fields may be mutated; however it's not recommended to do this since it can affect other plugins in the
 // chain in unpredictable ways.
-type CallbackListenerMutableObjects struct {
+type MutableObjects struct {
+	// Listener is the listener being built. Must be initialized before Plugin methods are called.
+	Listener *xdsapi.Listener
 	// HTTPFilters is the slice of HTTP filters for the Listener. Append to only.
 	HTTPFilters *[]*http_conn.HttpFilter
 	// TCPFilters is the slice of TCP filters for the Listener. Append to only.
 	TCPFilters *[]listener.Filter
-	// Listener is the listener being built. Any field may be modified, but changing other than appending to slices
-	// is discouraged.
-	Listener *xdsapi.Listener
 }
 
 // Plugin is called during the construction of a xdsapi.Listener which may alter the Listener in any
@@ -72,28 +71,24 @@ type CallbackListenerMutableObjects struct {
 type Plugin interface {
 	// OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service.
 	// Can be used to add additional filters on the outbound path.
-	OnOutboundListener(in *CallbackListenerInputParams, mutable *CallbackListenerMutableObjects) error
+	OnOutboundListener(in *InputParams, mutable *MutableObjects) error
 
 	// OnInboundListener is called whenever a new listener is added to the LDS output for a given service
 	// Can be used to add additional filters.
-	OnInboundListener(in *CallbackListenerInputParams, mutable *CallbackListenerMutableObjects) error
+	OnInboundListener(in *InputParams, mutable *MutableObjects) error
 
-	// OnOutboundCluster is called whenever a new cluster is added to the CDS output
-	// Typically used by AuthN plugin to add mTLS settings
+	// OnOutboundCluster is called whenever a new cluster is added to the CDS output.
 	OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
 		cluster *xdsapi.Cluster)
 
-	// OnInboundCluster is called whenever a new cluster is added to the CDS output
-	// Not used typically
+	// OnInboundCluster is called whenever a new cluster is added to the CDS output.
 	OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
 		cluster *xdsapi.Cluster)
 
-	// OnOutboundHttpRoute is called whenever a new set of virtual hosts (a set of virtual hosts with routes) is
-	// added to RDS in the outbound path. Can be used to add route specific metadata or additional headers to forward
-	OnOutboundRoute(env model.Environment, node model.Proxy, route *xdsapi.RouteConfiguration)
+	// OnOutboundRouteConfiguration is called whenever a new set of virtual hosts (a set of virtual hosts with routes) is
+	// added to RDS in the outbound path.
+	OnOutboundRouteConfiguration(in *InputParams, routeConfiguration *xdsapi.RouteConfiguration)
 
-	// OnInboundRoute is called whenever a new set of virtual hosts are added to the inbound path.
-	// Can be used to enable route specific stuff like Lua filters or other metadata.
-	OnInboundRoute(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
-		route *xdsapi.RouteConfiguration)
+	// OnInboundRouteConfiguration is called whenever a new set of virtual hosts are added to the inbound path.
+	OnInboundRouteConfiguration(in *InputParams, routeConfiguration *xdsapi.RouteConfiguration)
 }

--- a/pilot/pkg/networking/route/route.go
+++ b/pilot/pkg/networking/route/route.go
@@ -72,7 +72,7 @@ func TranslateVirtualHosts(
 
 	// translate all virtual service configs
 	for _, config := range serviceConfigs {
-		out = append(out, TranslateVirtualHost(config, services, proxyLabels, gatewayName)...)
+		out = append(out, translateVirtualHost(config, services, proxyLabels, gatewayName)...)
 	}
 
 	// compute services missing service configs
@@ -104,8 +104,8 @@ func TranslateVirtualHosts(
 	return out
 }
 
-// MatchServiceHosts splits the virtual service hosts into services and literal hosts
-func MatchServiceHosts(in model.Config, serviceIndex map[string]*model.Service) ([]string, []*model.Service) {
+// matchServiceHosts splits the virtual service hosts into services and literal hosts
+func matchServiceHosts(in model.Config, serviceIndex map[string]*model.Service) ([]string, []*model.Service) {
 	rule := in.Spec.(*networking.VirtualService)
 	hosts := make([]string, 0)
 	services := make([]*model.Service, 0)
@@ -119,10 +119,10 @@ func MatchServiceHosts(in model.Config, serviceIndex map[string]*model.Service) 
 	return hosts, services
 }
 
-// TranslateVirtualHost creates virtual hosts corresponding to a virtual service.
-func TranslateVirtualHost(in model.Config, serviceIndex map[string]*model.Service,
+// translateVirtualHost creates virtual hosts corresponding to a virtual service.
+func translateVirtualHost(in model.Config, serviceIndex map[string]*model.Service,
 	proxyLabels model.LabelsCollection, gatewayName string) []GuardedHost {
-	hosts, services := MatchServiceHosts(in, serviceIndex)
+	hosts, services := matchServiceHosts(in, serviceIndex)
 	serviceByPort := make(map[int][]*model.Service)
 	for _, svc := range services {
 		for _, port := range svc.Ports {
@@ -139,8 +139,8 @@ func TranslateVirtualHost(in model.Config, serviceIndex map[string]*model.Servic
 
 	out := make([]GuardedHost, len(serviceByPort))
 	for port, services := range serviceByPort {
-		clusterNaming := TranslateDestination(serviceIndex, port)
-		routes := TranslateRoutes(in, clusterNaming, port, proxyLabels, gatewayName)
+		clusterNameGenerator := ConvertDestinationToCluster(serviceIndex, port)
+		routes := TranslateRoutes(in, clusterNameGenerator, port, proxyLabels, gatewayName)
 		if len(routes) == 0 {
 			continue
 		}
@@ -155,10 +155,10 @@ func TranslateVirtualHost(in model.Config, serviceIndex map[string]*model.Servic
 	return out
 }
 
-// TranslateDestination produces a cluster naming function using the config context.
-func TranslateDestination(
+// ConvertDestinationToCluster produces a cluster naming function using the config context.
+func ConvertDestinationToCluster(
 	serviceIndex map[string]*model.Service,
-	defaultPort int) ClusterNaming {
+	defaultPort int) ClusterNameGenerator {
 	return func(destination *networking.Destination) string {
 		// detect if it is a service
 		svc := serviceIndex[destination.Host]
@@ -188,13 +188,13 @@ func TranslateDestination(
 	}
 }
 
-// ClusterNaming specifies cluster name for a destination
-type ClusterNaming func(*networking.Destination) string
+// ClusterNameGenerator specifies cluster name for a destination
+type ClusterNameGenerator func(*networking.Destination) string
 
 // TranslateRoutes creates virtual host routes from the v1alpha3 config.
 // The rule should be adapted to destination names (outbound clusters).
 // Each rule is guarded by source labels.
-func TranslateRoutes(in model.Config, name ClusterNaming, port int,
+func TranslateRoutes(in model.Config, nameF ClusterNameGenerator, port int,
 	proxyLabels model.LabelsCollection, gatewayName string) []route.Route {
 	rule, ok := in.Spec.(*networking.VirtualService)
 	if !ok {
@@ -206,16 +206,15 @@ func TranslateRoutes(in model.Config, name ClusterNaming, port int,
 	out := make([]route.Route, 0)
 	for _, http := range rule.Http {
 		if len(http.Match) == 0 {
-			r := TranslateRoute(http, nil, port, operation, name, proxyLabels, gatewayName)
-			if r != nil { // this cannot be nil
+			if r := translateRoute(http, nil, port, operation, nameF, proxyLabels, gatewayName); r != nil {
+				// this cannot be nil
 				out = append(out, *r)
 			}
 			break // we have a rule with catch all match prefix: /. Other rules are of no use
 		} else {
 			// TODO: https://github.com/istio/istio/issues/4239
 			for _, match := range http.Match {
-				r := TranslateRoute(http, match, port, operation, name, proxyLabels, gatewayName)
-				if r != nil {
+				if r := translateRoute(http, match, port, operation, nameF, proxyLabels, gatewayName); r != nil {
 					out = append(out, *r)
 				}
 			}
@@ -225,42 +224,48 @@ func TranslateRoutes(in model.Config, name ClusterNaming, port int,
 	return out
 }
 
-// TranslateRoute translates HTTP routes
+// sourceMatchHttp checks if the sourceLabels or the gateways in a match condition match with the
+// labels for the proxy or the gateway name for which we are generating a route
+func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels model.LabelsCollection, gatewayName string) bool {
+	if match == nil {
+		return true
+	}
+
+	// Trim by source labels or mesh gateway
+	if len(match.Gateways) > 0 {
+		for _, g := range match.Gateways {
+			if g == gatewayName {
+				return true
+			}
+		}
+	} else if proxyLabels.IsSupersetOf(match.GetSourceLabels()) {
+		return true
+	}
+
+	return false
+}
+
+// translateRoute translates HTTP routes
 // TODO: fault filters -- issue https://github.com/istio/api/issues/388
-func TranslateRoute(in *networking.HTTPRoute,
+func translateRoute(in *networking.HTTPRoute,
 	match *networking.HTTPMatchRequest, port int,
 	operation string,
-	name ClusterNaming,
+	nameF ClusterNameGenerator,
 	proxyLabels model.LabelsCollection,
 	gatewayName string) *route.Route {
 
-	sourceMatched := false
-	// Trim by source labels or mesh gateway
-	if match != nil {
-		if len(match.Gateways) > 0 {
-			for _, g := range match.Gateways {
-				if g == gatewayName {
-					sourceMatched = true
-					break
-				}
-			}
-		} else if proxyLabels.IsSupersetOf(match.GetSourceLabels()) {
-			sourceMatched = true
-		}
-	} else {
-		sourceMatched = true
-	}
-
-	if !sourceMatched {
+	// Match by source labels/gateway names inside the match condition
+	if !sourceMatchHTTP(match, proxyLabels, gatewayName) {
 		return nil
 	}
 
+	// Match by the destination port specified in the match condition
 	if match != nil && match.Port != nil && match.Port.GetNumber() != uint32(port) {
 		return nil
 	}
 
 	out := &route.Route{
-		Match: TranslateRouteMatch(match),
+		Match: translateRouteMatch(match),
 		Decorator: &route.Decorator{
 			Operation: operation,
 		},
@@ -277,8 +282,8 @@ func TranslateRoute(in *networking.HTTPRoute,
 	} else {
 		d := util.GogoDurationToDuration(in.Timeout)
 		action := &route.RouteAction{
-			Cors:         TranslateCORSPolicy(in.CorsPolicy),
-			RetryPolicy:  TranslateRetryPolicy(in.Retries),
+			Cors:         translateCORSPolicy(in.CorsPolicy),
+			RetryPolicy:  translateRetryPolicy(in.Retries),
 			Timeout:      &d,
 			UseWebsocket: &types.BoolValue{Value: in.WebsocketUpgrade},
 		}
@@ -304,7 +309,7 @@ func TranslateRoute(in *networking.HTTPRoute,
 		}
 
 		if in.Mirror != nil {
-			action.RequestMirrorPolicy = &route.RouteAction_RequestMirrorPolicy{Cluster: name(in.Mirror)}
+			action.RequestMirrorPolicy = &route.RouteAction_RequestMirrorPolicy{Cluster: nameF(in.Mirror)}
 		}
 
 		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
@@ -314,7 +319,7 @@ func TranslateRoute(in *networking.HTTPRoute,
 				weight.Value = uint32(100)
 			}
 			weighted = append(weighted, &route.WeightedCluster_ClusterWeight{
-				Name:   name(dst.Destination),
+				Name:   nameF(dst.Destination),
 				Weight: weight,
 			})
 		}
@@ -334,15 +339,15 @@ func TranslateRoute(in *networking.HTTPRoute,
 	return out
 }
 
-// TranslateRouteMatch translates match condition
-func TranslateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
+// translateRouteMatch translates match condition
+func translateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
 	out := route.RouteMatch{PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"}}
 	if in == nil {
 		return out
 	}
 
 	for name, stringMatch := range in.Headers {
-		matcher := TranslateHeaderMatcher(name, stringMatch)
+		matcher := translateHeaderMatch(name, stringMatch)
 		out.Headers = append(out.Headers, &matcher)
 	}
 
@@ -366,25 +371,25 @@ func TranslateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
 	}
 
 	if in.Method != nil {
-		matcher := TranslateHeaderMatcher(HeaderMethod, in.Method)
+		matcher := translateHeaderMatch(HeaderMethod, in.Method)
 		out.Headers = append(out.Headers, &matcher)
 	}
 
 	if in.Authority != nil {
-		matcher := TranslateHeaderMatcher(HeaderAuthority, in.Authority)
+		matcher := translateHeaderMatch(HeaderAuthority, in.Authority)
 		out.Headers = append(out.Headers, &matcher)
 	}
 
 	if in.Scheme != nil {
-		matcher := TranslateHeaderMatcher(HeaderScheme, in.Scheme)
+		matcher := translateHeaderMatch(HeaderScheme, in.Scheme)
 		out.Headers = append(out.Headers, &matcher)
 	}
 
 	return out
 }
 
-// TranslateHeaderMatcher translates to HeaderMatcher
-func TranslateHeaderMatcher(name string, in *networking.StringMatch) route.HeaderMatcher {
+// translateHeaderMatch translates to HeaderMatcher
+func translateHeaderMatch(name string, in *networking.StringMatch) route.HeaderMatcher {
 	out := route.HeaderMatcher{
 		Name: name,
 	}
@@ -405,8 +410,8 @@ func TranslateHeaderMatcher(name string, in *networking.StringMatch) route.Heade
 	return out
 }
 
-// TranslateRetryPolicy translates retry policy
-func TranslateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
+// translateRetryPolicy translates retry policy
+func translateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
 	if in != nil && in.Attempts > 0 {
 		d := util.GogoDurationToDuration(in.PerTryTimeout)
 		return &route.RouteAction_RetryPolicy{
@@ -418,8 +423,8 @@ func TranslateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPoli
 	return nil
 }
 
-// TranslateCORSPolicy translates CORS policy
-func TranslateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
+// translateCORSPolicy translates CORS policy
+func translateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 	if in == nil {
 		return nil
 	}
@@ -441,7 +446,7 @@ func TranslateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 // BuildDefaultHTTPRoute builds a default route.
 func BuildDefaultHTTPRoute(clusterName string) *route.Route {
 	return &route.Route{
-		Match: TranslateRouteMatch(nil),
+		Match: translateRouteMatch(nil),
 		Decorator: &route.Decorator{
 			Operation: DefaultRoute,
 		},

--- a/pilot/pkg/networking/route/route.go
+++ b/pilot/pkg/networking/route/route.go
@@ -1,0 +1,452 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/gogo/protobuf/types"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/util"
+)
+
+// Headers with special meaning in Envoy
+const (
+	HeaderMethod    = ":method"
+	HeaderAuthority = ":authority"
+	HeaderScheme    = ":scheme"
+)
+
+const (
+	// UnresolvedCluster for destinations pointing to unknown clusters.
+	UnresolvedCluster = "unresolved-cluster"
+
+	// DefaultRoute is the default decorator
+	DefaultRoute = "default-route"
+)
+
+// GuardedHost is a context-dependent virtual host entry with guarded routes.
+type GuardedHost struct {
+	// Port is the capture port (e.g. service port)
+	Port int
+
+	// Services are the services matching the virtual host.
+	// The service host names need to be contextualized by the source.
+	Services []*model.Service
+
+	// Hosts is a list of alternative literal host names for the host.
+	Hosts []string
+
+	// Routes in the virtual host
+	Routes []route.Route
+}
+
+// TranslateVirtualHosts creates the entire routing table for Istio v1alpha3 configs.
+// Services are indexed by FQDN hostnames.
+// Cluster domain is used to resolve short service names (e.g. "svc.cluster.local").
+func TranslateVirtualHosts(
+	serviceConfigs []model.Config,
+	services map[string]*model.Service,
+	proxyLabels model.LabelsCollection,
+	gatewayName string) []GuardedHost {
+	out := make([]GuardedHost, 0)
+
+	// translate all virtual service configs
+	for _, config := range serviceConfigs {
+		out = append(out, TranslateVirtualHost(config, services, proxyLabels, gatewayName)...)
+	}
+
+	// compute services missing service configs
+	missing := make(map[string]bool)
+	for fqdn := range services {
+		missing[fqdn] = true
+	}
+	for _, host := range out {
+		for _, service := range host.Services {
+			delete(missing, service.Hostname)
+		}
+	}
+
+	// append default hosts for the service missing virtual services
+	for fqdn := range missing {
+		svc := services[fqdn]
+		for _, port := range svc.Ports {
+			if port.Protocol.IsHTTP() {
+				cluster := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", svc.Hostname, port)
+				out = append(out, GuardedHost{
+					Port:     port.Port,
+					Services: []*model.Service{svc},
+					Routes:   []route.Route{*BuildDefaultHTTPRoute(cluster)},
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+// MatchServiceHosts splits the virtual service hosts into services and literal hosts
+func MatchServiceHosts(in model.Config, serviceIndex map[string]*model.Service) ([]string, []*model.Service) {
+	rule := in.Spec.(*networking.VirtualService)
+	hosts := make([]string, 0)
+	services := make([]*model.Service, 0)
+	for _, host := range rule.Hosts {
+		if svc := serviceIndex[host]; svc != nil {
+			services = append(services, svc)
+		} else {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts, services
+}
+
+// TranslateVirtualHost creates virtual hosts corresponding to a virtual service.
+func TranslateVirtualHost(in model.Config, serviceIndex map[string]*model.Service,
+	proxyLabels model.LabelsCollection, gatewayName string) []GuardedHost {
+	hosts, services := MatchServiceHosts(in, serviceIndex)
+	serviceByPort := make(map[int][]*model.Service)
+	for _, svc := range services {
+		for _, port := range svc.Ports {
+			if port.Protocol.IsHTTP() {
+				serviceByPort[port.Port] = append(serviceByPort[port.Port], svc)
+			}
+		}
+	}
+
+	// if no services matched, then we have no port information -- default to 80 for now
+	if len(serviceByPort) == 0 {
+		serviceByPort[80] = nil
+	}
+
+	out := make([]GuardedHost, len(serviceByPort))
+	for port, services := range serviceByPort {
+		clusterNaming := TranslateDestination(serviceIndex, port)
+		routes := TranslateRoutes(in, clusterNaming, port, proxyLabels, gatewayName)
+		if len(routes) == 0 {
+			continue
+		}
+		out = append(out, GuardedHost{
+			Port:     port,
+			Services: services,
+			Hosts:    hosts,
+			Routes:   routes,
+		})
+	}
+
+	return out
+}
+
+// TranslateDestination produces a cluster naming function using the config context.
+func TranslateDestination(
+	serviceIndex map[string]*model.Service,
+	defaultPort int) ClusterNaming {
+	return func(destination *networking.Destination) string {
+		// detect if it is a service
+		svc := serviceIndex[destination.Host]
+
+		// TODO: create clusters for non-service hostnames/IPs
+		if svc == nil {
+			return UnresolvedCluster
+		}
+
+		// default port uses port number
+		svcPort, _ := svc.Ports.GetByPort(defaultPort)
+		if destination.Port != nil {
+			switch selector := destination.Port.Port.(type) {
+			case *networking.PortSelector_Name:
+				svcPort, _ = svc.Ports.Get(selector.Name)
+			case *networking.PortSelector_Number:
+				svcPort, _ = svc.Ports.GetByPort(int(selector.Number))
+			}
+		}
+
+		if svcPort == nil {
+			return UnresolvedCluster
+		}
+
+		// use subsets if it is a service
+		return model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, svc.Hostname, svcPort)
+	}
+}
+
+// ClusterNaming specifies cluster name for a destination
+type ClusterNaming func(*networking.Destination) string
+
+// TranslateRoutes creates virtual host routes from the v1alpha3 config.
+// The rule should be adapted to destination names (outbound clusters).
+// Each rule is guarded by source labels.
+func TranslateRoutes(in model.Config, name ClusterNaming, port int,
+	proxyLabels model.LabelsCollection, gatewayName string) []route.Route {
+	rule, ok := in.Spec.(*networking.VirtualService)
+	if !ok {
+		return nil
+	}
+
+	operation := in.ConfigMeta.Name
+
+	out := make([]route.Route, 0)
+	for _, http := range rule.Http {
+		if len(http.Match) == 0 {
+			r := TranslateRoute(http, nil, port, operation, name, proxyLabels, gatewayName)
+			if r != nil { // this cannot be nil
+				out = append(out, *r)
+			}
+			break // we have a rule with catch all match prefix: /. Other rules are of no use
+		} else {
+			// TODO: https://github.com/istio/istio/issues/4239
+			for _, match := range http.Match {
+				r := TranslateRoute(http, match, port, operation, name, proxyLabels, gatewayName)
+				if r != nil {
+					out = append(out, *r)
+				}
+			}
+		}
+	}
+
+	return out
+}
+
+// TranslateRoute translates HTTP routes
+// TODO: fault filters -- issue https://github.com/istio/api/issues/388
+func TranslateRoute(in *networking.HTTPRoute,
+	match *networking.HTTPMatchRequest, port int,
+	operation string,
+	name ClusterNaming,
+	proxyLabels model.LabelsCollection,
+	gatewayName string) *route.Route {
+
+	sourceMatched := false
+	// Trim by source labels or mesh gateway
+	if match != nil {
+		if len(match.Gateways) > 0 {
+			for _, g := range match.Gateways {
+				if g == gatewayName {
+					sourceMatched = true
+					break
+				}
+			}
+		} else if proxyLabels.IsSupersetOf(match.GetSourceLabels()) {
+			sourceMatched = true
+		}
+	} else {
+		sourceMatched = true
+	}
+
+	if !sourceMatched {
+		return nil
+	}
+
+	if match != nil && match.Port != nil && match.Port.GetNumber() != uint32(port) {
+		return nil
+	}
+
+	out := &route.Route{
+		Match: TranslateRouteMatch(match),
+		Decorator: &route.Decorator{
+			Operation: operation,
+		},
+	}
+
+	if redirect := in.Redirect; redirect != nil {
+		out.Action = &route.Route_Redirect{
+			Redirect: &route.RedirectAction{
+				HostRedirect: redirect.Authority,
+				PathRewriteSpecifier: &route.RedirectAction_PathRedirect{
+					PathRedirect: redirect.Uri,
+				},
+			}}
+	} else {
+		action := &route.RouteAction{
+			Cors:         TranslateCORSPolicy(in.CorsPolicy),
+			RetryPolicy:  TranslateRetryPolicy(in.Retries),
+			Timeout:      util.TranslateTime(in.Timeout),
+			UseWebsocket: &types.BoolValue{Value: in.WebsocketUpgrade},
+		}
+		out.Action = &route.Route_Route{Route: action}
+
+		if rewrite := in.Rewrite; rewrite != nil {
+			action.PrefixRewrite = rewrite.Uri
+			action.HostRewriteSpecifier = &route.RouteAction_HostRewrite{
+				HostRewrite: rewrite.Authority,
+			}
+		}
+
+		if len(in.AppendHeaders) > 0 {
+			action.RequestHeadersToAdd = make([]*core.HeaderValueOption, 0)
+			for key, value := range in.AppendHeaders {
+				action.RequestHeadersToAdd = append(action.RequestHeadersToAdd, &core.HeaderValueOption{
+					Header: &core.HeaderValue{
+						Key:   key,
+						Value: value,
+					},
+				})
+			}
+		}
+
+		if in.Mirror != nil {
+			action.RequestMirrorPolicy = &route.RouteAction_RequestMirrorPolicy{Cluster: name(in.Mirror)}
+		}
+
+		weighted := make([]*route.WeightedCluster_ClusterWeight, 0)
+		for _, dst := range in.Route {
+			weight := &types.UInt32Value{Value: uint32(dst.Weight)}
+			if dst.Weight == 0 {
+				weight.Value = uint32(100)
+			}
+			weighted = append(weighted, &route.WeightedCluster_ClusterWeight{
+				Name:   name(dst.Destination),
+				Weight: weight,
+			})
+		}
+
+		// rewrite to a single cluster if there is only weighted cluster
+		if len(weighted) == 1 {
+			action.ClusterSpecifier = &route.RouteAction_Cluster{Cluster: weighted[0].Name}
+		} else {
+			action.ClusterSpecifier = &route.RouteAction_WeightedClusters{
+				WeightedClusters: &route.WeightedCluster{
+					Clusters: weighted,
+				},
+			}
+		}
+	}
+
+	return out
+}
+
+// TranslateRouteMatch translates match condition
+func TranslateRouteMatch(in *networking.HTTPMatchRequest) route.RouteMatch {
+	out := route.RouteMatch{PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"}}
+	if in == nil {
+		return out
+	}
+
+	for name, stringMatch := range in.Headers {
+		matcher := TranslateHeaderMatcher(name, stringMatch)
+		out.Headers = append(out.Headers, &matcher)
+	}
+
+	// guarantee ordering of headers
+	sort.Slice(out.Headers, func(i, j int) bool {
+		if out.Headers[i].Name == out.Headers[j].Name {
+			return out.Headers[i].Value < out.Headers[j].Value
+		}
+		return out.Headers[i].Name < out.Headers[j].Name
+	})
+
+	if in.Uri != nil {
+		switch m := in.Uri.MatchType.(type) {
+		case *networking.StringMatch_Exact:
+			out.PathSpecifier = &route.RouteMatch_Path{Path: m.Exact}
+		case *networking.StringMatch_Prefix:
+			out.PathSpecifier = &route.RouteMatch_Prefix{Prefix: m.Prefix}
+		case *networking.StringMatch_Regex:
+			out.PathSpecifier = &route.RouteMatch_Regex{Regex: m.Regex}
+		}
+	}
+
+	if in.Method != nil {
+		matcher := TranslateHeaderMatcher(HeaderMethod, in.Method)
+		out.Headers = append(out.Headers, &matcher)
+	}
+
+	if in.Authority != nil {
+		matcher := TranslateHeaderMatcher(HeaderAuthority, in.Authority)
+		out.Headers = append(out.Headers, &matcher)
+	}
+
+	if in.Scheme != nil {
+		matcher := TranslateHeaderMatcher(HeaderScheme, in.Scheme)
+		out.Headers = append(out.Headers, &matcher)
+	}
+
+	return out
+}
+
+// TranslateHeaderMatcher translates to HeaderMatcher
+func TranslateHeaderMatcher(name string, in *networking.StringMatch) route.HeaderMatcher {
+	out := route.HeaderMatcher{
+		Name: name,
+	}
+
+	switch m := in.MatchType.(type) {
+	case *networking.StringMatch_Exact:
+		out.Value = m.Exact
+	case *networking.StringMatch_Prefix:
+		// Envoy regex grammar is ECMA-262 (http://en.cppreference.com/w/cpp/regex/ecmascript)
+		// Golang has a slightly different regex grammar
+		out.Value = fmt.Sprintf("^%s.*", regexp.QuoteMeta(m.Prefix))
+		out.Regex = &types.BoolValue{Value: true}
+	case *networking.StringMatch_Regex:
+		out.Value = m.Regex
+		out.Regex = &types.BoolValue{Value: true}
+	}
+
+	return out
+}
+
+// TranslateRetryPolicy translates retry policy
+func TranslateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
+	if in != nil && in.Attempts > 0 {
+		return &route.RouteAction_RetryPolicy{
+			NumRetries:    &types.UInt32Value{Value: uint32(in.GetAttempts())},
+			RetryOn:       "5xx,connect-failure,refused-stream",
+			PerTryTimeout: util.TranslateTime(in.PerTryTimeout),
+		}
+	}
+	return nil
+}
+
+// TranslateCORSPolicy translates CORS policy
+func TranslateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
+	if in == nil {
+		return nil
+	}
+
+	out := route.CorsPolicy{
+		AllowOrigin: in.AllowOrigin,
+		Enabled:     &types.BoolValue{Value: true},
+	}
+	out.AllowCredentials = in.AllowCredentials
+	out.AllowHeaders = strings.Join(in.AllowHeaders, ",")
+	out.AllowMethods = strings.Join(in.AllowMethods, ",")
+	out.ExposeHeaders = strings.Join(in.ExposeHeaders, ",")
+	if in.MaxAge != nil {
+		out.MaxAge = in.MaxAge.String()
+	}
+	return &out
+}
+
+// BuildDefaultHTTPRoute builds a default route.
+func BuildDefaultHTTPRoute(clusterName string) *route.Route {
+	return &route.Route{
+		Match: TranslateRouteMatch(nil),
+		Decorator: &route.Decorator{
+			Operation: DefaultRoute,
+		},
+		Action: &route.Route_Route{
+			Route: &route.RouteAction{
+				ClusterSpecifier: &route.RouteAction_Cluster{Cluster: clusterName},
+			},
+		},
+	}
+}

--- a/pilot/pkg/networking/route/route.go
+++ b/pilot/pkg/networking/route/route.go
@@ -275,10 +275,11 @@ func TranslateRoute(in *networking.HTTPRoute,
 				},
 			}}
 	} else {
+		d := util.GogoDurationToDuration(in.Timeout)
 		action := &route.RouteAction{
 			Cors:         TranslateCORSPolicy(in.CorsPolicy),
 			RetryPolicy:  TranslateRetryPolicy(in.Retries),
-			Timeout:      util.TranslateTime(in.Timeout),
+			Timeout:      &d,
 			UseWebsocket: &types.BoolValue{Value: in.WebsocketUpgrade},
 		}
 		out.Action = &route.Route_Route{Route: action}
@@ -407,10 +408,11 @@ func TranslateHeaderMatcher(name string, in *networking.StringMatch) route.Heade
 // TranslateRetryPolicy translates retry policy
 func TranslateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
 	if in != nil && in.Attempts > 0 {
+		d := util.GogoDurationToDuration(in.PerTryTimeout)
 		return &route.RouteAction_RetryPolicy{
 			NumRetries:    &types.UInt32Value{Value: uint32(in.GetAttempts())},
 			RetryOn:       "5xx,connect-failure,refused-stream",
-			PerTryTimeout: util.TranslateTime(in.PerTryTimeout),
+			PerTryTimeout: &d,
 		}
 	}
 	return nil

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -14,6 +14,8 @@
 
 package util
 
+// TODO(mostrowski): move most of these functions to a lower level util pkg, they are not Pilot specific.
+
 import (
 	"bytes"
 	"strconv"
@@ -168,26 +170,16 @@ func MessageToStruct(msg proto.Message) *types.Struct {
 	return s
 }
 
-// ConvertGogoDurationToDuration converts from gogo proto duration to time.duration
-func ConvertGogoDurationToDuration(d *types.Duration) time.Duration {
+// GogoDurationToDuration converts from gogo proto duration to time.duration
+func GogoDurationToDuration(d *types.Duration) time.Duration {
 	if d == nil {
 		return 0
 	}
 	dur, err := types.DurationFromProto(d)
 	if err != nil {
+		// TODO(mostrowski): add error handling instead.
 		log.Warnf("error converting duration %#v, using 0: %v", d, err)
+		return 0
 	}
 	return dur
-}
-
-// TranslateTime converts time protos.
-func TranslateTime(in *types.Duration) *time.Duration {
-	if in == nil {
-		return nil
-	}
-	out, err := types.DurationFromProto(in)
-	if err != nil {
-		log.Warnf("error converting duration %#v, using 0: %v", in, err)
-	}
-	return &out
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -179,3 +179,15 @@ func ConvertGogoDurationToDuration(d *types.Duration) time.Duration {
 	}
 	return dur
 }
+
+// TranslateTime converts time protos.
+func TranslateTime(in *types.Duration) *time.Duration {
+	if in == nil {
+		return nil
+	}
+	out, err := types.DurationFromProto(in)
+	if err != nil {
+		log.Warnf("error converting duration %#v, using 0: %v", in, err)
+	}
+	return &out
+}


### PR DESCRIPTION
Attach a mixer config to each route within the Plugin callback.

Note: route.go is just a move of some functions out of v1alpha3/httproute.go - this is required for plugins on which v1alpha3 depends. 