### PR TITLE
Fix tracing addon missing issue in release package.

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-auth.yaml
@@ -25,7 +25,7 @@ sidecar-injector:
 grafana:
   enabled: true
 
-zipkin:
+tracing:
   enabled: true
 
 servicegraph:

--- a/install/kubernetes/helm/istio/values-istio-demo.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo.yaml
@@ -23,7 +23,7 @@ sidecar-injector:
 grafana:
   enabled: true
 
-zipkin:
+tracing:
   enabled: true
 
 servicegraph:


### PR DESCRIPTION
Since `zipkin` has been replaced with `jaeger `: https://github.com/istio/istio/commit/6dbbacac0b478017179480778637c9d8d781ac25#diff-b6a1565b257517e23073e89749791828
It is necessary to update `values-istio-demo*.yaml` to add `jaeger` to release package, like other addons(prometheus, grafana and servicegraph).