### PR TITLE
Add tool to check for TLS conflict between authentication policy and destination rule

### DIFF
--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -1,0 +1,107 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type AuthenticationDebug struct {
+	Host                     string
+	Port                     int
+	AuthenticationPolicyName string
+	DestinationRuleName      string
+	ServerProtocol           string
+	ClientProtocol           string
+	TLSConflictStatus        string
+}
+
+// can allows user to query Istio RBAC effect for a specific request.
+func check() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tls_check",
+		Short: "Check whether TLS setting are matching between authentication policy and destination rules",
+		Long: `
+`,
+		Example: ``,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pilots, err := getPilotPods()
+			if err != nil {
+				return err
+			}
+			if len(pilots) == 0 {
+				return errors.New("unable to find any Pilot instances")
+			}
+			if debug, pilotErr := callPilotDiscoveryDebug(pilots, "", "authn"); pilotErr == nil {
+				// fmt.Println(debug)
+				var dat []AuthenticationDebug
+				if err := json.Unmarshal([]byte(debug), &dat); err != nil {
+					panic(err)
+				}
+				sort.Slice(dat, func(i, j int) bool {
+					if dat[i].Host == dat[j].Host {
+						return dat[i].Port < dat[j].Port
+					}
+					return dat[i].Host < dat[j].Host
+				})
+				w := new(tabwriter.Writer)
+				w.Init(os.Stdout, 0, 0, 4, ' ', 0)
+				fmt.Fprintln(w, "Host\tStatus\tServer\tClient\tAuthN Policy Name/Namespace\tDst Rule Name/Namespace")
+				for _, entry := range dat {
+					if entry.Host == "" {
+						continue
+					}
+					host := fmt.Sprintf("%s:%5d", entry.Host, entry.Port)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", host, entry.TLSConflictStatus,
+						entry.ServerProtocol, entry.ClientProtocol,
+						entry.AuthenticationPolicyName, entry.DestinationRuleName)
+				}
+				w.Flush()
+			} else {
+				fmt.Printf("%v\n", pilotErr)
+			}
+
+			return nil
+		},
+	}
+	return cmd
+}
+
+// AuthN provides a command named authn that allows user to interact with Istio authentication policies.
+func AuthN() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "authn",
+		Short: "Interact with Istio authentication policies",
+		Long: `
+`,
+		Example: `# Check whether TLS setting are matching between authentication policy and destination rules:
+istioctl authn tls_check`,
+	}
+
+	cmd.AddCommand(check())
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(AuthN())
+}

--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -23,6 +23,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	proxy "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
 

