### PR TITLE
Fix nil reference error when mock server fails to start

### DIFF
--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -110,6 +110,10 @@ func (ms *MockOpenIDDiscoveryServer) Start() error {
 func (ms *MockOpenIDDiscoveryServer) Stop() error {
 	atomic.StoreUint64(&ms.OpenIDHitNum, 0)
 	atomic.StoreUint64(&ms.PubKeyHitNum, 0)
+	if ms.server == nil {
+		return nil
+	}
+
 	return ms.server.Close()
 }
 


### PR DESCRIPTION
Fix nil reference error when mock server fails to start

=== RUN   TestResolveJwksURIUsingOpenID
2018-04-26T01:07:53.786687Z	info	Server not yet serving: Get http://localhost:46568/.well-known/openid-configuration: dial tcp 127.0.0.1:46568: connect: connection refused
2018-04-26T01:07:54.387742Z	info	Server not yet serving: Get http://localhost:46568/.well-known/openid-configuration: dial tcp 127.0.0.1:46568: connect: connection refused
2018-04-26T01:07:55.588891Z	info	Server not yet serving: Get http://localhost:46568/.well-known/openid-configuration: dial tcp 127.0.0.1:46568: connect: connection refused
--- FAIL: TestResolveJwksURIUsingOpenID (2.10s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x732992]