### PR TITLE
pilot: make sure disabling access logging actually work with proxyv2

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -601,11 +601,7 @@ func buildHTTPConnectionManager(mesh *meshconfig.MeshConfig, httpOpts *httpListe
 
 	connectionManager := httpOpts.connectionManager
 	connectionManager.CodecType = http_conn.AUTO
-	connectionManager.AccessLog = []*accesslog.AccessLog{
-		{
-			Config: nil,
-		},
-	}
+	connectionManager.AccessLog = []*accesslog.AccessLog{}
 	connectionManager.HttpFilters = filters
 	connectionManager.StatPrefix = HTTPStatPrefix
 	connectionManager.UseRemoteAddress = &google_protobuf.BoolValue{httpOpts.useRemoteAddress}


### PR DESCRIPTION
Without this change setting AccessLogFile="" makes envoy very unhappy
and istio-ingressgateway reports back with:

envoy.api.v2.Listener rejected:
Error adding/updating listener 0.0.0.0_80: Provided name for static registration lookup was empty

It also makes much more sense to specify 0 access logging filters, when disabled.