### PR TITLE
Use the global image pull policy flag in the sidecar-injector ConfigMap

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
         {{ "[[ else -]]" }}
         - "{{ .Values.excludeInboundPorts }}"
         {{ "[[ end -]]" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
             add:
@@ -123,7 +123,7 @@ data:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
             privileged: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
In addition to the changes done in #5401, also updated `imagePullPolicy` in `sidecar-injector` ConfigMap to follow the global flag.