### PR TITLE
Add mixer tests for the Istio authn filter

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -32,11 +32,11 @@ type Envoy struct {
 }
 
 // NewEnvoy creates a new Envoy struct and starts envoy.
-func (s *TestSetup) NewEnvoy(stress, faultInject bool, mfConf *MixerFilterConf, ports *Ports, epoch int,
+func (s *TestSetup) NewEnvoy(stress bool, filtersBeforeMixer string, mfConf *MixerFilterConf, ports *Ports, epoch int,
 	confVersion string) (*Envoy, error) {
 	confPath := filepath.Join(util.IstioOut, fmt.Sprintf("config.conf.%v.json", ports.AdminPort))
 	log.Printf("Envoy config: in %v\n", confPath)
-	if err := s.CreateEnvoyConf(confPath, stress, faultInject, mfConf, ports, confVersion); err != nil {
+	if err := s.CreateEnvoyConf(confPath, stress, filtersBeforeMixer, mfConf, ports, confVersion); err != nil {
 		return nil, err
 	}
 

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -26,18 +26,18 @@ import (
 )
 
 type confParam struct {
-	ClientPort      uint16
-	ServerPort      uint16
-	TCPProxyPort    uint16
-	AdminPort       uint16
-	MixerServer     string
-	Backend         string
-	ClientConfig    string
-	ServerConfig    string
-	TCPServerConfig string
-	AccessLog       string
-	MixerRouteFlags string
-	FaultFilter     string
+	ClientPort         uint16
+	ServerPort         uint16
+	TCPProxyPort       uint16
+	AdminPort          uint16
+	MixerServer        string
+	Backend            string
+	ClientConfig       string
+	ServerConfig       string
+	TCPServerConfig    string
+	AccessLog          string
+	MixerRouteFlags    string
+	FiltersBeforeMixer string
 
 	// Ports contains the allocated ports.
 	Ports    *Ports
@@ -47,19 +47,6 @@ type confParam struct {
 	// Options are additional config options for the template
 	Options map[string]interface{}
 }
-
-const allAbortFaultFilter = `
-               {
-                   "type": "decoder",
-                   "name": "fault",
-                   "config": {
-                       "abort": {
-                           "abort_percent": 100,
-                           "http_status": 503
-                       }
-                   }
-               },
-`
 
 // TODO: convert to v2, real clients use bootstrap v2 and all configs are switching !!!
 // The envoy config template
@@ -100,7 +87,7 @@ const envoyConfTempl = `
               }
             ],
             "filters": [
-{{.FaultFilter}}
+{{.FiltersBeforeMixer}}
               {
                 "type": "decoder",
                 "name": "mixer",
@@ -264,7 +251,7 @@ func (c *confParam) write(outPath, confTmpl string) error {
 }
 
 // CreateEnvoyConf create envoy config.
-func (s *TestSetup) CreateEnvoyConf(path string, stress, faultInject bool, mfConfig *MixerFilterConf, ports *Ports,
+func (s *TestSetup) CreateEnvoyConf(path string, stress bool, filtersBeforeMixer string, mfConfig *MixerFilterConf, ports *Ports,
 	confVersion string) error {
 	c := &confParam{
 		ClientPort:      ports.ClientProxyPort,
@@ -288,8 +275,8 @@ func (s *TestSetup) CreateEnvoyConf(path string, stress, faultInject bool, mfCon
 	if stress {
 		c.AccessLog = "/dev/null"
 	}
-	if faultInject {
-		c.FaultFilter = allAbortFaultFilter
+	if len(filtersBeforeMixer) > 0 {
+		c.FiltersBeforeMixer = filtersBeforeMixer
 	}
 
 	confTmpl := envoyConfTempl

--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -43,6 +43,14 @@ const (
 	TCPMixerFilterTest
 	TCPMixerFilterV1ConfigTest
 	XDSTest
+	CheckReportIstioAuthnAttributesTestOriginJwtBoundToOrigin
+	CheckReportIstioAuthnAttributesTestOriginJwtBoundToPeer
+	CheckReportIstioAuthnAttributesTestPeerJwtBoundToPeer
+	CheckReportIstioAuthnAttributesTestPeerJwtBoundToOrigin
+	IstioAuthnTestOriginRejectNoJwt
+	IstioAuthnTestPeerRejectNoJwt
+	IstioAuthnTestPeerRejectNoMtls
+	IstioAuthnTestPeerRejectNoTLS
 
 	// The number of total tests. has to be the last one.
 	maxTestNum

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -34,14 +34,14 @@ type TestSetup struct {
 	mfConf *MixerFilterConf
 	ports  *Ports
 
-	envoy         *Envoy
-	mixer         *MixerServer
-	backend       *HTTPServer
-	testName      uint16
-	stress        bool
-	faultInject   bool
-	noMixer       bool
-	mfConfVersion string
+	envoy              *Envoy
+	mixer              *MixerServer
+	backend            *HTTPServer
+	testName           uint16
+	stress             bool
+	filtersBeforeMixer string
+	noMixer            bool
+	mfConfVersion      string
 
 	// EnvoyTemplate is the bootstrap config used by envoy.
 	EnvoyTemplate string
@@ -143,15 +143,15 @@ func (s *TestSetup) SetNoMixer(no bool) {
 	s.noMixer = no
 }
 
-// SetFaultInject set FaultInject flag
-func (s *TestSetup) SetFaultInject(f bool) {
-	s.faultInject = f
+// SetFiltersBeforeMixer set the configurations of the filters before the Mixer filter
+func (s *TestSetup) SetFiltersBeforeMixer(filters string) {
+	s.filtersBeforeMixer = filters
 }
 
 // SetUp setups Envoy, Mixer, and Backend server for test.
 func (s *TestSetup) SetUp() error {
 	var err error
-	s.envoy, err = s.NewEnvoy(s.stress, s.faultInject, s.mfConf, s.ports, s.epoch, s.mfConfVersion)
+	s.envoy, err = s.NewEnvoy(s.stress, s.filtersBeforeMixer, s.mfConf, s.ports, s.epoch, s.mfConfVersion)
 	if err != nil {
 		log.Printf("unable to create Envoy %v", err)
 	}
@@ -195,7 +195,7 @@ func (s *TestSetup) ReStartEnvoy() {
 	log.Printf("new allocated ports are %v:", s.ports)
 	var err error
 	s.epoch++
-	s.envoy, err = s.NewEnvoy(s.stress, s.faultInject, s.mfConf, s.ports, s.epoch, s.mfConfVersion)
+	s.envoy, err = s.NewEnvoy(s.stress, s.filtersBeforeMixer, s.mfConf, s.ports, s.epoch, s.mfConfVersion)
 	if err != nil {
 		s.t.Errorf("unable to re-start Envoy %v", err)
 	} else {

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -66,9 +66,22 @@ const reportAttributes = `
 }
 `
 
+const allAbortFaultFilter = `
+               {
+                   "type": "decoder",
+                   "name": "fault",
+                   "config": {
+                       "abort": {
+                           "abort_percent": 100,
+                           "http_status": 503
+                       }
+                   }
+               },
+`
+
 func TestFaultInject(t *testing.T) {
 	s := env.NewTestSetup(env.FaultInjectTest, t)
-	s.SetFaultInject(true)
+	s.SetFiltersBeforeMixer(allAbortFaultFilter)
 	// fault injection filer is before mixer filter.
 	// If a request is rejected, per-route service config could not
 	// be used, has to use default service_configs map to send Report.

--- a/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
@@ -1,0 +1,188 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnOriginJwtBoundOrigin
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good GET request
+const checkAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.principal": "issuer@foo.com/sub@foo.com",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// Report attributes from a good GET request with Istio authn policy binding to origin
+const reportAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "check.cache_hit": false,
+  "quota.cache_hit": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "request.total_size": 553,
+  "response.total_size": 99,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.principal": "issuer@foo.com/sub@foo.com",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "origins": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ],
+      "principal_binding": 1
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const secIstioAuthUserInfoHeaderKey = "sec-istio-auth-jwt-output"
+
+const secIstioAuthUserinfoHeaderValue = `
+{
+  "iss": "issuer@foo.com",
+  "sub": "sub@foo.com",
+  "aud": "aud1",
+  "non-string-will-be-ignored": 1512754205,
+  "some-other-string-claims": "some-claims-kept"
+}
+`
+
+func TestAuthnCheckReportAttributesOriginJwtBoundToOrigin(t *testing.T) {
+	s := env.NewTestSetup(env.CheckReportIstioAuthnAttributesTestOriginJwtBoundToOrigin, t)
+	// In the Envoy config, principal_binding binds to origin
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// Add jwt_auth header to be consumed by Istio authn filter
+	headers := map[string]string{}
+	headers[secIstioAuthUserInfoHeaderKey] =
+		base64.StdEncoding.EncodeToString([]byte(secIstioAuthUserinfoHeaderValue))
+
+	if _, _, err := env.HTTPGetWithHeaders(url, headers); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the authn attributes in the actual check call match those in the expected check call
+	s.VerifyCheck(tag, checkAttributesOkGet)
+	// Verify that the authn attributes in the actual report call match those in the expected report call
+	s.VerifyReport(tag, reportAttributesOkGet)
+}

--- a/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
@@ -1,0 +1,186 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnOriginJwtBoundPeer
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good GET request
+const checkAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// Report attributes from a good GET request
+const reportAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "check.cache_hit": false,
+  "quota.cache_hit": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "request.total_size": 517,
+  "response.total_size": 99,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "origins": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ]
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const secIstioAuthUserInfoHeaderKey = "sec-istio-auth-jwt-output"
+
+const secIstioAuthUserinfoHeaderValue = `
+{
+  "iss": "issuer@foo.com",
+  "sub": "sub@foo.com",
+  "aud": "aud1",
+  "non-string-will-be-ignored": 1512754205,
+  "some-other-string-claims": "some-claims-kept"
+}
+`
+
+func TestAuthnCheckReportAttributesOriginJwtNoBoundToOrigin(t *testing.T) {
+	s := env.NewTestSetup(env.CheckReportIstioAuthnAttributesTestOriginJwtBoundToPeer, t)
+	// In the Envoy config, no binding to origin, binds to peer by default.
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// Add jwt_auth header to be consumed by Istio authn filter
+	headers := map[string]string{}
+	headers[secIstioAuthUserInfoHeaderKey] =
+		base64.StdEncoding.EncodeToString([]byte(secIstioAuthUserinfoHeaderValue))
+
+	if _, _, err := env.HTTPGetWithHeaders(url, headers); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// As the origin is empty, the request principal will not be set.
+	// Verify that the authn attributes in the actual check call match those in the expected check call
+	s.VerifyCheck(tag, checkAttributesOkGet)
+	// Verify that the authn attributes in the actual report call match those in the expected report call
+	s.VerifyReport(tag, reportAttributesOkGet)
+}

--- a/mixer/test/client/istio_authn_origin_reject_no_jwt/authn_origin_reject_no_jwt_test.go
+++ b/mixer/test/client/istio_authn_origin_reject_no_jwt/authn_origin_reject_no_jwt_test.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnOriginRejectNoJwt
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "origins": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ],
+      "principal_binding": 1
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const respExpected = "Origin authentication failed."
+
+func TestAuthnOriginRejectNoJwt(t *testing.T) {
+	s := env.NewTestSetup(env.IstioAuthnTestOriginRejectNoJwt, t)
+	// In the Envoy config, requires a JWT for origin
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// No jwt_auth header to be consumed by Istio authn filter.
+	// The request will be rejected by Istio authn filter.
+	code, resp, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the http request is rejected
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp != respExpected {
+		t.Errorf("Expected response: %s, got %s.", respExpected, resp)
+	}
+}

--- a/mixer/test/client/istio_authn_peer_jwt_bound_origin/authn_report_test.go
+++ b/mixer/test/client/istio_authn_peer_jwt_bound_origin/authn_report_test.go
@@ -1,0 +1,97 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnPeerJwtBoundOrigin
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "peers": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ],
+      "principal_binding": 1
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const secIstioAuthUserInfoHeaderKey = "sec-istio-auth-jwt-output"
+
+const secIstioAuthUserinfoHeaderValue = `
+{
+  "iss": "issuer@foo.com",
+  "sub": "sub@foo.com",
+  "aud": "aud1",
+  "non-string-will-be-ignored": 1512754205,
+  "some-other-string-claims": "some-claims-kept"
+}
+`
+
+const respExpected = "Origin authentication failed."
+
+func TestAuthnCheckReportAttributesPeerJwtBoundToOrigin(t *testing.T) {
+	s := env.NewTestSetup(env.CheckReportIstioAuthnAttributesTestPeerJwtBoundToOrigin, t)
+	// In the Envoy config, principal_binding binds to origin
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// Add jwt_auth header to be consumed by Istio authn filter
+	headers := map[string]string{}
+	headers[secIstioAuthUserInfoHeaderKey] =
+		base64.StdEncoding.EncodeToString([]byte(secIstioAuthUserinfoHeaderValue))
+
+	// Principal is binded to origin, but no method specified in origin policy.
+	// The request will be rejected by Istio authn filter.
+	code, resp, err := env.HTTPGetWithHeaders(url, headers)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the http request is rejected
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp != respExpected {
+		t.Errorf("Expected response: %s, got %s.", respExpected, resp)
+	}
+}

--- a/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
@@ -1,0 +1,192 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnPeerJwtBoundPeer
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// Check attributes from a good GET request
+const checkAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "source.principal": "issuer@foo.com/sub@foo.com",
+  "source.user": "issuer@foo.com/sub@foo.com",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.principal": "issuer@foo.com/sub@foo.com",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// Report attributes from a good GET request with Istio authn policy
+const reportAttributesOkGet = `
+{
+  "context.protocol": "http",
+  "mesh1.ip": "[1 1 1 1]",
+  "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
+  "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",
+  "request.host": "*",
+  "request.path": "/echo",
+  "request.time": "*",
+  "request.useragent": "Go-http-client/1.1",
+  "request.method": "GET",
+  "request.scheme": "http",
+  "source.uid": "POD11",
+  "source.namespace": "XYZ11",
+  "source.ip": "[127 0 0 1]",
+  "source.port": "*",
+  "source.principal": "issuer@foo.com/sub@foo.com",
+  "source.user": "issuer@foo.com/sub@foo.com",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "target.name": "target-name",
+  "target.user": "target-user",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "connection.mtls": false,
+  "check.cache_hit": false,
+  "quota.cache_hit": false,
+  "request.headers": {
+     ":method": "GET",
+     ":path": "/echo",
+     ":authority": "*",
+     "x-forwarded-proto": "http",
+     "x-istio-attributes": "-",
+     "x-request-id": "*"
+  },
+  "request.size": 0,
+  "request.total_size": 589,
+  "response.total_size": 99,
+  "response.time": "*",
+  "response.size": 0,
+  "response.duration": "*",
+  "response.code": 200,
+  "response.headers": {
+     "date": "*",
+     "content-length": "0",
+     ":status": "200",
+     "server": "envoy"
+  },
+  "request.auth.audiences": "aud1",
+  "request.auth.principal": "issuer@foo.com/sub@foo.com",
+  "request.auth.claims": {
+     "iss": "issuer@foo.com", 
+     "sub": "sub@foo.com",
+     "aud": "aud1",
+     "some-other-string-claims": "some-claims-kept"
+  }
+}
+`
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "peers": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ],
+      "principal_binding": 0
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const secIstioAuthUserInfoHeaderKey = "sec-istio-auth-jwt-output"
+
+const secIstioAuthUserinfoHeaderValue = `
+{
+  "iss": "issuer@foo.com",
+  "sub": "sub@foo.com",
+  "aud": "aud1",
+  "non-string-will-be-ignored": 1512754205,
+  "some-other-string-claims": "some-claims-kept"
+}
+`
+
+func TestAuthnCheckReportAttributesPeerJwtBoundToPeer(t *testing.T) {
+	s := env.NewTestSetup(env.CheckReportIstioAuthnAttributesTestPeerJwtBoundToPeer, t)
+	// In the Envoy config, principal_binding binds to peer
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// Add jwt_auth header to be consumed by Istio authn filter
+	headers := map[string]string{}
+	headers[secIstioAuthUserInfoHeaderKey] =
+		base64.StdEncoding.EncodeToString([]byte(secIstioAuthUserinfoHeaderValue))
+
+	if _, _, err := env.HTTPGetWithHeaders(url, headers); err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the authn attributes in the actual check call match those in the expected check call
+	s.VerifyCheck(tag, checkAttributesOkGet)
+	// Verify that the authn attributes in the actual report call match those in the expected report call
+	s.VerifyReport(tag, reportAttributesOkGet)
+}

--- a/mixer/test/client/istio_authn_peer_reject_no_jwt/authn_peer_reject_no_jwt_test.go
+++ b/mixer/test/client/istio_authn_peer_reject_no_jwt/authn_peer_reject_no_jwt_test.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnPeerRejectNoJwt
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "peers": [
+        {
+          "jwt": {
+            "issuer": "issuer@foo.com",
+            "jwks_uri": "http://localhost:8081/"
+          }
+        }
+      ],
+      "principal_binding": 0
+    },
+    "jwt_output_payload_locations": {
+      "issuer@foo.com": "sec-istio-auth-jwt-output"
+    }
+  }
+},
+`
+
+const respExpected = "Peer authentication failed."
+
+func TestAuthnPeerRejectNoJwt(t *testing.T) {
+	s := env.NewTestSetup(env.IstioAuthnTestPeerRejectNoJwt, t)
+	// In the Envoy config, requires a JWT for peer
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// No jwt_auth header to be consumed by Istio authn filter.
+	// The request will be rejected by Istio authn filter.
+	code, resp, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the http request is rejected
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp != respExpected {
+		t.Errorf("Expected response: %s, got %s.", respExpected, resp)
+	}
+}

--- a/mixer/test/client/istio_authn_peer_reject_no_mtls/authn_peer_reject_no_mtls_test.go
+++ b/mixer/test/client/istio_authn_peer_reject_no_mtls/authn_peer_reject_no_mtls_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnPeerRejectNoMtls
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "peers": [
+        {
+          "mtls": {
+            "allow_tls": false
+          }
+        }
+      ],
+      "principal_binding": 0
+    }
+  }
+},
+`
+
+const respExpected = "Peer authentication failed."
+
+func TestAuthnPeerRejectNoMtls(t *testing.T) {
+	s := env.NewTestSetup(env.IstioAuthnTestPeerRejectNoMtls, t)
+	// In the Envoy config, requires mTLS for peer
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// No mTLS connection required by Istio authn peer policy.
+	// The request will be rejected by Istio authn filter.
+	code, resp, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the http request is rejected
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp != respExpected {
+		t.Errorf("Expected response: %s, got %s.", respExpected, resp)
+	}
+}

--- a/mixer/test/client/istio_authn_peer_reject_no_tls/authn_peer_reject_no_tls_test.go
+++ b/mixer/test/client/istio_authn_peer_reject_no_tls/authn_peer_reject_no_tls_test.go
@@ -1,0 +1,75 @@
+// Copyright 2018 Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istioAuthnPeerRejectNoTls
+
+import (
+	"fmt"
+	"testing"
+
+	"istio.io/istio/mixer/test/client/env"
+)
+
+// The Istio authn envoy config
+const authnConfig = `
+{
+  "type": "decoder",
+  "name": "istio_authn",
+  "config": {
+    "policy": {
+      "peers": [
+        {
+          "mtls": {
+            "allow_tls": true
+          }
+        }
+      ],
+      "principal_binding": 0
+    }
+  }
+},
+`
+
+const respExpected = "Peer authentication failed."
+
+func TestAuthnPeerRejectNoTls(t *testing.T) {
+	s := env.NewTestSetup(env.IstioAuthnTestPeerRejectNoTLS, t)
+	// In the Envoy config, requires TLS for peer
+	s.SetFiltersBeforeMixer(authnConfig)
+
+	env.SetStatsUpdateInterval(s.MfConfig(), 1)
+	if err := s.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	defer s.TearDown()
+
+	url := fmt.Sprintf("http://localhost:%d/echo", s.Ports().ClientProxyPort)
+
+	// Issues a GET echo request with 0 size body
+	tag := "OKGet"
+
+	// No TLS connection required by Istio authn peer policy.
+	// The request will be rejected by Istio authn filter.
+	code, resp, err := env.HTTPGet(url)
+	if err != nil {
+		t.Errorf("Failed in request %s: %v", tag, err)
+	}
+	// Verify that the http request is rejected
+	if code != 401 {
+		t.Errorf("Status code 401 is expected, got %d.", code)
+	}
+	if resp != respExpected {
+		t.Errorf("Expected response: %s, got %s.", respExpected, resp)
+	}
+}


### PR DESCRIPTION
Add the following Mixer tests for Istio authn filter

- Test when requiring JWT for peer and binding to peer, the authn attributes in the actual check and report calls match those in the expected check call
- Test when requiring JWT for peer and binding to origin, but no method specified in origin policy, the request will be rejected by Istio authn filter.
- Test when when requiring JWT for origin and binding to origin, the authn attributes in the actual check and report calls match those in the expected check call.
- Test when requiring JWT for origin and no binding to origin, the authn attributes in the actual check and report calls match those in the expected check call.
- Test when the HTTP request is rejected by the Istio authn filter for peer JWT authentication, the response code and the response message is as expected.
- Test when the HTTP request is rejected by the Istio authn filter for origin JWT authentication, the response code and the response message is as expected.
- Test when the Istio authn filter requires mTLS for peer connection, the non mTLS connection is rejected and the response code and the response message are as expected.
- Test when the Istio authn filter requires TLS for peer connection, the non TLS connection is rejected and the response code and the response message are as expected.