### PR TITLE
[Pilot] Adding support for config-backed service registry

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -268,9 +268,9 @@ func timeDuration(dur *duration.Duration) time.Duration {
 func init() {
 	proxyCmd.PersistentFlags().StringVar((*string)(&registry), "serviceregistry",
 		string(serviceregistry.KubernetesRegistry),
-		fmt.Sprintf("Select the platform for service registry, options are {%s, %s, %s, %s, %s}",
+		fmt.Sprintf("Select the platform for service registry, options are {%s, %s, %s, %s, %s, %s}",
 			serviceregistry.KubernetesRegistry, serviceregistry.ConsulRegistry, serviceregistry.EurekaRegistry,
-			serviceregistry.CloudFoundryRegistry, serviceregistry.MockRegistry))
+			serviceregistry.CloudFoundryRegistry, serviceregistry.MockRegistry, serviceregistry.ConfigRegistry))
 	proxyCmd.PersistentFlags().StringVar(&role.IPAddress, "ip", "",
 		"Proxy IP address. If not provided uses ${INSTANCE_IP} environment variable.")
 	proxyCmd.PersistentFlags().StringVar(&role.ID, "id", "",

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -77,9 +77,9 @@ var (
 func init() {
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Service.Registries, "registries",
 		[]string{string(serviceregistry.KubernetesRegistry)},
-		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s, %s, %s})",
+		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s, %s, %s, %s})",
 			serviceregistry.KubernetesRegistry, serviceregistry.ConsulRegistry, serviceregistry.EurekaRegistry,
-			serviceregistry.CloudFoundryRegistry, serviceregistry.MockRegistry))
+			serviceregistry.CloudFoundryRegistry, serviceregistry.MockRegistry, serviceregistry.ConfigRegistry))
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.CFConfig, "cfConfig", "",
 		"Cloud Foundry config file")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesConfigmap, "clusterRegistriesConfigMap", "",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -590,8 +590,10 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		registered[serviceRegistry] = true
 		log.Infof("Adding %s registry adapter", serviceRegistry)
 		switch serviceRegistry {
+		case serviceregistry.ConfigRegistry:
+			s.initConfigRegistry(serviceControllers)
 		case serviceregistry.MockRegistry:
-			initMemoryRegistry(s, serviceControllers)
+			s.initMemoryRegistry(serviceControllers)
 		case serviceregistry.KubernetesRegistry:
 
 			if err := s.createK8sServiceControllers(serviceControllers, args); err != nil {
@@ -702,7 +704,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 
 	return nil
 }
-func initMemoryRegistry(s *Server, serviceControllers *aggregate.Controller) {
+
+func (s *Server) initMemoryRegistry(serviceControllers *aggregate.Controller) {
 	// MemServiceDiscovery implementation
 	discovery1 := mock.NewDiscovery(
 		map[model.Hostname]*model.Service{ // mock.HelloService.Hostname: mock.HelloService,
@@ -731,6 +734,17 @@ func initMemoryRegistry(s *Server, serviceControllers *aggregate.Controller) {
 	}
 	serviceControllers.AddRegistry(registry1)
 	serviceControllers.AddRegistry(registry2)
+}
+
+func (s *Server) initConfigRegistry(serviceControllers *aggregate.Controller) {
+	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore)
+	serviceControllers.AddRegistry(aggregate.Registry{
+		Name:             serviceregistry.ConfigRegistry,
+		ClusterID:        string(serviceregistry.ConfigRegistry),
+		ServiceDiscovery: serviceEntryStore,
+		ServiceAccounts:  serviceEntryStore,
+		Controller:       serviceEntryStore,
+	})
 }
 
 func (s *Server) initDiscoveryService(args *PilotArgs) error {

--- a/pilot/pkg/serviceregistry/platform.go
+++ b/pilot/pkg/serviceregistry/platform.go
@@ -18,14 +18,16 @@ package serviceregistry
 type ServiceRegistry string
 
 const (
-	// MockRegistry environment flag
+	// MockRegistry is a service registry that contains 2 hard-coded test services
 	MockRegistry ServiceRegistry = "Mock"
-	// KubernetesRegistry environment flag
+	// ConfigRegistry is a service registry that listens for service entries in a backing ConfigStore
+	ConfigRegistry ServiceRegistry = "Config"
+	// KubernetesRegistry is a service registry backed by k8s API server
 	KubernetesRegistry ServiceRegistry = "Kubernetes"
-	// ConsulRegistry environment flag
+	// ConsulRegistry is a service registry backed by Consul
 	ConsulRegistry ServiceRegistry = "Consul"
-	// EurekaRegistry environment flag
+	// EurekaRegistry is a service registry backed by Eureka
 	EurekaRegistry ServiceRegistry = "Eureka"
-	// CloudFoundryRegistry environment flag
+	// CloudFoundryRegistry is a service registry backed by Cloud Foundry.
 	CloudFoundryRegistry ServiceRegistry = "CloudFoundry"
 )


### PR DESCRIPTION
Adding a new "Config" service registry that is backed by the provided
config store. The service registry will be updated via events for
ServiceEntry CRDs. This will allow the testing framework to eliminate
the dependency on k8s entirely and use the file-based config store as
the backend for the service registry.

Fixes #5974