### PR TITLE
mixer: bind gRPC API locally to 9092 and use proxy on 9091

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -20,7 +20,7 @@
           - --port
           - "9092"
           - --portLocal
-          - true
+          - "true"
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
@@ -93,7 +93,7 @@
           - --port
           - "9092"
           - --portLocal
-          - true
+          - "true"
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -20,7 +20,6 @@
           - --port
           - "9092"
           - --portLocal
-          - "true"
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
@@ -93,7 +92,6 @@
           - --port
           - "9092"
           - --portLocal
-          - "true"
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -13,10 +13,14 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: 9091
+        - containerPort: 9092
         - containerPort: 9093
         - containerPort: 42422
         args:
+          - --port
+          - "9092"
+          - --portLocal
+          - true
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
@@ -26,6 +30,7 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxyv2.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
+        - containerPort: 9091
         - containerPort: 15004
         args:
         - proxy
@@ -81,10 +86,14 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: 9091
+        - containerPort: 9092
         - containerPort: 9093
         - containerPort: 42422
         args:
+          - --port
+          - "9092"
+          - --portLocal
+          - true
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
@@ -94,6 +103,7 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
+        - containerPort: 9091
         - containerPort: 15004
         args:
         - proxy

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -17,9 +17,8 @@
         - containerPort: 9093
         - containerPort: 42422
         args:
-          - --port
-          - "9092"
-          - --portLocal
+          - --address
+          - tcp://127.0.0.1:9092
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
@@ -89,9 +88,8 @@
         - containerPort: 9093
         - containerPort: 42422
         args:
