### PR TITLE
Delete custom resources before uninstalling chart.

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
   resources: ["*"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "get", "list", "watch", "delete"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]

--- a/install/kubernetes/helm/istio/charts/mixer/templates/delete-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/delete-custom-resources-job.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-mixer-delete-cr
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: {{ template "mixer.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-mixer-delete-cr
+      labels:
+        app: {{ template "mixer.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          command:
+            - ./kubectl
+            - delete
+            - -f
+            - /tmp/mixer/custom-resources.yaml
+          volumeMounts:
+            - mountPath: "/tmp/mixer"
+              name: tmp-configmap-mixer
+      volumes:
+        - name: tmp-configmap-mixer
+          configMap:
+            name: istio-mixer-custom-resources
+      restartPolicy: Never # CRD might take some time till they are available to consume


### PR DESCRIPTION
`post-hook` of `mixer` will create some custom resources that need to be deleted by `pre-hook` before uninstall `istio` chart.

/cc @gyliu513