### PR TITLE
Add/Update Mixer e2e tests to cover more attributes sent from Envoy.

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -12,6 +12,6 @@
 		"repoName": "proxy",
 		"prodBranch": "master",
 		"file": "",
-		"lastStableSHA": "d223f496ca5f15214869f5215cbf114c00012899"
+		"lastStableSHA": "1b94ad7f1464686807956d299ec598209e96deef"
 	}
 ]

--- a/istio.deps
+++ b/istio.deps
@@ -12,6 +12,6 @@
 		"repoName": "proxy",
 		"prodBranch": "master",
 		"file": "",
-		"lastStableSHA": "5d868bea87d4dbc485f9bebcb27e944bde672eff"
+		"lastStableSHA": "d223f496ca5f15214869f5215cbf114c00012899"
 	}
 ]

--- a/mixer/test/client/check_cache_hit/check_cache_hit_test.go
+++ b/mixer/test/client/check_cache_hit/check_cache_hit_test.go
@@ -101,8 +101,8 @@ var reportAttributesOkGet = [...]string{`{
     ":status": "200",
     "server": "envoy"
   },
-  "response.totle_size": 88,
-  "request.totle_size": 306
+  "response.total_size": 88,
+  "request.total_size": 306
 }`,
 	`{
   "context.protocol": "http",
@@ -147,8 +147,8 @@ var reportAttributesOkGet = [...]string{`{
     ":status": "200",
     "server": "envoy"
   },
-  "response.totle_size": 88,
-  "request.totle_size": 306
+  "response.total_size": 88,
+  "request.total_size": 306
 }`}
 
 func TestCheckCacheHit(t *testing.T) {

--- a/mixer/test/client/check_cache_hit/check_cache_hit_test.go
+++ b/mixer/test/client/check_cache_hit/check_cache_hit_test.go
@@ -100,7 +100,9 @@ var reportAttributesOkGet = [...]string{`{
     "content-length": "0",
     ":status": "200",
     "server": "envoy"
-  }
+  },
+  "response.totle_size": 88,
+  "request.totle_size": 306
 }`,
 	`{
   "context.protocol": "http",
@@ -144,7 +146,9 @@ var reportAttributesOkGet = [...]string{`{
     "content-length": "0",
     ":status": "200",
     "server": "envoy"
-  }
+  },
+  "response.totle_size": 88,
+  "request.totle_size": 306
 }`}
 
 func TestCheckCacheHit(t *testing.T) {

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -183,8 +183,8 @@ const reportAttributesOkPost = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 123,
-  "request.totle_size": 342
+  "response.total_size": 123,
+  "request.total_size": 342
 }
 `
 

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -98,7 +98,9 @@ const reportAttributesOkGet = `
      "content-length": "0",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 88,
+  "request.totle_size": 306
 }
 `
 
@@ -180,7 +182,9 @@ const reportAttributesOkPost = `
      "content-length": "12",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 123,
+  "request.totle_size": 342
 }
 `
 

--- a/mixer/test/client/check_report/check_report_test.go
+++ b/mixer/test/client/check_report/check_report_test.go
@@ -99,8 +99,8 @@ const reportAttributesOkGet = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 88,
-  "request.totle_size": 306
+  "response.total_size": 88,
+  "request.total_size": 306
 }
 `
 

--- a/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
+++ b/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
@@ -93,7 +93,9 @@ const reportAttributesOkPost = `
      "content-length": "10485760",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 10485877,
+  "request.totle_size": 10485966
 }
 `
 

