### PR TITLE
[pilot] Support manually specifying config controller

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -120,6 +120,9 @@ type ConfigArgs struct {
 	CFConfig                   string
 	ControllerOptions          kube.ControllerOptions
 	FileDir                    string
+
+	// Controller if specified, this controller overrides the other config settings.
+	Controller model.ConfigStoreCache
 }
 
 // ConsulArgs provides configuration for the Consul service registry.
@@ -456,7 +459,9 @@ func (c *mockController) Run(<-chan struct{}) {}
 
 // initConfigController creates the config controller in the pilotConfig.
 func (s *Server) initConfigController(args *PilotArgs) error {
-	if args.Config.FileDir != "" {
+	if args.Config.Controller != nil {
+		s.configController = args.Config.Controller
+	} else if args.Config.FileDir != "" {
 		store := memory.Make(ConfigDescriptor)
 		configController := memory.NewController(store)
 
@@ -487,6 +492,34 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 		go s.configController.Run(stop)
 		return nil
 	})
+
+	// If running in ingress mode (requires k8s), wrap the config controller.
+	if hasKubeRegistry(args) && s.mesh.IngressControllerMode != meshconfig.MeshConfig_OFF {
+		// Wrap the config controller with a cache.
+		configController, err := configaggregate.MakeCache([]model.ConfigStoreCache{
+			s.configController,
+			ingress.NewController(s.kubeClient, s.mesh, args.Config.ControllerOptions),
+		})
+		if err != nil {
+			return err
+		}
+
+		// Update the config controller
+		s.configController = configController
+
+		if ingressSyncer, errSyncer := ingress.NewStatusSyncer(s.mesh, s.kubeClient,
+			args.Namespace, args.Config.ControllerOptions); errSyncer != nil {
+			log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
+		} else {
+			s.addStartFunc(func(stop chan struct{}) error {
+				go ingressSyncer.Run(stop)
+				return nil
+			})
+		}
+	}
+
+	// Create the config store.
+	s.istioConfigStore = model.MakeIstioStore(s.configController)
 
 	return nil
 }
@@ -577,6 +610,15 @@ func (s *Server) initMultiClusterController(args *PilotArgs) (err error) {
 	return
 }
 
+func hasKubeRegistry(args *PilotArgs) bool {
+	for _, r := range args.Service.Registries {
+		if serviceregistry.ServiceRegistry(r) == serviceregistry.KubernetesRegistry {
+			return true
+		}
+	}
+	return false
+}
+
 // initServiceControllers creates and initializes the service controllers
 func (s *Server) initServiceControllers(args *PilotArgs) error {
 	serviceControllers := aggregate.NewController()
@@ -595,32 +637,8 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		case serviceregistry.MockRegistry:
 			s.initMemoryRegistry(serviceControllers)
 		case serviceregistry.KubernetesRegistry:
-
 			if err := s.createK8sServiceControllers(serviceControllers, args); err != nil {
 				return err
-			}
-			if s.mesh.IngressControllerMode != meshconfig.MeshConfig_OFF {
-				// Wrap the config controller with a cache.
-				configController, err := configaggregate.MakeCache([]model.ConfigStoreCache{
-					s.configController,
-					ingress.NewController(s.kubeClient, s.mesh, args.Config.ControllerOptions),
-				})
-				if err != nil {
-					return err
-				}
-
-				// Update the config controller
-				s.configController = configController
-
-				if ingressSyncer, errSyncer := ingress.NewStatusSyncer(s.mesh, s.kubeClient,
-					args.Namespace, args.Config.ControllerOptions); errSyncer != nil {
-					log.Warnf("Disabled ingress status syncer due to %v", errSyncer)
-				} else {
-					s.addStartFunc(func(stop chan struct{}) error {
-						go ingressSyncer.Run(stop)
-						return nil
-					})
-				}
 			}
 		case serviceregistry.ConsulRegistry:
 			log.Infof("Consul url: %v", args.Service.Consul.ServerURL)
@@ -680,8 +698,6 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			return multierror.Prefix(nil, "Service registry "+r+" is not supported.")
 		}
 	}
-	// TODO: use the existing one !
-	s.istioConfigStore = model.MakeIstioStore(s.configController)
 	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore)
 
 	// add service entry registry to aggregator by default


### PR DESCRIPTION
This is needed to support local testing using an in-memory controller
that is modified directly by the test code.