### PR TITLE
Use openssl base64 encode/decode in install scripts

### DIFF
--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -90,7 +90,7 @@ metadata:
 spec:
   groups:
   - system:authenticated
-  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  request: $(cat ${tmpdir}/server.csr | openssl base64 | tr -d '\n')
   usages:
   - digital signature
   - key encipherment

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -120,7 +120,7 @@ function istio_provision_certs() {
   if [[ -n "$NS" ]] ; then
     NS="-n $NS"
   fi
-  local B64_DECODE=${BASE64_DECODE:-base64 --decode}
+  local B64_DECODE=${BASE64_DECODE:-openssl base64 -d}
   kubectl get $NS secret $CERT_NAME -o jsonpath='{.data.root-cert\.pem}' | $B64_DECODE   > root-cert.pem
   echo "Generated root-cert.pem. It should be installed on /etc/certs"
   if [ "$ALL" == "all" ] ; then


### PR DESCRIPTION
Use openssl base64 encode/decode in install scripts to make it work on macOS