### PR TITLE
mixer: implement reporter attributes

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -74,6 +74,10 @@ spec:
       valueType: TIMESTAMP
     context.time:
       valueType: TIMESTAMP
+    context.reporter.local:
+      valueType: BOOL
+    context.reporter.uid:
+      valueType: STRING
     api.service:
       valueType: STRING
     api.version:

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -67,6 +67,10 @@ spec:
         valueType: TIMESTAMP
       context.time:
         valueType: TIMESTAMP
+      context.reporter.local:
+        valueType: BOOL
+      context.reporter.uid:
+        valueType: STRING
       api.service:
         valueType: STRING
       api.version:

--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -90,6 +90,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15003
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server
@@ -160,6 +164,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15011
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server
@@ -225,6 +233,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15005
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server
@@ -290,6 +302,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15007
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -61,10 +61,6 @@ static_resources:
     filter_chains:
     - filters:
       - config:
-          access_log:
-          - config:
-              path: /dev/stdout
-            name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
             max_concurrent_streams: 1073741824
@@ -88,6 +84,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15004
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server
@@ -133,10 +133,6 @@ static_resources:
     filter_chains:
     - filters:
       - config:
-          access_log:
-          - config:
-              path: /dev/stdout
-            name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
             max_concurrent_streams: 1073741824
@@ -160,6 +156,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 9091
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: mixer_report_server

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -33,10 +33,6 @@ static_resources:
     filter_chains:
     - filters:
       - config:
-          access_log:
-          - config:
-              path: /dev/stdout
-            name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
             max_concurrent_streams: 1073741824
@@ -60,6 +56,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 15004
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: in.9092
@@ -105,10 +105,6 @@ static_resources:
     filter_chains:
     - filters:
       - config:
-          access_log:
-          - config:
-              path: /dev/stdout
-            name: envoy.file_access_log
           codec_type: HTTP2
           http2_protocol_options:
             max_concurrent_streams: 1073741824
@@ -132,6 +128,10 @@ static_resources:
                         bytes_value: {{ .PodIP }}
                       destination.port:
                         int64_value: 9091
+                      context.reporter.local:
+                        bool_value: true
+                      context.reporter.uid:
+                        string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
               transport:
                 check_cluster: mixer_check_server
                 report_cluster: in.9092

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -230,7 +230,7 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 	mxConfig := &mccpb.HttpClientConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"context.reporter.uid": &mpb.Attributes_AttributeValue{
+				"context.reporter.uid": {
 					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: "kubernetes://" + role.ID},
 				},
 			},

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -229,7 +229,11 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 
 	mxConfig := &mccpb.HttpClientConfig{
 		MixerAttributes: &mpb.Attributes{
-			Attributes: map[string]*mpb.Attributes_AttributeValue{},
+			Attributes: map[string]*mpb.Attributes_AttributeValue{
+				"context.reporter.uid": &mpb.Attributes_AttributeValue{
+					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: "kubernetes://" + role.ID},
+				},
+			},
 		},
 		ServiceConfigs: map[string]*mccpb.ServiceConfig{},
 		Transport:      transport,
@@ -247,6 +251,9 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 		// for outboundRoutes there are no default MixerAttributes except for gateway.
 		// specific MixerAttributes are in per route configuration.
 		v1.AddStandardNodeAttributes(mxConfig.MixerAttributes.Attributes, v1.AttrDestinationPrefix, role.IPAddress, role.ID, labels)
+		mxConfig.MixerAttributes.Attributes["context.reporter.local"] = &mpb.Attributes_AttributeValue{
+			Value: &mpb.Attributes_AttributeValue_BoolValue{BoolValue: true},
+		}
 	}
 
 	if role.Type == model.Sidecar && !outboundRoute {
@@ -275,6 +282,12 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 func buildTCPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, instance *model.ServiceInstance) *mccpb.TcpClientConfig {
 	attrs := v1.StandardNodeAttributes(v1.AttrDestinationPrefix, role.IPAddress, role.ID, nil)
 	attrs[v1.AttrDestinationService] = &mpb.Attributes_AttributeValue{Value: &mpb.Attributes_AttributeValue_StringValue{instance.Service.Hostname.String()}}
+	attrs["context.reporter.uid"] = &mpb.Attributes_AttributeValue{
+		Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: "kubernetes://" + role.ID},
+	}
+	attrs["context.reporter.local"] = &mpb.Attributes_AttributeValue{
+		Value: &mpb.Attributes_AttributeValue_BoolValue{BoolValue: true},
+	}
 
 	mcs, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
 	mrs, _, _ := net.SplitHostPort(mesh.MixerReportServer)


### PR DESCRIPTION
Sets the values for `context.reporter` attributes.
Pilot change is temporary until the mixer plugin gets a rewrite.
Removes access log filter from static bootstraps to further optimize mixer latency.

Signed-off-by: Kuat Yessenov <kuat@google.com>