### PR TITLE
Correct the reference file path in galley

### DIFF
--- a/galley/cmd/gals/main.go
+++ b/galley/cmd/gals/main.go
@@ -18,7 +18,7 @@ import (
 	"os"
 
 	"istio.io/istio/galley/cmd/gals/cmd"
-	"istio.io/istio/mixer/cmd/shared"
+	"istio.io/istio/galley/cmd/shared"
 )
 
 func main() {


### PR DESCRIPTION
I think it should use "istio.io/istio/galley/cmd/shared" instead of "istio.io/istio/mixer/cmd/shared" in galley.