### PR TITLE
Use access log configuration in template and

### DIFF
--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -260,7 +260,7 @@ func (s *TestSetup) CreateEnvoyConf(path string, stress bool, filtersBeforeMixer
 		AdminPort:       ports.AdminPort,
 		MixerServer:     fmt.Sprintf("localhost:%d", ports.MixerPort),
 		Backend:         fmt.Sprintf("localhost:%d", ports.BackendPort),
-		AccessLog:       "/tmp/envoy-access.log",
+		AccessLog:       s.AccessLogPath,
 		ServerConfig:    getConfig(mfConfig.HTTPServerConf, confVersion),
 		ClientConfig:    getConfig(mfConfig.HTTPClientConf, confVersion),
 		TCPServerConfig: getConfig(mfConfig.TCPServerConf, confVersion),

--- a/mixer/test/client/env/envoy_conf.go
+++ b/mixer/test/client/env/envoy_conf.go
@@ -260,7 +260,7 @@ func (s *TestSetup) CreateEnvoyConf(path string, stress bool, filtersBeforeMixer
 		AdminPort:       ports.AdminPort,
 		MixerServer:     fmt.Sprintf("localhost:%d", ports.MixerPort),
 		Backend:         fmt.Sprintf("localhost:%d", ports.BackendPort),
-		AccessLog:       "/dev/stdout",
+		AccessLog:       "/tmp/envoy-access.log",
 		ServerConfig:    getConfig(mfConfig.HTTPServerConf, confVersion),
 		ClientConfig:    getConfig(mfConfig.HTTPClientConf, confVersion),
 		TCPServerConfig: getConfig(mfConfig.TCPServerConf, confVersion),

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -61,6 +61,9 @@ type TestSetup struct {
 
 	// IstioOut is the base output directory.
 	IstioOut string
+
+	// AccessLogPath is the access log path for Envoy
+	AccessLogPath string
 }
 
 // MixerFilterConfigV1 is version v1 for Mixer filter config.
@@ -78,6 +81,7 @@ func NewTestSetup(name uint16, t *testing.T) *TestSetup {
 		ports:         NewPorts(name),
 		testName:      name,
 		mfConfVersion: MixerFilterConfigV2,
+		AccessLogPath: "/tmp/envoy-access.log",
 	}
 }
 

--- a/tests/testdata/bootstrap_tmpl.json
+++ b/tests/testdata/bootstrap_tmpl.json
@@ -13,7 +13,7 @@
     "use_all_default_tags": false
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "{{.AccessLog}}",
     "address": {
       "socket_address": {
         "address": "0.0.0.0",
@@ -208,7 +208,7 @@
                 {
                   "name": "envoy.file_access_log",
                   "config": {
-                      "path":  "/dev/stdout"
+                      "path":  "{{.AccessLog}}"
                    }
                 }
               ]
@@ -251,7 +251,7 @@
                 {
                   "name": "envoy.file_access_log",
                   "config": {
-                      "path":  "/dev/stdout"
+                      "path":  "{{.AccessLog}}"
                    }
                 }
               ]


### PR DESCRIPTION
write access log to a fixed file in /tmp to avoid permission problem
on MacOS with /dev/stdout.