### PR TITLE
parameterize mtlsexcludedservices

### DIFF
--- a/install/ansible/istio/tasks/install_on_cluster.yml
+++ b/install/ansible/istio/tasks/install_on_cluster.yml
@@ -3,6 +3,15 @@
   when: not istio.auth
   ignore_errors: true
 
+- name: Replace mtlsExcludedServices in k8s manifests
+  lineinfile:
+    path: "{{ istio_dir }}/install/kubernetes/istio-auth.yaml"
+    regexp: '^(\s*mtlsExcludedServices:).*$'
+    line: "\\1 {{ istio.mtlsexcludedservices | to_json }}"
+    backrefs: yes
+    backup: yes
+  when: istio.auth and istio.mtlsexcludedservices is defined
+
 - name: Deploy Istio Auth from kubernetes file
   shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-auth.yaml"
   when: istio.auth


### PR DESCRIPTION
faclilitates the provisioning of a list of services to be contacted by
istio without mtls. List has to be passed as a list to the
ansible-playbook,i.e.
ansible-playbook main.yml -e '{"cluster_flavour": "k8s"}' \
-e '{"istio": {"auth":true, "mtlsexcludedservices": \
["kubernetes.default.svc.dev.cluster","test.default.svc.dev.cluster"]}}'