### PR TITLE
Fish imagePullPolicy to istioctl in e2e test framework

### DIFF
--- a/tests/e2e/framework/istioctl.go
+++ b/tests/e2e/framework/istioctl.go
@@ -40,19 +40,20 @@ var (
 
 // Istioctl gathers istioctl information.
 type Istioctl struct {
-	localPath  string
-	remotePath string
-	binaryPath string
-	namespace  string
-	proxyHub   string
-	proxyTag   string
-	yamlDir    string
+	localPath       string
+	remotePath      string
+	binaryPath      string
+	namespace       string
+	proxyHub        string
+	proxyTag        string
+	imagePullPolicy string
+	yamlDir         string
 	// If true, will ignore proxyHub and proxyTag but use the default one.
 	defaultProxy bool
 }
 
 // NewIstioctl create a new istioctl by given temp dir.
-func NewIstioctl(yamlDir, namespace, istioNamespace, proxyHub, proxyTag string) (*Istioctl, error) {
+func NewIstioctl(yamlDir, namespace, istioNamespace, proxyHub, proxyTag string, imagePullPolicy string) (*Istioctl, error) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), tmpPrefix)
 	if err != nil {
 		return nil, err
@@ -66,14 +67,15 @@ func NewIstioctl(yamlDir, namespace, istioNamespace, proxyHub, proxyTag string) 
 	}
 
 	return &Istioctl{
-		localPath:    *localPath,
-		remotePath:   *remotePath,
-		binaryPath:   filepath.Join(tmpDir, "istioctl"),
-		namespace:    namespace,
-		proxyHub:     proxyHub,
-		proxyTag:     proxyTag,
-		yamlDir:      filepath.Join(yamlDir, "istioctl"),
-		defaultProxy: *defaultProxy,
+		localPath:       *localPath,
+		remotePath:      *remotePath,
+		binaryPath:      filepath.Join(tmpDir, "istioctl"),
+		namespace:       namespace,
+		proxyHub:        proxyHub,
+		proxyTag:        proxyTag,
+		imagePullPolicy: imagePullPolicy,
+		yamlDir:         filepath.Join(yamlDir, "istioctl"),
+		defaultProxy:    *defaultProxy,
 	}, nil
 }
 
@@ -148,8 +150,13 @@ func (i *Istioctl) KubeInject(src, dest string) error {
 		return i.run(`kube-inject -f %s -o %s -n %s -i %s --meshConfigMapName=istio`,
 			src, dest, i.namespace, i.namespace)
 	}
-	return i.run(`kube-inject -f %s -o %s --hub %s --tag %s -n %s -i %s --meshConfigMapName=istio`,
-		src, dest, i.proxyHub, i.proxyTag, i.namespace, i.namespace)
+
+	imagePullPolicyStr := ""
+	if i.imagePullPolicy != "" {
+		imagePullPolicyStr = fmt.Sprintf("--imagePullPolicy %s", i.imagePullPolicy)
+	}
+	return i.run(`kube-inject -f %s -o %s --hub %s --tag %s %s -n %s -i %s --meshConfigMapName=istio`,
+		src, dest, i.proxyHub, i.proxyTag, imagePullPolicyStr, i.namespace, i.namespace)
 }
 
 // CreateRule create new rule(s)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -153,7 +153,7 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		}
 	}
 	yamlDir := filepath.Join(tmpDir, "yaml")
-	i, err := NewIstioctl(yamlDir, *namespace, *namespace, *proxyHub, *proxyTag)
+	i, err := NewIstioctl(yamlDir, *namespace, *namespace, *proxyHub, *proxyTag, *imagePullPolicy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We already have an imagePullPolicy flag in the e2e test framework, but
we're not currently passing it to istioctl. In local testing, this
has resulted in stale istio-init images, which do not respect the new
iptables flags.