### PR TITLE
Remove depend.* targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,17 +446,17 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: make depend.update
+      - run: mkdir -p /go/out
+      - run:
+          name: Updating all dependencies
+          command: dep ensure --update
       - run: ( cd vendor ; git status  ) # just to see what changes
       - run: make init build
       - run:
           name: Status and artifacts
-          command: make depend.status ISTIO_OUT=/go/out
-      - store_artifacts:
-          path: vendor/Gopkg.lock
+          command: dep status -dot > /go/out/dep.dot
       - store_artifacts:
           path: /go/out/dep.dot
-      # TODO: auto-commit Gopkg.lock if test is successful
 
   codecov:
     <<: *defaults
@@ -559,8 +559,12 @@ jobs:
       - checkout
       - run: make sync
       - run: make lint
-      # Make sure that any modification to vendor is correct.
-      - run: make depend.diff
+      # Make sure that any modification to vendor is correct. Always use the latest version of dep.
+      - run:
+          name: Creating vendor diff
+          command: make depend.diff ISTIO_OUT=/go/out
+      - store_artifacts:
+          path: /go/out/dep.diff
 
   nightly:
     <<: *defaults

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ where-is-docker-tar:
 #-----------------------------------------------------------------------------
 # Target: depend
 #-----------------------------------------------------------------------------
-.PHONY: depend depend.diff depend.update depend.cleanlock depend.update.full init
+.PHONY: depend depend.diff init
 
 # Parse out the x.y or x.y.z version and output a single value x*10000+y*100+z (e.g., 1.9 is 10900)
 # that allows the three components to be checked in a single comparison.
@@ -230,25 +230,17 @@ ${ISTIO_ENVOY_DEBUG_PATH}: init
 ${ISTIO_ENVOY_RELEASE_PATH}: init
 
 # Pull depdendencies, based on the checked in Gopkg.lock file.
-# Developers must manually call make depend.update if adding new deps
+# Developers must manually run `dep ensure` if adding new deps
 depend: init | $(ISTIO_OUT)
 
 $(ISTIO_OUT) $(ISTIO_BIN):
 	@mkdir -p $@
 
-# Updates the dependencies and generates a git diff of the vendor files against HEAD.
-depend.diff: depend.update | $(ISTIO_OUT)
+# Used by CI to update the dependencies and generates a git diff of the vendor files against HEAD.
+depend.diff: $(ISTIO_OUT)
+	go get -u github.com/golang/dep/cmd/dep
+	dep ensure
 	git diff HEAD --exit-code -- Gopkg.lock vendor > $(ISTIO_OUT)/dep.diff
-
-depend.update.full: depend.cleanlock depend.update
-
-depend.cleanlock:
-	-rm Gopkg.lock
-
-depend.update:
-	@echo "Running dep ensure with DEPARGS=$(DEPARGS)"
-	dep version
-	time dep ensure $(DEPARGS)
 
 ${GEN_CERT}:
 	GOOS=$(GOOS_LOCAL) && GOARCH=$(GOARCH_LOCAL) && CGO_ENABLED=1 bin/gobuild.sh $@ istio.io/istio/pkg/version ./security/cmd/generate_cert


### PR DESCRIPTION
We have several depend.* targets that to various things, wrapping
dep ensure. This has caused confusion and has also led to the
breakage of the depend.update target. PR #3678 changed the behavior
of `depend.update` to remove the `--update` option when running
`dep ensure`.

This PR removes all of the depend.* targets and replaces them
with the raw commands in the CircleCI yaml.