### PR TITLE
Build: Allow downstream to tweak symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ depend.diff: $(ISTIO_OUT)
 	git diff HEAD --exit-code -- Gopkg.lock vendor > $(ISTIO_OUT)/dep.diff
 
 ${GEN_CERT}:
-	GOOS=$(GOOS_LOCAL) && GOARCH=$(GOARCH_LOCAL) && CGO_ENABLED=1 bin/gobuild.sh $@ istio.io/istio/pkg/version ./security/cmd/generate_cert
+	GOOS=$(GOOS_LOCAL) && GOARCH=$(GOARCH_LOCAL) && CGO_ENABLED=1 bin/gobuild.sh $@ ./security/cmd/generate_cert
 
 #-----------------------------------------------------------------------------
 # Target: precommit
@@ -284,50 +284,50 @@ PILOT_GO_BINS:=${ISTIO_OUT}/pilot-discovery ${ISTIO_OUT}/pilot-agent \
 PILOT_GO_BINS_SHORT:=pilot-discovery pilot-agent sidecar-injector
 define pilotbuild
 $(1):
-	bin/gobuild.sh ${ISTIO_OUT}/$(1) istio.io/istio/pkg/version ./pilot/cmd/$(1)
+	bin/gobuild.sh ${ISTIO_OUT}/$(1) ./pilot/cmd/$(1)
 
 ${ISTIO_OUT}/$(1):
-	bin/gobuild.sh ${ISTIO_OUT}/$(1) istio.io/istio/pkg/version ./pilot/cmd/$(1)
+	bin/gobuild.sh ${ISTIO_OUT}/$(1) ./pilot/cmd/$(1)
 endef
 $(foreach ITEM,$(PILOT_GO_BINS_SHORT),$(eval $(call pilotbuild,$(ITEM))))
 
 .PHONY: istioctl
 istioctl ${ISTIO_OUT}/istioctl:
-	bin/gobuild.sh ${ISTIO_OUT}/istioctl istio.io/istio/pkg/version ./istioctl/cmd/istioctl
+	bin/gobuild.sh ${ISTIO_OUT}/istioctl ./istioctl/cmd/istioctl
 
 # Non-static istioctls. These are typically a build artifact.
 ${ISTIO_OUT}/istioctl-linux: depend
-	STATIC=0 GOOS=linux   bin/gobuild.sh $@ istio.io/istio/pkg/version ./istioctl/cmd/istioctl
+	STATIC=0 GOOS=linux   bin/gobuild.sh $@ ./istioctl/cmd/istioctl
 ${ISTIO_OUT}/istioctl-osx: depend
-	STATIC=0 GOOS=darwin  bin/gobuild.sh $@ istio.io/istio/pkg/version ./istioctl/cmd/istioctl
+	STATIC=0 GOOS=darwin  bin/gobuild.sh $@ ./istioctl/cmd/istioctl
 ${ISTIO_OUT}/istioctl-win.exe: depend
-	STATIC=0 GOOS=windows bin/gobuild.sh $@ istio.io/istio/pkg/version ./istioctl/cmd/istioctl
+	STATIC=0 GOOS=windows bin/gobuild.sh $@ ./istioctl/cmd/istioctl
 
 MIXER_GO_BINS:=${ISTIO_OUT}/mixs ${ISTIO_OUT}/mixc
 mixc:
-	bin/gobuild.sh ${ISTIO_OUT}/mixc istio.io/istio/pkg/version ./mixer/cmd/mixc
+	bin/gobuild.sh ${ISTIO_OUT}/mixc ./mixer/cmd/mixc
 mixs:
-	bin/gobuild.sh ${ISTIO_OUT}/mixs istio.io/istio/pkg/version ./mixer/cmd/mixs
+	bin/gobuild.sh ${ISTIO_OUT}/mixs ./mixer/cmd/mixs
 
 $(MIXER_GO_BINS):
-	bin/gobuild.sh $@ istio.io/istio/pkg/version ./mixer/cmd/$(@F)
+	bin/gobuild.sh $@ ./mixer/cmd/$(@F)
 
 GALLEY_GO_BINS:=${ISTIO_OUT}/galley
 galley:
-	bin/gobuild.sh ${ISTIO_OUT}/galley istio.io/istio/pkg/version ./galley/cmd/galley
+	bin/gobuild.sh ${ISTIO_OUT}/galley ./galley/cmd/galley
 
 $(GALLEY_GO_BINS):
-	bin/gobuild.sh $@ istio.io/istio/pkg/version ./galley/cmd/$(@F)
+	bin/gobuild.sh $@ ./galley/cmd/$(@F)
 
 servicegraph:
-	bin/gobuild.sh ${ISTIO_OUT}/$@ istio.io/istio/pkg/version ./addons/servicegraph/cmd/server
+	bin/gobuild.sh ${ISTIO_OUT}/$@ ./addons/servicegraph/cmd/server
 
 ${ISTIO_OUT}/servicegraph:
-	bin/gobuild.sh $@ istio.io/istio/pkg/version ./addons/$(@F)/cmd/server
+	bin/gobuild.sh $@ ./addons/$(@F)/cmd/server
 
 SECURITY_GO_BINS:=${ISTIO_OUT}/node_agent ${ISTIO_OUT}/istio_ca
 $(SECURITY_GO_BINS):
