### PR TITLE
fix one namespace issue for chart.

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
           - "discovery"
-{{- if $.Values.global.oneNamespace }}
+{{- if .Values.global.istiotesting.oneNameSpace }}
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
           - "discovery"
-{{- if .Values.global.istiotesting.oneNameSpace }}
+{{- if .Values.global.oneNamespace }}
           - "-a"
           - {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -99,6 +99,10 @@ global:
     s390x: 2
     ppc64le: 2
 
+  # Whether to restrict the applications namespace the controller manages;
+  # If not set, controller watches all namespaces
+  oneNamespace: false
+
 # Any customization for istio testing should be here
 istiotesting:
   oneNameSpace: false


### PR DESCRIPTION
We have exposed a `oneNamespace` parameter in [values.yaml](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/values.yaml#L102-L104)
to restrict the applications namespace the controller manages; if not set, controller watches all namespaces, but we haven't get the right parameter in template file.