### PR TITLE
[WIP] Add gateway and VirtualServices for istio services

### DIFF
--- a/install/kubernetes/istio-gateway.yaml
+++ b/install/kubernetes/istio-gateway.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: istio-gateway
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 15007
+      name: pilot-http-discovery
+      protocol: TCP
+    hosts:
+    - "*"
+  - port:
+      number: 15010
+      name: pilot-grpc-xds
+      protocol: TCP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: pilot-http-discovery
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - istio-gateway
+  tcp:
+  - match:
+    - port: 15007
+    route:
+    - destination:
+        host: istio-pilot.istio-system.svc.cluster.local
+        port:
+          number: 15007
+---
+kind: VirtualService
+metadata:
+  name: pilot-grpc-xds
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - istio-gateway
+  tcp:
+  - match:
+    - port: 15010
+    route:
+    - destination:
+        host: istio-pilot.istio-system.svc.cluster.local
+        port:
+          number: 15010


### PR DESCRIPTION
See  issue #4822 and issue #5535 

pilot pod restart would cause pilot's endpoint IPs to be changed. Therefore, using pilot's endpoint IPs in the remote cluster to access to pilot is not appropriate for a sound/production deployment of istio in multiple cluster environment, and should be avoided. This is a deployment issue, and there are many ways to address the problem depending on the environment and load balancer used. For example, with k8s, using a load balancer type for the pilot service and expose the load balancer IP to the remote cluster will work just fine.

Since a remote sidecar requires access to multiple istio services (pilot, policy, telemetry, stats), each of the service would have to be exposed with a load balancer IP, which results in a few balancer IPs that are needed. Using LB IPs might come with a cost or be restricted by quota in certain environments. Through discussions in the istio-dev alias, it seems to be desirable to use a single LB IP to access all the istio services required. One way to achieve that is to use a istio Gateway, which seems to be favored by the community.

This PR gives the initial attempt to come up with a gateway manifest. Due to a bug, it will not work in 0.8.0 yet. It'll work with master branch due to the fix (PR #6042).

A few caveats:
  - the ingress gateway should expose the same ports as the istio services that's being proxied by the gateway. This is important so that remote sidecars use the same configuration.
  - Initially, I just added a couple of pilot's ports (15010 for grpc, 15007 for http-discovery, which doesn't seem to be needed). 
  -  some istio services use UDP (such as stats). UDP proxy is not supported yet. Therefore, it may not be a complete solution until UDP proxy is added in the istio gateway resource.
  - mTLS support is not added
  - I placed the file in install/kubernetes. whether or not it should be/can be integrated in the helm install needs to be discussed.

The manifest can be applied on the primary cluster as 
``` istioctl apply -f istio-gateway.yaml```

if a load balancer ip is available for the ingress gateway in your environment, then use the load balancer IP as pilot's endpoint IP. Otherwise, if pod-to-pod network exists, the endpoint IP of the ingress gateway may be used for a quick run.

Note that this is a work in progress PR. We need to figure out/discuss what services/ports should be exposed by the Gateway, and have this manifest fully populated. So please comment.