### PR TITLE
Examples should use current rule types

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -96,10 +96,13 @@ system.
 
 Available routing and traffic management configuration types:
 
-	[routerule ingressrule egressrule destinationpolicy]
+	[virtualservice gateway destinationrule serviceentry httpapispec httpapispecbinding quotaspec quotaspecbinding servicerole servicerolebinding policy]
 
-See https://istio.io/docs/reference/ for an overview of routing rules
-and destination policies.
+Legacy routing and traffic management configuration types:
+
+	[routerule egressrule destinationpolicy]
+
+See https://istio.io/docs/reference/ for an overview of Istio routing.
 
 `,
 		PersistentPreRunE: istioPersistentPreRunE,
@@ -271,14 +274,14 @@ and destination policies.
 	getCmd = &cobra.Command{
 		Use:   "get <type> [<name>]",
 		Short: "Retrieve policies and rules",
-		Example: `# List all route rules
-istioctl get routerules
+		Example: `# List all virtual services
+istioctl get virtualservices
 
-# List all destination policies
-istioctl get destinationpolicies
+# List all destination rules
+istioctl get destinationrules
 
-# Get a specific rule named productpage-default
-istioctl get routerule productpage-default
+# Get a specific virtual service named bookinfo
+istioctl get virtualservice bookinfo
 `,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, err := newClient()
@@ -337,8 +340,8 @@ istioctl get routerule productpage-default
 		Example: `# Delete a rule using the definition in example-routing.yaml.
 istioctl delete -f example-routing.yaml
 
-# Delete the rule productpage-default
-istioctl delete routerule productpage-default
+# Delete the virtual service bookinfo
+istioctl delete virtualservice bookinfo
 `,
 		RunE: func(c *cobra.Command, args []string) error {
 			configClient, errs := newClient()


### PR DESCRIPTION
Takes the suggestion of Issue https://github.com/istio/istio/issues/5604 to use the new rule format in the _istioctl_ usage examples.

This updates the CLI usage text but not https://istio.io/docs/reference/commands/istioctl.html .