### PR TITLE
Make Kube Pod cache log line more helpful

### DIFF
--- a/pilot/pkg/serviceregistry/kube/cache.go
+++ b/pilot/pkg/serviceregistry/kube/cache.go
@@ -47,7 +47,7 @@ func newPodCache(ch cacheHandler) *PodCache {
 		pod := *obj.(*v1.Pod)
 		ip := pod.Status.PodIP
 
-		log.Printf("Handle pod %s in namespace %s -> %v", pod.Name, pod.Namespace, pod.Status.PodIP)
+		log.Printf("Handling event %s for pod %s in namespace %s -> %v", ev, pod.Name, pod.Namespace, ip)
 
 		if len(ip) > 0 {
 			key := KeyFunc(pod.Name, pod.Namespace)


### PR DESCRIPTION
This log line could be more helpful by including the event name.