### PR TITLE
Put registry and secrets into a nodeagent package.

### DIFF
--- a/security/cmd/flexvolume/driver/driver.go
+++ b/security/cmd/flexvolume/driver/driver.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
-	nagent "istio.io/istio/security/cmd/node_agent/management"
+	nagent "istio.io/istio/security/pkg/nodeagent/registry"
 	pb "istio.io/istio/security/proto"
 )
 

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -23,12 +23,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	nam "istio.io/istio/security/cmd/node_agent/management"
 	"istio.io/istio/security/cmd/node_agent/na"
 	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
 	wlapi "istio.io/istio/security/cmd/node_agent_k8s/workloadapi"
 	"istio.io/istio/security/pkg/caclient"
 	"istio.io/istio/security/pkg/caclient/protocol"
+	"istio.io/istio/security/pkg/nodeagent/registry"
 	"istio.io/istio/security/pkg/platform"
 )
 
@@ -117,13 +117,13 @@ func startManagement() {
 	if err != nil {
 		log.Fatalf("failed to create CAClient %v", err)
 	}
-	mgmtServer, err := nam.New(&naConfig, caClient)
+	mgmtServer, err := registry.New(&naConfig, caClient)
 	if err != nil {
 		log.Fatalf("failed to create node agent management server %v", err)
 	}
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
-	go func(s *nam.Server, c chan os.Signal) {
+	go func(s *registry.Server, c chan os.Signal) {
 		<-c
 		s.Stop()
 		s.WaitDone()

--- a/security/pkg/caclient/client.go
+++ b/security/pkg/caclient/client.go
@@ -21,9 +21,9 @@ import (
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/caclient/protocol"
+	"istio.io/istio/security/pkg/nodeagent/secrets"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
 	"istio.io/istio/security/pkg/platform"
-	"istio.io/istio/security/pkg/workload"
 	pb "istio.io/istio/security/proto"
 )
 
@@ -110,8 +110,8 @@ func (c *CAClient) createCSRRequest(opts *pkiutil.CertOptions) ([]byte, *pb.CsrR
 // SaveKeyCert stores the specified key/cert into file specified by the path.
 // TODO(incfly): move this into CAClient struct's own method later.
 func SaveKeyCert(keyFile, certFile string, privKey, cert []byte) error {
-	if err := ioutil.WriteFile(keyFile, privKey, workload.KeyFilePermission); err != nil {
+	if err := ioutil.WriteFile(keyFile, privKey, secrets.KeyFilePermission); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(certFile, cert, workload.CertFilePermission)
+	return ioutil.WriteFile(certFile, cert, secrets.CertFilePermission)
 }

--- a/security/pkg/nodeagent/registry/client.go
+++ b/security/pkg/nodeagent/registry/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package management
+package registry
 
 import (
 	"net"

--- a/security/pkg/nodeagent/registry/client_test.go
+++ b/security/pkg/nodeagent/registry/client_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package management
+package registry
 
 import (
 	"net"

--- a/security/pkg/nodeagent/registry/server.go
+++ b/security/pkg/nodeagent/registry/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package management
+package registry
 
 import (
 	"fmt"
@@ -27,8 +27,8 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/cmd/node_agent/na"
 	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
+	"istio.io/istio/security/pkg/nodeagent/secrets"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
-	"istio.io/istio/security/pkg/workload"
 	pb "istio.io/istio/security/proto"
 )
 
@@ -45,7 +45,7 @@ type Server struct {
 	// TODO(incfly): uses this once Server supports vm mode.
 	identity string // nolint
 	// secretServer manages the secrets associated for different workload.
-	secretServer workload.SecretServer
+	secretServer secrets.SecretServer
 }
 
 // Retriever is the interface responsible for retrieving key/cert from upstream CA.
@@ -58,8 +58,8 @@ func New(cfg *na.Config, retriever Retriever) (*Server, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("unablet to create when config is nil")
 	}
-	ss, err := workload.NewSecretServer(&workload.Config{
-		Mode:            workload.SecretFile,
+	ss, err := secrets.NewSecretServer(&secrets.Config{
+		Mode:            secrets.SecretFile,
 		SecretDirectory: cfg.SecretDirectory,
 	})
 	if err != nil {

--- a/security/pkg/nodeagent/registry/server_test.go
+++ b/security/pkg/nodeagent/registry/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package management
+package registry
 
 import (
 	"encoding/pem"
@@ -31,8 +31,8 @@ import (
 	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
 	wapi "istio.io/istio/security/cmd/node_agent_k8s/workloadapi"
 	"istio.io/istio/security/pkg/caclient"
+	"istio.io/istio/security/pkg/nodeagent/secrets"
 	pkiutil "istio.io/istio/security/pkg/pki/util"
-	"istio.io/istio/security/pkg/workload"
 	pb "istio.io/istio/security/proto"
 )
 
@@ -72,13 +72,13 @@ func setupCertFiles(t *testing.T) (*certFiles, func()) {
 		certChainFile: filepath.Join(dir, "cert-chain.pem"),
 		bundle:        kb,
 	}
-	if err := ioutil.WriteFile(cf.rootFile, rootCertBytes, workload.CertFilePermission); err != nil {
+	if err := ioutil.WriteFile(cf.rootFile, rootCertBytes, secrets.CertFilePermission); err != nil {
 		t.Errorf("failed to write testing root-cert into file %v err %v", cf.rootFile, err)
 	}
-	if err := ioutil.WriteFile(cf.keyFile, rootKeyBytes, workload.KeyFilePermission); err != nil {
+	if err := ioutil.WriteFile(cf.keyFile, rootKeyBytes, secrets.KeyFilePermission); err != nil {
 		t.Errorf("failed to write private key file %v error %v", cf.keyFile, err)
 	}
-	if err := ioutil.WriteFile(cf.certChainFile, rootCertBytes, workload.CertFilePermission); err != nil {
+	if err := ioutil.WriteFile(cf.certChainFile, rootCertBytes, secrets.CertFilePermission); err != nil {
 		t.Errorf("failed to write cert chain file %v error %v", cf.certChainFile, err)
 	}
 	return cf, func() {

--- a/security/pkg/nodeagent/secrets/secretfileserver.go
+++ b/security/pkg/nodeagent/secrets/secretfileserver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package secrets
 
 import (
 	"fmt"

--- a/security/pkg/nodeagent/secrets/secretserver.go
+++ b/security/pkg/nodeagent/secrets/secretserver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package secrets
 
 import (
 	"fmt"

--- a/security/pkg/nodeagent/secrets/secretserver_test.go
+++ b/security/pkg/nodeagent/secrets/secretserver_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package secrets
 
 import (
 	"bytes"

--- a/security/pkg/nodeagent/secrets/server.go
+++ b/security/pkg/nodeagent/secrets/server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package secrets
 
 import (
 	"fmt"

--- a/security/pkg/nodeagent/secrets/server_test.go
+++ b/security/pkg/nodeagent/secrets/server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package secrets
 
 import (
 	"fmt"


### PR DESCRIPTION
Two sub-package under nodeagent/
- `registry/`, is to handle the workload pod creation, deletion, etc, contains interaction with flexvolumedriver.
- `secrets/`, is to handle the secrets management, containing envoy SDS API interaction.
