### PR TITLE
Fixes cases when kubeconfig has a ref path

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
@@ -1,0 +1,26 @@
+# This is used to generate istio-auth-multicluster.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: true
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: true
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+  multicluster:
+    enabled: true
+
+istiotesting:
+  oneNameSpace: false
+
+prometheus:
+  enabled: true
+

--- a/install/kubernetes/helm/istio/values-istio-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-multicluster.yaml
@@ -1,0 +1,25 @@
+# This is used to generate istio-multicluster.yaml
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: false
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+  multicluster:
+    enabled: true
+
+istiotesting:
+  oneNameSpace: false
+
+prometheus:
+  enabled: true

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -56,7 +56,7 @@ function gen_file() {
 }
 
 
-for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml;do
+for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-multicluster.yaml istio-auth-multicluster.yaml;do
     gen_file $target ${DEST_DIR}
 done
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -508,6 +508,7 @@ func (k *KubeInfo) deployIstio() error {
 	yamlDir := filepath.Join(istioInstallDir, istioYaml)
 	baseIstioYaml := filepath.Join(k.ReleaseDir, yamlDir)
 	testIstioYaml := filepath.Join(k.TmpDir, "yaml", istioYaml)
+	log.Infof("JAJ Generating yaml baseIstio = %s testIstio = %s", baseIstioYaml, testIstioYaml)
 
 	if err := k.generateIstio(baseIstioYaml, testIstioYaml); err != nil {
 		log.Errorf("Generating yaml %s failed", testIstioYaml)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -34,6 +34,8 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/util"
+
+	"k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strconv"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+
+	"istio.io/istio/pkg/log"
+)
+
+var (
+	supportedExtensions = map[string]bool{
+		".yaml": true,
+		".yml":  true,
+	}
+)
+
+// annotations for a Cluster
+const (
+	// the pilot's endpoint IP address where this cluster is part of
+	ClusterPilotEndpoint = "config.istio.io/pilotEndpoint"
+
+	// The cluster's platform: Kubernetes, Consul, Eureka, CloudFoundry
+	ClusterPlatform = "config.istio.io/platform"
+
+	// The cluster's access configuration file
+	// E.g., on kubenetes, this file can be usually copied from .kube/config
+	ClusterAccessConfigFile = "config.istio.io/accessConfigFile"
+
+	// For the time being, assume that ClusterPilotCfgStore is only set for one cluster.
+	// If set to be true, this cluster will be used as the pilot's config store.
+	ClusterPilotCfgStore = "config.istio.io/pilotCfgStore"
+)
+
+func getKubeConfigFromFile(dirname string) (string, string, error) {
+
+	var clusters []*k8s_cr.Cluster
+	err := filepath.Walk(dirname, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !supportedExtensions[filepath.Ext(path)] || (info.Mode()&os.ModeType) != 0 {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			log.Warnf("Failed to read %s: %v", path, err)
+			return err
+		}
+		result, err := parseClusters(dirname, data)
+		if err != nil {
+			log.Warnf("Failed to parse cluster file %s: %v", path, err)
+			return err
+		}
+		clusters = append(clusters, result...)
+		return nil
+	})
+
+	var localKube, remoteKube string
+	if err == nil {
+		// The tests assume that ClusterPilotCfgStore is only set for one cluster only.
+		// This cluster will be used as the pilot's config store.
+		for _, cluster := range clusters {
+			log.Infof("ClusterPilotCfgStore: %s", cluster.ObjectMeta.Annotations[ClusterPilotCfgStore])
+			log.Infof("jaj cluster: %s, localKube, remoteKube", cluster, localKube, remoteKube)
+			if isCfgStore, _ := strconv.ParseBool(cluster.ObjectMeta.Annotations[ClusterPilotCfgStore]); isCfgStore {
+				localKube = cluster.ObjectMeta.Annotations[ClusterAccessConfigFile]
+			} else {
+				remoteKube = cluster.ObjectMeta.Annotations[ClusterAccessConfigFile]
+			}
+		}
+		if localKube == "" {
+			log.Warnf("no config store is defined in the cluster registries")
+			return "", "", nil
+		}
+		localKube = path.Join(dirname, localKube)
+		if remoteKube != "" {
+			remoteKube = path.Join(dirname, remoteKube)
+		}
+	}
+
+	return localKube, remoteKube, nil
+}
+
+// parseClusters reads multiple clusters from a single file
+func parseClusters(crPath string, clusterData []byte) (clusters []*k8s_cr.Cluster, err error) {
+	reader := bytes.NewReader(clusterData)
+	var empty = k8s_cr.Cluster{}
+
+	// We store configs as a YaML stream; there may be more than one decoder.
+	yamlDecoder := yaml.NewYAMLOrJSONDecoder(reader, 512*1024)
+	for {
+		obj := k8s_cr.Cluster{}
+		err1 := yamlDecoder.Decode(&obj)
+		if err1 == io.EOF {
+			break
+		}
+		if err1 != nil {
+			err = multierror.Append(err, err1)
+			return nil, err
+		}
+		if reflect.DeepEqual(obj, empty) {
+			continue
+		}
+		clusters = append(clusters, &obj)
+
+	}
+	return
+}

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -609,13 +609,3 @@ func GetKubeConfig(filename string) error {
 	log.Infof("kubeconfig file %s created\n", filename)
 	return nil
 }
-
-// GetKubeConfigFromFile will parse the provided directory for a file that provides two kubeconfig
-// formatted blocks.  One for the local cluster where Istio is installed and another for a remote
-// cluster
-func GetKubeConfigFromFile(dirname string) (string, string, error) {
-	//TODO complete function
-	err := fmt.Errorf("the function to parse the test config is not completed and is a TODO")
-	return "", "", err
-
-}


### PR DESCRIPTION
This issue addresses scenarios where the in cluster
kubeconfig uses a reference path instead of a complete
path.  It aslo adds back some functionality lost as
part of PR4884.
