### PR TITLE
Change bookinfo to use Gateway instead of Ingress

### DIFF
--- a/samples/bookinfo/kube/bookinfo.yaml
+++ b/samples/bookinfo/kube/bookinfo.yaml
@@ -193,30 +193,30 @@ spec:
 ###########################################################################
 # Ingress resource (gateway)
 ##########################################################################
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: gateway
-  annotations:
-    kubernetes.io/ingress.class: "istio"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /productpage
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /login
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /logout
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /api/v1/products.*
-        backend:
-          serviceName: productpage
-          servicePort: 9080
----
+#apiVersion: extensions/v1beta1
+#kind: Ingress
+#metadata:
+#  name: gateway
+#  annotations:
+#    kubernetes.io/ingress.class: "istio"
+#spec:
+#  rules:
+#  - http:
+#      paths:
+#      - path: /productpage
+#        backend:
+#          serviceName: productpage
+#          servicePort: 9080
+#      - path: /login
+#        backend:
+#          serviceName: productpage
+#          servicePort: 9080
+#      - path: /logout
+#        backend:
+#          serviceName: productpage
+#          servicePort: 9080
+#      - path: /api/v1/products.*
+#        backend:
+#          serviceName: productpage
+#          servicePort: 9080
+#---

--- a/samples/bookinfo/routing/bookinfo-gateway.yaml
+++ b/samples/bookinfo/routing/bookinfo-gateway.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  #- istio-ingressgateway 
+  http:
+  - match:
+    - uri:
+        exact: /productpage
+    - uri:
+        exact: /login
+    - uri:
+        exact: /logout
+    - uri:
+        prefix: /api/v1/products
+    route:
+    - destination:
+        host: productpage

--- a/samples/bookinfo/routing/route-rule-all-v1.yaml
+++ b/samples/bookinfo/routing/route-rule-all-v1.yaml
@@ -60,7 +60,7 @@ metadata:
 spec:
   host: productpage
   subsets:
-  - host: v1
+  - name: v1
     labels:
       version: v1
 ---


### PR DESCRIPTION
This is a WIP first pass at trying to use a Gateway, instead of Ingress, to access the Bookinfo app. It doesn't work yet.

@rshriram @vadimeisenbergibm : I'm not sure if the problem is just that my environment is not configured correctly for envoyv2/v1alpha3, or something else, but here's what I tried:

```
Franks-MacBook-Pro:istio frankbudinsky$ istioctl create -f samples/bookinfo/routing/bookinfo-gateway.yaml 
Created config gateway/default/bookinfo-gateway at revision 361465
Created config virtual-service/default/bookinfo at revision 361466
Franks-MacBook-Pro:istio frankbudinsky$ export GATEWAY_URL=$(kubectl get po -l istio=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc istio-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[0].nodePort}')
Franks-MacBook-Pro:istio frankbudinsky$ echo $GATEWAY_URL
192.168.99.100:31380
Franks-MacBook-Pro:istio frankbudinsky$ curl -v http://${GATEWAY_URL}/productpage
*   Trying 192.168.99.100...
* TCP_NODELAY set
* Connection failed
* connect to 192.168.99.100 port 31380 failed: Connection refused
* Failed to connect to 192.168.99.100 port 31380: Connection refused
* Closing connection 0
curl: (7) Failed to connect to 192.168.99.100 port 31380: Connection refused
```

I'm creating a Gateway and corresponding VirtualService in the `default` namespace, which is using a `selector` to try to use the istio-ingressgateway implementation pod running in `istio-system`. I'm wondering if this might be the problem. How can we do cross-namespace referencing?
