### PR TITLE
Add per proxy pilot querying

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -375,7 +375,7 @@ func adsz(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if proxyID := req.Form.Get("proxyID"); proxyID != "" {
+	if proxyID := req.URL.Query().Get("proxyID"); proxyID != "" {
 		writeADSForSidecar(w, proxyID)
 		return
 	}


### PR DESCRIPTION
This is the final chunk of functionality for the base proxy-config command. It adds the ability to query Pilot for a specific proxy as well as the full mesh.