### PR TITLE
restructure unit test to incrementally add rule files

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -35,7 +35,7 @@ func TestCDS(t *testing.T) {
 		}
 
 		strResponse, _ := model.ToJSONWithIndent(res, " ")
-		_ = ioutil.WriteFile(util.IstioOut + "/cdsv2_sidecar.json", []byte(strResponse), 0644)
+		_ = ioutil.WriteFile(util.IstioOut+"/cdsv2_sidecar.json", []byte(strResponse), 0644)
 
 		t.Log("CDS response", strResponse)
 		if len(res.Resources) == 0 {

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -24,22 +24,24 @@ import (
 func TestCDS(t *testing.T) {
 	initLocalPilotTestEnv(t)
 
-	cdsr := connectADS(t, util.MockPilotGrpcAddr)
-	sendCDSReq(t, sidecarId(app3Ip, "app3"), cdsr)
+	t.Run("sidecar no rules", func(t *testing.T) {
+		cdsr := connectADS(t, util.MockPilotGrpcAddr)
+		sendCDSReq(t, sidecarId(app3Ip, "app3"), cdsr)
 
-	res, err := cdsr.Recv()
-	if err != nil {
-		t.Fatal("Failed to receive CDS", err)
-		return
-	}
+		res, err := cdsr.Recv()
+		if err != nil {
+			t.Fatal("Failed to receive CDS", err)
+			return
+		}
 
-	strResponse, _ := model.ToJSONWithIndent(res, " ")
-	_ = ioutil.WriteFile(util.IstioOut+"/cdsv2_sidecar.json", []byte(strResponse), 0644)
+		strResponse, _ := model.ToJSONWithIndent(res, " ")
+		_ = ioutil.WriteFile(util.IstioOut + "/cdsv2_sidecar.json", []byte(strResponse), 0644)
 
-	t.Log("CDS response", strResponse)
-	if len(res.Resources) == 0 {
-		t.Fatal("No response")
-	}
+		t.Log("CDS response", strResponse)
+		if len(res.Resources) == 0 {
+			t.Fatal("No response")
+		}
+	})
 
 	// TODO: dump the response resources, compare with some golden once it's stable
 	// check that each mocked service and destination rule has a corresponding resource

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -45,6 +45,10 @@ func TestLDS(t *testing.T) {
 
 	// 'router' or 'gateway' type of listener
 	t.Run("gateway", func(t *testing.T) {
+		if err := util.ApplyRuleFiles([]string{"gateway-all.yaml"}); err != nil {
+			t.Fatalf("Failed to apply rule files: %v", err)
+			return
+		}
 		ldsr := connectADS(t, util.MockPilotGrpcAddr)
 		sendLDSReq(t, gatewayId(gatewayIP), ldsr)
 
@@ -64,6 +68,10 @@ func TestLDS(t *testing.T) {
 	})
 
 	t.Run("ingress", func(t *testing.T) {
+		if err := util.ApplyRuleFiles([]string{"ingress.yaml"}); err != nil {
+			t.Fatalf("Failed to apply rule files: %v", err)
+			return
+		}
 		ldsr := connectADS(t, util.MockPilotGrpcAddr)
 		sendLDSReq(t, ingressId(ingressIP), ldsr)
 

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -105,12 +105,12 @@ func ingressId(ip string) string {
 }
 
 func compareResponse(body []byte, file string, t *testing.T) {
-	err := ioutil.WriteFile(file, body, 0644)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
-
 	// TODO golden files to be added in separate PR
+	//err := ioutil.WriteFile(file, body, 0644)
+	//if err != nil {
+	//	t.Fatalf(err.Error())
+	//}
+	//
 	//pilotutil.CompareYAML(file, t)
 }
 


### PR DESCRIPTION
this PR restructures the proxy v2 unit tests so that rule files can be incrementally added to the test env

follow-up PR will add `pilot/pkg/proxy/v2/goldens/` dir and populate golden files