### PR TITLE
Quick fix for consistent upgrade e2e test failure

### DIFF
--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -34,21 +34,22 @@ import (
 )
 
 const (
-	u1             = "normal-user"
-	u2             = "test-user"
-	bookinfoYaml   = "samples/bookinfo/kube/bookinfo.yaml"
-	modelDir       = "tests/apps/bookinfo/output"
-	rulesDir       = "samples/bookinfo/kube"
-	allRule        = "route-rule-all-v1.yaml"
-	testRule       = "route-rule-reviews-test-v2.yaml"
-	testRetryTimes = 10
+	u1              = "normal-user"
+	u2              = "test-user"
+	bookinfoYaml    = "samples/bookinfo/kube/bookinfo.yaml"
+	bookinfoGateway = "bookinfo-gateway.yaml"
+	modelDir        = "tests/apps/bookinfo/output"
+	rulesDir        = "samples/bookinfo/kube"
+	allRule         = "route-rule-all-v1.yaml"
+	testRule        = "route-rule-reviews-test-v2.yaml"
+	testRetryTimes  = 10
 )
 
 var (
 	tc                *testConfig
 	baseConfig        *framework.CommonConfig
 	targetConfig      *framework.CommonConfig
-	defaultRules      = []string{allRule, testRule}
+	defaultRules      = []string{allRule, testRule, bookinfoGateway}
 	flagBaseVersion   = flag.String("base_version", "0.4.0", "Base version to upgrade from.")
 	flagTargetVersion = flag.String("target_version", "0.5.1", "Target version to upgrade to.")
 	flagSmoothCheck   = flag.Bool("smooth_check", false, "Whether to check the upgrade is smooth.")


### PR DESCRIPTION
Upgrade e2e test is failing consistently because the gateway definition has been removed from bookinfo.yaml #4937. This PR is a quick fix which adds bookinfo gateway definition back.