### PR TITLE
[helm] Don't set prom-bridge address in proxy config if mixer disabled

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -82,8 +82,6 @@ data:
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
     {{- if .Values.mixer.enabled }}
       statsdUdpAddress: istio-statsd-prom-bridge.{{ .Release.Namespace }}:9125
-    {{- else }}
-      statsdUdpAddress: ""
     {{- end }}
     
     {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -80,7 +80,12 @@ data:
       zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
+    {{- if .Values.mixer.enabled }}
       statsdUdpAddress: istio-statsd-prom-bridge.{{ .Release.Namespace }}:9125
+    {{- else }}
+      statsdUdpAddress: ""
+    {{- end }}
+    
     {{- if .Values.global.controlPlaneSecurityEnabled }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.


### PR DESCRIPTION
Helm installation isn't working with `mixer.enabled=false` due to an invalid `statsdUdpAddress` getting injected into the envoy configuration. Example log output from a failing pod's istio-proxy container.

```text
[2018-06-08 03:08:27.085][47][info][config] external/envoy/source/server/configuration_impl.cc:109] loading stats sink configuration
[2018-06-08 03:08:27.085][47][critical][main] external/envoy/source/server/server.cc:77] error initializing configuration '/etc/istio/proxy/envoy-rev0.json': malformed IP address: istio-statsd-prom-bridge.istio-system
[2018-06-08 03:08:27.085][47][info][main] external/envoy/source/server/server.cc:435] exiting
2018-06-08T03:08:27.086609Z	warn	Epoch 0 terminated with an error: exit status 1
2018-06-08T03:08:27.086621Z	warn	Aborted all epochs
2018-06-08T03:08:27.086638Z	info	Epoch 0: set retry delay to 25.6s, budget to 2
2018-06-08T03:08:52.686743Z	info	Reconciling configuration (budget 2)
2018-06-08T03:08:52.686789Z	info	Epoch 0 starting
```