### PR TITLE
Add buffering in front of REPORT adapters.

### DIFF
--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -46,6 +46,7 @@ type testState struct {
 	gs         *grpc.Server
 	gp         *pool.GoroutinePool
 	s          *grpcServer
+	ctx        context.Context
 
 	check   checkCallback
 	report  reportCallback
@@ -133,8 +134,20 @@ func (ts *testState) Check(ctx context.Context, bag attribute.Bag) (*adapter.Che
 	return ts.check(ctx, bag)
 }
 
-func (ts *testState) Report(ctx context.Context, bag attribute.Bag) error {
-	return ts.report(ctx, bag)
+func (ts *testState) GetReporter(ctx context.Context) dispatcher.Reporter {
+	ts.ctx = ctx
+	return ts
+}
+
+func (ts *testState) Report(bag attribute.Bag) error {
+	return ts.report(ts.ctx, bag)
+}
+
+func (ts *testState) Flush() error {
+	return nil
+}
+
+func (ts *testState) Done() {
 }
 
 func (ts *testState) Quota(ctx context.Context, bag attribute.Bag,

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -117,8 +117,19 @@ func (bs *benchState) Check(ctx context.Context, bag attribute.Bag) (*adapter.Ch
 	return result, nil
 }
 
-func (bs *benchState) Report(_ context.Context, _ attribute.Bag) error {
+func (bs *benchState) GetReporter(ctx context.Context) dispatcher.Reporter {
+	return bs
+}
+
+func (bs *benchState) Report(bag attribute.Bag) error {
 	return nil
+}
+
+func (bs *benchState) Flush() error {
+	return nil
+}
+
+func (bs *benchState) Done() {
 }
 
 func (bs *benchState) Quota(ctx context.Context, requestBag attribute.Bag,

--- a/mixer/pkg/perf/run.go
+++ b/mixer/pkg/perf/run.go
@@ -189,7 +189,12 @@ func runDispatcherOnly(b benchmark, setup *Setup, settings *Settings) {
 
 		switch r.(type) {
 		case *istio_mixer_v1.ReportRequest:
-			err = dispatcher.Report(context.Background(), bag)
+			r := dispatcher.GetReporter(context.Background())
+			err = r.Report(bag)
+			if err == nil {
+				err = r.Flush()
+			}
+			r.Done()
 
 		case *istio_mixer_v1.CheckRequest:
 			_, err = dispatcher.Check(context.Background(), bag)
@@ -207,7 +212,10 @@ func runDispatcherOnly(b benchmark, setup *Setup, settings *Settings) {
 
 				switch r.(type) {
 				case *istio_mixer_v1.ReportRequest:
-					_ = dispatcher.Report(context.Background(), bag)
+					r := dispatcher.GetReporter(context.Background())
+					_ = r.Report(bag)
+					_ = r.Flush()
+					r.Done()
 
 				case *istio_mixer_v1.CheckRequest:
 					_, _ = dispatcher.Check(context.Background(), bag)

--- a/mixer/pkg/runtime/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher.go
@@ -17,30 +17,18 @@
 //
 // Once the dispatcher receives a request, it acquires the current routing table, and uses it until the end
 // of the request. Additionally, it acquires an executor from a pool, which is used to perform and track the
-// parallel calls that will be performed against the handlers. The executors scatter the calls
+// parallel calls that will be performed against the handlers. The executors scatter the calls.
 package dispatcher
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"runtime/debug"
 	"sync"
-	"sync/atomic"
-	"time"
-
-	rpc "github.com/gogo/googleapis/google/rpc"
-	multierror "github.com/hashicorp/go-multierror"
-	opentracing "github.com/opentracing/opentracing-go"
 
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/pool"
-	"istio.io/istio/mixer/pkg/runtime/config"
 	"istio.io/istio/mixer/pkg/runtime/routing"
-	"istio.io/istio/mixer/pkg/status"
-	"istio.io/istio/pkg/log"
 )
 
 // Dispatcher dispatches incoming API calls to configured adapters.
@@ -52,8 +40,8 @@ type Dispatcher interface {
 	// Check dispatches to the set of adapters associated with the Check API method
 	Check(ctx context.Context, requestBag attribute.Bag) (*adapter.CheckResult, error)
 
-	// Report dispatches to the set of adapters associated with the Report API method
-	Report(ctx context.Context, requestBag attribute.Bag) error
+	// GetReporter get an interface where reports are buffered.
+	GetReporter(ctx context.Context) Reporter
 
 	// Quota dispatches to the set of adapters associated with the Quota API method
 	Quota(ctx context.Context, requestBag attribute.Bag,
@@ -83,410 +71,165 @@ type QuotaMethodArgs struct {
 type Impl struct {
 	identityAttribute string
 
-	// Current dispatch context.
-	context *RoutingContext
+	// Current routing context.
+	rc *RoutingContext
 
 	// the reader-writer lock for accessing or changing the context.
-	contextLock sync.RWMutex
+	rcLock sync.RWMutex
 
 	// pool of sessions
-	sessionPool *sessionPool
+	sessionPool sync.Pool
 
 	// pool of dispatch states
-	statePool *dispatchStatePool
+	statePool sync.Pool
 
+	// pool of reporters
+	reporterPool sync.Pool
+
+	// pool of goroutines
 	gp *pool.GoroutinePool
+
+	enableTracing bool
 }
 
 var _ Dispatcher = &Impl{}
 
-// RoutingContext is the currently active dispatching context, based on a config snapshot. As config changes,
-// the current/live RoutingContext also changes.
-type RoutingContext struct {
-	// the routing table of this context.
-	Routes *routing.Table
-
-	// the current reference count. Indicates how many calls are currently using this RoutingContext.
-	refCount int32
-}
-
-// IncRef increases the reference count on the RoutingContext.
-func (t *RoutingContext) IncRef() {
-	atomic.AddInt32(&t.refCount, 1)
-}
-
-// DecRef decreases the reference count on the RoutingContext.
-func (t *RoutingContext) DecRef() {
-	atomic.AddInt32(&t.refCount, -1)
-}
-
-// GetRefs returns the current reference count on the dispatch context.
-func (t *RoutingContext) GetRefs() int32 {
-	return atomic.LoadInt32(&t.refCount)
-}
-
 // New returns a new Impl instance. The Impl instance is initialized with an empty routing table.
 func New(identityAttribute string, handlerGP *pool.GoroutinePool, enableTracing bool) *Impl {
-	return &Impl{
+	d := &Impl{
 		identityAttribute: identityAttribute,
-		sessionPool:       newSessionPool(enableTracing),
-		statePool:         newDispatchStatePool(),
 		gp:                handlerGP,
-		context: &RoutingContext{
+		enableTracing:     enableTracing,
+		rc: &RoutingContext{
 			Routes: routing.Empty(),
 		},
 	}
-}
 
-// ChangeRoute changes the routing table on the Impl which, in turn, ends up creating a new RoutingContext.
-func (d *Impl) ChangeRoute(new *routing.Table) *RoutingContext {
-	newContext := &RoutingContext{
-		Routes: new,
-	}
+	d.sessionPool.New = func() interface{} { return &session{} }
+	d.statePool.New = func() interface{} { return &dispatchState{} }
+	d.reporterPool.New = func() interface{} { return &reporter{states: make(map[*routing.Destination]*dispatchState)} }
 
-	d.contextLock.Lock()
-	old := d.context
-	d.context = newContext
-	d.contextLock.Unlock()
-
-	return old
+	return d
 }
 
 // Check implementation of runtime.Impl.
 func (d *Impl) Check(ctx context.Context, bag attribute.Bag) (*adapter.CheckResult, error) {
-	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_CHECK, bag)
+	s := d.getSession(ctx, tpb.TEMPLATE_VARIETY_CHECK, bag)
 
 	var r *adapter.CheckResult
-	err := d.dispatch(s)
+	err := s.dispatch()
 	if err == nil {
 		r = s.checkResult
 		err = s.err
 	}
 
-	d.completeSession(s)
-
+	d.putSession(s)
 	return r, err
 }
 
-// Report implementation of runtime.Impl.
-func (d *Impl) Report(ctx context.Context, bag attribute.Bag) error {
-	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_REPORT, bag)
-
-	err := d.dispatch(s)
-	if err == nil {
-		err = s.err
-	}
-
-	d.completeSession(s)
-
-	return err
+// GetReporter implementation of runtime.Impl.
+func (d *Impl) GetReporter(ctx context.Context) Reporter {
+	return d.getReporter(ctx)
 }
 
 // Quota implementation of runtime.Impl.
 func (d *Impl) Quota(ctx context.Context, bag attribute.Bag, qma *QuotaMethodArgs) (*adapter.QuotaResult, error) {
-	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_QUOTA, bag)
+	s := d.getSession(ctx, tpb.TEMPLATE_VARIETY_QUOTA, bag)
 	s.quotaArgs.QuotaAmount = qma.Amount
 	s.quotaArgs.DeduplicationID = qma.DeduplicationID
 	s.quotaArgs.BestEffort = qma.BestEffort
 
-	err := d.dispatch(s)
+	err := s.dispatch()
 	if err == nil {
 		err = s.err
 	}
+	qr := s.quotaResult
 
-	r := s.quotaResult
-	d.completeSession(s)
-
-	return r, err
+	d.putSession(s)
+	return qr, err
 }
 
 // Preprocess implementation of runtime.Impl.
 func (d *Impl) Preprocess(ctx context.Context, bag attribute.Bag, responseBag *attribute.MutableBag) error {
-	s := d.beginSession(ctx, tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR, bag)
+	s := d.getSession(ctx, tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR, bag)
 	s.responseBag = responseBag
 
-	err := d.dispatch(s)
+	err := s.dispatch()
 	if err == nil {
 		err = s.err
 	}
 
-	d.completeSession(s)
-
+	d.putSession(s)
 	return err
 }
 
-func (d *Impl) dispatch(session *session) error {
-	// Lookup the value of the identity attribute, so that we can extract the namespace to use for route
-	// lookup.
-	identityAttributeValue, err := getIdentityAttributeValue(session.bag, d.identityAttribute)
-	if err != nil {
-		// early return.
-		updateRequestCounters(time.Since(session.start), 0, 0, err != nil)
-		log.Warnf("unable to determine identity attribute value: '%v', operation='%d'", err, session.variety)
-		return err
-	}
-	namespace := getNamespace(identityAttributeValue)
+func (d *Impl) getSession(context context.Context, variety tpb.TemplateVariety, bag attribute.Bag) *session {
+	s := d.sessionPool.Get().(*session)
 
-	// Capture the routing context locally. It can change underneath us. We also need to decRef before
-	// completing the call.
-	r := d.acquireRoutingContext()
-
-	destinations := r.Routes.GetDestinations(session.variety, namespace)
-
-	// Update the context after ensuring that we will not short-circuit and return. This causes allocations.
-	session.ctx = d.updateContext(session.ctx, session.bag)
-
-	// TODO(Issue #2139): This is for old-style metadata based policy decisions. This should be eventually removed.
-	ctxProtocol, _ := session.bag.Get(config.ContextProtocolAttributeName)
-	tcp := ctxProtocol == config.ContextProtocolTCP
-
-	// Ensure that we can run dispatches to all destinations in parallel.
-	session.ensureParallelism(destinations.Count())
-
-	ninputs := 0
-	ndestinations := 0
-	for _, destination := range destinations.Entries() {
-		for _, group := range destination.InstanceGroups {
-			if !group.Matches(session.bag) || group.ResourceType.IsTCP() != tcp {
-				continue
-			}
-			ndestinations++
-
-			var state *dispatchState
-			// We dispatch multiple instances together at once to a handler for report calls. pre-acquire
-			// the state, so that we can use its instances field to stage the instance values before dispatch.
-			if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
-				state = d.statePool.get(session, destination)
-			}
-
-			for j, input := range group.Builders {
-				var instance interface{}
-				if instance, err = input(session.bag); err != nil {
-					log.Warnf("error creating instance: destination='%v', error='%v'", destination.FriendlyName, err)
-					continue
-				}
-				ninputs++
-
-				// For report templates, accumulate instances as much as possible before commencing dispatch.
-				if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
-					state.instances = append(state.instances, instance)
-					continue
-				}
-
-				// for other templates, dispatch for each instance individually.
-				state = d.statePool.get(session, destination)
-				state.instance = instance
-				if session.variety == tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR {
-					state.mapper = group.Mappers[j]
-					state.inputBag = session.bag
-				}
-
-				// Dispatch for singleton dispatches
-				state.quotaArgs = session.quotaArgs
-				d.dispatchToHandler(state)
-			}
-
-			if session.variety == tpb.TEMPLATE_VARIETY_REPORT {
-				// Do a multi-instance dispatch for report.
-				d.dispatchToHandler(state)
-			}
-		}
-	}
-
-	// wait on the dispatch states and accumulate results
-	var buf *bytes.Buffer
-	code := rpc.OK
-
-	err = nil
-	for session.activeDispatches > 0 {
-		state := <-session.completed
-		session.activeDispatches--
-
-		// Aggregate errors
-		if state.err != nil {
-			err = multierror.Append(err, state.err)
-		}
-
-		st := rpc.Status{Code: int32(rpc.OK)}
-
-		switch session.variety {
-		case tpb.TEMPLATE_VARIETY_REPORT:
-			// Do nothing
-
-		case tpb.TEMPLATE_VARIETY_CHECK:
-			if session.checkResult == nil {
-				r := state.checkResult
-				session.checkResult = &r
-			} else {
-				// clamp duration & use count to the minimum of current and new results
-				if session.checkResult.ValidDuration > state.checkResult.ValidDuration {
-					session.checkResult.ValidDuration = state.checkResult.ValidDuration
-				}
-				if session.checkResult.ValidUseCount > state.checkResult.ValidUseCount {
-					session.checkResult.ValidUseCount = state.checkResult.ValidUseCount
-				}
-			}
-			st = state.checkResult.Status
-
-		case tpb.TEMPLATE_VARIETY_QUOTA:
-			if session.quotaResult == nil {
-				r := state.quotaResult
-				session.quotaResult = &r
-			} else {
-				log.Warnf("Skipping quota op result due to previous value: '%v', op: '%s'",
-					state.quotaResult, state.destination.FriendlyName)
-			}
-			st = state.quotaResult.Status
-
-		case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
-			if state.outputBag != nil {
-				session.responseBag.Merge(state.outputBag)
-			}
-		}
-
-		if !status.IsOK(st) {
-			if buf == nil {
-				buf = pool.GetBuffer()
-				// the first failure result's code becomes the result code for the output
-				code = rpc.Code(st.Code)
-			} else {
-				buf.WriteString(", ")
-			}
-
-			buf.WriteString(state.destination.HandlerName + ":" + st.Message)
-		}
-
-		d.statePool.put(state)
-	}
-
-	if buf != nil {
-		switch session.variety {
-		case tpb.TEMPLATE_VARIETY_CHECK:
-			session.checkResult.Status = status.WithMessage(code, buf.String())
-		case tpb.TEMPLATE_VARIETY_QUOTA:
-			session.quotaResult.Status = status.WithMessage(code, buf.String())
-		}
-		pool.PutBuffer(buf)
-	}
-
-	session.err = err
-
-	r.DecRef()
-	updateRequestCounters(time.Since(session.start), ndestinations, ninputs, err != nil)
-
-	return nil
-}
-
-func (d *Impl) acquireRoutingContext() *RoutingContext {
-	d.contextLock.RLock()
-	ctx := d.context
-	ctx.IncRef()
-	d.contextLock.RUnlock()
-	return ctx
-}
-
-func (d *Impl) updateContext(ctx context.Context, bag attribute.Bag) context.Context {
-	data := &adapter.RequestData{}
-
-	// fill the destination information
-	if destSrvc, found := bag.Get(d.identityAttribute); found {
-		data.DestinationService = adapter.Service{FullName: destSrvc.(string)}
-	}
-
-	return adapter.NewContextWithRequestData(ctx, data)
-}
-
-func (d *Impl) beginSession(ctx context.Context, variety tpb.TemplateVariety, bag attribute.Bag) *session {
-	s := d.sessionPool.get()
-	s.start = time.Now()
+	s.impl = d
+	s.rc = d.acquireRoutingContext()
+	s.ctx = context
 	s.variety = variety
-	s.ctx = ctx
 	s.bag = bag
 
 	return s
 }
 
-func (d *Impl) completeSession(s *session) {
+func (d *Impl) putSession(s *session) {
+	s.rc.decRef()
 	s.clear()
-	d.sessionPool.put(s)
+	d.sessionPool.Put(s)
 }
 
-func (d *Impl) dispatchToHandler(s *dispatchState) {
-	s.session.activeDispatches++
+func (d *Impl) getDispatchState(context context.Context, destination *routing.Destination) *dispatchState {
+	ds := d.statePool.Get().(*dispatchState)
 
-	d.gp.ScheduleWork(doDispatchToHandler, s)
+	ds.destination = destination
+	ds.ctx = context
+
+	return ds
 }
 
-func doDispatchToHandler(param interface{}) {
-	s := param.(*dispatchState)
+func (d *Impl) putDispatchState(ds *dispatchState) {
+	ds.clear()
+	d.statePool.Put(ds)
+}
 
-	reachedEnd := false
+func (d *Impl) getReporter(context context.Context) *reporter {
+	r := d.reporterPool.Get().(*reporter)
 
-	defer func() {
-		if reachedEnd {
-			return
-		}
+	r.impl = d
+	r.rc = d.acquireRoutingContext()
+	r.ctx = context
 
-		r := recover()
-		s.err = fmt.Errorf("panic during handler dispatch: %v", r)
-		log.Errorf("%v", s.err)
+	return r
+}
 
-		if log.DebugEnabled() {
-			log.Debugf("stack dump for handler dispatch panic:\n%s", debug.Stack())
-		}
+func (d *Impl) putReporter(r *reporter) {
+	r.rc.decRef()
+	r.clear()
+	d.reporterPool.Put(r)
+}
 
-		s.session.completed <- s
-	}()
+func (d *Impl) acquireRoutingContext() *RoutingContext {
+	d.rcLock.RLock()
+	rc := d.rc
+	rc.incRef()
+	d.rcLock.RUnlock()
 
-	ctx := s.session.ctx
-	var span opentracing.Span
-	var start time.Time
-	span, ctx, start = s.beginSpan(ctx)
+	return rc
+}
 
-	log.Debugf("begin dispatch: destination='%s'", s.destination.FriendlyName)
-
-	switch s.destination.Template.Variety {
-	case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
-		s.outputBag, s.err = s.destination.Template.DispatchGenAttrs(
-			ctx, s.destination.Handler, s.instance, s.inputBag, s.mapper)
-
-	case tpb.TEMPLATE_VARIETY_CHECK:
-		s.checkResult, s.err = s.destination.Template.DispatchCheck(
-			ctx, s.destination.Handler, s.instance)
-
-	case tpb.TEMPLATE_VARIETY_REPORT:
-		s.err = s.destination.Template.DispatchReport(
-			ctx, s.destination.Handler, s.instances)
-
-	case tpb.TEMPLATE_VARIETY_QUOTA:
-		s.quotaResult, s.err = s.destination.Template.DispatchQuota(
-			ctx, s.destination.Handler, s.instance, s.quotaArgs)
-
-	default:
-		panic(fmt.Sprintf("unknown variety type: '%v'", s.destination.Template.Variety))
+// ChangeRoute changes the routing table on the Impl which, in turn, ends up creating a new RoutingContext.
+func (d *Impl) ChangeRoute(new *routing.Table) *RoutingContext {
+	newRC := &RoutingContext{
+		Routes: new,
 	}
 
-	log.Debugf("complete dispatch: destination='%s' {err:%v}", s.destination.FriendlyName, s.err)
+	d.rcLock.Lock()
+	old := d.rc
+	d.rc = newRC
+	d.rcLock.Unlock()
 
-	s.completeSpan(span, time.Since(start), s.err)
-	s.session.completed <- s
-
-	reachedEnd = true
-}
-
-func (s *dispatchState) beginSpan(ctx context.Context) (opentracing.Span, context.Context, time.Time) {
-	var span opentracing.Span
-	if s.session.trace {
-		span, ctx = opentracing.StartSpanFromContext(ctx, s.destination.FriendlyName)
-	}
-
-	return span, ctx, time.Now()
-}
-
-func (s *dispatchState) completeSpan(span opentracing.Span, duration time.Duration, err error) {
-	if s.session.trace {
-		logToDispatchSpan(span, s.destination.Template.Name, s.destination.HandlerName, s.destination.AdapterName, err)
-		span.Finish()
-	}
-	s.destination.Counters.Update(duration, err != nil)
+	return old
 }

--- a/mixer/pkg/runtime/dispatcher/dispatchstate.go
+++ b/mixer/pkg/runtime/dispatcher/dispatchstate.go
@@ -15,25 +15,32 @@
 package dispatcher
 
 import (
-	"sync"
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
 
+	opentracing "github.com/opentracing/opentracing-go"
+
+	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/runtime/routing"
 	"istio.io/istio/mixer/pkg/template"
+	"istio.io/istio/pkg/log"
 )
 
 // dispatchState keeps the input/output state during the dispatch to a handler. It is used as temporary
 // memory location to keep ephemeral state, thus avoiding garbage creation.
 type dispatchState struct {
 	session *session
+	ctx     context.Context
 
 	destination *routing.Destination
 	mapper      template.OutputMapperFn
 
 	inputBag  attribute.Bag
 	quotaArgs adapter.QuotaArgs
-	instance  interface{}
 	instances []interface{}
 
 	// output state that was collected from the handler.
@@ -43,47 +50,87 @@ type dispatchState struct {
 	quotaResult adapter.QuotaResult
 }
 
-func (s *dispatchState) clear() {
-	s.session = nil
-	s.destination = nil
-	s.mapper = nil
-	s.inputBag = nil
-	s.quotaArgs = adapter.QuotaArgs{}
-	s.instance = nil
-	s.err = nil
-	s.outputBag = nil
-	s.checkResult = adapter.CheckResult{}
-	s.quotaResult = adapter.QuotaResult{}
+func (ds *dispatchState) clear() {
+	ds.session = nil
+	ds.ctx = nil
+	ds.destination = nil
+	ds.mapper = nil
+	ds.inputBag = nil
+	ds.quotaArgs = adapter.QuotaArgs{}
+	ds.err = nil
+	ds.outputBag = nil
+	ds.checkResult = adapter.CheckResult{}
+	ds.quotaResult = adapter.QuotaResult{}
 
-	if s.instances != nil {
-		// re-slice to change the length to 0 without changing capacity.
-		s.instances = s.instances[:0]
+	// re-slice to change the length to 0 without changing capacity.
+	ds.instances = ds.instances[:0]
+}
+
+func (ds *dispatchState) beginSpan(ctx context.Context) (opentracing.Span, context.Context, time.Time) {
+	var span opentracing.Span
+	if ds.session.impl.enableTracing {
+		span, ctx = opentracing.StartSpanFromContext(ctx, ds.destination.FriendlyName)
 	}
+
+	return span, ctx, time.Now()
 }
 
-// pool of dispatchStates
-type dispatchStatePool struct {
-	pool sync.Pool
-}
-
-func newDispatchStatePool() *dispatchStatePool {
-	return &dispatchStatePool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				return &dispatchState{}
-			},
-		},
+func (ds *dispatchState) completeSpan(span opentracing.Span, duration time.Duration, err error) {
+	if ds.session.impl.enableTracing {
+		logToDispatchSpan(span, ds.destination.Template.Name, ds.destination.HandlerName, ds.destination.AdapterName, err)
+		span.Finish()
 	}
+	ds.destination.Counters.Update(duration, err != nil)
 }
 
-func (p *dispatchStatePool) get(session *session, destination *routing.Destination) *dispatchState {
-	s := p.pool.Get().(*dispatchState)
-	s.session = session
-	s.destination = destination
-	return s
-}
+func (ds *dispatchState) invokeHandler(interface{}) {
+	reachedEnd := false
 
-func (p *dispatchStatePool) put(s *dispatchState) {
-	s.clear()
-	p.pool.Put(s)
+	defer func() {
+		if reachedEnd {
+			return
+		}
+
+		r := recover()
+		ds.err = fmt.Errorf("panic during handler dispatch: %v", r)
+		log.Errorf("%v", ds.err)
+
+		if log.DebugEnabled() {
+			log.Debugf("stack dump for handler dispatch panic:\n%s", debug.Stack())
+		}
+
+		ds.session.completed <- ds
+	}()
+
+	span, ctx, start := ds.beginSpan(ds.ctx)
+
+	log.Debugf("begin dispatch: destination='%s'", ds.destination.FriendlyName)
+
+	switch ds.destination.Template.Variety {
+	case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
+		ds.outputBag, ds.err = ds.destination.Template.DispatchGenAttrs(
+			ctx, ds.destination.Handler, ds.instances[0], ds.inputBag, ds.mapper)
+
+	case tpb.TEMPLATE_VARIETY_CHECK:
+		ds.checkResult, ds.err = ds.destination.Template.DispatchCheck(
+			ctx, ds.destination.Handler, ds.instances[0])
+
+	case tpb.TEMPLATE_VARIETY_REPORT:
+		ds.err = ds.destination.Template.DispatchReport(
+			ctx, ds.destination.Handler, ds.instances)
+
+	case tpb.TEMPLATE_VARIETY_QUOTA:
+		ds.quotaResult, ds.err = ds.destination.Template.DispatchQuota(
+			ctx, ds.destination.Handler, ds.instances[0], ds.quotaArgs)
+
+	default:
+		panic(fmt.Sprintf("unknown variety type: '%v'", ds.destination.Template.Variety))
+	}
+
+	log.Debugf("complete dispatch: destination='%s' {err:%v}", ds.destination.FriendlyName, ds.err)
+
+	ds.completeSpan(span, time.Since(start), ds.err)
+	ds.session.completed <- ds
+
+	reachedEnd = true
 }

--- a/mixer/pkg/runtime/dispatcher/dispatchstate_test.go
+++ b/mixer/pkg/runtime/dispatcher/dispatchstate_test.go
@@ -15,6 +15,7 @@
 package dispatcher
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -25,45 +26,44 @@ import (
 )
 
 func TestDispatchStatePool(t *testing.T) {
-	session := &session{}
 	dest := &routing.Destination{}
+	ctx := context.TODO()
 
-	pool := newDispatchStatePool()
+	d := New("", nil, false)
 
 	// Prime the pool
 	states := make([]*dispatchState, 100)
 	for i := 0; i < 100; i++ {
-		s := pool.get(nil, nil)
+		s := d.getDispatchState(nil, nil)
 		states[i] = s
 	}
 	for i := 0; i < 100; i++ {
-		pool.put(states[i])
+		d.putDispatchState(states[i])
 	}
 
 	// test cleaning
 	for i := 0; i < 100; i++ {
-		s := pool.get(session, dest)
-		s.instance = "instanc"
+		s := d.getDispatchState(ctx, dest)
 		states[i] = s
 	}
 	for i := 0; i < 100; i++ {
-		pool.put(states[i])
+		d.putDispatchState(states[i])
 	}
 
 	expected := &dispatchState{}
 
 	for i := 0; i < 100; i++ {
-		s := pool.get(nil, nil)
+		s := d.getDispatchState(nil, nil)
 		if !reflect.DeepEqual(s, expected) {
-			t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
+			t.Fatalf("mismatch '%+v' != '%+v'", s, expected)
 		}
 	}
 }
 
 func TestDispatchState_Clear(t *testing.T) {
 	state := &dispatchState{
-		instance:    "instance",
 		session:     &session{},
+		ctx:         context.TODO(),
 		quotaResult: adapter.QuotaResult{Amount: 64},
 		checkResult: adapter.CheckResult{ValidUseCount: 32},
 		err:         errors.New("err"),

--- a/mixer/pkg/runtime/dispatcher/monitoring.go
+++ b/mixer/pkg/runtime/dispatcher/monitoring.go
@@ -15,33 +15,11 @@
 package dispatcher
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	buckets           = []float64{.0001, .00025, .0005, .001, .0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
-	countBuckets      = []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 15, 20}
-	requestLabelNames = []string{errorStr}
-
-	requestCountVector = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "mixer",
-		Subsystem: "dispatcher",
-		Name:      "request_count",
-		Help:      "Total number of requests that are handled by Mixer.",
-	}, requestLabelNames)
-	requestCount          = requestCountVector.WithLabelValues("false")
-	requestWithErrorCount = requestCountVector.WithLabelValues("true")
-
-	requestDuration = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: "mixer",
-			Subsystem: "dispatcher",
-			Name:      "request_duration",
-			Help:      "Histogram of times for requests handled by Mixer.",
-			Buckets:   buckets,
-		})
+	countBuckets = []float64{0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 15, 20}
 
 	destinationsPerRequest = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: "mixer",
@@ -61,24 +39,14 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(requestCountVector)
 	prometheus.MustRegister(destinationsPerRequest)
 	prometheus.MustRegister(instancesPerRequest)
-	prometheus.MustRegister(requestDuration)
 }
 
 // updateRequestCounters updates request related counters. Duration is the total request handling duration. Destinations
 // is the number of destinations (i.a. handlers) that were dispatched to, during handling. Similarly, inputs is the
-// total number of instances that got created and sent to the adapter. Failure indicates whether at least one of the
-// dispatches had an error.
-func updateRequestCounters(duration time.Duration, destinations int, inputs int, failure bool) {
-	if failure {
-		requestWithErrorCount.Inc()
-	} else {
-		requestCount.Inc()
-	}
-
+// total number of instances that got created and sent to the adapter.
+func updateRequestCounters(destinations int, inputs int) {
 	destinationsPerRequest.Observe(float64(destinations))
 	instancesPerRequest.Observe(float64(inputs))
-	requestDuration.Observe(duration.Seconds())
 }

--- a/mixer/pkg/runtime/dispatcher/reporter.go
+++ b/mixer/pkg/runtime/dispatcher/reporter.go
@@ -1,0 +1,83 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+
+	tpb "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/runtime/routing"
+)
+
+// Reporter is used to produce a series of reports
+type Reporter interface {
+	// Report adds an entry to the report state
+	Report(requestBag attribute.Bag) error
+
+	// Flush dispatches all buffered state to the appropriate adapters.
+	Flush() error
+
+	// Completes use of the reporter
+	Done()
+}
+
+// reporter is the implementation of the Reporter interface
+type reporter struct {
+	impl   *Impl
+	rc     *RoutingContext
+	ctx    context.Context
+	states map[*routing.Destination]*dispatchState
+}
+
+var _ Reporter = &reporter{}
+
+func (r *reporter) clear() {
+	r.impl = nil
+	r.rc = nil
+	r.ctx = nil
+
+	for k := range r.states {
+		delete(r.states, k)
+	}
+}
+
+func (r *reporter) Report(bag attribute.Bag) error {
+	s := r.impl.getSession(r.ctx, tpb.TEMPLATE_VARIETY_REPORT, bag)
+	s.reportStates = r.states
+
+	err := s.dispatch()
+	if err == nil {
+		err = s.err
+	}
+
+	r.impl.putSession(s)
+	return err
+}
+
+func (r *reporter) Flush() error {
+	s := r.impl.getSession(r.ctx, tpb.TEMPLATE_VARIETY_REPORT, nil)
+	s.reportStates = r.states
+
+	s.dispatchBufferedReports()
+	err := s.err
+
+	r.impl.putSession(s)
+	return err
+}
+
+func (r *reporter) Done() {
+	r.impl.putReporter(r)
+}

--- a/mixer/pkg/runtime/dispatcher/reporter_test.go
+++ b/mixer/pkg/runtime/dispatcher/reporter_test.go
@@ -1,0 +1,83 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"istio.io/istio/mixer/pkg/runtime/routing"
+)
+
+func TestReporterPool(t *testing.T) {
+	ctx := context.TODO()
+
+	d := New("", nil, false)
+
+	// Prime the pool
+	reporters := make([]*reporter, 100)
+	for i := 0; i < 100; i++ {
+		r := d.getReporter(nil)
+		reporters[i] = r
+	}
+	for i := 0; i < 100; i++ {
+		d.putReporter(reporters[i])
+	}
+
+	// test cleaning
+	for i := 0; i < 100; i++ {
+		r := d.getReporter(ctx)
+		reporters[i] = r
+	}
+	for i := 0; i < 100; i++ {
+		d.putReporter(reporters[i])
+	}
+
+	expected := &reporter{
+		impl:   d,
+		rc:     d.rc,
+		ctx:    ctx,
+		states: make(map[*routing.Destination]*dispatchState),
+	}
+
+	for i := 0; i < 100; i++ {
+		r := d.getReporter(ctx)
+		if !reflect.DeepEqual(r, expected) {
+			t.Fatalf("mismatch '%+v' != '%+v'", r, expected)
+		}
+	}
+}
+
+func TestReporter_Clear(t *testing.T) {
+	r := &reporter{
+		impl:   &Impl{},
+		ctx:    context.TODO(),
+		rc:     &RoutingContext{},
+		states: make(map[*routing.Destination]*dispatchState),
+	}
+
+	r.states[&routing.Destination{}] = &dispatchState{}
+
+	r.clear()
+
+	expected := &reporter{
+		states: make(map[*routing.Destination]*dispatchState),
+	}
+
+	if !reflect.DeepEqual(r, expected) {
+		t.Fatalf("mismatch '%+v' != '%+v'", r, expected)
+	}
+}

--- a/mixer/pkg/runtime/dispatcher/routingcontext.go
+++ b/mixer/pkg/runtime/dispatcher/routingcontext.go
@@ -1,0 +1,46 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"sync/atomic"
+
+	"istio.io/istio/mixer/pkg/runtime/routing"
+)
+
+// RoutingContext is the currently active dispatching context, based on a config snapshot. As config changes,
+// the current/live RoutingContext also changes.
+type RoutingContext struct {
+	// the routing table of this context.
+	Routes *routing.Table
+
+	// the current reference count. Indicates how many calls are currently using this RoutingContext.
+	refCount int32
+}
+
+// incRef increases the reference count on the RoutingContext.
+func (rc *RoutingContext) incRef() {
+	atomic.AddInt32(&rc.refCount, 1)
+}
+
+// decRef decreases the reference count on the RoutingContext.
+func (rc *RoutingContext) decRef() {
+	atomic.AddInt32(&rc.refCount, -1)
+}
+
+// GetRefs returns the current reference count on the dispatch context.
+func (rc *RoutingContext) GetRefs() int32 {
+	return atomic.LoadInt32(&rc.refCount)
+}

--- a/mixer/pkg/runtime/dispatcher/session.go
+++ b/mixer/pkg/runtime/dispatcher/session.go
@@ -15,13 +15,19 @@
 package dispatcher
 
 import (
+	"bytes"
 	"context"
-	"sync"
-	"time"
+
+	"github.com/gogo/googleapis/google/rpc"
+	multierror "github.com/hashicorp/go-multierror"
 
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/pool"
+	"istio.io/istio/mixer/pkg/runtime/config"
+	"istio.io/istio/mixer/pkg/runtime/routing"
+	"istio.io/istio/mixer/pkg/status"
 	"istio.io/istio/pkg/log"
 )
 
@@ -30,15 +36,18 @@ const queueAllocSize = 64
 // session represents a call session to the Impl. It contains all the mutable state needed for handling the
 // call. It is used as temporary memory location to keep ephemeral state, thus avoiding garbage creation.
 type session struct {
+	// owner
+	impl *Impl
 
-	// start time of the session.
-	start time.Time
+	// routing context for the life of this session
+	rc *RoutingContext
 
 	// input parameters that was collected as part of the call.
-	ctx         context.Context
-	bag         attribute.Bag
-	quotaArgs   adapter.QuotaArgs
-	responseBag *attribute.MutableBag
+	ctx          context.Context
+	bag          attribute.Bag
+	quotaArgs    adapter.QuotaArgs
+	responseBag  *attribute.MutableBag
+	reportStates map[*routing.Destination]*dispatchState
 
 	// output parameters that gets collected / accumulated as result.
 	checkResult *adapter.CheckResult
@@ -53,32 +62,17 @@ type session struct {
 
 	// The variety of the operation that is being performed.
 	variety tpb.TemplateVariety
-
-	// whether to trace spans or not
-	trace bool
-}
-
-// pool of sessions
-type sessionPool struct {
-	sessions sync.Pool
-}
-
-func (s *session) ensureParallelism(minParallelism int) {
-	// Resize the channel to accommodate the parallelism, if necessary.
-	if cap(s.completed) < minParallelism {
-		allocSize := ((minParallelism / queueAllocSize) + 1) * queueAllocSize
-		s.completed = make(chan *dispatchState, allocSize)
-	}
 }
 
 func (s *session) clear() {
+	s.impl = nil
+	s.rc = nil
 	s.variety = 0
 	s.ctx = nil
 	s.bag = nil
 	s.quotaArgs = adapter.QuotaArgs{}
 	s.responseBag = nil
-
-	s.start = time.Time{}
+	s.reportStates = nil
 
 	s.activeDispatches = 0
 	s.err = nil
@@ -98,27 +92,183 @@ func (s *session) clear() {
 	}
 }
 
-// returns a new pool of sessions that uses the provided go-routine pool to execute dispatches.
-func newSessionPool(enableTracing bool) *sessionPool {
-	return &sessionPool{
-		sessions: sync.Pool{
-			New: func() interface{} {
-				return &session{
-					trace: enableTracing,
-				}
-			},
-		},
+func (s *session) ensureParallelism(minParallelism int) {
+	// Resize the channel to accommodate the parallelism, if necessary.
+	if cap(s.completed) < minParallelism {
+		allocSize := ((minParallelism / queueAllocSize) + 1) * queueAllocSize
+		s.completed = make(chan *dispatchState, allocSize)
 	}
 }
 
-// returns a session from the pool that can support the specified number of parallel executions.
-func (p *sessionPool) get() *session {
-	session := p.sessions.Get().(*session)
+func (s *session) dispatch() error {
+	// Lookup the value of the identity attribute, so that we can extract the namespace to use for route
+	// lookup.
+	identityAttributeValue, err := getIdentityAttributeValue(s.bag, s.impl.identityAttribute)
+	if err != nil {
+		// early return.
+		updateRequestCounters(0, 0)
+		log.Warnf("unable to determine identity attribute value: '%v', operation='%d'", err, s.variety)
+		return err
+	}
+	namespace := getNamespace(identityAttributeValue)
+	destinations := s.rc.Routes.GetDestinations(s.variety, namespace)
+	ctx := adapter.NewContextWithRequestData(s.ctx, &adapter.RequestData{adapter.Service{identityAttributeValue}})
 
-	return session
+	// TODO(Issue #2139): This is for old-style metadata based policy decisions. This should be eventually removed.
+	ctxProtocol, _ := s.bag.Get(config.ContextProtocolAttributeName)
+	tcp := ctxProtocol == config.ContextProtocolTCP
+
+	// Ensure that we can run dispatches to all destinations in parallel.
+	s.ensureParallelism(destinations.Count())
+
+	ninputs := 0
+	ndestinations := 0
+	for _, destination := range destinations.Entries() {
+		var state *dispatchState
+
+		if s.variety == tpb.TEMPLATE_VARIETY_REPORT {
+			// We buffer states for report calls and dispatch them later
+			state = s.reportStates[destination]
+			if state == nil {
+				state = s.impl.getDispatchState(ctx, destination)
+				s.reportStates[destination] = state
+			}
+		}
+
+		for _, group := range destination.InstanceGroups {
+			if !group.Matches(s.bag) || group.ResourceType.IsTCP() != tcp {
+				continue
+			}
+			ndestinations++
+
+			for j, input := range group.Builders {
+				var instance interface{}
+				if instance, err = input(s.bag); err != nil {
+					log.Warnf("error creating instance: destination='%v', error='%v'", destination.FriendlyName, err)
+					continue
+				}
+				ninputs++
+
+				// For report templates, accumulate instances as much as possible before commencing dispatch.
+				if s.variety == tpb.TEMPLATE_VARIETY_REPORT {
+					state.instances = append(state.instances, instance)
+					continue
+				}
+
+				// for other templates, dispatch for each instance individually.
+				state = s.impl.getDispatchState(ctx, destination)
+				state.instances = append(state.instances, instance)
+				if s.variety == tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR {
+					state.mapper = group.Mappers[j]
+					state.inputBag = s.bag
+				}
+
+				// Dispatch for singleton dispatches
+				state.quotaArgs = s.quotaArgs
+				s.dispatchToHandler(state)
+			}
+		}
+	}
+
+	updateRequestCounters(ndestinations, ninputs)
+	s.waitForDispatched()
+
+	return nil
 }
 
-func (p *sessionPool) put(session *session) {
-	session.clear()
-	p.sessions.Put(session)
+func (s *session) dispatchBufferedReports() {
+	// Ensure that we can run dispatches to all destinations in parallel.
+	s.ensureParallelism(len(s.reportStates))
+
+	// dispatch the buffered dispatchStates we've got
+	for k, v := range s.reportStates {
+		s.dispatchToHandler(v)
+		delete(s.reportStates, k)
+	}
+
+	s.waitForDispatched()
+}
+
+func (s *session) dispatchToHandler(ds *dispatchState) {
+	s.activeDispatches++
+	ds.session = s
+	s.impl.gp.ScheduleWork(ds.invokeHandler, nil)
+}
+
+func (s *session) waitForDispatched() {
+	// wait on the dispatch states and accumulate results
+	var buf *bytes.Buffer
+	code := rpc.OK
+
+	var err error
+	for s.activeDispatches > 0 {
+		state := <-s.completed
+		s.activeDispatches--
+
+		// Aggregate errors
+		if state.err != nil {
+			err = multierror.Append(err, state.err)
+		}
+
+		st := rpc.Status{Code: int32(rpc.OK)}
+
+		switch s.variety {
+		case tpb.TEMPLATE_VARIETY_REPORT:
+			// Do nothing
+
+		case tpb.TEMPLATE_VARIETY_CHECK:
+			if s.checkResult == nil {
+				r := state.checkResult
+				s.checkResult = &r
+			} else {
+				if s.checkResult.ValidDuration > state.checkResult.ValidDuration {
+					s.checkResult.ValidDuration = state.checkResult.ValidDuration
+				}
+				if s.checkResult.ValidUseCount > state.checkResult.ValidUseCount {
+					s.checkResult.ValidUseCount = state.checkResult.ValidUseCount
+				}
+			}
+			st = state.checkResult.Status
+
+		case tpb.TEMPLATE_VARIETY_QUOTA:
+			if s.quotaResult == nil {
+				r := state.quotaResult
+				s.quotaResult = &r
+			} else {
+				log.Warnf("Skipping quota op result due to previous value: '%v', op: '%s'",
+					state.quotaResult, state.destination.FriendlyName)
+			}
+			st = state.quotaResult.Status
+
+		case tpb.TEMPLATE_VARIETY_ATTRIBUTE_GENERATOR:
+			if state.outputBag != nil {
+				s.responseBag.Merge(state.outputBag)
+			}
+		}
+
+		if !status.IsOK(st) {
+			if buf == nil {
+				buf = pool.GetBuffer()
+				// the first failure result's code becomes the result code for the output
+				code = rpc.Code(st.Code)
+			} else {
+				buf.WriteString(", ")
+			}
+
+			buf.WriteString(state.destination.HandlerName + ":" + st.Message)
+		}
+
+		s.impl.putDispatchState(state)
+	}
+	s.err = err
+
+	if buf != nil {
+		switch s.variety {
+		case tpb.TEMPLATE_VARIETY_CHECK:
+			s.checkResult.Status = status.WithMessage(code, buf.String())
+		case tpb.TEMPLATE_VARIETY_QUOTA:
+			s.quotaResult.Status = status.WithMessage(code, buf.String())
+		}
+		pool.PutBuffer(buf)
+	}
 }

--- a/mixer/pkg/runtime/dispatcher/session_test.go
+++ b/mixer/pkg/runtime/dispatcher/session_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-	"time"
 
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -27,56 +26,46 @@ import (
 )
 
 func TestSessionPool(t *testing.T) {
-	expected := &session{}
-
-	pool := newSessionPool(false)
+	d := New("", nil, false)
 
 	// Prime the pool
 	sessions := make([]*session, 100)
 	for i := 0; i < 100; i++ {
-		s := pool.get()
+		s := d.getSession(nil, 0, nil)
 		sessions[i] = s
 	}
 	for i := 0; i < 100; i++ {
-		pool.put(sessions[i])
+		d.putSession(sessions[i])
 	}
 
 	// test cleaning
 	for i := 0; i < 100; i++ {
-		s := pool.get()
+		s := d.getSession(nil, 0, nil)
 		s.activeDispatches = 53 + i
 		sessions[i] = s
 	}
 	for i := 0; i < 100; i++ {
-		pool.put(sessions[i])
+		d.putSession(sessions[i])
 	}
 
 	for i := 0; i < 100; i++ {
-		s := pool.get()
+		s := d.getSession(nil, 0, nil)
+
+		// all fields should be clean, except for these two
+		expected := &session{
+			impl: d,
+			rc:   d.rc,
+		}
+
 		if !reflect.DeepEqual(s, expected) {
 			t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
 		}
 	}
 }
 
-func TestSessionPool_TracingStickiness(t *testing.T) {
-	pool := newSessionPool(true)
-
-	s := pool.get()
-
-	expected := &session{trace: true}
-	if !reflect.DeepEqual(s, expected) {
-		t.Fatalf("session mismatch '%+v' != '%+v'", s, expected)
-	}
-	if !s.trace {
-		t.Fail()
-	}
-}
-
 func TestSession_Clear(t *testing.T) {
 	s := &session{
-		trace:            true,
-		start:            time.Now(),
+		impl:             New("", nil, false),
 		activeDispatches: 23,
 		bag:              attribute.GetMutableBag(nil),
 		completed:        make(chan *dispatchState, 10),
@@ -97,9 +86,7 @@ func TestSession_Clear(t *testing.T) {
 	}
 	s.completed = nil
 
-	expected := &session{
-		trace: true,
-	}
+	expected := &session{}
 
 	if !reflect.DeepEqual(s, expected) {
 		t.Fatalf("'%+v' != '%+v'", s, expected)

--- a/mixer/pkg/runtime/runtime_test.go
+++ b/mixer/pkg/runtime/runtime_test.go
@@ -253,6 +253,7 @@ func TestRuntime_InFlightRequestsDuringConfigChange(t *testing.T) {
 	callErr := errors.New("call haven't completed yet")
 	go func() {
 		_, callErr = rt.Dispatcher().Check(context.Background(), bag)
+
 		callComplete = true
 		callCompleteCh <- struct{}{}
 	}()


### PR DESCRIPTION
The proxy calls Mixer with large batches of reports (on the order
of 1000 items). Instead of calling adapters for each of these reports,
Mixer buffers the generated instances and calls into the adapters a
single time. This eliminates a fairly large amount of computation in Mixer
proper. But more importantly, adapters can leverage these large incoming
batches to use batches when talking to their back end, potentially reducing
RPC overhead considerably.

Also, remove the request_count and request_duration metrics. They weren't actually
measuring the right thing and they're redundant with gRPC metrics we already have.