### PR TITLE
Fix cluster building for egress gateway

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -88,7 +88,8 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env model.Environmen
 			var hosts []*core.Address
 			if proxy.Type == model.Router && service.MeshExternal {
 				// In case of Router (e.g. ingress/egress gateway) and external service, we want the service resolution
-				// to be DNS. The router can't use ORIGINAL_DST since it's not aware of it.
+				// to be DNS. The router can't use ORIGINAL_DST since, as opposed to a sidecar, it does not get the
+				// traffic by iptables so original_dst is not set.
 				service.Resolution = model.DNSLB
 				hosts = buildClusterHostsForRouterMeshExternal(service, port)
 			} else {

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -85,7 +85,15 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env model.Environmen
 	for _, service := range services {
 		config := env.DestinationRule(service.Hostname)
 		for _, port := range service.Ports {
-			hosts := buildClusterHosts(env, service, port)
+			var hosts []*core.Address
+			if proxy.Type == model.Router && service.MeshExternal {
+				// In case of Router (e.g. ingress/egress gateway) and external service, we want the service resolution
+				// to be DNS. The router can't use ORIGINAL_DST since it's not aware of it.
+				service.Resolution = model.DNSLB
+				hosts = buildClusterHostsForRouterMeshExternal(service, port)
+			} else {
+				hosts = buildClusterHosts(env, service, port)
+			}
 
 			// create default cluster
 			clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port)
@@ -154,6 +162,14 @@ func buildClusterHosts(env model.Environment, service *model.Service, port *mode
 		host := util.BuildAddress(instance.Endpoint.Address, uint32(instance.Endpoint.Port))
 		hosts = append(hosts, &host)
 	}
+
+	return hosts
+}
+
+func buildClusterHostsForRouterMeshExternal(service *model.Service, port *model.Port) []*core.Address {
+	hosts := make([]*core.Address, 0)
+	host := util.BuildAddress(service.Hostname, uint32(port.Port))
+	hosts = append(hosts, &host)
 
 	return hosts
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -90,12 +90,12 @@ func ConvertAddressToCidr(addr string) *core.CidrRange {
 //	return out
 //}
 
-// BuildAddress returns a SocketAddress with the given ip and port.
-func BuildAddress(ip string, port uint32) core.Address {
+// BuildAddress returns a SocketAddress with the given ip/hostname and port.
+func BuildAddress(ipOrHost string, port uint32) core.Address {
 	return core.Address{
 		Address: &core.Address_SocketAddress{
 			SocketAddress: &core.SocketAddress{
-				Address: ip,
+				Address: ipOrHost,
 				PortSpecifier: &core.SocketAddress_PortValue{
 					PortValue: port,
 				},


### PR DESCRIPTION
Egress Gateway fails to forward the requests to the destination.

To demonstrate it, one can do the following:

Configure a `sleep` app inside the mesh to curl to a service outside the mesh (e.g. httpbin.org) going through the egress gateway. (Please see the attached yaml)

The traffic gets to the egress gateway but stops there because the cluster for httpbin.org is configured of type `ORIGINAL_DST`. It should be of type `STRICT_DNS`.
See also: [Original destination](https://www.envoyproxy.io/docs/envoy/v1.6.0/intro/arch_overview/service_discovery#original-destination)

This PR fixes the problem.

I used the following configuration of `Gateway`, `ServiceEntry` and `VirtualService` for the use case:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: istio-egressgateway
spec:
  selector:
    # DO NOT CHANGE THESE LABELS
    # The egressgateway is defined in install/kubernetes/helm/istio/values.yaml
    # with these labels
    istio: egressgateway
  servers:
  - port:
      number: 80 #also declared in gateway's deployment files
      name: http
      protocol: HTTP
    hosts:
    - httpbin.org
    #tls:
    #  httpsRedirect: true # sends 302 redirect for http requests
---
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: httpbin
spec:
  hosts:
    - "httpbin.org"
  ports:
    - number: 80
      name: http-port
      protocol: HTTP
  resolution: NONE
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: route-via-egressgateway
spec:
  hosts:
    - httpbin.org
  gateways:
  # Pinned to both the sidecars (mesh) and egress gateway
  - istio-egressgateway
  - mesh
  http:
    - match:
      - gateways:
        - mesh # from sidecars, route to egress gateway service
      route:
      - destination:
          host: istio-egressgateway.istio-system.svc.cluster.local
        weight: 100
    - match:
      - gateways: # from egress gateway, route to actual external service
        - istio-egressgateway
      route:
      - destination:
          host: httpbin.org
        weight: 100

```



