### PR TITLE
Correct mixer-codegen param name

### DIFF
--- a/bin/mixer_codegen.sh
+++ b/bin/mixer_codegen.sh
@@ -180,7 +180,7 @@ if [ "$opttemplate" = true ]; then
     die "template generation failure: $err";
   fi
 
-  go run $GOPATH/src/istio.io/istio/mixer/tools/mixgen/main.go api -t $templateDS --out_go $templateHG --out_proto $templateHSP $TMPL_GEN_MAP
+  go run $GOPATH/src/istio.io/istio/mixer/tools/mixgen/main.go api -t $templateDS --go_out $templateHG --proto_out $templateHSP $TMPL_GEN_MAP
 
   err=`$protoc $IMPORTS $TMPL_PLUGIN $templateHSP`
   if [ ! -z "$err" ]; then


### PR DESCRIPTION
This fails mixer codegen. I guess out_go and out_proto should be go_out and proto_out?