### PR TITLE
fix incorrect upstream tls context generation

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -314,20 +314,29 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings) 
 		return
 	}
 
+	var certValidationContext *auth.CertificateValidationContext
+	var trustedCa *core.DataSource
+	if len(tls.CaCertificates) != 0 {
+		trustedCa = &core.DataSource{
+			Specifier: &core.DataSource_Filename{
+				Filename: tls.CaCertificates,
+			},
+		}
+	}
+	if trustedCa != nil || len(tls.SubjectAltNames) > 0 {
+		certValidationContext = &auth.CertificateValidationContext{
+			TrustedCa:            trustedCa,
+			VerifySubjectAltName: tls.SubjectAltNames,
+		}
+	}
+
 	switch tls.Mode {
 	case networking.TLSSettings_DISABLE:
 		// TODO: Need to make sure that authN does not override this setting
 	case networking.TLSSettings_SIMPLE:
 		cluster.TlsContext = &auth.UpstreamTlsContext{
 			CommonTlsContext: &auth.CommonTlsContext{
-				ValidationContext: &auth.CertificateValidationContext{
-					TrustedCa: &core.DataSource{
-						Specifier: &core.DataSource_Filename{
-							Filename: tls.CaCertificates,
-						},
-					},
-					VerifySubjectAltName: tls.SubjectAltNames,
-				},
+				ValidationContext: certValidationContext,
 			},
 			Sni: tls.Sni,
 		}
@@ -348,14 +357,7 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings) 
 						},
 					},
 				},
-				ValidationContext: &auth.CertificateValidationContext{
-					TrustedCa: &core.DataSource{
-						Specifier: &core.DataSource_Filename{
-							Filename: tls.CaCertificates,
-						},
-					},
-					VerifySubjectAltName: tls.SubjectAltNames,
-				},
+				ValidationContext: certValidationContext,
 			},
 			Sni: tls.Sni,
 		}


### PR DESCRIPTION
When there are no CA certs, do not add cert validation context.
This should fix envoy error when using TLS mode SIMPLE.

cc @costinm

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>