### PR TITLE
[WIP] Rewrite routing to egress e2e tests for v1alpha3

### DIFF
--- a/tests/e2e/tests/pilot/routing_to_external_service_test.go
+++ b/tests/e2e/tests/pilot/routing_to_external_service_test.go
@@ -24,9 +24,8 @@ import (
 )
 
 func TestExternalServiceRouteFaultInjection(t *testing.T) {
-	// egress rules are v1alpha1
-	if !tc.V1alpha1 {
-		t.Skipf("Skipping %s: v1alpha1=false", t.Name())
+	if !tc.V1alpha3 {
+		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}
 
 	var cfgs *deployableConfig

--- a/tests/e2e/tests/pilot/routing_to_external_service_test.go
+++ b/tests/e2e/tests/pilot/routing_to_external_service_test.go
@@ -21,8 +21,8 @@ import (
 )
 
 func TestExternalServiceRouteHeaders(t *testing.T) {
-	if !tc.Egress {
-		t.Skipf("Skipping %s: egress=false", t.Name())
+	if !tc.V1alpha3 {
+		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}
 
 	cfgs := &deployableConfig{

--- a/tests/e2e/tests/pilot/routing_to_external_service_test.go
+++ b/tests/e2e/tests/pilot/routing_to_external_service_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestExternalServiceRouteHeaders(t *testing.T) {
+func TestExternalServiceAppendHeaders(t *testing.T) {
 	if !tc.V1alpha3 {
 		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}

--- a/tests/e2e/tests/pilot/routing_to_external_service_test.go
+++ b/tests/e2e/tests/pilot/routing_to_external_service_test.go
@@ -16,9 +16,114 @@ package pilot
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
+
+	"istio.io/istio/tests/util"
 )
+
+func TestExternalServiceRouteFaultInjection(t *testing.T) {
+	// egress rules are v1alpha1
+	if !tc.V1alpha1 {
+		t.Skipf("Skipping %s: v1alpha1=false", t.Name())
+	}
+
+	var cfgs *deployableConfig
+	applyRuleFunc := func(t *testing.T, yamlFiles []string) {
+		// Delete the previous rule if there was one. No delay on the teardown, since we're going to apply
+		// a delay when we push the new config.
+		if cfgs != nil {
+			if err := cfgs.TeardownNoDelay(); err != nil {
+				t.Fatal(err)
+			}
+			cfgs = nil
+		}
+
+		// Apply the new rule
+		cfgs = &deployableConfig{
+			Namespace:  tc.Kube.Namespace,
+			YamlFiles:  yamlFiles,
+			kubeconfig: tc.Kube.KubeConfig,
+		}
+		if err := cfgs.Setup(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Upon function exit, delete the active rule.
+	defer func() {
+		if cfgs != nil {
+			_ = cfgs.Teardown()
+		}
+	}()
+
+	cases := []struct {
+		testName              string
+		externalServiceConfig string
+		routingTemplate       string
+		url                   string
+		routingParams         map[string]string
+	}{
+		// Fault Injection
+		{
+			testName:              "httpbin",
+			externalServiceConfig: "testdata/v1alpha3/external-service-httpbin.yaml",
+			routingTemplate:       "testdata/v1alpha3/rule-fault-injection-to-external-service.yaml.tmpl",
+			routingParams: map[string]string{
+				"host": "httpbin.org",
+			},
+			url: "http://httpbin.org",
+		},
+		{
+			testName:              "*.httpbin",
+			externalServiceConfig: "testdata/v1alpha3/external-service-httpbin.yaml",
+			routingTemplate:       "testdata/v1alpha3/rule-fault-injection-to-external-service.yaml.tmpl",
+			routingParams: map[string]string{
+				"host": "*.httpbin.org",
+			},
+			url: "http://www.httpbin.org",
+		},
+		{
+			testName:              "google",
+			externalServiceConfig: "testdata/v1alpha3/external-service-google.yaml",
+			routingTemplate:       "testdata/v1alpha3/rule-fault-injection-to-external-service.yaml.tmpl",
+			routingParams: map[string]string{
+				"host": "*google.com",
+			},
+			url: "http://www.google.com:443",
+		},
+	}
+
+	for _, c := range cases {
+		// Run case in a function to scope the configuration changes.
+		func() {
+			// Fill out the routing template
+			routingYaml, err := util.CreateAndFill(tc.Info.TempDir, c.routingTemplate, c.routingParams)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Push all of the configs
+			applyRuleFunc(t, []string{c.externalServiceConfig, routingYaml})
+
+			runRetriableTest(t, c.testName, 3, func() error {
+				resp := ClientRequest("a", c.url, 1, "")
+
+				statusCode := ""
+				if len(resp.Code) > 0 {
+					statusCode = resp.Code[0]
+				}
+
+				expectedRespCode := 418
+				if strconv.Itoa(expectedRespCode) != statusCode {
+					return fmt.Errorf("fault injection verification failed: status code %s, expected status code %d",
+						statusCode, expectedRespCode)
+				}
+				return nil
+			})
+		}()
+	}
+}
 
 func TestExternalServiceAppendHeaders(t *testing.T) {
 	if !tc.V1alpha3 {

--- a/tests/e2e/tests/pilot/routing_to_external_service_test.go
+++ b/tests/e2e/tests/pilot/routing_to_external_service_test.go
@@ -1,0 +1,62 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestExternalServiceRouteHeaders(t *testing.T) {
+	if !tc.Egress {
+		t.Skipf("Skipping %s: egress=false", t.Name())
+	}
+
+	cfgs := &deployableConfig{
+		Namespace: tc.Kube.Namespace,
+		YamlFiles: []string{
+			"testdata/v1alpha3/external-service-httpbin.yaml",
+			"testdata/v1alpha3/rule-route-append-headers-httpbin.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
+	}
+	if err := cfgs.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer cfgs.Teardown()
+
+	runRetriableTest(t, "httpbin", 3,
+		func() error {
+			resp := ClientRequest("a", "http://httpbin.org/headers", 1, "")
+
+			containsAllExpectedHeaders := true
+
+			headers := []string{
+				"\"istio-custom-header1\": \"user-defined-value1\"",
+				"\"istio-custom-header2\": \"user-defined-value2\""}
+			for _, header := range headers {
+				if !strings.Contains(strings.ToLower(resp.Body), header) {
+					containsAllExpectedHeaders = false
+				}
+			}
+
+			if !containsAllExpectedHeaders {
+				return fmt.Errorf("headers verification failed: headers: %s, expected headers: %s",
+					resp.Body, headers)
+			}
+			return nil
+		})
+
+}

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-httpbin.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ExternalService
+metadata:
+  name: external-service-httpbin
+spec:
+  hosts:
+    - httpbin.org
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  discovery: DNS

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-httpbin.yaml
@@ -9,4 +9,3 @@ spec:
   - number: 80
     name: http
     protocol: HTTP
-  discovery: DNS

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-https-google.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/external-service-https-google.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ExternalService
+metadata:
+  name: external-service-https-google
+spec:
+  hosts:
+  - www.google.com
+  ports:
+  - number: 443
+    name: https
+    protocol: http
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: destination-rule-https-google
+spec:
+  host: www.google.com
+  trafficPolicy:
+    tls:
+      mode: SIMPLE

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/rule-fault-injection-to-external-service.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/rule-fault-injection-to-external-service.yaml.tmpl
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fault-injection-to-external-service-rule
+spec:
+  hosts:
+  - "{{.host}}"
+  http:
+  - route:
+    - destination:
+        host: "{{.host}}"
+    fault:
+      abort:
+        percent: 100
+        httpStatus: 418

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/rule-route-append-headers-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/rule-route-append-headers-httpbin.yaml
@@ -4,11 +4,11 @@ metadata:
   name: httpbin-append-headers
 spec:
   hosts:
-    - httpbin.org
+    - "httpbin.org"
   http:
-    route:
-    - destination:
-        host: httpbin.org
+  - route:
+      - destination:
+          host: httpbin.org
     appendHeaders:
       istio-custom-header1: user-defined-value1
       istio-custom-header2: user-defined-value2

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/rule-route-append-headers-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/rule-route-append-headers-httpbin.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin-append-headers
+spec:
+  hosts:
+    - httpbin.org
+  http:
+    route:
+    - destination:
+        host: httpbin.org
+    appendHeaders:
+      istio-custom-header1: user-defined-value1
+      istio-custom-header2: user-defined-value2


### PR DESCRIPTION
Rewrite the routing to egress e2e tests for valpha3 based on the v1alpha1 version:
https://github.com/istio/istio/blob/master/tests/e2e/tests/pilot/routing_to_egress_test.go
