### PR TITLE
Remove security enablement flag

### DIFF
--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -85,7 +85,6 @@ Helm charts expose configuration options which are currently in alpha.  The curr
 | `galley.enabled` | Specifies whether Galley should be installed for server-side config validation | true/false | `true` |
 | `mixer.enabled` | Specifies whether Mixer should be installed | true/false | `true` |
 | `pilot.enabled` | Specifies whether Pilot should be installed | true/false | `true` |
-| `security.enabled` | Specifies whether Citadel should be installed | true/false | `true` |
 | `grafana.enabled` | Specifies whether Grafana addon should be installed | true/false | `false` |
 | `prometheus.enabled` | Specifies whether Prometheus addon should be installed | true/false | `true` |
 | `servicegraph.enabled` | Specifies whether Servicegraph addon should be installed | true/false | `false` |

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -6,7 +6,6 @@ dependencies:
   - name: security
     version: 0.8.0
     # repository: file://../security
-    condition: security.enabled
   - name: ingress
     version: 0.8.0
     # repository: file://../ingress

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -287,7 +287,6 @@ pilot:
 # security configuration
 #
 security:
-  enabled: true
   serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: citadel


### PR DESCRIPTION
A miniature change meant to avoid confusion by users.

Turning this `enabled` flag to `false` won't install Istio-Citadel which is required by several components. The istio-citadel generates the secrets to be used by the envoy and without those the envoy (withing Pilot and others) would crash.
Therefore, as of today, Pilot simply can't run without Citadel therefore no reason to allow users to disable this.

It also get rid of the confusion with the `controlPlaneSecurityEnabled` flag.