### PR TITLE
Add new attributes to manifests

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -117,6 +117,8 @@ spec:
       valueType: STRING
     source.namespace:
       valueType: STRING
+    source.owner:
+      valueType: STRING      
     source.service:  # DEPRECATED
       valueType: STRING
     source.serviceAccount:
@@ -129,16 +131,14 @@ spec:
       valueType: STRING
     source.workload.namespace:
       valueType: STRING
-    source.workload.labels:
-      valueType: STRING_MAP
-    source.workload.metadata:
-      valueType: STRING_MAP
     destination.ip:
       valueType: IP_ADDRESS
     destination.labels:
       valueType: STRING_MAP
     destination.metadata:
       valueType: STRING_MAP
+    destination.owner:
+      valueType: STRING
     destination.name:
       valueType: STRING
     destination.namespace:
@@ -151,10 +151,6 @@ spec:
       valueType: STRING
     destination.service.namespace:
       valueType: STRING
-    destination.service.labels:
-      valueType: STRING_MAP
-    destination.service.metadata:
-      valueType: STRING_MAP
     destination.service.host:
       valueType: STRING
     destination.serviceAccount:
@@ -165,10 +161,6 @@ spec:
       valueType: STRING
     destination.workload.namespace:
       valueType: STRING
-    destination.workload.labels:
-      valueType: STRING_MAP
-    destination.workload.metadata:
-      valueType: STRING_MAP
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: stdio

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -50,9 +50,13 @@ spec:
       valueType: TIMESTAMP
     source.uid:
       valueType: STRING
-    source.user:
+    source.user: # DEPRECATED
+      valueType: STRING
+    source.principal:
       valueType: STRING
     destination.uid:
+      valueType: STRING
+    destination.principal:
       valueType: STRING
     connection.id:
       valueType: STRING
@@ -107,26 +111,64 @@ spec:
       valueType: IP_ADDRESS
     source.labels:
       valueType: STRING_MAP
+    source.metadata:
+      valueType: STRING_MAP
     source.name:
       valueType: STRING
     source.namespace:
       valueType: STRING
-    source.service:
+    source.service:  # DEPRECATED
       valueType: STRING
     source.serviceAccount:
       valueType: STRING
+    source.services:
+      valueType: STRING
+    source.workload.uid:
+      valueType: STRING
+    source.workload.name:
+      valueType: STRING
+    source.workload.namespace:
+      valueType: STRING
+    source.workload.labels:
+      valueType: STRING_MAP
+    source.workload.metadata:
+      valueType: STRING_MAP
     destination.ip:
       valueType: IP_ADDRESS
     destination.labels:
+      valueType: STRING_MAP
+    destination.metadata:
       valueType: STRING_MAP
     destination.name:
       valueType: STRING
     destination.namespace:
       valueType: STRING
-    destination.service:
+    destination.service: # DEPRECATED
+      valueType: STRING
+    destination.service.uid:
+      valueType: STRING
+    destination.service.name:
+      valueType: STRING
+    destination.service.namespace:
+      valueType: STRING
+    destination.service.labels:
+      valueType: STRING_MAP
+    destination.service.metadata:
+      valueType: STRING_MAP
+    destination.service.host:
       valueType: STRING
     destination.serviceAccount:
       valueType: STRING
+    destination.workload.uid:
+      valueType: STRING
+    destination.workload.name:
+      valueType: STRING
+    destination.workload.namespace:
+      valueType: STRING
+    destination.workload.labels:
+      valueType: STRING_MAP
+    destination.workload.metadata:
+      valueType: STRING_MAP
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: stdio

--- a/mixer/pkg/attribute/list.gen.go
+++ b/mixer/pkg/attribute/list.gen.go
@@ -3,14 +3,14 @@
 
 package attribute
 
-func GlobalList() ([]string) { 
-    tmp := make([]string, len(globalList))
-    copy(tmp, globalList)
-    return tmp
+func GlobalList() []string {
+	tmp := make([]string, len(globalList))
+	copy(tmp, globalList)
+	return tmp
 }
 
-var ( 
-    globalList = []string{
+var (
+	globalList = []string{
 		"source.ip",
 		"source.port",
 		"source.name",
@@ -209,5 +209,5 @@ var (
 		"destination.container.image",
 		"context.reporter.local",
 		"context.reporter.uid",
-    }
+	}
 )

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -45,7 +45,11 @@ spec:
         valueType: TIMESTAMP
       source.uid:
         valueType: STRING
-      source.user:
+      source.user: # DEPRECATED
+        valueType: STRING
+      source.principal:
+        valueType: STRING
+      destination.principal:
         valueType: STRING
       destination.uid:
         valueType: STRING
@@ -103,20 +107,47 @@ spec:
         valueType: STRING
       source.namespace:
         valueType: STRING
-      source.service:
+      source.owner:
+        valueType: STRING      
+      source.service:  # DEPRECATED
         valueType: STRING
       source.serviceAccount:
         valueType: STRING
+      source.services:
         valueType: STRING
+      source.workload.uid:
+        valueType: STRING
+      source.workload.name:
+        valueType: STRING
+      source.workload.namespace:
+        valueType: STRING        
       destination.ip:
         valueType: IP_ADDRESS
       destination.labels:
+        valueType: STRING_MAP      
+      destination.metadata:
         valueType: STRING_MAP
       destination.name:
         valueType: STRING
       destination.namespace:
         valueType: STRING
-      destination.service:
+      destination.owner:
+        valueType: STRING        
+      destination.service: # DEPRECATED
+        valueType: STRING
+      destination.service.uid:
+        valueType: STRING
+      destination.service.name:
+        valueType: STRING
+      destination.service.namespace:
+        valueType: STRING
+      destination.service.host:
         valueType: STRING
       destination.serviceAccount:
+        valueType: STRING
+      destination.workload.uid:
+        valueType: STRING
+      destination.workload.name:
+        valueType: STRING
+      destination.workload.namespace:
         valueType: STRING


### PR DESCRIPTION
This PR adds the proposed new attributes to handle source and destination workload information
to the attribute manifests used by Mixer.

This PR is based on the current proposal documented in [Updated Source & Destination Attributes](https://docs.google.com/document/d/1IcR6C7j5Vl-4Jx8ervVT4lCTBDrBgsD7Uac77K5C5h4/edit#).

Subsequent PRs will be needed to update Mixer's dependence on `destination.service` as we transition to `destination.service.host`.