### PR TITLE
add envoyv2 alphav3 tests to prow

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -30,7 +30,7 @@ set -u
 # Print commands
 set -x
 
-TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot test/local/noauth/e2e_pilotv2)
+TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2_v1aplha3)
 SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -30,7 +30,7 @@ set -u
 # Print commands
 set -x
 
-TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2_v1aplha3)
+TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2_v1alpha3)
 SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -30,8 +30,7 @@ set -u
 # Print commands
 set -x
 
-TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot)
-TEST_TARGETS_SET=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2)
+TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot test/local/noauth/e2e_pilotv2)
 SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
@@ -89,7 +88,7 @@ if ${SINGLE_MODE}; then
 
     # Check if it's a valid test file
     VALID_TEST=false
-    for T in ${TEST_TARGETS_SET[@]}; do
+    for T in ${TEST_TARGETS[@]}; do
         if [ "${T}" == "${SINGLE_TEST}" ]; then
             VALID_TEST=true
             time ISTIO_DOCKER_HUB=$HUB \

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -31,6 +31,7 @@ set -u
 set -x
 
 TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot)
+TEST_TARGETS_SET=(e2e_simple e2e_mixer e2e_bookinfo e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2)
 SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
@@ -88,7 +89,7 @@ if ${SINGLE_MODE}; then
 
     # Check if it's a valid test file
     VALID_TEST=false
-    for T in ${TEST_TARGETS[@]}; do
+    for T in ${TEST_TARGETS_SET[@]}; do
         if [ "${T}" == "${SINGLE_TEST}" ]; then
             VALID_TEST=true
             time ISTIO_DOCKER_HUB=$HUB \

--- a/prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
+++ b/prow/istio-pilot-e2e-envoyv2-v1alpha3.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#######################################
+#                                     #
+#        pilot-e2e (v1alpha3)         #
+#                                     #
+#######################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# Run tests with auth disabled
+#echo 'Running pilot e2e tests (v1alpha3, noauth)'
+./prow/e2e-suite.sh --single_test e2e_pilotv2_v1alpha3
+
+# Run tests with auth enabled
+#echo 'Running pilot e2e tests (v1alpha3, auth)'
+#./prow/e2e-suite.sh --auth_enable=true --v1alpha1=false --single_test e2e_pilot "$@"

--- a/prow/istio-pilot-e2e-v1alpha3.sh
+++ b/prow/istio-pilot-e2e-v1alpha3.sh
@@ -29,7 +29,7 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
-./prow/e2e-suite.sh --single_test e2e_pilotv2_v1aplha3
+./prow/e2e-suite.sh --single_test e2e_pilotv2_v1alpha3
 
 # Run tests with auth enabled
 #echo 'Running pilot e2e tests (v1alpha3, auth)'

--- a/prow/istio-pilot-e2e-v1alpha3.sh
+++ b/prow/istio-pilot-e2e-v1alpha3.sh
@@ -29,9 +29,8 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
-./prow/e2e-suite.sh --single_test e2e_pilotv2 "$@"
+./prow/e2e-suite.sh --single_test test/local/noauth/e2e_pilotv2
 
 # Run tests with auth enabled
 #echo 'Running pilot e2e tests (v1alpha3, auth)'
 #./prow/e2e-suite.sh --auth_enable=true --v1alpha1=false --single_test e2e_pilot "$@"
-echo "v1alpha3 tests are disabled temporarily while we switch to envoyv2 for v1alpha3"

--- a/prow/istio-pilot-e2e-v1alpha3.sh
+++ b/prow/istio-pilot-e2e-v1alpha3.sh
@@ -29,7 +29,7 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
-./prow/e2e-suite.sh --single_test test/local/noauth/e2e_pilotv2
+./prow/e2e-suite.sh --single_test e2e_pilotv2_v1aplha3
 
 # Run tests with auth enabled
 #echo 'Running pilot e2e tests (v1alpha3, auth)'

