### PR TITLE
Enable Websocket for all v1alpha3 routes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -30,13 +30,19 @@ import (
 )
 
 // buildSidecarInboundHTTPRouteConfig builds the route config with a single wildcard virtual host on the inbound path
-// TODO: enable websockets, trace decorators, inbound timeouts
+// TODO: trace decorators, inbound timeouts
 func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env model.Environment,
 	node model.Proxy, instance *model.ServiceInstance) *xdsapi.RouteConfiguration {
 
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, "",
 		instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
 	defaultRoute := istio_route.BuildDefaultHTTPRoute(clusterName)
+
+	// Enable websocket on default route
+	actionRoute, ok := defaultRoute.Action.(*route.Route_Route)
+	if ok && actionRoute != nil {
+		actionRoute.Route.UseWebsocket = &types.BoolValue{Value: true}
+	}
 
 	inboundVHost := route.VirtualHost{
 		Name:    fmt.Sprintf("%s|http|%d", model.TrafficDirectionInbound, instance.Endpoint.ServicePort.Port),

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -189,11 +189,6 @@ func TestRoutes(t *testing.T) {
 			}
 
 			for _, c := range cases {
-				if strings.Contains(c.testName, "websocket") && version == "v1alpha3" {
-					log.Infof("Skipping Websocket tests in v1alpha3 as they are not implemented yet")
-					continue
-				}
-
 				// Run each case in a function to scope the configuration's lifecycle.
 				func() {
 					ruleYaml := fmt.Sprintf("testdata/%s/%s", version, c.config)


### PR DESCRIPTION
Enabling the support for Websocket upgrade in v1alpha3.

We had two options here:
1. From a given pod scan for http rules that have the websocketUpgrade field as true. Apparently this is a compute intensive and not scalable (need to find relevant clusters, virtual services and then http rules with the flag).
2. Enable websocket upgrade for all inbound routes. If the application does not support websocket, but the caller upgrades to websocket via Envoy, the call will end up being rejected by the application. 
Note that the user still has to add `websocketUpgrade: true` to virtualServices for setting websocket upgrade on the outbound path.

This PR is following the 2nd option and re-enabled the v1alpha3 websocket tests.