--- a/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
+++ b/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
@@ -94,8 +94,8 @@ const reportAttributesOkPost = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 10485877,
-  "request.totle_size": 10485966
+  "response.totle_size": "*",
+  "request.totle_size": "*"
 }
 `
 

--- a/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
+++ b/mixer/test/client/check_report_large_post_request/check_report_large_post_request_test.go
@@ -94,8 +94,8 @@ const reportAttributesOkPost = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": "*",
-  "request.totle_size": "*"
+  "response.total_size": "*",
+  "request.total_size": "*"
 }
 `
 

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -40,7 +40,7 @@ const reportAttributesOkPost = `
   "connection.sent.bytes_total": 133,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "open"
+  "connection.event": "close"
 }
 `
 

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -43,7 +43,7 @@ func (s *TestSetup) NewEnvoy(stress, faultInject bool, mfConf *MixerFilterConf, 
 
 	debugLevel := os.Getenv("ENVOY_DEBUG")
 	if len(debugLevel) == 0 {
-		debugLevel = "debug"
+		debugLevel = "info"
 	}
 
 	// Don't use hot-start, each Envoy re-start use different base-id

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -43,7 +43,7 @@ func (s *TestSetup) NewEnvoy(stress, faultInject bool, mfConf *MixerFilterConf, 
 
 	debugLevel := os.Getenv("ENVOY_DEBUG")
 	if len(debugLevel) == 0 {
-		debugLevel = "info"
+		debugLevel = "debug"
 	}
 
 	// Don't use hot-start, each Envoy re-start use different base-id

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -102,7 +102,7 @@ const envoyConfTempl = `
             "filters": [
 {{.FaultFilter}}
               {
-                "type": "decoder",
+                "type": "both",
                 "name": "mixer",
                 "config": {
 {{.ServerConfig}}

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -152,7 +152,7 @@ const envoyConfTempl = `
             ],
             "filters": [
               {
-                "type": "decoder",
+                "type": "both",
                 "name": "mixer",
                 "config": {
 {{.ClientConfig}}

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -106,8 +106,8 @@ const reportAttributesMixerFail = `
      ":status": "401",
      "server": "envoy"
   },
-  "response.totle_size": 89,
-  "request.totle_size": 306
+  "response.total_size": 89,
+  "request.total_size": 306
 }
 `
 
@@ -156,8 +156,8 @@ const reportAttributesBackendFail = `
      ":status": "400",
      "server": "envoy"
   },
-  "response.totle_size": 151,
-  "request.totle_size": 329
+  "response.total_size": 151,
+  "request.total_size": 329
 }
 `
 

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -105,7 +105,9 @@ const reportAttributesMixerFail = `
      "content-length": "41",
      ":status": "401",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 89,
+  "request.totle_size": 306
 }
 `
 
@@ -153,7 +155,9 @@ const reportAttributesBackendFail = `
      "content-length": "25",
      ":status": "400",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 151,
+  "request.totle_size": 329
 }
 `
 

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -60,7 +60,9 @@ const reportAttributes = `
      "content-length": "18",
      ":status": "503",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 66,
+  "request.totle_size": 0
 }
 `
 

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -61,8 +61,8 @@ const reportAttributes = `
      ":status": "503",
      "server": "envoy"
   },
-  "response.totle_size": 66,
-  "request.totle_size": 0
+  "response.total_size": 66,
+  "request.total_size": 0
 }
 `
 

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -65,7 +65,9 @@ const reportAttributesOkGet = `
      "content-length": "0",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 88,
+  "request.totle_size": 306
 }
 `
 
@@ -114,7 +116,9 @@ const reportAttributesOkPost1 = `
      "content-length": "12",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 123,
+  "request.totle_size": 342
 }
 `
 
@@ -163,7 +167,9 @@ const reportAttributesOkPost2 = `
      "content-length": "18",
      ":status": "200",
      "server": "envoy"
-  }
+  },
+  "response.totle_size": 129,
+  "request.totle_size": 348
 }
 `
 

--- a/mixer/test/client/report_batch/report_batch_test.go
+++ b/mixer/test/client/report_batch/report_batch_test.go
@@ -66,8 +66,8 @@ const reportAttributesOkGet = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 88,
-  "request.totle_size": 306
+  "response.total_size": 88,
+  "request.total_size": 306
 }
 `
 
@@ -117,8 +117,8 @@ const reportAttributesOkPost1 = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 123,
-  "request.totle_size": 342
+  "response.total_size": 123,
+  "request.total_size": 342
 }
 `
 
@@ -168,8 +168,8 @@ const reportAttributesOkPost2 = `
      ":status": "200",
      "server": "envoy"
   },
-  "response.totle_size": 129,
-  "request.totle_size": 348
+  "response.total_size": 129,
+  "request.total_size": 348
 }
 `
 

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -60,7 +60,7 @@ const reportAttributesOkPost = `
   "connection.sent.bytes_total": 133,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "close"
+  "connection.event": "close"
 }
 `
 

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -35,7 +35,7 @@ const checkAttributesOkPost = `
   "target.namespace": "XYZ222",
   "connection.mtls": false,
   "connection.id": "*",
-	"connection.event": "open"
+  "connection.event": "open"
 }
 `
 
@@ -60,7 +60,7 @@ const reportAttributesOkPost = `
   "connection.sent.bytes_total": 133,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "open"
+	"connection.event": "close"
 }
 `
 
@@ -87,7 +87,7 @@ const reportAttributesFailPost = `
   "check.error_code": 16,
   "check.error_message": "UNAUTHENTICATED",
   "connection.id": "*",
-	"connection.event": "close"
+  "connection.event": "close"
 }
 `
 

--- a/mixer/test/client/tcp_filter_periodical_report/tcp_filter_periodical_report_test.go
+++ b/mixer/test/client/tcp_filter_periodical_report/tcp_filter_periodical_report_test.go
@@ -41,7 +41,7 @@ const deltaReportAttributesOkPost = `
   "connection.sent.bytes": 0,
   "connection.sent.bytes_total": 0,
   "connection.id": "*",
-	"connection.event": "continue"
+  "connection.event": "continue"
 }
 `
 const finalReportAttributesOkPost = `
@@ -64,7 +64,7 @@ const finalReportAttributesOkPost = `
   "connection.sent.bytes_total": 138,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "continue"
+  "connection.event": "close"
 }
 `
 

--- a/mixer/test/client/tcp_filter_v1_config/tcp_filter_v1_config_test.go
+++ b/mixer/test/client/tcp_filter_v1_config/tcp_filter_v1_config_test.go
@@ -60,7 +60,7 @@ const reportAttributesOkPost = `
   "connection.sent.bytes_total": 133,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "close"
+  "connection.event": "close"
 }
 `
 

--- a/mixer/test/client/tcp_filter_v1_config/tcp_filter_v1_config_test.go
+++ b/mixer/test/client/tcp_filter_v1_config/tcp_filter_v1_config_test.go
@@ -35,7 +35,7 @@ const checkAttributesOkPost = `
   "target.namespace": "XYZ222",
   "connection.mtls": false,
   "connection.id": "*",
-	"connection.event": "open"
+  "connection.event": "open"
 }
 `
 
@@ -60,7 +60,7 @@ const reportAttributesOkPost = `
   "connection.sent.bytes_total": 133,
   "connection.duration": "*",
   "connection.id": "*",
