### PR TITLE
Define request.auth.claims

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -84,6 +84,8 @@ spec:
       valueType: STRING
     request.auth.presenter:
       valueType: STRING
+    request.auth.claims:
+      valueType: STRING
     request.api_key:
       valueType: STRING
 

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -85,7 +85,7 @@ spec:
     request.auth.presenter:
       valueType: STRING
     request.auth.claims:
-      valueType: STRING
+      valueType: STRING_MAP
     request.api_key:
       valueType: STRING
 

--- a/mixer/pkg/attribute/list.gen.go
+++ b/mixer/pkg/attribute/list.gen.go
@@ -185,5 +185,7 @@ var (
 		"connection.event",
 		"check.cache_hit",
 		"quota.cache_hit",
+		"source.principal",
+		"request.auth.claims",
     }
 )

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -3598,6 +3598,7 @@ var istio06AttributeSet = map[string]*pb.AttributeManifest_AttributeInfo{
 	"request.auth.principal":          {ValueType: descriptor.STRING},
 	"request.auth.audiences":          {ValueType: descriptor.STRING},
 	"request.auth.presenter":          {ValueType: descriptor.STRING},
+	"request.auth.claims":             {ValueType: descriptor.STRING},
 	"request.api_key":                 {ValueType: descriptor.STRING},
 	"source.ip":                       {ValueType: descriptor.IP_ADDRESS},
 	"source.labels":                   {ValueType: descriptor.STRING_MAP},

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -3598,7 +3598,7 @@ var istio06AttributeSet = map[string]*pb.AttributeManifest_AttributeInfo{
 	"request.auth.principal":          {ValueType: descriptor.STRING},
 	"request.auth.audiences":          {ValueType: descriptor.STRING},
 	"request.auth.presenter":          {ValueType: descriptor.STRING},
-	"request.auth.claims":             {ValueType: descriptor.STRING},
+	"request.auth.claims":             {ValueType: descriptor.STRING_MAP},
 	"request.api_key":                 {ValueType: descriptor.STRING},
 	"source.ip":                       {ValueType: descriptor.IP_ADDRESS},
 	"source.labels":                   {ValueType: descriptor.STRING_MAP},

--- a/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
@@ -770,7 +770,7 @@ func statdardVocabulary() ast.AttributeDescriptorFinder {
 		"request.auth.audiences":          {ValueType: v1beta1.STRING},
 		"request.auth.presenter":          {ValueType: v1beta1.STRING},
 		"request.auth.principal":          {ValueType: v1beta1.STRING},
-		"request.auth.claims":             {ValueType: v1beta1.STRING},
+		"request.auth.claims":             {ValueType: v1beta1.STRING_MAP},
 		"request.headers":                 {ValueType: v1beta1.STRING_MAP},
 		"request.host":                    {ValueType: v1beta1.STRING},
 		"request.id":                      {ValueType: v1beta1.STRING},

--- a/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
@@ -770,6 +770,7 @@ func statdardVocabulary() ast.AttributeDescriptorFinder {
 		"request.auth.audiences":          {ValueType: v1beta1.STRING},
 		"request.auth.presenter":          {ValueType: v1beta1.STRING},
 		"request.auth.principal":          {ValueType: v1beta1.STRING},
+		"request.auth.claims":             {ValueType: v1beta1.STRING},
 		"request.headers":                 {ValueType: v1beta1.STRING_MAP},
 		"request.host":                    {ValueType: v1beta1.STRING},
 		"request.id":                      {ValueType: v1beta1.STRING},

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -80,7 +80,7 @@ spec:
       request.auth.audiences:
         valueType: STRING
       request.auth.claims:
-        valueType: STRING
+        valueType: STRING_MAP
       request.auth.presenter:
         valueType: STRING
       request.api_key:

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -79,6 +79,8 @@ spec:
         valueType: STRING
       request.auth.audiences:
         valueType: STRING
+      request.auth.claims:
+        valueType: STRING
       request.auth.presenter:
         valueType: STRING
       request.api_key:


### PR DESCRIPTION
Ensure `request.auth.claims` attribute is present and defined as STRING_MAP. 
The `go generate` on attribute list also picked up `source.principal`.
Closes #3194, Closes #5040