### PR TITLE
Update Pilot to provide new destination.service.* attributes

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -17,6 +17,7 @@ package mixer
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -271,7 +272,7 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 	disableReport := outboundRoute && role.Type != model.Router
 
 	for _, instance := range nodeInstances {
-		mxConfig.ServiceConfigs[instance.Service.Hostname.String()] = v1.ServiceConfig(instance.Service.Hostname.String(), instance, config,
+		mxConfig.ServiceConfigs[instance.Service.Hostname.String()] = serviceConfig(instance.Service.Hostname.String(), instance, config,
 			disablePolicy, disableReport)
 	}
 
@@ -281,10 +282,14 @@ func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, n
 // buildTCPMixerFilterConfig builds a TCP filter config for inbound requests.
 func buildTCPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, instance *model.ServiceInstance) *mccpb.TcpClientConfig {
 	attrs := v1.StandardNodeAttributes(v1.AttrDestinationPrefix, role.IPAddress, role.ID, nil)
-	attrs[v1.AttrDestinationService] = &mpb.Attributes_AttributeValue{Value: &mpb.Attributes_AttributeValue_StringValue{instance.Service.Hostname.String()}}
-	attrs["context.reporter.uid"] = &mpb.Attributes_AttributeValue{
-		Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: "kubernetes://" + role.ID},
-	}
+
+	name, ns := nameAndNamespace(instance.Service.Hostname.String())
+	attrs[v1.AttrDestinationService] = attrStringValue(instance.Service.Hostname.String())
+	attrs["destination.service.host"] = attrStringValue(instance.Service.Hostname.String())
+	attrs["destination.service.uid"] = attrStringValue(fmt.Sprintf("istio://%s/services/%s", ns, name))
+	attrs["destination.service.name"] = attrStringValue(name)
+	attrs["destination.service.namespace"] = attrStringValue(ns)
+	attrs["context.reporter.uid"] = attrStringValue("kubernetes://" + role.ID)
 	attrs["context.reporter.local"] = &mpb.Attributes_AttributeValue{
 		Value: &mpb.Attributes_AttributeValue_BoolValue{BoolValue: true},
 	}
@@ -332,4 +337,29 @@ func addStandardNodeAttributes(attr map[string]*mpb.Attributes_AttributeValue, p
 			},
 		}
 	}
+}
+
+func serviceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool) *mccpb.ServiceConfig {
+	sc := v1.ServiceConfig(serviceHostname, dest, config, disableCheck, disableReport)
+
+	name, ns := nameAndNamespace(serviceHostname)
+	sc.MixerAttributes.Attributes["destination.service.host"] = attrStringValue(serviceHostname)
+	sc.MixerAttributes.Attributes["destination.service.uid"] = attrStringValue(fmt.Sprintf("istio://%s/services/%s", ns, name))
+	sc.MixerAttributes.Attributes["destination.service.name"] = attrStringValue(name)
+	sc.MixerAttributes.Attributes["destination.service.namespace"] = attrStringValue(ns)
+
+	return sc
+}
+
+func nameAndNamespace(serviceHostname string) (name, namespace string) {
+	if !strings.HasSuffix(serviceHostname, "svc.cluster.local") {
+		return serviceHostname, ""
+	}
+
+	parts := strings.Split(serviceHostname, ".")
+	return parts[0], parts[1]
+}
+
+func attrStringValue(value string) *mpb.Attributes_AttributeValue {
+	return &mpb.Attributes_AttributeValue{Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: value}}
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -335,7 +335,7 @@ func addStandardNodeAttributes(attr map[string]*mpb.Attributes_AttributeValue, p
 }
 
 // borrows heavily from v1.ServiceConfig (which this replaces)
