### PR TITLE
Update dash tests to use ingressgateway

### DIFF
--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -147,7 +147,7 @@ func sendTrafficToCluster(gateway string) (*fhttp.HTTPRunnerResults, error) {
 			Out:        os.Stderr,
 		},
 		HTTPOptions: fhttp.HTTPOptions{
-			URL: gateway + "/fortio/?status=404:10,503:15&size=1024:10,512:5",
+			URL: gateway + "/?status=404:10,503:15&size=1024:10,512:5",
 		},
 		AllowInitialErrors: true,
 	}
@@ -327,7 +327,7 @@ func (t *testConfig) Setup() (err error) {
 		return fmt.Errorf("mixer's proxy never was ready to serve traffic: %v", err)
 	}
 
-	gateway, errGw := tc.Kube.Ingress()
+	gateway, errGw := tc.Kube.IngressGateway()
 	if errGw != nil {
 		return errGw
 	}

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -147,7 +147,7 @@ func sendTrafficToCluster(gateway string) (*fhttp.HTTPRunnerResults, error) {
 			Out:        os.Stderr,
 		},
 		HTTPOptions: fhttp.HTTPOptions{
-			URL: gateway + "/?status=404:10,503:15&size=1024:10,512:5",
+			URL: gateway + "/?status=418:10,520:15&size=1024:10,512:5",
 		},
 		AllowInitialErrors: true,
 	}

--- a/tests/e2e/tests/dashboard/fortio-rules.yaml
+++ b/tests/e2e/tests/dashboard/fortio-rules.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: fortio-gateway
+  name: fortiogateway
 spec:
   selector:
     istio: ingressgateway
@@ -22,7 +22,8 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - echosrv
+    - "*"
+
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -30,18 +31,16 @@ metadata:
   name: fortio
 spec:
   hosts:
-  - echosrv
+  - "*"
   gateways:
-  - fortio-gateway
+  - fortiogateway
   http:
-  - match
-    - uri:
-        prefix: /
-    route:
+  - route:
     - destination:
         port:
           number: 8080
         host: echosrv
+
 ---
 apiVersion: apps/v1beta1
 kind: Deployment

--- a/tests/e2e/tests/dashboard/fortio-rules.yaml
+++ b/tests/e2e/tests/dashboard/fortio-rules.yaml
@@ -9,39 +9,39 @@ spec:
   selector:
     app: echosrv
 ---
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: istio
-  name: istio-ingress
+  name: fortio-gateway
 spec:
-  rules:
-    - http:
-        paths:
-          - path: /fortio/.*
-            backend:
-              serviceName: echosrv
-              servicePort: http-echo
-          - path: /tcp/.*
-            backend:
-              serviceName: tcpechosrv
-              servicePort: tcp-echo
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - echosrv
 ---
-apiVersion: config.istio.io/v1alpha2
-kind: RouteRule
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
 metadata:
-  name: fortio-redir
+  name: fortio
 spec:
-    destination:
-      name: echosrv
-    match:
-        request:
-          headers:
-            uri:
-              prefix: /fortio/ # prefix
-    rewrite:
-        uri: /  # drop the /fortio prefix when talking to fortio such as /fortio/foo -> /foo
+  hosts:
+  - echosrv
+  gateways:
+  - fortio-gateway
+  http:
+  - match
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        port:
+          number: 8080
+        host: echosrv
 ---
 apiVersion: apps/v1beta1
 kind: Deployment


### PR DESCRIPTION
The dashboard e2e tests were never updated to use ingressgateway. This
PR is an attempt to "modernize" the network config for those tests.

Fixes: https://github.com/istio/istio/issues/6164