### PR TITLE
re-add istioctl unit tests to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 test: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
-	$(MAKE) --keep-going common-test pilot-test mixer-test security-test broker-test galley-test \
+	$(MAKE) --keep-going common-test pilot-test mixer-test security-test broker-test galley-test istioctl-test \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 
 GOTEST_PARALLEL ?= '-test.parallel=4'
@@ -432,6 +432,10 @@ localTestEnvCleanup: test-bins
 .PHONY: pilot-test
 pilot-test: pilot-agent
 	go test -p 1 ${T} ./pilot/...
+
+.PHONY: istioctl-test
+istioctl-test: istioctl
+	go test -p 1 ${T} ./istioctl/...
 
 .PHONY: mixer-test
 MIXER_TEST_T ?= ${T} ${GOTEST_PARALLEL}
@@ -463,11 +467,15 @@ common-test:
 .PHONY: coverage
 
 # Run coverage tests
-coverage: pilot-coverage mixer-coverage security-coverage broker-coverage galley-coverage common-coverage
+coverage: pilot-coverage mixer-coverage security-coverage broker-coverage galley-coverage common-coverage istioctl-coverage
 
 .PHONY: pilot-coverage
 pilot-coverage:
 	bin/codecov.sh pilot
+
+.PHONY: istioctl-coverage
+istioctl-coverage:
+	bin/codecov.sh istioctl
 
 .PHONY: mixer-coverage
 mixer-coverage:
@@ -497,11 +505,15 @@ common-coverage:
 .PHONY: racetest
 
 # Run race tests
-racetest: pilot-racetest mixer-racetest security-racetest broker-racetest galley-test common-racetest
+racetest: pilot-racetest mixer-racetest security-racetest broker-racetest galley-test common-racetest istioctl-racetest
 
 .PHONY: pilot-racetest
 pilot-racetest: pilot-agent
 	RACE_TEST=true go test -p 1 ${T} -race ./pilot/...
+
+.PHONY: istioctl-racetest
+istioctl-racetest: istioctl
+	RACE_TEST=true go test -p 1 ${T} -race ./istioctl/...
 
 .PHONY: mixer-racetest
 mixer-racetest: mixs

--- a/istioctl/cmd/istioctl/convert/cmd_test.go
+++ b/istioctl/cmd/istioctl/convert/cmd_test.go
@@ -88,8 +88,8 @@ func TestCommand(t *testing.T) {
 		{in: []string{"destination-policy-helloworld.yaml", "route-rule-80-20.yaml"},
 			out: "destination-rule-helloworld-with-80-20.yaml"},
 
-		// {in: []string{"nolabel-destination-policy.yaml"},
-		// 	out: "nolabel-destination-rule.yaml"},
+		{in: []string{"nolabel-destination-policy.yaml"},
+			out: "nolabel-destination-rule.yaml"},
 	}
 
 	for _, tc := range tt {

--- a/istioctl/cmd/istioctl/convert/cmd_test.go
+++ b/istioctl/cmd/istioctl/convert/cmd_test.go
@@ -88,8 +88,8 @@ func TestCommand(t *testing.T) {
 		{in: []string{"destination-policy-helloworld.yaml", "route-rule-80-20.yaml"},
 			out: "destination-rule-helloworld-with-80-20.yaml"},
 
-		{in: []string{"nolabel-destination-policy.yaml"},
-			out: "nolabel-destination-rule.yaml"},
+		// {in: []string{"nolabel-destination-policy.yaml"},
+		// 	out: "nolabel-destination-rule.yaml"},
 	}
 
 	for _, tc := range tt {

--- a/istioctl/cmd/istioctl/convert/testdata/v1alpha1/nolabel-destination-policy.yaml
+++ b/istioctl/cmd/istioctl/convert/testdata/v1alpha1/nolabel-destination-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: config.istio.io/v1beta1
+kind: DestinationPolicy
+metadata:
+  name: helloworld-circuit-breaker
+spec:
+  destination:
+    name: alpha-service
+  circuitBreaker:
+    simpleCb:
+      maxConnections: 64
+      httpMaxPendingRequests: 16
+      sleepWindow: 1m
+      httpDetectionInterval: 10s
+      httpMaxEjectionPercent: 100
+      httpConsecutiveErrors: 2
+      httpMaxRequestsPerConnection: 2

--- a/istioctl/cmd/istioctl/convert/testdata/v1alpha3/nolabel-destination-rule.yaml.golden
+++ b/istioctl/cmd/istioctl/convert/testdata/v1alpha3/nolabel-destination-rule.yaml.golden
@@ -1,0 +1,23 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  creationTimestamp: null
+  name: alpha-service
+  namespace: default
+spec:
+  host: alpha-service
+  subsets:
+  - name: default
+    trafficPolicy:
+      connectionPool:
+        http:
+          http1MaxPendingRequests: 16
+          maxRequestsPerConnection: 2
+        tcp:
+          maxConnections: 64
+      outlierDetection:
+        http:
+          baseEjectionTime: 60.000s
+          consecutiveErrors: 2
+          interval: 10.000s
+          maxEjectionPercent: 100

--- a/istioctl/cmd/istioctl/gendeployment/helm_test.go
+++ b/istioctl/cmd/istioctl/gendeployment/helm_test.go
@@ -15,37 +15,23 @@
 package gendeployment
 
 import (
-	"io/ioutil"
-	"path"
 	"testing"
+
+	"istio.io/istio/pilot/test/util"
 )
 
 func TestValuesFromInstallation(t *testing.T) {
-	tests := []struct {
+	cases := []struct {
 		name   string
 		in     *installation
 		golden string
 	}{
-		{"default", defaultInstall(), "default-values"},
+		{"default", defaultInstall(), "testdata/default-values.yaml.golden"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			contents := valuesFromInstallation(tt.in)
-			want := readGolden(t, tt.golden)
-			if contents != want {
-				t.Fatalf("valuesFromInstallation(%v)\n got %q\nwant %q", tt.in, contents, want)
-			}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			contents := valuesFromInstallation(c.in)
+			util.CompareContent([]byte(contents), c.golden, t)
 		})
 	}
-}
-
-func readGolden(t *testing.T, name string) string {
-	t.Helper()
-
-	p := path.Join("testdata", name+".yaml.golden")
-	data, err := ioutil.ReadFile(p)
-	if err != nil {
-		t.Fatalf("failed to read %q", p)
-	}
-	return string(data)
 }

--- a/istioctl/cmd/istioctl/gendeployment/testdata/default-values.yaml.golden
+++ b/istioctl/cmd/istioctl/gendeployment/testdata/default-values.yaml.golden
@@ -4,20 +4,20 @@ global:
     enabled: false
   proxy:
     hub: gcr.io/istio-testing
-    tag: 0.4.0
+    tag: 0.7.1
     debug: false
   pilot:
     enabled: true
     hub: gcr.io/istio-testing
-    tag: 0.4.0
+    tag: 0.7.1
   security:
     enabled: true
     hub: gcr.io/istio-testing
-    tag: 0.4.0
+    tag: 0.7.1
   mixer:
     enabled: true
     hub: gcr.io/istio-testing
-    tag: 0.4.0
+    tag: 0.7.1
   ingress:
     use_nodeport: false
     nodeport_port: 0


### PR DESCRIPTION
https://github.com/istio/istio/pull/3820 moved istioctl out of pilot
subdirectory but forgot to re-add istioctl unit tests to top-level
Makefile. Fix that problem and also the currently broken tests.

fixes https://github.com/istio/istio/issues/5202