### PR TITLE
Make pilot port configuration consistent

### DIFF
--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -182,8 +182,8 @@ function stopIstio() {
 function startPilot() {
   printf "Pilot starting...\n"
   POD_NAME=pilot POD_NAMESPACE=istio-system \
-  ${ISTIO_OUT}/pilot-discovery discovery --port 18080 \
-                                         --monitoringPort 19093 \
+  ${ISTIO_OUT}/pilot-discovery discovery --httpAddr ":18080" \
+                                         --monitoringAddr ":19093" \
                                          --log_target ${LOG_DIR}/pilot.log \
                                          --kubeconfig ${ISTIO_GO}/.circleci/config &
   echo $! > $LOG_DIR/pilot.pid

--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -61,7 +61,7 @@ services:
     ports:
       - "8081:15007"
     command: ["discovery",
-              "--port", "15007",
+              "--httpAddr", ":15007",
               "--registries", "Consul",
               "--consulserverURL", "http://consul:8500",
               "--kubeconfig", "/etc/istio/config/kubeconfig"

--- a/install/eureka/templates/istio.yaml.tmpl
+++ b/install/eureka/templates/istio.yaml.tmpl
@@ -43,7 +43,7 @@ services:
     ports:
       - "8081:15007"
     command: ["discovery",
-             "--port", "15007",
+             "--httpAddr", ":15007",
              "--registries", "Eureka",
              "--eurekaserverURL", "http://eureka:8080",
              "--kubeconfig", "/etc/istio/config/kubeconfig"]

--- a/pilot/pkg/bootstrap/monitoring.go
+++ b/pilot/pkg/bootstrap/monitoring.go
@@ -46,7 +46,7 @@ func addMonitor(mux *http.ServeMux) {
 
 // Deprecated: we shouldn't have 2 http ports. Will be removed after code using
 // this port is removed.
-func startMonitor(port int, mux *http.ServeMux) (*monitor, error) {
+func startMonitor(addr string, mux *http.ServeMux) (*monitor, net.Addr, error) {
 	m := &monitor{
 		shutdown: make(chan struct{}),
 	}
@@ -54,8 +54,8 @@ func startMonitor(port int, mux *http.ServeMux) (*monitor, error) {
 	// get the network stuff setup
 	var listener net.Listener
 	var err error
-	if listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {
-		return nil, fmt.Errorf("unable to listen on socket: %v", err)
+	if listener, err = net.Listen("tcp", addr); err != nil {
+		return nil, nil, fmt.Errorf("unable to listen on socket: %v", err)
 	}
 
 	// NOTE: this is a temporary solution to provide bare-bones debug functionality
@@ -78,7 +78,7 @@ func startMonitor(port int, mux *http.ServeMux) (*monitor, error) {
 	// Serve, the call may be ignored and Serve never returns.
 	<-m.shutdown
 
-	return m, nil
+	return m, listener.Addr(), nil
 }
 
 func (m *monitor) Close() error {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -159,29 +159,27 @@ type PilotArgs struct {
 
 // Server contains the runtime configuration for the Pilot discovery service.
 type Server struct {
-	mesh                    *meshconfig.MeshConfig
-	ServiceController       *aggregate.Controller
-	configController        model.ConfigStoreCache
-	mixerSAN                []string
-	kubeClient              kubernetes.Interface
-	startFuncs              []startFunc
 	HTTPListeningAddr       net.Addr
 	GRPCListeningAddr       net.Addr
 	SecureGRPCListeningAddr net.Addr
-	clusterStore            *clusterregistry.ClusterStore
+	MonitorListeningAddr    net.Addr
 
-	EnvoyXdsServer   *envoyv2.DiscoveryServer
-	HTTPServer       *http.Server
-	GRPCServer       *grpc.Server
+	// TODO(nmittler): Consider alternatives to exposing these directly
+	EnvoyXdsServer    *envoyv2.DiscoveryServer
+	ServiceController *aggregate.Controller
+
+	mesh             *meshconfig.MeshConfig
+	configController model.ConfigStoreCache
+	mixerSAN         []string
+	kubeClient       kubernetes.Interface
+	startFuncs       []startFunc
+	clusterStore     *clusterregistry.ClusterStore
+	httpServer       *http.Server
+	grpcServer       *grpc.Server
 	secureGRPCServer *grpc.Server
-	DiscoveryService *envoy.DiscoveryService
+	discoveryService *envoy.DiscoveryService
 	istioConfigStore model.IstioConfigStore
-
-	// An in-memory service discovery, enabled if 'mock' registry is added.
-	// Currently used for tests.
-	MemoryServiceDiscovery *mock.ServiceDiscovery
-
-	mux *http.ServeMux
+	mux              *http.ServeMux
 }
 
 func createInterface(kubeconfig string) (kubernetes.Interface, error) {
@@ -264,10 +262,11 @@ type startFunc func(stop chan struct{}) error
 // initMonitor initializes the configuration for the pilot monitoring server.
 func (s *Server) initMonitor(args *PilotArgs) error {
 	s.addStartFunc(func(stop chan struct{}) error {
-		monitor, err := startMonitor(args.DiscoveryOptions.MonitoringPort, s.mux)
+		monitor, addr, err := startMonitor(args.DiscoveryOptions.MonitoringAddr, s.mux)
 		if err != nil {
 			return err
 		}
+		s.MonitorListeningAddr = addr
 
 		go func() {
 			<-stop
@@ -601,7 +600,7 @@ func (s *Server) initMultiClusterController(args *PilotArgs) (err error) {
 		err = clusterregistry.StartSecretController(s.kubeClient,
 			s.clusterStore,
 			s.ServiceController,
-			s.DiscoveryService,
+			s.discoveryService,
 			args.Config.ClusterRegistriesNamespace,
 			args.Config.ControllerOptions.ResyncPeriod,
 			args.Config.ControllerOptions.WatchedNamespace,
@@ -727,8 +726,6 @@ func (s *Server) initMemoryRegistry(serviceControllers *aggregate.Controller) {
 		map[model.Hostname]*model.Service{ // mock.HelloService.Hostname: mock.HelloService,
 		}, 2)
 
-	s.MemoryServiceDiscovery = discovery1
-
 	discovery2 := mock.NewDiscovery(
 		map[model.Hostname]*model.Service{ // mock.WorldService.Hostname: mock.WorldService,
 		}, 2)
@@ -782,25 +779,24 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	if err != nil {
 		return fmt.Errorf("failed to create discovery service: %v", err)
 	}
-	s.DiscoveryService = discovery
+	s.discoveryService = discovery
 
-	s.mux = s.DiscoveryService.RestContainer.ServeMux
+	s.mux = s.discoveryService.RestContainer.ServeMux
 
 	// For now we create the gRPC server sourcing data from Pilot's older data model.
 	s.initGrpcServer()
 	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(environment, v1alpha3.NewConfigGenerator(registry.NewPlugins()))
 	// TODO: decouple v2 from the cache invalidation, use direct listeners.
 	envoy.V2ClearCache = s.EnvoyXdsServer.ClearCacheFunc()
-	s.EnvoyXdsServer.Register(s.GRPCServer)
+	s.EnvoyXdsServer.Register(s.grpcServer)
 
 	s.EnvoyXdsServer.InitDebug(s.mux, s.ServiceController)
 
-	s.HTTPServer = &http.Server{
-		Addr:    ":" + strconv.Itoa(args.DiscoveryOptions.Port),
+	s.httpServer = &http.Server{
+		Addr:    args.DiscoveryOptions.HTTPAddr,
 		Handler: discovery.RestContainer}
 
-	addr := s.HTTPServer.Addr
-	listener, err := net.Listen("tcp", addr)
+	listener, err := net.Listen("tcp", args.DiscoveryOptions.HTTPAddr)
 	if err != nil {
 		return err
 	}
@@ -823,12 +819,12 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 		log.Infof("Discovery service started at http=%s grpc=%s", listener.Addr().String(), grpcListener.Addr().String())
 
 		go func() {
-			if err = s.HTTPServer.Serve(listener); err != nil {
+			if err = s.httpServer.Serve(listener); err != nil {
 				log.Warna(err)
 			}
 		}()
 		go func() {
-			if err = s.GRPCServer.Serve(grpcListener); err != nil {
+			if err = s.grpcServer.Serve(grpcListener); err != nil {
 				log.Warna(err)
 			}
 		}()
@@ -840,11 +836,11 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			<-stop
 			model.JwtKeyResolver.Close()
 
-			err = s.HTTPServer.Close()
+			err = s.httpServer.Close()
 			if err != nil {
 				log.Warna(err)
 			}
-			s.GRPCServer.Stop()
+			s.grpcServer.Stop()
 			if s.secureGRPCServer != nil {
 				s.secureGRPCServer.Stop()
 			}
@@ -858,7 +854,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 func (s *Server) initGrpcServer() {
 	grpcOptions := s.grpcServerOptions()
-	s.GRPCServer = grpc.NewServer(grpcOptions...)
+	s.grpcServer = grpc.NewServer(grpcOptions...)
 }
 
 // The secure grpc will start when the credentials are found.

--- a/pilot/pkg/proxy/envoy/v1/discovery.go
+++ b/pilot/pkg/proxy/envoy/v1/discovery.go
@@ -318,10 +318,22 @@ const (
 // DiscoveryServiceOptions contains options for create a new discovery
 // service instance.
 type DiscoveryServiceOptions struct {
-	Port            int
-	GrpcAddr        string
-	SecureGrpcAddr  string
-	MonitoringPort  int
+	// The listening address for HTTP. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
+	// a port number is automatically chosen.
+	HTTPAddr string
+
+	// The listening address for GRPC. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
+	// a port number is automatically chosen.
+	GrpcAddr string
+
+	// The listening address for secure GRPC. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
+	// a port number is automatically chosen.
+	SecureGrpcAddr string
+
+	// The listening address for the monitoring port. If the port in the address is empty or "0" (as in "127.0.0.1:" or "[::1]:0")
+	// a port number is automatically chosen.
+	MonitoringAddr string
+
 	EnableProfiling bool
 	EnableCaching   bool
 	WebhookEndpoint string

--- a/tests/local/cluster_registry_test.go
+++ b/tests/local/cluster_registry_test.go
@@ -196,7 +196,7 @@ func initMulticlusterPilot(IstioSrc string) (*bootstrap.Server, error) {
 	serverAgrs := bootstrap.PilotArgs{
 		Namespace: "istio-system",
 		DiscoveryOptions: envoy.DiscoveryServiceOptions{
-			Port:            18080, // An unused port will be chosen
+			HTTPAddr:        ":18080", // An unused port will be chosen
 			GrpcAddr:        ":0",
 			EnableCaching:   true,
 			EnableProfiling: true,

--- a/tests/local/xds_local_test.go
+++ b/tests/local/xds_local_test.go
@@ -161,7 +161,7 @@ func initLocalPilot(IstioSrc string) (*bootstrap.Server, error) {
 	serverAgrs := bootstrap.PilotArgs{
 		Namespace: "istio-system",
 		DiscoveryOptions: envoy.DiscoveryServiceOptions{
-			Port:            18080, // An unused port will be chosen
+			HTTPAddr:        ":18080", // An unused port will be chosen
 			GrpcAddr:        ":0",
 			EnableCaching:   true,
 			EnableProfiling: true,

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -128,13 +128,13 @@ func setup() error {
 	if len(pilotHTTP) == 0 {
 		pilotHTTP = "0"
 	}
-	pilotHTTPPort, _ := strconv.Atoi(pilotHTTP)
+	httpAddr := ":" + pilotHTTP
 
 	// Create a test pilot discovery service configured to watch the tempDir.
 	args := bootstrap.PilotArgs{
 		Namespace: "testing",
 		DiscoveryOptions: envoy.DiscoveryServiceOptions{
-			Port:            pilotHTTPPort,
+			HTTPAddr:        httpAddr,
 			GrpcAddr:        ":0",
 			SecureGrpcAddr:  ":0",
 			EnableCaching:   true,

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -148,7 +148,7 @@ func startPilot() error {
 	args := bootstrap.PilotArgs{
 		Namespace: "testing",
 		DiscoveryOptions: envoy.DiscoveryServiceOptions{
-			Port:            15007,
+			HTTPAddr:        ":15007",
 			GrpcAddr:        ":15010",
 			SecureGrpcAddr:  ":15011",
 			EnableCaching:   true,


### PR DESCRIPTION
This change attempts to resolve a few things:

- Make it clear (via documentation) that if ports are unspecified,
ports will be dynamically assigned.

- Make the configuration of the HTTP and monitoring ports consistent
with the new GRPC addresses.

- Expose all listening addresses to the user. This is especially useful
if ports were dynamically assigned.

- Lock down the pilot server. Many variables were public that shouldn't be.