### PR TITLE
Use openssl base64 encode/decode in install scripts

### DIFF
--- a/install/kubernetes/webhook-create-signed-cert.sh
+++ b/install/kubernetes/webhook-create-signed-cert.sh
@@ -90,7 +90,7 @@ metadata:
 spec:
   groups:
   - system:authenticated
-  request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  request: $(cat ${tmpdir}/server.csr | openssl base64 | tr -d '\n')
   usages:
   - digital signature
   - key encipherment


### PR DESCRIPTION
Use openssl base64 encode/decode in install scripts to make it work on macOS