### PR TITLE
Add Mixer perf tests that includes the RPC path.

### DIFF
--- a/mixer/test/perf/multimetric_test.go
+++ b/mixer/test/perf/multimetric_test.go
@@ -61,9 +61,9 @@ func Benchmark_Multi_Metric(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_Multi_Metric_R2(b *testing.B) {
+func Benchmark_Multi_Metric_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseMultiMetricSetup
 

--- a/mixer/test/perf/norule_test.go
+++ b/mixer/test/perf/norule_test.go
@@ -75,9 +75,9 @@ func Benchmark_NoRule_Report(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_NoRule_Report_R2(b *testing.B) {
+func Benchmark_NoRule_Report_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseNoRuleReportSetup
 
@@ -93,9 +93,9 @@ func Benchmark_NoRule_Check(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_NoRule_Check_R2(b *testing.B) {
+func Benchmark_NoRule_Check_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseNoRuleCheckSetup
 

--- a/mixer/test/perf/singlecheck_test.go
+++ b/mixer/test/perf/singlecheck_test.go
@@ -59,9 +59,9 @@ func Benchmark_Single_Check(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_Single_Check_R2(b *testing.B) {
+func Benchmark_Single_Check_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseSingleCheckSetup
 

--- a/mixer/test/perf/singlemetric_test.go
+++ b/mixer/test/perf/singlemetric_test.go
@@ -60,9 +60,9 @@ func Benchmark_Single_Metric(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_Single_Metric_R2(b *testing.B) {
+func Benchmark_Single_Metric_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseSingleMetricSetup
 

--- a/mixer/test/perf/singlereport_test.go
+++ b/mixer/test/perf/singlereport_test.go
@@ -58,9 +58,9 @@ func Benchmark_Single_Report(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_Single_Report_R2(b *testing.B) {
+func Benchmark_Single_Report_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseSingleReportSetup
 
@@ -77,9 +77,9 @@ func Benchmark_Single_Report_SuccessCondition(b *testing.B) {
 	perf.Run(b, &setup, settings)
 }
 
-func Benchmark_Single_Report_SuccessCondition_R2(b *testing.B) {
+func Benchmark_Single_Report_SuccessCondition_Rpc(b *testing.B) {
 	settings := baseSettings
-	settings.RunMode = perf.InProcessBypassGrpc
+	settings.RunMode = perf.InProcess
 
 	setup := baseSingleReportSetup
 	setup.Config.Global = joinConfigs(h1Noop, i1ReportNothing, r3UsingH1AndI1Conditional)


### PR DESCRIPTION
The perf tests included two sets of tests (proper v.s. with _R2 suffix).
The tests with _R2 suffix was for testing runtime2 implementation.

Now that there is only one runtime, repurposing some of the tests to
include the gRpc layer as well.