### PR TITLE
[vendor change] Add metrics command to istioctl experimental cli

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1511,6 +1511,7 @@
     "tools/leaderelection/resourcelock",
     "tools/metrics",
     "tools/pager",
+    "tools/portforward",
     "tools/record",
     "tools/reference",
     "tools/remotecommand",
@@ -1590,6 +1591,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9cf016f4a8a87414a82efb9176e5effaed32c3fa4a700331882cb167ba83703c"
+  inputs-digest = "45050edea8a7ceb9422ba4bc71be7953a951e25217645d8c3386ffe9e16f5c90"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1591,6 +1591,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "45050edea8a7ceb9422ba4bc71be7953a951e25217645d8c3386ffe9e16f5c90"
+  inputs-digest = "9d8fb5da90af4f66e82f1d0329d510f83511cdba1db3671c482d6b48f21a6400"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -1,0 +1,270 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	"istio.io/istio/pkg/log"
+)
+
+var (
+	metricsCmd = &cobra.Command{
+		Use:   "metrics <service name>...",
+		Short: "Prints the metrics for the specified service(s) when running in Kubernetes.",
+		Long: `
+Prints the metrics for the specified service(s) when running in Kubernetes.
+
+This command finds a Prometheus pod running in the specified istio system 
+namespace. It then executes a series of queries per requested service to
+find the following top-level service metrics: total requests per second,
+error rate, and request latency at p50, p90, and p99 percentiles. The 
+query results are printed to the console, organized by service name.
+
+All metrics returned are from server-side reports. This means that latencies
+and error rates are from the perspective of the service itself and not of an
+individual client (or aggregate set of clients). Rates and latencies are
+calculated over a time interval of 1 minute.
+`,
+		Example: `
+# Retrieve service metrics for productpage service
+istioctl experimental metrics productpage
+
+# Retrieve service metrics for various services in the different namespaces
+istioctl experimental metrics productpage.foo reviews.bar ratings.baz
+`,
+		Aliases: []string{"m"},
+		Args:    cobra.MinimumNArgs(1),
+		RunE:    run,
+		DisableFlagsInUseLine: true,
+	}
+)
+
+func init() {
+	experimentalCmd.AddCommand(metricsCmd)
+}
+
+type serviceMetrics struct {
+	service                            string
+	totalRPS, errorRPS                 float64
+	p50Latency, p90Latency, p99Latency time.Duration
+}
+
+func run(c *cobra.Command, args []string) error {
+	log.Debugf("metrics command invoked for service(s): %v", args)
+
+	config, _ := defaultRestConfig()
+	client, err := createCoreV1Client()
+	if err != nil {
+		return fmt.Errorf("failed to create k8s client: %v", err)
+	}
+
+	pl, err := prometheusPods(client)
+	if err != nil {
+		return fmt.Errorf("not able to locate prometheus pod: %v", err)
+	}
+
+	if len(pl.Items) < 1 {
+		return errors.New("no prometheus pods found")
+	}
+
+	port, err := availablePort()
+	if err != nil {
+		return fmt.Errorf("not able to find available port: %v", err)
+	}
+	log.Debugf("Using local port: %d", port)
+
+	// only use the first pod in the list
+	promPod := pl.Items[0]
+	fw, readyCh, err := buildPortForwarder(client, config, promPod.Name, port)
+	if err != nil {
+		return fmt.Errorf("could not build port forwarder for prometheus: %v", err)
+	}
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- fw.ForwardPorts()
+	}()
+
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("failure running port forward process: %v", err)
+	case <-readyCh:
+		log.Debugf("port-forward to prometheus pod ready")
+
+		promAPI, err := prometheusAPI(port)
+		if err != nil {
+			return err
+		}
+
+		services := args
+		for _, service := range services {
+			sm, err := metrics(promAPI, service)
+			if err != nil {
+				return fmt.Errorf("could not build metrics for service '%s': %v", service, err)
+			}
+
+			printMetrics(sm)
+		}
+
+		fw.Close()
+		return nil
+	}
+}
+
+func prometheusPods(client *rest.RESTClient) (*v1.PodList, error) {
+	podGet := client.Get().Resource("pods").Namespace(istioNamespace).Param("labelSelector", "app=prometheus")
+	obj, err := podGet.Do().Get()
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving pod: %v", err)
+	}
+	return obj.(*v1.PodList), nil
+}
+
+func buildPortForwarder(client *rest.RESTClient, config *rest.Config, podName string, port int) (*portforward.PortForwarder, <-chan struct{}, error) {
+	req := client.Post().Resource("pods").Namespace(istioNamespace).Name(podName).SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failure creating roundtripper: %v", err)
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	stop := make(chan struct{})
+	ready := make(chan struct{})
+	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:9090", port)}, stop, ready, ioutil.Discard, os.Stderr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed establishing port-forward: %v", err)
+	}
+
+	return fw, ready, nil
+}
+
+func availablePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port, nil
+}
+
+func prometheusAPI(port int) (promv1.API, error) {
+	promClient, err := api.NewClient(api.Config{Address: fmt.Sprintf("http://localhost:%d", port)})
+	if err != nil {
+		return nil, fmt.Errorf("could not build prometheus client: %v", err)
+	}
+	return promv1.NewAPI(promClient), nil
+}
+
+func metrics(promAPI promv1.API, service string) (serviceMetrics, error) {
+	rpsQuery := fmt.Sprintf(`sum(rate(istio_request_count{destination_service=~"%s.*"}[1m]))`, service)
+	errRPSQuery := fmt.Sprintf(`sum(rate(istio_request_count{destination_service=~"%s.*",response_code!="200"}[1m]))`, service)
+	p50LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(istio_request_duration_bucket{destination_service=~"%s.*"}[1m])) by (le))`, 0.5, service)
+	p90LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(istio_request_duration_bucket{destination_service=~"%s.*"}[1m])) by (le))`, 0.9, service)
+	p99LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(istio_request_duration_bucket{destination_service=~"%s.*"}[1m])) by (le))`, 0.99, service)
+
+	var me *multierror.Error
+	var err error
+	sm := serviceMetrics{service: service}
+	sm.totalRPS, err = vectorValue(promAPI, rpsQuery)
+	if err != nil {
+		me = multierror.Append(me, err)
+	}
+
+	sm.errorRPS, err = vectorValue(promAPI, errRPSQuery)
+	if err != nil {
+		me = multierror.Append(me, err)
+	}
+
+	p50Latency, err := vectorValue(promAPI, p50LatencyQuery)
+	if err != nil {
+		me = multierror.Append(me, err)
+	}
+	sm.p50Latency = time.Duration(p50Latency*1000) * time.Millisecond
+
+	p90Latency, err := vectorValue(promAPI, p90LatencyQuery)
+	if err != nil {
+		me = multierror.Append(me, err)
+	}
+	sm.p90Latency = time.Duration(p90Latency*1000) * time.Millisecond
+
+	p99Latency, err := vectorValue(promAPI, p99LatencyQuery)
+	if err != nil {
+		me = multierror.Append(me, err)
+	}
+	sm.p99Latency = time.Duration(p99Latency*1000) * time.Millisecond
+
+	if me.ErrorOrNil() != nil {
+		return sm, fmt.Errorf("error retrieving some metrics: %v", me.Error())
+	}
+
+	return sm, nil
+}
+
+func vectorValue(promAPI promv1.API, query string) (float64, error) {
+	log.Debugf("executing query: %s", query)
+	val, err := promAPI.Query(context.Background(), query, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("query() failure for '%s': %v", query, err)
+	}
+
+	switch v := val.(type) {
+	case model.Vector:
+		if v.Len() < 1 {
+			log.Debugf("no values for query: %s", query)
+			return 0, nil
+		}
+		return float64(v[0].Value), nil
+	default:
+		return 0, errors.New("bad metric value type returned for query")
+	}
+}
+
+func printMetrics(sm serviceMetrics) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 1, 2, ' ', 0)
+	fmt.Fprintf(w, "%s:\n", sm.service)
+	fmt.Fprintf(w, "\tTotal RPS: \t%f\n", sm.totalRPS)
+	fmt.Fprintf(w, "\tError RPS: \t%f\n", sm.errorRPS)
+	fmt.Fprintf(w, "\tP50 Latency: \t%s\n", sm.p50Latency)
+	fmt.Fprintf(w, "\tP90 Latency: \t%s\n", sm.p90Latency)
+	fmt.Fprintf(w, "\tP99 Latency: \t%s\n", sm.p99Latency)
+	w.Flush()
+}

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -122,6 +122,7 @@ func run(c *cobra.Command, args []string) error {
 		return fmt.Errorf("failure running port forward process: %v", err)
 	case <-readyCh:
 		log.Debugf("port-forward to prometheus pod ready")
+		defer fw.Close()
 
 		promAPI, err := prometheusAPI(port)
 		if err != nil {
@@ -137,8 +138,6 @@ func run(c *cobra.Command, args []string) error {
 
 			printMetrics(sm)
 		}
-
-		fw.Close()
 		return nil
 	}
 }

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 
@@ -142,7 +143,7 @@ func run(c *cobra.Command, args []string) error {
 	}
 }
 
-func prometheusPods(client *rest.RESTClient) (*v1.PodList, error) {
+func prometheusPods(client cache.Getter) (*v1.PodList, error) {
 	podGet := client.Get().Resource("pods").Namespace(istioNamespace).Param("labelSelector", "app=prometheus")
 	obj, err := podGet.Do().Get()
 	if err != nil {

--- a/vendor/k8s.io/client-go/tools/portforward/doc.go
+++ b/vendor/k8s.io/client-go/tools/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward // import "k8s.io/client-go/tools/portforward"

--- a/vendor/k8s.io/client-go/tools/portforward/portforward.go
+++ b/vendor/k8s.io/client-go/tools/portforward/portforward.go
@@ -1,0 +1,342 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// TODO move to API machinery and re-unify with kubelet/server/portfoward
+// The subprotocol "portforward.k8s.io" is used for port forwarding.
+const PortForwardProtocolV1Name = "portforward.k8s.io"
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	ports    []ForwardedPort
+	stopChan <-chan struct{}
+
+	dialer        httpstream.Dialer
+	streamConn    httpstream.Connection
+	listeners     []io.Closer
+	Ready         chan struct{}
+	requestIDLock sync.Mutex
+	requestID     int
+	out           io.Writer
+	errOut        io.Writer
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+	valid port specifications:
+
+	5000
+	- forwards from localhost:5000 to pod:5000
+
+	8888:5000
+	- forwards from localhost:8888 to pod:5000
+
+	0:5000
+	:5000
+	- selects a random available local port,
+	  forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("Invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("Remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+// New creates a new PortForwarder.
+func New(dialer httpstream.Dialer, ports []string, stopChan <-chan struct{}, readyChan chan struct{}, out, errOut io.Writer) (*PortForwarder, error) {
+	if len(ports) == 0 {
+		return nil, errors.New("You must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+	return &PortForwarder{
+		dialer:   dialer,
+		ports:    parsedPorts,
+		stopChan: stopChan,
+		Ready:    readyChan,
+		out:      out,
+		errOut:   errOut,
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	var err error
+	pf.streamConn, _, err = pf.dialer.Dial(PortForwardProtocolV1Name)
+	if err != nil {
+		return fmt.Errorf("error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for _, port := range pf.ports {
+		err = pf.listenOnPort(&port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			if pf.errOut != nil {
+				fmt.Fprintf(pf.errOut, "Unable to listen on port %d: %v\n", port.Local, err)
+			}
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("Unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	if pf.Ready != nil {
+		close(pf.Ready)
+	}
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		runtime.HandleError(errors.New("lost connection to pod"))
+	}
+
+	return nil
+}
+
+// listenOnPort delegates tcp4 and tcp6 listener creation and waits for connections on both of these addresses.
+// If both listener creation fail, an error is raised.
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
+	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "[::1]")
+	if errTcp4 != nil && errTcp6 != nil {
+		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+				runtime.HandleError(fmt.Errorf("Error accepting connection on port %d: %v", port.Local, err))
+			}
+			return
+		}
+		go pf.handleConnection(conn, port)
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+	}
+}
+
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			runtime.HandleError(fmt.Errorf("error closing listener: %v", err))
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new command for retrieving service-level metrics
for services within an Istio service mesh. In combination with
the `watch` command, this tool may be used to display a rudimentary
service dashboard from the commandline.

This command requires the deployment of a prometheus instance for
monitoring the mesh. It discovers a prometheus pod, establishes a
port-forward to that pod, and executes a series of queries to extract
the metrics for display.

Currently, this command pulls all metrics from the current time, 
calculating rates and latencies over a time window of 1 minute. In 
the future, it will be possible to add support for flexible time
windows.

Example usage (bookinfo example):

```
$ istioctl experimental metrics productpage reviews ratings details
productpage:
  Total RPS:     7.872870
  Error RPS:     0.000000
  P50 Latency:   40ms
  P90 Latency:   80ms
  P99 Latency:   98ms
reviews:
  Total RPS:     7.909235
  Error RPS:     0.000000
  P50 Latency:   4ms
  P90 Latency:   9ms
  P99 Latency:   21ms
ratings:
  Total RPS:     5.309187
  Error RPS:     0.000000
  P50 Latency:   2ms
  P90 Latency:   4ms
  P99 Latency:   4ms
details:
  Total RPS:     7.872870
  Error RPS:     0.000000
  P50 Latency:   3ms
  P90 Latency:   38ms
  P99 Latency:   48ms
``` 

This tool is intended primarily to aid with debugging, as discovering
what is happening with a mesh and/or a particular service can be somewhat
cumbersome.

Reviewers: please let me know if there is a more appropriate place for 
such a tool and if there is more/different information that you think
is relevant to display for a service.

Vendor PR: https://github.com/istio/vendor-istio/pull/58