### PR TITLE
Add loadBalancerIP to istio-ingress service in Helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
     istio: ingress
 spec:
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
   type: LoadBalancer
   ports:
   - port: 80

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -45,12 +45,12 @@ global:
 
   # Default is 1 second
   refreshInterval: 10s
-  
+
   # Enable multicluster operation.  Must be set to true if multicluster operation
   # is desired.
   multicluster:
     enabled: false
-  
+
   # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
   #   0 - Never scheduled
   #   1 - Least preferred
@@ -82,6 +82,7 @@ ingress:
 #  cpu: 100m
 #  memory: 128Mi
   service:
+    loadBalancerIP: ""
     nodePort:
       enabled: false
       port: 32000


### PR DESCRIPTION
This allows to bind an existing IP address (from a cloud provider) with istio-ingress LoadBalancer service instead of creating a new IP address