### PR TITLE
Make ci2gubernator unblocking

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -43,4 +43,4 @@ if [ -n "$CIRCLE_PULL_REQUEST" ]; then
 	ARGS+=(--stage=presubmit)
 fi
 
-/go/bin/ci2gubernator ${@} ${ARGS[@]}
+/go/bin/ci2gubernator ${@} ${ARGS[@]} || true


### PR DESCRIPTION
There seems to be issues with locking files on GCS that fails ci2gubernator, whose exit status fails the entire test job. This PR unblocks otherwise healthy PRs while investigation goes on. 