### PR TITLE
Temporarily disable mixer filter in gateway

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -44,6 +44,11 @@ func NewPlugin() plugin.Plugin {
 
 // OnOutboundListener implements the Callbacks interface method.
 func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	// TODO: remove this bypass when https://github.com/istio/istio/issues/5694 is closed.
+	if in.Node.Type == model.Router {
+		return nil
+	}
+
 	env := in.Env
 	node := in.Node
 	proxyInstances := in.ProxyInstances
@@ -66,6 +71,11 @@ func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.Mutable
 
 // OnInboundListener implements the Callbacks interface method.
 func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	// TODO: remove this bypass when https://github.com/istio/istio/issues/5694 is closed.
+	if in.Node.Type == model.Router {
+		return nil
+	}
+
 	env := in.Env
 	node := in.Node
 	proxyInstances := in.ProxyInstances

--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -71,7 +71,6 @@ func TestIngressGateway503DuringRuleChange(t *testing.T) {
 	if !tc.V1alpha3 {
 		t.Skipf("Skipping %s: v1alpha3=false", t.Name())
 	}
-	t.Skip("https://github.com/istio/istio/issues/5652")
 
 	istioNamespace := tc.Kube.IstioSystemNamespace()
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()


### PR DESCRIPTION
Disabling mixer filter in gateway only. This will mean mixer does not work in this node type. 
Temporary, will be restored once https://github.com/istio/istio/issues/5694 is resolved. 
Also reinstating the TestIngressGateway503DuringRuleChange which was failing due to the crash.