### PR TITLE
ServiceEntry supports unix domain sockets

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -152,6 +152,28 @@ const (
 	ProtocolUnsupported Protocol = "UnsupportedProtocol"
 )
 
+// AddressFamily indicates the kind of transport used to reach a NetworkEndpoint
+type AddressFamily int
+
+const (
+	// AddressFamilyTCP represents an address that connects to a TCP endpoint. It consists of an IP address or host and
+	// a port number.
+	AddressFamilyTCP AddressFamily = iota
+	// AddressFamilyUnix represents an address that connects to a Unix Domain Socket. It consists of a socket file path.
+	AddressFamilyUnix
+)
+
+func (f AddressFamily) String() string {
+	switch f {
+	case AddressFamilyTCP:
+		return "tcp"
+	case AddressFamilyUnix:
+		return "unix"
+	default:
+		return fmt.Sprintf("%d", f)
+	}
+}
+
 // TrafficDirection defines whether traffic exists a service instance or enters a service instance
 type TrafficDirection string
 
@@ -234,12 +256,18 @@ func (p Protocol) IsTCP() bool {
 //  --> 172.16.0.1:54546 (with ServicePort pointing to 80) and
 //  --> 172.16.0.1:33333 (with ServicePort pointing to 8080)
 type NetworkEndpoint struct {
-	// Address of the network endpoint, typically an IPv4 address
+	// Family indicates what type of endpoint, such as TCP or Unix Domain Socket.
+	Family AddressFamily
+
+	// Address of the network endpoint. If Family is `AddressFamilyTCP`, it is
+	// typically an IPv4 address. If Family is `AddressFamilyUnix`, it is the
+	// path to the domain socket.
 	Address string
 
 	// Port number where this instance is listening for connections This
 	// need not be the same as the port where the service is accessed.
 	// e.g., catalog.mystore.com:8080 -> 172.16.0.1:55446
+	// Ignored for `AddressFamilyUnix`.
 	Port int
 
 	// Port declaration from the service declaration This is the port for

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -61,6 +62,10 @@ const (
 	drainTimeMax          = time.Hour
 	parentShutdownTimeMax = time.Hour
 )
+
+// UnixAddressPrefix is the prefix used to indicate an address is for a Unix Domain socket. It is used in
+// ServiceEntry.Endpoint.Address message.
+const UnixAddressPrefix = "unix://"
 
 var (
 	dns1123LabelRegexp   = regexp.MustCompile("^" + dns1123LabelFmt + "$")
@@ -555,6 +560,19 @@ func ValidateIPv4Address(addr string) error {
 		return fmt.Errorf("%v is not a valid IPv4 address", addr)
 	}
 
+	return nil
+}
+
+// ValidateUnixAddress validates that the string is a valid unix domain socket path.
+func ValidateUnixAddress(addr string) error {
+	if len(addr) == 0 {
+		return errors.New("unix address must not be empty")
+	}
+	// Note that we use path, not path/filepath even though a domain socket path is a file path.  We don't want the
+	// Pilot output to depend on which OS Pilot is run on, so we always use Unix-style forward slashes.
+	if !path.IsAbs(addr) {
+		return fmt.Errorf("%s is not an absolute path", addr)
+	}
 	return nil
 }
 
@@ -2156,19 +2174,29 @@ func ValidateServiceEntry(config proto.Message) (errs error) {
 				fmt.Errorf("endpoints must be provided if service entry discovery mode is static"))
 		}
 
+		unixEndpoint := false
 		for _, endpoint := range serviceEntry.Endpoints {
-			errs = appendErrors(errs,
-				ValidateIPv4Address(endpoint.Address),
-				Labels(endpoint.Labels).Validate())
-
-			for name, port := range endpoint.Ports {
-				if !servicePorts[name] {
-					errs = appendErrors(errs, fmt.Errorf("endpoint port %v is not defined by the service entry", port))
+			addr := endpoint.GetAddress()
+			if strings.HasPrefix(addr, UnixAddressPrefix) {
+				unixEndpoint = true
+				errs = appendErrors(errs, ValidateUnixAddress(strings.TrimPrefix(addr, UnixAddressPrefix)))
+				if len(endpoint.Ports) != 0 {
+					errs = appendErrors(errs, fmt.Errorf("unix endpoint %s must not include ports", addr))
 				}
-				errs = appendErrors(errs,
-					validatePortName(name),
-					ValidatePort(int(port)))
+			} else {
+				errs = appendErrors(errs, ValidateIPv4Address(addr))
+
+				for name, port := range endpoint.Ports {
+					if !servicePorts[name] {
+						errs = appendErrors(errs, fmt.Errorf("endpoint port %v is not defined by the service entry", port))
+					}
+				}
 			}
+			errs = appendErrors(errs, Labels(endpoint.Labels).Validate())
+
+		}
+		if unixEndpoint && len(serviceEntry.Ports) != 1 {
+			errs = appendErrors(errs, errors.New("exactly 1 service port required for unix endpoints"))
 		}
 	case networking.ServiceEntry_DNS:
 		if len(serviceEntry.Endpoints) == 0 {
@@ -2245,4 +2273,21 @@ func appendErrors(err error, errs ...error) error {
 		err = appendError(err, err2)
 	}
 	return err
+}
+
+// ValidateNetworkEndpointAddress checks the Address field of a NetworkEndpoint. If the family is TCP, it checks the
+// address is a valid IP address. If the family is Unix, it checks the address is a valid socket file path.
+func ValidateNetworkEndpointAddress(n *NetworkEndpoint) error {
+	switch n.Family {
+	case AddressFamilyTCP:
+		ipAddr := net.ParseIP(n.Address)
+		if ipAddr == nil {
+			return errors.New("invalid IP address " + n.Address)
+		}
+	case AddressFamilyUnix:
+		return ValidateUnixAddress(n.Address)
+	default:
+		panic(fmt.Sprintf("unhandled Family %v", n.Family))
+	}
+	return nil
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	base_json "encoding/json"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
 )
 
@@ -99,6 +101,23 @@ func BuildAddress(ip string, port uint32) core.Address {
 				},
 			},
 		},
+	}
+}
+
+// BuildPipeAddress returns a Pipe address with the given path.
+func BuildPipeAddress(path string) core.Address {
+	return core.Address{Address: &core.Address_Pipe{Pipe: &core.Pipe{Path: path}}}
+}
+
+// GetNetworkEndpointAddress returns an Envoy v2 API `Address` that represents this NetworkEndpoint
+func GetNetworkEndpointAddress(n *model.NetworkEndpoint) core.Address {
+	switch n.Family {
+	case model.AddressFamilyTCP:
+		return BuildAddress(n.Address, uint32(n.Port))
+	case model.AddressFamilyUnix:
+		return BuildPipeAddress(n.Address)
+	default:
+		panic(fmt.Sprintf("unhandled Family %v", n.Family))
 	}
 }
 

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestGetNetworkEndpointAddress(t *testing.T) {
+	neUnix := &model.NetworkEndpoint{
+		Family:  model.AddressFamilyUnix,
+		Address: "/var/run/test/test.sock",
+	}
+	aUnix := GetNetworkEndpointAddress(neUnix)
+	if aUnix.GetPipe() == nil {
+		t.Fatalf("GetAddress() => want Pipe, got %s", aUnix.String())
+	}
+	if aUnix.GetPipe().GetPath() != neUnix.Address {
+		t.Fatalf("GetAddress() => want path %s, got %s", neUnix.Address, aUnix.GetPipe().GetPath())
+	}
+
+	neIP := &model.NetworkEndpoint{
+		Family:  model.AddressFamilyTCP,
+		Address: "192.168.10.45",
+		Port:    4558,
+	}
+	aIP := GetNetworkEndpointAddress(neIP)
+	sock := aIP.GetSocketAddress()
+	if sock == nil {
+		t.Fatalf("GetAddress() => want SocketAddress, got %s", aIP.String())
+	}
+	if sock.GetAddress() != neIP.Address {
+		t.Fatalf("GetAddress() => want %s, got %s", neIP.Address, sock.GetAddress())
+	}
+	if int(sock.GetPortValue()) != neIP.Port {
+		t.Fatalf("GetAddress() => want port %d, got port %d", neIP.Port, sock.GetPortValue())
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -156,7 +156,7 @@ func sendCDSReq(t *testing.T, node string, edsstr ads.AggregatedDiscoveryService
 func TestAdsReconnectWithNonce(t *testing.T) {
 	_ = initLocalPilotTestEnv(t)
 	edsstr := connectADS(t, util.MockPilotGrpcAddr)
-	sendEDSReq(t, []string{"service3.default.svc.cluster.local|80"}, app3Ip, edsstr)
+	sendEDSReq(t, []string{"service3.default.svc.cluster.local|http"}, app3Ip, edsstr)
 	res, _ := adsReceive(edsstr, 5*time.Second)
 
 	// closes old process
@@ -164,8 +164,8 @@ func TestAdsReconnectWithNonce(t *testing.T) {
 
 	edsstr = connectADS(t, util.MockPilotGrpcAddr)
 	defer edsstr.CloseSend()
-	sendEDSReqReconnect(t, []string{"service3.default.svc.cluster.local|80"}, edsstr, res)
-	sendEDSReq(t, []string{"service3.default.svc.cluster.local|80"}, app3Ip, edsstr)
+	sendEDSReqReconnect(t, []string{"service3.default.svc.cluster.local|http"}, edsstr, res)
+	sendEDSReq(t, []string{"service3.default.svc.cluster.local|http"}, app3Ip, edsstr)
 	res, _ = adsReceive(edsstr, 5*time.Second)
 	_ = edsstr.CloseSend()
 
@@ -250,7 +250,7 @@ func TestAdsUpdate(t *testing.T) {
 	_ = server.EnvoyXdsServer.MemRegistry.AddEndpoint("adsupdate.default.svc.cluster.local",
 		"http-main", 2080, "10.2.0.1", 1080)
 
-	sendEDSReq(t, []string{"adsupdate.default.svc.cluster.local|2080"},
+	sendEDSReq(t, []string{"adsupdate.default.svc.cluster.local|http-main"},
 		"1.1.1.1", edsstr)
 
 	res1, err := adsReceive(edsstr, 5*time.Second)
@@ -341,7 +341,7 @@ func testAdsMultiple(t *testing.T, server *pilotbootstrap.Server) {
 		i := i
 		go func() {
 			edsstr := connectADS(t, util.MockPilotGrpcAddr)
-			sendEDSReq(t, []string{"service3.default.svc.cluster.local|1080"},
+			sendEDSReq(t, []string{"service3.default.svc.cluster.local|http-main"},
 				testIp(uint32(0x0a200000+i)), edsstr)
 
 			res1, err := adsReceive(edsstr, 5*time.Second)

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -334,8 +334,8 @@ func (s *DiscoveryServer) endpointz(w http.ResponseWriter, req *http.Request) {
 					return
 				}
 				for _, svc := range all {
-					fmt.Fprintf(w, "%s:%s %s:%d %v %v %s\n", ss.Hostname,
-						p.Name, svc.Endpoint.Address, svc.Endpoint.Port, svc.Labels,
+					fmt.Fprintf(w, "%s:%s %v %s:%d %v %v %s\n", ss.Hostname,
+						p.Name, svc.Endpoint.Family, svc.Endpoint.Address, svc.Endpoint.Port, svc.Labels,
 						svc.GetAZ(), svc.ServiceAccount)
 				}
 			}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -60,11 +60,12 @@ func (s *DiscoveryServer) InitDebug(mux *http.ServeMux, sctl *aggregate.Controll
 // NewMemServiceDiscovery builds an in-memory MemServiceDiscovery
 func NewMemServiceDiscovery(services map[model.Hostname]*model.Service, versions int) *MemServiceDiscovery {
 	return &MemServiceDiscovery{
-		services:    services,
-		versions:    versions,
-		controller:  &memServiceController{},
-		instances:   map[string][]*model.ServiceInstance{},
-		ip2instance: map[string][]*model.ServiceInstance{},
+		services:            services,
+		versions:            versions,
+		controller:          &memServiceController{},
+		instancesByPortNum:  map[string][]*model.ServiceInstance{},
+		instancesByPortName: map[string][]*model.ServiceInstance{},
+		ip2instance:         map[string][]*model.ServiceInstance{},
 	}
 }
 
@@ -92,7 +93,8 @@ func (c *memServiceController) Run(<-chan struct{}) {}
 type MemServiceDiscovery struct {
 	services map[model.Hostname]*model.Service
 	// Endpoints table. Key is the fqdn of the service, ':', port
-	instances                     map[string][]*model.ServiceInstance
+	instancesByPortNum            map[string][]*model.ServiceInstance
+	instancesByPortName           map[string][]*model.ServiceInstance
 	ip2instance                   map[string][]*model.ServiceInstance
 	versions                      int
 	WantGetProxyServiceInstances  []*model.ServiceInstance
@@ -135,13 +137,12 @@ func (sd *MemServiceDiscovery) AddInstance(service model.Hostname, instance *mod
 	sd.ip2instance[instance.Endpoint.Address] = []*model.ServiceInstance{instance}
 
 	key := fmt.Sprintf("%s:%d", service, instance.Endpoint.ServicePort.Port)
-	instanceList := sd.instances[key]
-	if instanceList == nil {
-		instanceList = []*model.ServiceInstance{instance}
-		sd.instances[key] = instanceList
-		return
-	}
-	sd.instances[key] = append(instanceList, instance)
+	instanceList := sd.instancesByPortNum[key]
+	sd.instancesByPortNum[key] = append(instanceList, instance)
+
+	key = fmt.Sprintf("%s:%s", service, instance.Endpoint.ServicePort.Name)
+	instanceList = sd.instancesByPortName[key]
+	sd.instancesByPortName[key] = append(instanceList, instance)
 }
 
 // AddEndpoint adds an endpoint to a service.
@@ -201,7 +202,7 @@ func (sd *MemServiceDiscovery) Instances(hostname model.Hostname, ports []string
 		return nil, nil
 	}
 	key := hostname.String() + ":" + ports[0]
-	instances, ok := sd.instances[key]
+	instances, ok := sd.instancesByPortName[key]
 	if !ok {
 		return nil, nil
 	}
@@ -218,7 +219,7 @@ func (sd *MemServiceDiscovery) InstancesByPort(hostname model.Hostname, port int
 		return nil, sd.InstancesError
 	}
 	key := fmt.Sprintf("%s:%d", hostname.String(), port)
-	instances, ok := sd.instances[key]
+	instances, ok := sd.instancesByPortNum[key]
 	if !ok {
 		return nil, nil
 	}

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -197,7 +197,7 @@ func connectAndSend(id uint32, t *testing.T) (xdsapi.EndpointDiscoveryService_St
 		Node: &envoy_api_v2_core1.Node{
 			Id: sidecarId(testIp(uint32(0x0a100000+id)), "app3"),
 		},
-		ResourceNames: []string{"hello.default.svc.cluster.local|80"}})
+		ResourceNames: []string{"hello.default.svc.cluster.local|http"}})
 	if err != nil {
 		t.Fatal("Send failed", err)
 	}
@@ -414,7 +414,7 @@ func testEdsz(t *testing.T) {
 	}
 	statusStr := string(data)
 
-	if !strings.Contains(statusStr, "\"hello.default.svc.cluster.local|80\"") {
+	if !strings.Contains(statusStr, "\"hello.default.svc.cluster.local|http\"") {
 		t.Fatal("Mock hello service not found ", statusStr)
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -38,45 +38,39 @@ import (
 )
 
 func connect(t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
-	conn, err := grpc.Dial(util.MockPilotGrpcAddr, grpc.WithInsecure())
-	if err != nil {
-		t.Fatal("Connection failed", err)
-	}
-
-	xds := xdsapi.NewEndpointDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamEndpoints(context.Background())
-	if err != nil {
-		t.Fatal("Rpc failed", err)
-	}
-	err = edsstr.Send(&xdsapi.DiscoveryRequest{
+	req := &xdsapi.DiscoveryRequest{
 		Node: &envoy_api_v2_core1.Node{
 			Id: sidecarId(app3Ip, "app3"),
 		},
-		ResourceNames: []string{"hello.default.svc.cluster.local|http"}})
-	if err != nil {
-		t.Fatal("Send failed", err)
+		ResourceNames: []string{"hello.default.svc.cluster.local|http"},
 	}
-	return edsstr
+	return connectWithRequest(req, t)
 }
 
 func reconnect(res *xdsapi.DiscoveryResponse, t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
-	conn, err := grpc.Dial(util.MockPilotGrpcAddr, grpc.WithInsecure())
-	if err != nil {
-		t.Fatal("Connection failed", err)
-	}
-
-	xds := xdsapi.NewEndpointDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamEndpoints(context.Background())
-	if err != nil {
-		t.Fatal("Rpc failed", err)
-	}
-	err = edsstr.Send(&xdsapi.DiscoveryRequest{
+	req := &xdsapi.DiscoveryRequest{
 		Node: &envoy_api_v2_core1.Node{
 			Id: sidecarId(app3Ip, "app3"),
 		},
 		VersionInfo:   res.VersionInfo,
 		ResponseNonce: res.Nonce,
-		ResourceNames: []string{"hello.default.svc.cluster.local|http"}})
+		ResourceNames: []string{"hello.default.svc.cluster.local|http"},
+	}
+	return connectWithRequest(req, t)
+}
+
+func connectWithRequest(r *xdsapi.DiscoveryRequest, t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
+	conn, err := grpc.Dial(util.MockPilotGrpcAddr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal("Connection failed", err)
+	}
+
+	xds := xdsapi.NewEndpointDiscoveryServiceClient(conn)
+	edsstr, err := xds.StreamEndpoints(context.Background())
+	if err != nil {
+		t.Fatal("Rpc failed", err)
+	}
+	err = edsstr.Send(r)
 	if err != nil {
 		t.Fatal("Send failed", err)
 	}
@@ -311,13 +305,96 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
+func udsRequest(server *bootstrap.Server, t *testing.T) {
+	udsPath := "/var/run/test/socket"
+	server.EnvoyXdsServer.MemRegistry.AddService("localuds.cluster.local", &model.Service{
+		Hostname: "localuds.cluster.local",
+		Ports: model.PortList{
+			{
+				Name:                 "grpc",
+				Port:                 0,
+				Protocol:             model.ProtocolGRPC,
+				AuthenticationPolicy: meshconfig.AuthenticationPolicy_INHERIT,
+			},
+		},
+		MeshExternal: true,
+		Resolution:   model.ClientSideLB,
+	})
+	server.EnvoyXdsServer.MemRegistry.AddInstance("localuds.cluster.local", &model.ServiceInstance{
+		Endpoint: model.NetworkEndpoint{
+			Family:  model.AddressFamilyUnix,
+			Address: udsPath,
+			Port:    0,
+			ServicePort: &model.Port{
+				Name:                 "grpc",
+				Port:                 0,
+				Protocol:             model.ProtocolGRPC,
+				AuthenticationPolicy: meshconfig.AuthenticationPolicy_INHERIT,
+			},
+		},
+		Labels:           map[string]string{"socket": "unix"},
+		AvailabilityZone: "localhost",
+	})
+
+	req := &xdsapi.DiscoveryRequest{
+		Node: &envoy_api_v2_core1.Node{
+			Id: sidecarId(app3Ip, "app3"),
+		},
+		ResourceNames: []string{"localuds.cluster.local|grpc"},
+	}
+	edsstr := connectWithRequest(req, t)
+
+	cla := &xdsapi.ClusterLoadAssignment{}
+	// Race condition in the server might cause it to send a Resource with no endpoints at first, so retry once more if
+	// that happens.
+	for i := 0; i < 2; i++ {
+		res, err := edsstr.Recv()
+		if err != nil {
+			t.Fatal("Recv2 failed", err)
+		}
+		t.Log(res.String())
+		if len(res.Resources) != 1 {
+			t.Fatalf("expected 1 resources got %d", len(res.Resources))
+		}
+		err = cla.Unmarshal(res.Resources[0].Value)
+		if err != nil {
+			t.Fatal("Failed to parse proto ", err)
+		}
+		t.Log(cla.String())
+		if len(cla.Endpoints) != 1 {
+			if i == 1 {
+				// Second attempt, fail test case
+				t.Fatalf("expected 1 endpoint but got %d", len(cla.Endpoints))
+			}
+			log.Println(fmt.Sprintf("expected 1 endpoint but got %d, retrying", len(cla.Endpoints)))
+			continue
+		}
+		break
+	}
+	ep0 := cla.Endpoints[0]
+	if len(ep0.LbEndpoints) != 1 {
+		t.Fatalf("expected 1 LB endpoint but got %d", len(ep0.LbEndpoints))
+	}
+	lbep := ep0.LbEndpoints[0]
+	path := lbep.GetEndpoint().GetAddress().GetPipe().GetPath()
+	if path != udsPath {
+		t.Fatalf("expected Pipe to %s, got %s", udsPath, path)
+	}
+}
+
 func TestEds(t *testing.T) {
 	initLocalPilotTestEnv(t)
 	server := util.EnsureTestServer()
 
-	directRequest(server, t)
-	multipleRequest(server, t)
-
+	t.Run("DirectRequest", func(t *testing.T) {
+		directRequest(server, t)
+	})
+	t.Run("MultipleRequest", func(t *testing.T) {
+		multipleRequest(server, t)
+	})
+	t.Run("UDSRequest", func(t *testing.T) {
+		udsRequest(server, t)
+	})
 }
 
 // Verify the endpoint debug interface is installed and returns some string.

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -169,6 +169,17 @@ var multiAddrInternal = &networking.ServiceEntry{
 	Resolution: networking.ServiceEntry_NONE,
 }
 
+var udsLocal = &networking.ServiceEntry{
+	Hosts: []string{"uds.cluster.local"},
+	Ports: []*networking.Port{
+		{Number: 6553, Name: "grpc-1", Protocol: "grpc"},
+	},
+	Endpoints: []*networking.ServiceEntry_Endpoint{
+		{Address: "unix:///test/sock"},
+	},
+	Resolution: networking.ServiceEntry_STATIC,
+}
+
 func convertPortNameToProtocol(name string) model.Protocol {
 	prefix := name
 	i := strings.Index(name, "-")
@@ -205,9 +216,14 @@ func makeService(hostname model.Hostname, address string, ports map[string]int, 
 
 func makeInstance(serviceEntry *networking.ServiceEntry, address string, port int,
 	svcPort *networking.Port, labels map[string]string) *model.ServiceInstance {
+	family := model.AddressFamilyTCP
+	if port == 0 {
+		family = model.AddressFamilyUnix
+	}
 	return &model.ServiceInstance{
 		Service: convertServices(serviceEntry)[0],
 		Endpoint: model.NetworkEndpoint{
+			Family:  family,
 			Address: address,
 			Port:    port,
 			ServicePort: &model.Port{
@@ -376,6 +392,13 @@ func TestConvertInstances(t *testing.T) {
 			out: []*model.ServiceInstance{
 				makeInstance(tcpStatic, "1.1.1.1", 444, tcpStatic.Ports[0], nil),
 				makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil),
+			},
+		},
+		{
+			// service entry unix domain socket static
+			externalSvc: udsLocal,
+			out: []*model.ServiceInstance{
+				makeInstance(udsLocal, "/test/sock", 0, udsLocal.Ports[0], nil),
 			},
 		},
 	}


### PR DESCRIPTION
Adds support for Unix Domain Sockets as ServiceEntry Endpoints; EDS v2 only.

Signed-off-by: Spike Curtis <spike@tigera.io>