### PR TITLE
stackdriver adapter bug fixes and clean up

### DIFF
--- a/mixer/adapter/stackdriver/metric/distribution.go
+++ b/mixer/adapter/stackdriver/metric/distribution.go
@@ -16,6 +16,7 @@ package metric
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/genproto/googleapis/api/distribution"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
@@ -38,6 +39,12 @@ func toDist(val interface{}, i info) (*monitoringpb.TypedValue, error) {
 			fval = dval
 		} else {
 			return nil, fmt.Errorf("expected float64 value, got: %#v", val)
+		}
+	case descriptor.DURATION:
+		if duval, ok := val.(time.Duration); ok {
+			fval = float64(duval.Nanoseconds()) / float64(time.Millisecond)
+		} else {
+			return nil, fmt.Errorf("expected duration value, got: %#v", val)
 		}
 	}
 

--- a/mixer/adapter/stackdriver/metric/merge_test.go
+++ b/mixer/adapter/stackdriver/metric/merge_test.go
@@ -217,27 +217,27 @@ func TestGroupBySeries(t *testing.T) {
 			map[uint64]ts{m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0)}}},
 		{"multiple points",
 			ts{makeTS(m1, mr1, 1, 1), makeTS(m1, mr1, 2, 2)},
-			map[uint64]ts{m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0), makeTSCumulative(m1, mr1, 2, 2, 0)}}},
+			map[uint64]ts{m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0), makeTSDelta(m1, mr1, 2, 2, 0)}}},
 		{"two metrics",
 			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr1, 1, 1)},
 			map[uint64]ts{
-				m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0)},
-				m2mr1: {makeTSCumulative(m2, mr1, 1, 1, 0)}}},
+				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)},
+				m2mr1: {makeTSDelta(m2, mr1, 1, 1, 0)}}},
 		{"two MRs",
 			ts{makeTS(m1, mr2, 1, 1), makeTS(m1, mr1, 1, 1)},
 			map[uint64]ts{
-				m1mr2: {makeTSCumulative(m1, mr2, 1, 1, 0)},
-				m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0)}}},
+				m1mr2: {makeTSDelta(m1, mr2, 1, 1, 0)},
+				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)}}},
 		{"disjoint",
 			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr2, 1, 1)},
 			map[uint64]ts{
-				m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0)},
-				m2mr2: {makeTSCumulative(m2, mr2, 1, 1, 0)}}},
+				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)},
+				m2mr2: {makeTSDelta(m2, mr2, 1, 1, 0)}}},
 		{"disjoint, multiple points",
 			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr2, 1, 1), makeTS(m1, mr1, 2, 2), makeTS(m2, mr2, 2, 2)},
 			map[uint64]ts{
-				m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0), makeTSCumulative(m1, mr1, 2, 2, 0)},
-				m2mr2: {makeTSCumulative(m2, mr2, 1, 1, 0), makeTSCumulative(m2, mr2, 2, 2, 0)}}},
+				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0), makeTSDelta(m1, mr1, 2, 2, 0)},
+				m2mr2: {makeTSDelta(m2, mr2, 1, 1, 0), makeTSDelta(m2, mr2, 2, 2, 0)}}},
 	}
 
 	for idx, tt := range tests {

--- a/mixer/adapter/stackdriver/metric/metric.go
+++ b/mixer/adapter/stackdriver/metric/metric.go
@@ -178,8 +178,6 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 }
 
 func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error {
-	h.l.Infof("stackdriver.Record called with %d vals", len(vals))
-
 	// TODO: len(vals) is constant for config lifetime, consider pooling
 	data := make([]*monitoringpb.TimeSeries, 0, len(vals))
 	for _, val := range vals {

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -230,7 +230,7 @@ func TestRecord(t *testing.T) {
 						GrowthFactor:     10,
 					}}},
 			},
-			vtype: descriptor.DOUBLE,
+			vtype: descriptor.INT64,
 		},
 		"distribution-explicit": {
 			ttype: "type",
@@ -243,7 +243,7 @@ func TestRecord(t *testing.T) {
 						Bounds: []float64{1, 10, 100},
 					}}},
 			},
-			vtype: descriptor.DOUBLE,
+			vtype: descriptor.DURATION,
 		},
 	}
 	now := time.Now()
@@ -336,7 +336,7 @@ func TestRecord(t *testing.T) {
 		{"distribution-exp", []*metrict.Instance{
 			{
 				Name:       "distribution-exp",
-				Value:      float64(99),
+				Value:      int64(99),
 				Dimensions: map[string]interface{}{"str": "str", "int": int64(34)},
 			},
 		}, []*monitoringpb.TimeSeries{
@@ -359,7 +359,7 @@ func TestRecord(t *testing.T) {
 		{"distribution-explicit", []*metrict.Instance{
 			{
 				Name:       "distribution-explicit",
-				Value:      float64(9),
+				Value:      9 * time.Millisecond,
 				Dimensions: map[string]interface{}{"str": "str", "int": int64(34)},
 			},
 		}, []*monitoringpb.TimeSeries{


### PR DESCRIPTION
Several bug fixes and cleanups in stackdriver adapter:

- add duration type into distribution processing, which is used for latency metrics.
- remove a duplicated layer of loop.
- remove metric kind override since now adapter could deal with not only custom metrics.
- remove a log line which overwhelms mixer logs.