### PR TITLE
Set listeners h2 max streams to override nghttp2 client default of 100

### DIFF
--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -136,7 +136,7 @@ static_resources:
             name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
-            max_concurrent_streams: 2147483646
+            max_concurrent_streams: 1073741824
           http_filters:
           - config:
               default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local

--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -135,6 +135,8 @@ static_resources:
               path: /dev/stdout
             name: envoy.file_access_log
           codec_type: HTTP2
+          http2_protocol_options:
+            max_concurrent_streams: 2147483646
           http_filters:
           - config:
               default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -68,7 +68,7 @@ static_resources:
             name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
-            max_concurrent_streams: 2147483646
+            max_concurrent_streams: 1073741824
           generate_request_id: true
           http_filters:
           - config:

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -67,6 +67,8 @@ static_resources:
               path: /dev/stdout
             name: envoy.file_access_log
           codec_type: HTTP2
+          http2_protocol_options:
+            max_concurrent_streams: 2147483646
           generate_request_id: true
           http_filters:
           - config:

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -39,6 +39,8 @@ static_resources:
               path: /dev/stdout
             name: envoy.file_access_log
           codec_type: HTTP2
+          http2_protocol_options:
+            max_concurrent_streams: 2147483646
           generate_request_id: true
           http_filters:
           - config:

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -40,7 +40,7 @@ static_resources:
             name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
-            max_concurrent_streams: 2147483646
+            max_concurrent_streams: 1073741824
           generate_request_id: true
           http_filters:
           - config:


### PR DESCRIPTION
Reference issue: https://github.com/envoyproxy/envoy/issues/3076
Signed-off-by: Kuat Yessenov <kuat@google.com>