### PR TITLE
Remove duplicated resources declaration for proxy

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -18,7 +18,7 @@ global:
     image: proxyv2
     resources:
       requests:
-        cpu: 500m
+        cpu: 100m
         memory: 128Mi
       # limits:
       #   cpu: 100m

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -20,19 +20,15 @@ global:
       requests:
         cpu: 500m
         memory: 128Mi
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
 
     # istio-sidecar-injector configmap stores configuration for sidecar injection.
     # This config map is used by istioctl kube-inject and the injector webhook.
     enableCoreDump: false
     serviceAccountName: default # used only if RBAC is not enabled
     replicaCount: 1
-    resources:
-      requests:
-        cpu: 100m
-        memory: 128Mi
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
 
     # istio egress capture whitelist
     # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly


### PR DESCRIPTION
The resources limit for proxy is declared twice therefore removing those that were added by @mandarjog in #5722.

I left the `100m` mainly because I didn't want to update all golden testdata when it wasn't actually intended to be `500m`.
@costinm, I am assuming you had a reason to raise the requested cpu to `500m` in #5794 ?
If you think it should indeed be `500m` (or other value) please let me know and I will update the testdata.