### PR TITLE
WIP/RFC add liveness & readness probes into loadtest service echosvc1

### DIFF
--- a/tools/perf_k8svcs.yaml
+++ b/tools/perf_k8svcs.yaml
@@ -31,6 +31,21 @@ spec:
         imagePullPolicy: Always # needed despite what is documented to really get latest
         ports:
         - containerPort: 8080
+        - containerPort: 12000
+          name: health
+          protocol: UDP
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 12000
+        initialDelaySeconds: 5
+        periodSeconds: 5
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 12000
+        initialDelaySeconds: 5
+        periodSeconds: 5
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Istio customers experiencing stability issues with Istio service configured with liveness probes and multiple replicas. However, I am not able to repo the issue with demo services. I want to test if such instability happens when the service is under load.

I need to create a loadtest service exposing a healthz port and being wired to liveness and readiness probers.  Run loadtest for a prolonged time to see if the liveness probe will fail