### PR TITLE
Dogstatsd should have a default namespace

### DIFF
--- a/mixer/adapter/dogstatsd/config/adapter.dogstatsd.config.pb.html
+++ b/mixer/adapter/dogstatsd/config/adapter.dogstatsd.config.pb.html
@@ -37,8 +37,8 @@ Default: localhost:8125</p>
 <td><code>prefix</code></td>
 <td><code>string</code></td>
 <td>
-<p>Prefix to prepend to all metrics handled by the adapter. Metric &ldquo;bar&rdquo; with prefix &ldquo;foo.&rdquo; becomes &ldquo;foo.bar&rdquo; in DataDog.
-Default: &ldquo;&rdquo;</p>
+<p>Prefix to prepend to all metrics handled by the adapter. Metric &ldquo;bar&rdquo; with prefix &ldquo;foo.&rdquo; becomes &ldquo;foo.bar&rdquo; in DataDog. In order to make sure the metrics get populated into Datadog properly and avoid any billing issues, it&rsquo;s important to leave the metric prefix to its default value of &lsquo;istio.&rsquo;
+Default: &ldquo;istio.&rdquo;</p>
 
 </td>
 </tr>

--- a/mixer/adapter/dogstatsd/config/config.pb.go
+++ b/mixer/adapter/dogstatsd/config/config.pb.go
@@ -80,8 +80,8 @@ type Params struct {
 	// Address of the dogstatsd server.
 	// Default: localhost:8125
 	Address string `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	// Prefix to prepend to all metrics handled by the adapter. Metric "bar" with prefix "foo." becomes "foo.bar" in DataDog.
-	// Default: ""
+	// Prefix to prepend to all metrics handled by the adapter. Metric "bar" with prefix "foo." becomes "foo.bar" in DataDog. In order to make sure the metrics get populated into Datadog properly and avoid any billing issues, it's important to leave the metric prefix to its default value of 'istio.'
+	// Default: "istio."
 	Prefix string `protobuf:"bytes,2,opt,name=prefix,proto3" json:"prefix,omitempty"`
 	// Number of individual metrics to buffer before flushing metrics to the network. When buffered, metrics are flushed every 100ms or when the buffer is filled.
 	// When buffer is 0, metrics are not buffered.

--- a/mixer/adapter/dogstatsd/config/config.proto
+++ b/mixer/adapter/dogstatsd/config/config.proto
@@ -35,8 +35,8 @@ message Params {
     // Default: localhost:8125
     string address = 1;
 
-    // Prefix to prepend to all metrics handled by the adapter. Metric "bar" with prefix "foo." becomes "foo.bar" in DataDog.
-    // Default: ""
+    // Prefix to prepend to all metrics handled by the adapter. Metric "bar" with prefix "foo." becomes "foo.bar" in DataDog. In order to make sure the metrics get populated into Datadog properly and avoid any billing issues, it's important to leave the metric prefix to its default value of 'istio.'
+    // Default: "istio."
     string prefix = 2;
 
     // Number of individual metrics to buffer before flushing metrics to the network. When buffered, metrics are flushed every 100ms or when the buffer is filled.

--- a/mixer/adapter/dogstatsd/dogstatsd.go
+++ b/mixer/adapter/dogstatsd/dogstatsd.go
@@ -58,7 +58,12 @@ func (b *builder) Build(_ context.Context, env adapter.Env) (adapter.Handler, er
 	if err != nil {
 		return nil, env.Logger().Errorf("Unable to create dogstatsd client: %v", err)
 	}
-	client.Namespace = ac.Prefix
+
+	if !strings.HasSuffix(ac.Prefix, ".") {
+		client.Namespace = ac.Prefix + "."
+	} else {
+		client.Namespace = ac.Prefix
+	}
 	client.Tags = flattenTags(ac.GlobalTags)
 
 	// Create an empty map if tags aren't provided
@@ -204,7 +209,7 @@ func GetInfo() adapter.Info {
 		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
 		DefaultConfig: &config.Params{
 			Address:      "localhost:8125",
-			Prefix:       "",
+			Prefix:       "istio.",
 			BufferLength: 0,
 			GlobalTags:   map[string]string{},
 		},

--- a/mixer/adapter/dogstatsd/operatorconfig/config.yaml
+++ b/mixer/adapter/dogstatsd/operatorconfig/config.yaml
@@ -5,23 +5,31 @@ metadata:
   namespace: istio-system
 spec:
   address: "localhost:8125"
-  prefix: "service."
-  global_tags: 
+  prefix: "istio."
+  global_tags:
     service_mesh: istio
   sample_rate: 1.0
   metrics:
     requestcount.metric.istio-system:
       name: requestcount
       type: COUNTER
+      tags:
+        my: "istio_metric"
     requestduration.metric.istio-system:
       name: requestduration
       type: DISTRIBUTION
+      tags:
+        my: "istio_metric"
     requestsize.metric.istio-system:
       name: requestsize
       type: DISTRIBUTION
+      tags:
+        my: "istio_metric"
     responsesize.metric.istio-system:
       name: responsesize
       type: DISTRIBUTION
+      tags:
+        my: "istio_metric"
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule


### PR DESCRIPTION
The metric name is very important in Datadog. In order to ensure that metrics from integrations are properly ingested and to avoid any billing issues, metrics need to have the right prefixes.

So, this PR changes the default prefix for Istio to `istio.` and changes the docs to warn people about the implications of using another prefix.