### PR TITLE
Remove cluster-admin assertion for Ansible installation

### DIFF
--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -29,9 +29,6 @@
       - "vo.stdout >= minimum_cluster_version"
     msg: "Cluster version must be at least {{ minimum_cluster_version }}"
 
-- include_tasks: assert_oc_admin.yml
-  when: cluster_flavour == 'ocp'
-
 - include_tasks: install_distro.yml
 - include_tasks: delete_resources.yml
   when: istio.delete_resources == true


### PR DESCRIPTION
This assertion is creating more problems that it's solving. This is
because the assertion checks for a clusterrolebinding with a specific
name.
It's best that we drop the assertion since we have already stated in the
docs that in order to Istio on Openshift the user has to be logged in
with a cluster admin role