### PR TITLE
Generate junit reports for all e2e jobs in Prow presubmit

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -30,7 +30,16 @@ set -u
 # Print commands
 set -x
 
-TEST_TARGETS=(e2e_simple e2e_mixer e2e_bookinfo e2e_bookinfo_envoyv2_v1alpha3 e2e_upgrade e2e_dashboard e2e_pilot e2e_pilotv2_v1alpha3)
+TEST_TARGETS=(
+  e2e_simple
+  e2e_mixer
+  e2e_bookinfo
+  e2e_bookinfo_envoyv2_v1alpha3
+  e2e_upgrade
+  e2e_dashboard
+  e2e_pilot
+  e2e_pilotv2_v1alpha3
+)
 SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
@@ -93,7 +102,8 @@ if ${SINGLE_MODE}; then
             VALID_TEST=true
             time ISTIO_DOCKER_HUB=$HUB \
               E2E_ARGS="${E2E_ARGS[@]}" \
-              make "${SINGLE_TEST}"
+              JUNIT_E2E_XML="${ARTIFACTS_DIR}/junit.xml" \
+              make with_junit_report TARGET="${SINGLE_TEST}"
         fi
     done
     if [ "${VALID_TEST}" == "false" ]; then


### PR DESCRIPTION
Without junit report xml, Prow will report 
```
Result | FAILURE
Tests  | 0 failed / 0 succeeded
```
and some developers were confused by the `0 failed` but result being FAILURE. Having the junit report, the summary of successes vs failures then reflects the actual test.