### PR TITLE
Fix git for windows compatibility

### DIFF
--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -76,7 +76,7 @@ DNS.3 = ${service}.${namespace}.svc
 EOF
 
 openssl genrsa -out ${tmpdir}/server-key.pem 2048
-openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+openssl req -new -key ${tmpdir}/server-key.pem -subj "/OU=istio:system/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
 
 # clean-up any previously created CSR for our service. Ignore errors if not present.
 kubectl delete csr ${csrName} 2>/dev/null || true


### PR DESCRIPTION
MSYS interprets the /CN=${service}.${namespace}.svc as a path, leading to an `openssl` error.
Adding a `/OU=some:thing` allows Windows users to run script without having to add a `/` to the `/CN=${service}.${namespace}.svc` to disable MSYS path converter.