### PR TITLE
Make istio-certs required for istio pilot deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -123,6 +123,5 @@ spec:
       - name: istio-certs
         secret:
           secretName: "istio.istio-pilot-service-account"
-          optional: true
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
Pilot's sidecar bootstrap configuration always requires certs for port
15005 (mTLS). Make the dependent k8s cert volume mount required so
that proxies don't try to prematurely access pilot before it's ready to serve
config.

potentially fixes https://github.com/istio/istio/issues/4842