### PR TITLE
Add standalone Citadel deployment.

### DIFF
--- a/install/kubernetes/templates/istio-citadel-standalone.yaml.tmpl
+++ b/install/kubernetes/templates/istio-citadel-standalone.yaml.tmpl
@@ -1,0 +1,94 @@
+################################
+# Deploy Citadel as a stand alone service in a cluster
+################################
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: istio-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-citadel-{ISTIO_NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+---
+# Grant permissions to Citadel.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-citadel-role-binding-{ISTIO_NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: istio-citadel-{ISTIO_NAMESPACE}
+  apiGroup: rbac.authorization.k8s.io
+---
+# Service account for Citadel
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: istio-standalone-citadel
+  namespace: {ISTIO_NAMESPACE}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: citadel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+      - name: citadel
+        image: {CA_HUB}/citadel:{CA_TAG}
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --istio-ca-storage-namespace={ISTIO_NAMESPACE}
+          - --grpc-port=8060
+          - --grpc-hostname=istio-standalone-citadel
+          - --self-signed-ca=true
+          - --self-signed-ca-org=test-org
+          - --self-signed-ca-cert-ttl=24000h
+          - --multicluster-ca=true # Whether Citadel issues certs for other Citadels.
+          - --workload-cert-ttl=21h
+          - --logtostderr
+          - --stderrthreshold
+          - INFO
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standalone-citadel-ilb
+  namespace: istio-system
+  annotations:
+    cloud.google.com/load-balancer-type: "internal"
+  labels:
+    istio: standalone-citadel
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8060
+    protocol: TCP
+  selector:
+    istio: standalone-citadel

--- a/install/updateVersion_orig.sh
+++ b/install/updateVersion_orig.sh
@@ -139,8 +139,9 @@ function merge_files() {
   ISTIO_AUTH=$DEST/istio-auth.yaml
   ISTIO_ONE_NAMESPACE=$DEST/istio-one-namespace.yaml
   ISTIO_ONE_NAMESPACE_AUTH=$DEST/istio-one-namespace-auth.yaml
-  ISTIO_CA_PLUGIN_CERTS=$DEST/istio-citadel-plugin-certs.yaml
-  ISTIO_CA_HEALTH_CHECK=$DEST/istio-citadel-with-health-check.yaml
+  ISTIO_CITADEL_PLUGIN_CERTS=$DEST/istio-citadel-plugin-certs.yaml
+  ISTIO_CITADEL_HEALTH_CHECK=$DEST/istio-citadel-with-health-check.yaml
+  ISTIO_CITADEL_STANDALONE=$DEST/istio-citadel-standalone.yaml
   ISTIO_MIXER_HEALTH_CHECK=$DEST/istio-mixer-with-health-check.yaml
   ISTIO_MIXER_VALIDATOR=$DEST/istio-mixer-validator.yaml
 
@@ -195,13 +196,17 @@ function merge_files() {
   execute_sed "s/envoy_mixer.json/envoy_mixer_auth.json/" $ISTIO_ONE_NAMESPACE_AUTH
   execute_sed "s/envoy_pilot.json/envoy_pilot_auth.json/" $ISTIO_ONE_NAMESPACE_AUTH
 
-  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CA_PLUGIN_CERTS
-  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CA_PLUGIN_CERTS
-  cat $SRC/istio-citadel-plugin-certs.yaml.tmpl >> $ISTIO_CA_PLUGIN_CERTS
+  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CITADEL_PLUGIN_CERTS
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CITADEL_PLUGIN_CERTS
+  cat $SRC/istio-citadel-plugin-certs.yaml.tmpl >> $ISTIO_CITADEL_PLUGIN_CERTS
 
-  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CA_HEALTH_CHECK
-  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CA_HEALTH_CHECK
-  cat $SRC/istio-citadel-with-health-check.yaml.tmpl >> $ISTIO_CA_HEALTH_CHECK
+  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CITADEL_HEALTH_CHECK
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CITADEL_HEALTH_CHECK
+  cat $SRC/istio-citadel-with-health-check.yaml.tmpl >> $ISTIO_CITADEL_HEALTH_CHECK
+
+  echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_CITADEL_STANDALONE
+  echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_CITADEL_STANDALONE
+  cat $SRC/istio-citadel-standalone.yaml.tmpl >> $ISTIO_CITADEL_STANDALONE
 
   echo "# GENERATED FILE. Use with Kubernetes 1.7+" > $ISTIO_MIXER_HEALTH_CHECK
   echo "# TO UPDATE, modify files in install/kubernetes/templates and run install/updateVersion.sh" >> $ISTIO_MIXER_HEALTH_CHECK
@@ -261,6 +266,7 @@ function update_istio_install() {
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-citadel-one-namespace.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-citadel-plugin-certs.yaml.tmpl
   execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-citadel-with-health-check.yaml.tmpl
+  execute_sed "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|" istio-citadel-standalone.yaml.tmpl
 
   execute_sed "s|image: {PILOT_HUB}/\(.*\):{PILOT_TAG}|image: ${PILOT_HUB}/\1:${PILOT_TAG}|" istio-pilot.yaml.tmpl
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PROXY_HUB}/${PROXY_IMAGE}:${PROXY_TAG}|" istio-pilot.yaml.tmpl
@@ -273,6 +279,7 @@ function update_istio_install() {
   execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-citadel-one-namespace.yaml.tmpl
   execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-citadel-plugin-certs.yaml.tmpl
   execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-citadel-with-health-check.yaml.tmpl
+  execute_sed "s|image: {CA_HUB}/\(.*\):{CA_TAG}|image: ${CA_HUB}/\1:${CA_TAG}|" istio-citadel-standalone.yaml.tmpl
 
   execute_sed "s|image: {PROXY_HUB}/{PROXY_IMAGE}:{PROXY_TAG}|image: ${PROXY_HUB}/${PROXY_IMAGE}:${PROXY_TAG}|" istio-ingress.yaml.tmpl
   popd


### PR DESCRIPTION
Deploy Citadel in a dedicated (trusted) cluster. This will be helpful for enhancing security of Istio Citadel, and the stand alone Citadel can also be a multicluster Citadel.