### PR TITLE
Update istio-remote to match mixer rename

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: istio-mixer
+  name: istio-policy
   namespace: istio-system
 subsets:
 - addresses:
-  - ip: {{ .Values.global.mixerIp }}
+  - ip: {{ .Values.global.policyEndpoint }}
   ports:
   - name: tcp-plain
     port: 9091
@@ -30,10 +30,12 @@ metadata:
   namespace: istio-system
 subsets:
 - addresses:
-  - ip: {{ .Values.global.pilotIp }}
+  - ip: {{ .Values.global.pilotEndpoint }}
   ports:
+  - port: 15011
+    name: https-xds
   - port: 15003
-    name: discovery
+    name: http-old-discovery
   - port: 15005
     name: https-discovery
   - port: 15007

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -8,14 +8,15 @@ metadata:
     istio: pilot
 spec:
   ports:
-  - port: 15003
-    name: discovery
   - port: 15005
     name: https-discovery
   - port: 15007
     name: http-discovery
+    targetPort: 15007
+  - port: 15003
+    name: http-old-discovery
   - port: 15010
-    name: grpc-discovery
+    name: grpc-xds
   - port: 8080
     name: http-legacy-discovery
   - port: 9093
@@ -23,11 +24,10 @@ spec:
   - port: 443
     name: admission-webhook
 ---
-# Mixer service for discovery
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-mixer
+  name: istio-policy
   namespace: istio-system
   labels:
     istio: mixer
@@ -39,13 +39,4 @@ spec:
     port: 15004
   - name: http-monitoring
     port: 9093
-  - name: configapi
-    port: 9094
-  - name: statsd-prom
-    port: 9102
-  - name: statsd-udp
-    port: 9125
-    protocol: UDP
-  - name: prometheus
-    port: 42422
 ---

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -1,7 +1,7 @@
-# Use --set to specify the pilot and mixer IPs on the main Istio control plane
+# Use --set to specify the Pilot and Policy IPs on the main Istio control plane
 global:
-  # The Istio control plane Pilot IP address
-  pilotIp: none
+  # The Istio control plane Pilot endpoint
+  pilotEndpoint: none
 
-  # The Istio control plane Mixer IP address
-  mixerIp: none
+  # The Istio control plane Policy endpoint
+  policyEndpoint: none


### PR DESCRIPTION
Mixer was renamed to two components.  This makes an istio-remote
for both of them.