### PR TITLE
add in-memory secret cache for NodeAgent

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -1,0 +1,195 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache is the in-memory secret store.
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/pkg/pki/util"
+)
+
+// The size of a private key for a leaf certificate.
+const keySize = 2048
+
+// CAClient interface defines the clients need to implement to talk to CA for CSR.
+// TODO(quanlin): CAClient here is a placeholder, will move it to separated pkg.
+type CAClient interface {
+	Sign(csrPEM []byte /*PEM-encoded certificate request*/, subjectID string, certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error)
+}
+
+// SecretItem is the cached item in in-memory secret store.
+type SecretItem struct {
+	CertificateChain []byte
+	PrivateKey       []byte
+	jwtToken         string
+	lastUsedTime     time.Time
+	createdTime      time.Time
+}
+
+// SecretCache is the in-memory cache for secrets.
+type SecretCache struct {
+	// secrets map is the cache for secrets.
+	// map key is Envoy instance ID, map value is secretItem.
+	secrets        sync.Map
+	rotationTicker *time.Ticker
+	caClient       CAClient
+	closing        chan bool
+
+	// Cached secret will be removed from cache if (time.now - secretItem.lastUsedTime >= evictionDuration), this prevents cache growing indefinitely.
+	evictionDuration time.Duration
+
+	// Key rotation job running interval.
+	rotationInterval time.Duration
+
+	// secret TTL.
+	secretTTL time.Duration
+
+	// How may times that key rotation job has detected secret change happened, used in unit test.
+	secretChangedCount uint64
+}
+
+// NewSecretCache creates a new secret cache.
+func NewSecretCache(cl CAClient, secretTTL, rotationInterval, evictionDuration time.Duration) *SecretCache {
+	ret := &SecretCache{
+		caClient:         cl,
+		rotationInterval: rotationInterval,
+		evictionDuration: evictionDuration,
+		secretTTL:        secretTTL,
+		closing:          make(chan bool, 1),
+	}
+
+	atomic.StoreUint64(&ret.secretChangedCount, 0)
+	go ret.keyRotationJob()
+	return ret
+}
+
+// GetSecret gets secret from cache.
+func (sc *SecretCache) GetSecret(proxyID, jwtToken string) (*SecretItem, error) {
+	now := time.Now()
+
+	// Return directly if secret could be found from cache and not expired.
+	val, found := sc.secrets.Load(proxyID)
+	if found {
+		s := val.(SecretItem)
+		if s.jwtToken == jwtToken && !sc.checkExpired(&s) {
+			// Update cached secret's lastUsedTime.
+			s.lastUsedTime = now
+			return &s, nil
+		}
+	}
+
+	ns, err := sc.generateSecret(jwtToken, now)
+	if err != nil {
+		log.Errorf("Failed to generate secret for proxy %q: %v", proxyID, err)
+		return nil, err
+	}
+
+	sc.secrets.Store(proxyID, *ns)
+	return ns, nil
+}
+
+// Close shuts down the secret cache.
+func (sc *SecretCache) Close() {
+	sc.closing <- true
+}
+
+func (sc *SecretCache) keyRotationJob() {
+	// Wake up once in a while and refresh stale items.
+	sc.rotationTicker = time.NewTicker(sc.rotationInterval)
+	for {
+		select {
+		case now := <-sc.rotationTicker.C:
+			sc.rotate(now)
+		case <-sc.closing:
+			sc.rotationTicker.Stop()
+			return
+		}
+	}
+}
+
+func (sc *SecretCache) rotate(t time.Time) {
+	sc.secrets.Range(func(key interface{}, value interface{}) bool {
+		proxyID := key.(string)
+		now := time.Now()
+
+		e := value.(SecretItem)
+
+		// Remove from cache if the secret hasn't been used for a while, this prevent the cache growing indefinitely.
+		if now.After(e.lastUsedTime.Add(sc.evictionDuration)) {
+			sc.secrets.Delete(proxyID)
+			return true
+		}
+
+		// Re-generate secret if it's expired.
+		if sc.checkExpired(&e) {
+			go func() {
+				ns, err := sc.generateSecret(e.jwtToken, now)
+				if err != nil {
+					log.Errorf("Failed to generate secret for proxy %q: %v", proxyID, err)
+					return
+				}
+
+				sc.secrets.Store(proxyID, *ns)
+
+				//TODO(quanlin): push new secret to proxy.
+
+				atomic.AddUint64(&sc.secretChangedCount, 1)
+			}()
+		}
+
+		return true
+	})
+}
+
+func (sc *SecretCache) generateSecret(jwtToken string, t time.Time) (*SecretItem, error) {
+	options := util.CertOptions{
+		Host:       jwtToken,
+		RSAKeySize: keySize,
+	}
+
+	// Generate the cert/key, send CSR to CA.
+	csrPEM, keyPEM, err := util.GenCSR(options)
+	if err != nil {
+		return nil, err
+	}
+
+	certChainPER, err := sc.caClient.Sign(csrPEM, jwtToken, int64(sc.secretTTL.Seconds()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &SecretItem{
+		CertificateChain: certChainPER,
+		PrivateKey:       keyPEM,
+		jwtToken:         jwtToken,
+		lastUsedTime:     t,
+		createdTime:      t,
+	}, nil
+}
+
+func (sc *SecretCache) checkExpired(s *SecretItem) bool {
+	now := time.Now()
+	if now.After(s.createdTime.Add(sc.secretTTL)) {
+		return true
+	}
+
+	// TODO(quanlin), check if JWT token has expired.
+
+	return false
+}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+var (
+	mockCertificateChain1st    = []byte{01}
+	mockCertificateChainRemain = []byte{02}
+)
+
+func TestGetSecret(t *testing.T) {
+	fakeCACli := newMockCAClient()
+	sc := NewSecretCache(fakeCACli, time.Minute /*secret TTL*/, 300*time.Microsecond /*rotation Interval*/, 2*time.Second /*evictionDuration*/)
+	defer sc.Close()
+
+	proxyID := "proxy1-id"
+	jwtToken := "jwtToken1"
+	gotSecret, err := sc.GetSecret(proxyID, jwtToken)
+	if err != nil {
+		t.Fatalf("Failed to get secrets: %v", err)
+	}
+	if got, want := gotSecret.CertificateChain, mockCertificateChain1st; bytes.Compare(got, want) != 0 {
+		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
+	}
+
+	cachedSecret, found := sc.secrets.Load(proxyID)
+	if !found {
+		t.Errorf("Failed to find secret for proxy %q from secret store: %v", proxyID, err)
+	}
+	if !reflect.DeepEqual(*gotSecret, cachedSecret) {
+		t.Errorf("Secret key: got %+v, want %+v", *gotSecret, cachedSecret)
+	}
+
+	// Try to get secret again using same token, verify secret isn't re-generated again since cached secret hasn't expired.
+	gotSecret, err = sc.GetSecret(proxyID, jwtToken)
+	if err != nil {
+		t.Fatalf("Failed to get secrets: %v", err)
+	}
+	if got, want := gotSecret.CertificateChain, mockCertificateChain1st; bytes.Compare(got, want) != 0 {
+		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
+	}
+
+	// Try to get secret again using different jwt token, verify secret is re-generated.
+	jwtToken = "newToken"
+	gotSecret, err = sc.GetSecret(proxyID, jwtToken)
+	if err != nil {
+		t.Fatalf("Failed to get secrets: %v", err)
+	}
+	if got, want := gotSecret.CertificateChain, mockCertificateChainRemain; bytes.Compare(got, want) != 0 {
+		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
+	}
+
+	// Wait until unused secrets are evicted.
+	wait := 500 * time.Millisecond
+	retries := 0
+	for ; retries < 3; retries++ {
+		time.Sleep(wait)
+		if _, found := sc.secrets.Load(proxyID); found {
+			// Retry after some sleep.
+			wait *= 2
+			continue
+		}
+
+		break
+	}
+	if retries == 3 {
+		t.Errorf("Unused secrets failed to be evicted from cache")
+	}
+}
+
+func TestRefreshSecret(t *testing.T) {
+	fakeCACli := newMockCAClient()
+	sc := NewSecretCache(fakeCACli, 300*time.Microsecond /*secret TTL*/, 300*time.Microsecond /*rotation Interval*/, 10*time.Second /*evictionDuration*/)
+	defer sc.Close()
+
+	proxyID := "proxy1-id"
+	jwtToken := "jwtToken1"
+	_, err := sc.GetSecret(proxyID, jwtToken)
+	if err != nil {
+		t.Fatalf("Failed to get secrets: %v", err)
+	}
+
+	// Wait until key rotation job run to update cached secret.
+	wait := 400 * time.Millisecond
+	retries := 0
+	for ; retries < 3; retries++ {
+		time.Sleep(wait)
+		if atomic.LoadUint64(&sc.secretChangedCount) == uint64(0) {
+			// Retry after some sleep.
+			wait *= 2
+			continue
+		}
+
+		break
+	}
+	if retries == 3 {
+		t.Errorf("Cached secret failed to get refreshed, %d", atomic.LoadUint64(&sc.secretChangedCount))
+	}
+}
+
+type mockCAClient struct {
+	signInvokeCount uint64
+}
+
+func newMockCAClient() *mockCAClient {
+	cl := mockCAClient{}
+	atomic.StoreUint64(&cl.signInvokeCount, 0)
+	return &cl
+}
+
+func (c *mockCAClient) Sign(csrPEM []byte, /*PEM-encoded certificate request*/
+	subjectID string, certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error) {
+	atomic.AddUint64(&c.signInvokeCount, 1)
+
+	if atomic.LoadUint64(&c.signInvokeCount) == 1 {
+		return mockCertificateChain1st, nil
+	}
+
+	return mockCertificateChainRemain, nil
+}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -50,15 +50,6 @@ func TestGetSecret(t *testing.T) {
 		t.Errorf("Secret key: got %+v, want %+v", *gotSecret, cachedSecret)
 	}
 
-	// Try to get secret again using same token, verify secret isn't re-generated again since cached secret hasn't expired.
-	gotSecret, err = sc.GetSecret(proxyID, jwtToken)
-	if err != nil {
-		t.Fatalf("Failed to get secrets: %v", err)
-	}
-	if got, want := gotSecret.CertificateChain, mockCertificateChain1st; bytes.Compare(got, want) != 0 {
-		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
-	}
-
 	// Try to get secret again using different jwt token, verify secret is re-generated.
 	jwtToken = "newToken"
 	gotSecret, err = sc.GetSecret(proxyID, jwtToken)
@@ -127,7 +118,7 @@ func newMockCAClient() *mockCAClient {
 	return &cl
 }
 
-func (c *mockCAClient) Sign(csrPEM []byte, /*PEM-encoded certificate request*/
+func (c *mockCAClient) CSRSign(csrPEM []byte, /*PEM-encoded certificate request*/
 	subjectID string, certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error) {
 	atomic.AddUint64(&c.signInvokeCount, 1)
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

This PR includes:
1. in-memory secret cache
2. key rotation job

To be added in later PRs:
1. thread secret cache into SDS
2. move caClient to separated pkg and add implementation 