### PR TITLE
Fix duplicate key on helm ingress/deployment.yaml template

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: 80
-              containerPort: 443
+            - containerPort: 443
           args:
           - proxy
           - ingress


### PR DESCRIPTION
Fix duplicate key(not array) on helm ingress `deployment.yaml` template.

ref: #5433