### PR TITLE
return an error when Envoy fails to start

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -71,13 +71,16 @@ func (s *TestSetup) NewEnvoy(stress, faultInject bool, mfConf *MixerFilterConf, 
 // Start starts the envoy process
 func (s *Envoy) Start() error {
 	err := s.cmd.Start()
-	if err == nil {
-		url := fmt.Sprintf("http://localhost:%v/server_info", s.ports.AdminPort)
-		WaitForHTTPServer(url)
-		WaitForPort(s.ports.ClientProxyPort)
-		WaitForPort(s.ports.ServerProxyPort)
+	if err != nil {
+		return err
 	}
-	return err
+
+	url := fmt.Sprintf("http://localhost:%v/server_info", s.ports.AdminPort)
+	WaitForHTTPServer(url)
+	WaitForPort(s.ports.ClientProxyPort)
+	WaitForPort(s.ports.ServerProxyPort)
+
+	return nil
 }
 
 // Stop stops the envoy process

--- a/mixer/test/client/env/http_server.go
+++ b/mixer/test/client/env/http_server.go
@@ -128,6 +128,7 @@ func NewHTTPServer(port uint16) (*HTTPServer, error) {
 }
 
 // Start starts the server
+// TODO: Add a channel so this can return an error
 func (s *HTTPServer) Start() {
 	go func() {
 		http.HandleFunc("/", handler)

--- a/mixer/test/client/env/mixer_server.go
+++ b/mixer/test/client/env/mixer_server.go
@@ -154,6 +154,7 @@ func NewMixerServer(port uint16, stress bool) (*MixerServer, error) {
 }
 
 // Start starts the mixer server
+// TODO: Add a channel so this can return an error
 func (ts *MixerServer) Start() {
 	go func() {
 		err := ts.gs.Serve(ts.lis)

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -154,8 +154,11 @@ func (s *TestSetup) SetUp() error {
 	s.envoy, err = s.NewEnvoy(s.stress, s.faultInject, s.mfConf, s.ports, s.epoch, s.mfConfVersion)
 	if err != nil {
 		log.Printf("unable to create Envoy %v", err)
-	} else {
-		_ = s.envoy.Start()
+	}
+
+	err = s.envoy.Start()
+	if err != nil {
+		return err
 	}
 
 	if !s.noMixer {

--- a/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
+++ b/tests/e2e/tests/pilot/cloudfoundry/copilot_test.go
@@ -154,7 +154,9 @@ func TestWildcardHostEdgeRouterWithMockCopilot(t *testing.T) {
 	}
 
 	t.Log("run envoy...")
-	testEnv.SetUp()
+	if err := testEnv.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
 	defer testEnv.TearDown()
 
 	t.Log("curling the app with expected host header")


### PR DESCRIPTION
test setup errors can be obscured otherwise.

mixer and backend should also do this, but that involves slightly more
work. added TODOs for those. 