### PR TITLE
Fix problems around level enablement for logs captured from glog

### DIFF
--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -64,45 +64,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-// This type exists so we can have a bit of logic sitting in front of all the real core calls for the
-// case where we are intercepting other log packages. This lets us subject the log output to the
-// default scope's log level, as is these other log packages were in fact directly outputting to the
-// default scope.
-type interceptor struct {
-	zapcore.Core
-}
-
-func (in interceptor) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	switch ent.Level {
-	case zapcore.ErrorLevel:
-		if !defaultScope.ErrorEnabled() {
-			return nil
-		}
-	case zapcore.WarnLevel:
-		if !defaultScope.WarnEnabled() {
-			return nil
-		}
-	case zapcore.InfoLevel:
-		if !defaultScope.InfoEnabled() {
-			return nil
-		}
-	case zapcore.DebugLevel:
-		if !defaultScope.DebugEnabled() {
-			return nil
-		}
-	}
-
-	return in.Core.Check(ent, ce)
-}
-
-func (in interceptor) With(fields []zapcore.Field) zapcore.Core {
-	return &interceptor{Core: in.Core.With(fields)}
-}
-
-func (in interceptor) Write(ent zapcore.Entry, f []zapcore.Field) error {
-	return in.Core.Write(ent, f)
-}
-
 // none is used to disable logging output as well as to disable stack tracing.
 const none zapcore.Level = 100
 
@@ -120,7 +81,7 @@ func init() {
 }
 
 // prepZap is a utility function used by the Configure function.
-func prepZap(options *Options) (zapcore.Core, zapcore.WriteSyncer, error) {
+func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer, error) {
 	encCfg := zapcore.EncoderConfig{
 		TimeKey:        "time",
 		LevelKey:       "level",
@@ -154,7 +115,7 @@ func prepZap(options *Options) (zapcore.Core, zapcore.WriteSyncer, error) {
 
 	errSink, closeErrorSink, err := zap.Open(options.ErrorOutputPaths...)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var outputSink zapcore.WriteSyncer
@@ -162,7 +123,7 @@ func prepZap(options *Options) (zapcore.Core, zapcore.WriteSyncer, error) {
 		outputSink, _, err = zap.Open(options.OutputPaths...)
 		if err != nil {
 			closeErrorSink()
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
@@ -175,7 +136,21 @@ func prepZap(options *Options) (zapcore.Core, zapcore.WriteSyncer, error) {
 		sink = outputSink
 	}
 
-	return zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(zapcore.DebugLevel)), errSink, nil
+	var enabler zap.LevelEnablerFunc = func(lvl zapcore.Level) bool {
+		switch lvl {
+		case zapcore.ErrorLevel:
+			return defaultScope.ErrorEnabled()
+		case zapcore.WarnLevel:
+			return defaultScope.WarnEnabled()
+		case zapcore.InfoLevel:
+			return defaultScope.InfoEnabled()
+		}
+		return defaultScope.DebugEnabled()
+	}
+
+	return zapcore.NewCore(enc, sink, zap.NewAtomicLevelAt(zapcore.DebugLevel)),
+		zapcore.NewCore(enc, sink, enabler),
+		errSink, nil
 }
 
 func formatDate(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
@@ -275,7 +250,7 @@ func updateScopes(options *Options, core zapcore.Core, errSink zapcore.WriteSync
 // You typically call this once at process startup.
 // Once this call returns, the logging system is ready to accept data.
 func Configure(options *Options) error {
-	core, errSink, err := prepZap(options)
+	core, captureCore, errSink, err := prepZap(options)
 	if err != nil {
 		return err
 	}
@@ -298,7 +273,7 @@ func Configure(options *Options) error {
 		opts = append(opts, zap.AddStacktrace(levelToZap[l]))
 	}
 
-	captureLogger := zap.New(interceptor{core}, opts...)
+	captureLogger := zap.New(captureCore, opts...)
 
 	// capture global zap logging and force it through our logger
 	_ = zap.ReplaceGlobals(captureLogger)
@@ -320,9 +295,10 @@ var syncFn atomic.Value
 // Sync flushes any buffered log entries.
 // Processes should normally take care to call Sync before exiting.
 func Sync() error {
+	var err error
 	if s := syncFn.Load().(func() error); s != nil {
-		return s()
+		err = s()
 	}
 
-	return nil
+	return err
 }

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -335,7 +335,7 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 		}
 
 		cmd.PersistentFlags().StringVar(&o.outputLevels, "log_output_level", o.outputLevels,
-			fmt.Sprintf("Comma-separated minimum per-scope logging level of messages to output in the form of "+
+			fmt.Sprintf("Comma-separated minimum per-scope logging level of messages to output, in the form of "+
 				"<scope>:<level>,<scope>:<level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s]",
 				s,
 				levelToString[DebugLevel],
@@ -345,7 +345,7 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 				levelToString[NoneLevel]))
 
 		cmd.PersistentFlags().StringVar(&o.stackTraceLevels, "log_stacktrace_level", o.stackTraceLevels,
-			fmt.Sprintf("Comma-separated minimum per-scope logging level at which stack traces are captured in the form of "+
+			fmt.Sprintf("Comma-separated minimum per-scope logging level at which stack traces are captured, in the form of "+
 				"<scope>:<level>,<scope:level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s]",
 				s,
 				levelToString[DebugLevel],
@@ -355,7 +355,7 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 				levelToString[NoneLevel]))
 
 		cmd.PersistentFlags().StringVar(&o.logCallers, "log_caller", o.logCallers,
-			fmt.Sprintf("Comma-separated list of scopes for which to include called information, scopes can be any of [%s]", s))
+			fmt.Sprintf("Comma-separated list of scopes for which to include caller information, scopes can be any of [%s]", s))
 	} else {
 		cmd.PersistentFlags().StringVar(&o.outputLevels, "log_output_level", o.outputLevels,
 			fmt.Sprintf("The minimum logging level of messages to output,  can be one of [%s, %s, %s, %s, %s]",


### PR DESCRIPTION
We now use a much simpler, and more efficient, approach to provide
specialized level enablement control via a custom level enabler callback.
Zap logging is pretty gnarly, lots of potential ways to interact with the
thing...

This fixes excessive logging output from the k8s client lib.