-	bin/gobuild.sh $@ istio.io/istio/pkg/version ./security/cmd/$(@F)
+	bin/gobuild.sh $@ ./security/cmd/$(@F)
 
 .PHONY: build
 # Build will rebuild the go binaries.
@@ -341,18 +341,18 @@ build: depend $(PILOT_GO_BINS_SHORT) mixc mixs node_agent istio_ca istioctl gall
 
 .PHONY: citadel
 citadel:
-	bin/gobuild.sh ${ISTIO_OUT}/istio_ca istio.io/istio/pkg/version ./security/cmd/istio_ca
+	bin/gobuild.sh ${ISTIO_OUT}/istio_ca ./security/cmd/istio_ca
 
 .PHONY: node-agent
 node-agent:
-	bin/gobuild.sh ${ISTIO_OUT}/node-agent istio.io/istio/pkg/version ./security/cmd/node_agent
+	bin/gobuild.sh ${ISTIO_OUT}/node-agent ./security/cmd/node_agent
 
 .PHONY: pilot
 pilot: pilot-discovery
 
 .PHONY: node_agent istio_ca
 node_agent istio_ca:
-	bin/gobuild.sh ${ISTIO_OUT}/$@ istio.io/istio/pkg/version ./security/cmd/$(@F)
+	bin/gobuild.sh ${ISTIO_OUT}/$@ ./security/cmd/$(@F)
 
 # istioctl-all makes all of the non-static istioctl executables for each supported OS
 .PHONY: istioctl-all

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -51,10 +51,10 @@ if [[ -n ${ISTIO_DOCKER_HUB} ]]; then
   DOCKER_HUB="${ISTIO_DOCKER_HUB}"
 fi
 
-# used by pkg/version
-echo buildVersion       "${VERSION}"
-echo buildGitRevision   "${BUILD_GIT_REVISION}"
-echo buildUser          "$(whoami)"
-echo buildHost          "$(hostname -f)"
-echo buildDockerHub     "${DOCKER_HUB}"
-echo buildStatus        "${tree_status}"
+# used by bin/gobuild.sh
+echo "istio.io/istio/pkg/version.buildVersion=${VERSION}"
+echo "istio.io/istio/pkg/version.buildGitRevision=${BUILD_GIT_REVISION}"
+echo "istio.io/istio/pkg/version.buildUser=$(whoami)"
+echo "istio.io/istio/pkg/version.buildHost=$(hostname -f)"
+echo "istio.io/istio/pkg/version.buildDockerHub=${DOCKER_HUB}"
+echo "istio.io/istio/pkg/version.buildStatus=${tree_status}"

--- a/bin/gobuild.sh
+++ b/bin/gobuild.sh
@@ -26,8 +26,7 @@ fi
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 OUT=${1:?"output path"}
-VERSION_PACKAGE=${2:?"version go package"} # istio.io/istio/pkg/version
-BUILDPATH=${3:?"path to build"}
+BUILDPATH=${2:?"path to build"}
 
 set -e
 
@@ -54,13 +53,12 @@ if [[ -z ${BUILDINFO} ]];then
     ${ROOT}/bin/get_workspace_status > ${BUILDINFO}
 fi
 
-# BUILD LD_VERSIONFLAGS
-LD_VERSIONFLAGS=""
+# BUILD LD_EXTRAFLAGS
+LD_EXTRAFLAGS=""
 while read line; do
-    read SYMBOL VALUE < <(echo $line)
-    LD_VERSIONFLAGS=${LD_VERSIONFLAGS}" -X ${VERSION_PACKAGE}.${SYMBOL}=${VALUE}"
+    LD_EXTRAFLAGS="${LD_EXTRAFLAGS} -X ${line}"
 done < "${BUILDINFO}"
 
 # forgoing -i (incremental build) because it will be deprecated by tool chain. 
 time GOOS=${GOOS} GOARCH=${GOARCH} ${GOBINARY} build ${V} ${GOBUILDFLAGS} ${GCFLAGS:+-gcflags "${GCFLAGS}"} -o ${OUT} \
-       -pkgdir=${GOPKG}/${GOOS}_${GOARCH} -ldflags "${LDFLAGS} ${LD_VERSIONFLAGS}" "${BUILDPATH}"
+       -pkgdir=${GOPKG}/${GOOS}_${GOARCH} -ldflags "${LDFLAGS} ${LD_EXTRAFLAGS}" "${BUILDPATH}"


### PR DESCRIPTION
Currently we allow users who build istio to override some
version values, by providing their own "buildinfo" file with
values for the version variables. Those are linked properly
by the gobuild.sh script, that makes use of the -X ldflags
option for the go linker.

This PR makes this ability more general allowing users to
override any symbol they want, by providing their own "buildinfo"
file with one symbol (full path) per line, like for example:

istio.io/istio/pkg/version.buildVersion=0.8
istio.io/istio/pkg/version.buildStatus=Clean

This is especially useful for downstream distributors that
need to tweak (at build time) a hardcoded variable other
than those who control the version output.