### PR TITLE
[DO NOT MERGE] Turn on rbac e2e test.

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -160,7 +160,7 @@ test/local/auth/e2e_pilot: generate_yaml
 test/local/noauth/e2e_pilotv2: generate_yaml-envoyv2_transition
 	@mkdir -p ${OUT_DIR}/logs
 	set -o pipefail; ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/pilot \
- 	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=false --ingress=false --rbac_enable=false --v1alpha1=false --cluster_wide \
+	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=false --ingress=false --rbac_enable=true --v1alpha1=false --cluster_wide \
 	${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} \
 		| tee ${OUT_DIR}/logs/test-report.raw
 


### PR DESCRIPTION
The rbac e2e got disabled in #5268 and I'm using this PR to trigger a test in CircleCI to check the logs.