### PR TITLE
Upgrade from 0.7.1 to 0.8.0 fails

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
   resources: ["*"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "get", "list", "watch", "patch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
need patch in CRD creation - atleast with Kubernetes 1.10.2.