### PR TITLE
Add a default secure ingress volume

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -143,9 +143,9 @@ ingressgateway:
     - containerPort: 443
     - containerPort: 31400
     secretVolumes:
-    - name: ingress-certs
-      secretName: istio-ingress-certs
-      mountPath: /etc/istio/ingress-certs
+    - name: ingressgateway-certs
+      secretName: istio-ingressgateway-certs
+      mountPath: /etc/istio/ingressgateway-certs
 
 #
 # egressgateway configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -142,7 +142,10 @@ ingressgateway:
     - containerPort: 80
     - containerPort: 443
     - containerPort: 31400
-    secretVolumes: []
+    secretVolumes:
+    - name: ingress-certs
+      secretName: istio-ingress-certs
+      mountPath: /etc/istio/ingress-certs
 
 #
 # egressgateway configuration


### PR DESCRIPTION
its usage is described here https://vadimeisenbergibm.github.io/docs/tasks/traffic-management-v1alpha3/ingress.html#add-a-secure-port-https-to-our-gateway

It should fix https://github.com/istio/issues/issues/340.