### PR TITLE
Disable TestVMExtendsIstio that is not critical for 0.8.0

### DIFF
--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -544,6 +544,7 @@ func TestDbRoutingMysql(t *testing.T) {
 }
 
 func TestVMExtendsIstio(t *testing.T) {
+	t.Skip("issue https://github.com/istio/istio/issues/4794")
 	if *framework.TestVM {
 		// TODO (chx) vm_provider flag to select venders
 		vm, err := framework.NewGCPRawVM(tc.CommonConfig.Kube.Namespace)


### PR DESCRIPTION
Checked with @costinm . The test is not critical for 0.8.0 and there is no resource to debug at this point. Hence we are temporarily disabling it to unblock daily releases (and the 0.8.0 RC which is supposed to happen on 4/14).