### PR TITLE
Pin fortio version to correct one for istio 0.6.0

### DIFF
--- a/tests/e2e/tests/simple/simple1_test.go
+++ b/tests/e2e/tests/simple/simple1_test.go
@@ -173,7 +173,7 @@ func setTestConfig() error {
 	tag := os.Getenv("FORTIO_TAG")
 	image := hub + "/fortio:" + tag
 	if hub == "" || tag == "" {
-		image = "istio/fortio:latest" // TODO: change
+		image = "istio/fortio:0.7.1"
 	}
 	log.Infof("Fortio hub %s tag %s -> image %s", hub, tag, image)
 	services := []framework.App{


### PR DESCRIPTION
Latest fortio is moving along and it's now changed enough that it doesn't work with 0.6.0 tests.