### PR TITLE
Make metrics command ready for web scale.

### DIFF
--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -129,6 +129,8 @@ func run(c *cobra.Command, args []string) error {
 			return err
 		}
 
+		printHeader()
+
 		services := args
 		for _, service := range services {
 			sm, err := metrics(promAPI, service)
@@ -258,13 +260,19 @@ func vectorValue(promAPI promv1.API, query string) (float64, error) {
 	}
 }
 
+func printHeader() {
+	w := tabwriter.NewWriter(os.Stdout, 13, 1, 2, ' ', tabwriter.AlignRight)
+	fmt.Fprintf(w, "%13sService\tTotal RPS\tError RPS\tP50 Latency\tP90 Latency\tP99 Latency\t\n", "")
+	w.Flush()
+}
+
 func printMetrics(sm serviceMetrics) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 1, 2, ' ', 0)
-	fmt.Fprintf(w, "%s:\n", sm.service)
-	fmt.Fprintf(w, "\tTotal RPS: \t%f\n", sm.totalRPS)
-	fmt.Fprintf(w, "\tError RPS: \t%f\n", sm.errorRPS)
-	fmt.Fprintf(w, "\tP50 Latency: \t%s\n", sm.p50Latency)
-	fmt.Fprintf(w, "\tP90 Latency: \t%s\n", sm.p90Latency)
-	fmt.Fprintf(w, "\tP99 Latency: \t%s\n", sm.p99Latency)
+	w := tabwriter.NewWriter(os.Stdout, 13, 1, 2, ' ', tabwriter.AlignRight)
+	fmt.Fprintf(w, "%20s\t", sm.service)
+	fmt.Fprintf(w, "%.3f\t", sm.totalRPS)
+	fmt.Fprintf(w, "%.3f\t", sm.errorRPS)
+	fmt.Fprintf(w, "%s\t", sm.p50Latency)
+	fmt.Fprintf(w, "%s\t", sm.p90Latency)
+	fmt.Fprintf(w, "%s\t\n", sm.p99Latency)
 	w.Flush()
 }

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -262,7 +262,7 @@ func vectorValue(promAPI promv1.API, query string) (float64, error) {
 
 func printHeader() {
 	w := tabwriter.NewWriter(os.Stdout, 13, 1, 2, ' ', tabwriter.AlignRight)
-	fmt.Fprintf(w, "%13sService\tTotal RPS\tError RPS\tP50 Latency\tP90 Latency\tP99 Latency\t\n", "")
+	fmt.Fprintf(w, "%13sSERVICE\tTOTAL RPS\tERROR RPS\tP50 LATENCY\tP90 LATENCY\tP99 LATENCY\t\n", "")
 	w.Flush()
 }
 


### PR DESCRIPTION
This change makes the output denser and easier to read.

Example usage (bookinfo example):

```
$ istioctl experimental metrics productpage reviews ratings details
    SERVICE    TOTAL RPS    ERROR RPS  P50 LATENCY  P90 LATENCY  P99 LATENCY
productpage        7.873        0.000         40ms         80ms         98ms
    reviews        7.909        0.000          4ms          9ms         21ms
    ratings        5.309        0.000          2ms          4ms          4ms
    details        7.873        0.000          3ms         38ms         48ms
```