### PR TITLE
Fixing fallout of renames in earlier commit + restore auth for e2e-simple on circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             make docker.all generate_yaml
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
-      - run: make test/minikube/noauth/e2e_simple | tee -a /go/out/tests/build-log.txt
+      - run: make test/minikube/auth/e2e_simple | tee -a /go/out/tests/build-log.txt
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - <<: *dumpsysNonPilot

--- a/tests/e2e/tests/simple/a_simple_1_test.go
+++ b/tests/e2e/tests/simple/a_simple_1_test.go
@@ -205,7 +205,7 @@ func TestAuthWithHeaders(t *testing.T) {
 	// Get the istio pod without extra unique port. We can't use the service name or cluster ip as
 	// that vip only exists for declared host:port and the exploit relies on not having a listener
 	// for that port.
-	podList, err = getPodIPList(ns, "app=echosrv,extrap=no")
+	podList, err = getPodIPList(ns, "app=echosrv,extrap=non")
 	if err != nil {
 		t.Fatalf("kubectl failure to get deployment1 pod %v", err)
 	}
@@ -215,7 +215,8 @@ func TestAuthWithHeaders(t *testing.T) {
 	podIstioIP := podList[0]
 	log.Infof("From client, non istio injected pod \"%s\" to istio pod \"%s\"", podNoIstio, podIstioIP)
 	// TODO: ipv6 fix
-	res, err := util.Shell("kubectl exec -n %s %s -- /usr/local/bin/fortio curl -H Host:echosrv2.%s:8088 http://%s:8088/debug", ns, podNoIstio, ns, podIstioIP)
+	res, err := util.Shell("kubectl exec -n %s %s -- /usr/local/bin/fortio curl -H Host:echosrv-extrap.%s:8088 http://%s:8088/debug",
+		ns, podNoIstio, ns, podIstioIP)
 	if tc.Kube.AuthEnabled {
 		if err == nil {
 			t.Errorf("Running with auth on yet able to connect from non istio to istio (insecure): %v", res)


### PR DESCRIPTION
makes sure the test for auth does exercise the issue correctly

you can see the expected pre-fix failure in
#5228
https://circleci.com/gh/istio/istio/82652

```
--- FAIL: TestAuthWithHeaders (0.70s)
	a_simple_1_test.go:228: Running with auth off but yet able to connect from non istio to istio pod ip with wrong port: HTTP/1.1 200 OK
		Φορτίο version 0.9.0 2018-04-06 06:57 e50943e8e525197f36f9b4f81464615c063a0a65 go1.10.1 echo debug server up for 26.3s on echosrv-deployment-2-7494c6b8f4-92hgn - request from 127.0.0.1:55364
		
		GET /debug HTTP/1.1
		
		headers:
		
		Host: echosrv-extrap.istio-system:8088
		Content-Length: 0
		User-Agent: istio/fortio-0.9.0
		X-B3-Sampled: 1
		X-B3-Spanid: 0164c3fa95602eaf
		X-B3-Traceid: 0164c3fa95602eaf
		X-Forwarded-Proto: http
		X-Request-Id: 77274637-10c7-9046-9ddf-30287b005567
```