### PR TITLE
mixerfilter: client telemetry settings

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/OWNERS
+++ b/pilot/pkg/networking/plugin/mixer/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - kyessenov
+  - douglas-reid
+  - mandarjog

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -67,22 +67,26 @@ func (mixerplugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.Mu
 		return nil
 	}
 
-	env := in.Env
-	node := in.Node
-	proxyInstances := in.ProxyInstances
+	uid := "kubernetes://" + in.Node.ID
+	attrs := attributes{
+		"source.uid":             attrStringValue(uid),
+		"context.reporter.uid":   attrStringValue(uid),
+		"context.reporter.local": attrBoolValue(false),
+	}
 
 	switch in.ListenerType {
 	case plugin.ListenerTypeHTTP:
+		if in.Node.Type == model.Router {
+			return nil
+		}
+		m := buildOutboundHTTPFilter(in.Env.Mesh, attrs, in.Node)
 		for cnum := range mutable.FilterChains {
-			m := buildMixerHTTPFilter(env, node, proxyInstances, true)
-			if m != nil {
-				mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, m)
-			}
+			mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, m)
 		}
 		return nil
 	case plugin.ListenerTypeTCP:
+		m := buildOutboundTCPFilter(in.Env.Mesh, attrs, in.Node)
 		for cnum := range mutable.FilterChains {
-			m := buildOutboundTCPFilter(in.Env.Mesh, in.Node)
 			mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, m)
 		}
 		return nil
@@ -126,22 +130,17 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 	if port != 0 {
 		attrs["destination.port"] = attrIntValue(int64(port))
 	}
-	// TODO(rshriram): labels should be pod labels in the proxy node
-	instances := in.ProxyInstances
-	if len(instances) > 0 {
-		attrs["destination.labels"] = attrMapValue(instances[0].Labels)
-	}
 
 	switch in.ListenerType {
 	case plugin.ListenerTypeHTTP:
+		m := buildInboundHTTPFilter(in.Env.Mesh, in.Node, attrs, in.ProxyInstances)
 		for cnum := range mutable.FilterChains {
-			m := buildInboundHTTPFilter(in.Env.Mesh, in.Node, attrs, in.ProxyInstances)
 			mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, m)
 		}
 		return nil
 	case plugin.ListenerTypeTCP:
+		m := buildInboundTCPFilter(in.Env.Mesh, in.Node, attrs, in.ProxyInstances)
 		for cnum := range mutable.FilterChains {
-			m := buildInboundTCPFilter(in.Env.Mesh, in.Node, attrs, in.ProxyInstances)
 			mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, m)
 		}
 		return nil
@@ -162,6 +161,7 @@ func (mixerplugin) OnInboundCluster(env model.Environment, node model.Proxy, ser
 
 // OnOutboundRouteConfiguration implements the Plugin interface method.
 func (mixerplugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+	// TODO:
 }
 
 // oc := BuildMixerConfig(node, serviceName, dest, proxyInstances, config, mesh.DisablePolicyChecks, false)
@@ -203,7 +203,6 @@ func (mixerplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConf
 
 func buildMixerPerRouteConfig(in *plugin.InputParams, outboundRoute bool, _ /*disableForward*/ bool, destinationService string) *mccpb.ServiceConfig {
 	role := in.Node
-	nodeInstances := in.ProxyInstances
 	disableCheck := in.Env.Mesh.DisablePolicyChecks
 	config := in.Env.IstioConfigStore
 
@@ -219,38 +218,18 @@ func buildMixerPerRouteConfig(in *plugin.InputParams, outboundRoute bool, _ /*di
 		addDestinationServiceAttributes(out.MixerAttributes.Attributes, destinationService, role.Domain)
 	}
 
-	var labels map[string]string
-	// Note: instances are all running on mode.Node named 'role'
-	// So instance labels are the workload / Node labels.
-	if len(nodeInstances) > 0 {
-		labels = nodeInstances[0].Labels
-	}
-
 	if !outboundRoute || role.Type == model.Router {
 		// for outboundRoutes there are no default MixerAttributes except for gateway.
 		// specific MixerAttributes are in per route configuration.
-		v1.AddStandardNodeAttributes(out.MixerAttributes.Attributes, v1.AttrDestinationPrefix, role.IPAddress, role.ID, labels)
+		v1.AddStandardNodeAttributes(out.MixerAttributes.Attributes, v1.AttrDestinationPrefix, role.IPAddress, role.ID, nil)
 	}
 
 	return out
 }
 
-// buildMixerHTTPFilter builds a filter with a v1 mixer config encapsulated as JSON in a proto.Struct for v2 consumption.
-func buildMixerHTTPFilter(env *model.Environment, node *model.Proxy,
-	proxyInstances []*model.ServiceInstance, outbound bool) *http_conn.HttpFilter {
-	mesh := env.Mesh
-	config := env.IstioConfigStore
-
-	c := buildHTTPMixerFilterConfig(mesh, *node, proxyInstances, outbound, config)
-	return &http_conn.HttpFilter{
-		Name:   v1.MixerFilter,
-		Config: util.MessageToStruct(c),
-	}
-}
-
 func buildTransport(mesh *meshconfig.MeshConfig, uid string) *mccpb.TransportConfig {
-	mcs, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
-	mrs, _, _ := net.SplitHostPort(mesh.MixerReportServer)
+	policy, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
+	telemetry, _, _ := net.SplitHostPort(mesh.MixerReportServer)
 
 	port := mixerPortNumber
 	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
@@ -258,14 +237,38 @@ func buildTransport(mesh *meshconfig.MeshConfig, uid string) *mccpb.TransportCon
 	}
 
 	return &mccpb.TransportConfig{
-		CheckCluster:  model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(mcs), port),
-		ReportCluster: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(mrs), port),
+		CheckCluster:  model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(policy), port),
+		ReportCluster: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(telemetry), port),
 		// internal telemetry forwarding
 		AttributesForMixerProxy: &mpb.Attributes{
 			Attributes: attributes{
 				"source.uid": attrStringValue(uid),
 			},
 		},
+	}
+}
+
+func buildOutboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node *model.Proxy) *http_conn.HttpFilter {
+	uid := "kubernetes://" + node.ID
+
+	return &http_conn.HttpFilter{
+		Name: mixer,
+		Config: util.MessageToStruct(&mccpb.HttpClientConfig{
+			MixerAttributes: &mpb.Attributes{Attributes: attrs},
+			ForwardAttributes: &mpb.Attributes{Attributes: attributes{
+				"source.uid": attrStringValue(uid),
+			}},
+			DefaultDestinationService: UnknownDestination,
+			ServiceConfigs: map[string]*mccpb.ServiceConfig{
+				UnknownDestination: {
+					DisableCheckCalls: true, /* TODO: enable client-side checks */
+					MixerAttributes: &mpb.Attributes{Attributes: attributes{
+						"destination.service": attrStringValue(UnknownDestination),
+					}},
+				},
+			},
+			Transport: buildTransport(mesh, uid),
+		}),
 	}
 }
 
