### PR TITLE
Replace the hard-coded proxy image for chart.

### DIFF
--- a/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: {{ template "istio.name" . }}
-          image: "{{ .Values.global.hub }}/proxyv2:{{ .Values.global.tag }}"
+          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             {{- range $key, $val := .Values.deployment.ports }}

--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
         - name: {{ template "istio.name" . }}
-          image: "{{ .Values.global.hub }}/proxyv2:{{ .Values.global.tag }}"
+          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             {{- range $key, $val := .Values.deployment.ports }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -25,7 +25,7 @@
         resources:
 {{ toYaml $.Values.resources | indent 12 }}
       - name: istio-proxy
-        image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
+        image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
         - containerPort: 9091

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             mountPath: /etc/certs
             readOnly: true
         - name: istio-proxy
-          image: "{{ .Values.global.hub }}/proxyv2:{{ .Values.global.tag }}"
+          image: "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
           - containerPort: 15003


### PR DESCRIPTION
As we switch proxy to proxyv2 in https://github.com/istio/istio/pull/5741, we still have a strong desire to customized proxy image name, hopefully the hardcoded proxy image name can be replaced.

/cc @linsun @gyliu513 