### PR TITLE
Enhance debug logging for Mixer grpc methods

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -77,6 +77,8 @@ func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool) mix
 
 // Check is the entry point for the external Check method
 func (s *grpcServer) Check(legacyCtx legacyContext.Context, req *mixerpb.CheckRequest) (*mixerpb.CheckResponse, error) {
+	lg.Debugf("Check (GlobalWordCount:%d, DeduplicationID:%s, Quota:%v)", req.GlobalWordCount, req.DeduplicationId, req.Quotas)
+
 	lg.Debug("Dispatching Preprocess Check")
 
 	globalWordCount := int(req.GlobalWordCount)
@@ -183,6 +185,8 @@ var reportResp = &mixerpb.ReportResponse{}
 
 // Report is the entry point for the external Report method
 func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.ReportRequest) (*mixerpb.ReportResponse, error) {
+	lg.Debugf("Report (Count: %d)", len(req.Attributes))
+
 	if len(req.Attributes) == 0 {
 		// early out
 		return reportResp, nil
@@ -231,7 +235,7 @@ func (s *grpcServer) Report(legacyCtx legacyContext.Context, req *mixerpb.Report
 
 		lg.Debug("Dispatching to main adapters after running preprocessors")
 		lg.Debuga("Attribute Bag: \n", reportBag)
-		lg.Debugf("Dispatching Report %d out of %d", i, len(req.Attributes))
+		lg.Debugf("Dispatching Report %d out of %d", i+1, len(req.Attributes))
 
 		err = s.dispatcher.Report(legacyCtx, reportBag)
 		if err != nil {


### PR DESCRIPTION
In trying to figure out rate limits were not working with proxyv2, we discovered a slight hole in the logging, even with debug levels on. This PR attempts to add more info to the logging to make debugging slightly better.

Example:
- client requests:
  `$ mixc check -a destination.service=foo.default -q RequestCount=1`
  `$ mixc report -a destination.service=foo.default`

- server:
  ```
  $ mixs server --configStoreURL=fs://${pwd}/mixer/testdata/config --log_output_level=api:debug
  ...
  2018-05-21T22:19:21.736306Z	debug	api	Check (GlobalWordCount:0, DeduplicationID:734693961, Quota:map[RequestCount:{1 true}])
  ...
  2018-05-21T22:19:22.878903Z	debug	api	Report (Count: 1)
  ...
  2018-05-21T22:19:22.879030Z	debug	api	Dispatching Report 1 out of 1
  ```

NOTE: This should probably be done with a grpc interceptor, but wiring up the scoped loggers, etc., for that seemed like a much bigger change than is needed right now.