### PR TITLE
[test-framework] Add internal interface for the environment

### DIFF
--- a/pkg/test/cluster/environment.go
+++ b/pkg/test/cluster/environment.go
@@ -22,7 +22,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Environment a cluster-based environment for testing.
+// Environment a cluster-based environment for testing. It implements environment.Interface, and also
+// hosts publicly accessible methods that are specific to cluster environment.
 type Environment struct {
 	config *rest.Config
 
@@ -31,6 +32,7 @@ type Environment struct {
 }
 
 var _ environment.Interface = &Environment{}
+var _ Internal = &Environment{}
 
 // NewEnvironment returns a new instance of cluster environment.
 func NewEnvironment(kubeConfigPath string) (*Environment, error) {
@@ -39,7 +41,7 @@ func NewEnvironment(kubeConfigPath string) (*Environment, error) {
 		return nil, err
 	}
 
-	return	&Environment{
+	return &Environment{
 		config: config,
 	}, nil
 }

--- a/pkg/test/cluster/environment.go
+++ b/pkg/test/cluster/environment.go
@@ -18,16 +18,31 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/environment"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Environment a cluster-based environment for testing.
 type Environment struct {
-	T                    testing.TB
+	config *rest.Config
+
 	IstioSystemNamespace string
 	AppNamespace         string
 }
 
 var _ environment.Interface = &Environment{}
+
+// NewEnvironment returns a new instance of cluster environment.
+func NewEnvironment(kubeConfigPath string) (*Environment, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return	&Environment{
+		config: config,
+	}, nil
+}
 
 // Configure applies the given configuration to the mesh.
 func (e *Environment) Configure(config string) {

--- a/pkg/test/cluster/internal.go
+++ b/pkg/test/cluster/internal.go
@@ -1,0 +1,21 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package cluster
+
+// Internal interface defines internal implementation details of the environment that is used by the
+// test framework *only*. It should never be used directly in a test, or a test utility that resides with the
+// tests themselves.
+type Internal interface {
+}

--- a/pkg/test/dependency/apps.go
+++ b/pkg/test/dependency/apps.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // Apps is a dependency on fake networked apps. This can be used to mimic traffic thru a mesh.
 var Apps Dependency = &apps{}
@@ -29,14 +32,14 @@ func (a *apps) String() string {
 	return "apps"
 }
 
-func (a *apps) Initialize() (interface{}, error) {
+func (a *apps) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (a *apps) Reset(interface{}) error {
+func (a *apps) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (a *apps) Cleanup(interface{}) {
+func (a *apps) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/dependency/cluster.go
+++ b/pkg/test/dependency/cluster.go
@@ -26,7 +26,7 @@ var GKE Dependency = &clusterDependency{gke: true}
 
 // ClusterDependency represents a typed ClusterDependency dependency.
 type clusterDependency struct {
-	gke       bool
+	gke bool
 }
 
 // Dependency is the default dependency

--- a/pkg/test/dependency/cluster.go
+++ b/pkg/test/dependency/cluster.go
@@ -15,6 +15,7 @@
 package dependency
 
 import (
+	"istio.io/istio/pkg/test/environment"
 	"k8s.io/client-go/rest"
 
 	"istio.io/istio/pkg/test/internal"
@@ -25,7 +26,6 @@ var GKE Dependency = &clusterDependency{gke: true}
 
 // ClusterDependency represents a typed ClusterDependency dependency.
 type clusterDependency struct {
-	exclusive bool
 	gke       bool
 }
 
@@ -37,16 +37,16 @@ func (a *clusterDependency) String() string {
 	return "cluster"
 }
 
-func (a *clusterDependency) Initialize() (interface{}, error) {
+func (a *clusterDependency) Initialize(env environment.Interface) (interface{}, error) {
 	// TODO
 	return nil, nil
 }
 
-func (a *clusterDependency) Reset(interface{}) error {
+func (a *clusterDependency) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (a *clusterDependency) Cleanup(interface{}) {
+func (a *clusterDependency) Cleanup(env environment.Interface, state interface{}) {
 }
 
 // GetConfig returns the configuration

--- a/pkg/test/dependency/fortioapps.go
+++ b/pkg/test/dependency/fortioapps.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // FortioApps indicates a dependency on FortioApps.
 var FortioApps Dependency = &fortioapps{}
@@ -29,14 +32,14 @@ func (f *fortioapps) String() string {
 	return ""
 }
 
-func (f *fortioapps) Initialize() (interface{}, error) {
+func (f *fortioapps) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (f *fortioapps) Reset(interface{}) error {
+func (f *fortioapps) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (f *fortioapps) Cleanup(interface{}) {
+func (f *fortioapps) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/dependency/mixer.go
+++ b/pkg/test/dependency/mixer.go
@@ -15,14 +15,21 @@
 package dependency
 
 import (
+	"fmt"
+	"reflect"
+
+	"istio.io/istio/pkg/test/cluster"
 	"istio.io/istio/pkg/test/environment"
 	"istio.io/istio/pkg/test/internal"
+	"istio.io/istio/pkg/test/local"
 )
 
 // Mixer indicates a dependency on Mixer.
 var Mixer Dependency = &mixer{}
 
 type mixer struct {
+	cluster cluster.Internal
+	local   local.Internal
 }
 
 var _ Dependency = &mixer{}
@@ -33,7 +40,13 @@ func (a *mixer) String() string {
 }
 
 func (a *mixer) Initialize(env environment.Interface) (interface{}, error) {
-	return nil, nil
+	if c, ok := env.(cluster.Internal); ok {
+		return a.initializeCluster(c)
+	} else if l, ok := env.(local.Internal); ok {
+		return a.initializeLocal(l)
+	} else {
+		return nil, fmt.Errorf("unknown environment type: %v", reflect.TypeOf(env))
+	}
 }
 
 func (a *mixer) Reset(env environment.Interface, state interface{}) error {
@@ -42,4 +55,12 @@ func (a *mixer) Reset(env environment.Interface, state interface{}) error {
 
 func (a *mixer) Cleanup(env environment.Interface, state interface{}) {
 
+}
+
+func (a *mixer) initializeCluster(e cluster.Internal) (interface{}, error) {
+	return nil, nil
+}
+
+func (a *mixer) initializeLocal(e local.Internal) (interface{}, error) {
+	return nil, nil
 }

--- a/pkg/test/dependency/mixer.go
+++ b/pkg/test/dependency/mixer.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // Mixer indicates a dependency on Mixer.
 var Mixer Dependency = &mixer{}
@@ -29,14 +32,14 @@ func (a *mixer) String() string {
 	return "mixer"
 }
 
-func (a *mixer) Initialize() (interface{}, error) {
+func (a *mixer) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (a *mixer) Reset(interface{}) error {
+func (a *mixer) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (a *mixer) Cleanup(interface{}) {
+func (a *mixer) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/dependency/mtls.go
+++ b/pkg/test/dependency/mtls.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // MTLS indicates a dependency on MTLS being enabled.
 var MTLS Dependency = &mtls{}
@@ -29,14 +32,14 @@ func (r *mtls) String() string {
 	return ""
 }
 
-func (r *mtls) Initialize() (interface{}, error) {
+func (r *mtls) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (r *mtls) Reset(interface{}) error {
+func (r *mtls) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (r *mtls) Cleanup(interface{}) {
+func (r *mtls) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/dependency/pilot.go
+++ b/pkg/test/dependency/pilot.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // Pilot indicates a dependency on Pilot.
 var Pilot Dependency = &pilot{}
@@ -29,14 +32,14 @@ func (a *pilot) String() string {
 	return ""
 }
 
-func (a *pilot) Initialize() (interface{}, error) {
+func (a *pilot) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (a *pilot) Reset(interface{}) error {
+func (a *pilot) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (a *pilot) Cleanup(interface{}) {
+func (a *pilot) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/dependency/policybackend.go
+++ b/pkg/test/dependency/policybackend.go
@@ -14,7 +14,10 @@
 
 package dependency
 
-import "istio.io/istio/pkg/test/internal"
+import (
+	"istio.io/istio/pkg/test/environment"
+	"istio.io/istio/pkg/test/internal"
+)
 
 // PolicyBackend indicates a dependency on the mock policy backend.
 var PolicyBackend Dependency = &policyBackend{}
@@ -29,14 +32,14 @@ func (r *policyBackend) String() string {
 	return "policyBackend"
 }
 
-func (r *policyBackend) Initialize() (interface{}, error) {
+func (r *policyBackend) Initialize(env environment.Interface) (interface{}, error) {
 	return nil, nil
 }
 
-func (r *policyBackend) Reset(interface{}) error {
+func (r *policyBackend) Reset(env environment.Interface, state interface{}) error {
 	return nil
 }
 
-func (r *policyBackend) Cleanup(interface{}) {
+func (r *policyBackend) Cleanup(env environment.Interface, state interface{}) {
 
 }

--- a/pkg/test/impl/driver/instance.go
+++ b/pkg/test/impl/driver/instance.go
@@ -43,10 +43,10 @@ type driver struct {
 
 	allowedLabels map[label.Label]struct{}
 
-	testID string
-	runID  string
-	m      *testing.M
-	env   environment.Interface
+	testID  string
+	runID   string
+	m       *testing.M
+	env     environment.Interface
 	running bool
 
 	suiteDependencies []dependency.Dependency

--- a/pkg/test/impl/driver/instance.go
+++ b/pkg/test/impl/driver/instance.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"istio.io/istio/pkg/test/cluster"
+	"istio.io/istio/pkg/test/local"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/dependency"
@@ -44,8 +46,10 @@ type driver struct {
 	testID string
 	runID  string
 	m      *testing.M
-
+	env   environment.Interface
 	running bool
+
+	suiteDependencies []dependency.Dependency
 
 	initializedDependencies map[dependency.Dependency]interface{}
 }
@@ -82,6 +86,27 @@ func (d *driver) Initialize(a *Args) error {
 	// 	return
 	// }
 	//
+
+	d.suiteDependencies = a.SuiteDependencies
+
+	var env environment.Interface
+	var err error
+	switch a.Environment {
+	case EnvLocal:
+		env, err = local.NewEnvironment()
+
+	case EnvKubernetes:
+		env, err = cluster.NewEnvironment(a.KubeConfig)
+
+	default:
+		return fmt.Errorf("unrecognized environment: %s", a.Environment)
+	}
+
+	if err != nil {
+		return fmt.Errorf("unable to initialize environment '%s': %v", a.Environment, err)
+	}
+	d.env = env
+
 	d.testID = a.TestID
 	d.runID = generateRunID(a.TestID)
 	d.m = a.M
@@ -94,12 +119,6 @@ func (d *driver) Initialize(a *Args) error {
 			d.allowedLabels[label.Label(p)] = struct{}{}
 		}
 		scope.Debugf("Suite level labels: %s", a.Labels)
-	}
-
-	for _, dep := range a.SuiteDependencies {
-		if err := d.initializeDependency(dep); err != nil {
-			return fmt.Errorf("unable to initialize dependency '%v': %v", dep, err)
-		}
 	}
 
 	return nil
@@ -137,7 +156,14 @@ func (d *driver) Run() int {
 	if d.running {
 		d.lock.Unlock()
 		scope.Error("test driver is already running")
-		return -1
+		return -2
+	}
+
+	for _, dep := range d.suiteDependencies {
+		if err := d.initializeDependency(dep); err != nil {
+			log.Errorf("Failed initializing dependency '%s': %v", dep, err)
+			return -3
+		}
 	}
 
 	d.running = true
@@ -160,18 +186,28 @@ func (d *driver) Run() int {
 
 // GetEnvironment implements same-named Interface method.
 func (d *driver) GetEnvironment(t testing.TB) environment.Interface {
+	t.Helper()
 	scope.Debugf("Enter: driver.GetEnvironment (%s)", d.testID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
-	// TODO
-	panic("Not yet implemented.")
+
+	if !d.running {
+		t.Fatalf("Test driver is not running.")
+	}
+
+	return d.env
 }
 
 // InitializeTestDependencies implements same-named Interface method.
 func (d *driver) InitializeTestDependencies(t testing.TB, dependencies []dependency.Dependency) {
+	t.Helper()
 	scope.Debugf("Enter: driver.InitializeTestDependencies (%s)", d.testID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
+
+	if !d.running {
+		t.Fatalf("Test driver is not running.")
+	}
 
 	// Initialize dependencies only once.
 	for _, dep := range dependencies {
@@ -183,9 +219,14 @@ func (d *driver) InitializeTestDependencies(t testing.TB, dependencies []depende
 
 // CheckLabels implements same-named Interface method.
 func (d *driver) CheckLabels(t testing.TB, labels []label.Label) {
+	t.Helper()
 	scope.Debugf("Enter: driver.CheckLabels (%s)", d.testID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
+
+	if !d.running {
+		t.Fatalf("Test driver is not running.")
+	}
 
 	skip := false
 	if len(d.allowedLabels) > 0 {
@@ -209,7 +250,7 @@ func (d *driver) doCleanup() {
 
 	for k, v := range d.initializedDependencies {
 		if s, ok := k.(internal.Stateful); ok {
-			s.Cleanup(v)
+			s.Cleanup(d.env, v)
 		}
 	}
 }
@@ -224,14 +265,14 @@ func (d *driver) initializeDependency(dep dependency.Dependency) error {
 	instance, ok := d.initializedDependencies[dep]
 	if ok {
 		// If they are already satisfied, then signal a "reset", to ensure a clean, well-known driverState.
-		if err := s.Reset(instance); err != nil {
+		if err := s.Reset(d.env, instance); err != nil {
 			return fmt.Errorf("unable to reset: %v", err)
 		}
 		return nil
 	}
 
 	var err error
-	if instance, err = s.Initialize(); err != nil {
+	if instance, err = s.Initialize(d.env); err != nil {
 		return fmt.Errorf("dependency init error: %v", err)
 	}
 

--- a/pkg/test/internal/stateful.go
+++ b/pkg/test/internal/stateful.go
@@ -14,16 +14,18 @@
 
 package internal
 
+import "istio.io/istio/pkg/test/environment"
+
 // Stateful is an interface for managing the life-cycle of stateful dependencies.
 type Stateful interface {
 
 	// Initialize the dependency. The returned value can be used to store state, and will be passed back
 	// for reset and cleanup.
-	Initialize() (interface{}, error)
+	Initialize(environment.Interface) (interface{}, error)
 
 	// Reset will be called prior to the start of a test for resetting the state of the dependency, if needed.
-	Reset(interface{}) error
+	Reset(environment.Interface, interface{}) error
 
 	// Cleanup the dependency after a test run.
-	Cleanup(interface{})
+	Cleanup(environment.Interface, interface{})
 }

--- a/pkg/test/local/environment.go
+++ b/pkg/test/local/environment.go
@@ -22,10 +22,14 @@ import (
 
 // Environment a local environment for testing.
 type Environment struct {
-	T testing.TB
 }
 
 var _ environment.Interface = &Environment{}
+
+// NewEnvironment returns a new instance of local environment.
+func NewEnvironment() (*Environment, error) {
+	return	&Environment{}, nil
+}
 
 // Configure applies the given configuration to the mesh.
 func (e *Environment) Configure(config string) {

--- a/pkg/test/local/environment.go
+++ b/pkg/test/local/environment.go
@@ -20,15 +20,17 @@ import (
 	"istio.io/istio/pkg/test/environment"
 )
 
-// Environment a local environment for testing.
+// Environment a local environment for testing. It implements environment.Interface, and also
+// hosts publicly accessible methods that are specific to local environment.
 type Environment struct {
 }
 
 var _ environment.Interface = &Environment{}
+var _ Internal = &Environment{}
 
 // NewEnvironment returns a new instance of local environment.
 func NewEnvironment() (*Environment, error) {
-	return	&Environment{}, nil
+	return &Environment{}, nil
 }
 
 // Configure applies the given configuration to the mesh.

--- a/pkg/test/local/internal.go
+++ b/pkg/test/local/internal.go
@@ -1,0 +1,21 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package local
+
+// Internal interface defines internal implementation details of the environment that is used by the
+// test framework *only*. It should never be used directly in a test, or a test utility that resides with the
+// tests themselves.
+type Internal interface {
+}

--- a/tests/e2e/tests/showcase/mixer_showcase_test.go
+++ b/tests/e2e/tests/showcase/mixer_showcase_test.go
@@ -50,7 +50,9 @@ Value: 2,
 Dimensions:
 	- source: mysrc
 	- target_ip: somesrvcname
+    - request_id: ...
 `)
+	//be.ExpectReport(t).With("request_id: ,....")
 }
 
 var testConfig = `


### PR DESCRIPTION
- Introduce an environment specific internal interface for use internally within the test-framework. Various pieces of the test framework can take environment specific actions using this interface.
- Plumb the environment initialization and environment access for dependencies.
- Also bolster the state validation checks in the driver.