### PR TITLE
allow 'istioctl get gateway' etc

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -581,11 +581,11 @@ func main() {
 func protoSchema(configClient *crd.Client, typ string) (model.ProtoSchema, error) {
 	for _, desc := range configClient.ConfigDescriptor() {
 		switch typ {
+		case crd.ResourceName(desc.Type), crd.ResourceName(desc.Plural):
+			return desc, nil
 		case desc.Type, desc.Plural: // legacy hyphenated resources names
 			return model.ProtoSchema{}, fmt.Errorf("%q not recognized. Please use non-hyphenated resource name %q",
 				typ, crd.ResourceName(typ))
-		case crd.ResourceName(desc.Type), crd.ResourceName(desc.Plural):
-			return desc, nil
 		}
 	}
 	return model.ProtoSchema{}, fmt.Errorf("configuration type %s not found, the types are %v",


### PR DESCRIPTION
The commands `istioctl get gateway` and `istioctl get service` (and `put`, `delete`) are broken.  They trigger messages like

```
istioctl get gateway
Error: "gateway" not recognized. Please use non-hyphenated resource name "gateway"
$ istioctl delete gateway foo bar
Error: "gateway" not recognized. Please use non-hyphenated resource name "gateway"
```