--- a/prow/istio-pilot-e2e-v1alpha3.sh
+++ b/prow/istio-pilot-e2e-v1alpha3.sh
@@ -29,7 +29,7 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
-#./prow/e2e-suite.sh --auth_enable=false --v1alpha1=false --single_test e2e_pilot "$@"
+./prow/e2e-suite.sh --single_test e2e_pilotv2 "$@"
 
 # Run tests with auth enabled
 #echo 'Running pilot e2e tests (v1alpha3, auth)'

--- a/release/pipeline/dags/istio_common_dag.py
+++ b/release/pipeline/dags/istio_common_dag.py
@@ -92,7 +92,7 @@ def MakeCommonDag(name='istio_daily_flow_test',
         however we dont backfill and only need to run one build therefore use
         the current date instead of the date that is passed in """
 #    date = kwargs['execution_date']
-date = datetime.datetime.now()
+    date = datetime.datetime.now()
 
     timestamp = time.mktime(date.timetuple())
 

--- a/release/pipeline/dags/istio_common_dag.py
+++ b/release/pipeline/dags/istio_common_dag.py
@@ -92,7 +92,7 @@ def MakeCommonDag(name='istio_daily_flow_test',
         however we dont backfill and only need to run one build therefore use
         the current date instead of the date that is passed in """
 #    date = kwargs['execution_date']
-    date = datetime.datetime.now()
+date = datetime.datetime.now()
 
     timestamp = time.mktime(date.timetuple())
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -120,6 +120,8 @@ e2e_all_run_junit_report:
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
+e2e_pilotv2: istioctl test/local/noauth/e2e_pilotv2
+
 ## Targets for fast local development and staged CI.
 # The test take a T argument. Example:
 # make test/local/noauth/e2e_pilotv2 T=-test.run=TestPilot/ingress

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -120,7 +120,9 @@ e2e_all_run_junit_report:
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
-e2e_pilotv2: | istioctl test/local/noauth/e2e_pilotv2
+e2e_pilotv2:
+	$(MAKE) istioctl
+	$(MAKE) test/local/noauth/e2e_pilotv2
 
 ## Targets for fast local development and staged CI.
 # The test take a T argument. Example:

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -120,9 +120,7 @@ e2e_all_run_junit_report:
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
-e2e_pilotv2:
-	$(MAKE) istioctl
-	$(MAKE) test/local/noauth/e2e_pilotv2
+e2e_pilotv2: | istioctl test/local/noauth/e2e_pilotv2
 
 ## Targets for fast local development and staged CI.
 # The test take a T argument. Example:

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -101,6 +101,12 @@ e2e_upgrade_run:
 e2e_version_skew_run:
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args --smooth_check=true ${E2E_ARGS} ${EXTRA_E2E_ARGS} ${UPGRADE_E2E_ARGS}
 
+# v1alpha3+envoyv2 test without MTLS
+e2e_pilotv2: istioctl generate_yaml-envoyv2_transition
+	ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/pilot \
+ 	--skip_cleanup --auth_enable=false --v1alpha3=true --egress=false --ingress=false --rbac_enable=false --v1alpha1=false \
+	${E2E_ARGS} ${EXTRA_E2E_ARGS} ${T} 
+
 e2e_all_run:
 	$(MAKE) --keep-going e2e_simple_run e2e_mixer_run e2e_bookinfo_run e2e_dashboard_run e2e_upgrade_run
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -101,12 +101,6 @@ e2e_upgrade_run:
 e2e_version_skew_run:
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args --smooth_check=true ${E2E_ARGS} ${EXTRA_E2E_ARGS} ${UPGRADE_E2E_ARGS}
 
-# v1alpha3+envoyv2 test without MTLS
-e2e_pilotv2: istioctl generate_yaml-envoyv2_transition
-	ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/pilot \
- 	--skip_cleanup --auth_enable=false --v1alpha3=true --egress=false --ingress=false --rbac_enable=false --v1alpha1=false \
-	${E2E_ARGS} ${EXTRA_E2E_ARGS} ${T} 
-
 e2e_all_run:
 	$(MAKE) --keep-going e2e_simple_run e2e_mixer_run e2e_bookinfo_run e2e_dashboard_run e2e_upgrade_run
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -120,7 +120,7 @@ e2e_all_run_junit_report:
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
-e2e_pilotv2: istioctl test/local/noauth/e2e_pilotv2
+e2e_pilotv2: | istioctl test/local/noauth/e2e_pilotv2
 
 ## Targets for fast local development and staged CI.
 # The test take a T argument. Example:

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -120,7 +120,7 @@ e2e_all_run_junit_report:
 e2e_pilot: istioctl generate_yaml
 	go test -v -timeout 20m ./tests/e2e/tests/pilot ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
-e2e_pilotv2: | istioctl test/local/noauth/e2e_pilotv2
+e2e_pilotv2_v1alpha3: | istioctl test/local/noauth/e2e_pilotv2
 
 ## Targets for fast local development and staged CI.
 # The test take a T argument. Example:

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -46,29 +46,11 @@ else
   TOOLS_DIR=${TOOLS_DIR:-$(dirname $0)}
   echo "$0 is Executed, (Tools in $TOOLS_DIR) (can also be sourced interactively)..."
   echo "In case of errors, retry at the failed step (readyness checks missing)"
-  #set -e
+  set -e
   SOURCED=0
   if [[ -z "${PROJECT}" ]]; then
     Usage
   fi
-
-  while getopts ":sh" opt; do
-    case ${opt} in
-      s)
-        SKIP_CREATE="true"
-        ;;
-      h)
-        Usage
-        exit 0
-        ;;
-      \?)
-        echo "Invalid option: -$OPTARG" >&2
-        Usage
-        exit 1
-        ;;
-    esac
-  done
-
 fi
 
 
