### PR TITLE
Multicluster Adding Delete logic for dynamically created controllers

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -544,45 +544,45 @@ func (s *Server) makeCopilotMonitor(args *PilotArgs, configController model.Conf
 }
 
 // createK8sServiceControllers creates all the k8s service controllers under this pilot
-func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
-	clusterID := string(serviceregistry.KubernetesRegistry)
-	log.Infof("Primary Cluster name: %s", clusterID)
-	kubectl := kube.NewController(s.kubeClient, args.Config.ControllerOptions)
-	serviceControllers.AddRegistry(
-		aggregate.Registry{
-			Name:             serviceregistry.ServiceRegistry(serviceregistry.KubernetesRegistry),
-			ClusterID:        clusterID,
-			ServiceDiscovery: kubectl,
-			ServiceAccounts:  kubectl,
-			Controller:       kubectl,
-		})
+// func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
+//	clusterID := string(serviceregistry.KubernetesRegistry)
+//	log.Infof("Primary Cluster name: %s", clusterID)
+//	kubectl := kube.NewController(s.kubeClient, args.Config.ControllerOptions)
+//	serviceControllers.AddRegistry(
+//		aggregate.Registry{
+//			Name:             serviceregistry.ServiceRegistry(serviceregistry.KubernetesRegistry),
+//			ClusterID:        clusterID,
+//			ServiceDiscovery: kubectl,
+//			ServiceAccounts:  kubectl,
+//			Controller:       kubectl,
+//		})
 
-	// Add clusters under the same pilot
-	if s.clusterStore != nil {
-		clusters := s.clusterStore.GetPilotClusters()
-		clientAccessConfigs := s.clusterStore.GetClientAccessConfigs()
-		for _, cluster := range clusters {
-			log.Infof("Cluster name: %s", clusterregistry.GetClusterID(cluster))
-			clusterClient := clientAccessConfigs[cluster.ObjectMeta.Name]
-			client, kuberr := kube.CreateInterfaceFromClusterConfig(&clusterClient)
-			if kuberr != nil {
-				err = multierror.Append(err, multierror.Prefix(kuberr, fmt.Sprintf("failed to connect to Access API with access config: %s", cluster.ObjectMeta.Name)))
-			}
-
-			kubectl := kube.NewController(client, args.Config.ControllerOptions)
-			serviceControllers.AddRegistry(
-				aggregate.Registry{
-					Name:             serviceregistry.KubernetesRegistry,
-					ClusterID:        clusterregistry.GetClusterID(cluster),
-					ServiceDiscovery: kubectl,
-					ServiceAccounts:  kubectl,
-					Controller:       kubectl,
-				})
-		}
-	}
-
-	return
-}
+// Add clusters under the same pilot
+//	if s.clusterStore != nil {
+//		clusters := s.clusterStore.GetPilotClusters()
+//		clientAccessConfigs := s.clusterStore.GetClientAccessConfigs()
+//		for _, cluster := range clusters {
+//			log.Infof("Cluster name: %s", clusterregistry.GetClusterID(cluster))
+//			clusterClient := clientAccessConfigs[cluster.ObjectMeta.Name]
+//			client, kuberr := kube.CreateInterfaceFromClusterConfig(&clusterClient)
+//			if kuberr != nil {
+//				err = multierror.Append(err, multierror.Prefix(kuberr, fmt.Sprintf("failed to connect to Access API with access config: %s", cluster.ObjectMeta.Name)))
+//			}
+//
+//			kubectl := kube.NewController(client, args.Config.ControllerOptions)
+//			serviceControllers.AddRegistry(
+//				aggregate.Registry{
+//					Name:             serviceregistry.KubernetesRegistry,
+//					ClusterID:        clusterregistry.GetClusterID(cluster),
+//					ServiceDiscovery: kubectl,
+//					ServiceAccounts:  kubectl,
+//					Controller:       kubectl,
+//				})
+//		}
+//	}
+//
+//	return
+//}
 
 // initMultiClusterController initializes multi cluster controller
 // currently implemented only for kubernetes registries
