### PR TITLE
Fix labelNames getting filled in stackdriver logging.

### DIFF
--- a/mixer/adapter/stackdriver/log/log.go
+++ b/mixer/adapter/stackdriver/log/log.go
@@ -208,7 +208,7 @@ func toLabelMap(names []string, variables map[string]interface{}) map[string]str
 		case string:
 			out[name] = vt
 		default:
-			out[name] = fmt.Sprintf("%v", v)
+			out[name] = fmt.Sprintf("%v", vt)
 		}
 	}
 	return out

--- a/mixer/testdata/config/stackdriver.yaml
+++ b/mixer/testdata/config/stackdriver.yaml
@@ -70,7 +70,7 @@ spec:
       - responseCode
       - responseSize
       - requestSize
-    latency: response.duration | "0ms"
+      - latency
       sinkInfo:
         id: '<sink_id>'
         destination: '<sink_destination>'

--- a/mixer/testdata/config/stackdriver.yaml
+++ b/mixer/testdata/config/stackdriver.yaml
@@ -60,6 +60,17 @@ spec:
         latency: latency
         localIp: sourceIp
         remoteIp: destinationIp
+      labelNames:
+      - sourceIp
+      - destinationIp
+      - sourceUser
+      - method
+      - url
+      - protocol
+      - responseCode
+      - responseSize
+      - requestSize
+    latency: response.duration | "0ms"
       sinkInfo:
         id: '<sink_id>'
         destination: '<sink_destination>'


### PR DESCRIPTION
Added LabelNames in testdata/stackdriver.yaml file
Also, fixed that if label was not string, it was getting filled as null.