### PR TITLE
mixer: add dispatcher scope

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -30,7 +30,7 @@ import (
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/dispatcher"
 	"istio.io/istio/mixer/pkg/status"
-	"istio.io/istio/pkg/log"
+	istio_log "istio.io/istio/pkg/log"
 )
 
 // We have a slightly messy situation around the use of context objects. gRPC stubs are
@@ -56,6 +56,8 @@ const (
 	// defaultValidUseCount is the default number of calls for which a check or quota result is valid.
 	defaultValidUseCount = 200
 )
+
+var log = istio_log.RegisterScope("dispatcher", "Dispatcher messages.", 0)
 
 // NewGRPCServer creates a gRPC serving stack.
 func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool) mixerpb.MixerServer {


### PR DESCRIPTION
We've lost the ability to print processed attributes in the log output...
This adds a new scope for the dispatcher that should print the complete attribute bag.

Signed-off-by: Kuat Yessenov <kuat@google.com>