-          - --port
-          - "9092"
-          - --portLocal
+          - --address
+          - tcp://127.0.0.1:9092
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -40,9 +40,9 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 	// TODO: need to pick appropriate defaults for all these settings below
 
 	serverCmd.PersistentFlags().Uint16VarP(&sa.APIPort, "port", "p", sa.APIPort,
-		"TCP port to use for Mixer's gRPC API")
-	serverCmd.PersistentFlags().BoolVarP(&sa.APIPortLocal, "portLocal", "", sa.APIPortLocal,
-		"If true, bind gRPC API port to the local interface only")
+		"TCP port to use for Mixer's gRPC API, if the address option is not specified")
+	serverCmd.PersistentFlags().StringVarP(&sa.APIAddress, "address", "", sa.APIAddress,
+		"Address to use for Mixer's gRPC API, e.g. tcp://127.0.0.1:9092 or unix:///path/to/file")
 	serverCmd.PersistentFlags().Uint16Var(&sa.MonitoringPort, "monitoringPort", sa.MonitoringPort,
 		"HTTP port to use for the exposing mixer self-monitoring information")
 	serverCmd.PersistentFlags().UintVarP(&sa.MaxMessageSize, "maxMessageSize", "", sa.MaxMessageSize,

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -41,6 +41,8 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 
 	serverCmd.PersistentFlags().Uint16VarP(&sa.APIPort, "port", "p", sa.APIPort,
 		"TCP port to use for Mixer's gRPC API")
+	serverCmd.PersistentFlags().BoolVarP(&sa.APIPortLocal, "portLocal", "", sa.APIPortLocal,
+		"If true, bind gRPC API port to the local interface only")
 	serverCmd.PersistentFlags().Uint16Var(&sa.MonitoringPort, "monitoringPort", sa.MonitoringPort,
 		"HTTP port to use for the exposing mixer self-monitoring information")
 	serverCmd.PersistentFlags().UintVarP(&sa.MaxMessageSize, "maxMessageSize", "", sa.MaxMessageSize,

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -87,8 +87,8 @@ type Args struct {
 	// Port to use for Mixer's gRPC API
 	APIPort uint16
 
-	// Bind gRPC API server to local interface only
-	APIPortLocal bool
+	// Address to use for Mixer's gRPC API. This setting supercedes the API port setting.
+	APIAddress string
 
 	// Port to use for exposing mixer self-monitoring information
 	MonitoringPort uint16
@@ -145,6 +145,7 @@ func (a *Args) String() string {
 	fmt.Fprint(buf, "APIWorkerPoolSize: ", a.APIWorkerPoolSize, "\n")
 	fmt.Fprint(buf, "AdapterWorkerPoolSize: ", a.AdapterWorkerPoolSize, "\n")
 	fmt.Fprint(buf, "APIPort: ", a.APIPort, "\n")
+	fmt.Fprint(buf, "APIAddress: ", a.APIAddress, "\n")
 	fmt.Fprint(buf, "MonitoringPort: ", a.MonitoringPort, "\n")
 	fmt.Fprint(buf, "EnableProfiling: ", a.EnableProfiling, "\n")
 	fmt.Fprint(buf, "SingleThreaded: ", a.SingleThreaded, "\n")

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -107,7 +107,6 @@ type Args struct {
 func DefaultArgs() *Args {
 	return &Args{
 		APIPort:                       9091,
-		APIPortLocal:                  true,
 		MonitoringPort:                9093,
 		MaxMessageSize:                1024 * 1024,
 		MaxConcurrentStreams:          1024,

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -87,6 +87,9 @@ type Args struct {
 	// Port to use for Mixer's gRPC API
 	APIPort uint16
 
+	// Bind gRPC API server to local interface only
+	APIPortLocal bool
+
 	// Port to use for exposing mixer self-monitoring information
 	MonitoringPort uint16
 
@@ -104,6 +107,7 @@ type Args struct {
 func DefaultArgs() *Args {
 	return &Args{
 		APIPort:                       9091,
+		APIPortLocal:                  true,
 		MonitoringPort:                9093,
 		MaxMessageSize:                1024 * 1024,
 		MaxConcurrentStreams:          1024,

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -141,13 +142,21 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	}
 
 	// get the network stuff setup
+	network := "tcp"
 	address := fmt.Sprintf(":%d", a.APIPort)
-	if a.APIPortLocal {
-		address = fmt.Sprintf("127.0.0.1:%d", a.APIPort)
+	if a.APIAddress != "" {
+		idx := strings.Index(a.APIAddress, "://")
+		if idx < 0 {
+			address = a.APIAddress
+		} else {
+			network = a.APIAddress[:idx]
+			address = a.APIAddress[idx+3:]
+		}
 	}
-	if s.listener, err = p.listen("tcp", address); err != nil {
+
+	if s.listener, err = p.listen(network, address); err != nil {
 		_ = s.Close()
-		return nil, fmt.Errorf("unable to listen on socket: %v", err)
+		return nil, fmt.Errorf("unable to listen: %v", err)
 	}
 
 	st := a.ConfigStore

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -141,7 +141,11 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	}
 
 	// get the network stuff setup
-	if s.listener, err = p.listen("tcp", fmt.Sprintf(":%d", a.APIPort)); err != nil {
+	address := fmt.Sprintf(":%d", a.APIPort)
+	if a.APIPortLocal {
+		address = fmt.Sprintf("127.0.0.1:%d", a.APIPort)
+	}
+	if s.listener, err = p.listen("tcp", address); err != nil {
 		_ = s.Close()
 		return nil, fmt.Errorf("unable to listen on socket: %v", err)
 	}

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -16,9 +16,9 @@ static_resources:
     hosts:
     - socket_address:
         address: 127.0.0.1
-        port_value: 9091
+        port_value: 9092
     http2_protocol_options: {}
-    name: in.9091
+    name: in.9092
   - connect_timeout: 1.000s
     hosts:
     - socket_address:
@@ -102,7 +102,7 @@ static_resources:
                 match:
                   prefix: /
                 route:
-                  cluster: in.9091
+                  cluster: in.9092
                   timeout: 0.000s
           stat_prefix: "15004"
           tracing: {}
@@ -123,6 +123,59 @@ static_resources:
         require_client_certificate: true
 {{- end }}
     name: "15004"
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9091
+    filter_chains:
+    - filters:
+      - config:
+          access_log:
+          - config:
+              path: /dev/stdout
+            name: envoy.file_access_log
+          codec_type: HTTP2
+          http2_protocol_options:
+            max_concurrent_streams: 1073741824
+          generate_request_id: true
+          http_filters:
+          - config:
+              default_destination_service: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              service_configs:
+                istio-policy.{{ .PodNamespace }}.svc.cluster.local:
+                  disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
+                  mixer_attributes:
+                    attributes:
+                      destination.service:
+                        string_value: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+                      destination.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
+              transport:
+                check_cluster: mixer_check_server
+                report_cluster: mixer_report_server
+            name: mixer
+          - name: envoy.router
+          route_config:
+            name: "9091"
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              routes:
+              - decorator:
+                  operation: Check
+                match:
+                  prefix: /
+                route:
+                  cluster: in.9092
+                  timeout: 0.000s
+          stat_prefix: "9091"
+          tracing: {}
+        name: envoy.http_connection_manager
+    name: "9091"
 tracing:
   http:
     config:

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -16,9 +16,9 @@ static_resources:
     hosts:
     - socket_address:
         address: 127.0.0.1
-        port_value: 9091
+        port_value: 9092
     http2_protocol_options: {}
-    name: in.9091
+    name: in.9092
   - connect_timeout: 1.000s
     hosts:
     - socket_address:
@@ -59,7 +59,7 @@ static_resources:
                         string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
-                report_cluster: in.9091
+                report_cluster: in.9092
             name: mixer
           - name: envoy.router
           route_config:
@@ -74,7 +74,7 @@ static_resources:
                 match:
                   prefix: /
                 route:
-                  cluster: in.9091
+                  cluster: in.9092
                   timeout: 0.000s
           stat_prefix: "15004"
           tracing: {}
@@ -95,6 +95,59 @@ static_resources:
         require_client_certificate: true
 {{- end }}
     name: "15004"
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9091
+    filter_chains:
+    - filters:
+      - config:
+          access_log:
+          - config:
+              path: /dev/stdout
+            name: envoy.file_access_log
+          codec_type: HTTP2
+          http2_protocol_options:
+            max_concurrent_streams: 1073741824
+          generate_request_id: true
+          http_filters:
+          - config:
+              default_destination_service: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              service_configs:
+                istio-telemetry.{{ .PodNamespace }}.svc.cluster.local:
+                  disable_check_calls: true
+{{- if .DisableReportCalls }}
+                  disable_report_calls: true
+{{- end }}
+                  mixer_attributes:
+                    attributes:
+                      destination.service:
+                        string_value: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+                      destination.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
+              transport:
+                check_cluster: mixer_check_server
+                report_cluster: in.9092
+            name: mixer
+          - name: envoy.router
+          route_config:
+            name: "9091"
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              routes:
+              - decorator:
+                  operation: Report
+                match:
+                  prefix: /
+                route:
+                  cluster: in.9092
+                  timeout: 0.000s
+          stat_prefix: "9091"
+          tracing: {}
+        name: envoy.http_connection_manager
+    name: "9091"
 tracing:
   http:
     config:


### PR DESCRIPTION
Bind to local interface only (to make sure mixer API goes through the proxy)

Signed-off-by: Kuat Yessenov <kuat@google.com>