### PR TITLE
Remove chgrp in tproxy that suppressed core dumps

### DIFF
--- a/pilot/docker/Dockerfile.proxy
+++ b/pilot/docker/Dockerfile.proxy
@@ -10,9 +10,10 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 # istio-proxy" will not match connections from those processes anymore.
 # Instead, rely on the process's effective gid being istio-proxy and create a
 # "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
-RUN \
-chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
-chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+# TODO: disabling due to https://github.com/istio/istio/issues/5745
+# RUN \
+# chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+# chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -10,9 +10,10 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 # istio-proxy" will not match connections from those processes anymore.
 # Instead, rely on the process's effective gid being istio-proxy and create a
 # "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
-RUN \
-chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
-chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+# TODO: disabling due to https://github.com/istio/istio/issues/5745
+# RUN \
+# chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+# chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -10,9 +10,10 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 # istio-proxy" will not match connections from those processes anymore.
 # Instead, rely on the process's effective gid being istio-proxy and create a
 # "-m owner --gid-owner istio-proxy" iptables rule in istio-iptables.sh.
-RUN \
-chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
-chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
+# TODO: disabling due to https://github.com/istio/istio/issues/5745
+# RUN \
+# chgrp 1337 /usr/local/bin/envoy /usr/local/bin/pilot-agent && \
+# chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl


### PR DESCRIPTION
Background to this is in https://github.com/istio/istio/issues/5745.
The chgrp causes a setgid that has the side effect of disabling core dumps in envoy. 
Temporarily removing this to unblock 0.8.
See also https://github.com/istio/istio/issues/5848 and https://github.com/istio/istio/issues/5847 for followup work.