### PR TITLE
Added a new file to route request between v2 and v3.

### DIFF
--- a/samples/bookinfo/routing/route-rule-reviews-jason-v2-v3.yaml.yaml
+++ b/samples/bookinfo/routing/route-rule-reviews-jason-v2-v3.yaml.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reviews
 spec:
   hosts:
-    - reviews
+  - reviews
   http:
   - match:
     - headers:
@@ -17,4 +17,4 @@ spec:
   - route:
     - destination:
         host: reviews
-        subset: v1
+        subset: v3

--- a/samples/bookinfo/routing/route-rule-reviews-test-v2.yaml
+++ b/samples/bookinfo/routing/route-rule-reviews-test-v2.yaml
@@ -17,4 +17,4 @@ spec:
   - route:
     - destination:
         host: reviews
-        subset: v1
+        subset: v3


### PR DESCRIPTION
Many test cases in doc want to use jason+v2 and v3 reviews, so it is better update this file to support.

Such as 
- https://istio.io/docs/tasks/security/basic-access-control/#before-you-begin
- https://istio.io/docs/tasks/policy-enforcement/rate-limiting/#before-you-begin

/cc @frankbu @rshriram 