### PR TITLE
added resolution type ClientsideStaticLB

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -92,8 +92,10 @@ type Service struct {
 type Resolution int
 
 const (
-	// ClientSideLB implies that the proxy will decide the endpoint from its local lb pool
-	ClientSideLB Resolution = iota
+	// ClientSideDynamicLB implies that the proxy will decide the endpoint from its local lb pool from EDS
+	ClientSideDynamicLB Resolution = iota
+	// ClientSideStaticLB implies that the proxy will decide the endpoint from its local lb pool of static IPs
+	ClientSideStaticLB
 	// DNSLB implies that the proxy will resolve a DNS address and forward to the resolved address
 	DNSLB
 	// Passthrough implies that the proxy should forward traffic to the destination IP requested by the caller

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -202,8 +202,8 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusters(env model.Environment
 
 func convertResolution(resolution model.Resolution) v2.Cluster_DiscoveryType {
 	switch resolution {
-	case model.ClientSideLB:
-		return v2.Cluster_EDS
+	case model.ClientSideStaticLB:
+		return v2.Cluster_STATIC
 	case model.DNSLB:
 		return v2.Cluster_STRICT_DNS
 	case model.Passthrough:

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery.go
@@ -53,7 +53,7 @@ func (sd *ServiceDiscovery) Services() ([]*model.Service, error) {
 			Hostname:     model.Hostname(hostname),
 			Ports:        []*model.Port{port},
 			MeshExternal: false,
-			Resolution:   model.ClientSideLB,
+			Resolution:   model.ClientSideDynamicLB,
 		})
 	}
 
@@ -74,7 +74,7 @@ func (sd *ServiceDiscovery) Services() ([]*model.Service, error) {
 			Address:      internalRoute.Vip,
 			Ports:        []*model.Port{internalRouteServicePort},
 			MeshExternal: false,
-			Resolution:   model.ClientSideLB,
+			Resolution:   model.ClientSideDynamicLB,
 		})
 	}
 
@@ -122,7 +122,7 @@ func (sd *ServiceDiscovery) InstancesByPort(hostname model.Hostname, _ int, _ mo
 				Hostname:     hostname,
 				Ports:        []*model.Port{port},
 				MeshExternal: false,
-				Resolution:   model.ClientSideLB,
+				Resolution:   model.ClientSideDynamicLB,
 			},
 		})
 	}
@@ -152,7 +152,7 @@ func (sd *ServiceDiscovery) InstancesByPort(hostname model.Hostname, _ int, _ mo
 						Address:      internalRoute.Vip,
 						Ports:        []*model.Port{internalRouteServicePort},
 						MeshExternal: false,
-						Resolution:   model.ClientSideLB,
+						Resolution:   model.ClientSideDynamicLB,
 					},
 				})
 			}

--- a/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/cloudfoundry/servicediscovery_test.go
@@ -110,17 +110,20 @@ func TestServiceDiscovery_Services(t *testing.T) {
 	g.Expect(serviceModels).To(gomega.HaveLen(3))
 	g.Expect(serviceModels).To(gomega.ConsistOf([]*model.Service{
 		{
-			Hostname: "process-guid-a.cfapps.io",
-			Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
+			Hostname:   "process-guid-a.cfapps.io",
+			Resolution: model.ClientSideDynamicLB,
+			Ports:      []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
 		},
 		{
-			Hostname: "process-guid-b.cfapps.io",
-			Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
+			Hostname:   "process-guid-b.cfapps.io",
+			Resolution: model.ClientSideDynamicLB,
+			Ports:      []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
 		},
 		{
-			Hostname: "something.apps.internal",
-			Address:  "127.1.1.1",
-			Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolTCP, Name: "tcp"}},
+			Hostname:   "something.apps.internal",
+			Resolution: model.ClientSideDynamicLB,
+			Address:    "127.1.1.1",
+			Ports:      []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolTCP, Name: "tcp"}},
 		},
 	}))
 }
@@ -146,8 +149,9 @@ func TestServiceDiscovery_GetService_Success(t *testing.T) {
 
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(serviceModel).To(gomega.Equal(&model.Service{
-		Hostname: "process-guid-b.cfapps.io",
-		Ports:    []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
+		Hostname:   "process-guid-b.cfapps.io",
+		Resolution: model.ClientSideDynamicLB,
+		Ports:      []*model.Port{{Port: defaultServicePort, Protocol: model.ProtocolHTTP, Name: "http"}},
 	}))
 }
 
