### PR TITLE
[WIP]fix service account issues.

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "security.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "security.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -53,7 +53,6 @@ global:
 # security configuration
 #
 security:
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: citadel
   resources: {}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -16,9 +16,7 @@ spec:
       labels:
         istio: galley
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-galley-service-account
-{{- end }}
       containers:
         - name: validator
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/galley/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -18,9 +18,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-ingress-service-account
-{{- end }}
       containers:
         - name: {{ template "istio.name" . }}
           image: "{{ .Values.global.hub }}/proxy:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/ingress/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       labels:
         app: kiali
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: kiali-service-account
-{{ end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: kiali

--- a/install/kubernetes/helm/istio/charts/kiali/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "mixer.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "mixer.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -1,8 +1,6 @@
 {{- define "policy_container" }}
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-mixer-service-account
-{{- end }}
       volumes:
       - name: istio-certs
         secret:
@@ -77,9 +75,7 @@
 
 {{- define "telemetry_container" }}
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-mixer-service-account
-{{- end }}
       volumes:
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -13,9 +14,6 @@ roleRef:
   name: istio-pilot-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-pilot-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -21,9 +21,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-pilot-service-account
-{{- end }}
       containers:
         - name: discovery
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
@@ -123,10 +121,6 @@ spec:
           name: istio
       - name: istio-certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-pilot-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -21,9 +21,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: prometheus
-{{ end }}
       containers:
         - name: prometheus
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -10,4 +9,3 @@ imagePullSecrets:
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "security.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "security.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -13,11 +14,7 @@ roleRef:
   name: istio-citadel-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-citadel-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
 
 {{- if $.Values.cleanUpOldCA }}
@@ -38,10 +35,7 @@ roleRef:
   name: istio-cleanup-old-ca-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-cleanup-old-ca-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-citadel-service-account
-{{- end }}
       containers:
         - name: citadel
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -34,5 +33,4 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -13,9 +14,6 @@ roleRef:
   name: istio-sidecar-injector-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-sidecar-injector-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -16,9 +16,7 @@ spec:
       labels:
         istio: sidecar-injector
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-sidecar-injector-service-account
-{{- end }}
       containers:
         - name: sidecar-injector-webhook
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
@@ -67,11 +65,7 @@ spec:
           name: istio
       - name: certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-sidecar-injector-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
       - name: inject-config
         configMap:
           name: istio-sidecar-injector

--- a/install/kubernetes/helm/istio/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/templates/_helpers.tpl
@@ -16,17 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Service account name.
-*/}}
-{{- define "istio.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "istio.fullname" . -}}
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create a fully qualified configmap name.
 */}}
 {{- define "istio.configmap.fullname" -}}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -24,7 +24,6 @@ global:
     # istio-sidecar-injector configmap stores configuration for sidecar injection.
     # This config map is used by istioctl kube-inject and the injector webhook.
     enableCoreDump: false
-    serviceAccountName: default # used only if RBAC is not enabled
     replicaCount: 1
     resources:
       requests:
@@ -114,7 +113,6 @@ istiotesting:
 #
 ingress:
   enabled: true
-  serviceAccountName: default
   replicaCount: 1
   autoscaleMin: 1
   autoscaleMax: 1
@@ -241,7 +239,6 @@ sidecarInjectorWebhook:
 #
 galley:
   enabled: true
-  serviceAccountName: default
   replicaCount: 1
   image: galley
   resources: {}
@@ -257,7 +254,6 @@ galley:
 #
 mixer:
   enabled: true
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: mixer
   resources: {}
@@ -278,7 +274,6 @@ mixer:
 #
 pilot:
   enabled: true
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: pilot
   resources: {}
@@ -293,7 +288,6 @@ pilot:
 # security configuration
 #
 security:
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: citadel
   resources: {}


### PR DESCRIPTION
There are some inconsistent conditions for `serviceaccount` templates, which in certain situation will result in failure, for example:

The chart will create serviceaccount `istio-galley-service-account` for `galley` if `rbac` is enabled: https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/galley/templates/serviceaccount.yaml

But the `galley` deployment will always mount the secret `istio.istio-galley-service-account` for the serviceaccount: https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml#L66

And the `default` serviceaccount is defined in `values.yaml` many times, but they aren't actually used. 