--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -23,17 +23,8 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	proxy "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
-
-type authenticationDebug struct {
-	Host                     string
-	Port                     int
-	AuthenticationPolicyName string
-	DestinationRuleName      string
-	ServerProtocol           string
-	ClientProtocol           string
-	TLSConflictStatus        string
-}
 
 func tlsCheck() *cobra.Command {
 	cmd := &cobra.Command{
@@ -54,7 +45,7 @@ service registry, and check if TLS settings are compatible between them.
 				return errors.New("unable to find any Pilot instances")
 			}
 			if debug, pilotErr := callPilotDiscoveryDebug(pilots, "", "authn"); pilotErr == nil {
-				var dat []authenticationDebug
+				var dat []proxy.AuthenticationDebug
 				if err := json.Unmarshal([]byte(debug), &dat); err != nil {
 					panic(err)
 				}

--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -53,7 +53,6 @@ func check() *cobra.Command {
 				return errors.New("unable to find any Pilot instances")
 			}
 			if debug, pilotErr := callPilotDiscoveryDebug(pilots, "", "authn"); pilotErr == nil {
-				// fmt.Println(debug)
 				var dat []AuthenticationDebug
 				if err := json.Unmarshal([]byte(debug), &dat); err != nil {
 					panic(err)
@@ -66,7 +65,7 @@ func check() *cobra.Command {
 				})
 				w := new(tabwriter.Writer)
 				w.Init(os.Stdout, 0, 0, 4, ' ', 0)
-				fmt.Fprintln(w, "Host\tStatus\tServer\tClient\tAuthN Policy Name/Namespace\tDst Rule Name/Namespace")
+				fmt.Fprintln(w, "Host:Port\tStatus\tServer\tClient\tAuthN Policy Name/Namespace\tDst Rule Name/Namespace")
 				for _, entry := range dat {
 					if entry.Host == "" {
 						continue

--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type AuthenticationDebug struct {
+type authenticationDebug struct {
 	Host                     string
 	Port                     int
 	AuthenticationPolicyName string
@@ -35,14 +35,15 @@ type AuthenticationDebug struct {
 	TLSConflictStatus        string
 }
 
-// can allows user to query Istio RBAC effect for a specific request.
-func check() *cobra.Command {
+func tlsCheck() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tls_check",
 		Short: "Check whether TLS setting are matching between authentication policy and destination rules",
 		Long: `
+Requests Pilot to check for what authentication policy and destination rule it uses for each service in
+service registry, and check if TLS settings are compatible between them.
 `,
-		Example: ``,
+		Example: `istioclt authn tls_check`,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pilots, err := getPilotPods()
@@ -53,7 +54,7 @@ func check() *cobra.Command {
 				return errors.New("unable to find any Pilot instances")
 			}
 			if debug, pilotErr := callPilotDiscoveryDebug(pilots, "", "authn"); pilotErr == nil {
-				var dat []AuthenticationDebug
+				var dat []authenticationDebug
 				if err := json.Unmarshal([]byte(debug), &dat); err != nil {
 					panic(err)
 				}
@@ -92,12 +93,14 @@ func AuthN() *cobra.Command {
 		Use:   "authn",
 		Short: "Interact with Istio authentication policies",
 		Long: `
+A group of commands used to interact with Istio authentication policies.
+  tls_check
 `,
 		Example: `# Check whether TLS setting are matching between authentication policy and destination rules:
 istioctl authn tls_check`,
 	}
 
-	cmd.AddCommand(check())
+	cmd.AddCommand(tlsCheck())
 	return cmd
 }
 

--- a/pilot/cmd/pilot-discovery/debug.go
+++ b/pilot/cmd/pilot-discovery/debug.go
@@ -34,9 +34,10 @@ type debug struct {
 
 var (
 	configTypes = map[string]string{
-		"all": "",
-		"ads": "adsz",
-		"eds": "edsz",
+		"all":   "",
+		"ads":   "adsz",
+		"eds":   "edsz",
+		"authn": "authenticationz",
 	}
 
 	debugCmd = &cobra.Command{

--- a/pilot/cmd/pilot-discovery/debug_test.go
+++ b/pilot/cmd/pilot-discovery/debug_test.go
@@ -38,7 +38,7 @@ func (p *pilotStubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.Lock()
 	proxyID := r.URL.Query().Get("proxyID")
 	switch r.URL.Path {
-	case "/debug/adsz", "/debug/edsz":
+	case "/debug/adsz", "/debug/edsz", "/debug/authenticationz":
 		if proxyID == p.States[0].wantProxyID {
 			w.WriteHeader(p.States[0].StatusCode)
 			_, _ = w.Write([]byte(p.States[0].Response))
@@ -69,12 +69,14 @@ func Test_debug_run(t *testing.T) {
 			pilotStates: []pilotStubState{
 				{StatusCode: 200, Response: "fine", wantProxyID: "proxyID"},
 				{StatusCode: 404, Response: "fine", wantProxyID: "proxyID"},
+				{StatusCode: 404, Response: "fine", wantProxyID: "proxyID"},
 			},
 		},
 		{
 			name: "all configType with all proxyID passes no proxyID",
 			args: []string{"all", "all"},
 			pilotStates: []pilotStubState{
+				{StatusCode: 200, Response: "fine", wantProxyID: ""},
 				{StatusCode: 200, Response: "fine", wantProxyID: ""},
 				{StatusCode: 200, Response: "fine", wantProxyID: ""},
 			},
@@ -91,6 +93,7 @@ func Test_debug_run(t *testing.T) {
 			pilotStates: []pilotStubState{
 				{StatusCode: 200, Response: "fine", wantProxyID: "proxyID"},
 				{StatusCode: 500, Response: "not fine", wantProxyID: "proxyID"},
+				{StatusCode: 200, Response: "fine", wantProxyID: "proxyID"},
 			},
 			wantError: true,
 		},
@@ -133,6 +136,13 @@ func Test_debug_run(t *testing.T) {
 			args:              []string{"proxyID", "eds"},
 			pilotNotReachable: true,
 			wantError:         true,
+		},
+		{
+			name: "authenticationz configType no error with 200",
+			args: []string{"proxyID", "authn"},
+			pilotStates: []pilotStubState{
+				{StatusCode: 200, Response: "fine", wantProxyID: "proxyID"},
+			},
 		},
 		{
 			name:      "invalid configType returns an error",

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -258,10 +258,9 @@ func buildIstioMutualTLS(upstreamServiceAccount []string) *networking.TLSSetting
 	}
 }
 
-func applyTrafficPolicy(cluster *v2.Cluster, policy *networking.TrafficPolicy, port *model.Port) {
-	if policy == nil {
-		return
-	}
+
+// SelectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
+func SelectTrafficPolicyComponents(policy *networking.TrafficPolicy, port *model.Port) (*networking.ConnectionPoolSettings, *networking.OutlierDetection, *networking.LoadBalancerSettings, *networking.TLSSettings) {
 	connectionPool := policy.ConnectionPool
 	outlierDetection := policy.OutlierDetection
 	loadBalancer := policy.LoadBalancer
@@ -291,6 +290,15 @@ func applyTrafficPolicy(cluster *v2.Cluster, policy *networking.TrafficPolicy, p
 			}
 		}
 	}
+	return connectionPool, outlierDetection, loadBalancer, tls
+}
+
+func applyTrafficPolicy(cluster *v2.Cluster, policy *networking.TrafficPolicy, port *model.Port) {
+	if policy == nil {
+		return
+	}
+	connectionPool, outlierDetection, loadBalancer, tls := SelectTrafficPolicyComponents(policy, port)
+
 	applyConnectionPool(cluster, connectionPool)
 	applyOutlierDetection(cluster, outlierDetection)
 	applyLoadBalancer(cluster, loadBalancer)

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -259,7 +259,8 @@ func buildIstioMutualTLS(upstreamServiceAccount []string) *networking.TLSSetting
 }
 
 // SelectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
-func SelectTrafficPolicyComponents(policy *networking.TrafficPolicy, port *model.Port) (*networking.ConnectionPoolSettings, *networking.OutlierDetection, *networking.LoadBalancerSettings, *networking.TLSSettings) {
+func SelectTrafficPolicyComponents(policy *networking.TrafficPolicy, port *model.Port) (
+	*networking.ConnectionPoolSettings, *networking.OutlierDetection, *networking.LoadBalancerSettings, *networking.TLSSettings) {
 	connectionPool := policy.ConnectionPool
 	outlierDetection := policy.OutlierDetection
 	loadBalancer := policy.LoadBalancer

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -258,7 +258,6 @@ func buildIstioMutualTLS(upstreamServiceAccount []string) *networking.TLSSetting
 	}
 }
 
-
 // SelectTrafficPolicyComponents returns the components of TrafficPolicy that should be used for given port.
 func SelectTrafficPolicyComponents(policy *networking.TrafficPolicy, port *model.Port) (*networking.ConnectionPoolSettings, *networking.OutlierDetection, *networking.LoadBalancerSettings, *networking.TLSSettings) {
 	connectionPool := policy.ConnectionPool

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -453,7 +453,7 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 					info.ServerProtocol = "HTTP"
 				}
 			} else {
-				info.AuthenticationPolicyName = "N/A"
+				info.AuthenticationPolicyName = "-"
 				if s.env.Mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
 					serverSideTLS = true
 					info.ServerProtocol = "TLS"
@@ -473,7 +473,7 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 					info.ClientProtocol = "HTTP"
 				}
 			} else {
-				info.DestinationRuleName = "N/A"
+				info.DestinationRuleName = "-"
 				if s.env.Mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
 					clientSideTLS = true
 					info.ClientProtocol = "TLS"

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -28,8 +28,8 @@ import (
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
-	authn_plugin "istio.io/istio/pilot/pkg/networking/plugin/authn"
 	networking_core "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
+	authn_plugin "istio.io/istio/pilot/pkg/networking/plugin/authn"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 )
@@ -405,21 +405,7 @@ func isMTlsOn(mesh *meshconfig.MeshConfig, rule *networking.DestinationRule, por
 	if rule.TrafficPolicy == nil {
 		return false
 	}
-	/*
-	for _, prule := range rule.TrafficPolicy.PortLevelSettings {
-		switch selector := prule.Port.Port.(type) {
-		case *networking.PortSelector_Name:
-			if port.Name == selector.Name {
-				return prule.Tls != nil && prule.Tls.Mode == networking.TLSSettings_ISTIO_MUTUAL
-			}
-		case *networking.PortSelector_Number:
-			if uint32(port.Port) == selector.Number {
-				return prule.Tls != nil && prule.Tls.Mode == networking.TLSSettings_ISTIO_MUTUAL
-			}
-		}
-	}
-	*/
-	_, _, _, tls :=  networking_core.SelectTrafficPolicyComponents(rule.TrafficPolicy, port)
+	_, _, _, tls := networking_core.SelectTrafficPolicyComponents(rule.TrafficPolicy, port)
 
 	return tls != nil && tls.Mode == networking.TLSSettings_ISTIO_MUTUAL
 }

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -29,6 +29,7 @@ import (
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	authn_plugin "istio.io/istio/pilot/pkg/networking/plugin/authn"
+	networking_core "istio.io/istio/pilot/pkg/networking/core/v1alpha3"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 )
@@ -404,6 +405,7 @@ func isMTlsOn(mesh *meshconfig.MeshConfig, rule *networking.DestinationRule, por
 	if rule.TrafficPolicy == nil {
 		return false
 	}
+	/*
 	for _, prule := range rule.TrafficPolicy.PortLevelSettings {
 		switch selector := prule.Port.Port.(type) {
 		case *networking.PortSelector_Name:
@@ -416,8 +418,10 @@ func isMTlsOn(mesh *meshconfig.MeshConfig, rule *networking.DestinationRule, por
 			}
 		}
 	}
+	*/
+	_, _, _, tls :=  networking_core.SelectTrafficPolicyComponents(rule.TrafficPolicy, port)
 
-	return rule.TrafficPolicy.Tls != nil && rule.TrafficPolicy.Tls.Mode == networking.TLSSettings_ISTIO_MUTUAL
+	return tls != nil && tls.Mode == networking.TLSSettings_ISTIO_MUTUAL
 }
 
 // AuthenticationDebug holds debug information for service authentication policy.

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -443,7 +443,9 @@ func mTLSModeToString(useTLS bool) string {
 func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	interestedSvc := req.Form.Get("svc")
+	// This should be svc. However, use proxyID param for now so it can be used with
+	// `pilot-discovery debug` command
+	interestedSvc := req.Form.Get("proxyID")
 
 	fmt.Fprintf(w, "\n[\n")
 	svc, _ := s.env.ServiceDiscovery.Services()


### PR DESCRIPTION
- Add debug/authnenticationz handler to pilot to expose TLS status (`istio-pilot:8080/debug/authenticationz`)
- Add command to istioctl to query pilot and display output in simple text format. 

Example command and output is below

```
$ istioctl authn check -n istio-system
Host:Port                                                        Status      Server    Client    AuthN Policy Name/Namespace           Dst Rule Name/Namespace
a.istio-system.svc.cluster.local:   70                           OK          mTLS       mTLS       -                                     -
d.istio-system.svc.cluster.local:   80                           OK          mTLS       mTLS       d-ports-mtls-enabled/istio-system     d-dr-mtls/istio-system
d.istio-system.svc.cluster.local: 8080                           CONFLICT    HTTP      mTLS       d-ports-mtls-disabled/istio-system    d-dr-mtls/istio-system
d.istio-system.svc.cluster.local: 9090                           OK          mTLS       mTLS       d-ports-mtls-enabled/istio-system     d-dr-mtls/istio-system
```