### PR TITLE
Remove populating mtlsExcludeServices in mesh config.

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -45,10 +45,6 @@ global:
     # Default setting for service-to-service mtls. Can be set explicitly using
     # destination rules or service annotations.
     enabled: false
-    # List of fully qualified services to exclude from mtls
-    # TODO: add the templating.
-    mtlsExcludedServices:
-    - "kubernetes.default.svc.cluster.local"
 
   # create RBAC resources. Must be set for any cluster configured with rbac.
   rbacEnabled: true

--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -73,7 +73,6 @@ Helm charts expose configuration options which are currently in alpha.  The curr
 | `global.imagePullPolicy` | Specifies the image pull policy | valid image pull policy | `IfNotPresent` |
 | `global.controlPlaneSecurityEnabled` | Specifies whether control plane mTLS is enabled | true/false | `false` |
 | `global.mtls.enabled` | Specifies whether mTLS is enabled by default between services | true/false | `false` |
-| `global.mtls.mtlsExcludedServices` | List of FQDNs to exclude from mTLS | a list of FQDNs | `- kubernetes.default.svc.cluster.local` |
 | `global.rbacEnabled` | Specifies whether to create Istio RBAC rules or not | true/false | `true` |
 | `global.refreshInterval` | Specifies the mesh discovery refresh interval | integer followed by s | `10s` |
 | `global.arch.amd64` | Specifies the scheduling policy for `amd64` architectures | 0 = never, 1 = least preferred, 2 = no preference, 3 = most preferred | `2` |

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -13,13 +13,7 @@ data:
   {{- if .Values.global.mtls.enabled }}
     # Mutual TLS between proxies
     authPolicy: MUTUAL_TLS
-    mtlsExcludedServices: ["kubernetes.default.svc.cluster.local"]
   {{- end }}
-    #
-    # Edit this list to avoid using mTLS to connect to these services.
-    # Typically, these are control services (e.g kubernetes API server) that don't have istio sidecar
-    # to transparently terminate mTLS authentication.
-    # mtlsExcludedServices: ["kubernetes.default.svc.cluster.local"]
 
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.

--- a/install/kubernetes/templates/istio-config.yaml.tmpl
+++ b/install/kubernetes/templates/istio-config.yaml.tmpl
@@ -10,11 +10,6 @@ data:
   mesh: |-
     # Uncomment the following line to enable mutual TLS between proxies
     # authPolicy: MUTUAL_TLS
-    #
-    # Edit this list to avoid using mTLS to connect to these services.
-    # Typically, these are control services (e.g kubernetes API server) that don't have Istio sidecar
-    # to transparently terminate mTLS authentication.
-    mtlsExcludedServices: ["kubernetes.default.svc.cluster.local"]
 
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.

--- a/pilot/pkg/proxy/envoy/v1/policy.go
+++ b/pilot/pkg/proxy/envoy/v1/policy.go
@@ -24,16 +24,6 @@ import (
 	authn_plugin "istio.io/istio/pilot/pkg/networking/plugin/authn"
 )
 
-func isDestinationExcludedForMTLS(serviceName string, mtlsExcludedServices []string) bool {
-	hostname, _, _ := model.ParseServiceKey(serviceName)
-	for _, serviceName := range mtlsExcludedServices {
-		if hostname.String() == serviceName {
-			return true
-		}
-	}
-	return false
-}
-
 // ApplyClusterPolicy assumes an outbound cluster and inserts custom configuration for the cluster
 func ApplyClusterPolicy(cluster *Cluster,
 	proxyInstances []*model.ServiceInstance,
@@ -52,7 +42,7 @@ func ApplyClusterPolicy(cluster *Cluster,
 	// where Istio auth does not apply.
 	if cluster.Type != ClusterTypeOriginalDST {
 		requireTLS, _ := authn_plugin.RequireTLS(model.GetConsolidateAuthenticationPolicy(mesh, config, model.Hostname(cluster.Hostname), cluster.Port))
-		if !isDestinationExcludedForMTLS(cluster.ServiceName, mesh.MtlsExcludedServices) && requireTLS {
+		if requireTLS {
 			// apply auth policies
 			ports := model.PortList{cluster.Port}.GetNames()
 			serviceAccounts := accounts.GetIstioServiceAccounts(model.Hostname(cluster.Hostname), ports)

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -85,9 +85,6 @@ func setTestConfig() error {
 
 	tc.Kube.InstallAddons = true // zipkin is used
 
-	// Add mTLS auth exclusion policy.
-	tc.Kube.MTLSExcludedServices = []string{fmt.Sprintf("fake-control.%s.svc.cluster.local", tc.Kube.Namespace)}
-
 	appDir, err := ioutil.TempDir(os.TempDir(), "pilot_test")
 	if err != nil {
 		return err
@@ -273,9 +270,8 @@ func getApps(tc *testConfig) []framework.App {
 		getApp("c-v1", "c", 80, 8080, 90, 9090, 70, 7070, "v1", true),
 		getApp("c-v2", "c", 80, 8080, 90, 9090, 70, 7070, "v2", true),
 		getApp("d", "d", 80, 8080, 90, 9090, 70, 7070, "per-svc-auth", true),
-		// Add another service without sidecar to test mTLS blacklisting (as in the e2e test
-		// environment, pilot can see only services in the test namespaces). This service
-		// will be listed in mtlsExcludedServices in the mesh config.
+		// This service was used to test mtlsExcludedServices in the mesh config. This flag is removed in
+		// PR #. This service and the involved tests can also be removed in the following up PRs.
 		getApp("e", "fake-control", 80, 8080, 90, 9090, 70, 7070, "fake-control", false),
 	}
 }


### PR DESCRIPTION
mtlsExcludeServices flag was used to exclude certain services (common use is for API server) from mutual TLS set up on client side. Since 0.8, this (client settings) needs to be defined explicitly with destination rules, this flag is no longer needed.