### PR TITLE
fix sidecar webhook default values missing for chart.

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -221,8 +221,15 @@ egressgateway:
 #
 sidecarInjectorWebhook:
   enabled: true
+  replicaCount: 1
   image: sidecar_injector
-
+  resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
 
 #
 # galley configuration


### PR DESCRIPTION
Fix issue that default values(`replicaCount` and `resources`) for sidecar webhook are missing.