### PR TITLE
Istioctl kube-inject requires injectConfigFile or injectConfigMapName

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ export OUT_DIR=$(GO_TOP)/out
 export ISTIO_OUT:=$(GO_TOP)/out/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 export HELM=$(ISTIO_OUT)/helm
 
+# istioctl kube-inject uses builtin config only if this env var is set.
+export ISTIOCTL_USE_BUILTIN_DEFAULTS=1
+
 # scratch dir: this shouldn't be simply 'docker' since that's used for docker.save to store tar.gz files
 ISTIO_DOCKER:=${ISTIO_OUT}/docker_temp
 # Config file used for building istio:proxy container.

--- a/istioctl/cmd/istioctl/inject.go
+++ b/istioctl/cmd/istioctl/inject.go
@@ -253,21 +253,10 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 			}
 
 			var sidecarTemplate string
-			if injectConfigFile != "" {
-				injectionConfig, err := ioutil.ReadFile(injectConfigFile) // nolint: vetshadow
-				if err != nil {
-					return err
-				}
-				var config inject.Config
-				if err := yaml.Unmarshal(injectionConfig, &config); err != nil {
-					return err
-				}
-				sidecarTemplate = config.Template
-			} else if injectConfigMapName != "" {
-				if sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {
-					return err
-				}
-			} else {
+
+			// hub and tag params only work with ISTIOCTL_USE_BUILTIN_DEFAULTS
+			// so must be specified together. hub and tag no longer have defaults.
+			if hub != "" || tag != "" {
 				// ISTIOCTL_USE_BUILTIN_DEFAULTS is used to have legacy behaviour.
 				if !getBoolEnv("ISTIOCTL_USE_BUILTIN_DEFAULTS", false) {
 					return errors.New("one of injectConfigFile or injectConfigMapName is required\n" +
@@ -291,6 +280,21 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 					ExcludeInboundPorts: excludeInboundPorts,
 					DebugMode:           debugMode,
 				}); err != nil {
+					return err
+				}
+
+			} else if injectConfigFile != "" {
+				injectionConfig, err := ioutil.ReadFile(injectConfigFile) // nolint: vetshadow
+				if err != nil {
+					return err
+				}
+				var config inject.Config
+				if err := yaml.Unmarshal(injectionConfig, &config); err != nil {
+					return err
+				}
+				sidecarTemplate = config.Template
+			} else {
+				if sidecarTemplate, err = getInjectConfigFromConfigMap(kubeconfig); err != nil {
 					return err
 				}
 			}
@@ -320,11 +324,16 @@ func getBoolEnv(key string, defaultVal bool) bool {
 	return defaultVal
 }
 
+const (
+	defaultMeshConfigMapName   = "istio"
+	defaultInjectConfigMapName = "istio-sidecar-injector"
+)
+
 func init() {
 	rootCmd.AddCommand(injectCmd)
 
-	injectCmd.PersistentFlags().StringVar(&hub, "hub", version.Info.DockerHub, "Docker hub")
-	injectCmd.PersistentFlags().StringVar(&tag, "tag", version.Info.Version, "Docker tag")
+	injectCmd.PersistentFlags().StringVar(&hub, "hub", "", "Docker hub")
+	injectCmd.PersistentFlags().StringVar(&tag, "tag", "", "Docker tag")
 
 	injectCmd.PersistentFlags().StringVar(&meshConfigFile, "meshConfigFile", "",
 		"mesh configuration filename. Takes precedence over --meshConfigMapName if set")
@@ -371,15 +380,15 @@ func init() {
 			"are excluded.")
 	injectCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Use debug images and settings for the sidecar")
 
-	deprecateFlags := []string{"coreDump", "imagePullPolicy", "includeIPRanges", "excludeIPRanges",
+	deprecatedFlags := []string{"coreDump", "imagePullPolicy", "includeIPRanges", "excludeIPRanges", "hub", "tag",
 		"includeInboundPorts", "excludeInboundPorts", "debug", "verbosity", "sidecarProxyUID", "setVersionString"}
-	for _, opt := range deprecateFlags {
+	for _, opt := range deprecatedFlags {
 		injectCmd.PersistentFlags().MarkDeprecated(opt, "Use --injectConfigMapName or --injectConfigFile instead")
 	}
 
-	injectCmd.PersistentFlags().StringVar(&meshConfigMapName, "meshConfigMapName", "istio",
+	injectCmd.PersistentFlags().StringVar(&meshConfigMapName, "meshConfigMapName", defaultMeshConfigMapName,
 		fmt.Sprintf("ConfigMap name for Istio mesh configuration, key should be %q", configMapKey))
-	injectCmd.PersistentFlags().StringVar(&injectConfigMapName, "injectConfigMapName", "",
+	injectCmd.PersistentFlags().StringVar(&injectConfigMapName, "injectConfigMapName", defaultInjectConfigMapName,
 		fmt.Sprintf("ConfigMap name for Istio sidecar injection, key should be %q."+
 			"This option overrides any other sidecar injection config options, eg. --hub",
 			injectConfigMapKey))

--- a/istioctl/cmd/istioctl/inject.go
+++ b/istioctl/cmd/istioctl/inject.go
@@ -265,6 +265,10 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 						"-o=jsonpath='{.data.config}' > /tmp/injectConfigFile.yaml")
 				}
 
+				if hub == "" || tag == "" {
+					return fmt.Errorf("hub and tag are both required. got hub: '%v', tag: '%v'", hub, tag)
+				}
+
 				if sidecarTemplate, err = inject.GenerateTemplateFromParams(&inject.Params{
 					InitImage:           inject.InitImageName(hub, tag, debugMode),
 					ProxyImage:          inject.ProxyImageName(hub, tag, debugMode),


### PR DESCRIPTION
This forces users to use injectConfigFile or injectConfigMapName to use manual kube inject.

All old params are deprecated, though they will continue to work.
Added 'ISTIOCTL_USE_BUILTIN_DEFAULTS` for legacy behaviour.