### PR TITLE
Turn off logging for AZ as it is not in scope for 0.8

### DIFF
--- a/pilot/pkg/proxy/envoy/v1/watcher.go
+++ b/pilot/pkg/proxy/envoy/v1/watcher.go
@@ -125,7 +125,8 @@ func (w *watcher) retrieveAZ(ctx context.Context, delay time.Duration, retries i
 	checkin, err := bootstrap.Checkin(w.config.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS,
 		w.config.DiscoveryAddress, w.config.ServiceCluster, w.role.ServiceNode(), delay, retries)
 	if err != nil {
-		log.Errorf("Failed to connect to pilot. Fallback to starting with defaults and no AZ %v", err)
+		// TODO: turn back on when fully implemented, commented out to avoid confusing users
+		// log.Errorf("Failed to connect to pilot. Fallback to starting with defaults and no AZ %v", err)
 		// TODO: should we exit ? Envoy is unlikely to start without pilot.
 	} else {
 		w.config.AvailabilityZone = checkin.AvailabilityZone

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -333,7 +333,8 @@ func Checkin(secure bool, addr, cluster, node string, delay time.Duration, retri
 
 		resp, err := client.Get(fmt.Sprintf("%v%v/v1/az/%v/%v", protocol, addr, cluster, node))
 		if err != nil || resp.StatusCode != 200 {
-			log.Infof("Unable to retrieve availability zone from pilot: %v %d", err, attempts)
+			// TODO: turn back on when fully implemented, commented out to avoid confusing users
+			// log.Infof("Unable to retrieve availability zone from pilot: %v %d", err, attempts)
 			if attempts >= retries {
 				if err != nil {
 					return nil, err
@@ -343,14 +344,18 @@ func Checkin(secure bool, addr, cluster, node string, delay time.Duration, retri
 		} else {
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				log.Infof("Unable to read availability zone response from pilot: %v", err)
+				// TODO: turn back on when fully implemented, commented out to avoid confusing users
+				// log.Infof("Unable to read availability zone response from pilot: %v", err)
 			}
 			if resp.StatusCode != http.StatusOK {
-				log.Infof("Received %v status from pilot when retrieving availability zone: %v", resp.StatusCode, string(body))
+				// TODO: turn back on when fully implemented, commented out to avoid confusing users
+				// log.Infof("Received %v status from pilot when retrieving availability zone: %v", resp.StatusCode, string(body))
 			} else {
 				// TODO: replace with json containing Checkin data.
 				w.AvailabilityZone = string(body)
-				log.Infof("Proxy availability zone: %v", w.AvailabilityZone)
+
+				// TODO: turn back on when fully implemented, commented out to avoid confusing users
+				// log.Infof("Proxy availability zone: %v", w.AvailabilityZone)
 				return w, nil
 			}
 			_ = resp.Body.Close()


### PR DESCRIPTION
These logs are not useful because zone aware load balancing is not supported yet. Currently these logs are just confusing users so should be disabled until zone aware is fully implemented.