### PR TITLE
Modernize istio-remote helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -577,8 +577,6 @@ $(HELM):
 istio-remote.yaml: $(HELM)
 	cat install/kubernetes/templates/namespace.yaml > install/kubernetes/$@
 	$(HELM) template --namespace=istio-system \
-		  --set global.pilotEndpoint="pilotIpReplace" \
-		  --set global.policyEndpoint="mixerIpReplace" \
 		  install/kubernetes/helm/istio-remote >> install/kubernetes/$@
 
 # creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml

--- a/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+name: security
+version: 0.8.0
+description: Helm chart for istio authentication
+keywords:
+  - istio
+  - security
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "security.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "security.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "security.serviceAccountName" -}}
+{{- if .Values.global.rbacEnabled -}}
+{{- template "security.fullname" . -}}-service-account
+{{- else }}
+{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
+{{- end -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.global.rbacEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-citadel-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.rbacEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-citadel-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-citadel-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-citadel-service-account
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
@@ -1,0 +1,35 @@
+# istio CA watching all namespaces
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-citadel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: citadel
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        istio: citadel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+        - name: citadel
+          image: "{{ .Values.global.hub }}/citadel:{{ .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            - --append-dns-names=true
+            - --grpc-port=8060
+            - --grpc-hostname=citadel
+            - --self-signed-ca=true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  # we use the normal name here (e.g. 'prometheus')
+  # as grafana is configured to use this as a data source
+  name: istio-citadel
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-citadel
+spec:
+  ports:
+    - name: grpc-citadel
+      port: 8060
+      targetPort: 8060
+      protocol: TCP
+    - name: http-monitoring
+      port: 9093
+  selector:
+    istio: citadel

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 2 }}
+{{- end }}
+metadata:
+  name: istio-citadel-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}

