### PR TITLE
A job hook to cleanup remnant secrets from the release namespace

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -93,8 +93,9 @@ spec:
           - /bin/bash
           - -c
           - >
-              NS="{{ .Release.Namespace }}";
-              for resource in $(kubectl get secret -n $NS | grep "istio.io/key-and-cert" | awk 'NR>0{print $1}'); do
-                kubectl delete secret $resource -n $NS;
+              kubectl get secret --all-namespaces | grep "istio.io/key-and-cert" |  while read -r entry; do
+                ns=$(echo $entry | awk '{print $1}');
+                name=$(echo $entry | awk '{print $2}');
+                kubectl delete secret $name -n $ns;
               done
       restartPolicy: Never

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -1,4 +1,4 @@
-# The reason for creating a ServiceAccount nd ClusterRole specifically for this
+# The reason for creating a ServiceAccount and ClusterRole specifically for this
 # post-delete hooked job is because the citadel ServiceAccount is being deleted
 # before this hook is launched. On the other hand, running this hook before the
 # deletion of the citadel (e.g. pre-delete) won't delete the secrets because they

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -1,0 +1,100 @@
+# The reason for creating a ServiceAccount nd ClusterRole specifically for this
+# post-delete hooked job is because the citadel ServiceAccount is being deleted
+# before this hook is launched. On the other hand, running this hook before the
+# deletion of the citadel (e.g. pre-delete) won't delete the secrets because they
+# will be re-created immediately by the to-be-deleted citadel.
+#
+# It's also important that the ServiceAccount, ClusterRole and ClusterRoleBinding
+# will be ready before running the hooked Job therefore the hook weights.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-cleanup-secrets-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-cleanup-secrets-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-cleanup-secrets-{{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "2"
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-cleanup-secrets-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-cleanup-secrets-service-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-cleanup-secrets
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
+  labels:
+    app: {{ template "security.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-cleanup-secrets
+      labels:
+        app: {{ template "security.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-cleanup-secrets-service-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          command:
+          - /bin/bash
+          - -c
+          - >
+              NS="{{ .Release.Namespace }}";
+              for resource in $(kubectl get secret -n $NS | grep "istio.io/key-and-cert" | awk 'NR>0{print $1}'); do
+                kubectl delete secret $resource -n $NS;
+              done
+      restartPolicy: Never


### PR DESCRIPTION
An addition to the effort (#5380) to clean-up remnants that were left behind by Istio.

This `post-delete` hook for the Citadel will clean up secrets that were generated by Citadel and aren't being monitored by Helm because they are programatically generated.

Without this hook the secrets are left there even after running a `helm delete istio --purge` command.