### PR TITLE
Re-enable the tracing (zipkin) test

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
@@ -21,3 +21,7 @@ global:
 
 istiotesting:
   oneNameSpace: true
+
+tracing:
+  enabled: true
+

--- a/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
@@ -22,3 +22,7 @@ global:
 
 istiotesting:
   oneNameSpace: true
+
+tracing:
+  enabled: true
+

--- a/tests/e2e/tests/pilot/a_tracing_test.go
+++ b/tests/e2e/tests/pilot/a_tracing_test.go
@@ -77,13 +77,13 @@ func TestTracingMixer(t *testing.T) {
 		// the mixer check spans can only exist in this trace as child spans. If they weren't child spans then they would be
 		// in a separate trace instance not retrieved by the query based on the single x-client-trace-id.
 		if !strings.Contains(response.Body, checkOperation) {
-			return fmt.Errorf("Check operation (%s) not found in response body: %s", checkOperation, response.Body)
+			return fmt.Errorf("check operation (%s) not found in response body: %s", checkOperation, response.Body)
 		}
 		if !strings.Contains(response.Body, mixerCheckOperation) {
-			return fmt.Errorf("Mixer Check operation (%s) not found in response body: %s", mixerCheckOperation, response.Body)
+			return fmt.Errorf("mixer Check operation (%s) not found in response body: %s", mixerCheckOperation, response.Body)
 		}
 		if spanCount := strings.Count(response.Body, traceIDField); spanCount != 4 {
-			return fmt.Errorf("Number of spans for trace (expected 4) is: %d", spanCount)
+			return fmt.Errorf("number of spans for trace (expected 4) is: %d", spanCount)
 		}
 
 		return nil
@@ -124,7 +124,7 @@ func TestTracingEnabled(t *testing.T) {
 		// Check that the trace contains the id value (must occur more than once, as the
 		// response also contains the request URL with query parameter).
 		if idCount := strings.Count(response.Body, id); idCount <= 1 {
-			return fmt.Errorf("Id should occur more than once: %d", idCount)
+			return fmt.Errorf("id should occur more than once: %d", idCount)
 		}
 
 		return nil

--- a/tests/e2e/tests/pilot/a_tracing_test.go
+++ b/tests/e2e/tests/pilot/a_tracing_test.go
@@ -26,67 +26,103 @@ import (
 
 const (
 	traceHeader         = "X-Client-Trace-Id"
-	numTraces           = 5
 	mixerCheckOperation = "\"name\":\"/istio.mixer.v1.mixer/check\""
 	checkOperation      = "\"name\":\"check\""
 	traceIDField        = "\"traceId\""
 )
 
-func TestTracing(t *testing.T) {
-	for i := 0; i < numTraces; i++ {
-		testName := fmt.Sprintf("index_%d", i)
-		traceSent := false
-		var id string
+func TestTracingMixer(t *testing.T) {
+	traceSent := false
+	var id string
 
-		runRetriableTest(t, primaryCluster, testName, defaultRetryBudget, func() error {
-			if !traceSent {
-				// Send a request with a trace header.
-				id = uuid.NewV4().String()
-				response := ClientRequest(primaryCluster, "a", "http://b", 1,
-					fmt.Sprintf("-key %v -val %v", traceHeader, id))
-				if !response.IsHTTPOk() {
-					// Keep retrying until we successfully send a trace request.
-					return errAgain
-				}
-
-				traceSent = true
-			}
-
-			// Check the tracing server to verify the trace was received.
-			response := ClientRequest(
-				primaryCluster,
-				"t",
-				fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces?annotationQuery=guid:x-client-trace-id=%s",
-					tc.Kube.IstioSystemNamespace(), id),
-				1, "",
-			)
-
+	runRetriableTest(t, primaryCluster, "isMixerTraced", defaultRetryBudget, func() error {
+		if !traceSent {
+			// Send a request with a trace header.
+			id = uuid.NewV4().String()
+			response := ClientRequest(primaryCluster, "a", "http://b", 1,
+				fmt.Sprintf("-key %v -val %v", traceHeader, id))
 			if !response.IsHTTPOk() {
+				// Keep retrying until we successfully send a trace request.
 				return errAgain
 			}
 
-			// Check that the trace contains the id value (must occur more than once, as the
-			// response also contains the request URL with query parameter).
-			if strings.Count(response.Body, id) == 1 {
+			traceSent = true
+		}
+
+		// Check the tracing server to verify the trace was received.
+		response := ClientRequest(
+			primaryCluster,
+			"t",
+			fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces?annotationQuery=guid:x-client-trace-id=%s",
+				tc.Kube.IstioSystemNamespace(), id),
+			1, "",
+		)
+
+		if !response.IsHTTPOk() {
+			return errAgain
+		}
+
+		// Check that the trace contains the id value (must occur more than once, as the
+		// response also contains the request URL with query parameter).
+		if strings.Count(response.Body, id) == 1 {
+			return errAgain
+		}
+
+		// Check that the mixer spans are also included in the trace:
+		// a) Count the number of spans - should be 4, one for the invocation of service b, and the other 3 for the
+		//		mixer check
+		// b) Check that the trace data contains the "check" operation name associated with the mixer check client span
+		// c) Check that the trace data contains the "/istio.mixer.v1.mixer/check" operation name for the server span
+		// NOTE: We are also indirectly verifying that the mixer check spans are child spans of the service invocation, as
+		// the mixer check spans can only exist in this trace as child spans. If they weren't child spans then they would be
+		// in a separate trace instance not retrieved by the query based on the single x-client-trace-id.
+		if strings.Count(response.Body, traceIDField) != 4 ||
+			!strings.Contains(response.Body, checkOperation) ||
+			!strings.Contains(response.Body, mixerCheckOperation) {
+			return errAgain
+		}
+
+		return nil
+	})
+}
+
+func TestTracingEnabled(t *testing.T) {
+	traceSent := false
+	var id string
+
+	runRetriableTest(t, primaryCluster, "checkEnabled", defaultRetryBudget, func() error {
+		if !traceSent {
+			// Send a request with a trace header.
+			id = uuid.NewV4().String()
+			response := ClientRequest(primaryCluster, "a", "http://b", 1,
+				fmt.Sprintf("-key %v -val %v", traceHeader, id))
+			if !response.IsHTTPOk() {
+				// Keep retrying until we successfully send a trace request.
 				return errAgain
 			}
 
-			// If first invocation (due to mixer check result caching), then check that the mixer
-			// span is also included in the trace
-			// a) Count the number of spans - should be 4, one for the invocation of service b, and the other 3 for the
-			//		mixer check
-			// b) Check that the trace data contains the "check" operation name associated with the mixer check client span
-			// c) Check that the trace data contains the "/istio.mixer.v1.mixer/check" operation name for the server span
-			// NOTE: We are also indirectly verifying that the mixer check spans are child spans of the service invocation, as
-			// the mixer check spans can only exist in this trace as child spans. If they weren't child spans then they would be
-			// in a separate trace instance not retrieved by the query based on the single x-client-trace-id.
-			if i == 0 && (strings.Count(response.Body, traceIDField) != 4 ||
-				!strings.Contains(response.Body, checkOperation) ||
-				!strings.Contains(response.Body, mixerCheckOperation)) {
-				return errAgain
-			}
+			traceSent = true
+		}
 
-			return nil
-		})
-	}
+		// Check the tracing server to verify the trace was received.
+		response := ClientRequest(
+			primaryCluster,
+			"t",
+			fmt.Sprintf("http://zipkin.%s:9411/api/v1/traces?annotationQuery=guid:x-client-trace-id=%s",
+				tc.Kube.IstioSystemNamespace(), id),
+			1, "",
+		)
+
+		if !response.IsHTTPOk() {
+			return errAgain
+		}
+
+		// Check that the trace contains the id value (must occur more than once, as the
+		// response also contains the request URL with query parameter).
+		if strings.Count(response.Body, id) == 1 {
+			return errAgain
+		}
+
+		return nil
+	})
 }


### PR DESCRIPTION
Enables the zipkin test again, renaming to tracing.

As the tests are performed against a deployment based on the `values-istio-one-namespace.yaml` I updated this file to enable the tracing. However if there is a better way to just allow the tests to have tracing enabled let me know, if you want to avoid having tracing enabled by default on the one namespace values file.
