### PR TITLE
[test-framework] Switch from testing.T => testing.TB and uniformize *OrFail.

### DIFF
--- a/pkg/test/cluster/app.go
+++ b/pkg/test/cluster/app.go
@@ -233,7 +233,7 @@ func (a *app) Call(u *url.URL, count int, headers http.Header) (environment.AppC
 	return out, nil
 }
 
-func (a *app) CallOrFail(u *url.URL, count int, headers http.Header, t *testing.T) environment.AppCallResult {
+func (a *app) CallOrFail(u *url.URL, count int, headers http.Header, t testing.TB) environment.AppCallResult {
 	r, err := a.Call(u, count, headers)
 	if err != nil {
 		t.Fatalf("Call to app failed: app='%s', url='%s', err='%v'", a.appName, u, err)

--- a/pkg/test/cluster/environment.go
+++ b/pkg/test/cluster/environment.go
@@ -35,6 +35,7 @@ type Environment struct {
 var _ environment.Interface = &Environment{}
 var _ Internal = &Environment{}
 
+// DoFoo is a fake method that should be removed.
 func (e *Environment) DoFoo() {
 	// TODO: Remove. Dummy method.
 }
@@ -52,21 +53,45 @@ func NewEnvironment(kubeConfigPath string) (*Environment, error) {
 }
 
 // Configure applies the given configuration to the mesh.
-func (e *Environment) Configure(config string) {
+func (e *Environment) Configure(t testing.TB, config string) {
 	// TODO
 	panic("Not yet implemented")
 }
 
 // GetMixer returns a deployed Mixer instance in the environment.
-func (e *Environment) GetMixer() environment.DeployedMixer {
+func (e *Environment) GetMixer() (environment.DeployedMixer, error) {
 	// TODO
 	panic("Not yet implemented")
 }
 
+// GetMixerOrFail returns a deployed Mixer instance in the environment, or fails the test if unsuccessful.
+func (e *Environment) GetMixerOrFail(t testing.TB) environment.DeployedMixer {
+	t.Helper()
+
+	m, err := e.GetMixer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return m
+}
+
 // GetPilot returns a deployed Pilot instance in the environment.
-func (e *Environment) GetPilot() environment.DeployedPilot {
+func (e *Environment) GetPilot() (environment.DeployedPilot, error) {
 	// TODO
 	panic("Not yet implemented")
+}
+
+// GetPilotOrFail returns a deployed Pilot instance in the environment, or fails the test if unsuccessful.
+func (e *Environment) GetPilotOrFail(t testing.TB) environment.DeployedPilot {
+	t.Helper()
+
+	m, err := e.GetPilot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return m
 }
 
 // GetApp returns a fake testing app object for the given name.
@@ -75,7 +100,7 @@ func (e *Environment) GetApp(name string) (environment.DeployedApp, error) {
 }
 
 // GetAppOrFail returns a fake testing app object for the given name, or fails the test if unsuccessful.
-func (e *Environment) GetAppOrFail(name string, t *testing.T) environment.DeployedApp {
+func (e *Environment) GetAppOrFail(name string, t testing.TB) environment.DeployedApp {
 	t.Helper()
 	a, err := getApp(name, e.AppNamespace)
 	if err != nil {
@@ -91,19 +116,23 @@ func (e *Environment) GetFortioApp(name string) (environment.DeployedFortioApp, 
 }
 
 // GetFortioAppOrFail returns a Fortio App object for the given name, or fails the test if unsuccessful.
-func (e *Environment) GetFortioAppOrFail(name string, t *testing.T) (environment.DeployedFortioApp, error) {
-	// TODO
-	panic("Not yet implemented")
+func (e *Environment) GetFortioAppOrFail(name string, t testing.TB) environment.DeployedFortioApp {
+	t.Helper()
+	a, err := e.GetFortioApp(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
 }
 
 // GetFortioApps returns a set of Fortio Apps based on the given selector.
-func (e *Environment) GetFortioApps(selector string, t *testing.T) []environment.DeployedFortioApp {
+func (e *Environment) GetFortioApps(selector string, t testing.TB) []environment.DeployedFortioApp {
 	// TODO
 	panic("Not yet implemented")
 }
 
 // GetPolicyBackendOrFail returns the mock policy backend that is used by Mixer for policy checks and reports.
-func (e *Environment) GetPolicyBackendOrFail(t *testing.T) environment.DeployedPolicyBackend {
+func (e *Environment) GetPolicyBackendOrFail(t testing.TB) environment.DeployedPolicyBackend {
 	// TODO
 	panic("Not yet implemented")
 }

--- a/pkg/test/environment/environment.go
+++ b/pkg/test/environment/environment.go
@@ -32,31 +32,37 @@ const (
 type Interface interface {
 
 	// Configure applies the given configuration to the mesh.
-	Configure(config string)
+	Configure(tb testing.TB, config string)
+
+	// TODO: Implement Configure overload that can consume config from a directory
 
 	// GetMixer returns a deployed Mixer instance in the environment.
-	GetMixer() DeployedMixer
+	GetMixer() (DeployedMixer, error)
+	// GetMixerOrFail returns a deployed Mixer instance in the environment, or fails the test if unsuccessful.
+	GetMixerOrFail(t testing.TB) DeployedMixer
 
 	// GetPilot returns a deployed Pilot instance in the environment.
-	GetPilot() DeployedPilot
+	GetPilot() (DeployedPilot, error)
+	// GetPilotOrFail returns a deployed Pilot instance in the environment, or fails the test if unsuccessful.
+	GetPilotOrFail(t testing.TB) DeployedPilot
 
 	// GetApp returns a fake testing app object for the given name.
 	GetApp(name string) (DeployedApp, error)
 	// GetAppOrFail returns a fake testing app object for the given name, or fails the test if unsuccessful.
-	GetAppOrFail(name string, t *testing.T) DeployedApp
+	GetAppOrFail(name string, t testing.TB) DeployedApp
 
 	// GetFortioApp returns a Fortio App object for the given name.
 	GetFortioApp(name string) (DeployedFortioApp, error)
 	// GetFortioAppOrFail returns a Fortio App object for the given name, or fails the test if unsuccessful.
-	GetFortioAppOrFail(name string, t *testing.T) (DeployedFortioApp, error)
+	GetFortioAppOrFail(name string, t testing.TB) DeployedFortioApp
 
 	// TODO: We should remove this overload in favor of the previous two.
 
 	// GetFortioApps returns a set of Fortio Apps based on the given selector.
-	GetFortioApps(selector string, t *testing.T) []DeployedFortioApp
+	GetFortioApps(selector string, t testing.TB) []DeployedFortioApp
 
 	// GetPolicyBackendOrFail returns the mock policy backend that is used by Mixer for policy checks and reports.
-	GetPolicyBackendOrFail(t *testing.T) DeployedPolicyBackend
+	GetPolicyBackendOrFail(t testing.TB) DeployedPolicyBackend
 }
 
 // Deployed represents a deployed component
@@ -70,7 +76,7 @@ type DeployedApp interface {
 	Endpoints() []DeployedAppEndpoint
 	EndpointsForProtocol(protocol model.Protocol) []DeployedAppEndpoint
 	Call(u *url.URL, count int, headers http.Header) (AppCallResult, error)
-	CallOrFail(u *url.URL, count int, headers http.Header, t *testing.T) AppCallResult
+	CallOrFail(u *url.URL, count int, headers http.Header, t testing.TB) AppCallResult
 }
 
 // DeployedPolicyBackend represents a deployed fake policy backend for Mixer.
@@ -81,7 +87,7 @@ type DeployedPolicyBackend interface {
 	DenyCheck(deny bool)
 
 	// ExpectReport checks that the backend has received the given report request.
-	ExpectReport(t *testing.T, expected string)
+	ExpectReport(t testing.TB, expected string)
 }
 
 // DeployedAppEndpoint represents a single endpoint in a DeployedApp.

--- a/pkg/test/local/environment.go
+++ b/pkg/test/local/environment.go
@@ -34,21 +34,45 @@ func NewEnvironment() (*Environment, error) {
 }
 
 // Configure applies the given configuration to the mesh.
-func (e *Environment) Configure(config string) {
+func (e *Environment) Configure(t testing.TB, config string) {
 	// TODO
 	panic("Not yet implemented")
 }
 
 // GetMixer returns a deployed Mixer instance in the environment.
-func (e *Environment) GetMixer() environment.DeployedMixer {
+func (e *Environment) GetMixer() (environment.DeployedMixer, error) {
 	// TODO
 	panic("Not yet implemented")
 }
 
+// GetMixerOrFail returns a deployed Mixer instance in the environment, or fails the test if unsuccessful.
+func (e *Environment) GetMixerOrFail(t testing.TB) environment.DeployedMixer {
+	t.Helper()
+
+	m, err := e.GetMixer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return m
+}
+
 // GetPilot returns a deployed Pilot instance in the environment.
-func (e *Environment) GetPilot() environment.DeployedPilot {
+func (e *Environment) GetPilot() (environment.DeployedPilot, error) {
 	// TODO
 	panic("Not yet implemented")
+}
+
+// GetPilotOrFail returns a deployed Pilot instance in the environment, or fails the test if unsuccessful.
+func (e *Environment) GetPilotOrFail(t testing.TB) environment.DeployedPilot {
+	t.Helper()
+
+	m, err := e.GetPilot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return m
 }
 
 // GetApp returns a fake testing app object for the given name.
@@ -58,7 +82,7 @@ func (e *Environment) GetApp(name string) (environment.DeployedApp, error) {
 }
 
 // GetAppOrFail returns a fake testing app object for the given name, or fails the test if unsuccessful.
-func (e *Environment) GetAppOrFail(name string, t *testing.T) environment.DeployedApp {
+func (e *Environment) GetAppOrFail(name string, t testing.TB) environment.DeployedApp {
 	t.Helper()
 	// TODO
 	panic("Not yet implemented")
@@ -71,21 +95,24 @@ func (e *Environment) GetFortioApp(name string) (environment.DeployedFortioApp, 
 }
 
 // GetFortioAppOrFail returns a Fortio App object for the given name, or fails the test if unsuccessful.
-func (e *Environment) GetFortioAppOrFail(name string, t *testing.T) (environment.DeployedFortioApp, error) {
+func (e *Environment) GetFortioAppOrFail(name string, t testing.TB) environment.DeployedFortioApp {
 	t.Helper()
-	// TODO
-	panic("Not yet implemented")
+	a, err := e.GetFortioApp(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a
 }
 
 // GetFortioApps returns a set of Fortio Apps based on the given selector.
-func (e *Environment) GetFortioApps(selector string, t *testing.T) []environment.DeployedFortioApp {
+func (e *Environment) GetFortioApps(selector string, t testing.TB) []environment.DeployedFortioApp {
 	t.Helper()
 	// TODO
 	panic("Not yet implemented")
 }
 
 // GetPolicyBackendOrFail returns the mock policy backend that is used by Mixer for policy checks and reports.
-func (e *Environment) GetPolicyBackendOrFail(t *testing.T) environment.DeployedPolicyBackend {
+func (e *Environment) GetPolicyBackendOrFail(t testing.TB) environment.DeployedPolicyBackend {
 	t.Helper()
 	// TODO
 	panic("Not yet implemented")

--- a/pkg/test/operations.go
+++ b/pkg/test/operations.go
@@ -86,6 +86,6 @@ func Tag(t testing.TB, labels ...label.Label) {
 }
 
 // GetEnvironment returns the current, ambient environment.
-func GetEnvironment(t *testing.T) environment.Interface {
+func GetEnvironment(t testing.TB) environment.Interface {
 	return d.GetEnvironment(t)
 }

--- a/tests/e2e/tests/showcase/mixer_showcase_test.go
+++ b/tests/e2e/tests/showcase/mixer_showcase_test.go
@@ -26,7 +26,7 @@ func TestMixer_Report(t *testing.T) {
 	test.Requires(t, dependency.PolicyBackend)
 
 	env := test.GetEnvironment(t)
-	env.Configure(testConfig)
+	env.Configure(t, testConfig)
 
 	be := env.GetPolicyBackendOrFail(t)
 	// TODO: Define how backend should behave when Mixer dispatches the request

--- a/tests/e2e/tests/showcase/pilot_showcase_test.go
+++ b/tests/e2e/tests/showcase/pilot_showcase_test.go
@@ -28,7 +28,7 @@ func TestHTTPWithMTLS(t *testing.T) {
 	test.Requires(t, dependency.Apps, dependency.Pilot, dependency.MTLS)
 
 	env := test.GetEnvironment(t)
-	env.Configure(cfg)
+	env.Configure(t, cfg)
 
 	appa := env.GetAppOrFail("a", t)
 	appt := env.GetAppOrFail("t", t)

--- a/tests/e2e/tests/showcase/showcase_test.go
+++ b/tests/e2e/tests/showcase/showcase_test.go
@@ -78,7 +78,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 ...
 `
-	env.Configure(cfg)
+	env.Configure(t, cfg)
 
 	// Get handles to the fake applications to drive the test.
 	appa := env.GetAppOrFail("a", t)

--- a/tests/e2e/tests/showcase/simple_showcase_test.go
+++ b/tests/e2e/tests/showcase/simple_showcase_test.go
@@ -29,7 +29,7 @@ func TestSvcLoading(t *testing.T) {
 	test.Requires(t, dependency.FortioApps, dependency.Pilot)
 
 	env := test.GetEnvironment(t)
-	env.Configure(svcCfg)
+	env.Configure(t, svcCfg)
 
 	apps := env.GetFortioApps("app=echosrv", t)
 


### PR DESCRIPTION
- testing.TB is a more generic interface that also supports *testing.B
- All Environment.GetXXX() methods are standardized to Envionment.GetXXX() (XXX, error)
- All Environment.GetXXX() are complemented with Environment.GetXXXOrFail(testing.TB).