### PR TITLE
Multicluster Fixing locks for add/delete/read

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -60,7 +60,7 @@ func (c *Controller) AddRegistry(registry Registry) {
 	c.registries = registries
 }
 
-// DeleteRegistry deletes registries into the aggregated controller
+// DeleteRegistry deletes specified registry from the aggregated controller
 func (c *Controller) DeleteRegistry(registry Registry) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -73,27 +73,14 @@ func (c *Controller) DeleteRegistry(registry Registry) {
 	c.registries = append(c.registries[:index], c.registries[index+1:]...)
 }
 
-// RegistryElement is used to send Registry over a channel
-type RegistryElement struct {
-	index int
-	Registry
-}
+// GetRegistries returns a copy of all registries
+func (c *Controller) GetRegistries() []Registry {
+	c.storeLock.Lock()
+	defer c.storeLock.Unlock()
 
-// GetRegistry returns Registry element in a protected maner
-func (c *Controller) GetRegistry() <-chan RegistryElement {
-	ch := make(chan RegistryElement)
-
-	f := func() {
-		c.storeLock.Lock()
-		defer c.storeLock.Unlock()
-		for index, value := range c.registries {
-			ch <- RegistryElement{index, value}
-		}
-		close(ch)
-	}
-	go f()
-
-	return ch
+	registries := make([]Registry, len(c.registries))
+	copy(registries, c.registries)
+	return registries
 }
 
 // GetRegistryIndex returns the index of a registry
@@ -115,7 +102,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 	services := make([]*model.Service, 0)
 	var errs error
 	// Locking Registries list while walking it to prevent inconsistent results
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		svcs, err := r.Services()
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -156,7 +143,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 // GetService retrieves a service by hostname if exists
 func (c *Controller) GetService(hostname model.Hostname) (*model.Service, error) {
 	var errs error
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		service, err := r.GetService(hostname)
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -174,7 +161,7 @@ func (c *Controller) GetService(hostname model.Hostname) (*model.Service, error)
 // ManagementPorts retrieves set of health check ports by instance IP
 // Return on the first hit.
 func (c *Controller) ManagementPorts(addr string) model.PortList {
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		if portList := r.ManagementPorts(addr); portList != nil {
 			return portList
 		}
@@ -188,7 +175,7 @@ func (c *Controller) Instances(hostname model.Hostname, ports []string,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {
 	var instances, tmpInstances []*model.ServiceInstance
 	var errs error
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		var err error
 		tmpInstances, err = r.Instances(hostname, ports, labels)
 		if err != nil {
@@ -212,7 +199,7 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, port int,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {
 	var instances, tmpInstances []*model.ServiceInstance
 	var errs error
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		var err error
 		tmpInstances, err = r.InstancesByPort(hostname, port, labels)
 		if err != nil {
@@ -236,7 +223,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 	var errs error
 	// It doesn't make sense for a single proxy to be found in more than one registry.
 	// TODO: if otherwise, warning or else what to do about it.
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		instances, err := r.GetProxyServiceInstances(node)
 		if err != nil {
 			errs = multierror.Append(errs, err)
@@ -260,7 +247,7 @@ func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.Servi
 // Run starts all the controllers
 func (c *Controller) Run(stop <-chan struct{}) {
 
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		go r.Run(stop)
 	}
 
@@ -270,7 +257,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 // AppendServiceHandler implements a service catalog operation
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		if err := r.AppendServiceHandler(f); err != nil {
 			log.Infof("Fail to append service handler to adapter %s", r.Name)
 			return err
@@ -281,7 +268,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 
 // AppendInstanceHandler implements a service instance catalog operation
 func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		if err := r.AppendInstanceHandler(f); err != nil {
 			log.Infof("Fail to append instance handler to adapter %s", r.Name)
 			return err
@@ -292,7 +279,7 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 
 // GetIstioServiceAccounts implements model.ServiceAccounts operation
 func (c *Controller) GetIstioServiceAccounts(hostname model.Hostname, ports []string) []string {
-	for r := range c.GetRegistry() {
+	for _, r := range c.GetRegistries() {
 		if svcAccounts := r.GetIstioServiceAccounts(hostname, ports); svcAccounts != nil {
 			return svcAccounts
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -55,16 +55,13 @@ func NewController() *Controller {
 func (c *Controller) AddRegistry(registry Registry) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
-	registries := c.registries
-	registries = append(registries, registry)
-	c.registries = registries
+	c.registries = append(c.registries, registry)
 }
 
 // DeleteRegistry deletes specified registry from the aggregated controller
 func (c *Controller) DeleteRegistry(registry Registry) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
-	registries := c.registries
 	if len(c.registries) == 0 {
 		log.Warnf("Registry list is empty, nothing to delete")
 		return
@@ -74,15 +71,18 @@ func (c *Controller) DeleteRegistry(registry Registry) {
 		log.Warnf("Registry is not found in the registries list, nothing to delete")
 		return
 	}
-	registries = append(registries[:index], registries[index+1:]...)
-	c.registries = registries
+	c.registries = append(c.registries[:index], c.registries[index+1:]...)
 }
 
 // GetRegistries returns a copy of all registries
 func (c *Controller) GetRegistries() []Registry {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
-	registries := c.registries
+	registries := make([]Registry, len(c.registries))
+	l := reflect.Copy(reflect.ValueOf(registries), reflect.ValueOf(c.registries))
+	if l != len(c.registries) {
+		log.Warnf("The length of copied Registry slice does not match the original.")
+	}
 	return registries
 }
 

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -469,3 +469,72 @@ func TestManagementPorts(t *testing.T) {
 		}
 	}
 }
+
+func TestAddRegistry(t *testing.T) {
+
+	registries := []Registry{
+		{
+			Name:      "registry1",
+			ClusterID: "cluster1",
+		},
+		{
+			Name:      "registry2",
+			ClusterID: "cluster2",
+		},
+	}
+	ctrl := NewController()
+	for _, r := range registries {
+		ctrl.AddRegistry(r)
+	}
+	if l := len(ctrl.registries); l != 2 {
+		t.Fatalf("Expected length of the registries slice should be 2, got %d", l)
+	}
+}
+
+func TestDeleteRegistry(t *testing.T) {
+	registries := []Registry{
+		{
+			Name:      "registry1",
+			ClusterID: "cluster1",
+		},
+		{
+			Name:      "registry2",
+			ClusterID: "cluster2",
+		},
+	}
+	ctrl := NewController()
+	for _, r := range registries {
+		ctrl.AddRegistry(r)
+	}
+	ctrl.DeleteRegistry(registries[0])
+	if l := len(ctrl.registries); l != 1 {
+		t.Fatalf("Expected length of the registries slice should be 1, got %d", l)
+	}
+}
+
+func TestGetRegistries(t *testing.T) {
+	registries := []Registry{
+		{
+			Name:      "registry1",
+			ClusterID: "cluster1",
+		},
+		{
+			Name:      "registry2",
+			ClusterID: "cluster2",
+		},
+	}
+	ctrl := NewController()
+	for _, r := range registries {
+		ctrl.AddRegistry(r)
+	}
+	result := ctrl.GetRegistries()
+	if len(ctrl.registries) != len(result) {
+		t.Fatal("Length of the original registries slice does not match to returned by GetRegistries.")
+	}
+
+	for i := range result {
+		if !reflect.DeepEqual(result[i], ctrl.registries[i]) {
+			t.Fatal("The original registries slice and resulting slice supposed to be identical.")
+		}
+	}
+}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -511,30 +511,3 @@ func TestDeleteRegistry(t *testing.T) {
 		t.Fatalf("Expected length of the registries slice should be 1, got %d", l)
 	}
 }
-
-func TestGetRegistries(t *testing.T) {
-	registries := []Registry{
-		{
-			Name:      "registry1",
-			ClusterID: "cluster1",
-		},
-		{
-			Name:      "registry2",
-			ClusterID: "cluster2",
-		},
-	}
-	ctrl := NewController()
-	for _, r := range registries {
-		ctrl.AddRegistry(r)
-	}
-	result := ctrl.GetRegistries()
-	if len(ctrl.registries) != len(result) {
-		t.Fatal("Length of the original registries slice does not match to returned by GetRegistries.")
-	}
-
-	for i := range result {
-		if !reflect.DeepEqual(result[i], ctrl.registries[i]) {
-			t.Fatal("The original registries slice and resulting slice supposed to be identical.")
-		}
-	}
-}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -511,3 +511,30 @@ func TestDeleteRegistry(t *testing.T) {
 		t.Fatalf("Expected length of the registries slice should be 1, got %d", l)
 	}
 }
+
+func TestGetRegistries(t *testing.T) {
+	registries := []Registry{
+		{
+			Name:      "registry1",
+			ClusterID: "cluster1",
+		},
+		{
+			Name:      "registry2",
+			ClusterID: "cluster2",
+		},
+	}
+	ctrl := NewController()
+	for _, r := range registries {
+		ctrl.AddRegistry(r)
+	}
+	result := ctrl.GetRegistries()
+	if len(ctrl.registries) != len(result) {
+		t.Fatal("Length of the original registries slice does not match to returned by GetRegistries.")
+	}
+
+	for i := range result {
+		if !reflect.DeepEqual(result[i], ctrl.registries[i]) {
+			t.Fatal("The original registries slice and resulting slice supposed to be identical.")
+		}
+	}
+}


### PR DESCRIPTION
This PR address required locking for aggregate controller.
It addresses cases of `adding` registry into Registries slice,  `deleting` registry and `walking` through registries list by providing a copy of registries to a reader. 