### PR TITLE
Address a few causes of Gateway/Filterchain failures

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
+	"github.com/hashicorp/go-multierror"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -69,6 +70,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 	merged := model.MergeGateways(gateways...)
 	log.Debugf("buildGatewayListeners: gateways after merging: %v", merged)
 
+	errs := &multierror.Error{}
 	listeners := make([]*xdsapi.Listener, 0, len(merged.Servers))
 	for portNumber, servers := range merged.Servers {
 		// TODO: this works because all Servers on the same port use the same protocol due to model.MergeGateways's implementation.
@@ -117,7 +119,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 
 		// Filters are serialized one time into an opaque struct once we have the complete list.
 		if err := marshalFilters(mutable.Listener, opts, mutable.FilterChains); err != nil {
-			log.Warn(err.Error())
+			errs = multierror.Append(errs, fmt.Errorf("omitting listener %q due to: %v", mutable.Listener.Name, err.Error()))
+			continue
 		}
 		if log.DebugEnabled() {
 			// pprint does JSON marshalling, so we skip it if debugging is not enabled
@@ -125,6 +128,14 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 				len(mutable.Listener.FilterChains), mutable.Listener)
 		}
 		listeners = append(listeners, mutable.Listener)
+	}
+	// We'll try to return any listeners we successfully marshaled; if we have none, we'll emit the error we built up
+	err = errs.ErrorOrNil()
+	if len(listeners) == 0 {
+		return listeners, err
+	} else if err != nil {
+		// we have some listeners to return, but we also have some errors; log them
+		log.Info(err.Error())
 	}
 	return listeners, nil
 }

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -112,7 +112,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 				Node:           &node,
 				ProxyInstances: workloadInstances,
 			}
-			if err := p.OnOutboundListener(params, mutable); err != nil {
+			if err = p.OnOutboundListener(params, mutable); err != nil {
 				log.Warn(err.Error())
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -24,7 +24,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
@@ -132,8 +132,10 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 	// We'll try to return any listeners we successfully marshaled; if we have none, we'll emit the error we built up
 	err = errs.ErrorOrNil()
 	if len(listeners) == 0 {
-		return listeners, err
-	} else if err != nil {
+		return []*xdsapi.Listener{}, err
+	}
+
+	if err != nil {
 		// we have some listeners to return, but we also have some errors; log them
 		log.Info(err.Error())
 	}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -118,7 +118,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env model.Environmen
 		}
 
 		// Filters are serialized one time into an opaque struct once we have the complete list.
-		if err := marshalFilters(mutable.Listener, opts, mutable.FilterChains); err != nil {
+		if err = marshalFilters(mutable.Listener, opts, mutable.FilterChains); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("omitting listener %q due to: %v", mutable.Listener.Name, err.Error()))
 			continue
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/log"
 )
 
@@ -241,7 +242,7 @@ func buildGatewayInboundHTTPRouteConfig(
 		log.Debugf("constructed http route config for port %d with no vhosts; omitting", port)
 		return nil
 	}
-
+	util.SortVirtualHosts(virtualHosts)
 	return &xdsapi.RouteConfiguration{
 		Name:             fmt.Sprintf("%d", port),
 		VirtualHosts:     virtualHosts,

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -139,6 +139,7 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 		virtualHosts = vHostPortMap[port]
 	}
 
+	util.SortVirtualHosts(virtualHosts)
 	out := &xdsapi.RouteConfiguration{
 		Name:             fmt.Sprintf("%d", port),
 		VirtualHosts:     virtualHosts,

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -16,12 +16,14 @@ package util
 
 import (
 	"bytes"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -185,4 +187,14 @@ func GogoDurationToDuration(d *types.Duration) time.Duration {
 		return 0
 	}
 	return dur
+}
+
+// SortVirtualHosts sorts a slice of virtual hosts by name.
+//
+// Envoy computes a hash of the listener which is affected by order of elements in the filter. Therefore
+// we sort virtual hosts by name before handing them back so the ordering is stable across HTTP Route Configs.
+func SortVirtualHosts(hosts []route.VirtualHost) {
+	sort.SliceStable(hosts, func(i, j int) bool {
+		return hosts[i].Name < hosts[j].Name
+	})
 }


### PR DESCRIPTION
- Sort virtual hosts in our HTTP config before sending listeners to Envoy. This is because the hash of the filters in the listener's chains that Envoy constructs depends on the order of members in each filter, and if the hosts aren't identically ordered in each filter Envoy rejects the listener update.
- Rather than sending Listeners with no filters in them (which Envoy rejects) we instead skip sending them from Pilot