### PR TITLE
Change span name to be virtual service/host : port + uri match string

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -36,7 +36,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env mod
 
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, "",
 		instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
-	defaultRoute := istio_route.BuildDefaultHTTPRoute(clusterName)
+	traceOperation := fmt.Sprintf("%s:%d/*", instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
+	defaultRoute := istio_route.BuildDefaultHTTPRoute(clusterName, traceOperation)
 
 	inboundVHost := route.VirtualHost{
 		Name:    fmt.Sprintf("%s|http|%d", model.TrafficDirectionInbound, instance.Endpoint.ServicePort.Port),

--- a/pilot/pkg/proxy/envoy/v1/config.go
+++ b/pilot/pkg/proxy/envoy/v1/config.go
@@ -622,7 +622,8 @@ func buildDestinationHTTPRoutes(service *model.Service,
 			if envoyv2 {
 				cluster.Name = model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, servicePort.Port)
 			}
-			routes = append(routes, BuildDefaultRoute(cluster))
+			tracingOperation := fmt.Sprintf("%s:%d/*", service.Hostname, servicePort.Port)
+			routes = append(routes, BuildDefaultRoute(cluster, tracingOperation))
 		}
 
 		return routes
@@ -631,7 +632,8 @@ func buildDestinationHTTPRoutes(service *model.Service,
 		// as an exception, external name HTTPS port is sent in plain-text HTTP/1.1
 		if service.External() {
 			cluster := BuildOutboundCluster(service.Hostname, servicePort, nil, service.External())
-			return []*HTTPRoute{BuildDefaultRoute(cluster)}
+			tracingOperation := fmt.Sprintf("%s:%d/*", service.Hostname, servicePort.Port)
+			return []*HTTPRoute{BuildDefaultRoute(cluster, tracingOperation)}
 		}
 
 	case model.ProtocolTCP, model.ProtocolMongo, model.ProtocolRedis:
@@ -777,6 +779,7 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 		clusters = append(clusters, cluster)
 		authenticationPolicy := model.GetConsolidateAuthenticationPolicy(mesh,
 			config, instance.Service.Hostname, endpoint.ServicePort)
+		defaultOperation := fmt.Sprintf("%s:%d/*", instance.Service.Hostname, servicePort.Port)
 
 		var listener *Listener
 
@@ -789,7 +792,7 @@ func buildInboundListeners(mesh *meshconfig.MeshConfig, node model.Proxy,
 		// services' kubeproxy to our specific endpoint IP.
 		switch protocol {
 		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC:
-			defaultRoute := BuildDefaultRoute(cluster)
+			defaultRoute := BuildDefaultRoute(cluster, defaultOperation)
 
 			// set server-side mixer filter config for inbound HTTP routes
 			if mesh.MixerCheckServer != "" || mesh.MixerReportServer != "" {

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -81,7 +81,7 @@ func TestRoutes(t *testing.T) {
 			headerKey:     "",
 			headerVal:     "",
 			expectedCount: map[string]int{"v1": 100, "v2": 0},
-			operation:     "default-route",
+			operation:     "c.istio-system.svc.cluster.local:80/*",
 		},
 		{
 			testName:      "a->c[v1=75,v2=25]",
@@ -155,7 +155,7 @@ func TestRoutes(t *testing.T) {
 			headerKey:     "",
 			headerVal:     "",
 			expectedCount: map[string]int{"v1": 100, "v2": 0},
-			operation:     "default-route",
+			operation:     "c.istio-system.svc.cluster.local:80/*",
 		},
 		{
 			testName:      "a->c[v1=100]_CORS_policy",
@@ -167,7 +167,7 @@ func TestRoutes(t *testing.T) {
 			headerKey:     "",
 			headerVal:     "",
 			expectedCount: map[string]int{"v1": 100, "v2": 0},
-			operation:     "default-route",
+			operation:     "c.istio-system.svc.cluster.local:80/*",
 		},
 	}
 


### PR DESCRIPTION
This makes span name more intuitive comparing to only virtual service name.
before:
![screenshot from 2018-05-30 15-19-32](https://user-images.githubusercontent.com/34738376/40750722-0bc9a8da-641d-11e8-9ad6-8521b1bce749.png)
after:
![screenshot from 2018-05-30 15-20-03](https://user-images.githubusercontent.com/34738376/40750727-0fa8828c-641d-11e8-8d51-94b2e2a117a6.png)