### PR TITLE
Adding CI workflow for checking vendor diff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,23 +381,6 @@ jobs:
       - store_artifacts:
           path: /tmp
 
-  # Run nightly, to verify 'dep update' works
-  depupdate:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: make depend.update
-      - run: ( cd vendor ; git status  ) # just to see what changes
-      - run: make init build
-      - run:
-          name: Status and artifacts
-          command: make depend.status ISTIO_OUT=/go/out
-      - store_artifacts:
-          path: vendor/Gopkg.lock
-      - store_artifacts:
-          path: /go/out/dep.dot
-      # TODO: auto-commit Gopkg.lock if test is successful
-
   codecov:
     <<: *defaults
     resource_class: xlarge
@@ -472,6 +455,12 @@ jobs:
             make benchcheck | tee -a /go/out/benchcheck/go-benchcheck-report.out
       - store_test_results:
           path: /go/out/benchcheck
+
+  depdiff:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: make depend.diff
 
   build:
     <<: *defaults
@@ -549,38 +538,44 @@ workflows:
                only:
                  - master
     jobs: #daisy chained steps ending with docker push
-      - depupdate
       - build
       - test
       - e2e-simple:
           requires:
             - test
             - build
+            - depdiff
       - e2e-dashboard:
           requires:
             - test
             - build
+            - depdiff
       - e2e-mixer:
           requires:
             - test
             - build
+            - depdiff
       - e2e-pilot: #auth+v1alpha1
           requires:
             - test
             - build
+            - depdiff
       - e2e-pilot-noauth-v1alpha1-v1:
           requires:
             - test
             - build
+            - depdiff
       - benchcheck:
           requires:
             - test
             - build
+            - depdiff
       # Compile for mac and arm
       - goxbuild:
           requires:
             - test
             - build
+            - depdiff
       # Nightly release
       - nightly:
           context: org-global
@@ -597,24 +592,29 @@ workflows:
                only:
                  - master
     jobs:
-      - depupdate
+      - depdiff
       - build
       - test
       - e2e-simple:
           requires:
+            - depdiff
             - build
       - e2e-dashboard:
           requires:
+            - depdiff
             - build
       - e2e-pilot:  #auth+v1alpha1
           requires:
+            - depdiff
             - build
       - benchcheck:
           requires:
+            - depdiff
             - test
             - build
       - e2e-mixer:
           requires:
+            - depdiff
             - build
 
   # flaky:
@@ -640,23 +640,29 @@ workflows:
     jobs:
       - dependencies
       - lint
+      - depdiff
       - build
       - test
       - codecov:
            requires:
+            - depdiff
             - build
       - e2e-mixer:
           requires:
+            - depdiff
             - build
       - e2e-pilot: #auth+v1alpha1
           requires:
+            - depdiff
             - build
       - e2e-simple:
           requires:
+            - depdiff
             - build
       - racetest:
           requires:
             - test
       - e2e-pilot-noauth-v1alpha3-v2: #no auth+v1alpha3+v2
           requires:
+            - depdiff
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,12 +381,22 @@ jobs:
       - store_artifacts:
           path: /tmp
 
-  # Run nightly, to verify 'dep ensure' works
-  depdiff:
+  # Run nightly, to verify 'dep ensure --update' works
+  depupdate:
     <<: *defaults
     steps:
       - checkout
-      - run: make depend.diff
+      - run: make depend.update
+      - run: ( cd vendor ; git status  ) # just to see what changes
+      - run: make init build
+      - run:
+          name: Status and artifacts
+          command: make depend.status ISTIO_OUT=/go/out
+      - store_artifacts:
+          path: vendor/Gopkg.lock
+      - store_artifacts:
+          path: /go/out/dep.dot
+      # TODO: auto-commit Gopkg.lock if test is successful
 
   codecov:
     <<: *defaults
@@ -489,6 +499,8 @@ jobs:
       - checkout
       - run: make sync
       - run: make lint
+      # Make sure that any modification to vendor is correct.
+      - run: make depend.diff
 
   nightly:
     <<: *defaults
@@ -539,7 +551,7 @@ workflows:
                only:
                  - master
     jobs: #daisy chained steps ending with docker push
