### PR TITLE
Create client using mechanism of PR 5300

### DIFF
--- a/istioctl/cmd/istioctl/deregister.go
+++ b/istioctl/cmd/istioctl/deregister.go
@@ -31,7 +31,7 @@ var (
 			ip := args[1]
 			log.Infof("De-registering for service '%s' ip '%s'",
 				svcName, ip)
-			_, client, err := kube.CreateInterface(kubeconfig)
+			client, err := createInterface(kubeconfig)
 			if err != nil {
 				return err
 			}

--- a/istioctl/cmd/istioctl/register.go
+++ b/istioctl/cmd/istioctl/register.go
@@ -47,7 +47,7 @@ var (
 			}
 			log.Infof("%d labels (%v) and %d annotations (%v)",
 				len(labels), labels, len(annotations), annotations)
-			_, client, err := kube.CreateInterface(kubeconfig)
+			client, err := createInterface(kubeconfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/5255 .  Uses the mechanism of https://github.com/istio/istio/pull/5300 for the register/deregister commands.  That mechanism avoids problems when .pem files with non-absolute paths are referenced by Kubernetes configuration.