### PR TITLE
refactor secret controller

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -275,9 +275,6 @@ func (s *Server) initClusterRegistries(args *PilotArgs) (err error) {
 			s.clusterStore); err != nil {
 			return err
 		}
-	} else if err = clusterregistry.ReadClustersV2(s.kubeClient,
-		s.clusterStore, args.Namespace); err != nil {
-		return err
 	}
 	if s.clusterStore != nil {
 		log.Infof("clusters configuration %s", spew.Sdump(s.clusterStore))


### PR DESCRIPTION
Refactor secret controller, now the controller watches for all secrets with a specific label. This approach allows to track if the secret was created but the label was added/removed later and no extra logic requires for updates This PR also adds removal of a remote cluster from the slice of clusters.