-      - depdiff
+      - depupdate
       - build
       - test
       - e2e-simple:
@@ -587,7 +599,7 @@ workflows:
                only:
                  - master
     jobs:
-      - depdiff
+      - depupdate
       - build
       - test
       - e2e-simple:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,6 +381,13 @@ jobs:
       - store_artifacts:
           path: /tmp
 
+  # Run nightly, to verify 'dep ensure' works
+  depdiff:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: make depend.diff
+
   codecov:
     <<: *defaults
     resource_class: xlarge
@@ -455,12 +462,6 @@ jobs:
             make benchcheck | tee -a /go/out/benchcheck/go-benchcheck-report.out
       - store_test_results:
           path: /go/out/benchcheck
-
-  depdiff:
-    <<: *defaults
-    steps:
-      - checkout
-      - run: make depend.diff
 
   build:
     <<: *defaults
@@ -538,44 +539,38 @@ workflows:
                only:
                  - master
     jobs: #daisy chained steps ending with docker push
+      - depdiff
       - build
       - test
       - e2e-simple:
           requires:
             - test
             - build
-            - depdiff
       - e2e-dashboard:
           requires:
             - test
             - build
-            - depdiff
       - e2e-mixer:
           requires:
             - test
             - build
-            - depdiff
       - e2e-pilot: #auth+v1alpha1
           requires:
             - test
             - build
-            - depdiff
       - e2e-pilot-noauth-v1alpha1-v1:
           requires:
             - test
             - build
-            - depdiff
       - benchcheck:
           requires:
             - test
             - build
-            - depdiff
       # Compile for mac and arm
       - goxbuild:
           requires:
             - test
             - build
-            - depdiff
       # Nightly release
       - nightly:
           context: org-global
@@ -597,24 +592,19 @@ workflows:
       - test
       - e2e-simple:
           requires:
-            - depdiff
             - build
       - e2e-dashboard:
           requires:
-            - depdiff
             - build
       - e2e-pilot:  #auth+v1alpha1
           requires:
-            - depdiff
             - build
       - benchcheck:
           requires:
-            - depdiff
             - test
             - build
       - e2e-mixer:
           requires:
-            - depdiff
             - build
 
   # flaky:
@@ -640,29 +630,23 @@ workflows:
     jobs:
       - dependencies
       - lint
-      - depdiff
       - build
       - test
       - codecov:
            requires:
-            - depdiff
             - build
       - e2e-mixer:
           requires:
-            - depdiff
             - build
       - e2e-pilot: #auth+v1alpha1
           requires:
-            - depdiff
             - build
       - e2e-simple:
           requires:
-            - depdiff
             - build
       - racetest:
           requires:
             - test
       - e2e-pilot-noauth-v1alpha3-v2: #no auth+v1alpha3+v2
           requires:
-            - depdiff
             - build

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ where-is-docker-tar:
 #-----------------------------------------------------------------------------
 # Target: depend
 #-----------------------------------------------------------------------------
-.PHONY: depend depend.status depend.update depend.cleanlock depend.update.full init
+.PHONY: depend depend.diff depend.update depend.cleanlock depend.update.full init
 
 # Parse out the x.y or x.y.z version and output a single value x*10000+y*100+z (e.g., 1.9 is 10900)
 # that allows the three components to be checked in a single comparison.
@@ -236,8 +236,9 @@ depend: init | $(ISTIO_OUT)
 $(ISTIO_OUT) $(ISTIO_BIN):
 	@mkdir -p $@
 
-$(ISTIO_OUT)/dep.png: $(ISTIO_OUT)/dep.dot
-	dot -T png < $(ISTIO_OUT)/dep.dot > $(ISTIO_OUT)/dep.png
+# Updates the dependencies and generates a git diff of the vendor files against HEAD.
+depend.diff: depend.update | $(ISTIO_OUT)
+	git diff HEAD --exit-code -- Gopkg.lock vendor > $(ISTIO_OUT)/dep.diff
 
 depend.update.full: depend.cleanlock depend.update
 


### PR DESCRIPTION
This aims to help ensure that a PR contains the correct vendor change,
by running `dep ensure` and seeing if git detects any changes.