### PR TITLE
Update GCP DM template to add on correct Tracing flag

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -121,8 +121,8 @@ resources:
             ISTIO_OPTIONS=$ISTIO_OPTIONS" --set grafana.enabled=true"
           {% endif %}
 
-          {% if  properties['enableZipkin'] %}
-            ISTIO_OPTIONS=$ISTIO_OPTIONS" --set zipkin.enabled=true "
+          {% if  properties['enableTracing'] %}
+            ISTIO_OPTIONS=$ISTIO_OPTIONS" --set tracing.enabled=true "
           {% endif %}
 
           {% if  properties['enableServiceGraph'] %}

--- a/install/gcp/deployment_manager/istio-cluster.jinja.display
+++ b/install/gcp/deployment_manager/istio-cluster.jinja.display
@@ -100,9 +100,9 @@ input:
       section: MONITORING
       boolean_group: MONITORING_GROUP
 
-    - name: enableZipkin
-      title: Enable Zipkin for tracing
-      tooltip: Enable Zipkin on the cluster
+    - name: enableTracing
+      title: Enable Tracing
+      tooltip: Enable Tracing on the cluster
       section: MONITORING
       boolean_group: MONITORING_GROUP
 

--- a/install/gcp/deployment_manager/istio-cluster.jinja.schema
+++ b/install/gcp/deployment_manager/istio-cluster.jinja.schema
@@ -44,6 +44,8 @@ properties:
     type: string
     description: Install Istio Release version.
     default: 0.8.0
+    enum:
+      - 0.8.0
 
   enableBookInfoSample:
     type: boolean
@@ -70,9 +72,9 @@ properties:
     description: Enable Grafana for metrics/logs
     default: true
 
-  enableZipkin:
+  enableTracing:
     type: boolean
-    description: Enable Zipkin for metrics/logs
+    description: Enable Tracing
     default: true
 
   enableServiceGraph:

--- a/install/gcp/deployment_manager/istio-cluster.yaml
+++ b/install/gcp/deployment_manager/istio-cluster.yaml
@@ -11,10 +11,10 @@ resources:
     initialNodeCount: 4
     instanceType: n1-standard-2
     enableAutomaticSidecarInjection: true
-    enableMutualTLS: false
+    enableMutualTLS: true
     enablePrometheus: true
     enableGrafana: true
-    enableZipkin: true
+    enableTracing: true
     enableServiceGraph: true
     enableBookInfoSample: true
     installIstioRelease: 0.8.0


### PR DESCRIPTION
* Existing GCP Template didn't use the ```0.8``` helm tracing flag.
* Also update the template UI with the specific release number without allowing overrides.
