### PR TITLE
Multicluster deployment of Apps on remote

### DIFF
--- a/tests/e2e/framework/app_manager.go
+++ b/tests/e2e/framework/app_manager.go
@@ -47,7 +47,7 @@ type AppManager struct {
 	namespace  string
 	istioctl   *Istioctl
 	active     bool
-	kubeconfig string
+	Kubeconfig string
 }
 
 // NewAppManager create a new AppManager
@@ -56,7 +56,7 @@ func NewAppManager(tmpDir, namespace string, istioctl *Istioctl, kubeconfig stri
 		namespace:  namespace,
 		tmpDir:     tmpDir,
 		istioctl:   istioctl,
-		kubeconfig: kubeconfig,
+		Kubeconfig: kubeconfig,
 	}
 }
 
@@ -95,7 +95,7 @@ func (am *AppManager) deploy(a *App) error {
 			return err
 		}
 	}
-	if err := util.KubeApply(am.namespace, finalYaml, am.kubeconfig); err != nil {
+	if err := util.KubeApply(am.namespace, finalYaml, am.Kubeconfig); err != nil {
 		log.Errorf("Kubectl apply %s failed", finalYaml)
 		return err
 	}
@@ -148,7 +148,7 @@ func (am *AppManager) UndeployApp(a *App) error {
 		return nil
 	}
 
-	if err := util.KubeDelete(am.namespace, a.deployedYaml, am.kubeconfig); err != nil {
+	if err := util.KubeDelete(am.namespace, a.deployedYaml, am.Kubeconfig); err != nil {
 		log.Errorf("Kubectl delete %s failed", a.deployedYaml)
 		return err
 	}
@@ -157,5 +157,5 @@ func (am *AppManager) UndeployApp(a *App) error {
 
 // CheckDeployments waits for a period for the deployments to be started.
 func (am *AppManager) CheckDeployments() error {
-	return util.CheckDeployments(am.namespace, maxDeploymentRolloutTime, am.kubeconfig)
+	return util.CheckDeployments(am.namespace, maxDeploymentRolloutTime, am.Kubeconfig)
 }

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -106,6 +106,10 @@ func NewCommonConfigWithVersion(testID, version string) (*CommonConfig, error) {
 	c.Cleanup.RegisterCleanable(c.Kube)
 	c.Cleanup.RegisterCleanable(c.Kube.Istioctl)
 	c.Cleanup.RegisterCleanable(c.Kube.AppManager)
+	if c.Kube.RemoteKubeConfig != "" {
+		c.Cleanup.RegisterCleanable(c.Kube.RemoteAppManager)
+	}
+
 	return c, nil
 }
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -54,7 +54,7 @@ const (
 	defaultSidecarInjectorFile       = "istio-sidecar-injector.yaml"
 	ingressCertsName                 = "istio-ingress-certs"
 	defaultGalleyConfigValidatorFile = "istio-galley-config-validator.yaml"
-	maxDeploymentRolloutTime         = 240 * time.Second
+	maxDeploymentRolloutTime         = 480 * time.Second
 	mtlsExcludedServicesPattern      = "mtlsExcludedServices:\\s*\\[(.*)\\]"
 )
 
@@ -548,11 +548,6 @@ func (k *KubeInfo) deployIstio() error {
 		// Create the local secrets and configmap to start pilot
 		if err := util.CreateMultiClusterSecrets(k.Namespace, k.KubeClient, k.RemoteKubeConfig); err != nil {
 			log.Errorf("Unable to create secrets on local cluster %s", err.Error())
-			return err
-		}
-		// Create the remote secrets. This is temporary until a better CA strategy is used
-		if err := k.createRemoteSecrets(); err != nil {
-			log.Errorf("Unable to create secrets on Remote cluster %s", err.Error())
 			return err
 		}
 

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -95,6 +95,9 @@ func setTestConfig() error {
 	apps := getApps(tc)
 	for i := range apps {
 		tc.Kube.AppManager.AddApp(&apps[i])
+		if tc.Kube.RemoteKubeConfig != "" {
+			tc.Kube.RemoteAppManager.AddApp(&apps[i])
+		}
 	}
 
 	// Extra system configuration required for the pilot tests.
@@ -161,7 +164,6 @@ type deployableConfig struct {
 // Setup pushes the config and waits for it to propagate to all nodes in the cluster.
 func (c *deployableConfig) Setup() error {
 	c.applied = []string{}
-
 	// Apply the configs.
 	for _, yamlFile := range c.YamlFiles {
 		if err := util.KubeApply(c.Namespace, yamlFile, c.kubeconfig); err != nil {


### PR DESCRIPTION
This change deploys the remote applications in a multicluster
test.   It alps fixes a couple issues with the remote.yaml
and a typo from a prior PR. It makes some fixes to match up
with PR5083