### PR TITLE
Remove `set -u` in ci2gubernator.sh

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -2,8 +2,6 @@
 
 # Exit immediately for non zero status
 set -e
-# Check unset variables
-set -u
 # Print commands
 # set -x
 


### PR DESCRIPTION
`set -u` checks any reference to unbounded variables and exits immediately with nonzero status. What we want is to log that the referenced variable is not defined and exit with zero as a no op.