### PR TITLE
Close span when dispatch completes

### DIFF
--- a/mixer/pkg/runtime/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher.go
@@ -480,6 +480,7 @@ func (s *dispatchState) beginSpan(ctx context.Context) (opentracing.Span, contex
 func (s *dispatchState) completeSpan(span opentracing.Span, duration time.Duration, err error) {
 	if s.session.trace {
 		logToDispatchSpan(span, s.destination.Template.Name, s.destination.HandlerName, s.destination.AdapterName, err)
+		span.Finish()
 	}
 	s.destination.Counters.Update(duration, err != nil)
 }


### PR DESCRIPTION
Per adapter span does not show in trace if span is not closed. Before this PR:
![screenshot from 2018-05-17 17-11-06](https://user-images.githubusercontent.com/34738376/40209648-5e7332ea-59f5-11e8-9bb8-7af263c4d40d.png) After:
![screenshot from 2018-05-17 17-11-25](https://user-images.githubusercontent.com/34738376/40209654-6313178e-59f5-11e8-910c-56b91e89fe7e.png)

Not sure how it could work before.