### PR TITLE
Don't print usage text when commands exit on runtime error

### DIFF
--- a/galley/cmd/gals/cmd/root.go
+++ b/galley/cmd/gals/cmd/root.go
@@ -51,9 +51,10 @@ func createInterface(kubeconfig string) (kubernetes.Interface, error) {
 // GetRootCmd returns the root of the cobra command-tree.
 func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   "gals",
-		Short: "Galley provides configuration management services for Istio.",
-		Long:  "Galley provides configuration management services for Istio.",
+		Use:          "gals",
+		Short:        "Galley provides configuration management services for Istio.",
+		Long:         "Galley provides configuration management services for Istio.",
+		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				return fmt.Errorf("%q is an invalid argument", args[0])

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -70,9 +70,10 @@ var (
 	loggingOptions = log.DefaultOptions()
 
 	rootCmd = &cobra.Command{
-		Use:   "pilot-agent",
-		Short: "Istio Pilot agent",
-		Long:  "Istio Pilot agent runs in the side car or gateway container and bootstraps envoy.",
+		Use:          "pilot-agent",
+		Short:        "Istio Pilot agent",
+		Long:         "Istio Pilot agent runs in the side car or gateway container and bootstraps envoy.",
+		SilenceUsage: true,
 	}
 
 	proxyCmd = &cobra.Command{

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -40,9 +40,10 @@ var (
 	ctrlzOptions = ctrlz.DefaultOptions()
 
 	rootCmd = &cobra.Command{
-		Use:   "pilot-discovery",
-		Short: "Istio Pilot",
-		Long:  "Istio Pilot provides fleet-wide traffic management capabilities in the Istio Service Mesh.",
+		Use:          "pilot-discovery",
+		Short:        "Istio Pilot",
+		Long:         "Istio Pilot provides fleet-wide traffic management capabilities in the Istio Service Mesh.",
+		SilenceUsage: true,
 	}
 
 	discoveryCmd = &cobra.Command{

--- a/pilot/cmd/sidecar-injector/main.go
+++ b/pilot/cmd/sidecar-injector/main.go
@@ -58,8 +58,9 @@ var (
 	}
 
 	rootCmd = &cobra.Command{
-		Use:   "sidecar-injector",
-		Short: "Kubernetes webhook for automatic Istio sidecar injection",
+		Use:          "sidecar-injector",
+		Short:        "Kubernetes webhook for automatic Istio sidecar injection",
+		SilenceUsage: true,
 		RunE: func(*cobra.Command, []string) error {
 			if err := log.Configure(flags.loggingOptions); err != nil {
 				return err


### PR DESCRIPTION
Printing the full usage text on runtime error isn't helpful for non-input/flag related errors. It also adds noise to things like k8s events and makes it hard to spot the important part (i.e. the actual error). 

```bash
39m       39m       2         istio-sidecar-injector-d8f9c97c5-tmdw4.1535adae9e49d4cf   Pod       spec.containers{webhook}   Warning   Unhealthy   kubelet, gke-petclinic-cluster-v2-default-pool-f2188aff-chkn   Readiness probe failed: Error: fail on inspecting path /health: file /health is too old (last modified time 2018-06-06 20:56:52.434324629 +0000 UTC, should be within 1.01s)
Usage:
  sidecar-injector probe [flags]

Flags:
  -h, --help                help for probe
      --interval duration   Duration used for checking the target file's last modified time.
      --probe-path string   Path of the file for checking the availability.

Global Flags:
      --healthCheckFile string         File that should be periodically updated if health checking is enabled
      --healthCheckInterval duration   Configure how frequently the health check file specified by --healhCheckFile should be updated
      --injectConfig string            File containing the Istio sidecar injection configuration and template (default "/etc/istio/inject/config")
      --log_as_json                    Whether to format output as JSON or in plain console-friendly format
      --log_callers                    Include caller information, useful for debugging
      --log_output_level string        The minimum logging level of messages to output, can be one of "debug", "info", "warn", "error", or "none" (default "info")
      --log_rotate string              The path for the optional rotating log file
      --log_rotate_max_age int         The maximum age in days of a log file beyond which the file is rotated (0 indicates no limit) (default 30)
      --log_rotate_max_backups int     The maximum number of log file backups to keep before older files are deleted (0 indicates no limit) (default 1000)
      --log_rotate_max_size int        The maximum size in megabytes of a log file beyond which the file is rotated (default 104857600)
      --log_stacktrace_level string    The minimum logging level at which stack traces are captured, can be one of "debug", "info", "warn", "error", or "none" (default "none")
      --log_target stringArray         The set of paths where to output the log. This can be any path as well as the special values stdout and stderr (default [stdout])
      --meshConfig string              File containing the Istio mesh configuration (default "/etc/istio/config/mesh")
      --port int                       Webhook port (default 443)
      --tlsCertFile string             File containing the x509 Certificate for HTTPS. (default "/etc/istio/certs/cert.pem")
      --tlsKeyFile string              File containing the x509 private key matching --tlsCertFile. (default "/etc/istio/certs/key.pem")
```