### PR TITLE
[WIP] Migrating e2e v1alpha1 egress rules test to use fortio.istio.io instead of httpbin.org

### DIFF
--- a/tests/e2e/tests/pilot/egress_rules_test.go
+++ b/tests/e2e/tests/pilot/egress_rules_test.go
@@ -48,31 +48,25 @@ func TestEgress(t *testing.T) {
 			shouldBeReachable: true,
 		},
 		{
-			name:              "REACHABLE_httpbin.org",
-			config:            "testdata/v1alpha1/egress-rule-httpbin.yaml",
-			url:               "http://httpbin.org/headers",
+			name:              "REACHABLE_fortio.istio.io",
+			config:            "testdata/v1alpha1/egress-rule-fortio.yaml",
+			url:               "http://fortio.istio.io/debug",
 			shouldBeReachable: true,
 		},
 		{
-			name:   "UNREACHABLE_httpbin.org_443",
-			config: "testdata/v1alpha1/egress-rule-httpbin.yaml",
+			name:   "UNREACHABLE_fortio.istio.io_443",
+			config: "testdata/v1alpha1/egress-rule-fortio.yaml",
 			// Note that we're using http (not https). We're relying on Envoy to convert the outbound call to
 			// TLS for us. This is currently the suggested way for the application to call an external TLS service.\
 			// If the application uses TLS, then no metrics will be collected for the request.
-			url:               "http://httpbin.org:443/headers",
+			url:               "http://fortio.istio.io:443/debug",
 			shouldBeReachable: false,
 		},
 		{
-			name:              "REACHABLE_www.httpbin.org",
-			config:            "testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
-			url:               "http://www.httpbin.org/headers",
+			name:              "REACHABLE_fortio.istio.io",
+			config:            "testdata/v1alpha1/egress-rule-wildcard-istio.yaml",
+			url:               "http://fortio.istio.io/debug",
 			shouldBeReachable: true,
-		},
-		{
-			name:              "UNREACHABLE_httpbin.org",
-			config:            "testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
-			url:               "http://httpbin.org/headers",
-			shouldBeReachable: false,
 		},
 		{
 			name:              "REACHABLE_wikipedia",

--- a/tests/e2e/tests/pilot/routing_to_egress_test.go
+++ b/tests/e2e/tests/pilot/routing_to_egress_test.go
@@ -71,22 +71,22 @@ func TestEgressRouteFaultInjection(t *testing.T) {
 	}{
 		// Fault Injection
 		{
-			testName:        "httpbin",
-			egressConfig:    "testdata/v1alpha1/egress-rule-httpbin.yaml",
+			testName:        "fortio",
+			egressConfig:    "testdata/v1alpha1/egress-rule-fortio.yaml",
 			routingTemplate: "testdata/v1alpha1/rule-fault-injection-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service": "httpbin.org",
+				"service": "fortio.istio.io",
 			},
-			url: "http://httpbin.org",
+			url: "http://fortio.istio.io/debug",
 		},
 		{
-			testName:        "*.httpbin",
-			egressConfig:    "testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
+			testName:        "*.istio.io",
+			egressConfig:    "testdata/v1alpha1/egress-rule-wildcard-istio.yaml",
 			routingTemplate: "testdata/v1alpha1/rule-fault-injection-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service": "*.httpbin.org",
+				"service": "*.istio.io",
 			},
-			url: "http://www.httpbin.org",
+			url: "http://fortio.istio.io/debug",
 		},
 		{
 			testName:        "google",
@@ -143,8 +143,8 @@ func TestEgressRouteHeaders(t *testing.T) {
 	cfgs := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{
-			"testdata/v1alpha1/egress-rule-httpbin.yaml",
-			"testdata/v1alpha1/rule-route-append-headers-httpbin.yaml"},
+			"testdata/v1alpha1/egress-rule-fortio.yaml",
+			"testdata/v1alpha1/rule-route-append-headers-fortio.yaml"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
@@ -152,9 +152,9 @@ func TestEgressRouteHeaders(t *testing.T) {
 	}
 	defer cfgs.Teardown()
 
-	runRetriableTest(t, "httpbin", 3,
+	runRetriableTest(t, "fortio", 3,
 		func() error {
-			resp := ClientRequest("a", "http://httpbin.org/headers", 1, "")
+			resp := ClientRequest("a", "http://fortio.istio.io/debug", 1, "")
 
 			containsAllExpectedHeaders := true
 
@@ -222,118 +222,84 @@ func TestEgressRouteRedirectRewrite(t *testing.T) {
 		targetPath      string
 	}{
 		{
-			testName:        "REDIRECT[httbin/post->httpbin/get]",
-			egressConfig:    []string{"testdata/v1alpha1/egress-rule-httpbin.yaml"},
+			testName:        "REDIRECT[fortio/redirect_e2e_test->fortio/debug]",
+			egressConfig:    []string{"testdata/v1alpha1/egress-rule-fortio.yaml"},
 			routingTemplate: "testdata/v1alpha1/rule-redirect-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service":   "httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "httpbin.org",
+				"service":   "fortio.istio.io",
+				"from":      "/redirect_e2e_test",
+				"to":        "/debug",
+				"authority": "fortio.istio.io",
 			},
-			url:        "http://httpbin.org/post",
-			targetHost: "httpbin.org",
-			targetPath: "/get",
+			url:        "http://fortio.istio.io/redirect_e2e_test",
+			targetHost: "fortio.istio.io",
+			targetPath: "/debug",
 		},
 		{
-			testName: "REDIRECT[httpbin/post->*.httpbin/get]",
+			testName: "REDIRECT[archive/redirect_e2e_test->*.istio/debug]",
 			egressConfig: []string{
-				"testdata/v1alpha1/egress-rule-httpbin.yaml",
-				"testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
+				"testdata/v1alpha1/egress-rule-fortio.yaml",
+				"testdata/v1alpha1/egress-rule-wildcard-istio.yaml",
 			},
 			routingTemplate: "testdata/v1alpha1/rule-redirect-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service":   "httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "www.httpbin.org",
+				"service":   "archive.istio.io",
+				"from":      "/redirect_e2e_test",
+				"to":        "/debug",
+				"authority": "fortio.istio.io",
 			},
-			url:        "http://httpbin.org/post",
-			targetHost: "www.httpbin.org",
-			targetPath: "/get",
+			url:        "http://archive.istio.io/redirect_e2e_test",
+			targetHost: "fortio.istio.io",
+			targetPath: "/debug",
 		},
 		{
-			testName: "REDIRECT[*.httpbin/post->httpbin/get]",
+			testName: "REDIRECT[*.istio/redirect_e2e_test->fortio/debug]",
 			egressConfig: []string{
-				"testdata/v1alpha1/egress-rule-httpbin.yaml",
-				"testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
+				"testdata/v1alpha1/egress-rule-fortio.yaml",
+				"testdata/v1alpha1/egress-rule-wildcard-istio.yaml",
 			},
 			routingTemplate: "testdata/v1alpha1/rule-redirect-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service":   "*.httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "httpbin.org",
+				"service":   "*.istio.io",
+				"from":      "/redirect_e2e_test",
+				"to":        "/debug",
+				"authority": "fortio.istio.io",
 			},
-			url:        "http://www.httpbin.org/post",
-			targetHost: "httpbin.org",
-			targetPath: "/get",
+			url:        "http://archive.istio.io/redirect_e2e_test",
+			targetHost: "fortio.istio.io",
+			targetPath: "/debug",
 		},
 		{
-			testName: "REDIRECT[google/post->httpbin/get]",
+			testName: "REDIRECT[google/post->fortio/debug]",
 			egressConfig: []string{
 				"testdata/v1alpha1/egress-rule-google.yaml",
-				"testdata/v1alpha1/egress-rule-httpbin.yaml",
+				"testdata/v1alpha1/egress-rule-fortio.yaml",
 			},
 			routingTemplate: "testdata/v1alpha1/rule-redirect-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
 				"service":   "*google.com",
 				"from":      "/post",
-				"to":        "/get",
-				"authority": "httpbin.org",
+				"to":        "/debug",
+				"authority": "fortio.istio.io",
 			},
 			url:        "http://www.google.com:443/post",
-			targetHost: "httpbin.org",
-			targetPath: "/get",
+			targetHost: "fortio.istio.io",
+			targetPath: "/debug",
 		},
 		// Rewrite
 		{
-			testName:        "REWRITE[httpbin/post->httpbin/get]",
+			testName:        "REWRITE[fortio/rewrite_e2e_test->fortio/debug]",
 			egressConfig:    []string{"testdata/v1alpha1/egress-rule-httpbin.yaml"},
 			routingTemplate: "testdata/v1alpha1/rule-rewrite-to-egress.yaml.tmpl",
 			routingParams: map[string]string{
-				"service":   "httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "httpbin.org",
+				"service":   "fortio.istio.io",
+				"from":      "/rewrite_e2e_test",
+				"to":        "/debug",
+				"authority": "fortio.istio.io",
 			},
-			url:        "http://httpbin.org/post",
-			targetHost: "httpbin.org",
-			targetPath: "/get",
-		},
-		{
-			testName: "REWRITE[httpbin/post->*/httpbin/get]",
-			egressConfig: []string{
-				"testdata/v1alpha1/egress-rule-httpbin.yaml",
-				"testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
-			},
-			routingTemplate: "testdata/v1alpha1/rule-rewrite-to-egress.yaml.tmpl",
-			routingParams: map[string]string{
-				"service":   "httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "www.httpbin.org",
-			},
-			url:        "http://httpbin.org/post",
-			targetHost: "www.httpbin.org",
-			targetPath: "/get",
-		},
-		{
-			testName: "REWRITE[*.httpbin/post->httpbin/get]",
-			egressConfig: []string{
-				"testdata/v1alpha1/egress-rule-httpbin.yaml",
-				"testdata/v1alpha1/egress-rule-wildcard-httpbin.yaml",
-			},
-			routingTemplate: "testdata/v1alpha1/rule-rewrite-to-egress.yaml.tmpl",
-			routingParams: map[string]string{
-				"service":   "*.httpbin.org",
-				"from":      "/post",
-				"to":        "/get",
-				"authority": "httpbin.org",
-			},
-			url:        "http://www.httpbin.org/post",
-			targetHost: "httpbin.org",
-			targetPath: "/get",
+			url:        "http://fortio.istio.io/rewrite_e2e_test",
+			targetHost: "fortio.istio.io",
+			targetPath: "/debug",
 		},
 	}
 

--- a/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-fortio.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-fortio.yaml
@@ -1,10 +1,10 @@
 apiVersion: config.istio.io/v1alpha2
 kind: EgressRule
 metadata:
-  name: httpbin
+  name: fortio
 spec:
   destination:
-      service: "httpbin.org"
+      service: "fortio.istio.io"
   ports:
       - port: 80
         protocol: http

--- a/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-wildcard-istio.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha1/egress-rule-wildcard-istio.yaml
@@ -1,10 +1,10 @@
 apiVersion: config.istio.io/v1alpha2
 kind: EgressRule
 metadata:
-  name: httpbin-wildcard
+  name: fortio-wildcard
 spec:
   destination:
-      service: "*.httpbin.org"
+      service: "*.istio.io"
   ports:
       - port: 80
         protocol: http

--- a/tests/e2e/tests/pilot/testdata/v1alpha1/rule-route-append-headers-fortio.yaml
+++ b/tests/e2e/tests/pilot/testdata/v1alpha1/rule-route-append-headers-fortio.yaml
@@ -4,7 +4,7 @@ metadata:
   name: httpbin-append-headers
 spec:
   destination:
-    service: "httpbin.org"
+    service: "fortio.istio.io"
   appendHeaders:
     istio-custom-header1: user-defined-value1
     istio-custom-header2: user-defined-value2


### PR DESCRIPTION
httpbin.org became flaky lately, e2e egress tests consistently fail to access httpbin.org. It is possible that they applied some DOS protection or have some availability issues. This PR proposes to switch from using httpbin.org to fortio.istio.io/debug. The tests that access google.com and wikipedia.org pass, so we continue to use them as before