### PR TITLE
Istioctl Go tests for get/create/update/delete

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -17,14 +17,10 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
-
-	multierror "github.com/hashicorp/go-multierror"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/api/routing/v1alpha1"
@@ -36,6 +32,17 @@ import (
 // a stable List() which helps with testing `istioctl get` output.
 type sortedConfigStore struct {
 	store model.ConfigStore
+}
+
+type testCase struct {
+	configs []model.Config
+	args    []string
+
+	// Typically use one or the other
+	expectedOutput string         // Expected constant output
+	expectedRegexp *regexp.Regexp // Expected regexp output
+
+	wantException bool
 }
 
 var (
@@ -177,19 +184,13 @@ var (
 )
 
 func TestGet(t *testing.T) {
-	cases := []struct {
-		configs       []model.Config
-		args          []string
-		wantOutput    string
-		wantError     *regexp.Regexp
-		wantException bool
-	}{
+	cases := []testCase{
 		{ // case 0
 			[]model.Config{},
 			strings.Split("get routerules", " "),
 			`No resources found.
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{ // case 1
@@ -201,7 +202,7 @@ b         RouteRule.config.v1alpha2   default
 c         RouteRule.config.v1alpha2   istio-system
 d         RouteRule.config.v1alpha2   default
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{ // case 2
@@ -210,7 +211,7 @@ d         RouteRule.config.v1alpha2   default
 			`NAME               KIND                          NAMESPACE
 bookinfo-gateway   Gateway.networking.v1alpha3   default
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{ // case 3
@@ -219,7 +220,7 @@ bookinfo-gateway   Gateway.networking.v1alpha3   default
 			`NAME       KIND                                 NAMESPACE
 bookinfo   VirtualService.networking.v1alpha3   default
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{
@@ -232,125 +233,35 @@ bookinfo   VirtualService.networking.v1alpha3   default
 	}
 
 	for i, c := range cases {
-		// Override the client factory used by main.go
-		clientFactory = mockClientFactoryGenerator(c.configs)
-
-		// run getCmd capturing output
-		var out bytes.Buffer
-		rootCmd.SetOutput(&out)
-		rootCmd.SetArgs(c.args)
-
-		file = "" // Clear, because we re-use
-
-		stdOutput, fErr := captureStdout(
-			func() error {
-				rootCmd.SetArgs(c.args)
-				err := rootCmd.Execute()
-				if err != nil {
-					return multierror.Prefix(err, fmt.Sprintf("Could not run command %v", c.args))
-				}
-				return nil
-			})
-		errOutput := out.String()
-
-		if c.wantOutput != stdOutput {
-			t.Errorf("Stdout didn't match for case %d \"istioctl get %v\": Expected %q, got %q.  Stderr was %q",
-				i, strings.Join(c.args, " "),
-				c.wantOutput, stdOutput, errOutput)
-		}
-
-		if !c.wantError.MatchString(errOutput) {
-			t.Errorf("Stderr didn't match for case %d %v: Expected %v, got %q", i, c.args, c.wantError, errOutput)
-		}
-
-		if c.wantException {
-			if fErr == nil {
-				t.Errorf("Wanted an exception for case %d %v, didn't get one, output was %q", i, c.args, stdOutput)
-			}
-		} else {
-			if fErr != nil {
-				t.Errorf("Unwanted exception for case %d %v: %v", i, c.args, fErr)
-			}
-		}
+		verifyOutput(t, fmt.Sprintf("TestGet case %d", i), c)
 	}
 }
 
 func TestCreate(t *testing.T) {
-	cases := []struct {
-		configs       []model.Config
-		args          []string
-		wantOutput    *regexp.Regexp
-		wantError     *regexp.Regexp
-		wantException bool
-	}{
+	cases := []testCase{
 		{ // case 0 -- invalid doesn't provide -f filename
 			[]model.Config{},
 			strings.Split("create routerules", " "),
-			regexp.MustCompile("^$"),
+			"",
 			regexp.MustCompile("^Usage:.*"),
 			true,
 		},
 		{ // case 1
 			[]model.Config{},
 			strings.Split("create -f convert/testdata/v1alpha1/route-rule-80-20.yaml", " "), // todo add -f
+			"",
 			regexp.MustCompile("^Created config route-rule/default/route-rule-80-20.*"),
-			regexp.MustCompile("^$"),
 			false,
 		},
 	}
 
 	for i, c := range cases {
-		// Override the client factory used by main.go
-		clientFactory = mockClientFactoryGenerator(c.configs)
-
-		// run postCmd capturing output
-		var out bytes.Buffer
-		rootCmd.SetOutput(&out)
-		rootCmd.SetArgs(c.args)
-
-		file = "" // Clear, because we re-use
-
-		stdOutput, fErr := captureStdout(
-			func() error {
-				rootCmd.SetArgs(c.args)
-				err := rootCmd.Execute()
-				if err != nil {
-					return multierror.Prefix(err, fmt.Sprintf("Could not run command %v", c.args))
-				}
-				return nil
-			})
-		errOutput := out.String()
-
-		if !c.wantOutput.MatchString(stdOutput) {
-			t.Errorf("Stdout didn't match for create case %d \"istioctl create %v\": Expected %v, got %q.  Stderr was %q",
-				i, strings.Join(c.args, " "),
-				c.wantOutput, stdOutput, errOutput)
-		}
-
-		if !c.wantError.MatchString(errOutput) {
-			t.Errorf("Stderr didn't match for create case %d %v: Expected %v, got %q", i, c.args, c.wantError, errOutput)
-		}
-
-		if c.wantException {
-			if fErr == nil {
-				t.Errorf("Wanted an exception for case %d %v, didn't get one, output was %q", i, c.args, stdOutput)
-			}
-		} else {
-			if fErr != nil {
-				t.Errorf("Unwanted exception for case %d %v: %v", i, c.args, fErr)
-			}
-		}
+		verifyOutput(t, fmt.Sprintf("TestGet case %d", i), c)
 	}
 }
 
 func TestReplace(t *testing.T) {
-	cases := []struct {
-		configs       []model.Config
-		args          []string
-		wantOutput    string
-		wantError     *regexp.Regexp
-		wantException bool
-	}{
+	cases := []testCase{
 		{ // case 0 -- invalid doesn't provide -f
 			[]model.Config{},
 			strings.Split("replace routerules", " "),
@@ -361,58 +272,12 @@ func TestReplace(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		// Override the client factory used by main.go
-		clientFactory = mockClientFactoryGenerator(c.configs)
-
-		// run putCmd capturing output
-		var out bytes.Buffer
-		rootCmd.SetOutput(&out)
-		rootCmd.SetArgs(c.args)
-		// fErr := rootCmd.Execute()
-
-		file = "" // Clear, because we re-use
-
-		stdOutput, fErr := captureStdout(
-			func() error {
-				rootCmd.SetArgs(c.args)
-				err := rootCmd.Execute()
-				if err != nil {
-					return multierror.Prefix(err, fmt.Sprintf("Could not run command %v", c.args))
-				}
-				return nil
-			})
-		errOutput := out.String()
-
-		if c.wantOutput != stdOutput {
-			t.Errorf("Stdout didn't match for case %d \"istioctl replace %v\": Expected %q, got %q.  Stderr was %q",
-				i, strings.Join(c.args, " "),
-				c.wantOutput, stdOutput, errOutput)
-		}
-
-		if !c.wantError.MatchString(errOutput) {
-			t.Errorf("Stderr didn't match for case %d %v: Expected %v, got %q", i, c.args, c.wantError, errOutput)
-		}
-
-		if c.wantException {
-			if fErr == nil {
-				t.Errorf("Wanted an exception for case %d %v, didn't get one, output was %q", i, c.args, stdOutput)
-			}
-		} else {
-			if fErr != nil {
-				t.Errorf("Unwanted exception for case %d %v: %v", i, c.args, fErr)
-			}
-		}
+		verifyOutput(t, fmt.Sprintf("TestGet case %d", i), c)
 	}
 }
 
 func TestDelete(t *testing.T) {
-	cases := []struct {
-		configs       []model.Config
-		args          []string
-		wantOutput    string
-		wantError     *regexp.Regexp
-		wantException bool
-	}{
+	cases := []testCase{
 		{ // case 0
 			[]model.Config{},
 			strings.Split("delete routerule unknown", " "),
@@ -425,7 +290,7 @@ func TestDelete(t *testing.T) {
 			strings.Split("delete routerule a", " "),
 			`Deleted config: routerule a
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{ // case 1
@@ -434,7 +299,7 @@ func TestDelete(t *testing.T) {
 			`Deleted config: routerule a
 Deleted config: routerule b
 `,
-			regexp.MustCompile("^$"),
+			nil,
 			false,
 		},
 		{ // case 3 - delete by filename of istio config which doesn't exist
@@ -447,47 +312,7 @@ Deleted config: routerule b
 	}
 
 	for i, c := range cases {
-		// Override the client factory used by main.go
-		clientFactory = mockClientFactoryGenerator(c.configs)
-
-		// run deleteCmd capturing output
-		var out bytes.Buffer
-		rootCmd.SetOutput(&out)
-		rootCmd.SetArgs(c.args)
-		// fErr := rootCmd.Execute()
-
-		file = "" // Clear, because we re-use
-
-		stdOutput, fErr := captureStdout(
-			func() error {
-				rootCmd.SetArgs(c.args)
-				err := rootCmd.Execute()
-				if err != nil {
-					return multierror.Prefix(err, fmt.Sprintf("Could not run command %v", c.args))
-				}
-				return nil
-			})
-		errOutput := out.String()
-
-		if c.wantOutput != stdOutput {
-			t.Errorf("Stdout didn't match for delete case %d \"istioctl delete %v\": Expected %q, got %q.  Stderr was %q",
-				i, strings.Join(c.args, " "),
-				c.wantOutput, stdOutput, errOutput)
-		}
-
-		if !c.wantError.MatchString(errOutput) {
-			t.Errorf("Stderr didn't match for delete case %d %v: Expected %v, got %q", i, c.args, c.wantError, errOutput)
-		}
-
-		if c.wantException {
-			if fErr == nil {
-				t.Errorf("Wanted an exception for case %d %v, didn't get one, output was %q", i, c.args, stdOutput)
-			}
-		} else {
-			if fErr != nil {
-				t.Errorf("Unwanted exception for case %d %v: %v", i, c.args, fErr)
-			}
-		}
+		verifyOutput(t, fmt.Sprintf("TestGet case %d", i), c)
 	}
 }
 
@@ -513,28 +338,6 @@ func mockClientFactoryGenerator(configs []model.Config) func() (model.ConfigStor
 	}
 
 	return outFactory
-}
-
-// captureStdout invokes f capturing the output sent to stderr and stdout
-func captureStdout(f func() error) (string, error) {
-	origStdout := os.Stdout
-	rOut, wOut, _ := os.Pipe()
-	os.Stdout = wOut
-
-	errF := f()
-
-	outChannel := make(chan string)
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, rOut)
-		outChannel <- buf.String()
-	}()
-
-	wOut.Close()
-	os.Stdout = origStdout
-	capturedOutput := <-outChannel
-
-	return capturedOutput, errF
 }
 
 func (cs sortedConfigStore) Create(config model.Config) (string, error) {
@@ -574,4 +377,40 @@ func (cs sortedConfigStore) List(typ, namespace string) ([]model.Config, error) 
 	})
 
 	return out, nil
+}
+
+func verifyOutput(t *testing.T, label string, c testCase) {
+	// Override the client factory used by main.go
+	clientFactory = mockClientFactoryGenerator(c.configs)
+
+	var out bytes.Buffer
+	rootCmd.SetOutput(&out)
+	rootCmd.SetArgs(c.args)
+
+	file = "" // Clear, because we re-use
+
+	fErr := rootCmd.Execute()
+	output := out.String()
+
+	if c.expectedOutput != "" && c.expectedOutput != output {
+		t.Errorf("Unexpected output for %s %s: Expected\n%q,got\n%q",
+			label, strings.Join(c.args, " "),
+			c.expectedOutput, output)
+	}
+
+	if c.expectedRegexp != nil && !c.expectedRegexp.MatchString(output) {
+		t.Errorf("Output didn't match for %s %s: Expected\n%v,got\n%q",
+			label, strings.Join(c.args, " "),
+			c.expectedRegexp, output)
+	}
+
+	if c.wantException {
+		if fErr == nil {
+			t.Errorf("Wanted an exception for %s %s, didn't get one, output was %q", label, c.args, output)
+		}
+	} else {
+		if fErr != nil {
+			t.Errorf("Unwanted exception for %s %s: %v", label, c.args, fErr)
+		}
+	}
 }

--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -1,0 +1,357 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	multierror "github.com/hashicorp/go-multierror"
+
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/api/routing/v1alpha1"
+	"istio.io/istio/pilot/pkg/config/memory"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// sortedConfigStore lets us facade any ConfigStore (such as memory.Make()'s) providing
+// a stable List() which helps with testing `istioctl get` output.
+type sortedConfigStore struct {
+	store model.ConfigStore
+}
+
+const (
+	istioAPIVersion = "v1alpha2"
+)
+
+var (
+	testRouteRules = []model.Config{
+		{
+			ConfigMeta: model.ConfigMeta{
+				Name:      "d",
+				Namespace: "default",
+				Type:      model.RouteRule.Type,
+				Group:     model.RouteRule.Group,
+				Version:   model.RouteRule.Version,
+			},
+			Spec: &v1alpha1.RouteRule{
+				Precedence: 2,
+				Destination: &v1alpha1.IstioService{
+					Name: "d",
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "b",
+				Namespace: "default",
+				Type:      model.RouteRule.Type,
+				Group:     model.RouteRule.Group,
+				Version:   model.RouteRule.Version,
+			},
+			Spec: &v1alpha1.RouteRule{
+				Precedence: 3,
+				Destination: &v1alpha1.IstioService{
+					Name: "b",
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "c",
+				Namespace: "istio-system",
+				Type:      model.RouteRule.Type,
+				Group:     model.RouteRule.Group,
+				Version:   model.RouteRule.Version,
+			},
+			Spec: &v1alpha1.RouteRule{
+				Precedence: 2,
+				Destination: &v1alpha1.IstioService{
+					Name: "c",
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "a",
+				Namespace: "default",
+				Type:      model.RouteRule.Type,
+				Group:     model.RouteRule.Group,
+				Version:   model.RouteRule.Version,
+			},
+			Spec: &v1alpha1.RouteRule{
+				Precedence: 1,
+				Destination: &v1alpha1.IstioService{
+					Name: "a",
+				},
+			},
+		},
+	}
+
+	testGateways = []model.Config{
+		{
+			ConfigMeta: model.ConfigMeta{
+				Name:      "bookinfo-gateway",
+				Namespace: "default",
+				Type:      model.Gateway.Type,
+				Group:     model.Gateway.Group,
+				Version:   model.Gateway.Version,
+			},
+			Spec: &networking.Gateway{
+				Selector: map[string]string{"istio": "ingressgateway"},
+				Servers: []*networking.Server{
+					{
+						Port: &networking.Port{
+							Number:   80,
+							Protocol: "HTTP",
+						},
+						Hosts: []string{"*"},
+					},
+				},
+			},
+		},
+	}
+
+	testVirtualServices = []model.Config{
+		{
+			ConfigMeta: model.ConfigMeta{
+				Name:      "bookinfo",
+				Namespace: "default",
+				Type:      model.VirtualService.Type,
+				Group:     model.VirtualService.Group,
+				Version:   model.VirtualService.Version,
+			},
+			Spec: &networking.VirtualService{
+				Hosts:    []string{"*"},
+				Gateways: []string{"bookinfo-gateway"},
+				Http: []*networking.HTTPRoute{
+					{
+						Match: []*networking.HTTPMatchRequest{
+						//	{ &networking.HTTPMatchRequest{
+						//			Uri: &networking.StringMatch{ StringMatch_Exact{ "/productpage" } },
+						//		} },
+						},
+						Route: []*networking.DestinationWeight{
+							{
+								Destination: &networking.Destination{
+									Host: "productpage",
+									Port: &networking.PortSelector{
+										Port: &networking.PortSelector_Number{80},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestGet(t *testing.T) {
+	cases := []struct {
+		configs       []model.Config
+		args          []string
+		wantOutput    string
+		wantError     *regexp.Regexp
+		wantException bool
+	}{
+		{ // case 0
+			[]model.Config{},
+			[]string{"routerules"},
+			`No resources found.
+`,
+			regexp.MustCompile("^$"),
+			false,
+		},
+		{ // case 1
+			testRouteRules,
+			[]string{"routerules"},
+			`NAME      KIND                        NAMESPACE
+a         RouteRule.config.v1alpha2   default
+b         RouteRule.config.v1alpha2   default
+c         RouteRule.config.v1alpha2   istio-system
+d         RouteRule.config.v1alpha2   default
+`,
+			regexp.MustCompile("^$"),
+			false,
+		},
+		{ // case 2
+			testGateways,
+			[]string{"gateways"},
+			`NAME               KIND                          NAMESPACE
+bookinfo-gateway   Gateway.networking.v1alpha3   default
+`,
+			regexp.MustCompile("^$"),
+			false,
+		},
+		{ // case 3
+			testVirtualServices,
+			[]string{"virtualservices"},
+			`NAME       KIND                                 NAMESPACE
+bookinfo   VirtualService.networking.v1alpha3   default
+`,
+			regexp.MustCompile("^$"),
+			false,
+		},
+		{
+			[]model.Config{},
+			[]string{"invalid"},
+			"",
+			regexp.MustCompile("Usage:.*"),
+			true, // "istioctl get invalid" should fail
+		},
+	}
+
+	for i, c := range cases {
+		// Override the client factory used by main.go
+		clientFactory = mockClientFactoryGenerator(c.configs)
+
+		// run getCmd capturing output
+		stdOutput, errOutput, fErr := captureOutput(
+			func() error {
+				err := rootCmd.PersistentPreRunE(getCmd, c.args)
+				if err != nil {
+					return multierror.Prefix(err, "Could not prerun command")
+				}
+				err = getCmd.RunE(getCmd, c.args)
+				if err != nil {
+					return multierror.Prefix(err, "Could not run command")
+				}
+				return nil
+			})
+
+		if c.wantOutput != stdOutput {
+			t.Errorf("Stdout didn't match for case %d \"istioctl get %v\": Expected %q, got %q.  Stderr was %q",
+				i, strings.Join(c.args, " "),
+				c.wantOutput, stdOutput, errOutput)
+		}
+
+		if !c.wantError.MatchString(errOutput) {
+			t.Errorf("Stderr didn't match for case %d %v: Expected %v, got %q", i, c.args, c.wantError, errOutput)
+		}
+
+		if c.wantException {
+			if fErr == nil {
+				t.Errorf("Wanted an exception for case %d %v, didn't get one, output was %q", i, c.args, stdOutput)
+			}
+		} else {
+			if fErr != nil {
+				t.Errorf("Unwanted exception for case %d %v: %v", i, c.args, fErr)
+			}
+		}
+	}
+}
+
+// mockClientFactoryGenerator creates a factory for model.ConfigStore preloaded with data
+func mockClientFactoryGenerator(configs []model.Config) func() (model.ConfigStore, error) {
+	outFactory := func() (model.ConfigStore, error) {
+		// Initialize the real client to get the supported config types
+		realClient, err := newClient()
+		if err != nil {
+			return nil, err
+		}
+
+		// Initialize memory based model.ConfigStore with configs
+		outConfig := memory.Make(realClient.ConfigDescriptor())
+		for _, config := range configs {
+			if _, err := outConfig.Create(config); err != nil {
+				return nil, err
+			}
+		}
+
+		// Wrap the memory ConfigStore so List() is sorted
+		return sortedConfigStore{store: outConfig}, nil
+	}
+
+	return outFactory
+}
+
+// captureOutput invokes f capturing the output sent to stderr and stdout
+func captureOutput(f func() error) (string, string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, _ := os.Pipe()
+	os.Stdout = wOut
+
+	origStderr := os.Stderr
+	rErr, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+
+	errF := f()
+
+	outChannel := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, rOut)
+		outChannel <- buf.String()
+	}()
+
+	errChannel := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, rErr)
+		errChannel <- buf.String()
+	}()
+
+	wOut.Close()
+	os.Stdout = origStdout
+	capturedOutput := <-outChannel
+
+	wErr.Close()
+	os.Stderr = origStderr
+	capturedError := <-errChannel
+
+	return capturedOutput, capturedError, errF
+}
+
+func (cs sortedConfigStore) Create(config model.Config) (string, error) {
+	return cs.store.Create(config)
+}
+
+func (cs sortedConfigStore) Get(typ, name, namespace string) (*model.Config, bool) {
+	return cs.store.Get(typ, name, namespace)
+}
+
+func (cs sortedConfigStore) Update(config model.Config) (string, error) {
+	return cs.store.Update(config)
+}
+func (cs sortedConfigStore) Delete(typ, name, namespace string) error {
+	return cs.store.Delete(typ, name, namespace)
+}
+
+func (cs sortedConfigStore) ConfigDescriptor() model.ConfigDescriptor {
+	return cs.store.ConfigDescriptor()
+}
+
+func (cs sortedConfigStore) List(typ, namespace string) ([]model.Config, error) {
+	out, err := cs.store.List(typ, namespace)
+	if err != nil {
+		return out, err
+	}
+
+	// Sort by name, namespace
+	sort.Slice(out, func(i, j int) bool {
+		iName := out[i].ConfigMeta.Name
+		jName := out[j].ConfigMeta.Name
+		if iName == jName {
+			return out[i].ConfigMeta.Namespace < out[j].ConfigMeta.Namespace
+		}
+		return iName < jName
+	})
+
+	return out, nil
+}

--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -141,9 +141,26 @@ var (
 				Http: []*networking.HTTPRoute{
 					{
 						Match: []*networking.HTTPMatchRequest{
-						//	{ &networking.HTTPMatchRequest{
-						//			Uri: &networking.StringMatch{ StringMatch_Exact{ "/productpage" } },
-						//		} },
+							{
+								Uri: &networking.StringMatch{
+									&networking.StringMatch_Exact{"/productpage"},
+								},
+							},
+							{
+								Uri: &networking.StringMatch{
+									&networking.StringMatch_Exact{"/login"},
+								},
+							},
+							{
+								Uri: &networking.StringMatch{
+									&networking.StringMatch_Exact{"/logout"},
+								},
+							},
+							{
+								Uri: &networking.StringMatch{
+									&networking.StringMatch_Prefix{"/api/v1/products"},
+								},
+							},
 						},
 						Route: []*networking.DestinationWeight{
 							{

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -74,6 +74,9 @@ var (
 	// output format (yaml or short)
 	outputFormat string
 
+	// Create a model.ConfigStore (or mockCrdClient)
+	clientFactory = newClient
+
 	loggingOptions = log.DefaultOptions()
 
 	// all resources will be migrated out of config.istio.io to their own api group mapping to package path.
@@ -129,8 +132,8 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 					return err
 				}
 
-				var configClient *crd.Client
-				if configClient, err = newClient(); err != nil {
+				var configClient model.ConfigStore
+				if configClient, err = clientFactory(); err != nil {
 					return err
 				}
 				var rev string
@@ -199,8 +202,8 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 					return err
 				}
 
-				var configClient *crd.Client
-				if configClient, err = newClient(); err != nil {
+				var configClient model.ConfigStore
+				if configClient, err = clientFactory(); err != nil {
 					return err
 				}
 				// fill up revision
@@ -284,7 +287,7 @@ istioctl get destinationrules
 istioctl get virtualservice bookinfo
 `,
 		RunE: func(c *cobra.Command, args []string) error {
-			configClient, err := newClient()
+			configClient, err := clientFactory()
 			if err != nil {
 				return err
 			}
@@ -319,7 +322,7 @@ istioctl get virtualservice bookinfo
 				return nil
 			}
 
-			var outputters = map[string](func(*crd.Client, []model.Config)){
+			var outputters = map[string](func(model.ConfigStore, []model.Config)){
 				"yaml":  printYamlOutput,
 				"short": printShortOutput,
 			}
@@ -344,7 +347,7 @@ istioctl delete -f example-routing.yaml
 istioctl delete virtualservice bookinfo
 `,
 		RunE: func(c *cobra.Command, args []string) error {
-			configClient, errs := newClient()
+			configClient, errs := clientFactory()
 			if errs != nil {
 				return errs
 			}
@@ -581,7 +584,7 @@ func main() {
 }
 
 // The protoSchema is based on the kind (for example "routerule" or "destinationpolicy")
-func protoSchema(configClient *crd.Client, typ string) (model.ProtoSchema, error) {
+func protoSchema(configClient model.ConfigStore, typ string) (model.ProtoSchema, error) {
 	for _, desc := range configClient.ConfigDescriptor() {
 		switch typ {
 		case crd.ResourceName(desc.Type), crd.ResourceName(desc.Plural):
@@ -624,7 +627,7 @@ func readInputs() ([]model.Config, []crd.IstioKind, error) {
 }
 
 // Print a simple list of names
-func printShortOutput(_ *crd.Client, configList []model.Config) {
+func printShortOutput(_ model.ConfigStore, configList []model.Config) {
 	var w tabwriter.Writer
 	w.Init(os.Stdout, 10, 4, 3, ' ', 0)
 	fmt.Fprintf(&w, "NAME\tKIND\tNAMESPACE\n")
@@ -640,7 +643,7 @@ func printShortOutput(_ *crd.Client, configList []model.Config) {
 }
 
 // Print as YAML
-func printYamlOutput(configClient *crd.Client, configList []model.Config) {
+func printYamlOutput(configClient model.ConfigStore, configList []model.Config) {
 	descriptor := configClient.ConfigDescriptor()
 	for _, config := range configList {
 		schema, exists := descriptor.GetByType(config.Type)
@@ -663,7 +666,7 @@ func printYamlOutput(configClient *crd.Client, configList []model.Config) {
 	}
 }
 
-func newClient() (*crd.Client, error) {
+func newClient() (model.ConfigStore, error) {
 	// TODO: use model.IstioConfigTypes once model.IngressRule is deprecated
 	return crd.NewClient(kubeconfig, model.ConfigDescriptor{
 		model.RouteRule,
@@ -683,7 +686,7 @@ func newClient() (*crd.Client, error) {
 	}, "")
 }
 
-func supportedTypes(configClient *crd.Client) []string {
+func supportedTypes(configClient model.ConfigStore) []string {
 	types := configClient.ConfigDescriptor().Types()
 	for i := range types {
 		types[i] = crd.ResourceName(types[i])

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -70,7 +70,7 @@ type Client struct {
 type restClient struct {
 	apiVersion schema.GroupVersion
 
-	// descriptor from the same apiVerion.
+	// descriptor from the same apiVersion.
 	descriptor model.ConfigDescriptor
 
 	// types of the schema and objects in the descriptor.


### PR DESCRIPTION
This creates tests on the output of `istioctl get x` (also `delete` and a bit of `create`/`update`.)

The implementation uses _memory.Make()_ to create a _model.ConfigStore_ and uses it as a mock.

This doesn't fix any issues but I wanted to get it in place so that https://github.com/istio/istio/issues/5668 , https://github.com/istio/istio/issues/5538 , and https://github.com/istio/istio/issues/5502 will have test cases and code coverage.