### PR TITLE
Exit with an error if minikube fails to start

### DIFF
--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -35,9 +35,10 @@ function waitMinikube() {
         netstat -an
         docker images
         cat /var/lib/localkube/localkube.err
-        echo "\n\n\n"
+        echo -e "\n\n\n"
         kubectl cluster-info dump
-        #exit 1
+        echo "Exiting"
+        exit 1
     fi
     echo "Minikube is running"
 }


### PR DESCRIPTION
It doesn't make sense to continue the test if the
k8s cluster is not available.