### PR TITLE
Fix istioctl output format issue.

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -626,7 +626,7 @@ func readInputs() ([]model.Config, []crd.IstioKind, error) {
 // Print a simple list of names
 func printShortOutput(_ *crd.Client, configList []model.Config) {
 	var w tabwriter.Writer
-	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+	w.Init(os.Stdout, 10, 4, 3, ' ', 0)
 	fmt.Fprintf(&w, "NAME\tKIND\tNAMESPACE\n")
 	for _, c := range configList {
 		kind := fmt.Sprintf("%s.%s.%s",


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/5704
Align `istioctl` printer format with `kubectl`: https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/tabwriter.go#L24-L30