### PR TITLE
Use jaeger for zipkin service

### DIFF
--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+            - containerPort: {{ .Values.service.uiPort }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/deployment.yaml
@@ -29,14 +29,16 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.namespace
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: "{{ .Values.service.internalPort }}"
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.internalPort }}
+              port: {{ .Values.service.uiPort }}
           readinessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.internalPort }}
+              port: {{ .Values.service.uiPort }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       affinity:

--- a/install/kubernetes/helm/istio/charts/zipkin/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/zipkin/templates/service.yaml
@@ -15,5 +15,9 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
       name: {{ .Values.service.name }}
+    - port: 80
+      name: query-http
+      protocol: TCP
+      targetPort: {{ .Values.service.uiPort }}
   selector:
     app: zipkin

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -387,13 +387,16 @@ zipkin:
   enabled: false
   replicaCount: 1
   image:
-    repository: docker.io/openzipkin/zipkin
-    tag: 2.7
+    # TODO: switch name to tracing or other fix to reflect jaeger as the
+    #       default tracing option
+    repository: jaegertracing/all-in-one
+    tag: 1.4.1
   service:
     name: http
     type: ClusterIP
     externalPort: 9411
     internalPort: 9411
+    uiPort: 16686
   ingress:
     enabled: false
     # Used to create an Ingress record.


### PR DESCRIPTION
This switches out the image used for the deployments matching the `zipkin` service to use the `1.4.1` version of `jaeger` instead.

The PR adds a service port of `80` for ui concerns (forwarded here to jaeger's `16686` container port).

Based on discussions with: @costinm @mandarjog 