### PR TITLE
Fix xds_test on MacOS by configuring ...

### DIFF
--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -130,6 +130,13 @@ func setup() error {
 	}
 	pilotHTTPPort, _ := strconv.Atoi(pilotHTTP)
 
+	_, meshConfig, _ := bootstrap.GetMeshConfig(nil, "not used", "not used")
+	meshConfig.AccessLogFile = "/tmp/envoy-access.log" // TODO take value from TestSetup.AccessLogPath, needs refactoring to avoid import cycle
+	//TODO: start mixer first, get its address
+	meshConfig.MixerCheckServer = "istio-mixer.istio-system:9091"
+	meshConfig.MixerReportServer = "istio-mixer.istio-system:9091"
+	meshConfig.RdsRefreshDelay = ptypes.DurationProto(10 * time.Millisecond)
+
 	// Create a test pilot discovery service configured to watch the tempDir.
 	args := bootstrap.PilotArgs{
 		Namespace: "testing",
@@ -140,11 +147,7 @@ func setup() error {
 			EnableCaching:   true,
 			EnableProfiling: true,
 		},
-		//TODO: start mixer first, get its address
-		Mesh: bootstrap.MeshArgs{
-			MixerAddress:    "istio-mixer.istio-system:9091",
-			RdsRefreshDelay: ptypes.DurationProto(10 * time.Millisecond),
-		},
+		MeshConfig: meshConfig,
 		Config: bootstrap.ConfigArgs{
 			KubeConfig: IstioSrc + "/.circleci/config",
 		},


### PR DESCRIPTION
mesh in test setup so that listeners write access log to
/tmp/envoy-access.log instead of default /dev/stdout.
With this change `make test` shows the same failures on MacOS
as on linux. (Given a matching envoy executable version.)

Co-authored-by: Holger Oehm <holger.oehm@sap.com>