@@ -296,20 +299,14 @@ func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, node *model.Proxy, attr
 		}),
 	}
 }
-func buildOutboundTCPFilter(mesh *meshconfig.MeshConfig, node *model.Proxy) listener.Filter {
-	uid := "kubernetes://" + node.ID
+func buildOutboundTCPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node *model.Proxy) listener.Filter {
 	// TODO(rshriram): destination service for TCP outbound requires parsing the struct config
-	attrs := attributes{
-		"source.uid":             attrStringValue(uid),
-		"context.reporter.uid":   attrStringValue(uid),
-		"context.reporter.local": attrBoolValue(false),
-	}
 	return listener.Filter{
 		Name: mixer,
 		Config: util.MessageToStruct(&mccpb.TcpClientConfig{
 			DisableCheckCalls: true, /* TODO: enable client-side checks */
 			MixerAttributes:   &mpb.Attributes{Attributes: attrs},
-			Transport:         buildTransport(mesh, uid),
+			Transport:         buildTransport(mesh, "kubernetes://"+node.ID),
 		}),
 	}
 }
@@ -335,93 +332,6 @@ func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, node *model.Proxy, attrs
 	}
 }
 
-// buildHTTPMixerFilterConfig builds a mixer HTTP filter config. Mixer filter uses outbound configuration by default
-// (forward attributes, but not invoke check calls)  ServiceInstances belong to the Node.
-func buildHTTPMixerFilterConfig(mesh *meshconfig.MeshConfig, role model.Proxy, nodeInstances []*model.ServiceInstance, outboundRoute bool, config model.IstioConfigStore) *mccpb.HttpClientConfig { // nolint: lll
-	mcs, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
-	mrs, _, _ := net.SplitHostPort(mesh.MixerReportServer)
-
-	port := mixerPortNumber
-	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
-		port = mixerMTLSPortNumber
-	}
-
-	// TODO: derive these port types.
-	transport := &mccpb.TransportConfig{
-		CheckCluster:  model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(mcs), port),
-		ReportCluster: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(mrs), port),
-	}
-
-	mxConfig := &mccpb.HttpClientConfig{
-		MixerAttributes: &mpb.Attributes{
-			Attributes: map[string]*mpb.Attributes_AttributeValue{
-				"context.reporter.uid": {
-					Value: &mpb.Attributes_AttributeValue_StringValue{StringValue: "kubernetes://" + role.ID},
-				},
-			},
-		},
-		ServiceConfigs: map[string]*mccpb.ServiceConfig{},
-		Transport:      transport,
-	}
-
-	var labels map[string]string
-	// Note: instances are all running on mode.Node named 'role'
-	// So instance labels are the workload / Node labels.
-	if len(nodeInstances) > 0 {
-		labels = nodeInstances[0].Labels
-		mxConfig.DefaultDestinationService = nodeInstances[0].Service.Hostname.String()
-	}
-
-	if !outboundRoute || role.Type == model.Router {
-		// for outboundRoutes there are no default MixerAttributes except for gateway.
-		// specific MixerAttributes are in per route configuration.
-		v1.AddStandardNodeAttributes(mxConfig.MixerAttributes.Attributes, v1.AttrDestinationPrefix, role.IPAddress, role.ID, labels)
-		mxConfig.MixerAttributes.Attributes["context.reporter.local"] = &mpb.Attributes_AttributeValue{
-			Value: &mpb.Attributes_AttributeValue_BoolValue{BoolValue: true},
-		}
-	}
-
-	if role.Type == model.Sidecar && !outboundRoute {
-		// Don't forward mixer attributes to the app from inbound sidecar routes
-	} else {
-		mxConfig.ForwardAttributes = &mpb.Attributes{
-			Attributes: map[string]*mpb.Attributes_AttributeValue{},
-		}
-		addStandardNodeAttributes(mxConfig.ForwardAttributes.Attributes, v1.AttrSourcePrefix, role.IPAddress, role.ID, labels)
-	}
-
-	// gateway case is special because upstream listeners are considered outbound, however we don't want to
-	// automatically disable policy / report.
-	disablePolicy := (outboundRoute && role.Type != model.Router) || mesh.DisablePolicyChecks
-	disableReport := outboundRoute && role.Type != model.Router
-
-	for _, instance := range nodeInstances {
-		mxConfig.ServiceConfigs[instance.Service.Hostname.String()] =
-			serviceConfig(instance.Service.Hostname.String(), instance, config, disablePolicy, disableReport, role.Domain)
-	}
-
-	return mxConfig
-}
-
-// set ip, uid, and labels attributes
-func addStandardNodeAttributes(attr map[string]*mpb.Attributes_AttributeValue, prefix string, IPAddress string, ID string, labels map[string]string) {
-	if len(IPAddress) > 0 {
-		attr[prefix+".ip"] = &mpb.Attributes_AttributeValue{
-			Value: &mpb.Attributes_AttributeValue_BytesValue{BytesValue: net.ParseIP(IPAddress)},
-		}
-	}
-
-	attr[prefix+".uid"] = attrStringValue("kubernetes://" + ID)
-
-	if len(labels) > 0 {
-		attr[prefix+".labels"] = &mpb.Attributes_AttributeValue{
-			Value: &mpb.Attributes_AttributeValue_StringMapValue{
-				StringMapValue: &mpb.Attributes_StringMap{Entries: labels},
-			},
-		}
-	}
-}
-
 // borrows heavily from v1.ServiceConfig (which this replaces)
 func serviceConfig(serviceHostname string, dest *model.ServiceInstance, config model.IstioConfigStore, disableCheck, disableReport bool, proxyDomain string) *mccpb.ServiceConfig { // nolint: lll
 	sc := &mccpb.ServiceConfig{
@@ -432,14 +342,6 @@ func serviceConfig(serviceHostname string, dest *model.ServiceInstance, config m
 		},
 		DisableCheckCalls:  disableCheck,
 		DisableReportCalls: disableReport,
-	}
-
-	if len(dest.Labels) > 0 {
-		sc.MixerAttributes.Attributes["destination.labels"] = &mpb.Attributes_AttributeValue{
-			Value: &mpb.Attributes_AttributeValue_StringMapValue{
-				StringMapValue: &mpb.Attributes_StringMap{Entries: dest.Labels},
-			},
-		}
 	}
 
 	apiSpecs := config.HTTPAPISpecByDestination(dest)
@@ -497,14 +399,6 @@ func attrIntValue(value int64) *mpb.Attributes_AttributeValue {
 
 func attrIPValue(ip string) *mpb.Attributes_AttributeValue {
 	return &mpb.Attributes_AttributeValue{Value: &mpb.Attributes_AttributeValue_BytesValue{BytesValue: net.ParseIP(ip)}}
-}
-
-func attrMapValue(kv map[string]string) *mpb.Attributes_AttributeValue {
-	return &mpb.Attributes_AttributeValue{
-		Value: &mpb.Attributes_AttributeValue_StringMapValue{
-			StringMapValue: &mpb.Attributes_StringMap{Entries: kv},
-		},
-	}
 }
 
 func attrsCopy(attrs attributes) attributes {


### PR DESCRIPTION
Implements client-side telemetry, to the extent possible due to the well-known limitations of the pilot plugins. This is just upstreaming of the static config template defined by https://github.com/kyessenov/envoymesh/blob/master/envoy.jsonnet. It has been manually validated for awhile.

Missing pieces that require a follow-up:
- remove guessing for inbound destination services (it should not be the first service pointing to the workload, in whatever order is defined by pilot);
- attach correct destination service to the finer grained routes, pending plugin extensions
- attach destination UID to endpoints, pending plugin extensions
- gateway needs representative attributes and telemetry notions (is it a local or a remote reporter, is it a service or not)

Since some, if not all, of the items above are blocked, I suggest we merge the improvement here first.

I also took a pass at cleaning up the code. This is why there is less code, although it does more.

Signed-off-by: Kuat Yessenov <kuat@google.com>