--- a/install/kubernetes/helm/istio-remote/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio-remote/templates/_affinity.tpl
@@ -1,0 +1,36 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+
+{{- define "nodeaffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.global.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key }}
+          {{- end }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.global.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -1,6 +1,30 @@
 apiVersion: v1
 kind: Endpoints
 metadata:
+  name: istio-pilot
+  namespace: istio-system
+subsets:
+- addresses:
+  - ip: {{ .Values.global.pilotEndpoint }}
+  ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
+  - port: 15010
+    name: grpc-xds # direct
+  - port: 15011
+    name: https-xds # mTLS or non-mTLS depending on auth setting
+  - port: 8080
+    name: http-legacy-discovery # direct
+  - port: 9093
+    name: http-monitoring
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
   name: istio-policy
   namespace: istio-system
 subsets:
@@ -26,26 +50,15 @@ subsets:
 apiVersion: v1
 kind: Endpoints
 metadata:
-  name: istio-pilot
+  name: istio-statsd-prom-bridge
   namespace: istio-system
 subsets:
 - addresses:
-  - ip: {{ .Values.global.pilotEndpoint }}
+  - ip: {{ .Values.global.statsdEndpoint }}
   ports:
-  - port: 15011
-    name: https-xds
-  - port: 15003
-    name: http-old-discovery
-  - port: 15005
-    name: https-discovery
-  - port: 15007
-    name: http-discovery
-  - port: 15010
-    name: grpc-discovery
-  - port: 8080
-    name: http-legacy-discovery
-  - port: 9093
-    name: http-monitoring
-  - port: 443
-    name: admission-webhook
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
 ---

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -1,36 +1,32 @@
-# Pilot service for discovery
+
 apiVersion: v1
 kind: Service
 metadata:
   name: istio-pilot
   namespace: istio-system
-  labels:
-    istio: pilot
 spec:
   ports:
-  - port: 15005
-    name: https-discovery
-  - port: 15007
-    name: http-discovery
-    targetPort: 15007
   - port: 15003
-    name: http-old-discovery
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
   - port: 15010
-    name: grpc-xds
+    name: grpc-xds # direct
+  - port: 15011
+    name: https-xds # mTLS or non-mTLS depending on auth setting
   - port: 8080
-    name: http-legacy-discovery
+    name: http-legacy-discovery # direct
   - port: 9093
     name: http-monitoring
-  - port: 443
-    name: admission-webhook
+  clusterIP: None
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: istio-policy
   namespace: istio-system
-  labels:
-    istio: mixer
 spec:
   ports:
   - name: tcp-plain
@@ -39,4 +35,28 @@ spec:
     port: 15004
   - name: http-monitoring
     port: 9093
+  - name: configapi
+    port: 9094
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
+  - name: prometheus
+    port: 42422
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-statsd-prom-bridge
+  namespace: istio-system
+spec:
+  ports:
+  - name: statsd-prom
+    port: 9102
+  - name: statsd-udp
+    port: 9125
+    protocol: UDP
+  clusterIP: None
 ---

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -1,7 +1,84 @@
-# Use --set to specify the Pilot and Policy IPs on the main Istio control plane
+# Use --set to specify the endpoints of the main Istio control plane
+# NB: These defaults do not work properly - they must be overriden with
+# IP addresses
+
 global:
   # The Istio control plane Pilot endpoint
-  pilotEndpoint: none
+  pilotEndpoint: istio-pilot.istio-system
 
   # The Istio control plane Policy endpoint
-  policyEndpoint: none
+  policyEndpoint: istio-policy.istio-system
+
+  # The Istio control plane statsd endpoint
+  statsdEndpoint: istio-statsd-prom-bridge.istio-system
+
+  # Default tag for Istio images.
+  hub: docker.io/istionightly
+
+  # Default tag for Istio images.
+  # Should track latest released version.
+  # Currently using nightly build, for testing
+  tag: circleci-nightly
+  proxy:
+    image: proxy
+
+  # imagePullPolicy is applied to istio control plane components.
+  imagePullPolicy: IfNotPresent
+
+  # Not recommended for user to configure this. Hyperkube image to use when creating custom resources
+  hyperkube:
+    repository: quay.io/coreos/hyperkube
+    tag: v1.7.6_coreos.0
+
+  # Install istio CA.
+  securityEnabled: true
+
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: false
+
+  # Default mtls policy. If true, mtls between services will be enabled by default.
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: false
+    # List of fully qualified services to exclude from mtls
+    # TODO: add the templating.
+    mtlsExcludedServices:
+    - "kubernetes.default.svc.cluster.local"
+
+  # create RBAC resources. Must be set for any cluster configured with rbac.
+  rbacEnabled: true
+
+  ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
+  # imagePullSecrets:
+  #   - name: "private-registry-key"
+
+  # Default is 1 second
+  refreshInterval: 10s
+
+  # Specify pod scheduling arch(amd64, ppc64le, s390x) and weight as follows:
+  #   0 - Never scheduled
+  #   1 - Least preferred
+  #   2 - No preference
+  #   3 - Most preferred
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
+
+#
+# security configuration
+#
+security:
+  serviceAccountName: default # used only if RBAC is not enabled
+  replicaCount: 1
+  imagePullPolicy: IfNotPresent
+  resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+# Any customization for istio testing should be here

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -84,36 +84,30 @@ func (k *KubeInfo) generateRemoteIstio(src, dst string) error {
 		return err
 	}
 	getOpt := meta_v1.GetOptions{IncludeUninitialized: true}
-	var pilotEPS, policyEPS, statsdEPS *v1.Endpoints
+	var pilotEPS, mixerEPS *v1.Endpoints
 
 	for i := 0; i <= 200; i++ {
 		pilotEPS, err = k.KubeClient.CoreV1().Endpoints(k.Namespace).Get("istio-pilot", getOpt)
 		log.Infof("PilotEPS = %s ", pilotEPS)
 		if (len(pilotEPS.Subsets) != 0) && (err == nil) {
 
-			policyEPS, err = k.KubeClient.CoreV1().Endpoints(k.Namespace).Get("istio-policy", getOpt)
-			log.Infof("policyEPS = %s ", policyEPS)
-			if (len(policyEPS.Subsets) != 0) && (err == nil) {
-				break
-			}
-			statsdEPS, err = k.KubeClient.CoreV1().Endpoints(k.Namespace).Get("istio-statsd-prom-bridge", getOpt)
-			log.Infof("statsdEPS = %s ", policyEPS)
-			if (len(statsdEPS.Subsets) != 0) && (err == nil) {
+			mixerEPS, err = k.KubeClient.CoreV1().Endpoints(k.Namespace).Get("istio-policy", getOpt)
+			log.Infof("mixerEPS = %s ", mixerEPS)
+			if (len(mixerEPS.Subsets) != 0) && (err == nil) {
 				break
 			}
 		}
 		time.Sleep(time.Second * 1)
 	}
-	log.Infof("len pilot %i len policyEPS = %i ", len(pilotEPS.Subsets), len(policyEPS.Subsets))
+	log.Infof("len pilot %i len mixerEPS = %i ", len(pilotEPS.Subsets), len(mixerEPS.Subsets))
 	log.Infof("pilotEPS %s", spew.Sdump(pilotEPS))
-	log.Infof("policyEPS %s", spew.Sdump(policyEPS))
-	log.Infof("statsdEPS %s", spew.Sdump(statsdEPS))
+	log.Infof("mixerEPS %s", spew.Sdump(mixerEPS))
 	if err != nil {
 		err = fmt.Errorf("could not get endpoints from local cluster")
 		return err
 	}
 
-	var pilotIP, policyIP, statsdIP string
+	var pilotIP, mixerIP string
 	if len(pilotEPS.Subsets[0].Addresses) != 0 {
 		pilotIP = pilotEPS.Subsets[0].Addresses[0].IP
 	} else if len(pilotEPS.Subsets[0].NotReadyAddresses) != 0 {
@@ -122,27 +116,18 @@ func (k *KubeInfo) generateRemoteIstio(src, dst string) error {
 		err = fmt.Errorf("could not get endpoint addresses")
 		return err
 	}
-	if len(policyEPS.Subsets[0].Addresses) != 0 {
-		policyIP = policyEPS.Subsets[0].Addresses[0].IP
+	if len(mixerEPS.Subsets[0].Addresses) != 0 {
+		mixerIP = mixerEPS.Subsets[0].Addresses[0].IP
 	} else if len(pilotEPS.Subsets[0].NotReadyAddresses) != 0 {
-		policyIP = policyEPS.Subsets[0].NotReadyAddresses[0].IP
+		mixerIP = mixerEPS.Subsets[0].NotReadyAddresses[0].IP
 	} else {
 		err = fmt.Errorf("could not get endpoint addresses")
 		return err
 	}
-	if len(statsdEPS.Subsets[0].Addresses) != 0 {
-		statsdIP = statsdEPS.Subsets[0].Addresses[0].IP
-	} else if len(statsdEPS.Subsets[0].NotReadyAddresses) != 0 {
-		statsdIP = statsdEPS.Subsets[0].NotReadyAddresses[0].IP
-	} else {
-		err = fmt.Errorf("could not get endpoint addresses")
-		return err
-	}
-	log.Infof("istio-pilot endpoint IP = %s istio-policy endpoint IP = %s statsd endpoint IP %s", pilotIP, policyIP, statsdIP)
+	log.Infof("istio-pilot endpoint IP = %s istio-policy endpoint IP = %s", pilotIP, mixerIP)
 	content = replacePattern(content, istioSystem, k.Namespace)
-	content = replacePattern(content, "istio-policy.istio-system", policyIP)
-	content = replacePattern(content, "istio-pilot.istio-system", pilotIP)
-	content = replacePattern(content, "istio-statsd.istio-system", statsdIP)
+	content = replacePattern(content, "mixerIpReplace", mixerIP)
+	content = replacePattern(content, "pilotIpReplace", pilotIP)
 	err = ioutil.WriteFile(dst, content, 0600)
 	if err != nil {
 		log.Errorf("cannot write remote into generated yaml file %s", dst)


### PR DESCRIPTION
Modifies endpoints and services to match master
This PR further changes the Makefile target to use istio-${service}.istio-system
This PR further adds in the CA service and deploys it by default