### PR TITLE
telemetry: use UDS for policy and telemetry sidecar communication

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -6,6 +6,8 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      - name: uds-socket
+        emptyDir: {}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       containers:
@@ -13,17 +15,19 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: 9092
         - containerPort: 9093
         - containerPort: 42422
         args:
           - --address
-          - tcp://127.0.0.1:9092
+          - unix:///sock/mixer.socket
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
         resources:
 {{ toYaml $.Values.resources | indent 12 }}
+        volumeMounts:
+        - name: uds-socket
+          mountPath: /sock
       - name: istio-proxy
         image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
@@ -65,6 +69,8 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        - name: uds-socket
+          mountPath: /sock
 {{- end }}
 
 {{- define "telemetry_container" }}
@@ -75,6 +81,8 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      - name: uds-socket
+        emptyDir: {}
     {{- if $.Values.nodeSelector }}
       nodeSelector:
 {{ toYaml $.Values.nodeSelector | indent 8 }}
@@ -84,17 +92,19 @@
         image: "{{ $.Values.global.hub }}/{{ $.Values.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: 9092
         - containerPort: 9093
         - containerPort: 42422
         args:
           - --address
-          - tcp://127.0.0.1:9092
+          - unix:///sock/mixer.socket
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
         resources:
 {{ toYaml $.Values.resources | indent 12 }}
+        volumeMounts:
+        - name: uds-socket
+          mountPath: /sock
       - name: istio-proxy
         image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy.image }}:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
@@ -136,6 +146,8 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        - name: uds-socket
+          mountPath: /sock
 {{- end }}
 
 

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -14,9 +14,8 @@ static_resources:
         max_retries: 3
     connect_timeout: 1.000s
     hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 9092
+    - pipe:
+        path: /sock/mixer.socket
     http2_protocol_options: {}
     name: in.9092
   - connect_timeout: 1.000s

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -14,9 +14,8 @@ static_resources:
         max_retries: 3
     connect_timeout: 1.000s
     hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 9092
+    - pipe:
+        path: /sock/mixer.socket
     http2_protocol_options: {}
     name: in.9092
   - connect_timeout: 1.000s


### PR DESCRIPTION
UDS eliminates some of the overhead of TCP protocol.

/assign @douglas-reid @mandarjog 

Signed-off-by: Kuat Yessenov <kuat@google.com>