### PR TITLE
Create CA certs and make citadel run with designated certs in multi-c…

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
@@ -28,8 +28,21 @@ spec:
             - --append-dns-names=true
             - --grpc-port=8060
             - --grpc-hostname=citadel
-            - --self-signed-ca=true
+            - --citadel-storage-namespace={{ .Release.Namespace }}
+            - --self-signed-ca=false
+            - --signing-cert=/etc/cacerts/ca-cert.pem
+            - --signing-key=/etc/cacerts/ca-key.pem
+            - --root-cert=/etc/cacerts/root-cert.pem
+            - --cert-chain=/etc/cacerts/cert-chain.pem
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+          volumeMounts:
+          - name: cacerts
+            mountPath: /etc/cacerts
+            readOnly: true
+      volumes:
+      - name: cacerts
+        secret:
+         secretName: cacerts
+         optional: true
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -28,9 +28,27 @@ spec:
             - --append-dns-names=true
             - --grpc-port=8060
             - --grpc-hostname=citadel
-            - --self-signed-ca=true
             - --citadel-storage-namespace={{ .Release.Namespace }}
+          {{- if .Values.global.multicluster.enabled }}
+            - --self-signed-ca=false
+            - --signing-cert=/etc/cacerts/ca-cert.pem
+            - --signing-key=/etc/cacerts/ca-key.pem
+            - --root-cert=/etc/cacerts/root-cert.pem
+            - --cert-chain=/etc/cacerts/cert-chain.pem
+          {{- else }}
+            - --self-signed-ca=true
+          {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.global.multicluster.enabled }}
+          volumeMounts:
+          - name: cacerts
+            mountPath: /etc/cacerts
+            readOnly: true
+      volumes:
+      - name: cacerts
+        secret:
+         secretName: cacerts
+         optional: true
+{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -58,6 +58,10 @@ const (
 	defaultGalleyConfigValidatorFile = "istio-galley-config-validator.yaml"
 	maxDeploymentRolloutTime         = 480 * time.Second
 	mtlsExcludedServicesPattern      = "mtlsExcludedServices:\\s*\\[(.*)\\]"
+	caCertFileName                   = "samples/certs/ca-cert.pem"
+	caKeyFileName                    = "samples/certs/ca-key.pem"
+	rootCertFileName                 = "samples/certs/root-cert.pem"
+	certChainFileName                = "samples/certs/cert-chain.pem"
 )
 
 var (
@@ -564,6 +568,11 @@ func (k *KubeInfo) deployIstio() error {
 		return err
 	}
 
+	if *multiClusterDir != "" {
+		if err := k.createCacerts(false); err != nil {
+			log.Infof("Failed to create Cacerts with namespace %s in primary cluster", k.Namespace)
+		}
+	}
 	if err := util.KubeApply(k.Namespace, testIstioYaml, k.KubeConfig); err != nil {
 		log.Errorf("Istio core %s deployment failed", testIstioYaml)
 		return err
@@ -579,6 +588,10 @@ func (k *KubeInfo) deployIstio() error {
 		if err := util.CreateMultiClusterSecrets(k.Namespace, k.KubeClient, k.RemoteKubeConfig); err != nil {
 			log.Errorf("Unable to create secrets on local cluster %s", err.Error())
 			return err
+		}
+
+		if err := k.createCacerts(true); err != nil {
+			log.Infof("Failed to create Cacerts with namespace %s in remote cluster", k.Namespace)
 		}
 
 		yamlDir := filepath.Join(istioInstallDir, mcRemoteInstallFile)

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -25,6 +25,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/tests/util"
 )
 
 func getKubeConfigFromFile(dirname string) (string, error) {
@@ -114,4 +115,23 @@ func (k *KubeInfo) generateRemoteIstio(src, dst string) error {
 		log.Errorf("cannot write remote into generated yaml file %s", dst)
 	}
 	return nil
+}
+
+func (k *KubeInfo) createCacerts(remoteCluster bool) (err error) {
+	kc := k.KubeConfig
+	cluster := "primary"
+	if remoteCluster {
+		kc = k.RemoteKubeConfig
+		cluster = "remote"
+	}
+	caCertFile := filepath.Join(k.ReleaseDir, caCertFileName)
+	caKeyFile := filepath.Join(k.ReleaseDir, caKeyFileName)
+	rootCertFile := filepath.Join(k.ReleaseDir, rootCertFileName)
+	certChainFile := filepath.Join(k.ReleaseDir, certChainFileName)
+	if _, err = util.Shell("kubectl create secret generic cacerts --kubeconfig=%s -n %s "+
+		"--from-file=%s --from-file=%s --from-file=%s --from-file=%s",
+		kc, k.Namespace, caCertFile, caKeyFile, rootCertFile, certChainFile); err == nil {
+		log.Infof("Created Cacerts with namespace %s in %s cluster", k.Namespace, cluster)
+	}
+	return err
 }


### PR DESCRIPTION
To enable e2e tests in a multiple cluster environment, we choose to run citadel in each of the clusters with the same root certificate so that communications with mTLS between the clusters is possible. In a non-test environment, a user can create the same secret cacerts (with the designated file names), and use the same helm charts to deploy citadel.