### PR TITLE
Update Jaeger version and add limit on the number of traces held in m…

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -38,6 +38,8 @@ spec:
                 fieldPath: metadata.namespace
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
             value: "{{ .Values.service.internalPort }}"
+          - name: MEMORY_MAX_TRACES
+            value: "{{ .Values.jaeger.memory.max_traces }}"
           livenessProbe:
             httpGet:
               path: /

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -395,10 +395,12 @@ tracing:
   enabled: false
   jaeger:
     enabled: false
+    memory:
+      max_traces: 50000
   replicaCount: 1
   image:
     repository: jaegertracing/all-in-one
-    tag: 1.4.1
+    tag: 1.5.0
   service:
     name: http
     type: ClusterIP

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -400,7 +400,7 @@ tracing:
   replicaCount: 1
   image:
     repository: jaegertracing/all-in-one
-    tag: 1
+    tag: 1.5
   service:
     name: http
     type: ClusterIP

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -400,7 +400,7 @@ tracing:
   replicaCount: 1
   image:
     repository: jaegertracing/all-in-one
-    tag: 1.5.0
+    tag: 1
   service:
     name: http
     type: ClusterIP


### PR DESCRIPTION
…emory

This version provides a way to configure a maximum number of traces that should be held in memory (thanks to @jpkrohling), to avoid unrestricted memory growth and eventually crash.

The current default of 50000 is just an estimate - would be good if the PR could be run with regpatrol? Let me know if it is something I can try.