@@ -618,9 +618,9 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			initMemoryRegistry(s, serviceControllers)
 		case serviceregistry.KubernetesRegistry:
 			// TODO Since controllers are built dynamically, createK8sServiceControllers can be removed
-			if err := s.createK8sServiceControllers(serviceControllers, args); err != nil {
-				return err
-			}
+			//			if err := s.createK8sServiceControllers(serviceControllers, args); err != nil {
+			//				return err
+			//			}
 			if s.mesh.IngressControllerMode != meshconfig.MeshConfig_OFF {
 				// Wrap the config controller with a cache.
 				configController, err := configaggregate.MakeCache([]model.ConfigStoreCache{

--- a/pilot/pkg/config/clusterregistry/clusterregistry.gotmpl
+++ b/pilot/pkg/config/clusterregistry/clusterregistry.gotmpl
@@ -2,6 +2,7 @@ apiVersion: clusterregistry.k8s.io/v1alpha1
 kind: {{.Kind}}
 metadata:
   name: {{.Name}}
+  namespace: istio-testing
   annotations:
     config.istio.io/pilotEndpoint: "{{.PilotIP}}:9080"
     config.istio.io/platform: "{{if .Platform}}{{.Platform}}{{else}}Kubernetes{{end}}"

--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -163,10 +163,10 @@ func getClustersConfigs(k8s kubernetes.Interface, configMapName, configMapNamesp
 				secretName, secretNamespace, key, err))
 			continue
 		}
-		key := Metadata{Name: cluster.ObjectMeta.Name, Namespace: cluster.ObjectMeta.Namespace}
-		log.Infof("><SB> Cluster's key: %+v", key)
-		cs.rc[key].Client = clientConfig
-		cs.rc[key].Cluster = &cluster
+		s := Metadata{Name: cluster.ObjectMeta.Name, Namespace: cluster.ObjectMeta.Namespace}
+		cs.rc[s] = &RemoteCluster{}
+		cs.rc[s].Client = clientConfig
+		cs.rc[s].Cluster = &cluster
 	}
 
 	return

--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -59,10 +59,7 @@ type RemoteCluster struct {
 
 // ClusterStore is a collection of clusters
 type ClusterStore struct {
-	rc map[Metadata]*RemoteCluster
-
-	//	clusters      []*k8s_cr.Cluster
-	//	clientConfigs map[string]clientcmdapi.Config
+	rc        map[Metadata]*RemoteCluster
 	storeLock sync.RWMutex
 }
 
@@ -96,11 +93,6 @@ func GetClusterID(cluster *k8s_cr.Cluster) string {
 	}
 	return cluster.ObjectMeta.Name
 }
-
-// GetPilotClusters return a list of clusters under this pilot, exclude PilotCfgStore
-// func (cs *ClusterStore) GetPilotClusters() []*k8s_cr.Cluster {
-//	return cs.clusters
-// }
 
 // ReadClusters reads multiple clusters from a ConfigMap
 func ReadClusters(k8s kubernetes.Interface, configMapName string,

--- a/pilot/pkg/config/clusterregistry/conversion_test.go
+++ b/pilot/pkg/config/clusterregistry/conversion_test.go
@@ -92,53 +92,45 @@ func TestGetPilotClusters(t *testing.T) {
 		{
 			testName: "3 out of 3 Pilot in the store",
 			cs: &ClusterStore{
-				clusters: []*k8s_cr.Cluster{
+				rc: map[Metadata]*RemoteCluster{
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot2",
+						Name:      "cluster1",
+						Namespace: "istio-testing"}: {
+						Cluster: &k8s_cr.Cluster{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "fakePilot1",
+							},
 						},
+						Client: &clientcmdapi.Config{},
 					},
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot3",
+						Name:      "cluster2",
+						Namespace: "istio-testing"}: {
+						Cluster: &k8s_cr.Cluster{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "fakePilot2",
+							},
 						},
+						Client: &clientcmdapi.Config{},
 					},
 					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot4",
+						Name:      "cluster3",
+						Namespace: "istio-testing"}: {
+						Cluster: &k8s_cr.Cluster{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "fakePilot3",
+							},
 						},
-					},
-				},
-				clientConfigs: map[string]clientcmdapi.Config{"fakePilot": {}},
-			},
-			numberOfPilots: 3,
-		},
-		{
-			testName: "3 out of 3 Pilot in the store",
-			cs: &ClusterStore{
-				clusters: []*k8s_cr.Cluster{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot2",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot3",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "fakePilot4",
-						},
+						Client: &clientcmdapi.Config{},
 					},
 				},
 			},
 			numberOfPilots: 3,
 		},
 	}
