### PR TITLE
[test-framework] First pass cleanup of the model (#2)

### DIFF
--- a/pkg/test/cluster/app.go
+++ b/pkg/test/cluster/app.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -85,6 +86,8 @@ type app struct {
 	namespace   string
 	endpoints   []*endpoint
 }
+
+var _ test.DeployedApp = &app{}
 
 func getApp(serviceName, namespace string) (test.DeployedApp, error) {
 	// Get the yaml config for the service
@@ -209,6 +212,14 @@ func (a *app) Call(url string, count int, headers http.Header) (test.AppCallResu
 	}
 
 	return out, nil
+}
+
+func (a *app) CallOrFail(url string, count int, headers http.Header, t *testing.T) test.AppCallResult {
+	r, err := a.Call(url, count, headers)
+	if err != nil {
+		t.Fatalf("Call to app failed: app='%s', url='%s', err='%v'", a.appName, url, err)
+	}
+	return r
 }
 
 func toExtra(headers http.Header) string {

--- a/pkg/test/dependency/cluster.go
+++ b/pkg/test/dependency/cluster.go
@@ -21,17 +21,8 @@ import (
 	"istio.io/istio/pkg/test/internal"
 )
 
-// Cluster dependency.
-var Cluster Dependency = &clusterDependency{exclusive: false}
-
-// ExclusiveCluster dependency.
-var ExclusiveCluster Dependency = &clusterDependency{exclusive: true}
-
 // GKE dependency
 var GKE Dependency = &clusterDependency{gke: true}
-
-// ExclusiveGKE dependency
-var ExclusiveGKE Dependency = &clusterDependency{exclusive: true, gke: true}
 
 // ClusterDependency represents a typed ClusterDependency dependency.
 type clusterDependency struct {

--- a/pkg/test/dependency/policybackend.go
+++ b/pkg/test/dependency/policybackend.go
@@ -16,27 +16,27 @@ package dependency
 
 import "istio.io/istio/pkg/test/internal"
 
-// RemoteSpyAdapter indicates a dependency on the remote spy adapter.
-var RemoteSpyAdapter Dependency = &remoteAdapter{}
+// PolicyBackend indicates a dependency on the mock policy backend.
+var PolicyBackend Dependency = &policyBackend{}
 
-type remoteAdapter struct {
+type policyBackend struct {
 }
 
-var _ Dependency = &remoteAdapter{}
-var _ internal.Stateful = &remoteAdapter{}
+var _ Dependency = &policyBackend{}
+var _ internal.Stateful = &policyBackend{}
 
-func (r *remoteAdapter) String() string {
-	return ""
+func (r *policyBackend) String() string {
+	return "policyBackend"
 }
 
-func (r *remoteAdapter) Initialize() (interface{}, error) {
+func (r *policyBackend) Initialize() (interface{}, error) {
 	return nil, nil
 }
 
-func (r *remoteAdapter) Reset(interface{}) error {
+func (r *policyBackend) Reset(interface{}) error {
 	return nil
 }
 
-func (r *remoteAdapter) Cleanup(interface{}) {
+func (r *policyBackend) Cleanup(interface{}) {
 
 }

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -49,8 +49,8 @@ type Environment interface {
 
 	// GetFortioApps returns a set of Fortio Apps based on the given selector
 	GetFortioApps(selector string, t *testing.T) []DeployedFortioApp
-	GetFortioApp(name string) DeployedFortioApp
 
+	// GetPolicyBackend returns the handle to a deployed fake policy backend.
 	GetPolicyBackend(t *testing.T) DeployedPolicyBackend
 }
 
@@ -72,8 +72,9 @@ type DeployedPolicyBackend interface {
 	Deployed
 
 	// DenyCheck indicates that the policy backend should deny all incoming check requests.
-	DenyCheck()
+	DenyCheck(deny bool)
 
+	// ExpectReport checks that the backend has received the given report request.
 	ExpectReport(t *testing.T, expected string)
 }
 

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -49,6 +49,9 @@ type Environment interface {
 
 	// GetFortioApps returns a set of Fortio Apps based on the given selector
 	GetFortioApps(selector string, t *testing.T) []DeployedFortioApp
+	GetFortioApp(name string) DeployedFortioApp
+
+	GetPolicyBackend(t *testing.T) DeployedPolicyBackend
 }
 
 // Deployed represents a deployed component
@@ -61,6 +64,17 @@ type DeployedApp interface {
 	Endpoints() []DeployedAppEndpoint
 	EndpointsForProtocol(protocol model.Protocol) []DeployedAppEndpoint
 	Call(url string, count int, headers http.Header) (AppCallResult, error)
+	CallOrFail(url string, count int, headers http.Header, t *testing.T) AppCallResult
+}
+
+// DeployedPolicyBackend represents a deployed fake policy backend for Mixer.
+type DeployedPolicyBackend interface {
+	Deployed
+
+	// DenyCheck indicates that the policy backend should deny all incoming check requests.
+	DenyCheck()
+
+	ExpectReport(t *testing.T, expected string)
 }
 
 // DeployedAppEndpoint represents a single endpoint in a DeployedApp.

--- a/pkg/test/label/labels.go
+++ b/pkg/test/label/labels.go
@@ -15,16 +15,10 @@
 package label
 
 const (
-	// Integration label
-	Integration Label = "integration"
-	// Unit label
-	Unit Label = "unit"
-	// E2E label
-	E2E Label = "e2e"
-	// Pilot label
-	Pilot Label = "pilot"
-	// Mixer label
-	Mixer Label = "mixer"
-	// LinuxOnly label
-	LinuxOnly Label = "linuxonly"
+
+	// Policy label indicates that this test is for testing policy related functionality.
+	Policy Label = "policy"
+
+	// Networking label indicates that this test is for testing networking related functionality.
+	Networking Label = "networking"
 )

--- a/pkg/test/operations.go
+++ b/pkg/test/operations.go
@@ -17,7 +17,6 @@ package test
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -47,6 +46,10 @@ func Run(testID string, m *testing.M) {
 // Ignore the test with the given reason.
 func Ignore(t testing.TB, reason string) {
 	t.Skipf("Skipping(Ignored): %s", reason)
+}
+
+func SuiteRequires(m *testing.M, dependencies ...dependency.Dependency) {
+	// TODO
 }
 
 // Requires ensures that the given dependencies will be satisfied. If they cannot, then the
@@ -82,6 +85,10 @@ func Requires(t testing.TB, dependencies ...dependency.Dependency) {
 	}
 }
 
+func SuiteTag(m *testing.M, labels ...label.Label) {
+	// TODO
+}
+
 // Tag the test with the given labels. The user can filter using the labels.
 // TODO: The polarity of this is a bit borked. If the test doesn't call Tag, then it won't get filtered out.
 func Tag(t testing.TB, labels ...label.Label) {
@@ -103,22 +110,7 @@ func Tag(t testing.TB, labels ...label.Label) {
 		}
 	}
 
-	if !skip {
-		checkWellknownLabels(t, labels...)
-	}
-
 	if skip && !t.Skipped() {
 		t.Skip("Skipping(Filtered): No matching label found")
-	}
-}
-
-func checkWellknownLabels(t testing.TB, labels ...label.Label) {
-	for _, l := range labels {
-		switch l {
-		case label.LinuxOnly:
-			if runtime.GOOS != "linux" {
-				t.Skipf("Skipping(Filtered): The operating system is not Linux: %s", runtime.GOOS)
-			}
-		}
 	}
 }

--- a/pkg/test/operations.go
+++ b/pkg/test/operations.go
@@ -48,6 +48,7 @@ func Ignore(t testing.TB, reason string) {
 	t.Skipf("Skipping(Ignored): %s", reason)
 }
 
+// SuiteRequires applies the given dependencies to all tests in the suite.
 func SuiteRequires(m *testing.M, dependencies ...dependency.Dependency) {
 	// TODO
 }
@@ -85,6 +86,7 @@ func Requires(t testing.TB, dependencies ...dependency.Dependency) {
 	}
 }
 
+// SuiteTag tags all tests within the suite with the given labels. The user can filter using the labels.
 func SuiteTag(m *testing.M, labels ...label.Label) {
 	// TODO
 }


### PR DESCRIPTION
- Add CallOrFail to DeployedApp for expedient test authoring.
- Replace the Mixer mock adapter with a mock PolicyBackend. This is much
easier to manage from a testing standpoint.
- Remove label based custom logic. Labels are used for filtering only.
- Align Mixer showcase test with the Pilot app model. This way, we can
author Mixer integrations tests by applying configuration and controlling
app/Mixer backend behavior.