### PR TITLE
re-add flags for consul and eureka 

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -100,7 +100,14 @@ func init() {
 		"Controller resync interval")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ControllerOptions.DomainSuffix, "domain", "cluster.local",
 		"DNS domain suffix")
-
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Service.Consul.ServerURL, "consulserverURL", "",
+		"URL for the Consul server")
+	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Service.Consul.Interval, "consulserverInterval", 2*time.Second,
+		"Interval (in seconds) for polling the Consul service registry")
+	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Service.Eureka.ServerURL, "eurekaserverURL", "",
+		"URL for the Eureka server")
+	discoveryCmd.PersistentFlags().DurationVar(&serverArgs.Service.Eureka.Interval, "eurekaserverInterval", 2*time.Second,
+		"Interval (in seconds) for polling the Eureka service registry")
 	discoveryCmd.PersistentFlags().IntVar(&serverArgs.DiscoveryOptions.Port, "port", 8080,
 		"Discovery service port")
 	// using address, so it can be configured as localhost:.. (possibly UDS in future)


### PR DESCRIPTION
these flags were removed here:
https://github.com/istio/istio/commit/8d8a99096d57b78a5e4da863063ac3750bcc05b9#diff-25668e8ec7da689f06e6cea780cd748c

and as far as I can see, there is not another way to set them since they are not part of the meshconfig object.  re-adding flags until these fields can be set by config/file