### PR TITLE
Allow downstream to change the location of the root ca bundle file

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -59,7 +59,9 @@ const (
 
 	// JwtPubKeyRefreshInterval is the running interval of JWT pubKey refresh job.
 	JwtPubKeyRefreshInterval = time.Minute * 20
+)
 
+var (
 	// PublicRootCABundlePath is the path of public root CA bundle in pilot container.
 	publicRootCABundlePath = "/cacert.pem"
 )


### PR DESCRIPTION
By making publicRootCABundlePath a var instead of a const.

By using the -X ldflag option, the user bulding istio can override
the default location for this file.