### PR TITLE
Fix broken mixer develop document link.

### DIFF
--- a/mixer/README.md
+++ b/mixer/README.md
@@ -24,11 +24,13 @@ Mixer provides three distinct features:
 Learn more about Mixer
 [here](https://istio.io/docs/concepts/policy-and-control/mixer.html).
 
-Mixer's [Adapter Developer's Guide](doc/adapters.md) presents everything you
-need to know about extending Mixer to provide support for new backends through
-the development of new
+Mixer's 
+[Adapter Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Adapter-Dev-Guide) 
+presents everything you need to know about extending Mixer to provide support 
+for new backends through the development of new
 [adapters](https://istio.io/docs/concepts/policy-and-control/mixer.html#adapters).
 
-Mixer's [Template Developer's Guide](doc/templates.md) presents everything you
-need to know about you can create new templates to define whole new categories
-of adapters.
+Mixer's 
+[Template Developer's Guide](https://github.com/istio/istio/wiki/Mixer-Template-Dev-Guide) 
+presents everything you need to know about you can create new templates to define 
+whole new categories of adapters.


### PR DESCRIPTION
Mixer developer doc has moved to github wiki page, update the link url for README file.

Fix https://github.com/istio/istio/issues/5499.