### PR TITLE
Fix setting empty CA certificates field in gateway

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -189,7 +189,7 @@ func buildGatewayListenerTLSContext(server *networking.Server) *auth.DownstreamT
 		return nil
 	}
 
-	tlsContext := &auth.DownstreamTlsContext{
+	return &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			TlsCertificates: []*auth.TlsCertificate{
 				{
@@ -210,8 +210,6 @@ func buildGatewayListenerTLSContext(server *networking.Server) *auth.DownstreamT
 		},
 		RequireSni: boolTrue,
 	}
-
-	return tlsContext
 }
 
 func buildGatewayListnerTLSValidationContext(tls *networking.Server_TLSOptions) *auth.CertificateValidationContext {

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -226,7 +226,7 @@ func buildGatewayListnerTLSValidationContext(tls *networking.Server_TLSOptions) 
 		}
 	}
 
-	if len(tls.CaCertificates) != 0 || len(tls.SubjectAltNames) != 0 {
+	if trustedCa != nil || len(tls.SubjectAltNames) != 0 {
 		return &auth.CertificateValidationContext{
 			TrustedCa:            trustedCa,
 			VerifySubjectAltName: tls.SubjectAltNames,

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -189,7 +189,7 @@ func buildGatewayListenerTLSContext(server *networking.Server) *auth.DownstreamT
 		return nil
 	}
 
-	return &auth.DownstreamTlsContext{
+	tlsContext := &auth.DownstreamTlsContext{
 		CommonTlsContext: &auth.CommonTlsContext{
 			TlsCertificates: []*auth.TlsCertificate{
 				{
@@ -205,18 +205,36 @@ func buildGatewayListenerTLSContext(server *networking.Server) *auth.DownstreamT
 					},
 				},
 			},
-			ValidationContext: &auth.CertificateValidationContext{
-				TrustedCa: &core.DataSource{
-					Specifier: &core.DataSource_Filename{
-						Filename: server.Tls.CaCertificates,
-					},
-				},
-				VerifySubjectAltName: server.Tls.SubjectAltNames,
-			},
-			AlpnProtocols: ListenersALPNProtocols,
+			ValidationContext: buildGatewayListnerTLSValidationContext(server.Tls),
+			AlpnProtocols:     ListenersALPNProtocols,
 		},
 		RequireSni: boolTrue,
 	}
+
+	return tlsContext
+}
+
+func buildGatewayListnerTLSValidationContext(tls *networking.Server_TLSOptions) *auth.CertificateValidationContext {
+	if tls == nil {
+		return nil
+	}
+
+	var trustedCa *core.DataSource
+	if len(tls.CaCertificates) != 0 {
+		trustedCa = &core.DataSource{
+			Specifier: &core.DataSource_Filename{
+				Filename: tls.CaCertificates,
+			},
+		}
+	}
+
+	if len(tls.CaCertificates) != 0 || len(tls.SubjectAltNames) != 0 {
+		return &auth.CertificateValidationContext{
+			TrustedCa:            trustedCa,
+			VerifySubjectAltName: tls.SubjectAltNames,
+		}
+	}
+	return nil
 }
 
 func buildGatewayInboundHTTPRouteConfig(


### PR DESCRIPTION
Similar to the handling in https://github.com/istio/istio/blob/release-0.8/pilot/pkg/networking/core/v1alpha3/cluster.go,
applyUpstreamTLSSettings().

Empty CA certificates field causes Envoy to crash in validation -
Envoy requires non-empty CA certificates string.
Also Envoy requires non-empty TrustedCa struct