### PR TITLE
Add dns lookup family to the clusters

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -420,6 +420,11 @@ func buildDefaultCluster(env model.Environment, name string, discoveryType v2.Cl
 		Type:  discoveryType,
 		Hosts: hosts,
 	}
+
+	if discoveryType == v2.Cluster_STRICT_DNS || discoveryType == v2.Cluster_LOGICAL_DNS {
+		cluster.DnsLookupFamily = v2.Cluster_V4_ONLY
+	}
+
 	defaultTrafficPolicy := buildDefaultTrafficPolicy(env, discoveryType)
 	applyTrafficPolicy(cluster, defaultTrafficPolicy, nil)
 	return cluster

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -194,7 +194,7 @@ test/local/cloudfoundry/e2e_pilotv2:
 test/local/noauth/e2e_bookinfo_envoyv2: generate_yaml-envoyv2_transition_loadbalancer_ingressgateway
 	@mkdir -p ${OUT_DIR}/logs
 	set -o pipefail; ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/bookinfo \
-	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=false --ingress=false --rbac_enable=false \
+	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=true --ingress=false --rbac_enable=false \
 	--v1alpha1=false --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} \
                 ${CAPTURE_LOG}
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -194,7 +194,7 @@ test/local/cloudfoundry/e2e_pilotv2:
 test/local/noauth/e2e_bookinfo_envoyv2: generate_yaml-envoyv2_transition_loadbalancer_ingressgateway
 	@mkdir -p ${OUT_DIR}/logs
 	set -o pipefail; ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/bookinfo \
-	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=true --ingress=false --rbac_enable=false \
+	--skip_cleanup --auth_enable=true --v1alpha3=true --egress=false --ingress=false --rbac_enable=false \
 	--v1alpha1=false --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} \
                 ${CAPTURE_LOG}
 


### PR DESCRIPTION
required due to https://github.com/envoyproxy/envoy/issues/3306
in v2, the default value of `dns_lookup_family `changed from `v4_only` to `auto`