### PR TITLE
Security on flag fix

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -30,9 +30,6 @@ global:
     repository: quay.io/coreos/hyperkube
     tag: v1.7.6_coreos.0
 
-  # Install istio CA.
-  securityEnabled: true
-
   # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
   # propagated, not recommended for tests.
   controlPlaneSecurityEnabled: false

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -30,9 +30,6 @@ global:
     repository: quay.io/coreos/hyperkube
     tag: v1.7.6_coreos.0
 
-  # Install istio CA.
-  securityEnabled: true
-
   # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
   # propagated, not recommended for tests.
   controlPlaneSecurityEnabled: false

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -675,7 +675,7 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 
 	// construct setValue to pass into helm install
 	// mTLS
-	setValue := "--set global.securityEnabled=" + strconv.FormatBool(isSecurityOn)
+	setValue := "--set global.mtls.enabled=" + strconv.FormatBool(isSecurityOn)
 	// side car injector
 	if *useAutomaticInjection {
 		setValue += " --set sidecar-injector.enabled=true"


### PR DESCRIPTION
I noticed that the `securityEnabled` in Helm's global values is never being read and only being set when providing an `auth_enable` flag.
In this case I believe it should be the `global.mtls.enabled` that should be set rather then `securityEnabled`.