### PR TITLE
Force IPv4 DNS lookup

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -366,9 +366,10 @@ func setUpstreamProtocol(cluster *v2.Cluster, port *model.Port) {
 func buildDefaultCluster(env model.Environment, name string, discoveryType v2.Cluster_DiscoveryType,
 	hosts []*core.Address) *v2.Cluster {
 	cluster := &v2.Cluster{
-		Name:  name,
-		Type:  discoveryType,
-		Hosts: hosts,
+		Name:            name,
+		Type:            discoveryType,
+		Hosts:           hosts,
+		DnsLookupFamily: v2.Cluster_V4_ONLY,
 	}
 	defaultTrafficPolicy := buildDefaultTrafficPolicy(env, discoveryType)
 	applyTrafficPolicy(cluster, defaultTrafficPolicy)


### PR DESCRIPTION
The cluster DNSLookupFamily field is not being set when building clusters, so it defaults to `auto`. `auto` tries to resolve ipv6, then falls back to ipv4. This can cause issues when the ipv6 address isn't accessible, as reported here: https://github.com/istio/istio/issues/4958

This PR forces ipv4 DNS lookup. I'm not sure if this is how we want to handle this, but it is a one line change so I created a PR.

Docs:
https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#enum-cluster-dnslookupfamily