### PR TITLE
Remove zipkin tracing url from istio-policy

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -19,7 +19,6 @@
         args:
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
-          - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
         resources:
 {{ toYaml $.Values.resources | indent 12 }}
       - name: istio-proxy


### PR DESCRIPTION
One side effect of istio/proxy#1610 is istio-policy internal dispatch spans attached to Check grpc span:
![screenshot from 2018-05-03 11-50-17](https://user-images.githubusercontent.com/34738376/39596929-bcaf7ebe-4ec8-11e8-8788-9805bbe648b0.png)

Internal span becomes duplicated after policy sidecar tracks check span. After removing zipkin url from istio-policy config:
![screenshot from 2018-05-03 11-53-53](https://user-images.githubusercontent.com/34738376/39596912-b2440bc0-4ec8-11e8-8834-eb4048c04138.png)
