### PR TITLE
Move pkg/server/grpc to pkg/server/ca.

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -41,7 +41,7 @@ import (
 	probecontroller "istio.io/istio/security/pkg/probe"
 	"istio.io/istio/security/pkg/registry"
 	"istio.io/istio/security/pkg/registry/kube"
-	"istio.io/istio/security/pkg/server/grpc"
+	caserver "istio.io/istio/security/pkg/server/ca"
 )
 
 // TODO(myidpt): move the following constants to pkg/cmd.
@@ -312,11 +312,11 @@ func runCA() {
 
 		// The CA API uses cert with the max workload cert TTL.
 		hostnames := strings.Split(opts.grpcHosts, ",")
-		grpcServer, startErr := grpc.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort)
+		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort)
 		if startErr != nil {
 			fatalf("failed to create istio ca server: %v", startErr)
 		}
-		if serverErr := grpcServer.Run(); serverErr != nil {
+		if serverErr := caServer.Run(); serverErr != nil {
 			// stop the registry-related controllers
 			ch <- struct{}{}
 

--- a/security/pkg/server/ca/authenticator.go
+++ b/security/pkg/server/ca/authenticator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"fmt"

--- a/security/pkg/server/ca/authenticator_test.go
+++ b/security/pkg/server/ca/authenticator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"crypto/tls"

--- a/security/pkg/server/ca/authorizer.go
+++ b/security/pkg/server/ca/authorizer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"fmt"

--- a/security/pkg/server/ca/authorizer_test.go
+++ b/security/pkg/server/ca/authorizer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"testing"

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"crypto/tls"

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package grpc
+package ca
 
 import (
 	"bytes"


### PR DESCRIPTION
We will have pkg/server/monitoring as well. Since grpc is the only protocol supported by Istio CA, remove the directory name grpc.