### PR TITLE
Snapshot contract between the config builder and the runtime.

### DIFF
--- a/mixer/pkg/runtime/config/queries.go
+++ b/mixer/pkg/runtime/config/queries.go
@@ -16,17 +16,17 @@ package config
 
 // GetInstancesGroupedByHandlers queries the snapshot and returns all used instances, grouped by the handlers that will
 // receive them.
-func GetInstancesGroupedByHandlers(s *Snapshot) map[*Handler][]*Instance {
+func GetInstancesGroupedByHandlers(s *Snapshot) map[*HandlerLegacy][]*InstanceLegacy {
 	// There is no set in Go? map[<item>]bool to the rescue!
-	m := make(map[*Handler]map[*Instance]bool)
+	m := make(map[*HandlerLegacy]map[*InstanceLegacy]bool)
 
 	// Grovel over rules/actions and for each handler create a map entry and place all the instances in that action
 	// as values.
-	for _, r := range s.Rules {
+	for _, r := range s.RulesLegacy {
 		for _, a := range r.Actions {
 			instances, found := m[a.Handler]
 			if !found {
-				instances = make(map[*Instance]bool)
+				instances = make(map[*InstanceLegacy]bool)
 				m[a.Handler] = instances
 			}
 
@@ -36,10 +36,10 @@ func GetInstancesGroupedByHandlers(s *Snapshot) map[*Handler][]*Instance {
 		}
 	}
 
-	result := make(map[*Handler][]*Instance, len(m))
+	result := make(map[*HandlerLegacy][]*InstanceLegacy, len(m))
 	for k, v := range m {
 		i := 0
-		instances := make([]*Instance, len(v))
+		instances := make([]*InstanceLegacy, len(v))
 		for instance := range v {
 			instances[i] = instance
 			i++

--- a/mixer/pkg/runtime/config/snapshot.go
+++ b/mixer/pkg/runtime/config/snapshot.go
@@ -38,25 +38,25 @@ type (
 		// Config store based information
 		Attributes ast.AttributeDescriptorFinder
 
+		HandlersLegacy  map[string]*HandlerLegacy
+		InstancesLegacy map[string]*InstanceLegacy
+		RulesLegacy     []*RuleLegacy
+
+		//  TemplateMetadatas contains template descriptors loaded from the store
+		TemplateMetadatas map[string]*TemplateMetadata
+		//  AdapterMetadatas contains adapter metadata loaded from the store
+		AdapterMetadatas map[string]*AdapterMetadata
+
 		Handlers  map[string]*Handler
 		Instances map[string]*Instance
 		Rules     []*Rule
-
-		//  Templates2 contains template descriptors loaded from the store
-		Templates2 map[string]*TemplateMetadata
-		//  Adapters2 contains adapter metadata loaded from the store
-		Adapters2 map[string]*AdapterMetadata
-
-		Handlers2  map[string]*Handler2
-		Instances2 map[string]*Instance2
-		Rules2     []*Rule2
 
 		// Perf Counters relevant to configuration.
 		Counters Counters
 	}
 
-	// Handler2 configuration. Fully resolved.
-	Handler2 struct {
+	// Handler configuration. Fully resolved.
+	Handler struct {
 		Name string
 
 		Adapter *Adapter
@@ -68,8 +68,8 @@ type (
 		Connection *v1beta1.Connection
 	}
 
-	// Handler configuration. Fully resolved.
-	Handler struct {
+	// HandlerLegacy configuration. Fully resolved.
+	HandlerLegacy struct {
 
 		// Name of the Handler. Fully qualified.
 		Name string
@@ -81,8 +81,8 @@ type (
 		Params proto.Message
 	}
 
-	// Instance2 configuration. Fully resolved.
-	Instance2 struct {
+	// Instance configuration. Fully resolved.
+	Instance struct {
 		Name string
 
 		Template *Template
@@ -91,8 +91,8 @@ type (
 		Encoder *dynamic.Encoder
 	}
 
-	// Instance configuration. Fully resolved.
-	Instance struct {
+	// InstanceLegacy configuration. Fully resolved.
+	InstanceLegacy struct {
 		// Name of the instance. Fully qualified.
 		Name string
 
@@ -103,17 +103,17 @@ type (
 		Params proto.Message
 	}
 
-	// Rule2 configuration. Fully resolved.
-	Rule2 struct {
+	// Rule configuration. Fully resolved.
+	Rule struct {
 		Name         string
 		Namespace    string
 		Match        string
-		Actions      []*Action2
+		Actions      []*Action
 		ResourceType ResourceType
 	}
 
-	// Rule configuration. Fully resolved.
-	Rule struct {
+	// RuleLegacy configuration. Fully resolved.
+	RuleLegacy struct {
 		// Name of the rule
 		Name string
 
@@ -123,26 +123,26 @@ type (
 		// Match condition
 		Match string
 
-		Actions []*Action
+		Actions []*ActionLegacy
 
 		ResourceType ResourceType
-	}
-
-	// Action2 configuration. Fully resolved.
-	Action2 struct {
-		// Handler that this action is resolved to.
-		Handler *Handler2
-		// Instances that should be generated as part of invoking action.
-		Instances []*Instance2
 	}
 
 	// Action configuration. Fully resolved.
 	Action struct {
 		// Handler that this action is resolved to.
 		Handler *Handler
-
 		// Instances that should be generated as part of invoking action.
 		Instances []*Instance
+	}
+
+	// ActionLegacy configuration. Fully resolved.
+	ActionLegacy struct {
+		// Handler that this action is resolved to.
+		Handler *HandlerLegacy
+
+		// Instances that should be generated as part of invoking action.
+		Instances []*InstanceLegacy
 	}
 
 	// Template contains info about a template
@@ -186,8 +186,8 @@ type (
 // Empty returns a new, empty configuration snapshot.
 func Empty() *Snapshot {
 	return &Snapshot{
-		ID:       -1,
-		Rules:    []*Rule{},
-		Counters: newCounters(-1),
+		ID:          -1,
+		RulesLegacy: []*RuleLegacy{},
+		Counters:    newCounters(-1),
 	}
 }

--- a/mixer/pkg/runtime/config/snapshot.go
+++ b/mixer/pkg/runtime/config/snapshot.go
@@ -17,8 +17,8 @@ package config
 import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-	"google.golang.org/grpc"
 
+	"istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/lang/ast"
 	"istio.io/istio/mixer/pkg/protobuf/yaml/dynamic"
@@ -64,8 +64,8 @@ type (
 		// parameters used to construct the Handler.
 		Params []byte
 
-		// Client to invoke calls into the associated adapter.
-		Client *Client
+		// Connection information for the handler.
+		Connection *v1beta1.Connection
 	}
 
 	// Handler configuration. Fully resolved.
@@ -180,12 +180,6 @@ type (
 		SessionBased bool
 
 		Description string
-	}
-
-	// Client contains the connection data for the adapter
-	Client struct {
-		// gRPC connection to the adapter.
-		Connection *grpc.ClientConn
 	}
 )
 

--- a/mixer/pkg/runtime/config/strings.go
+++ b/mixer/pkg/runtime/config/strings.go
@@ -44,23 +44,23 @@ func (s *Snapshot) String() string {
 	writeAdapters(b, s.Adapters)
 
 	fmt.Fprintln(b, "Handlers:")
-	writeHandlers(b, s.Handlers)
+	writeHandlers(b, s.HandlersLegacy)
 
 	fmt.Fprintln(b, "Instances:")
-	writeInstances(b, s.Instances)
+	writeInstances(b, s.InstancesLegacy)
 
 	fmt.Fprintln(b, "Rules:")
-	writeRules(b, s.Rules)
+	writeRules(b, s.RulesLegacy)
 
-	if len(s.Adapters2) != 0 {
+	if len(s.AdapterMetadatas) != 0 {
 		fmt.Fprintln(b, "AdapterMetadata:")
-		writeAdapterMetadatas(b, s.Adapters2)
+		writeAdapterMetadatas(b, s.AdapterMetadatas)
 
 	}
 
-	if len(s.Templates2) != 0 {
+	if len(s.TemplateMetadatas) != 0 {
 		fmt.Fprintln(b, "TemplateMetadata:")
-		writeTemplateMetadatas(b, s.Templates2)
+		writeTemplateMetadatas(b, s.TemplateMetadatas)
 	}
 
 	fmt.Fprintf(b, "%v", s.Attributes)
@@ -100,7 +100,7 @@ func writeAdapters(w io.Writer, adapters map[string]*adapter.Info) {
 	}
 }
 
-func writeHandlers(w io.Writer, handlers map[string]*Handler) {
+func writeHandlers(w io.Writer, handlers map[string]*HandlerLegacy) {
 	i := 0
 	names := make([]string, len(handlers))
 	for n := range handlers {
@@ -122,7 +122,7 @@ func writeHandlers(w io.Writer, handlers map[string]*Handler) {
 	}
 }
 
-func writeInstances(w io.Writer, instances map[string]*Instance) {
+func writeInstances(w io.Writer, instances map[string]*InstanceLegacy) {
 	i := 0
 	names := make([]string, len(instances))
 	for n := range instances {
@@ -144,9 +144,9 @@ func writeInstances(w io.Writer, instances map[string]*Instance) {
 	}
 }
 
-func writeRules(w io.Writer, rules []*Rule) {
+func writeRules(w io.Writer, rules []*RuleLegacy) {
 	names := make([]string, len(rules))
-	m := make(map[string]*Rule, len(rules))
+	m := make(map[string]*RuleLegacy, len(rules))
 	for i, r := range rules {
 		names[i] = r.Name
 		m[r.Name] = r
@@ -206,7 +206,7 @@ func writeTemplateMetadatas(w io.Writer, templates map[string]*TemplateMetadata)
 	}
 }
 
-func writeActions(w io.Writer, actions []*Action) {
+func writeActions(w io.Writer, actions []*ActionLegacy) {
 	// write actions without sorting. This should be acceptable, as the action order within an order is
 	// based on the order on the original content. This is stricter than simple-equality, but should be good enough
 	// for testing purposes.

--- a/mixer/pkg/runtime/handler/factory.go
+++ b/mixer/pkg/runtime/handler/factory.go
@@ -53,8 +53,8 @@ func newFactory(snapshot *config.Snapshot) *factory {
 
 // build instantiates a handler object using the passed in handler and instances configuration.
 func (f *factory) build(
-	handler *config.Handler,
-	instances []*config.Instance,
+	handler *config.HandlerLegacy,
+	instances []*config.InstanceLegacy,
 	env adapter.Env) (h adapter.Handler, err error) {
 
 	// Do not assign the error to err directly, as this would overwrite the err returned by the inner function.
@@ -166,7 +166,7 @@ func (f *factory) buildHandler(
 	return builder.Build(context.Background(), env)
 }
 
-func (f *factory) inferTypes(instances []*config.Instance) (map[string]inferredTypesMap, error) {
+func (f *factory) inferTypes(instances []*config.InstanceLegacy) (map[string]inferredTypesMap, error) {
 
 	typesByTemplate := make(map[string]inferredTypesMap)
 	for _, instance := range instances {
@@ -185,7 +185,7 @@ func (f *factory) inferTypes(instances []*config.Instance) (map[string]inferredT
 	return typesByTemplate, nil
 }
 
-func (f *factory) inferType(instance *config.Instance) (proto.Message, error) {
+func (f *factory) inferType(instance *config.InstanceLegacy) (proto.Message, error) {
 
 	var inferredType proto.Message
 	var err error

--- a/mixer/pkg/runtime/handler/factory_test.go
+++ b/mixer/pkg/runtime/handler/factory_test.go
@@ -27,11 +27,11 @@ func TestBasic(t *testing.T) {
 	attributes := data.BuildAdapters(nil)
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
-	h, err := f.build(h1, []*config.Instance{i1}, nil)
+	h, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,17 +46,17 @@ func TestCacheUse(t *testing.T) {
 	attributes := data.BuildAdapters(nil)
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Do it again to use the cache.
-	h, err := f.build(h1, []*config.Instance{i1}, nil)
+	h, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -71,11 +71,11 @@ func TestAdapterSupportsAdditionalTemplates(t *testing.T) {
 	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", SupportedTemplates: []string{"additional-template"}})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
-	h, err := f.build(h1, []*config.Instance{i1}, nil)
+	h, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err != nil {
 		t.Fatal()
 	}
@@ -90,11 +90,11 @@ func TestInferError(t *testing.T) {
 	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -105,11 +105,11 @@ func TestNilBuilder(t *testing.T) {
 	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", NilBuilder: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -120,12 +120,12 @@ func TestBuilderDoesNotSupportTemplate(t *testing.T) {
 	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -136,12 +136,12 @@ func TestHandlerDoesNotSupportTemplate(t *testing.T) {
 	attributes := data.BuildAdapters(nil)
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -153,12 +153,12 @@ func TestHandlerDoesNotSupportTemplate_ErrorDuringClose(t *testing.T) {
 	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", ErrorAtHandlerClose: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -170,12 +170,12 @@ func TestHandlerDoesNotSupportTemplate_PanicDuringClose(t *testing.T) {
 	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", PanicAtHandlerClose: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -186,12 +186,12 @@ func TestPanicAtSetAdapterConfig(t *testing.T) {
 	attributes := data.BuildAdapters(nil, data.FakeAdapterSettings{Name: "acheck", PanicAtSetAdapterConfig: true})
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -203,12 +203,12 @@ func TestFailedValidation(t *testing.T) {
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}
@@ -220,12 +220,12 @@ func TestPanicAtValidation(t *testing.T) {
 
 	s := util.GetSnapshot(templates, attributes, data.ServiceConfig, globalCfg)
 
-	i1 := s.Instances[data.FqnI1]
-	h1 := s.Handlers[data.FqnACheck1]
+	i1 := s.InstancesLegacy[data.FqnI1]
+	h1 := s.HandlersLegacy[data.FqnACheck1]
 
 	f := newFactory(s)
 
-	_, err := f.build(h1, []*config.Instance{i1}, nil)
+	_, err := f.build(h1, []*config.InstanceLegacy{i1}, nil)
 	if err == nil {
 		t.Fatal()
 	}

--- a/mixer/pkg/runtime/handler/signature.go
+++ b/mixer/pkg/runtime/handler/signature.go
@@ -37,10 +37,10 @@ func (s signature) equals(other signature) bool {
 	return !bytes.Equal(s[:], zeroSignature[:]) && bytes.Equal(s[:], other[:])
 }
 
-func calculateSignature(handler *config.Handler, instances []*config.Instance) signature {
+func calculateSignature(handler *config.HandlerLegacy, instances []*config.InstanceLegacy) signature {
 
 	// sort the instances by name
-	instanceMap := make(map[string]*config.Instance)
+	instanceMap := make(map[string]*config.InstanceLegacy)
 	instanceNames := make([]string, len(instances))
 	for i, instance := range instances {
 		instanceMap[instance.Name] = instance

--- a/mixer/pkg/runtime/handler/signature_test.go
+++ b/mixer/pkg/runtime/handler/signature_test.go
@@ -47,8 +47,8 @@ var _ proto.Marshaler = &fakeProto{}
 func TestSignature_ProtoMarshalFailure(t *testing.T) {
 	p := &fakeProto{}
 
-	h := config.Handler{Name: "h1", Params: p, Adapter: &adapter.Info{Name: "a1"}}
-	s := calculateSignature(&h, []*config.Instance{})
+	h := config.HandlerLegacy{Name: "h1", Params: p, Adapter: &adapter.Info{Name: "a1"}}
+	s := calculateSignature(&h, []*config.InstanceLegacy{})
 
 	// The fake proto will fail serialization. It should return zero-signature.
 	if !reflect.DeepEqual(s, zeroSignature) {

--- a/mixer/pkg/runtime/routing/builder.go
+++ b/mixer/pkg/runtime/routing/builder.go
@@ -113,12 +113,12 @@ func BuildTable(
 		defaultConfigNamespace: defaultConfigNamespace,
 		nextIDCounter:          1,
 
-		matchesByID:       make(map[uint32]string, len(config.Rules)),
-		instanceNamesByID: make(map[uint32][]string, len(config.Instances)),
+		matchesByID:       make(map[uint32]string, len(config.RulesLegacy)),
+		instanceNamesByID: make(map[uint32][]string, len(config.InstancesLegacy)),
 
-		builders:    make(map[string]template.InstanceBuilderFn, len(config.Instances)),
-		mappers:     make(map[string]template.OutputMapperFn, len(config.Instances)),
-		expressions: make(map[string]compiled.Expression, len(config.Rules)),
+		builders:    make(map[string]template.InstanceBuilderFn, len(config.InstancesLegacy)),
+		mappers:     make(map[string]template.OutputMapperFn, len(config.InstancesLegacy)),
+		expressions: make(map[string]compiled.Expression, len(config.RulesLegacy)),
 	}
 
 	b.build(config)
@@ -141,7 +141,7 @@ func (b *builder) nextID() uint32 {
 
 func (b *builder) build(config *config.Snapshot) {
 
-	for _, rule := range config.Rules {
+	for _, rule := range config.RulesLegacy {
 
 		// Create a compiled expression for the rule condition first.
 		condition, err := b.getConditionExpression(rule)
@@ -213,7 +213,7 @@ func (b *builder) build(config *config.Snapshot) {
 // is an attribute generator.
 func (b *builder) getBuilderAndMapper(
 	finder ast.AttributeDescriptorFinder,
-	instance *config.Instance) (template.InstanceBuilderFn, template.OutputMapperFn, error) {
+	instance *config.InstanceLegacy) (template.InstanceBuilderFn, template.OutputMapperFn, error) {
 	var err error
 
 	t := instance.Template
@@ -244,7 +244,7 @@ func (b *builder) getBuilderAndMapper(
 }
 
 // get or create a compiled.Expression for the rule's match clause, if necessary.
-func (b *builder) getConditionExpression(rule *config.Rule) (compiled.Expression, error) {
+func (b *builder) getConditionExpression(rule *config.RuleLegacy) (compiled.Expression, error) {
 	text := strings.TrimSpace(rule.Match)
 
 	if text == "" {


### PR DESCRIPTION
Add new configuration data to the snapshot. Ephemeral.go builds the snapshot. Snapshot is used by the runtime dispatch table.

Following this PR, @mandarjog will work on consuming this snapshot during request path and I will work on building this snapshot as we load the config.