-func serviceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool, proxyDomain string) *mccpb.ServiceConfig {
+func serviceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool, proxyDomain string) *mccpb.ServiceConfig { // nolint: lll
 	sc := &mccpb.ServiceConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -376,20 +376,23 @@ func addDestinationServiceAttributes(attrs map[string]*mpb.Attributes_AttributeV
 	attrs["destination.service.host"] = attrStringValue(destinationHostname)
 	attrs["destination.service.uid"] = attrStringValue(fmt.Sprintf("istio://%s/services/%s", svcNamespace, svcName))
 	attrs["destination.service.name"] = attrStringValue(svcName)
-	attrs["destination.service.namespace"] = attrStringValue(svcNamespace)
+	if len(svcNamespace) > 0 {
+		attrs["destination.service.namespace"] = attrStringValue(svcNamespace)
+	}
 }
 
 func nameAndNamespace(serviceHostname, domain string) (name, namespace string) {
-
 	domainParts := strings.SplitN(domain, ".", 2)
-
 	if !strings.HasSuffix(serviceHostname, domainParts[1]) {
 		return serviceHostname, ""
 	}
 
-	// What happens for domains like: foo.com ?  This will map namespace to foo, I believe
 	parts := strings.Split(serviceHostname, ".")
-	return parts[0], parts[1]
+	if len(parts) > 1 {
+		return parts[0], parts[1]
+	}
+
+	return serviceHostname, ""
 }
 
 func attrStringValue(value string) *mpb.Attributes_AttributeValue {

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -155,6 +155,7 @@ func buildMixerPerRouteConfig(in *plugin.InputParams, outboundRoute bool, _ /*di
 		out.MixerAttributes.Attributes = map[string]*mpb.Attributes_AttributeValue{
 			v1.AttrDestinationService: {Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: destinationService}},
 		}
+		addDestinationServiceAttributes(out.MixerAttributes.Attributes, destinationService)
 	}
 
 	var labels map[string]string

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -380,7 +380,10 @@ func addDestinationServiceAttributes(attrs map[string]*mpb.Attributes_AttributeV
 }
 
 func nameAndNamespace(serviceHostname, domain string) (name, namespace string) {
-	if !strings.HasSuffix(serviceHostname, domain) {
+
+	domainParts := strings.SplitN(domain, ".", 2)
+
+	if !strings.HasSuffix(serviceHostname, domainParts[1]) {
 		return serviceHostname, ""
 	}
 

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -295,12 +295,12 @@ func StandardNodeAttributes(prefix string, IPAddress string, ID string, labels m
 }
 
 // ServiceConfig generates a ServiceConfig for a given instance
-func ServiceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool) *mccpb.ServiceConfig {
+func ServiceConfig(serviceName string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool) *mccpb.ServiceConfig {
 	sc := &mccpb.ServiceConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
 				AttrDestinationService: {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: serviceHostname},
+					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: serviceName},
 				},
 			},
 		},

--- a/pilot/pkg/proxy/envoy/v1/mixer.go
+++ b/pilot/pkg/proxy/envoy/v1/mixer.go
@@ -19,9 +19,7 @@ package v1
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
 	"net"
-	"strings"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
@@ -296,37 +294,13 @@ func StandardNodeAttributes(prefix string, IPAddress string, ID string, labels m
 	return attrs
 }
 
-func nameAndNamespace(serviceHostname string) (name, namespace string) {
-	if !strings.HasSuffix(serviceHostname, "svc.cluster.local") {
-		return serviceHostname, ""
-	}
-
-	parts := strings.Split(serviceHostname, ".")
-	return parts[0], parts[1]
-}
-
 // ServiceConfig generates a ServiceConfig for a given instance
-func ServiceConfig(serviceName string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool) *mccpb.ServiceConfig {
-
-	name, ns := nameAndNamespace(serviceName)
-
+func ServiceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool) *mccpb.ServiceConfig {
 	sc := &mccpb.ServiceConfig{
 		MixerAttributes: &mpb.Attributes{
 			Attributes: map[string]*mpb.Attributes_AttributeValue{
 				AttrDestinationService: {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: serviceName},
-				},
-				"destination.service.host": {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: serviceName},
-				},
-				"destination.service.uid": {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: fmt.Sprintf("istio://%s/services/%s", ns, name)},
-				},
-				"destination.service.name": {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: name},
-				},
-				"destination.service.namespace": {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: ns},
+					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: serviceHostname},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds initial support to the new destination service attributes to Pilot (in the Mixer plugin).  The new attributes are:
- `destination.service.uid`
- `destination.service.name`
- `destination.service.namespace`
- `destination.service.host`