### PR TITLE
Added missing kubeconfig setting in Pilot tests

### DIFF
--- a/tests/e2e/tests/pilot/egressgateway_test.go
+++ b/tests/e2e/tests/pilot/egressgateway_test.go
@@ -44,6 +44,7 @@ func TestEgressGateway(t *testing.T) {
 			"testdata/v1alpha3/egressgateway.yaml",
 			"testdata/v1alpha3/service-entry.yaml",
 			"testdata/v1alpha3/rule-route-via-egressgateway.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/externalservice_test.go
+++ b/tests/e2e/tests/pilot/externalservice_test.go
@@ -97,8 +97,9 @@ func TestServiceEntry(t *testing.T) {
 
 			// Apply the new rule
 			cfgs = &deployableConfig{
-				Namespace: tc.Kube.Namespace,
-				YamlFiles: []string{ruleYaml},
+				Namespace:  tc.Kube.Namespace,
+				YamlFiles:  []string{ruleYaml},
+				kubeconfig: tc.Kube.KubeConfig,
 			}
 			if err := cfgs.Setup(); err != nil {
 				t.Fatal(err)

--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -57,6 +57,7 @@ func TestGateway_HTTPIngress(t *testing.T) {
 			"testdata/v1alpha3/ingressgateway.yaml",
 			maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/destination-rule-c.yaml"),
 			"testdata/v1alpha3/rule-ingressgateway.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)
@@ -90,33 +91,39 @@ func TestIngressGateway503DuringRuleChange(t *testing.T) {
 	gateway := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{"testdata/v1alpha3/ingressgateway.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	// Add subsets
 	newDestRule := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c.yaml")},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	// route to subsets
 	newVirtService := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{"testdata/v1alpha3/rule-503test-virtualservice.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	addMoreSubsets := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-add-subset.yaml")},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	routeToNewSubsets := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{"testdata/v1alpha3/rule-503test-update-virtualservice.yaml"},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	deleteOldSubsets := &deployableConfig{
 		Namespace: tc.Kube.Namespace,
 		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-del-subset.yaml")},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	var resp ClientResponse
@@ -212,6 +219,7 @@ func TestGateway_TCP(t *testing.T) {
 			"testdata/v1alpha3/rule-gateway-a.yaml",
 			"testdata/v1alpha3/gateway-tcp-a.yaml",
 		},
+		kubeconfig: tc.Kube.KubeConfig,
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -89,40 +89,40 @@ func TestIngressGateway503DuringRuleChange(t *testing.T) {
 	ingressGatewayServiceName := tc.Kube.IstioIngressGatewayService()
 
 	gateway := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{"testdata/v1alpha3/ingressgateway.yaml"},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{"testdata/v1alpha3/ingressgateway.yaml"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	// Add subsets
 	newDestRule := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c.yaml")},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c.yaml")},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	// route to subsets
 	newVirtService := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{"testdata/v1alpha3/rule-503test-virtualservice.yaml"},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{"testdata/v1alpha3/rule-503test-virtualservice.yaml"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	addMoreSubsets := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-add-subset.yaml")},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-add-subset.yaml")},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	routeToNewSubsets := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{"testdata/v1alpha3/rule-503test-update-virtualservice.yaml"},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{"testdata/v1alpha3/rule-503test-update-virtualservice.yaml"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 
 	deleteOldSubsets := &deployableConfig{
-		Namespace: tc.Kube.Namespace,
-		YamlFiles: []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-del-subset.yaml")},
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{maybeAddTLSForDestinationRule(tc, "testdata/v1alpha3/rule-503test-destinationrule-c-del-subset.yaml")},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
 


### PR DESCRIPTION
When setting custom `kubeconfig` as an E2E arg the pilot tests fails because this parameter isn't being passed on.