### PR TITLE
let stackdriver adapter figure out project metadata by itself

### DIFF
--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -142,26 +142,26 @@ func TestFillProjectMetadata(t *testing.T) {
 		{
 			"empty metadata",
 			Metadata{ProjectID: "", Location: "", ClusterName: ""},
-			map[string]string{"project": "pid", "location": "location", "cluster_name": ""},
-			map[string]string{"project": "pid", "location": "location", "cluster_name": ""},
+			map[string]string{"project_id": "pid", "location": "location", "cluster_name": ""},
+			map[string]string{"project_id": "pid", "location": "location", "cluster_name": ""},
 		},
 		{
 			"fill metadata",
 			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
-			map[string]string{"project": "", "location": "location", "cluster_name": ""},
-			map[string]string{"project": "pid", "location": "location", "cluster_name": "cluster"},
+			map[string]string{"project_id": "", "location": "location", "cluster_name": ""},
+			map[string]string{"project_id": "pid", "location": "location", "cluster_name": "cluster"},
 		},
 		{
 			"do not override",
 			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
-			map[string]string{"project": "id", "location": "l", "cluster_name": "c"},
-			map[string]string{"project": "id", "location": "l", "cluster_name": "c"},
+			map[string]string{"project_id": "id", "location": "l", "cluster_name": "c"},
+			map[string]string{"project_id": "id", "location": "l", "cluster_name": "c"},
 		},
 		{
 			"unrelated field",
 			Metadata{ProjectID: "", Location: "", ClusterName: "cluster"},
-			map[string]string{"project": "pid", "location": "location", "cluster": ""},
-			map[string]string{"project": "pid", "location": "location", "cluster": ""},
+			map[string]string{"project_id": "pid", "location": "location", "cluster": ""},
+			map[string]string{"project_id": "pid", "location": "location", "cluster": ""},
 		},
 	}
 

--- a/mixer/adapter/stackdriver/helper/common_test.go
+++ b/mixer/adapter/stackdriver/helper/common_test.go
@@ -23,7 +23,6 @@ import (
 	gapiopts "google.golang.org/api/option"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
-	"istio.io/istio/mixer/pkg/adapter"
 )
 
 func TestToOpts(t *testing.T) {
@@ -71,27 +70,106 @@ func TestToOpts(t *testing.T) {
 	}
 }
 
-func TestFillProjectID(t *testing.T) {
+func TestMetadata(t *testing.T) {
 	tests := []struct {
-		name       string
-		shouldFill shouldFillFn
-		projectID  projectIDFn
-		in         adapter.Config
-		res        string
+		name          string
+		shouldFill    shouldFillFn
+		projectIDFn   metadataFn
+		locationFn    metadataFn
+		clusterNameFn metadataFn
+		want          Metadata
 	}{
-		{"has project id", func(*config.Params) bool { return false }, func() (string, error) { return "", nil }, &config.Params{ProjectId: "id"}, "id"},
-		{"should not fill", func(*config.Params) bool { return false }, func() (string, error) { return "", nil }, &config.Params{}, ""},
-		{"fail to get project id", func(*config.Params) bool { return true }, func() (string, error) { return "", errors.New("error") }, &config.Params{}, ""},
-		{"get project id", func(*config.Params) bool { return true }, func() (string, error) { return "id", nil }, &config.Params{}, "id"},
+		{
+			"should not fill",
+			func() bool { return false },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			Metadata{ProjectID: "", Location: "", ClusterName: ""},
+		},
+		{
+			"should fill",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
+		},
+		{
+			"project id error",
+			func() bool { return true },
+			func() (string, error) { return "", errors.New("error") },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", nil },
+			Metadata{ProjectID: "", Location: "location", ClusterName: "cluster"},
+		},
+		{
+			"location error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", errors.New("error") },
+			func() (string, error) { return "cluster", nil },
+			Metadata{ProjectID: "pid", Location: "", ClusterName: "cluster"},
+		},
+		{
+			"cluster name error",
+			func() bool { return true },
+			func() (string, error) { return "pid", nil },
+			func() (string, error) { return "location", nil },
+			func() (string, error) { return "cluster", errors.New("error") },
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: ""},
+		},
 	}
 
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			fp := NewProjectIDFiller(tt.shouldFill, tt.projectID)
-			fp.FillProjectID(tt.in)
-			cfg := tt.in.(*config.Params)
-			if cfg.ProjectId != tt.res {
-				t.Errorf("project ID %v is wrong, expected project ID %v.", cfg.ProjectId, tt.res)
+			mg := NewMetadataGenerator(tt.shouldFill, tt.projectIDFn, tt.locationFn, tt.clusterNameFn)
+			got := mg.GenerateMetadata()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Unexpected generated metadata: want %v got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFillProjectMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		md   Metadata
+		in   map[string]string
+		want map[string]string
+	}{
+		{
+			"empty metadata",
+			Metadata{ProjectID: "", Location: "", ClusterName: ""},
+			map[string]string{"project": "pid", "location": "location", "cluster_name": ""},
+			map[string]string{"project": "pid", "location": "location", "cluster_name": ""},
+		},
+		{
+			"fill metadata",
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
+			map[string]string{"project": "", "location": "location", "cluster_name": ""},
+			map[string]string{"project": "pid", "location": "location", "cluster_name": "cluster"},
+		},
+		{
+			"do not override",
+			Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
+			map[string]string{"project": "id", "location": "l", "cluster_name": "c"},
+			map[string]string{"project": "id", "location": "l", "cluster_name": "c"},
+		},
+		{
+			"unrelated field",
+			Metadata{ProjectID: "", Location: "", ClusterName: "cluster"},
+			map[string]string{"project": "pid", "location": "location", "cluster": ""},
+			map[string]string{"project": "pid", "location": "location", "cluster": ""},
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			tt.md.FillProjectMetadata(tt.in)
+			if !reflect.DeepEqual(tt.in, tt.want) {
+				t.Errorf("Unexpected map value, want %v got %v", tt.want, tt.in)
 			}
 		})
 	}

