### PR TITLE
Toggle proxy's --statsdUdpAddress arg by a global helm flag

### DIFF
--- a/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
@@ -48,8 +48,10 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
+        {{- if .Values.global.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
+        {{- end }}
           - --proxyAdminPort
           - "15000"
         {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.enableStatsd }}
+        {{- if .Values.global.proxy.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.enableStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd }}
           - --statsdUdpAddress
-          - istio-statsd-prom-bridge:9125
+          - {{ .Values.global.proxy.envoyStatsd }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/egressgateway/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.envoyStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd.enabled }}
           - --statsdUdpAddress
-          - {{ .Values.global.proxy.envoyStatsd }}
+          - {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
           - istio-ingress
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.envoyStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd.enabled }}
           - --statsdUdpAddress
-          - {{ .Values.global.proxy.envoyStatsd }}
+          - {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           - istio-ingress
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.enableStatsd }}
+        {{- if .Values.global.proxy.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -45,9 +45,9 @@ spec:
           - istio-ingress
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.enableStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd }}
           - --statsdUdpAddress
-          - istio-statsd-prom-bridge:9125
+          - {{ .Values.global.proxy.envoyStatsd }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -45,8 +45,10 @@ spec:
           - istio-ingress
           - --zipkinAddress
           - zipkin:9411
+        {{- if .Values.global.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
+        {{- end }}
           - --proxyAdminPort
           - "15000"
         {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -48,8 +48,10 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
+        {{- if .Values.global.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
+        {{- end }}
           - --proxyAdminPort
           - "15000"
         {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.enableStatsd }}
+        {{- if .Values.global.proxy.enableStatsd }}
           - --statsdUdpAddress
           - istio-statsd-prom-bridge:9125
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.enableStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd }}
           - --statsdUdpAddress
-          - istio-statsd-prom-bridge:9125
+          - {{ .Values.global.proxy.envoyStatsd }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingressgateway/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
           - {{ .Values.service.name }}
           - --zipkinAddress
           - zipkin:9411
-        {{- if .Values.global.proxy.envoyStatsd }}
+        {{- if .Values.global.proxy.envoyStatsd.enabled }}
           - --statsdUdpAddress
-          - {{ .Values.global.proxy.envoyStatsd }}
+          - {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
         {{- end }}
           - --proxyAdminPort
           - "15000"

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -77,10 +77,11 @@ data:
       proxyAdminPort: 15000
       #
       # Zipkin trace collector
-      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
+      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411    
+      
+    {{- if .Values.global.enableStatsd }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
-    {{- if .Values.mixer.enabled }}
       statsdUdpAddress: istio-statsd-prom-bridge.{{ .Release.Namespace }}:9125
     {{- end }}
     

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -79,10 +79,10 @@ data:
       # Zipkin trace collector
       zipkinAddress: zipkin.{{ .Release.Namespace }}:9411    
 
-    {{- if .Values.global.proxy.envoyStatsd }}
+    {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
-      statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd }}
+      statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
     {{- end }}
     
     {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -78,11 +78,11 @@ data:
       #
       # Zipkin trace collector
       zipkinAddress: zipkin.{{ .Release.Namespace }}:9411    
-      
-    {{- if .Values.global.enableStatsd }}
+
+    {{- if .Values.global.proxy.envoyStatsd }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
-      statsdUdpAddress: istio-statsd-prom-bridge.{{ .Release.Namespace }}:9125
+      statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd }}
     {{- end }}
     
     {{- if .Values.global.controlPlaneSecurityEnabled }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -97,9 +97,11 @@ data:
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
         - --connectTimeout
-        - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}
+        - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}      
+      {{- if .Values.global.enableStatsd }}
         - --statsdUdpAddress
         - {{ "[[ .ProxyConfig.StatsdUdpAddress ]]" }}
+      {{- end }}
         - --proxyAdminPort
         - {{ "[[ .ProxyConfig.ProxyAdminPort ]]" }}
         - --controlPlaneAuthPolicy

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -98,7 +98,7 @@ data:
         - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}      
-      {{- if .Values.global.enableStatsd }}
+      {{- if .Values.global.proxy.enableStatsd }}
         - --statsdUdpAddress
         - {{ "[[ .ProxyConfig.StatsdUdpAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -98,7 +98,7 @@ data:
         - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}      
-      {{- if .Values.global.proxy.enableStatsd }}
+      {{- if .Values.global.proxy.envoyStatsd }}
         - --statsdUdpAddress
         - {{ "[[ .ProxyConfig.StatsdUdpAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -98,7 +98,7 @@ data:
         - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}      
-      {{- if .Values.global.proxy.envoyStatsd }}
+      {{- if .Values.global.proxy.envoyStatsd.enabled }}
         - --statsdUdpAddress
         - {{ "[[ .ProxyConfig.StatsdUdpAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -54,7 +54,7 @@ global:
     # Sets the value of the "--statsdUdpAddress" proxy argument.
     # Can be disabled (e.g. when mixer is not installed) by setting this to empty string or removing it.
     # The default is to use the bridge provided by mixer.
-    envoyStatsd: "istio-statsd-prom-bridge.istio-system:9125"
+    envoyStatsd: "istio-statsd-prom-bridge:9125"
 
   proxy_init:
     image: proxy_init

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -51,9 +51,10 @@ global:
     excludeInboundPorts: ""
     policy: enabled
 
-    # Toggles whether to set the "--statsdUdpAddress" as an argument to the proxy.
-    # This should be false in environments where Mixer isn't installed. Default: true.
-    enableStatsd: true
+    # Sets the value of the "--statsdUdpAddress" proxy argument.
+    # Can be disabled (e.g. when mixer is not installed) by setting this to empty string or removing it.
+    # The default is to use the bridge provided by mixer.
+    envoyStatsd: "istio-statsd-prom-bridge:9125"
 
   proxy_init:
     image: proxy_init

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -51,10 +51,13 @@ global:
     excludeInboundPorts: ""
     policy: enabled
 
-    # Sets the value of the "--statsdUdpAddress" proxy argument.
-    # Can be disabled (e.g. when mixer is not installed) by setting this to empty string or removing it.
-    # The default is to use the bridge provided by mixer.
-    envoyStatsd: "istio-statsd-prom-bridge:9125"
+    # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
+    # would be <host>:<port>).
+    # Can also be disabled (e.g. when Mixer is not installed).
+    envoyStatsd:
+      enabled: true
+      host: istio-statsd-prom-bridge
+      port: 9125
 
   proxy_init:
     image: proxy_init

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -51,6 +51,10 @@ global:
     excludeInboundPorts: ""
     policy: enabled
 
+    # Toggles whether to set the "--statsdUdpAddress" as an argument to the proxy.
+    # This should be false in environments where Mixer isn't installed. Default: true.
+    enableStatsd: true
+
   proxy_init:
     image: proxy_init
 

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -54,7 +54,7 @@ global:
     # Sets the value of the "--statsdUdpAddress" proxy argument.
     # Can be disabled (e.g. when mixer is not installed) by setting this to empty string or removing it.
     # The default is to use the bridge provided by mixer.
-    envoyStatsd: "istio-statsd-prom-bridge:9125"
+    envoyStatsd: "istio-statsd-prom-bridge.istio-system:9125"
 
   proxy_init:
     image: proxy_init


### PR DESCRIPTION
A new global proxy flag is now controlling whether the `--statsdUdpAddress` proxy argument will be provided or not.

This is useful for cases when one would only want a minimal set (e.g. IngressGateway and Pilot as discussed in #1294) without mixer installed which leads to crashes. This has been partially addressed in #6091 because there are other charts (ingress, ingressgatway, egressgateway, sidecar-injector) that included this argument.
_I couldn't find a convenient way to examine values of other chart (`mixer.enabled`) from another chart therefore defined it in globals._

EDIT: Converted the flag into a string value that holds the statsd address following comment by @costinm  https://github.com/istio/istio/pull/6133#issuecomment-396032505