### PR TITLE
Assert requried circle CI envs in ci2gubernator

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -15,6 +15,12 @@ if [ -z "$GCS_BUCKET_TOKEN" ]; then
 	exit 0
 fi
 
+if [ -z "$CIRCLE_PR_NUMBER" ] || [ -z "$CIRCLE_SHA1" ] || [ -z "$CIRCLE_PROJECT_USERNAME" ] \
+	|| [ -z "$CIRCLE_PROJECT_REPONAME" ] || [ -z "$CIRCLE_JOB" ] || [ -z "$CIRCLE_BUILD_NUM" ]; then
+	echo "Circle CI envs incomplete"
+	exit 0
+fi
+
 # The GCP service account for circle ci is only authorized to edit gs://istio-circleci bucket
 TMP_SA_JSON=$(mktemp /tmp/XXXXX.json)
 ENCRYPTED_SA_JSON="${ROOTDIR}/.circleci/accounts/istio-circle-ci.gcp.serviceaccount"

--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -15,11 +15,21 @@ if [ -z "$GCS_BUCKET_TOKEN" ]; then
 	exit 0
 fi
 
-if [ -z "$CIRCLE_PR_NUMBER" ] || [ -z "$CIRCLE_SHA1" ] || [ -z "$CIRCLE_PROJECT_USERNAME" ] \
-	|| [ -z "$CIRCLE_PROJECT_REPONAME" ] || [ -z "$CIRCLE_JOB" ] || [ -z "$CIRCLE_BUILD_NUM" ]; then
-	echo "Circle CI envs incomplete"
-	exit 0
-fi
+REQUIRED_CIRCLE_ENVS=(
+	CIRCLE_SHA1
+	CIRCLE_PROJECT_USERNAME
+	CIRCLE_PROJECT_REPONAME
+	CIRCLE_JOB
+	CIRCLE_BUILD_NUM
+	CIRCLE_PR_NUMBER
+)
+
+for env in "${REQUIRED_CIRCLE_ENVS[@]}"; do
+	if eval [ -z \$${env} ]; then
+		echo "${env} not defined"
+		exit 0
+	fi
+done
 
 # The GCP service account for circle ci is only authorized to edit gs://istio-circleci bucket
 TMP_SA_JSON=$(mktemp /tmp/XXXXX.json)


### PR DESCRIPTION
There has been cases where tests on circle failed when calling ci2gubernator because `CIRCLE_PR_NUMBER` unbound. This PR asserts the existence of the circle ci envs required by ci2gubernator and resort to no op if any of those is not defined. 