### PR TITLE
Don't attempt to qualify the wildcard domain.

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -551,7 +551,11 @@ func ResolveHostname(meta ConfigMeta, svc *routing.IstioService) string {
 // to shortname of the service to FQDN
 func ResolveShortnameToFQDN(host string, meta ConfigMeta) string {
 	out := host
-
+	// Treat the wildcard host as fully qualified. Any other variant of a wildcard hostname will contain a `.` too,
+	// and skip the next if, so we only need to check for the literal wildcard itself.
+	if host == "*" {
+		return out
+	}
 	// if FQDN is specified, do not append domain or namespace to hostname
 	if !strings.Contains(host, ".") {
 		if meta.Namespace != "" {

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -16,12 +16,11 @@ package model_test
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-
-	"fmt"
 
 	authn "istio.io/api/authentication/v1alpha1"
 	routing "istio.io/api/routing/v1alpha1"


### PR DESCRIPTION
Given a VirtualService like:
```
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: bookinfo-gateway
spec:
  hosts:
  - "*"
  gateways:
  - test-server-gateway
  http:
  - match:
    - uri:
        exact: /productpage
    - uri:
        exact: /login
    - uri:
        exact: /logout
    - uri:
        prefix: /api/v1/products
    route:
    - destination:
        host: test-server
```
We generate a VirtualHost like:
```
"virtual_hosts": [
    {
        "domains": [
            "*.default.svc.cluster.local"
        ],
        "name": "bookinfo-gateway:80",
        "routes": [
            {
                "decorator": {
                    "operation": "bookinfo-gateway"
                },
                "match": {
                    "path": "/productpage"
                },
                "route": {
                    "cluster": "outbound|http||test-server.default.svc.cluster.local",
                    "timeout": "0.000s",
                    "use_websocket": false
                }
            },
```
We can see the Gateway respects this name, even though the operator clearly didn't intend the wildcard to be qualified:

```bash
$ curl -v http://192.168.99.100:31380/login -H "Host: foo.com"
*   Trying 192.168.99.100...
* TCP_NODELAY set
* Connected to 192.168.99.100 (192.168.99.100) port 31380 (#0)
> GET /login HTTP/1.1
> Host: foo.com
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
< date: Fri, 20 Apr 2018 22:32:32 GMT
< server: envoy
< content-length: 0
<
* Connection #0 to host 192.168.99.100 left intact

$ curl -v http://192.168.99.100:31380/login -H "Host: foo.default.svc.cluster.local"
*   Trying 192.168.99.100...
* TCP_NODELAY set
* Connected to 192.168.99.100 (192.168.99.100) port 31380 (#0)
> GET /login HTTP/1.1
> Host: foo.default.svc.cluster.local
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< date: Fri, 20 Apr 2018 22:34:34 GMT
< content-length: 27
< content-type: text/plain; charset=utf-8
< x-envoy-upstream-service-time: 1
< server: envoy
<
* Connection #0 to host 192.168.99.100 left intact
default handler echoing: ""%
```

The problem is that we read the `host: "*"` as a short name and fully qualify it (to `*.default.svc.cluster.local`) when we ingest the Gateway and VirtualService. This change avoids qualifying the wildcard host. This should unblock https://github.com/istio/istio/pull/5103.