### PR TITLE
[Ansible Installer] Kiali Addon 0.3.1.Alpha and Fixing the curl commands to specific version 

### DIFF
--- a/install/ansible/istio/tasks/install_addons.yml
+++ b/install/ansible/istio/tasks/install_addons.yml
@@ -24,8 +24,8 @@
 
 - name: Install Kiali on Openshift
   shell: |
-    curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=master envsubst | {{ cmd_path }} create -n istio-system -f -
-    curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/openshift/kiali.yaml | IMAGE_NAME=kiali/kiali IMAGE_VERSION=0.3.0.Alpha NAMESPACE=istio-system VERSION_LABEL=master VERBOSE_MODE=4 envsubst | {{ cmd_path }} create -n istio-system -f -
+    curl https://raw.githubusercontent.com/kiali/kiali/0.3.1.Alpha/deploy/openshift/kiali-configmap.yaml | VERSION_LABEL=0.3.1.Alpha envsubst | {{ cmd_path }} create -n istio-system -f -
+    curl https://raw.githubusercontent.com/kiali/kiali/0.3.1.Alpha/deploy/openshift/kiali.yaml | IMAGE_NAME=kiali/kiali IMAGE_VERSION=0.3.1.Alpha NAMESPACE=istio-system VERSION_LABEL=master VERBOSE_MODE=4 envsubst | {{ cmd_path }} create -n istio-system -f -
   when:
     - is_istioaddon_iterable
     - "'kiali' in istio.addon"
@@ -33,8 +33,8 @@
 
 - name: Install Kiali on Kubernetes
   shell: |
-   curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=master envsubst | {{ cmd_path }} create -n istio-system -f -
-   curl https://raw.githubusercontent.com/kiali/kiali/master/deploy/kubernetes/kiali.yaml | IMAGE_NAME=kiali/kiali IMAGE_VERSION=0.3.0.Alpha NAMESPACE=istio-system VERSION_LABEL=master  VERBOSE_MODE=4 envsubst | {{ cmd_path }} create -n istio-system -f -
+   curl https://raw.githubusercontent.com/kiali/kiali/0.3.1.Alpha/deploy/kubernetes/kiali-configmap.yaml | VERSION_LABEL=0.3.1.Alpha envsubst | {{ cmd_path }} create -n istio-system -f -
+   curl https://raw.githubusercontent.com/kiali/kiali/0.3.1.Alpha/deploy/kubernetes/kiali.yaml | IMAGE_NAME=kiali/kiali IMAGE_VERSION=0.3.1.Alpha NAMESPACE=istio-system VERSION_LABEL=master  VERBOSE_MODE=4 envsubst | {{ cmd_path }} create -n istio-system -f -
   when:
     - is_istioaddon_iterable
     - "'kiali' in istio.addon"


### PR DESCRIPTION
Fixing the curl commands to a specific version. On the merged, it was master and it would create a situation that master configmap or deployment could be different than a specific version.

Also taking this opportunity to update with new kiali release. 

cc @gyliu513 @jmazzitelli @ymesika 

Best Regards, 
Guilherme Baufaker Rêgo