### PR TITLE
Update mixer service port names to use http/2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1599,6 +1599,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4160cda2de0241237d507eaeb9112afb071ff23097287b2d8e4fc3a0c0e602bc"
+  inputs-digest = "fb4376dfd57c5e5f74a9aa1a37b4eded3a697974bfd1058333c698099426b718"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -31,9 +31,9 @@ subsets:
 - addresses:
   - ip: {{ .Values.global.policyEndpoint }}
   ports:
-  - name: tcp-plain
+  - name: grpc-mixer
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -29,9 +29,9 @@ metadata:
   namespace: istio-system
 spec:
   ports:
-  - name: tcp-plain
+  - name: grpc-mixer
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -11,9 +11,9 @@ metadata:
     istio: mixer
 spec:
   ports:
-  - name: http2-mixer
+  - name: grpc-mixer
     port: 9091
-  - name: tcp-mtls
+  - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
     port: 9093

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "42faac24eec913b4c9983003734bf658754e429d"
+		"lastStableSHA": "61c5a39b38c11cca47bc16f8d1f30797c290ea52"
 	}
 ]

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -200,8 +200,8 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 
 // defined in install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
 const (
-       mixerPortName     = "grpc-mixer"
-       mixerMTLSPortName = "grpc-mixer-mtls"
+	mixerPortName     = "grpc-mixer"
+	mixerMTLSPortName = "grpc-mixer-mtls"
 )
 
 // buildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
-	"github.com/prometheus/common/log"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
@@ -32,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v1"
+	"istio.io/istio/pkg/log"
 )
 
 // Plugin is a mixer plugin.
@@ -198,15 +198,21 @@ func buildMixerInboundTCPFilter(env *model.Environment, node *model.Proxy, insta
 // 	return listener.Filter{}
 // }
 
+// defined in install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+const (
+       mixerPortName     = "grpc-mixer"
+       mixerMTLSPortName = "grpc-mixer-mtls"
+)
+
 // buildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
 // (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.
 func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *mccpb.HttpClientConfig { // nolint: lll
 	mcs, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
 	mrs, _, _ := net.SplitHostPort(mesh.MixerReportServer)
 
-	pname := &model.Port{Name: "http2-mixer"}
+	pname := &model.Port{Name: mixerPortName}
 	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
-		pname = &model.Port{Name: "tcp-mtls"}
+		pname = &model.Port{Name: mixerMTLSPortName}
 	}
 
 	// TODO: derive these port types.


### PR DESCRIPTION
tcp-mtls port name generates an outbound cluster without http2 features.
This cause outbound connection to be downgraded over mtls to http1.1.
This is rejected at server side envoy.

This fixes the port name and imparts http2 features.

fixes #5331 

