### PR TITLE
pilot-agent: add a flag to disable internal telemetry

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -316,7 +316,7 @@ func init() {
 		"Use bootstrap v2")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",
 		"Go template bootstrap config")
-	proxyCmd.PersistentFlags().BoolVar(&disableInternalTelemetry, "disableInternalTelemetry", true,
+	proxyCmd.PersistentFlags().BoolVar(&disableInternalTelemetry, "disableInternalTelemetry", false,
 		"Disable internal telemetry")
 
 	// Attach the Istio logging options to the command.

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -45,24 +45,25 @@ var (
 	registry serviceregistry.ServiceRegistry
 
 	// proxy config flags (named identically)
-	configPath             string
-	binaryPath             string
-	serviceCluster         string
-	availabilityZone       string
-	drainDuration          time.Duration
-	parentShutdownDuration time.Duration
-	discoveryAddress       string
-	discoveryRefreshDelay  time.Duration
-	zipkinAddress          string
-	connectTimeout         time.Duration
-	statsdUDPAddress       string
-	proxyAdminPort         int
-	controlPlaneAuthPolicy string
-	customConfigFile       string
-	proxyLogLevel          string
-	concurrency            int
-	bootstrapv2            bool
-	templateFile           string
+	configPath               string
+	binaryPath               string
+	serviceCluster           string
+	availabilityZone         string
+	drainDuration            time.Duration
+	parentShutdownDuration   time.Duration
+	discoveryAddress         string
+	discoveryRefreshDelay    time.Duration
+	zipkinAddress            string
+	connectTimeout           time.Duration
+	statsdUDPAddress         string
+	proxyAdminPort           int
+	controlPlaneAuthPolicy   string
+	customConfigFile         string
+	proxyLogLevel            string
+	concurrency              int
+	bootstrapv2              bool
+	templateFile             string
+	disableInternalTelemetry bool
 
 	loggingOptions = log.DefaultOptions()
 
@@ -207,6 +208,9 @@ var (
 				if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
 					opts["ControlPlaneAuth"] = "enable"
 				}
+				if disableInternalTelemetry {
+					opts["DisableReportCalls"] = "true"
+				}
 				tmpl, err := template.ParseFiles(templateFile)
 				if err != nil {
 					return err
@@ -312,6 +316,8 @@ func init() {
 		"Use bootstrap v2")
 	proxyCmd.PersistentFlags().StringVar(&templateFile, "templateFile", "",
 		"Go template bootstrap config")
+	proxyCmd.PersistentFlags().BoolVar(&disableInternalTelemetry, "disableInternalTelemetry", true,
+		"Disable internal telemetry")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -77,6 +77,9 @@ static_resources:
               service_configs:
                 istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:
@@ -138,6 +141,9 @@ static_resources:
               service_configs:
                 istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:
@@ -198,6 +204,9 @@ static_resources:
               service_configs:
                 istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:
@@ -256,6 +265,9 @@ static_resources:
               service_configs:
                 istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -74,6 +74,9 @@ static_resources:
               service_configs:
                 istio-policy.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -46,6 +46,9 @@ static_resources:
               service_configs:
                 istio-telemetry.{{ .PodNamespace }}.svc.cluster.local:
                   disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
                   mixer_attributes:
                     attributes:
                       destination.service:


### PR DESCRIPTION
Enabled by default, but allows to turn off telemetry.

Signed-off-by: Kuat Yessenov <kuat@google.com>