### PR TITLE
Matching the new Sidecar Injector enablement key

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -678,7 +678,7 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 	setValue := "--set global.mtls.enabled=" + strconv.FormatBool(isSecurityOn)
 	// side car injector
 	if *useAutomaticInjection {
-		setValue += " --set sidecar-injector.enabled=true"
+		setValue += " --set sidecarInjectorWebhook.enabled=true"
 	}
 	// hubs and tags replacement.
 	// Helm chart assumes hub and tag are the same among multiple istio components.


### PR DESCRIPTION
Although it is now set to `true` by default I'm keeping this explicit setting to avoid a break if sidecar injector will return to be disabled by default.