@@ -89,6 +71,7 @@ function ExecuteEval() {
 
 function create_cluster() {
   Execute gcloud container clusters create $CLUSTER_NAME $GCP_OPTS --machine-type=$MACHINE_TYPE --num-nodes=$NUM_NODES --no-enable-legacy-authorization
+  Execute gcloud container clusters get-credentials $CLUSTER_NAME $GCP_OPTS
 }
 
 function delete_cluster() {
@@ -412,15 +395,9 @@ function run_canonical_perf_test() {
     curl -s "${URL}" -o "${OUT_FILE}"
 }
 
-function create_vm_cluster_all() {
-  update_gcp_opts
-  create_vm
-  echo "Setting up CLUSTER_NAME=$CLUSTER_NAME for PROJECT=$PROJECT in ZONE=$ZONE, NUM_NODES=$NUM_NODES * MACHINE_TYPE=$MACHINE_TYPE"
-  create_cluster
-}
-
 function setup_vm_all() {
   update_gcp_opts
+  create_vm
   setup_vm
   setup_vm_firewall
   update_fortio_on_vm
@@ -429,19 +406,17 @@ function setup_vm_all() {
 
 function setup_istio_all() {
   update_gcp_opts
-  if [[ -z "${SKIP_CREATE}" ]]; then
-    install_istio
-  fi
+  install_istio
   install_istio_svc
   install_istio_ingress_rules
   install_istio_cache_busting_rule
 }
 
 function setup_cluster_all() {
+  echo "Setting up CLUSTER_NAME=$CLUSTER_NAME for PROJECT=$PROJECT in ZONE=$ZONE, NUM_NODES=$NUM_NODES * MACHINE_TYPE=$MACHINE_TYPE"
+  create_cluster
   kubectl_setup
-  if [[ -z "${SKIP_CREATE}" ]]; then
-    install_non_istio_svc
-  fi
+  install_non_istio_svc
   setup_non_istio_ingress
   setup_istio_all
 }
@@ -498,12 +473,7 @@ function check_image_versions() {
 if [[ $SOURCED == 0 ]]; then
   # Normal mode: all at once:
   update_gcp_opts
-  if [[ -z "${SKIP_CREATE}" ]]; then
-    create_vm_cluster_all
-    setup_all
-  else
-    setup_vm_all
-  fi
+  setup_all
 
 #update_fortio_on_vm
 #run_fortio_on_vm


### PR DESCRIPTION
will enable istio-pilot-e2e-envoyv2-v1alpha3 tests in prow and disable the old test istio-pilot-e2e-v1alpha3 after this PR is in. Will also remove prow/istio-pilot-e2e-v1alpha3.sh in a subsequent PR as cleanup