### PR TITLE
target istio-telemetry from mixer ilb and update dnsmasq config

### DIFF
--- a/install/kubernetes/mesh-expansion.yaml
+++ b/install/kubernetes/mesh-expansion.yaml
@@ -56,7 +56,10 @@ spec:
     protocol: TCP
   selector:
     istio: mixer
+    istio-mixer-type: telemetry
 
+# This points to istio-telemetry until we are able to support both
+# istio-policy and istio-telemetry as separate services for mesh expansion.
 
 ---
 apiVersion: v1

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -70,12 +70,14 @@ function istioDnsmasq() {
 
   #/etc/dnsmasq.d/kubedns
   echo "server=/svc.cluster.local/$ISTIO_DNS" > kubedns
-  echo "address=/istio-mixer/$MIXER_IP" >> kubedns
+  echo "address=/istio-policy/$MIXER_IP" >> kubedns
+  echo "address=/istio-telemetry/$MIXER_IP" >> kubedns
   echo "address=/istio-pilot/$PILOT_IP" >> kubedns
   echo "address=/istio-ca/$CA_IP" >> kubedns
   # Also generate host entries for the istio-system. The generated config will work with both
   # 'cluster-wide' and 'per-namespace'.
-  echo "address=/istio-mixer.$NS/$MIXER_IP" >> kubedns
+  echo "address=/istio-policy.$NS/$MIXER_IP" >> kubedns
+  echo "address=/istio-telemetry.$NS/$MIXER_IP" >> kubedns
   echo "address=/istio-pilot.$NS/$PILOT_IP" >> kubedns
   echo "address=/istio-ca.$NS/$CA_IP" >> kubedns
 


### PR DESCRIPTION
1. Only target istio-telemetry pods for mixer-ilb service
2. Point istio-telemetry and istio-policy dns names to the ilb ip.

GCE only gives 5 ILB by default, so a single ILB has to support both policy and telemetry.
When Mixer cluster is delivered by pilot via EDS, this hack should be removed.