### PR TITLE
Enable sidecar auto injection use proxy_init as initContainer.

### DIFF
--- a/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector-configmap-debug.yaml.tmpl
@@ -29,7 +29,7 @@ data:
           unlimited
         command:
         - /bin/sh
-        image: alpine
+        image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}


### PR DESCRIPTION
This is a follow up patch for https://github.com/istio/istio/pull/4730

There is no need to use `alpine` as `initContainer`, but using `proxy_init ` is good enough.

/cc @linsun @sdake @ayj 