### PR TITLE
Update generated cluster names to be valid dns names

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1599,6 +1599,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4160cda2de0241237d507eaeb9112afb071ff23097287b2d8e4fc3a0c0e602bc"
+  inputs-digest = "660ce22ee470d41f6dd9aaef82d4ca6af2fda9a6b0a4332778fdd4f9ce92e543"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1599,6 +1599,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "660ce22ee470d41f6dd9aaef82d4ca6af2fda9a6b0a4332778fdd4f9ce92e543"
+  inputs-digest = "fb4376dfd57c5e5f74a9aa1a37b4eded3a697974bfd1058333c698099426b718"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -33,7 +33,7 @@ subsets:
   ports:
   - name: tcp-plain
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -31,9 +31,9 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.policyEndpoint }}
   ports:
-  - name: tcp-plain
+  - name: grpc-mixer
     port: 9091
-  - name: grpc-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -31,7 +31,7 @@ spec:
   ports:
   - name: tcp-plain
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -29,9 +29,9 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-  - name: tcp-plain
+  - name: grpc-mixer
     port: 9091
-  - name: grpc-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -11,9 +11,9 @@ metadata:
     istio: mixer
 spec:
   ports:
-  - name: http2-mixer
+  - name: grpc-mixer
     port: 9091
-  - name: grpc-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
   - name: http2-mixer
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -192,7 +192,7 @@ func TestSubsetKey(t *testing.T) {
 			hostname: "hostname",
 			subset:   "subset",
 			port:     &model.Port{Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound..subset.hostname",
+			want:     "outbound.80.subset.hostname",
 		},
 		{
 			hostname: "hostname",

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -178,57 +178,69 @@ func TestServiceKey(t *testing.T) {
 func TestSubsetKey(t *testing.T) {
 	hostname := model.Hostname("hostname")
 	cases := []struct {
-		got      string
-		hostname model.Hostname
-		subset   string
-		port     *model.Port
-		want     string
-		err      error
+		gotOverride string
+		hostname    model.Hostname
+		subset      string
+		port        *model.Port
+		want        string
+		err         error
+		inbound     bool
 	}{
 		{
 			hostname: "hostname",
 			subset:   "subset",
 			port:     &model.Port{Name: "http", Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound.http.subset.hostname",
+			want:     "_http._subset.hostname",
 		},
 		{
 			hostname: "hostname",
 			subset:   "subset",
 			port:     &model.Port{Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound.80.subset.hostname",
+			want:     "_80._subset.hostname",
 		},
 		{
 			hostname: "hostname",
 			subset:   "",
 			port:     &model.Port{Name: "http", Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound.http._default_.hostname",
+			want:     "_http._.hostname",
 		},
 		{
-			want:   "badClusterKey",
-			subset: "",
-			port:   &model.Port{Name: "dontcare", Port: 80, Protocol: model.ProtocolHTTP},
-			got:    "badClusterKey",
-			err:    fmt.Errorf("malformed cluster-key"),
+			hostname: "hostname",
+			subset:   "",
+			port:     &model.Port{Name: "http", Port: 80, Protocol: model.ProtocolHTTP},
+			want:     "in._http._.hostname",
+			inbound:  true,
+		},
+		{
+			want:        "badClusterKey",
+			subset:      "",
+			port:        &model.Port{Name: "dontcare", Port: 80, Protocol: model.ProtocolHTTP},
+			gotOverride: "badClusterKey",
+			err:         fmt.Errorf("malformed cluster-key"),
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.want, func(t *testing.T) {
-			got := c.got
-			if got == "" {
-				got = model.BuildSubsetKey(model.TrafficDirectionOutbound, c.subset, hostname, c.port)
+			var got string
+			var td model.TrafficDirection
+			if c.gotOverride != "" {
+				got = c.gotOverride
+			} else {
+				td = model.TrafficDirectionOutbound
+				if c.inbound {
+					td = model.TrafficDirectionInbound
+				}
+				got = model.BuildSubsetKey(td, c.subset, hostname, c.port)
 				if got != c.want {
 					t.Errorf("Failed: got %q want %q", got, c.want)
 				}
 			}
 			// test parse subset key. ParseSubsetKey is the inverse of BuildSubsetKey
-			_, s, h, p, err := model.ParseSubsetKey(got)
+			gotTd, s, h, p, err := model.ParseSubsetKey(got)
 
-			wantErr := c.err != nil
-			gotErr := err != nil
-
-			if gotErr != wantErr {
-				t.Fatalf("\n got: %v\nwant: %v", err, c.err)
+			if got, want := c.err != nil, err != nil; got != want {
+				t.Fatalf("\n got: %v\nwant: %v", got, want)
 			}
 
 			if c.err != nil {
@@ -238,8 +250,8 @@ func TestSubsetKey(t *testing.T) {
 				return
 			}
 
-			if s != c.subset || h != c.hostname || p.Name != c.port.Name {
-				t.Errorf("Failed: got %s,%s,%s want %s,%s,%s", s, h, p.Name, c.subset, c.hostname, c.port.Name)
+			if s != c.subset || h != c.hostname || (c.port.Name != "" && (p.Name != c.port.Name)) || gotTd != td {
+				t.Errorf("Failed: got %s,%s,%s,%s want %s,%s,%s,%s", td, p.Name, s, h, gotTd, c.port.Name, c.subset, c.hostname)
 			}
 		})
 	}

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -186,19 +186,19 @@ func TestSubsetKey(t *testing.T) {
 			hostname: "hostname",
 			subset:   "subset",
 			port:     &model.Port{Name: "http", Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound|http|subset|hostname",
+			want:     "outbound.http.subset.hostname",
 		},
 		{
 			hostname: "hostname",
 			subset:   "subset",
 			port:     &model.Port{Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound||subset|hostname",
+			want:     "outbound..subset.hostname",
 		},
 		{
 			hostname: "hostname",
 			subset:   "",
 			port:     &model.Port{Name: "http", Port: 80, Protocol: model.ProtocolHTTP},
-			want:     "outbound|http||hostname",
+			want:     "outbound.http._default_.hostname",
 		},
 	}
 

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -612,15 +612,21 @@ func ParseServiceKey(s string) (hostname Hostname, ports PortList, labels Labels
 // BuildSubsetKey generates a unique string referencing service instances for a given service name, a subset and a port.
 // The proxy queries Pilot with this key to obtain the list of instances in a subset.
 func BuildSubsetKey(direction TrafficDirection, subsetName string, hostname Hostname, port *Port) string {
-	return fmt.Sprintf("%s|%s|%s|%s", direction, port.Name, subsetName, hostname)
+	if subsetName == "" {
+		subsetName = "_default_"
+	}
+	return fmt.Sprintf("%s.%s.%s.%s", direction, port.Name, subsetName, hostname)
 }
 
 // ParseSubsetKey is the inverse of the BuildSubsetKey method
 func ParseSubsetKey(s string) (direction TrafficDirection, subsetName string, hostname Hostname, port *Port) {
-	parts := strings.Split(s, "|")
+	parts := strings.SplitN(s, ".", 4)
 	direction = TrafficDirection(parts[0])
 	port = &Port{Name: parts[1]}
 	subsetName = parts[2]
+	if subsetName == "_default_" {
+		subsetName = ""
+	}
 	hostname = Hostname(parts[3])
 	return
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -198,15 +198,19 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 // 	return listener.Filter{}
 // }
 
+// defined in install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+const mixerPortName = "grpc-mixer"
+const mixerMTLSPortName = "grpc-mixer-mtls"
+
 // buildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
 // (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.
 func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *mccpb.HttpClientConfig { // nolint: lll
 	mcs, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
 	mrs, _, _ := net.SplitHostPort(mesh.MixerReportServer)
 
-	pname := &model.Port{Name: "http2-mixer"}
+	pname := &model.Port{Name: mixerPortName}
 	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
-		pname = &model.Port{Name: "grpc-mtls"}
+		pname.Name = mixerMTLSPortName
 	}
 
 	// TODO: derive these port types.

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -206,7 +206,7 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 
 	pname := &model.Port{Name: "http2-mixer"}
 	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
-		pname = &model.Port{Name: "tcp-mtls"}
+		pname = &model.Port{Name: "grpc-mtls"}
 	}
 
 	// TODO: derive these port types.

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/common/log"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
+	"istio.io/istio/pkg/log"
 )
 
 // Plugin is a mixer plugin.

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -199,8 +199,10 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 // }
 
 // defined in install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
-const mixerPortName = "grpc-mixer"
-const mixerMTLSPortName = "grpc-mixer-mtls"
+const (
+	mixerPortName     = "grpc-mixer"
+	mixerMTLSPortName = "grpc-mixer-mtls"
+)
 
 // buildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
 // (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -159,9 +159,9 @@ func updateCluster(clusterName string, edsCluster *EdsCluster) error {
 	var portName string
 
 	// This is a gross hack but Costin will insist on supporting everything from ancient Greece
-	// v2 names start with outbound or inbound
-	if strings.Index(clusterName, "outbound") == 0 ||
-		strings.Index(clusterName, "inbound") == 0 { //new style cluster names
+	// v2 names start with _{portName} or in.
+	if strings.HasPrefix(clusterName, model.InboundPrefix) ||
+		strings.HasPrefix(clusterName, "_") {
 		var p *model.Port
 		var subsetName string
 		var err error

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -159,11 +159,16 @@ func updateCluster(clusterName string, edsCluster *EdsCluster) error {
 	var portName string
 
 	// This is a gross hack but Costin will insist on supporting everything from ancient Greece
+	// v2 names start with outbound or inbound
 	if strings.Index(clusterName, "outbound") == 0 ||
 		strings.Index(clusterName, "inbound") == 0 { //new style cluster names
 		var p *model.Port
 		var subsetName string
-		_, subsetName, hostname, p = model.ParseSubsetKey(clusterName)
+		var err error
+		_, subsetName, hostname, p, err = model.ParseSubsetKey(clusterName)
+		if err != nil {
+			return err
+		}
 		ports = []*model.Port{p}
 		portName = p.Name
 		labels = edsCluster.discovery.env.IstioConfigStore.SubsetToLabels(subsetName, hostname)

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -345,7 +345,7 @@ func envoyInit(t *testing.T) {
 	// Other interesting values for CDS: cluster_added: 19, active_clusters
 	// cds.update_attempt: 2, cds.update_rejected, cds.version
 
-	if statsMap["cluster.outbound.http._default_.service3.default.svc.cluster.local.update_success"] < 1 {
+	if statsMap["cluster._http._.service3.default.svc.cluster.local.update_success"] < 1 {
 		t.Error("Failed sds updates")
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -345,7 +345,7 @@ func envoyInit(t *testing.T) {
 	// Other interesting values for CDS: cluster_added: 19, active_clusters
 	// cds.update_attempt: 2, cds.update_rejected, cds.version
 
-	if statsMap["cluster.outbound|http||service3.default.svc.cluster.local.update_success"] < 1 {
+	if statsMap["cluster.outbound.http._default_.service3.default.svc.cluster.local.update_success"] < 1 {
 		t.Error("Failed sds updates")
 	}
 


### PR DESCRIPTION
tcp-mtls port name generates an outbound cluster without http2 features.
This cause outbound connection to be downgraded over mtls to http1.1.

This is rejected at server side envoy.

This fixes the port name and imparts http2 features.

fixes https://github.com/istio/istio/issues/5331

Also updates cluster name generation to produce valid dns names. 