### PR TITLE
Adds ingress to httpbin sample app

### DIFF
--- a/samples/httpbin/README.md
+++ b/samples/httpbin/README.md
@@ -13,9 +13,29 @@ To use it:
    ```bash
    kubectl apply -f <(istioctl kube-inject -f httpbin.yaml)
    ```
- 
-Because the httpbin service is not exposed outside of the cluster
-we cannot _curl_ it directly, however we can verify that it is working correctly using
+
+3. You can test the httpbin service by
+   [creating an ingress resource](https://istio.io/docs/tasks/traffic-management/ingress.html):
+
+   ```bash
+   kubectl apply -f <(istioctl kube-inject -f httpbin-gateway.yaml)
+   ```
+
+4. Test the Ingress:
+
+   ```bash
+   $ curl -I http://${INGRESS_IP}/html
+   HTTP/1.1 200 OK
+   server: envoy
+   date: Wed, 06 Jun 2018 18:34:43 GMT
+   content-type: text/html; charset=utf-8
+   content-length: 3741
+   access-control-allow-origin: *
+   access-control-allow-credentials: true
+   x-envoy-upstream-service-time: 10
+   ```
+
+Alternatively, you can verify that it is working correctly using
 a _curl_ command against `httpbin:8000` *from inside the cluster* using the public _dockerqa/curl_
 image from the Docker hub:
 
@@ -24,7 +44,3 @@ kubectl run -i --rm --restart=Never dummy --image=dockerqa/curl:ubuntu-trusty --
 kubectl run -i --rm --restart=Never dummy --image=dockerqa/curl:ubuntu-trusty --command -- curl --silent httpbin:8000/status/500
 time kubectl run -i --rm --restart=Never dummy --image=dockerqa/curl:ubuntu-trusty --command -- curl --silent httpbin:8000/delay/5
 ```
-
-Alternatively, you can test the httpbin service by
-[configuring an ingress resource](https://istio.io/docs/tasks/traffic-management/ingress.html) or
-by starting the [sleep service](../sleep) and calling httpbin from it.

--- a/samples/httpbin/httpbin-gateway.yaml
+++ b/samples/httpbin/httpbin-gateway.yaml
@@ -1,0 +1,40 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+###########################################################################
+# Ingress resource (gateway)
+##########################################################################
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gateway
+  annotations:
+    kubernetes.io/ingress.class: "istio"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /html
+        backend:
+          serviceName: httpbin
+          servicePort: 8000
+      - path: /status/500
+        backend:
+          serviceName: httpbin
+          servicePort: 8000
+      - path: /delay/5
+        backend:
+          serviceName: httpbin
+          servicePort: 8000
+---


### PR DESCRIPTION
Provides an alternative to using bookinfo for externally testing using an Ingress resource.