### PR TITLE
Added zipkin endpoint to istio remote chart.

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -62,3 +62,14 @@ subsets:
     port: 9125
     protocol: UDP
 ---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: zipkin
+  namespace: istio-system
+subsets:
+- addresses:
+  - ip: {{ .Values.global.zipkinEndpoint }}
+  ports:
+  - name: http-zipkin
+    port: 9411

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -60,3 +60,14 @@ spec:
     protocol: UDP
   clusterIP: None
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: istio-system
+spec:
+  ports:
+  - name: http-zipkin
+    port: 9411
+  clusterIP: None
+---

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -12,6 +12,9 @@ global:
   # The Istio control plane statsd endpoint
   statsdEndpoint: istio-statsd-prom-bridge.istio-system
 
+  # The Istio control plane zipkin endpoint
+  zipkinEndpoint: zipkin.istio-system
+
   # Default tag for Istio images.
   hub: docker.io/istionightly
 


### PR DESCRIPTION
This can make sure Jaeger can also trace services in remote cluster.

/cc @sdake @sbezverk @costinm 