### PR TITLE
Fix test code to be thread safe and enable racetest in ads_test.go

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -239,9 +238,6 @@ func adsReceive(ads ads.AggregatedDiscoveryService_StreamAggregatedResourcesClie
 }
 
 func TestAdsUpdate(t *testing.T) {
-	if os.Getenv("RACE_TEST") == "true" {
-		t.Skip("Test fails in race testing. Fixing in #5258")
-	}
 	server := initLocalPilotTestEnv(t)
 	edsstr := connectADS(t, util.MockPilotGrpcAddr)
 	// Old style cluster.

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -162,6 +162,7 @@ func (sd *MemServiceDiscovery) AddEndpoint(service model.Hostname, servicePortNa
 }
 
 // Services implements discovery interface
+// Each call to Services() should return a list of new *model.Service
 func (sd *MemServiceDiscovery) Services() ([]*model.Service, error) {
 	sd.mutex.Lock()
 	defer sd.mutex.Unlock()
@@ -170,12 +171,15 @@ func (sd *MemServiceDiscovery) Services() ([]*model.Service, error) {
 	}
 	out := make([]*model.Service, 0, len(sd.services))
 	for _, service := range sd.services {
-		out = append(out, service)
+		// Make a new service out of the existing one
+		newSvc := *service
+		out = append(out, &newSvc)
 	}
 	return out, sd.ServicesError
 }
 
 // GetService implements discovery interface
+// Each call to GetService() should return a new *model.Service
 func (sd *MemServiceDiscovery) GetService(hostname model.Hostname) (*model.Service, error) {
 	sd.mutex.Lock()
 	defer sd.mutex.Unlock()
@@ -183,7 +187,9 @@ func (sd *MemServiceDiscovery) GetService(hostname model.Hostname) (*model.Servi
 		return nil, sd.GetServiceError
 	}
 	val := sd.services[hostname]
-	return val, sd.GetServiceError
+	// Make a new service out of the existing one
+	newSvc := *val
+	return &newSvc, sd.GetServiceError
 }
 
 // Instances filters the service instances by labels. This assumes single port, as is

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -112,7 +112,7 @@ func TestServices(t *testing.T) {
 		t.Errorf("GetInstancesByPort() encountered unexpected error: %v", err)
 	}
 	if len(ep) != 2 {
-		t.Errorf("Invalid response for GetInstanesByPort %v", ep)
+		t.Errorf("Invalid response for GetInstancesByPort %v", ep)
 	}
 
 	missing := serviceHostname("does-not-exist", ns, domainSuffix)


### PR DESCRIPTION
Fix issue #5258 
Fix test code to be thread safe
enable race test in ads_test.go
remove the code to copy service in aggregate controller