### PR TITLE
[test-framework] Rationalize FortioApp model. (#1)

### DIFF
--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -41,7 +41,14 @@ type Environment interface {
 	GetApp(name string) (DeployedApp, error)
 	// GetAppOrFail attempts to return the app object for the given name, or fails the test if unsuccessful.
 	GetAppOrFail(name string, t *testing.T) DeployedApp
-	GetFortioApp(name string) DeployedFortioApp
+
+	// GetFortioApp returns a Fortio App object for the given name.
+	GetFortioApp(name string) (DeployedFortioApp, error)
+	// GetFortioApp returns a Fortio App object for the given name, or fails the test if unsuccessful.
+	GetFortioAppOrFail(name string, t *testing.T) (DeployedFortioApp, error)
+
+	// GetFortioApps returns a set of Fortio Apps based on the given selector
+	GetFortioApps(selector string, t *testing.T) []DeployedFortioApp
 }
 
 // Deployed represents a deployed component
@@ -100,7 +107,7 @@ type DeployedPilot interface {
 
 type DeployedFortioApp interface {
 	Deployed
-	CallFortio(arg string, path sting) (AppFortioCallResponse, error)
+	CallFortio(arg string, path string) (AppFortioCallResponse, error)
 }
 
 // AppFortioCallResponse provides details about the result of a fortio call

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -105,13 +105,14 @@ type DeployedPilot interface {
 	Deployed
 }
 
+// DeployedFortioApp represents a deployed fake Fortio App within the mesh.
 type DeployedFortioApp interface {
 	Deployed
-	CallFortio(arg string, path string) (AppFortioCallResponse, error)
+	CallFortio(arg string, path string) (FortioAppCallResult, error)
 }
 
-// AppFortioCallResponse provides details about the result of a fortio call
-type AppFortioCallResponse struct {
+// FortioAppCallResult provides details about the result of a fortio call
+type FortioAppCallResult struct {
 	// The raw content of the response
 	Raw string
 }

--- a/tests/e2e/tests/showcase/simple_showcase_test.go
+++ b/tests/e2e/tests/showcase/simple_showcase_test.go
@@ -1,4 +1,3 @@
-
 //  Copyright 2018 Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,28 +16,28 @@ package showcase
 
 import (
 	"istio.io/istio/pkg/test"
-	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/dependency"
 	"testing"
 )
 
-var cfg = ""
+var svcCfg = ""
 
 // Reimplement TestSvc2Svc in a_simple-1_test.go
 func TestSvcLoading(t *testing.T) {
 	// This Requires statement should ensure that all elements are in runnig states
-	test.Requires(t, denpendency.FortioApps, dependency.Pilot)
+	test.Requires(t, dependency.FortioApps, dependency.Pilot)
 
 	env := test.GetEnvironment(t)
-	env.Configure(cfg)
+	env.Configure(svcCfg)
 
-	apps := env.GetFortioApp("app=echosrv")
+	apps := env.GetFortioApps("app=echosrv", t)
 
 	path := "/echo"
 	arg := "load -qps 0 -t 10s "
 	// Test Loading
 	for _, app := range apps {
 		if _, err := app.CallFortio(arg, path); err != nil {
-			t.Fatal("Failed to run fortio %s.", err)
+			t.Fatalf("Failed to run fortio %s.", err)
 		}
 	}
 }


### PR DESCRIPTION
- GetFortioApp returns a single instance of DeployedFortioApp and error.
It uses a name pick the app directly, similar to the GetApp model.
- Add *OrFail overload, similar to GetApp case.
- Add GetFortioApps which has a label selector, and returns an array of
deployed apps.