### PR TITLE
Change zipkin {live,readi}ness path to '/health'

### DIFF
--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -31,11 +31,11 @@ spec:
                 fieldPath: metadata.namespace
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{ .Values.service.internalPort }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Change zipkin `{live,readi}ness` path to `/health`.
The ingress-gce needs the correct `readinessProbe` path that returns 200 status.

See https://github.com/openzipkin/zipkin/pull/997.