+
 	for _, test := range tests {
-		numberOfPilots := len(test.cs.GetPilotClusters())
+		numberOfPilots := len(test.cs.rc)
 		if numberOfPilots != test.numberOfPilots {
 			t.Errorf("Test '%s' failed, expected: %d number of Pilots, got: %d ", test.testName,
 				test.numberOfPilots, numberOfPilots)

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -45,8 +45,9 @@ type Controller struct {
 
 // NewController creates a new Aggregate controller
 func NewController() *Controller {
+
 	return &Controller{
-		registries: make([]Registry, 0),
+		registries: []Registry{},
 	}
 }
 
@@ -55,7 +56,8 @@ func (c *Controller) AddRegistry(registry Registry) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 
-	registries := make([]Registry, len(c.registries)+1)
+	registries := []Registry{}
+	registries = c.registries
 	registries = append(registries, registry)
 	c.registries = registries
 }
@@ -74,7 +76,8 @@ func (c *Controller) DeleteRegistry(clusterID string) {
 		log.Warnf("Registry is not found in the registries list, nothing to delete")
 		return
 	}
-	registries := make([]Registry, len(c.registries))
+	registries := []Registry{}
+	registries = c.registries
 	registries = append(registries[:index], registries[index+1:]...)
 	c.registries = registries
 }

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -45,6 +45,7 @@ type Controller struct {
 
 // NewController creates a new Aggregate controller
 func NewController() *Controller {
+	log.Infof("><SB> Aggregate Controller NewController was called")
 	return &Controller{
 		registries: make([]Registry, 0),
 	}
@@ -52,20 +53,21 @@ func NewController() *Controller {
 
 // AddRegistry adds registries into the aggregated controller
 func (c *Controller) AddRegistry(registry Registry) {
+	log.Infof("><SB> Aggregate Controller add registry")
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 	c.registries = append(c.registries, registry)
 }
 
 // DeleteRegistry deletes specified registry from the aggregated controller
-func (c *Controller) DeleteRegistry(registry Registry) {
+func (c *Controller) DeleteRegistry(clusterID string) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 	if len(c.registries) == 0 {
 		log.Warnf("Registry list is empty, nothing to delete")
 		return
 	}
-	index, ok := c.GetRegistryIndex(registry)
+	index, ok := c.GetRegistryIndex(clusterID)
 	if !ok {
 		log.Warnf("Registry is not found in the registries list, nothing to delete")
 		return
@@ -84,9 +86,9 @@ func (c *Controller) GetRegistries() []Registry {
 }
 
 // GetRegistryIndex returns the index of a registry
-func (c *Controller) GetRegistryIndex(registry Registry) (int, bool) {
+func (c *Controller) GetRegistryIndex(clusterID string) (int, bool) {
 	for i, r := range c.registries {
-		if r.ClusterID == registry.ClusterID {
+		if r.ClusterID == clusterID {
 			return i, true
 		}
 	}
@@ -95,6 +97,7 @@ func (c *Controller) GetRegistryIndex(registry Registry) (int, bool) {
 
 // Services lists services from all platforms
 func (c *Controller) Services() ([]*model.Service, error) {
+	log.Infof("><SB> Aggregate Controller's Services method was called")
 	// smap is a map of hostname (string) to service, used to identify services that
 	// are installed in multiple clusters.
 	smap := make(map[model.Hostname]*model.Service)
@@ -142,6 +145,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 
 // GetService retrieves a service by hostname if exists
 func (c *Controller) GetService(hostname model.Hostname) (*model.Service, error) {
+	log.Infof("><SB> Aggregate Controller's GetService called")
 	var errs error
 	for _, r := range c.GetRegistries() {
 		service, err := r.GetService(hostname)
@@ -173,6 +177,7 @@ func (c *Controller) ManagementPorts(addr string) model.PortList {
 // any of the supplied labels. All instances match an empty label list.
 func (c *Controller) Instances(hostname model.Hostname, ports []string,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Aggregate Controller's Instances called")
 	var instances, tmpInstances []*model.ServiceInstance
 	var errs error
 	for _, r := range c.GetRegistries() {
@@ -197,6 +202,7 @@ func (c *Controller) Instances(hostname model.Hostname, ports []string,
 // any of the supplied labels. All instances match an empty label list.
 func (c *Controller) InstancesByPort(hostname model.Hostname, port int,
 	labels model.LabelsCollection) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Aggregate Controller's InstancesByPort called")
 	var instances, tmpInstances []*model.ServiceInstance
 	var errs error
 	for _, r := range c.GetRegistries() {
@@ -219,6 +225,7 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, port int,
 
 // GetProxyServiceInstances lists service instances co-located with a given proxy
 func (c *Controller) GetProxyServiceInstances(node *model.Proxy) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Aggregate Controller's GetProxyServiceInstances called")
 	out := make([]*model.ServiceInstance, 0)
 	var errs error
 	// It doesn't make sense for a single proxy to be found in more than one registry.

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -78,6 +78,7 @@ func (c *Controller) DeleteRegistry(clusterID string) {
 	registries := c.registries
 	registries = append(registries[:index], registries[index+1:]...)
 	c.registries = registries
+	log.Infof("Registry for the cluster %s has been deleted.", clusterID)
 }
 
 // GetRegistries returns a copy of all registries

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -56,8 +56,7 @@ func (c *Controller) AddRegistry(registry Registry) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 
-	registries := []Registry{}
-	registries = c.registries
+	registries := c.registries
 	registries = append(registries, registry)
 	c.registries = registries
 }
@@ -76,8 +75,7 @@ func (c *Controller) DeleteRegistry(clusterID string) {
 		log.Warnf("Registry is not found in the registries list, nothing to delete")
 		return
 	}
-	registries := []Registry{}
-	registries = c.registries
+	registries := c.registries
 	registries = append(registries[:index], registries[index+1:]...)
 	c.registries = registries
 }

--- a/pilot/pkg/serviceregistry/aggregate/controller_test.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 
 	"istio.io/istio/pilot/pkg/model"
@@ -27,9 +26,7 @@ import (
 )
 
 // MockController specifies a mock Controller for testing
-type MockController struct {
-	storeLock sync.RWMutex
-}
+type MockController struct{}
 
 func (c *MockController) AppendServiceHandler(f func(*model.Service, model.Event)) error {
 	return nil
@@ -506,7 +503,7 @@ func TestDeleteRegistry(t *testing.T) {
 	for _, r := range registries {
 		ctrl.AddRegistry(r)
 	}
-	ctrl.DeleteRegistry(registries[0])
+	ctrl.DeleteRegistry(registries[0].ClusterID)
 	if l := len(ctrl.registries); l != 1 {
 		t.Fatalf("Expected length of the registries slice should be 1, got %d", l)
 	}

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -210,7 +210,6 @@ func (c *Controller) HasSynced() bool {
 
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop <-chan struct{}) {
-	log.Infof("><SB> Q/S/E/P/N controller started")
 	go c.queue.Run(stop)
 	go c.services.informer.Run(stop)
 	go c.endpoints.informer.Run(stop)
@@ -223,7 +222,6 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 // Services implements a service catalog operation
 func (c *Controller) Services() ([]*model.Service, error) {
-	log.Infof("><SB> Q/S/E/P/N controller's Services method was called")
 	list := c.services.informer.GetStore().List()
 	out := make([]*model.Service, 0, len(list))
 
@@ -237,7 +235,6 @@ func (c *Controller) Services() ([]*model.Service, error) {
 
 // GetService implements a service catalog operation
 func (c *Controller) GetService(hostname model.Hostname) (*model.Service, error) {
-	log.Infof("><SB> Q/S/E/P/N controller's GetServices method was called")
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
 		log.Infof("GetService(%s) => error %v", hostname, err)
@@ -293,7 +290,6 @@ func (c *Controller) GetPodAZ(pod *v1.Pod) (string, bool) {
 
 // ManagementPorts implements a service catalog operation
 func (c *Controller) ManagementPorts(addr string) model.PortList {
-	log.Infof("><SB> Q/S/E/P/N controller's ManagementPorts method was called")
 	pod, exists := c.pods.getPodByIP(addr)
 	if !exists {
 		return nil
@@ -313,7 +309,6 @@ func (c *Controller) ManagementPorts(addr string) model.PortList {
 // Instances implements a service catalog operation
 func (c *Controller) Instances(hostname model.Hostname, ports []string,
 	labelsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
-	log.Infof("><SB> Q/S/E/P/N controller's Instances method was called")
 	// Get actual service by name
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
@@ -385,7 +380,6 @@ func (c *Controller) Instances(hostname model.Hostname, ports []string,
 // InstancesByPort implements a service catalog operation
 func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 	labelsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
-	log.Infof("><SB> Q/S/E/P/N controller's InstancesByPort method was called")
 	// Get actual service by name
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
@@ -457,7 +451,6 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 
 // GetProxyServiceInstances returns service instances co-located with a given proxy
 func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
-	log.Infof("><SB> Q/S/E/P/N controller's GetProxyServiceInstances method was called")
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {
@@ -527,7 +520,6 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 // For example, a service account named "bar" in namespace "foo" is encoded as
 // "spiffe://cluster.local/ns/foo/sa/bar".
 func (c *Controller) GetIstioServiceAccounts(hostname model.Hostname, ports []string) []string {
-	log.Infof("><SB> Q/S/E/P/N controller's GetIstioServiceAccounts method was called")
 	saSet := make(map[string]bool)
 
 	// Get the service accounts running service within Kubernetes. This is reflected by the pods that
@@ -569,7 +561,6 @@ func (c *Controller) GetIstioServiceAccounts(hostname model.Hostname, ports []st
 
 // AppendServiceHandler implements a service catalog operation
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
-	log.Infof("><SB> Q/S/E/P/N controller's AppendServiceHandler method was called")
 	c.services.handler.Append(func(obj interface{}, event model.Event) error {
 		svc := *obj.(*v1.Service)
 
@@ -590,7 +581,6 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 
 // AppendInstanceHandler implements a service catalog operation
 func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
-	log.Infof("><SB> Q/S/E/P/N controller's AppendInstanceHandler method was called")
 	c.endpoints.handler.Append(func(obj interface{}, event model.Event) error {
 		ep := *obj.(*v1.Endpoints)
 

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -210,6 +210,7 @@ func (c *Controller) HasSynced() bool {
 
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop <-chan struct{}) {
+	log.Infof("><SB> Q/S/E/P/N controller started")
 	go c.queue.Run(stop)
 	go c.services.informer.Run(stop)
 	go c.endpoints.informer.Run(stop)
@@ -222,6 +223,7 @@ func (c *Controller) Run(stop <-chan struct{}) {
 
 // Services implements a service catalog operation
 func (c *Controller) Services() ([]*model.Service, error) {
+	log.Infof("><SB> Q/S/E/P/N controller's Services method was called")
 	list := c.services.informer.GetStore().List()
 	out := make([]*model.Service, 0, len(list))
 
@@ -235,6 +237,7 @@ func (c *Controller) Services() ([]*model.Service, error) {
 
 // GetService implements a service catalog operation
 func (c *Controller) GetService(hostname model.Hostname) (*model.Service, error) {
+	log.Infof("><SB> Q/S/E/P/N controller's GetServices method was called")
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
 		log.Infof("GetService(%s) => error %v", hostname, err)
@@ -290,6 +293,7 @@ func (c *Controller) GetPodAZ(pod *v1.Pod) (string, bool) {
 
 // ManagementPorts implements a service catalog operation
 func (c *Controller) ManagementPorts(addr string) model.PortList {
+	log.Infof("><SB> Q/S/E/P/N controller's ManagementPorts method was called")
 	pod, exists := c.pods.getPodByIP(addr)
 	if !exists {
 		return nil
@@ -309,6 +313,7 @@ func (c *Controller) ManagementPorts(addr string) model.PortList {
 // Instances implements a service catalog operation
 func (c *Controller) Instances(hostname model.Hostname, ports []string,
 	labelsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Q/S/E/P/N controller's Instances method was called")
 	// Get actual service by name
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
@@ -380,6 +385,7 @@ func (c *Controller) Instances(hostname model.Hostname, ports []string,
 // InstancesByPort implements a service catalog operation
 func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 	labelsList model.LabelsCollection) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Q/S/E/P/N controller's InstancesByPort method was called")
 	// Get actual service by name
 	name, namespace, err := parseHostname(hostname)
 	if err != nil {
@@ -451,6 +457,7 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 
 // GetProxyServiceInstances returns service instances co-located with a given proxy
 func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.ServiceInstance, error) {
+	log.Infof("><SB> Q/S/E/P/N controller's GetProxyServiceInstances method was called")
 	var out []*model.ServiceInstance
 	kubeNodes := make(map[string]*kubeServiceNode)
 	for _, item := range c.endpoints.informer.GetStore().List() {
@@ -520,6 +527,7 @@ func (c *Controller) GetProxyServiceInstances(proxy *model.Proxy) ([]*model.Serv
 // For example, a service account named "bar" in namespace "foo" is encoded as
 // "spiffe://cluster.local/ns/foo/sa/bar".
 func (c *Controller) GetIstioServiceAccounts(hostname model.Hostname, ports []string) []string {
+	log.Infof("><SB> Q/S/E/P/N controller's GetIstioServiceAccounts method was called")
 	saSet := make(map[string]bool)
 
 	// Get the service accounts running service within Kubernetes. This is reflected by the pods that
@@ -561,6 +569,7 @@ func (c *Controller) GetIstioServiceAccounts(hostname model.Hostname, ports []st
 
 // AppendServiceHandler implements a service catalog operation
 func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) error {
+	log.Infof("><SB> Q/S/E/P/N controller's AppendServiceHandler method was called")
 	c.services.handler.Append(func(obj interface{}, event model.Event) error {
 		svc := *obj.(*v1.Service)
 
@@ -581,6 +590,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 
 // AppendInstanceHandler implements a service catalog operation
 func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.Event)) error {
+	log.Infof("><SB> Q/S/E/P/N controller's AppendInstanceHandler method was called")
 	c.endpoints.handler.Append(func(obj interface{}, event model.Event) error {
 		ep := *obj.(*v1.Endpoints)
 


### PR DESCRIPTION
This PR adds delete logic to secret controller. On detection of remote cluster's secret removal, 1: corresponding service registry entry gets deleted, 2: Stop message sent to the controller, 3: remote cluster gets removed from the clusters store.
Closes: #5629
Closes: #5622
Closes: #5606
Closes: #5605