### PR TITLE
Support building Linux images on a Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GOARCH_LOCAL := $(LOCAL_ARCH)
 endif
 export GOARCH ?= $(GOARCH_LOCAL)
 
-LOCAL_OS := $(shell uname)
+LOCAL_OS := $(if $(TARGET_OS),$(TARGET_OS),$(shell uname))
 ifeq ($(LOCAL_OS),Linux)
    export GOOS_LOCAL = linux
 else ifeq ($(LOCAL_OS),Darwin)

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -45,7 +45,7 @@ export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 export GOARCH=${GOARCH:-'amd64'}
 
 # Determine the OS. Matches logic in the Makefile.
-LOCAL_OS="`uname`"
+LOCAL_OS=${TARGET_OS:-"`uname`"}
 case $LOCAL_OS in
   'Linux')
     LOCAL_OS='linux'


### PR DESCRIPTION
By setting a `TARGET_OS=Linux` flag this change allows me build and push Docker images for a Linux OS on a MacOS.
If the `TARGET_OS` is unset then it's functioning as it was before.

Minor contribution to #3921.