### PR TITLE
Fix single endpoint pilot ads look up bug

### DIFF
--- a/istioctl/cmd/istioctl/config.go
+++ b/istioctl/cmd/istioctl/config.go
@@ -91,7 +91,7 @@ istioctl proxy-config endpoint -n application productpage-v1-bb8d5cbc7-k7qbm sta
 				if podName == "mesh" {
 					proxyID = "all"
 				} else {
-					proxyID = fmt.Sprintf("%v:%v", podName, ns)
+					proxyID = fmt.Sprintf("%v.%v", podName, ns)
 				}
 				pilots, err := getPilotPods()
 				if err != nil {

--- a/pilot/cmd/pilot-discovery/debug.go
+++ b/pilot/cmd/pilot-discovery/debug.go
@@ -44,7 +44,7 @@ var (
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(c *cobra.Command, args []string) error {
 			d := &debug{
-				pilotAddress: "127.0.0.1:15007",
+				pilotAddress: "127.0.0.1:9093",
 				client:       &http.Client{},
 			}
 			return d.run(args)


### PR DESCRIPTION
As reported by @rshriram. Its probably not blocking but should be added to the 0.8 release.

I was doing dumb things, have verified it works manually. As an aside we should probably move some of this logic into pkg and improve the testing.