### PR TITLE
Allow register/degregister istioctl commands to work with .pem

### DIFF
--- a/istioctl/cmd/istioctl/deregister.go
+++ b/istioctl/cmd/istioctl/deregister.go
@@ -31,7 +31,7 @@ var (
 			ip := args[1]
 			log.Infof("De-registering for service '%s' ip '%s'",
 				svcName, ip)
-			_, client, err := kube.CreateInterface(kubeconfig)
+			client, err := createInterface(kubeconfig)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/istioctl/register.go
+++ b/istioctl/cmd/istioctl/register.go
@@ -40,14 +40,14 @@ var (
 				}
 				portsList[i] = p
 			}
-			log.Infof("Registering for service '%s' ip '%s', ports list %v",
+			log.Debugf("Registering for service '%s' ip '%s', ports list %v",
 				svcName, ip, portsList)
 			if svcAcctAnn != "" {
 				annotations = append(annotations, fmt.Sprintf("%s=%s", kube.KubeServiceAccountsOnVMAnnotation, svcAcctAnn))
 			}
-			log.Infof("%d labels (%v) and %d annotations (%v)",
+			log.Debugf("%d labels (%v) and %d annotations (%v)",
 				len(labels), labels, len(annotations), annotations)
-			_, client, err := kube.CreateInterface(kubeconfig)
+			client, err := createInterface(kubeconfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR adds the `istioctl kube-inject` fix to `istioctl register` and `deregister`.
See PR https://github.com/istio/istio/pull/5300

See Issue https://github.com/istio/istio/issues/5255