### PR TITLE
Fixes a build breakage due to 4815 and 4706

### DIFF
--- a/pilot/pkg/config/clusterregistry/conversion_test.go
+++ b/pilot/pkg/config/clusterregistry/conversion_test.go
@@ -16,19 +16,17 @@ package clusterregistry
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
 	"testing"
 	"text/template"
 
-	"io/ioutil"
-	"os"
-
+	"github.com/pborman/uuid"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
-
-	"github.com/pborman/uuid"
 )
 
 // type createCfgDataFilesFunc func(dir string, cData []clusterInfo) (err error)

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -609,3 +609,13 @@ func GetKubeConfig(filename string) error {
 	log.Infof("kubeconfig file %s created\n", filename)
 	return nil
 }
+
+// GetKubeConfigFromFile will parse the provided directory for a file that provides two kubeconfig
+// formatted blocks.  One for the local cluster where Istio is installed and another for a remote
+// cluster
+func GetKubeConfigFromFile(dirname string) (string, string, error) {
+	//TODO complete function
+	err := fmt.Errorf("the function to parse the test config is not completed and is a TODO")
+	return "", "", err
+
+}


### PR DESCRIPTION
PR4815 and PR4706 merged close to one another
and there was a conflict in the usage of
clusterregistery functions.  This is a quick
turn fix.