### PR TITLE
Enable tracing of prometheus scrape requests to be disabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -146,6 +146,9 @@ data:
 
     # scrape config for service endpoints.
     - job_name: 'kubernetes-service-endpoints'
+{{ if not .Values.tracing.sampled }}
+      proxy_url: 'http://prometheus-nginx:9191'
+{{ end }}
       kubernetes_sd_configs:
       - role: endpoints
       relabel_configs:
@@ -176,6 +179,9 @@ data:
 
     # Example scrape config for pods
     - job_name: 'kubernetes-pods'
+{{ if not .Values.tracing.sampled }}
+      proxy_url: 'http://prometheus-nginx:9191'
+{{ end }}
       kubernetes_sd_configs:
       - role: pod
 

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/nginx.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/nginx.yaml
@@ -1,0 +1,78 @@
+{{ if not .Values.tracing.sampled }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus-nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: prometheus-nginx
+    spec:
+{{- if .Values.global.rbacEnabled }}
+      serviceAccountName: prometheus
+{{ end }}
+      containers:
+      - image: nginx:latest
+        name: prometheus-nginx
+        ports:
+        - name: web
+          containerPort: 9191
+          protocol: TCP
+        volumeMounts:
+        - mountPath: "/etc/nginx"
+          name: config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 2500Mi
+      volumes:
+      - emptyDir: {}
+        name: data
+      - configMap:
+          name: nginx
+        name: config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx
+data:
+  nginx.conf: |
+    http {
+      proxy_http_version 1.1;
+      map $request $targetport {
+        ~^GET\ http://.*:([^/]*)/ "$1";
+      }
+      server {
+        listen 0.0.0.0:9191;
+        location / {
+          proxy_redirect off;
+          proxy_set_header X-B3-Sampled "0";
+          proxy_pass  $scheme://$host:$targetport$request_uri;
+        }
+      }
+    }
+    events {
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-nginx
+spec:
+  type: LoadBalancer
+  ports:
+  - name: web
+    nodePort: 30910
+    port: 9191
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: prometheus-nginx
+{{ end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -357,6 +357,8 @@ prometheus:
     nodePort:
       enabled: false
       port: 32090
+  tracing:
+    sampled: true
 
 servicegraph:
   enabled: false


### PR DESCRIPTION
When the helm chart is installed with both zipkin and prometheus enabled, and a service is deployed with annotation `prometheus.io/scrape: "true"`, it results in the prometheus scrape requests being traced by the service's inbound proxy.

For example, the following shows multiple trace instances for a service, without any "business request" actually being sent to the service:

![istio-zipkin-prom-sampled](https://user-images.githubusercontent.com/164562/39527309-034e2e84-4e19-11e8-80a9-0b4e33324774.png)

The details for one of the trace instances shows that it is a request to the exposed `/metrics` endpoint from prometheus, that is creating the trace instance.

![istio-zipkin-prom-sampled-details](https://user-images.githubusercontent.com/164562/39527318-067d8b22-4e19-11e8-8f9c-817ddd84345d.png)

This PR introduces a new value on the prometheus chart `prometheus.tracing.sampled` (default to true to maintain current behaviour and not install nginx), that can be used to install a nginx proxy that will add the `X-B3-Sampled: 0` header to the scrape request.

