### PR TITLE
Remove errant extra comma in ads response

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -449,7 +449,7 @@ func writeAllADS(w io.Writer) {
 		fmt.Fprintf(w, "\n\n  {\"node\": \"%s\",\n \"addr\": \"%s\",\n \"connect\": \"%v\",\n \"listeners\":[\n", c.ConID, c.PeerAddr, c.Connect)
 		printListeners(w, c)
 		fmt.Fprint(w, "],\n")
-		fmt.Fprintf(w, ",\"clusters\":[\n")
+		fmt.Fprintf(w, "\"clusters\":[\n")
 		printClusters(w, c)
 		fmt.Fprint(w, "]}\n")
 	}


### PR DESCRIPTION
```  {"node": "sidecar~172.30.203.236~node0-v1-cffd86cb-xmbsm.default~default.svc.cluster.local-114",
 "addr": "172.30.203.236:35442",
 "connect": "2018-05-24 16:11:26.79859438 +0000 UTC m=+146.025142122",
 "listeners":[
],
,"clusters":[
]}
```

Reported by @esnible 