### PR TITLE
Fix egressgateway e2e test when mTLS enable.

### DIFF
--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -33,10 +33,15 @@ func TestEgressGateway(t *testing.T) {
 		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}
 
+	// In authn enable test, mTLS is enabled globally, which mean all clients will use TLS
+	// to talk to egress-gateway. However, in 0.8 implementation, gateway TLS setting doesn't
+	// infer from authn policy, and thus need to be set via gateway API, or disable mTLS for
+	// egress-gateway. For this test, we choose the second option by deploying authn policy
+	// that disable mTLS for egress-gateway.
 	cfgs := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{
-			"testdata/v1alpha3/disable-mtls-t.yaml", // explicitly disable mTLS for service "t" so it won't be affected by mTLS global setting.
+			"testdata/v1alpha3/disable-mtls-egressgateway.yaml.yaml",
 			"testdata/v1alpha3/egressgateway.yaml",
 			"testdata/v1alpha3/service-entry.yaml",
 			"testdata/v1alpha3/rule-route-via-egressgateway.yaml"},

--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -41,7 +41,7 @@ func TestEgressGateway(t *testing.T) {
 	cfgs := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{
-			"testdata/v1alpha3/disable-mtls-egressgateway.yaml.yaml",
+			"testdata/v1alpha3/disable-mtls-egressgateway.yaml",
 			"testdata/v1alpha3/egressgateway.yaml",
 			"testdata/v1alpha3/service-entry.yaml",
 			"testdata/v1alpha3/rule-route-via-egressgateway.yaml"},

--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -29,6 +29,11 @@ import (
 //    3.b. Traffic from egress gateway goes to actual destination (in our case, its t)
 // The tests will only check for requests from a->t with host matching ext service
 func TestEgressGateway(t *testing.T) {
+	// Gateway doesn't work correctly with mTLS yet.
+	// Temporary disable this test when mTLS enable in order to run e2e for other test cases.
+	if tc.Kube.AuthEnabled {
+		t.Skipf("Skipping %s: auth_enabled=true", t.Name())
+	}
 	if !tc.V1alpha3 {
 		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}
@@ -36,6 +41,7 @@ func TestEgressGateway(t *testing.T) {
 	cfgs := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{
+			"testdata/v1alpha3/disable-mtls-t.yaml",
 			"testdata/v1alpha3/egressgateway.yaml",
 			"testdata/v1alpha3/service-entry.yaml",
 			"testdata/v1alpha3/rule-route-via-egressgateway.yaml"},

--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -41,7 +41,7 @@ func TestEgressGateway(t *testing.T) {
 	cfgs := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{
-			"testdata/v1alpha3/disable-mtls-t.yaml",
+			"testdata/v1alpha3/disable-mtls-t.yaml", // explicitly disable mTLS for service "t" so it won't be affected by mTLS global setting.
 			"testdata/v1alpha3/egressgateway.yaml",
 			"testdata/v1alpha3/service-entry.yaml",
 			"testdata/v1alpha3/rule-route-via-egressgateway.yaml"},

--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -29,11 +29,6 @@ import (
 //    3.b. Traffic from egress gateway goes to actual destination (in our case, its t)
 // The tests will only check for requests from a->t with host matching ext service
 func TestEgressGateway(t *testing.T) {
-	// Gateway doesn't work correctly with mTLS yet.
-	// Temporary disable this test when mTLS enable in order to run e2e for other test cases.
-	if tc.Kube.AuthEnabled {
-		t.Skipf("Skipping %s: auth_enabled=true", t.Name())
-	}
 	if !tc.V1alpha3 {
 		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-egressgateway.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-egressgateway.yaml
@@ -1,0 +1,8 @@
+# This authn policy to disable mTLS for egressgateway
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "disable-mtls-t"
+spec:
+  targets:
+  - name: "egressgateway"

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-egressgateway.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-egressgateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
-  name: "disable-mtls-t"
+  name: "disable-egress-mtls"
 spec:
   targets:
-  - name: "egressgateway"
+  - name: "istio-egressgateway"

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
@@ -1,0 +1,7 @@
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "disable-mtls-t"
+spec:
+  targets:
+  - name: "t"

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
@@ -1,8 +1,0 @@
-# This authn policy to disable mTLS for service "t" so that it can be used to 'fake' external service.
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "disable-mtls-t"
-spec:
-  targets:
-  - name: "t"

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/disable-mtls-t.yaml
@@ -1,3 +1,4 @@
+# This authn policy to disable mTLS for service "t" so that it can be used to 'fake' external service.
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/service-entry.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/service-entry.yaml
@@ -13,6 +13,6 @@ spec:
   endpoints:
   # Rather than relying on an external host that might become unreachable (causing test failures)
   # we can mock the external endpoint using service t which has no sidecar.
-  - address: t.istio-system.svc.cluster.local # TODO: this is brittle
+  - address: b.istio-system.svc.cluster.local # TODO: this is brittle
     ports:
       http: 8080 # TODO test https

--- a/tests/e2e/tests/pilot/testdata/v1alpha3/service-entry.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha3/service-entry.yaml
@@ -13,6 +13,6 @@ spec:
   endpoints:
   # Rather than relying on an external host that might become unreachable (causing test failures)
   # we can mock the external endpoint using service t which has no sidecar.
-  - address: b.istio-system.svc.cluster.local # TODO: this is brittle
+  - address: t.istio-system.svc.cluster.local # TODO: this is brittle
     ports:
       http: 8080 # TODO test https


### PR DESCRIPTION
Change service entry for egressgateway to use "b", which is in the mesh, so that test works when authn is enabled.