### PR TITLE
Ansible playbooks updated to use istio-demo*.yaml instead of istio*.yaml

### DIFF
--- a/install/ansible/istio/tasks/install_on_cluster.yml
+++ b/install/ansible/istio/tasks/install_on_cluster.yml
@@ -1,10 +1,10 @@
 - name: Deploy Istio from kubernetes file
-  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio.yaml"
+  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-demo.yaml"
   when: not istio.auth
   ignore_errors: true
 
 - name: Deploy Istio Auth from kubernetes file
-  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-auth.yaml"
+  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-demo-auth.yaml"
   when: istio.auth
   ignore_errors: true
 

--- a/install/ansible/istio/tasks/set_istio_distro_vars.yml
+++ b/install/ansible/istio/tasks/set_istio_distro_vars.yml
@@ -1,6 +1,6 @@
 - name: Define var containg Istio definition file name
   set_fact:
-    istio_definition_file_name: "{{'istio-auth.yaml' if istio.auth == true else 'istio.yaml'}}"
+    istio_definition_file_name: "{{'istio-demo-auth.yaml' if istio.auth == true else 'istio-demo.yaml'}}"
 
 - name: Define var containg Istio definition file full path
   set_fact:


### PR DESCRIPTION
Istio files are now called `istio-demo.yaml` and `istio-auth-demo.yaml` in released packages.
This is a quick fix for issue: #5985 however, as mentioned there, for future releases we might want to install using helm.