### PR TITLE
[Ansible Installer] Fixing the ansible installer for previous version to 0.8.0

### DIFF
--- a/install/ansible/istio/tasks/install_on_cluster.yml
+++ b/install/ansible/istio/tasks/install_on_cluster.yml
@@ -1,13 +1,6 @@
 - name: Deploy Istio from kubernetes file
-  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-demo.yaml"
-  when: not istio.auth
-  ignore_errors: true
-
-- name: Deploy Istio Auth from kubernetes file
-  shell: "{{ cmd_path }} create -f {{ istio_dir }}/install/kubernetes/istio-demo-auth.yaml"
-  when: istio.auth
+  shell: "{{ cmd_path }} create -f {{ istio_definition_full_path }}"
   ignore_errors: true
 
 - name: Deploy Addons defined such as Grafana, ...
   import_tasks: install_addons.yml
-

--- a/install/ansible/istio/tasks/set_istio_distro_vars.yml
+++ b/install/ansible/istio/tasks/set_istio_distro_vars.yml
@@ -1,6 +1,14 @@
-- name: Define var containg Istio definition file name
+- name: Define var containg Istio definition file name for Istio 0.8.0+
   set_fact:
     istio_definition_file_name: "{{'istio-demo-auth.yaml' if istio.auth == true else 'istio-demo.yaml'}}"
+  when: "istio_version_to_use is version('0.8.0', '>=')"
+
+- name: Define var containg Istio definition file name for Istio 0.8.0-
+  set_fact:
+    istio_definition_file_name: "{{'istio-auth.yaml' if istio.auth == true else 'istio.yaml'}}"
+  when: "istio_version_to_use is version('0.8.0', '<')"
+
+
 
 - name: Define var containg Istio definition file full path
   set_fact:


### PR DESCRIPTION
This PR fixes #6190.

When you try to use `istio.release_tag_version=0.7.1`, the ansible installer fails because the files were renamed `istio-demo`.

cc @gyliu513 @ymesika 

Best Regards,
Guilherme Baufaker Rêgo