### PR TITLE
Remove comment and fix {live,readi}ness path to '/graph'

### DIFF
--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -25,14 +25,14 @@ spec:
             - containerPort: {{ .Values.service.internalPort }}
           args:
           - --prometheusAddr=http://prometheus:9090
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: {{ .Values.service.internalPort }}
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: {{ .Values.service.internalPort }}
+          livenessProbe:
+            httpGet:
+              path: /graph
+              port: {{ .Values.service.internalPort }}
+          readinessProbe:
+            httpGet:
+              path: /graph
+              port: {{ .Values.service.internalPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       affinity:


### PR DESCRIPTION
Remove comment and fix `{live,readi}ness` path to `/graph` on servicegraph `Deployment` template yaml.

This is workaround because servicegraph haven't the health check path.
But the ingress-gce needs the readinessProbe path that returns 200 status, so we should get 'generic JSON serialization' body and 200(`http.StatusOK`) status.