### PR TITLE
Fix v1alpha3 abort rule not working in task

### DIFF
--- a/samples/bookinfo/routing/route-rule-ratings-test-abort.yaml
+++ b/samples/bookinfo/routing/route-rule-ratings-test-abort.yaml
@@ -14,6 +14,10 @@ spec:
       abort:
         percent: 100
         httpStatus: 500
+    route:
+    - destination:
+        host: ratings
+        subset: v1
   - route:
     - destination:
         host: ratings


### PR DESCRIPTION
A rule that aborts 100% of the time, should not need a corresponding route, but currently it fails to validate. This is a temporary fix for 0.8, but we should follow up with this to improve the validation to handle this case. See #5328