### PR TITLE
[vendor change] Add B3 codec to Jaeger tracer to enable mixer trace to be included in…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1592,6 +1592,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9d8fb5da90af4f66e82f1d0329d510f83511cdba1db3671c482d6b48f21a6400"
+  inputs-digest = "904b235d62bcdfe828b31d9ad66a81833ca508b8e45b83fe331fe601f8308fb6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -963,7 +963,8 @@
     "thrift-gen/zipkincore",
     "transport",
     "transport/zipkin",
-    "utils"
+    "utils",
+    "zipkin"
   ]
   revision = "c107110d057826281414cb964f167bce5be17588"
   version = "v2.12.0"

--- a/tests/e2e/tests/pilot/a_zipkin_test.go
+++ b/tests/e2e/tests/pilot/a_zipkin_test.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	traceHeader = "X-Client-Trace-Id"
-	numTraces   = 5
+	traceHeader         = "X-Client-Trace-Id"
+	numTraces           = 5
+	mixerCheckOperation = "mixer/check"
+	traceIDField        = "\"traceId\""
 )
 
 func TestZipkin(t *testing.T) {
@@ -64,6 +66,19 @@ func TestZipkin(t *testing.T) {
 			// Check that the trace contains the id value (must occur more than once, as the
 			// response also contains the request URL with query parameter).
 			if strings.Count(response.Body, id) == 1 {
+				return errAgain
+			}
+
+			// If first invocation (due to mixer check result caching), then check that the mixer
+			// span is also included in the trace
+			// a) Count the number of spans - should be 2, one for the invocation of service b, and the other for the
+			//			server span associated with the mixer check
+			// b) Check that the trace data contains the mixer/check (part of the operation name for the server span)
+			// NOTE: We are also indirectly verifying that the mixer/check span is a child span of the service invocation, as
+			// the mixer/check span can only exist in this trace as a child span. If it wasn't a child span then it would be
+			// in a separate trace instance not retrieved by the query based on the single x-client-trace-id.
+			if i == 0 && (strings.Count(response.Body, traceIDField) != 2 ||
+				!strings.Contains(response.Body, mixerCheckOperation)) {
 				return errAgain
 			}
 

--- a/tests/e2e/tests/pilot/a_zipkin_test.go
+++ b/tests/e2e/tests/pilot/a_zipkin_test.go
@@ -72,7 +72,7 @@ func TestZipkin(t *testing.T) {
 			// If first invocation (due to mixer check result caching), then check that the mixer
 			// span is also included in the trace
 			// a) Count the number of spans - should be 2, one for the invocation of service b, and the other for the
-			//			server span associated with the mixer check
+			//		server span associated with the mixer check
 			// b) Check that the trace data contains the mixer/check (part of the operation name for the server span)
 			// NOTE: We are also indirectly verifying that the mixer/check span is a child span of the service invocation, as
 			// the mixer/check span can only exist in this trace as a child span. If it wasn't a child span then it would be

--- a/vendor/github.com/uber/jaeger-client-go/zipkin/doc.go
+++ b/vendor/github.com/uber/jaeger-client-go/zipkin/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package zipkin comprises Zipkin functionality for Zipkin compatiblity.
+package zipkin

--- a/vendor/github.com/uber/jaeger-client-go/zipkin/propagation.go
+++ b/vendor/github.com/uber/jaeger-client-go/zipkin/propagation.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zipkin
+
+import (
+	"strconv"
+	"strings"
+
+	opentracing "github.com/opentracing/opentracing-go"
+
+	"github.com/uber/jaeger-client-go"
+)
+
+// Propagator is an Injector and Extractor
+type Propagator struct{}
+
+// NewZipkinB3HTTPHeaderPropagator creates a Propagator for extracting and injecting
+// Zipkin HTTP B3 headers into SpanContexts.
+func NewZipkinB3HTTPHeaderPropagator() Propagator {
+	return Propagator{}
+}
+
+// Inject conforms to the Injector interface for decoding Zipkin HTTP B3 headers
+func (p Propagator) Inject(
+	sc jaeger.SpanContext,
+	abstractCarrier interface{},
+) error {
+	textMapWriter, ok := abstractCarrier.(opentracing.TextMapWriter)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+
+	// TODO this needs to change to support 128bit IDs
+	textMapWriter.Set("x-b3-traceid", strconv.FormatUint(sc.TraceID().Low, 16))
+	if sc.ParentID() != 0 {
+		textMapWriter.Set("x-b3-parentspanid", strconv.FormatUint(uint64(sc.ParentID()), 16))
+	}
+	textMapWriter.Set("x-b3-spanid", strconv.FormatUint(uint64(sc.SpanID()), 16))
+	if sc.IsSampled() {
+		textMapWriter.Set("x-b3-sampled", "1")
+	} else {
+		textMapWriter.Set("x-b3-sampled", "0")
+	}
+	return nil
+}
+
+// Extract conforms to the Extractor interface for encoding Zipkin HTTP B3 headers
+func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
+	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
+	if !ok {
+		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier
+	}
+	var traceID uint64
+	var spanID uint64
+	var parentID uint64
+	sampled := false
+	err := textMapReader.ForeachKey(func(rawKey, value string) error {
+		key := strings.ToLower(rawKey) // TODO not necessary for plain TextMap
+		var err error
+		if key == "x-b3-traceid" {
+			traceID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-parentspanid" {
+			parentID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-spanid" {
+			spanID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-sampled" && value == "1" {
+			sampled = true
+		}
+		return err
+	})
+
+	if err != nil {
+		return jaeger.SpanContext{}, err
+	}
+	if traceID == 0 {
+		return jaeger.SpanContext{}, opentracing.ErrSpanContextNotFound
+	}
+	return jaeger.NewSpanContext(
+		jaeger.TraceID{Low: traceID},
+		jaeger.SpanID(spanID),
+		jaeger.SpanID(parentID),
+		sampled, nil), nil
+}


### PR DESCRIPTION
… the application trace - and extended zipkin test to check for the mixer span

Installs the B3 codec into the Jaeger tracer to enable B3 headers to be understood and therefore associate any spans with the existing application trace.

The PR also updates the zipkin e2e test to check that the mixer spans are included in the application trace instance. 

Once an initial review of the PR has been approved I'll commit the vendor change - using "dep ensure"? Locally this has resulted in a number of dependencies being deleted under `vendor/k8s.io/client-go/`.

Signed-off-by: Gary Brown <gary@brownuk.com>