### PR TITLE
Change default to 60 sec push

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -32,7 +32,7 @@ import (
 var (
 	// Failsafe to implement periodic refresh, in case events or cache invalidation fail.
 	// Disabled by default.
-	periodicRefreshDuration = 0 * time.Second
+	periodicRefreshDuration = 60 * time.Second
 
 	versionMutex sync.Mutex
 	// version is update by registry events.


### PR DESCRIPTION
This is a partial/safe fix - would also cover similar problems, the cost is 1-min update for all envoys.
Envoy is doing a diff - so it should not affect runtime, but for a large cluster it may become a problem.

https://github.com/istio/istio/issues/5588

Not yet sure what is the best long term solution, and if other cases exist - we'll need to figure it out for 1.0