--- a/mixer/adapter/stackdriver/metric/metric.go
+++ b/mixer/adapter/stackdriver/metric/metric.go
@@ -56,6 +56,7 @@ type (
 		createClient createClientFunc
 		metrics      map[string]*metric.Type
 		cfg          *config.Params
+		mg           *helper.MetadataGenerator
 	}
 
 	info struct {
@@ -68,7 +69,7 @@ type (
 		l   adapter.Logger
 		now func() time.Time // used to control time in tests
 
-		projectID  string
+		md         helper.Metadata
 		metricInfo map[string]info
 		client     bufferedClient
 		// We hold a ref for cleanup during Close()
@@ -104,8 +105,8 @@ var (
 )
 
 // NewBuilder returns a builder implementing the metric.HandlerBuilder interface.
-func NewBuilder() metric.HandlerBuilder {
-	return &builder{createClient: createClient}
+func NewBuilder(mg *helper.MetadataGenerator) metric.HandlerBuilder {
+	return &builder{createClient: createClient, mg: mg}
 }
 
 func createClient(cfg *config.Params) (*monitoring.MetricClient, error) {
@@ -126,6 +127,11 @@ func (b *builder) Validate() *adapter.ConfigErrors {
 // NewMetricsAspect provides an implementation for adapter.MetricsBuilder.
 func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	cfg := b.cfg
+	md := b.mg.GenerateMetadata()
+	if cfg.ProjectId == "" {
+		// Try to fill project ID if it is not provided with metadata.
+		cfg.ProjectId = md.ProjectID
+	}
 	types := make(map[string]info, len(b.metrics))
 	for name, t := range b.metrics {
 		i, found := cfg.MetricInfo[name]
@@ -169,8 +175,8 @@ func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, 
 	h := &handler{
 		l:          env.Logger(),
 		now:        time.Now,
-		projectID:  cfg.ProjectId,
 		client:     buffered,
+		md:         md,
 		metricInfo: types,
 		ticker:     ticker,
 	}
@@ -217,15 +223,17 @@ func (h *handler) HandleMetric(_ context.Context, vals []*metric.Instance) error
 		// The logging SDK has logic built in that does this for us: if a resource is not provided it fills in the global
 		// resource as a default. Since we don't have equivalent behavior for monitoring, we do it ourselves.
 		if val.MonitoredResourceType != "" {
+			labels := helper.ToStringMap(val.MonitoredResourceDimensions)
+			h.md.FillProjectMetadata(labels)
 			ts.Resource = &monitoredres.MonitoredResource{
 				Type:   val.MonitoredResourceType,
-				Labels: helper.ToStringMap(val.MonitoredResourceDimensions),
+				Labels: labels,
 			}
 		} else {
 			ts.Resource = &monitoredres.MonitoredResource{
 				Type: "global",
 				Labels: map[string]string{
-					"project_id": h.projectID,
+					"project_id": h.md.ProjectID,
 				},
 			}
 		}

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -477,7 +477,7 @@ func TestProjectMetadata(t *testing.T) {
 					Value: int64(1),
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
-						"project":      "id",
+						"project_id":   "id",
 						"location":     "l",
 						"cluster_name": "c",
 					},
@@ -486,7 +486,7 @@ func TestProjectMetadata(t *testing.T) {
 			&monitoredres.MonitoredResource{
 				Type: "mr-type",
 				Labels: map[string]string{
-					"project":      "id",
+					"project_id":   "id",
 					"location":     "l",
 					"cluster_name": "c",
 				},
@@ -500,7 +500,7 @@ func TestProjectMetadata(t *testing.T) {
 					Value: int64(1),
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
-						"project":      "",
+						"project_id":   "",
 						"location":     "",
 						"cluster_name": "",
 					},
@@ -509,7 +509,7 @@ func TestProjectMetadata(t *testing.T) {
 			&monitoredres.MonitoredResource{
 				Type: "mr-type",
 				Labels: map[string]string{
-					"project":      "pid",
+					"project_id":   "pid",
 					"location":     "location",
 					"cluster_name": "cluster",
 				},

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -31,6 +31,7 @@ import (
 
 	descriptor "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/adapter/stackdriver/config"
+	helper "istio.io/istio/mixer/adapter/stackdriver/helper"
 	"istio.io/istio/mixer/pkg/adapter/test"
 	metrict "istio.io/istio/mixer/template/metric"
 )
@@ -50,6 +51,10 @@ var clientFunc = func(err error) createClientFunc {
 		return nil, err
 	}
 }
+
+var dummyShouldFill = func() bool { return true }
+var dummyMetadataFn = func() (string, error) { return "", nil }
+var dummyMetadataGenerator = helper.NewMetadataGenerator(dummyShouldFill, dummyMetadataFn, dummyMetadataFn, dummyMetadataFn)
 
 func TestFactory_NewMetricsAspect(t *testing.T) {
 	tests := []struct {
@@ -77,7 +82,7 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 				metrics[name] = &metrict.Type{}
 			}
 			env := test.NewEnv(t)
-			b := &builder{createClient: clientFunc(nil)}
+			b := &builder{createClient: clientFunc(nil), mg: dummyMetadataGenerator}
 			b.SetMetricTypes(metrics)
 			b.SetAdapterConfig(tt.cfg)
 			_, err := b.Build(context.Background(), env)
@@ -112,7 +117,7 @@ func TestFactory_NewMetricsAspect(t *testing.T) {
 
 func TestFactory_NewMetricsAspect_Errs(t *testing.T) {
 	err := fmt.Errorf("expected")
-	b := &builder{createClient: clientFunc(err)}
+	b := &builder{createClient: clientFunc(err), mg: dummyMetadataGenerator}
 	b.SetAdapterConfig(&config.Params{})
 	res, e := b.Build(context.Background(), test.NewEnv(t))
 	if e != nil && !strings.Contains(e.Error(), err.Error()) {
@@ -153,7 +158,7 @@ func TestMetricType(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			metrics := map[string]*metrict.Type{"metric": {}}
-			b := &builder{createClient: clientFunc(nil)}
+			b := &builder{createClient: clientFunc(nil), mg: dummyMetadataGenerator}
 			b.SetMetricTypes(metrics)
 			b.SetAdapterConfig(tt.cfg)
 			env := test.NewEnv(t)
@@ -384,7 +389,7 @@ func TestRecord(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			buf := &fakebuf{}
-			s := &handler{metricInfo: info, projectID: projectID, client: buf, l: test.NewEnv(t).Logger(), now: func() time.Time { return now }}
+			s := &handler{metricInfo: info, md: helper.Metadata{ProjectID: projectID}, client: buf, l: test.NewEnv(t).Logger(), now: func() time.Time { return now }}
 			_ = s.HandleMetric(context.Background(), tt.vals)
 
 			if len(buf.buf) != len(tt.expected) {
@@ -398,6 +403,138 @@ func TestRecord(t *testing.T) {
 				if !found {
 					t.Errorf("Want timeseries %v, but not present: %v", expected, buf.buf)
 				}
+			}
+		})
+	}
+}
+
+func TestProjectID(t *testing.T) {
+	createClientFn := func(pid string) createClientFunc {
+		return func(cfg *config.Params) (*monitoring.MetricClient, error) {
+			if cfg.ProjectId != pid {
+				return nil, fmt.Errorf("wanted %v got %v", pid, cfg.ProjectId)
+			}
+			return nil, nil
+		}
+	}
+	tests := []struct {
+		name string
+		cfg  *config.Params
+		pid  func() (string, error)
+		want string
+	}{
+		{
+			"empty project id",
+			&config.Params{
+				ProjectId: "",
+			},
+			func() (string, error) { return "pid", nil },
+			"pid",
+		},
+		{
+			"empty project id",
+			&config.Params{
+				ProjectId: "pid",
+			},
+			func() (string, error) { return "meta-pid", nil },
+			"pid",
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			mg := helper.NewMetadataGenerator(dummyShouldFill, tt.pid, dummyMetadataFn, dummyMetadataFn)
+			b := &builder{createClient: createClientFn(tt.want), mg: mg}
+			b.SetAdapterConfig(tt.cfg)
+			_, err := b.Build(context.Background(), test.NewEnv(t))
+			if err != nil {
+				t.Errorf("Project id is not expected: %v", err)
+			}
+		})
+	}
+}
+
+func TestProjectMetadata(t *testing.T) {
+	now := time.Now()
+	info := map[string]info{
+		"metric": {
+			ttype: "type",
+			minfo: &config.Params_MetricInfo{Kind: metricpb.MetricDescriptor_GAUGE, Value: metricpb.MetricDescriptor_INT64},
+			vtype: descriptor.INT64,
+		},
+	}
+
+	tests := []struct {
+		name string
+		vals []*metrict.Instance
+		want *monitoredres.MonitoredResource
+	}{
+		{
+			"filled",
+			[]*metrict.Instance{
+				{
+					Name:  "metric",
+					Value: int64(1),
+					MonitoredResourceType: "mr-type",
+					MonitoredResourceDimensions: map[string]interface{}{
+						"project":      "id",
+						"location":     "l",
+						"cluster_name": "c",
+					},
+				},
+			},
+			&monitoredres.MonitoredResource{
+				Type: "mr-type",
+				Labels: map[string]string{
+					"project":      "id",
+					"location":     "l",
+					"cluster_name": "c",
+				},
+			},
+		},
+		{
+			"empty",
+			[]*metrict.Instance{
+				{
+					Name:  "metric",
+					Value: int64(1),
+					MonitoredResourceType: "mr-type",
+					MonitoredResourceDimensions: map[string]interface{}{
+						"project":      "",
+						"location":     "",
+						"cluster_name": "",
+					},
+				},
+			},
+			&monitoredres.MonitoredResource{
+				Type: "mr-type",
+				Labels: map[string]string{
+					"project":      "pid",
+					"location":     "location",
+					"cluster_name": "cluster",
+				},
+			},
+		},
+	}
+
+	for idx, tt := range tests {
+		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
+			buf := &fakebuf{}
+			s := &handler{
+				metricInfo: info,
+				md:         helper.Metadata{ProjectID: "pid", Location: "location", ClusterName: "cluster"},
+				client:     buf,
+				l:          test.NewEnv(t).Logger(),
+				now:        func() time.Time { return now },
+			}
+			_ = s.HandleMetric(context.Background(), tt.vals)
+
+			if len(buf.buf) != 1 {
+				t.Errorf("Want 1 values to send, got %d", len(buf.buf))
+			}
+			got := buf.buf[0].Resource
+			if !reflect.DeepEqual(tt.want.Labels, got.Labels) {
+				t.Errorf("Want monitored resource %v, got %v", tt.want, got)
 			}
 		})
 	}

--- a/mixer/adapter/stackdriver/stackdriver_test.go
+++ b/mixer/adapter/stackdriver/stackdriver_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"istio.io/istio/mixer/adapter/stackdriver/config"
-	"istio.io/istio/mixer/adapter/stackdriver/helper"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/adapter/test"
 	"istio.io/istio/mixer/template/logentry"
@@ -80,8 +79,7 @@ func (f *fakeAspect) HandleLogEntry(context.Context, []*logentry.Instance) error
 func TestDispatchConfigureAndBuild(t *testing.T) {
 	m := &fakeBuilder{}
 	l := &fakeBuilder{}
-	pf := helper.NewProjectIDFiller(func(*config.Params) bool { return false }, func() (string, error) { return "", nil })
-	b := &builder{m, l, pf}
+	b := &builder{m, l}
 	b.SetMetricTypes(make(map[string]*metric.Type))
 
 	if !m.calledConfigure {
@@ -127,8 +125,7 @@ func TestDispatchHandleAndClose(t *testing.T) {
 	lb := &fakeBuilder{instance: la}
 	ma := &fakeAspect{}
 	mb := &fakeBuilder{instance: ma}
-	pf := helper.NewProjectIDFiller(func(*config.Params) bool { return false }, func() (string, error) { return "", nil })
-	b := &builder{mb, lb, pf}
+	b := &builder{mb, lb}
 
 	superHandler, err := b.Build(context.Background(), test.NewEnv(t))
 	if err != nil {


### PR DESCRIPTION
This will make stackdriver adapter config generalized and usable for different projects.