### PR TITLE
Fixes #6108 Updated version checking statements in Ansible scripts

### DIFF
--- a/install/ansible/istio/tasks/main.yml
+++ b/install/ansible/istio/tasks/main.yml
@@ -26,7 +26,7 @@
 
 - assert:
     that:
-      - "vo.stdout >= minimum_cluster_version"
+      - "vo.stdout is version_compare(minimum_cluster_version,'>=')"
     msg: "Cluster version must be at least {{ minimum_cluster_version }}"
 
 - include_tasks: assert_oc_admin.yml


### PR DESCRIPTION
Using version-comparison feature of Ansible to compare the versions.
https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#version-comparison
Verified that it is working on both Ansible 2.4 and Ansible 2.5