### PR TITLE
Provide default requested resources for cpu/mem for sidecar

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecar-injector/templates/configmap.yaml
@@ -135,6 +135,8 @@ data:
             runAsUser: 1337
             {{ "[[ end -]]" }}
         restartPolicy: Always
+        resources:
+{{ toYaml .Values.global.proxy.resources | indent 10 }}
         volumeMounts:
         - mountPath: /etc/istio/proxy
           name: istio-envoy

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -14,6 +14,14 @@ global:
   tag: circleci-nightly
   proxy:
     image: proxy
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
   # proxyv2 image is the image to use for networking alpha3 and envoy v2
   proxyv2:
     image: proxyv2

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -144,6 +144,13 @@ containers:
   {{ else -}}
   imagePullPolicy: {{ .ImagePullPolicy }}
   {{ end -}}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   securityContext:
     {{ if eq .DebugMode true -}}
     privileged: true

--- a/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
     spec:
       template:
@@ -71,7 +71,13 @@ spec:
             image: docker.io/istio/proxy:unittest
             imagePullPolicy: IfNotPresent
             name: istio-proxy
-            resources: {}
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
             securityContext:
               privileged: false
               readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -70,7 +70,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -90,7 +90,13 @@ items:
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -75,7 +75,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"918b9a06caf0b325e3cad5f1734657eb4e89e5e98c13bb3c4c71c88d10aa1ca7","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"ca2f64f400cc029c9cb225a738330a4e9b085496490f3228247eb2a4a273d0a3","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/format-duration.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -90,7 +90,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"ae8f1a708f039b16c42ee829f72c71e19b50948b003ff5b83202b7b32ae71793","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"533218909219ec9fd4a5378fa7b12642c4236540595a04636fa7329e5ae2ccc1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: Always
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -73,7 +73,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -73,7 +73,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true
@@ -129,7 +135,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -193,7 +199,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"8d38d05383d22435af8f8b434abbf714b7386806c65ceb30464af129c16fea6f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ea21bc865323b627567eefeebb193b0a5ad1eea848862611c315f3037be27a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: Never
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -92,7 +92,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-proxy-override.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"version":"ee86065a70dcebc36f06ca4f6889bd86d7d7704c57995d8d104baf773010f073","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"181cac160a39193212fc823cd42441f1f76a8ff046723ce9f5e372616b6f8593","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -73,7 +73,13 @@ spec:
         image: docker.io/istio/proxy2_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false

--- a/pilot/pkg/kube/inject/testdata/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-tproxy-debug.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"ca16ee49bcf3f39b63512ec8c1101d269f16defd9d32dd3dd03137b475b21bbc","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"2adacff1af77d5780ea4c06fd560ba0657a454e3a2a0e36f5c3c94483db59141","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false

--- a/pilot/pkg/kube/inject/testdata/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello-tproxy.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"52fc11b25c772f86ace92eb7f00096508f66187338b43039ced576b3294f2848","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"2749eef3ed50a364264c38abe4d08be8a9392b257c467d2f497b62c9df9cfda2","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           capabilities:
             add:

--- a/pilot/pkg/kube/inject/testdata/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"ee86065a70dcebc36f06ca4f6889bd86d7d7704c57995d8d104baf773010f073","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"181cac160a39193212fc823cd42441f1f76a8ff046723ce9f5e372616b6f8593","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy_debug:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: true
           readOnlyRootFilesystem: false

--- a/pilot/pkg/kube/inject/testdata/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:
@@ -69,7 +69,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -91,7 +91,13 @@ items:
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -75,7 +75,13 @@ items:
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true
@@ -130,7 +136,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -194,7 +200,13 @@ items:
           image: docker.io/istio/proxy:unittest
           imagePullPolicy: IfNotPresent
           name: istio-proxy
-          resources: {}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
           securityContext:
             privileged: false
             readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -72,7 +72,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -69,7 +69,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -71,7 +71,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -75,7 +75,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""
@@ -74,7 +74,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'
@@ -74,7 +74,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"acd4b756a100f5fc7cd12b76c5d3f7ffce3e0562d86c74d79b00996e1f5ee98b","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"148b3f49ff4434872b0c3feae7ef3ab17dfed8aa06369af8905f13395dd852c1","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
@@ -74,7 +74,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-params-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"52fc11b25c772f86ace92eb7f00096508f66187338b43039ced576b3294f2848","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"2749eef3ed50a364264c38abe4d08be8a9392b257c467d2f497b62c9df9cfda2","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -70,7 +70,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/testdata/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/traffic-params.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"342598133176d3af7a18e9c179eb64e0caa783d011bb10fcbcdf80c0a8778c57","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"abe934a4136e9e19cc892663765d3b5f72cb91cf6f9481dd779f9238bcebede2","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic
@@ -70,7 +70,13 @@ spec:
         image: docker.io/istio/proxy:unittest
         imagePullPolicy: IfNotPresent
         name: istio-proxy
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
         securityContext:
           privileged: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Adding resources limits/requests default values to injected sidecar configuration.
Injected sidecar can be injected either manually or automatically.
The update of the helm charts for istio-injector will add the default values to the automatically injected sidecar while the update of the istioctl will add it to the manually injected (when users runs istioctl kube-inject).

Replaces #5358
Fixes #5175

/hold