### PR TITLE
bootstrapv2: Stop using deprecated cluster_names

### DIFF
--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -36,8 +36,12 @@
     "ads_config": {
       "api_type": "GRPC",
       "refresh_delay": {{ .refresh_delay }},
-      "cluster_names": [
-        "xds-grpc"
+      "grpc_services": [
+        {
+          "envoy_grpc": {
+            "cluster_name": "xds-grpc"
+          }
+        }
       ]
     }
   },


### PR DESCRIPTION
Using cluster_names in GRPC resource config is deprecated:
https://github.com/envoyproxy/envoy/commit/ad02e4ac036be359c435d33c987501477c648020

Signed-off-by: Romain Lenglet <romain@covalent.io>