### PR TITLE
Change GKE version from 1.9.6-gke.0 to 1.9.6-gke.1

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -8,7 +8,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ properties['gkeClusterName'] }}
-      initialClusterVersion: 1.9.6-gke.0
+      initialClusterVersion: 1.9.6-gke.1
       legacyAbac:
         enabled: false
       initialNodeCount: {{ properties['initialNodeCount'] }}


### PR DESCRIPTION
1.9.6-gke.0 is not available in GCP anymore, 1.9.6-gke.1 should be used instead.

Currently, GCP DM deployment fails with following error:
istio-cluster: {"ResourceType":"container.v1.cluster","ResourceErrorCode":"400","ResourceErrorMessage":{"code":400,"message":"Version "1.9.6-gke.0" is invalid.","status":"INVALID_ARGUMENT","statusMessage":"Bad Request","requestPath":"https://container.googleapis.com/v1/projects/aburnos-kube-playground/zones/us-central1-a/clusters","httpMethod":"POST"}}