### PR TITLE
do not filter service ports in BuildSidecarOutboundHTTPRouteConfig

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -83,14 +83,8 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 		if port == 0 {
 			nameToServiceMap[svc.Hostname] = svc
 		} else {
-			if svcPort, exists := svc.Ports.GetByPort(port); exists {
-				nameToServiceMap[svc.Hostname] = &model.Service{
-					Hostname:     svc.Hostname,
-					Address:      svc.Address,
-					Addresses:    svc.Addresses,
-					MeshExternal: svc.MeshExternal,
-					Ports:        []*model.Port{svcPort},
-				}
+			if _, exists := svc.Ports.GetByPort(port); exists {
+				nameToServiceMap[svc.Hostname] = svc
 			}
 		}
 	}


### PR DESCRIPTION
since they could be needed in port rewriting Virtual Services