### PR TITLE
use www.httpbin.org instead of httpbin.org in egress tests

### DIFF
--- a/tests/e2e/tests/pilot/egress_rules_test.go
+++ b/tests/e2e/tests/pilot/egress_rules_test.go
@@ -50,7 +50,7 @@ func TestEgress(t *testing.T) {
 		{
 			name:              "REACHABLE_httpbin.org",
 			config:            "testdata/v1alpha1/egress-rule-httpbin.yaml",
-			url:               "http://httpbin.org/headers",
+			url:               "http://www.httpbin.org/headers",
 			shouldBeReachable: true,
 		},
 		{
@@ -59,7 +59,7 @@ func TestEgress(t *testing.T) {
 			// Note that we're using http (not https). We're relying on Envoy to convert the outbound call to
 			// TLS for us. This is currently the suggested way for the application to call an external TLS service.\
 			// If the application uses TLS, then no metrics will be collected for the request.
-			url:               "http://httpbin.org:443/headers",
+			url:               "http://www.httpbin.org:443/headers",
 			shouldBeReachable: false,
 		},
 		{

--- a/tests/e2e/tests/pilot/externalservice_test.go
+++ b/tests/e2e/tests/pilot/externalservice_test.go
@@ -40,13 +40,13 @@ func TestServiceEntry(t *testing.T) {
 		{
 			name:              "REACHABLE_httpbin.org",
 			config:            "testdata/v1alpha3/serviceentry-httpbin.yaml",
-			url:               "http://httpbin.org/headers",
+			url:               "http://www.httpbin.org/headers",
 			shouldBeReachable: true,
 		},
 		{
 			name:              "UNREACHABLE_httpbin.org_443",
 			config:            "testdata/v1alpha3/serviceentry-httpbin.yaml",
-			url:               "https://httpbin.org:443/headers",
+			url:               "https://www.httpbin.org:443/headers",
 			shouldBeReachable: false,
 		},
 		{

--- a/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-httpbin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: httpbin
 spec:
   destination:
-      service: "httpbin.org"
+      service: "www.httpbin.org"
   ports:
       - port: 80
         protocol: http

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/serviceentry-httpbin.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/serviceentry-httpbin.yaml
@@ -4,7 +4,7 @@ metadata:
   name: httpbin
 spec:
   hosts:
-    - "httpbin.org"
+    - "www.httpbin.org"
   ports:
     - number: 80
       name: http-port


### PR DESCRIPTION
httpbin.org seems to become unreachable or redirecting to HTTPS (not related to Istio, related to httpbin.org itself).