### PR TITLE
Buid, packaging, script fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,9 @@ PILOT_TEST_BINS:=${ISTIO_OUT}/pilot-test-server ${ISTIO_OUT}/pilot-test-client $
 $(PILOT_TEST_BINS):
 	CGO_ENABLED=0 go build ${GOSTATIC} -o $@ istio.io/istio/$(subst -,/,$(@F))
 
+hyperistio:
+	CGO_ENABLED=0 go build ${GOSTATIC} -o ${ISTIO_OUT}/hyperistio istio.io/istio/tools/hyperistio
+
 test-bins: $(PILOT_TEST_BINS)
 
 localTestEnv: test-bins

--- a/pilot/docker/Dockerfile.pilot
+++ b/pilot/docker/Dockerfile.pilot
@@ -1,4 +1,5 @@
-FROM scratch
+FROM istionightly/base_debug
+
 ADD pilot-discovery /usr/local/bin/
 ADD cacert.pem /cacert.pem
 ENTRYPOINT ["/usr/local/bin/pilot-discovery"]

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -1,0 +1,30 @@
+FROM istionightly/base_debug
+
+# Install Envoy.
+ADD envoy /usr/local/bin/envoy
+
+ADD pilot-agent /usr/local/bin/pilot-agent
+
+# pilot-agent and envoy may run with effective uid 0 in order to run envoy with
+# CAP_NET_ADMIN, so any iptables rule matching on "-m owner --uid-owner
+# istio-proxy" will not match connections from those processes anymore.
+# Instead, rely on the process's effective gid being istio-proxy and create a
+# "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
+RUN \
+chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+
+ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
+ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
+ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
+ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
+
+COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+
+# Sudoers used to allow tcpdump and other debug utilities.
+RUN useradd -m --uid 1337 istio-proxy && \
+    echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
+    chown -R istio-proxy /var/lib/istio
+
+# The pilot-agent will bootstrap Envoy.
+ENTRYPOINT ["/usr/local/bin/pilot-agent"]

--- a/tools/deb/Dockerfile
+++ b/tools/deb/Dockerfile
@@ -1,11 +1,11 @@
-# Base dockerfile containing ubuntu and istio debian.
-# Can be used for testing
-FROM ubuntu:xenial
+# Test installing of the deb file
+FROM istionightly/base_debug
+
+# Micro pilot+mock mixer+echo
+ADD hyperistio /usr/local/bin/hyperistio
+ADD *.yaml /var/lib/istio/config/
+ADD certs/* /var/lib/istio/certs/
 
 ADD istio.deb /tmp
-RUN apt-get update && apt-get install -y \
-    iproute2 \
-    iptables \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN dpkg -i /tmp/istio.deb && rm /tmp/istio.deb
+

--- a/tools/deb/deb_test.sh
+++ b/tools/deb/deb_test.sh
@@ -18,5 +18,22 @@
 #
 # Test for istio debian. Will run in a docker image where the .deb has been installed.
 
+export ISTIO_SERVICE_CIDR=10.1.1.0/24
 
-exit 0
+# Echo server
+export ISTIO_INBOUND_PORTS=7070,7072,7073,7074,7075
+
+# Try out with TPROXY - the auth variant uses redirect
+#export ISTIO_INBOUND_INTERCEPTION_MODE=TPROXY
+
+#export ISTIO_PILOT_PORT=15005
+#export ISTIO_CP_AUTH=MUTUAL_TLS
+
+
+/usr/local/bin/hyperistio --envoy=false &
+sleep 1
+
+bash -x /usr/local/bin/istio-start.sh &
+sleep 3
+curl localhost:15000/stats
+

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -124,10 +124,11 @@ iptables -t nat -D OUTPUT -p tcp -j ISTIO_OUTPUT 2>/dev/null
 # Flush and delete the istio chains.
 iptables -t nat -F ISTIO_OUTPUT 2>/dev/null
 iptables -t nat -X ISTIO_OUTPUT 2>/dev/null
-iptables -t nat -F ISTIO_REDIRECT 2>/dev/null
-iptables -t nat -X ISTIO_REDIRECT 2>/dev/null
 iptables -t nat -F ISTIO_INBOUND 2>/dev/null
 iptables -t nat -X ISTIO_INBOUND 2>/dev/null
+# Must be last, the others refer to it
+iptables -t nat -F ISTIO_REDIRECT 2>/dev/null
+iptables -t nat -X ISTIO_REDIRECT 2>/dev/null
 iptables -t mangle -F ISTIO_INBOUND 2>/dev/null
 iptables -t mangle -X ISTIO_INBOUND 2>/dev/null
 iptables -t mangle -F ISTIO_DIVERT 2>/dev/null

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -42,8 +42,12 @@ ISTIO_SYSTEM_NAMESPACE=${ISTIO_SYSTEM_NAMESPACE:-istio-system}
 # The default matches the default istio.yaml - use sidecar.env to override this if you
 # enable auth. This requires node-agent to be running.
 ISTIO_PILOT_PORT=${ISTIO_PILOT_PORT:-8080}
-ISTIO_CP_AUTH=${ISTIO_CP_AUTH:-NONE}
 
+# If set, add the flag
+CONTROL_PLANE_AUTH_POLICY=""
+if [ ! -z "${ISTIO_CP_AUTH:-}" ]; then
+  CONTROL_PLANE_AUTH_POLICY="--controlPlaneAuthPolicy ${ISTIO_CP_AUTH}"
+fi
 
 if [ -z "${ISTIO_SVC_IP:-}" ]; then
   ISTIO_SVC_IP=$(hostname --ip-address)
@@ -72,4 +76,8 @@ if [ "${ISTIO_INBOUND_INTERCEPTION_MODE}" = "TPROXY" ] ; then
 fi
 
 # Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
-exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS:-} --serviceCluster $SVC --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} --controlPlaneAuthPolicy $CONTROL_PLANE_AUTH_POLICY 2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" ${EXEC_USER}
+exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS:-} \
+    --serviceCluster $SVC \
+    --discoveryAddress istio-pilot.${ISTIO_SYSTEM_NAMESPACE}:${ISTIO_PILOT_PORT} \
+    $CONTROL_PLANE_AUTH_POLICY \
+    2> ${ISTIO_LOG_DIR}/istio.err.log > ${ISTIO_LOG_DIR}/istio.log" ${EXEC_USER}

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -35,6 +35,10 @@ import (
 	"istio.io/istio/tests/util"
 )
 
+var (
+	runEnvoy = flag.Bool("envoy", true, "Start envoy")
+)
+
 // hyperistio runs all istio components in one binary, using a directory based config by
 // default. It is intended for testing/debugging/prototyping.
 func main() {
@@ -72,9 +76,11 @@ func startAll() error {
 	go util.RunGRPC(7073, "v1", "", "")
 	go util.RunHTTP(7074, "v2")
 	go util.RunGRPC(7075, "v2", "", "")
-	err = startEnvoy()
-	if err != nil {
-		return err
+	if *runEnvoy {
+		err = startEnvoy()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
- update deb to v2 (no point in shipping a v1 deb, users can stick
with 0.7 while upgrading)
- fix iptabes - it was not cleaning up properly
- fix istio-start - cp policy not matching the env
- added test programs to the deb-test docker

Also fix the base image for pilot to match that of the v2 sidecar,
debugging is more useful at this point and we are not saving any
disk. We can make a different option for 1.0 if nobody needs
debugging, but we're not there.

Also cleaned up a bit the build for the deb/docker.