### PR TITLE
Update dump_kubernetes.sh

### DIFF
--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -114,14 +114,18 @@ dump_logs() {
   done
 }
 
-dump_resources() {
-  log "Retrieving resource configurations"
+dump_kubernetes_resources() {
+  log "Retrieving kubernetes resource configurations"
 
   mkdir -p "${OUT_DIR}"
   # Only works in Kubernetes 1.8.0 and above.
   kubectl get --all-namespaces --export \
       all,ingresses,endpoints,customresourcedefinitions,configmaps,secrets,events \
       -o yaml > "${RESOURCES_FILE}"
+}
+
+dump_istio_custom_resource_definitions() {
+  log "Retrieving istio resource configurations"
 
   local istio_resources
   # Trim to only first field; join by comma; remove last comma.
@@ -134,6 +138,11 @@ dump_resources() {
     kubectl get "${istio_resources}" --all-namespaces -o yaml \
         > "${ISTIO_RESOURCES_FILE}"
   fi
+}
+
+dump_resources() {
+  dump_kubernetes_resources
+  dump_istio_custom_resource_definitions
 
   mkdir -p "${OUT_DIR}"
   kubectl cluster-info dump > "${OUT_DIR}/cluster-info.dump.txt"

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -156,18 +156,18 @@ dump_pilot_url(){
 
 dump_pilot() {
   local pilot_pod
-  local pilot_dir
-
-  pilot_dir="${OUT_DIR}/pilot"
-  mkdir -p "${pilot_dir}"
-
   pilot_pod=$(kubectl -n istio-system get pods -l istio=pilot \
       -o jsonpath='{.items[*].metadata.name}')
 
-  dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
-  dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"
-  dump_pilot_url "${pilot_pod}" debug/adsz "${pilot_dir}"
-  dump_pilot_url "${pilot_pod}" metrics "${pilot_dir}"
+  if [ ! -z "${pilot_pod}" ]; then
+    local pilot_dir="${OUT_DIR}/pilot"
+    mkdir -p "${pilot_dir}"
+
+    dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
+    dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"
+    dump_pilot_url "${pilot_pod}" debug/adsz "${pilot_dir}"
+    dump_pilot_url "${pilot_pod}" metrics "${pilot_dir}"
+  fi
 }
 
 archive() {

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -129,7 +129,8 @@ dump_istio_custom_resource_definitions() {
 
   local istio_resources
   # Trim to only first field; join by comma; remove last comma.
-  istio_resources=$(kubectl get customresourcedefinitions --no-headers \
+  istio_resources=$(kubectl get customresourcedefinitions \
+      --no-headers 2> /dev/null \
       | cut -d ' ' -f 1 \
       | tr '\n' ',' \
       | sed 's/,$//')

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -134,7 +134,7 @@ dump_resources() {
   mkdir -p "${LOG_DIR}"
   kubectl cluster-info dump > "${LOG_DIR}/cluster-info.dump.txt"
   kubectl describe pods -n istio-system > "${LOG_DIR}/istio-system-pods.txt"
-  kubectl get event --all-namespaces -o wide > "${LOG_DIR}/events.txt"
+  kubectl get events --all-namespaces -o wide > "${LOG_DIR}/events.txt"
 }
 
 dump_pilot_url(){
@@ -156,7 +156,7 @@ dump_pilot() {
   pilot_dir="${OUT_DIR}/pilot"
   mkdir -p "${pilot_dir}"
 
-  pilot_pod=$(kubectl --namespace istio-system get pods -listio=pilot -o=jsonpath='{.items[0].metadata.name}')
+  pilot_pod=$(kubectl --namespace istio-system get pods -l istio=pilot -o jsonpath='{.items[*].metadata.name}')
 
   dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
   dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -125,11 +125,12 @@ dump_resources() {
 
   local istio_resources
   # Trim to only first field; join by comma; remove last comma.
-  istio_resources=$(kubectl get crd --no-headers \
+  istio_resources=$(kubectl get customresourcedefinitions --no-headers \
       | cut -d ' ' -f 1 \
       | tr '\n' ',' \
       | sed 's/,$//')
-  kubectl get "${istio_resources}" --all-namespaces -o yaml > "${ISTIO_RESOURCES_FILE}"
+  kubectl get "${istio_resources}" --all-namespaces \
+      -o yaml > "${ISTIO_RESOURCES_FILE}"
 
   mkdir -p "${LOG_DIR}"
   kubectl cluster-info dump > "${LOG_DIR}/cluster-info.dump.txt"
@@ -146,7 +147,8 @@ dump_pilot_url(){
   outfile="${dname}/$(basename "${url}")"
 
   log "Fetching ${url} from pilot"
-  kubectl --namespace istio-system exec -i -t "${pilot_pod}" -c istio-proxy -- curl "http://localhost:8080/${url}" > "${outfile}"
+  kubectl -n istio-system exec -i -t "${pilot_pod}" -c istio-proxy -- \
+      curl "http://localhost:8080/${url}" > "${outfile}"
 }
 
 dump_pilot() {
@@ -156,7 +158,8 @@ dump_pilot() {
   pilot_dir="${OUT_DIR}/pilot"
   mkdir -p "${pilot_dir}"
 
-  pilot_pod=$(kubectl --namespace istio-system get pods -l istio=pilot -o jsonpath='{.items[*].metadata.name}')
+  pilot_pod=$(kubectl -n istio-system get pods -l istio=pilot \
+      -o jsonpath='{.items[*].metadata.name}')
 
   dump_pilot_url "${pilot_pod}" debug/configz "${pilot_dir}"
   dump_pilot_url "${pilot_pod}" debug/endpointz "${pilot_dir}"

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -131,9 +131,10 @@ dump_resources() {
       | sed 's/,$//')
   kubectl get "${istio_resources}" --all-namespaces -o yaml > "${ISTIO_RESOURCES_FILE}"
 
-  kubectl cluster-info dump > ${OUT_DIR}/logs/cluster-info.dump.txt
-  kubectl describe pods -n istio-system > ${OUT_DIR}/logs/pods-system.txt
-  kubectl get event --all-namespaces -o wide > ${OUT_DIR}/logs/events.txt
+  mkdir -p "${LOG_DIR}"
+  kubectl cluster-info dump > "${LOG_DIR}/cluster-info.dump.txt"
+  kubectl describe pods -n istio-system > "${LOG_DIR}/pods-system.txt"
+  kubectl get event --all-namespaces -o wide > "${LOG_DIR}/events.txt"
 }
 
 dump_pilot_url(){

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -132,10 +132,10 @@ dump_resources() {
   kubectl get "${istio_resources}" --all-namespaces \
       -o yaml > "${ISTIO_RESOURCES_FILE}"
 
-  mkdir -p "${LOG_DIR}"
-  kubectl cluster-info dump > "${LOG_DIR}/cluster-info.dump.txt"
-  kubectl describe pods -n istio-system > "${LOG_DIR}/istio-system-pods.txt"
-  kubectl get events --all-namespaces -o wide > "${LOG_DIR}/events.txt"
+  mkdir -p "${OUT_DIR}"
+  kubectl cluster-info dump > "${OUT_DIR}/cluster-info.dump.txt"
+  kubectl describe pods -n istio-system > "${OUT_DIR}/istio-system-pods.txt"
+  kubectl get events --all-namespaces -o wide > "${OUT_DIR}/events.txt"
 }
 
 dump_pilot_url(){

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -133,7 +133,7 @@ dump_resources() {
 
   mkdir -p "${LOG_DIR}"
   kubectl cluster-info dump > "${LOG_DIR}/cluster-info.dump.txt"
-  kubectl describe pods -n istio-system > "${LOG_DIR}/pods-system.txt"
+  kubectl describe pods -n istio-system > "${LOG_DIR}/istio-system-pods.txt"
   kubectl get event --all-namespaces -o wide > "${LOG_DIR}/events.txt"
 }
 

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -129,8 +129,11 @@ dump_resources() {
       | cut -d ' ' -f 1 \
       | tr '\n' ',' \
       | sed 's/,$//')
-  kubectl get "${istio_resources}" --all-namespaces \
-      -o yaml > "${ISTIO_RESOURCES_FILE}"
+
+  if [ ! -z "${istio_resources}" ]; then
+    kubectl get "${istio_resources}" --all-namespaces -o yaml \
+        > "${ISTIO_RESOURCES_FILE}"
+  fi
 
   mkdir -p "${OUT_DIR}"
   kubectl cluster-info dump > "${OUT_DIR}/cluster-info.dump.txt"

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -12,13 +12,17 @@ error() {
 }
 
 usage() {
-  error "usage: dump_kubernetes.sh [options]"
-  error ""
-  error "  -d, --output-directory   directory to output files; defaults to"
-  error "                               \"istio-dump\""
-  error "  -z, --archive            if present, archives and removes the output"
-  error "                               directory"
-  error "  -q, --quiet              if present, do not log"
+  error 'Collect all possible data from a Kubernetes cluster using kubectl.'
+  error ''
+  error 'Usage:'
+  error '  dump_kubernetes.sh [options]'
+  error ''
+  error 'Options:'
+  error '  -d, --output-directory   directory to output files; defaults to'
+  error '                               "istio-dump"'
+  error '  -z, --archive            if present, archives and removes the output'
+  error '                               directory'
+  error '  -q, --quiet              if present, do not log'
   exit 1
 }
 

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -124,7 +124,7 @@ copy_core_dumps_if_istio_proxy() {
     mkdir -p "${out_dir}"
     local core_dumps
     core_dumps=$(kubectl exec -n "${namespace}" "${pod}" -c "${container}" -- \
-        find /etc/istio/proxy -name 'core.*')
+        find /etc/istio/proxy /var/istio/proxy -name 'core.*')
     for f in ${core_dumps}; do
       local out_file
       out_file="${out_dir}/$(basename "${f}")"

--- a/bin/dump_kubernetes.sh
+++ b/bin/dump_kubernetes.sh
@@ -170,7 +170,7 @@ dump_kubernetes_resources() {
   mkdir -p "${OUT_DIR}"
   # Only works in Kubernetes 1.8.0 and above.
   kubectl get --all-namespaces --export \
-      all,ingresses,endpoints,customresourcedefinitions,configmaps,secrets,events \
+      all,jobs,ingresses,endpoints,customresourcedefinitions,configmaps,secrets,events \
       -o yaml > "${RESOURCES_FILE}"
 }
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -214,4 +214,4 @@ junit-report: ${ISTIO_BIN}/go-junit-report
 # Can be run after tests. It will also process the auto-saved log output
 # This assume istio runs in istio-system namespace, and 'skip-cleanup' was used in tests.
 dumpsys: out_dir
-	bin/dump_kubernetes.sh --output-directory ${OUT_DIR}/logs
+	bin/dump_kubernetes.sh --output-directory ${OUT_DIR}/logs --error-if-nasty-logs


### PR DESCRIPTION
- Add some resiliency
  - Add `mkdir -p`
  - Only request specific resources if they exist
- Dumps miscellaneous info to OUT_DIR not LOG_DIR
- Copies core dumps of all istio-proxy containers if present
- Adds flag --error-if-nasty-logs which errors if logs match a grep