### PR TITLE
fix bookinfo v1alpha3 version migration test

### DIFF
--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -203,6 +204,8 @@ func testVersionMigrationRule(t *testing.T, configVersion string, rule migration
 				c1++
 			} else if err = util.CompareToFile(body, rule.modelToMigrate); err == nil {
 				cVersionToMigrate++
+			} else {
+				log.Errorf("received unexpected version: %s", strings.TrimSpace(string(body)))
 			}
 			closeResponseBody(resp)
 		}

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -200,12 +199,16 @@ func testVersionMigrationRule(t *testing.T, configVersion string, rule migration
 				log.Errora(err)
 				continue
 			}
-			if err = util.CompareToFile(body, modelV1); err == nil {
+
+			var c1CompareError, cVersionToMigrateError error
+			if c1CompareError = util.CompareToFile(body, modelV1); c1CompareError == nil {
 				c1++
-			} else if err = util.CompareToFile(body, rule.modelToMigrate); err == nil {
+			} else if cVersionToMigrateError = util.CompareToFile(body, rule.modelToMigrate); cVersionToMigrateError == nil {
 				cVersionToMigrate++
 			} else {
-				log.Errorf("received unexpected version: %s", strings.TrimSpace(string(body)))
+				log.Error("received unexpected version: %s")
+				log.Infof("comparing to the original version: %v", c1CompareError)
+				log.Infof("comparing to the version to migrate to: %v", cVersionToMigrateError)
 			}
 			closeResponseBody(resp)
 		}

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -75,6 +75,7 @@ func testVersionRoutingRule(t *testing.T, configVersion string, rule versionRout
 	defer func() {
 		inspect(deleteRules(configVersion, []string{rule.key}),
 			fmt.Sprintf("failed to delete rules"), "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 
 	for _, userVersion := range rule.userVersions {
@@ -98,6 +99,7 @@ func doTestFaultDelay(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 	minDuration := 5
 	maxDuration := 8
@@ -169,6 +171,7 @@ func testVersionMigrationRule(t *testing.T, configVersion string, rule migration
 	defer func() {
 		inspect(deleteRules(configVersion, []string{rule.key}),
 			fmt.Sprintf("failed to delete rules"), "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 	modelV1 := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
 	tolerance := 0.05
@@ -246,6 +249,7 @@ func doTestDbRoutingMongo(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 
 	// TODO: update the rating in the db and check the value on page
@@ -271,6 +275,7 @@ func doTestDbRoutingMysql(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 
 	// TODO: update the rating in the db and check the value on page
@@ -320,6 +325,7 @@ func doTestExternalDetailsService(t *testing.T, configVersion string, rules []st
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
+		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
 	}()
 
 	isbnFetchedFromExternalService := "0486424618"

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -75,7 +75,7 @@ func testVersionRoutingRule(t *testing.T, configVersion string, rule versionRout
 	defer func() {
 		inspect(deleteRules(configVersion, []string{rule.key}),
 			fmt.Sprintf("failed to delete rules"), "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 
 	for _, userVersion := range rule.userVersions {
@@ -99,7 +99,7 @@ func doTestFaultDelay(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 	minDuration := 5
 	maxDuration := 8
@@ -171,7 +171,7 @@ func testVersionMigrationRule(t *testing.T, configVersion string, rule migration
 	defer func() {
 		inspect(deleteRules(configVersion, []string{rule.key}),
 			fmt.Sprintf("failed to delete rules"), "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 	modelV1 := util.GetResourcePath(filepath.Join(modelDir, "productpage-normal-user-v1.html"))
 	tolerance := 0.05
@@ -249,7 +249,7 @@ func doTestDbRoutingMongo(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 
 	// TODO: update the rating in the db and check the value on page
@@ -275,7 +275,7 @@ func doTestDbRoutingMysql(t *testing.T, configVersion string, rules []string) {
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 
 	// TODO: update the rating in the db and check the value on page
@@ -325,7 +325,7 @@ func doTestExternalDetailsService(t *testing.T, configVersion string, rules []st
 	inspect(applyRules(configVersion, rules), "failed to apply rules", "", t)
 	defer func() {
 		inspect(deleteRules(configVersion, rules), "failed to delete rules", "", t)
-		inspect(applyRules(configVersion, []string{allRule}), "failed to apply rules", "", t)
+		inspect(applyRules(configVersion, defaultRules), "failed to apply rules", "", t)
 	}()
 
 	isbnFetchedFromExternalService := "0486424618"


### PR DESCRIPTION
apply default rules after every bookinfo test
in v1alpha3 there is no rule precendence, a new rule just deletes the old one
there is no possibility to have two rules on the same host