### PR TITLE
relabel mixer pods from istio:mixer to istio:telemetry, istio:policy

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
   template:
     metadata:
       labels:
-        istio: mixer
+        istio: {{ $mname }}
         istio-mixer-type: {{ $mname }}
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
     port: 42422
 {{- end }}
   selector:
-    istio: mixer
+    istio: {{ $mname }}
     istio-mixer-type: {{ $mname }}
 ---
 {{- end }}


### PR DESCRIPTION
Policy to telemetry traffic shows up as `istio-mixer` since `istio: mixer` label was maintained even after the telemetry and policy split.
It is no longer needed. 

Mixer pods can still be queried as
`kubectl get pods -listio-mixer-type`