### PR TITLE
A new istioctl flag to choose the context from the kuebconfig

### DIFF
--- a/istioctl/cmd/istioctl/config.go
+++ b/istioctl/cmd/istioctl/config.go
@@ -135,7 +135,7 @@ func createCoreV1Client() (*rest.RESTClient, error) {
 }
 
 func defaultRestConfig() (*rest.Config, error) {
-	config, err := kube.BuildClientConfig(kubeconfig)
+	config, err := kube.BuildClientConfig(kubeconfig, configContext)
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/istioctl/inject.go
+++ b/istioctl/cmd/istioctl/inject.go
@@ -43,7 +43,8 @@ const (
 )
 
 func createInterface(kubeconfig string) (kubernetes.Interface, error) {
-	restConfig, err := kube.BuildClientConfig(kubeconfig)
+	restConfig, err := kube.BuildClientConfig(kubeconfig, configContext)
+
 	if err != nil {
 		return nil, err
 	}

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -62,6 +62,7 @@ var (
 	platform string
 
 	kubeconfig       string
+	configContext    string
 	namespace        string
 	istioNamespace   string
 	istioContext     string
@@ -549,6 +550,9 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "c", "",
 		"Kubernetes configuration file")
 
+	rootCmd.PersistentFlags().StringVar(&configContext, "context", "",
+		"The name of the kubeconfig context to use")
+
 	rootCmd.PersistentFlags().StringVarP(&istioNamespace, "istioNamespace", "i", kube.IstioNamespace,
 		"Istio system namespace")
 
@@ -694,7 +698,7 @@ func printYamlOutput(writer io.Writer, configClient model.ConfigStore, configLis
 
 func newClient() (model.ConfigStore, error) {
 	// TODO: use model.IstioConfigTypes once model.IngressRule is deprecated
-	return crd.NewClient(kubeconfig, model.ConfigDescriptor{
+	return crd.NewClient(kubeconfig, configContext, model.ConfigDescriptor{
 		model.RouteRule,
 		model.VirtualService,
 		model.Gateway,
@@ -735,7 +739,7 @@ func preprocMixerConfig(configs []crd.IstioKind) error {
 }
 
 func restConfig() (config *rest.Config, err error) {
-	config, err = kubecfg.BuildClientConfig(kubeconfig)
+	config, err = kubecfg.BuildClientConfig(kubeconfig, configContext)
 
 	if err != nil {
 		return

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -526,7 +526,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 
 func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCache, error) {
 	kubeCfgFile := s.getKubeCfgFile(args)
-	configClient, err := crd.NewClient(kubeCfgFile, ConfigDescriptor, args.Config.ControllerOptions.DomainSuffix)
+	configClient, err := crd.NewClient(kubeCfgFile, "", ConfigDescriptor, args.Config.ControllerOptions.DomainSuffix)
 	if err != nil {
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -115,8 +115,8 @@ func newClientSet(descriptor model.ConfigDescriptor) (map[string]*restClient, er
 	return cs, nil
 }
 
-func (rc *restClient) init(kubeconfig string) error {
-	cfg, err := rc.createRESTConfig(kubeconfig)
+func (rc *restClient) init(kubeconfig string, context string) error {
+	cfg, err := rc.createRESTConfig(kubeconfig, context)
 	if err != nil {
 		return err
 	}
@@ -132,8 +132,8 @@ func (rc *restClient) init(kubeconfig string) error {
 }
 
 // createRESTConfig for cluster API server, pass empty config file for in-cluster
-func (rc *restClient) createRESTConfig(kubeconfig string) (config *rest.Config, err error) {
-	config, err = kubecfg.BuildClientConfig(kubeconfig)
+func (rc *restClient) createRESTConfig(kubeconfig string, context string) (config *rest.Config, err error) {
+	config, err = kubecfg.BuildClientConfig(kubeconfig, context)
 
 	if err != nil {
 		return nil, err
@@ -161,7 +161,8 @@ func (rc *restClient) createRESTConfig(kubeconfig string) (config *rest.Config, 
 // NewClient creates a client to Kubernetes API using a kubeconfig file.
 // Use an empty value for `kubeconfig` to use the in-cluster config.
 // If the kubeconfig file is empty, defaults to in-cluster config as well.
-func NewClient(config string, descriptor model.ConfigDescriptor, domainSuffix string) (*Client, error) {
+// You can also choose a config context by providing the desired context name.
+func NewClient(config string, context string, descriptor model.ConfigDescriptor, domainSuffix string) (*Client, error) {
 	cs, err := newClientSet(descriptor)
 	if err != nil {
 		return nil, err
@@ -173,7 +174,7 @@ func NewClient(config string, descriptor model.ConfigDescriptor, domainSuffix st
 	}
 
 	for _, v := range out.clientset {
-		if err := v.init(config); err != nil {
+		if err := v.init(config, context); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -22,10 +22,11 @@ import (
 )
 
 // BuildClientConfig is a helper function that builds client config from a kubeconfig filepath.
+// It overrides the current context with the one provided (empty to use default).
 //
 // This is a modified version of k8s.io/client-go/tools/clientcmd/BuildConfigFromFlags with the
 // difference that it loads default configs if not running in-cluster.
-func BuildClientConfig(kubeconfig string) (*rest.Config, error) {
+func BuildClientConfig(kubeconfig string, context string) (*rest.Config, error) {
 	if kubeconfig != "" {
 		info, err := os.Stat(kubeconfig)
 		if err != nil || info.Size() == 0 {
@@ -43,6 +44,6 @@ func BuildClientConfig(kubeconfig string) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	loadingRules.ExplicitPath = kubeconfig
-	configOverrides := &clientcmd.ConfigOverrides{}
+	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: context}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
 }

--- a/tests/e2e/tests/controller/controller_test.go
+++ b/tests/e2e/tests/controller/controller_test.go
@@ -39,7 +39,7 @@ const (
 )
 
 func makeClient(t *testing.T, desc model.ConfigDescriptor) (*crd.Client, error) {
-	cl, err := crd.NewClient("", desc, "")
+	cl, err := crd.NewClient("", "", desc, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added a new `--context string` flag to `istioctl` that would allow users to choose the kubeconfig context they are willing to use.