### PR TITLE
Add option to override LOCAL_OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GOARCH_LOCAL := $(LOCAL_ARCH)
 endif
 export GOARCH ?= $(GOARCH_LOCAL)
 
-LOCAL_OS := $(shell uname)
+LOCAL_OS ?= $(shell uname)
 ifeq ($(LOCAL_OS),Linux)
    export GOOS_LOCAL = linux
 else ifeq ($(LOCAL_OS),Darwin)

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -44,8 +44,11 @@ export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 # Set the architecture. Matches logic in the Makefile.
 export GOARCH=${GOARCH:-'amd64'}
 
-# Determine the OS. Matches logic in the Makefile.
-LOCAL_OS="`uname`"
+if [ "${LOCAL_OS}x" = "x" ]; then
+  # Determine the OS. Matches logic in the Makefile.
+  LOCAL_OS="`uname`"
+fi
+
 case $LOCAL_OS in
   'Linux')
     LOCAL_OS='linux'
@@ -135,7 +138,7 @@ if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; 
     # Download release envoy binary.
     mkdir -p $ISTIO_ENVOY_RELEASE_DIR
     pushd $ISTIO_ENVOY_RELEASE_DIR
-    if [ "$LOCAL_OS" == "darwin" ]; then 
+    if [ "$LOCAL_OS" == "darwin" ]; then
        ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_MAC_RELEASE_URL}
     fi
     echo "Downloading envoy release artifact: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_RELEASE_URL}"


### PR DESCRIPTION
The `Makefile` honors the `GOOS` env var when you set it to "linux", but it doesn't use this value when using cURL to download the envoy binary from google storage. So if you compile Istio with `GOOS=linux`, it still downloads a Mach-O Mac OS compiled version of Envoy, so when the Istio ingress boots (and sidecars), it fails with an `exec: format error`.

By using an exported LOCAL_OS (which I know is confusing but this solved the problem), you can run:

```
$ GOOS=linux LOCAL_OS=Linux make build depends
```

This builds Istio w/ Linux as the OS and downloads the Linux version of Envoy.

Basically, my work flow is that I build the docker images against a minikube environment by doing:

```
$ eval (minikube docker-env)
```

So when I run:

```
$ make docker.all
```

The images just end up in my Minikube, I can bounce istio pods, and see changes. But I was hitting a snag with Envoy being the wrong file format.