### PR TITLE
Rename Service's field: Addresses -> ClusterVIPs

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -53,9 +53,9 @@ type Service struct {
 	// Address specifies the service IPv4 address of the load balancer
 	Address string `json:"address,omitempty"`
 
-	// Addresses specifies the service address of the load balancer
+	// MulticlusterAddresses specifies the service address of the load balancer
 	// in each of the clusters where the service resides
-	Addresses map[string]string `json:"addresses,omitempty"`
+	MulticlusterAddresses map[string]string `json:"multicluster-addresses,omitempty"`
 
 	// Ports is the set of network ports where the service is listening for
 	// connections
@@ -711,8 +711,8 @@ func ParseLabelsString(s string) Labels {
 
 // GetServiceAddressForProxy returns a Service's IP address specific to the cluster where the node resides
 func (s Service) GetServiceAddressForProxy(node *Proxy) string {
-	if node.ClusterID != "" && s.Addresses[node.ClusterID] != "" {
-		return s.Addresses[node.ClusterID]
+	if node.ClusterID != "" && s.MulticlusterAddresses[node.ClusterID] != "" {
+		return s.MulticlusterAddresses[node.ClusterID]
 	}
 	return s.Address
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -53,9 +53,9 @@ type Service struct {
 	// Address specifies the service IPv4 address of the load balancer
 	Address string `json:"address,omitempty"`
 
-	// MulticlusterAddresses specifies the service address of the load balancer
+	// ClusterVIPs specifies the service address of the load balancer
 	// in each of the clusters where the service resides
-	MulticlusterAddresses map[string]string `json:"multicluster-addresses,omitempty"`
+	ClusterVIPs map[string]string `json:"cluster-vips,omitempty"`
 
 	// Ports is the set of network ports where the service is listening for
 	// connections
@@ -711,8 +711,8 @@ func ParseLabelsString(s string) Labels {
 
 // GetServiceAddressForProxy returns a Service's IP address specific to the cluster where the node resides
 func (s Service) GetServiceAddressForProxy(node *Proxy) string {
-	if node.ClusterID != "" && s.MulticlusterAddresses[node.ClusterID] != "" {
-		return s.MulticlusterAddresses[node.ClusterID]
+	if node.ClusterID != "" && s.ClusterVIPs[node.ClusterID] != "" {
+		return s.ClusterVIPs[node.ClusterID]
 	}
 	return s.Address
 }

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -85,11 +85,11 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 		} else {
 			if svcPort, exists := svc.Ports.GetByPort(port); exists {
 				nameToServiceMap[svc.Hostname] = &model.Service{
-					Hostname:              svc.Hostname,
-					Address:               svc.Address,
-					MulticlusterAddresses: svc.MulticlusterAddresses,
-					MeshExternal:          svc.MeshExternal,
-					Ports:                 []*model.Port{svcPort},
+					Hostname:     svc.Hostname,
+					Address:      svc.Address,
+					ClusterVIPs:  svc.ClusterVIPs,
+					MeshExternal: svc.MeshExternal,
+					Ports:        []*model.Port{svcPort},
 				}
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -85,11 +85,11 @@ func (configgen *ConfigGeneratorImpl) BuildSidecarOutboundHTTPRouteConfig(env mo
 		} else {
 			if svcPort, exists := svc.Ports.GetByPort(port); exists {
 				nameToServiceMap[svc.Hostname] = &model.Service{
-					Hostname:     svc.Hostname,
-					Address:      svc.Address,
-					Addresses:    svc.Addresses,
-					MeshExternal: svc.MeshExternal,
-					Ports:        []*model.Port{svcPort},
+					Hostname:              svc.Hostname,
+					Address:               svc.Address,
+					MulticlusterAddresses: svc.MulticlusterAddresses,
+					MeshExternal:          svc.MeshExternal,
+					Ports:                 []*model.Port{svcPort},
 				}
 			}
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -92,10 +92,10 @@ func (c *Controller) Services() ([]*model.Service, error) {
 			// TODO: what is this used for ? Do we want to support multiple VIPs, or
 			// only use the 'primary' VIP ?
 			if r.ClusterID != "" {
-				if sp.MulticlusterAddresses == nil {
-					sp.MulticlusterAddresses = make(map[string]string)
+				if sp.ClusterVIPs == nil {
+					sp.ClusterVIPs = make(map[string]string)
 				}
-				sp.MulticlusterAddresses[r.ClusterID] = s.Address
+				sp.ClusterVIPs[r.ClusterID] = s.Address
 				smap[s.Hostname] = sp
 			}
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -92,10 +92,10 @@ func (c *Controller) Services() ([]*model.Service, error) {
 			// TODO: what is this used for ? Do we want to support multiple VIPs, or
 			// only use the 'primary' VIP ?
 			if r.ClusterID != "" {
-				if sp.Addresses == nil {
-					sp.Addresses = make(map[string]string)
+				if sp.MulticlusterAddresses == nil {
+					sp.MulticlusterAddresses = make(map[string]string)
 				}
-				sp.Addresses[r.ClusterID] = s.Address
+				sp.MulticlusterAddresses[r.ClusterID] = s.Address
 				smap[s.Hostname] = sp
 			}
 		}

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -151,8 +151,8 @@ func TestServicesForMultiCluster(t *testing.T) {
 		t.Fatalf("Service map expected size %d, actual %v", svcCount, serviceMap)
 	}
 
-	//Now verify Addresses for each service
-	Addresses := map[model.Hostname]map[string]string{
+	//Now verify MulticlusterAddresses for each service
+	MulticlusterAddresses := map[model.Hostname]map[string]string{
 		mock.HelloService.Hostname: {
 			"cluster-1": "10.1.1.0",
 			"cluster-2": "10.1.2.0",
@@ -162,11 +162,11 @@ func TestServicesForMultiCluster(t *testing.T) {
 		},
 	}
 	for _, svc := range services {
-		if !reflect.DeepEqual(svc.Addresses, Addresses[svc.Hostname]) {
-			t.Fatalf("Service %s addresses actual %v, expected %v", svc.Hostname, svc.Addresses, Addresses[svc.Hostname])
+		if !reflect.DeepEqual(svc.MulticlusterAddresses, MulticlusterAddresses[svc.Hostname]) {
+			t.Fatalf("Service %s MulticlusterAddresses actual %v, expected %v", svc.Hostname, svc.MulticlusterAddresses, MulticlusterAddresses[svc.Hostname])
 		}
 	}
-	t.Logf("Return service Addresses match ground truth")
+	t.Logf("Return service MulticlusterAddresses match ground truth")
 }
 
 func TestServices(t *testing.T) {

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -151,8 +151,8 @@ func TestServicesForMultiCluster(t *testing.T) {
 		t.Fatalf("Service map expected size %d, actual %v", svcCount, serviceMap)
 	}
 
-	//Now verify MulticlusterAddresses for each service
-	MulticlusterAddresses := map[model.Hostname]map[string]string{
+	//Now verify ClusterVIPs for each service
+	ClusterVIPs := map[model.Hostname]map[string]string{
 		mock.HelloService.Hostname: {
 			"cluster-1": "10.1.1.0",
 			"cluster-2": "10.1.2.0",
@@ -162,11 +162,11 @@ func TestServicesForMultiCluster(t *testing.T) {
 		},
 	}
 	for _, svc := range services {
-		if !reflect.DeepEqual(svc.MulticlusterAddresses, MulticlusterAddresses[svc.Hostname]) {
-			t.Fatalf("Service %s MulticlusterAddresses actual %v, expected %v", svc.Hostname, svc.MulticlusterAddresses, MulticlusterAddresses[svc.Hostname])
+		if !reflect.DeepEqual(svc.ClusterVIPs, ClusterVIPs[svc.Hostname]) {
+			t.Fatalf("Service %s ClusterVIPs actual %v, expected %v", svc.Hostname, svc.ClusterVIPs, ClusterVIPs[svc.Hostname])
 		}
 	}
-	t.Logf("Return service MulticlusterAddresses match ground truth")
+	t.Logf("Return service ClusterVIPs match ground truth")
 }
 
 func TestServices(t *testing.T) {


### PR DESCRIPTION
This PR is related to issue https://github.com/istio/istio/issues/5498. It renames `Addresses` field of Service to `MulticlusterAddresses`.

While being a part of large refactoring, this PR is useful in itself, to clarify the difference between the `Address` and `Addresses`, and to document by the name of the variable what `Addresses` are used for.
