### PR TITLE
use ISTIO_CP_AUTH variable in cluster.env to enable/disable mTLS for cp in mesh ex

### DIFF
--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -99,7 +99,7 @@ function istioClusterEnv() {
   CIDR=$(gcloud container clusters describe ${K8S_CLUSTER} ${GCP_OPTS:-} --format "value(servicesIpv4Cidr)")
   echo "ISTIO_SERVICE_CIDR=$CIDR" > cluster.env
   echo "ISTIO_SYSTEM_NAMESPACE=$ISTIO_NS" >> cluster.env
-  echo "CONTROL_PLANE_AUTH_POLICY=$CP_AUTH_POLICY" >> cluster.env
+  echo "ISTIO_CP_AUTH=$CP_AUTH_POLICY" >> cluster.env
 
   echo "Generated cluster.env, needs to be installed in each VM as /var/lib/istio/envoy/cluster.env"
   echo "the /var/lib/istio/envoy/ directory and files must be readable by 'istio-proxy' user"


### PR DESCRIPTION
ref: https://github.com/istio/istio/issues/5833

Currently setupMeshEx.sh create a variable CONTROL_PLANE_AUTH_POLICY in cluster.env to enable/disable control plane mTLS for VM.
```
...
echo "CONTROL_PLANE_AUTH_POLICY=$CP_AUTH_POLICY" >> cluster.env
...
```
It should be 
```
...
echo "ISTIO_CP_AUTH=$CP_AUTH_POLICY" >> cluster.env
...
```
since istio-start.sh https://github.com/istio/istio/blob/26262e8a1d89c4cd17f52db645d91ce9d9918e6e/tools/deb/istio-start.sh#L48 looks for ```ISTIO_CP_AUTH```