### PR TITLE
add support for secretVolumes in the deployment of ingressgateway

### DIFF
--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -89,10 +89,21 @@ spec:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          {{- range .Values.deployment.secretVolumes }}
+          - name: {{.name }}
+            mountPath: {{.mountPath | quote}}
+            readOnly: true
+          {{- end }}
       volumes:
       - name: istio-certs
         secret:
           secretName: "istio.default"
           optional: true
+      {{- range .Values.deployment.secretVolumes }}
+      - name: {{.name }}
+        secret:
+          secretName: {{.secretName | quote}}
+          optional: true
+      {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -136,10 +136,7 @@ ingressgateway:
     - containerPort: 80
     - containerPort: 443
     - containerPort: 31400
-  # secretVolumes: TODO
-  # - name: someName
-  #   mountPath: somePath
-  #   secretName: someName
+    secretVolumes: []
 
 #
 # egressgateway configuration


### PR DESCRIPTION
See instructions at https://vadimeisenbergibm.github.io/docs/tasks/traffic-management-v1alpha3/ingress.html#inject-our-private-key-and-certificate-into-the-pod-of-the-istio-ingress-gateway-controller .