### PR TITLE
Bump the GKE version to 1.9.7-gke.0

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -86,7 +86,7 @@ resources:
           # and https://github.com/istio/issues/issues/261) we have to force an earlier
           # version of kubectl than 1.10.0. 
           KUBECTL=/usr/local/bin/kubectl
-          curl -L -o $KUBECTL https://storage.googleapis.com/kubernetes-release/release/v1.9.6/bin/linux/amd64/kubectl
+          curl -L -o $KUBECTL https://storage.googleapis.com/kubernetes-release/release/v1.9.7/bin/linux/amd64/kubectl
           chmod +x /usr/local/bin/kubectl
           export HOME=/root
           gcloud components update -q

--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -8,7 +8,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ properties['gkeClusterName'] }}
-      initialClusterVersion: 1.9.6-gke.0
+      initialClusterVersion: 1.9.7-gke.0
       legacyAbac:
         enabled: false
       initialNodeCount: {{ properties['initialNodeCount'] }}


### PR DESCRIPTION
Note that the 1.9.6-gke.0 version is no longer a valid option.