@@ -191,8 +195,9 @@ func TestServiceDiscovery_Instances_Filtering(t *testing.T) {
 		Name:     "http",
 	}
 	service := &model.Service{
-		Hostname: "process-guid-a.cfapps.io",
-		Ports:    []*model.Port{servicePort},
+		Hostname:   "process-guid-a.cfapps.io",
+		Resolution: model.ClientSideDynamicLB,
+		Ports:      []*model.Port{servicePort},
 	}
 
 	g.Expect(instances).To(gomega.ConsistOf([]*model.ServiceInstance{
@@ -229,8 +234,9 @@ func TestServiceDiscovery_Instances_Filtering(t *testing.T) {
 				},
 			},
 			Service: &model.Service{
-				Hostname: "something.apps.internal",
-				Address:  "127.1.1.1",
+				Hostname:   "something.apps.internal",
+				Address:    "127.1.1.1",
+				Resolution: model.ClientSideDynamicLB,
 				Ports: []*model.Port{
 					{
 						Port:     defaultServicePort,

--- a/pilot/pkg/serviceregistry/consul/conversion.go
+++ b/pilot/pkg/serviceregistry/consul/conversion.go
@@ -61,7 +61,7 @@ func convertService(endpoints []*api.CatalogService) *model.Service {
 	name, addr, externalName := "", "", ""
 
 	meshExternal := false
-	resolution := model.ClientSideLB
+	resolution := model.ClientSideDynamicLB
 
 	ports := make(map[int]*model.Port)
 	for _, endpoint := range endpoints {
@@ -112,7 +112,7 @@ func convertInstance(instance *api.CatalogService) *model.ServiceInstance {
 	}
 
 	meshExternal := false
-	resolution := model.ClientSideLB
+	resolution := model.ClientSideDynamicLB
 	externalName := instance.NodeMeta[externalTagName]
 	if externalName != "" {
 		meshExternal = true

--- a/pilot/pkg/serviceregistry/eureka/conversion.go
+++ b/pilot/pkg/serviceregistry/eureka/conversion.go
@@ -49,7 +49,7 @@ func convertServices(apps []*application, hostnames map[model.Hostname]bool) map
 					Ports:        make(model.PortList, 0),
 					ExternalName: "",
 					MeshExternal: false,
-					Resolution:   model.ClientSideLB,
+					Resolution:   model.ClientSideDynamicLB,
 				}
 				services[hostname] = service
 			}

--- a/pilot/pkg/serviceregistry/eureka/conversion_test.go
+++ b/pilot/pkg/serviceregistry/eureka/conversion_test.go
@@ -285,8 +285,9 @@ func makeService(hostname model.Hostname, ports []int, protocols []model.Protoco
 	}
 
 	return &model.Service{
-		Hostname: hostname,
-		Ports:    portList,
+		Hostname:   hostname,
+		Ports:      portList,
+		Resolution: model.ClientSideDynamicLB,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -41,7 +41,7 @@ func convertServices(serviceEntry *networking.ServiceEntry) []*model.Service {
 	case networking.ServiceEntry_DNS:
 		resolution = model.DNSLB
 	case networking.ServiceEntry_STATIC:
-		resolution = model.ClientSideLB
+		resolution = model.ClientSideStaticLB
 	}
 
 	svcPorts := make(model.PortList, 0, len(serviceEntry.Ports))

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -244,7 +244,7 @@ func TestConvertService(t *testing.T) {
 			// service entry http  static
 			externalSvc: httpStatic,
 			services: []*model.Service{makeService("*.google.com", "",
-				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideLB),
+				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideStaticLB),
 			},
 		},
 		{
@@ -272,7 +272,7 @@ func TestConvertService(t *testing.T) {
 			// service entry tcp static
 			externalSvc: tcpStatic,
 			services: []*model.Service{makeService("tcpstatic.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+				map[string]int{"tcp-444": 444}, true, model.ClientSideStaticLB),
 			},
 		},
 		{

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -57,7 +57,7 @@ func TestServiceDiscoveryServices(t *testing.T) {
 	sd := NewServiceDiscovery(nil, store)
 	expectedServices := []*model.Service{
 		makeService("*.google.com", "", map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
-		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideStaticLB),
 	}
 
 	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -97,7 +97,7 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 		addr = svc.Spec.ClusterIP
 	}
 
-	resolution := model.ClientSideLB
+	resolution := model.ClientSideDynamicLB
 	meshExternal := false
 	loadBalancingDisabled := false
 


### PR DESCRIPTION
With the current model.Resolution type ClientsideLB there is no way to distinguish between endpoints with static IPs and endpoints that are meant to be retrieved from EDS.  Currently the cluster returned by CDS for ServiceEntry's with static IP's tells envoy to retrieve the instances from EDS, when they should be listed in the cluster.hosts field with cluster type set to STATIC