-	"connection.event": "open"
+	"connection.event": "close"
 }
 `
 
@@ -87,7 +87,7 @@ const reportAttributesFailPost = `
   "check.error_code": 16,
   "check.error_message": "UNAUTHENTICATED",
   "connection.id": "*",
-	"connection.event": "close"
+  "connection.event": "close"
 }
 `
 

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -395,7 +395,7 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *Listener {
 	if opts.mesh.MixerCheckServer != "" || opts.mesh.MixerReportServer != "" {
 		mixerConfig := BuildHTTPMixerFilterConfig(opts.mesh, opts.proxy, opts.proxyInstances, opts.outboundListener, opts.store)
 		filter := HTTPFilter{
-			Type:   both,
+			Type:   decoder,
 			Name:   MixerFilter,
 			Config: mixerConfig,
 		}

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -395,7 +395,7 @@ func buildHTTPListener(opts buildHTTPListenerOpts) *Listener {
 	if opts.mesh.MixerCheckServer != "" || opts.mesh.MixerReportServer != "" {
 		mixerConfig := BuildHTTPMixerFilterConfig(opts.mesh, opts.proxy, opts.proxyInstances, opts.outboundListener, opts.store)
 		filter := HTTPFilter{
-			Type:   decoder,
+			Type:   both,
 			Name:   MixerFilter,
 			Config: mixerConfig,
 		}

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-authn-jwt.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-authn-jwt.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -761,7 +761,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-httpproxy.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-httpproxy.json.golden
@@ -21,7 +21,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-ingress.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-ingress.json.golden
@@ -22,7 +22,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -97,7 +97,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-mixer-check-report-config.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-mixer-check-report-config.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -310,7 +310,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -518,7 +518,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -856,7 +856,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -146,7 +146,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -240,7 +240,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -448,7 +448,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -786,7 +786,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule-tcp.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -146,7 +146,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -240,7 +240,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -435,7 +435,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -736,7 +736,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-egress-rule.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -310,7 +310,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -505,7 +505,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -806,7 +806,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -248,7 +248,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -488,7 +488,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -826,7 +826,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-fault.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -248,7 +248,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -475,7 +475,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -776,7 +776,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optin.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optin.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -725,7 +725,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optout.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth-optout.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -749,7 +749,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -762,7 +762,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-none.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -762,7 +762,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v0-weighted.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -310,7 +310,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -518,7 +518,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -856,7 +856,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -146,7 +146,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -240,7 +240,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -448,7 +448,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -786,7 +786,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule-tcp.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -146,7 +146,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -240,7 +240,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -435,7 +435,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -736,7 +736,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-egress-rule.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -310,7 +310,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -505,7 +505,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -806,7 +806,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -762,7 +762,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-fault.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -762,7 +762,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-none.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-auth.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted-auth.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -424,7 +424,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -762,7 +762,7 @@
          }
         },
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-v1-weighted.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -411,7 +411,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -712,7 +712,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {

--- a/pilot/pkg/proxy/envoy/v1/testdata/lds-websocket.json.golden
+++ b/pilot/pkg/proxy/envoy/v1/testdata/lds-websocket.json.golden
@@ -28,7 +28,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -122,7 +122,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -216,7 +216,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -423,7 +423,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {
@@ -736,7 +736,7 @@
        },
        "filters": [
         {
-         "type": "decoder",
+         "type": "both",
          "name": "mixer",
          "config": {
           "v2": {


### PR DESCRIPTION
Add/Update Mixer e2e tests to cover more attributes sent from Envoy. The attributes are introduced by https://github.com/istio/proxy/commit/d20cd6d89dfa4f78d6502500ac64b19fe9521834 and https://github.com/istio/proxy/commit/e562a1b090e6d2cd73e321323d687af1315a4056.

Update Pilot to change the type of Mixer HTTP filter from "decoder" to "both".