### PR TITLE
fix resources in each deployment issues.

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           resources:
+{{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           - name: cacerts
             mountPath: /etc/cacerts

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -58,10 +58,8 @@ spec:
                 - --interval=2s
             initialDelaySeconds: 4
             periodSeconds: 4
-    {{- if .Values.nodeSelector }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- end }}
       volumes:
       - name: certs
         secret:

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
+        resources:
+{{ toYaml .Values.resources | indent 12 }}
       volumes:
       - name: kiali-configuration
         configMap:

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - --self-signed-ca=true
           {{- end }}
           resources:
+{{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.global.multicluster.enabled }}
           volumeMounts:
           - name: cacerts

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -57,10 +57,8 @@ spec:
                 - --interval=2s
             initialDelaySeconds: 4
             periodSeconds: 4
-    {{- if .Values.nodeSelector }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- end }}
       volumes:
       - name: config-volume
         configMap:


### PR DESCRIPTION
Fix the following issues for deployment resource request and limits:
- resources are always empty for Citadel deployment
- add resources requests and limits for kiali deployment
- resources are defined in `values.yaml` but get null for galley and sidecarWebhook deployments