### PR TITLE
Return a cacheable OK result when a Check request doesn't hit an adapter at runtime.

### DIFF
--- a/mixer/pkg/runtime/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher_test.go
@@ -82,7 +82,8 @@ var tests = []struct {
 			data.InstanceCheck1,
 			data.RuleCheck1,
 		},
-		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		variety:             tpb.TEMPLATE_VARIETY_CHECK,
+		expectedCheckResult: adapter.CheckResult{ValidDuration: 123 * time.Second, ValidUseCount: 123},
 		log: `
 [tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
 ident                         : dest.istio-system
@@ -235,7 +236,7 @@ ident                         : dest.istio-system
 			"attr.string": "bar",
 			"ident":       "dest.istio-system",
 		},
-		expectedCheckResult: adapter.CheckResult{},
+		expectedCheckResult: adapter.CheckResult{ValidDuration: 123 * time.Second, ValidUseCount: 123},
 		log: `
 [tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
 attr.string                   : bar
@@ -638,8 +639,9 @@ ident                         : dest.istio-system
 			"ident":            "dest.istio-system",
 			"destination.name": "barf", // "foo*" is expected
 		},
-		variety: tpb.TEMPLATE_VARIETY_CHECK,
-		log:     ``, // log should be empty
+		variety:             tpb.TEMPLATE_VARIETY_CHECK,
+		expectedCheckResult: adapter.CheckResult{ValidDuration: defaultValidDuration, ValidUseCount: defaultValidUseCount},
+		log:                 ``, // log should be empty
 	},
 
 	{
@@ -653,6 +655,7 @@ ident                         : dest.istio-system
 			Name: "tcheck", ErrorAtCreateInstance: true,
 		}},
 		variety: tpb.TEMPLATE_VARIETY_CHECK,
+		err:     "error at create instance",
 		log: `
 [tcheck] InstanceBuilderFn() => name: 'tcheck', bag: '---
 ident                         : dest.istio-system

--- a/mixer/pkg/runtime/dispatcher/session.go
+++ b/mixer/pkg/runtime/dispatcher/session.go
@@ -220,14 +220,13 @@ func (s *session) waitForDispatched() {
 	var buf *bytes.Buffer
 	code := rpc.OK
 
-	var err error
 	for s.activeDispatches > 0 {
 		state := <-s.completed
 		s.activeDispatches--
 
 		// Aggregate errors
 		if state.err != nil {
-			err = multierror.Append(err, state.err)
+			s.err = multierror.Append(s.err, state.err)
 		}
 
 		st := rpc.Status{Code: int32(rpc.OK)}
@@ -280,7 +279,6 @@ func (s *session) waitForDispatched() {
 
 		s.impl.putDispatchState(state)
 	}
-	s.err = err
 
 	if buf != nil {
 		switch s.variety {

--- a/mixer/pkg/runtime/testing/data/templates.go
+++ b/mixer/pkg/runtime/testing/data/templates.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -111,7 +112,10 @@ func createFakeTemplate(name string, s FakeTemplateSettings, l *Logger, variety 
 				return adapter.CheckResult{}, errors.New("error at dispatch check, as expected")
 			}
 
-			result := adapter.CheckResult{}
+			result := adapter.CheckResult{
+				ValidUseCount: 123,
+				ValidDuration: 123 * time.Second,
+			}
 			if callCount < len(s.CheckResults) {
 				result = s.CheckResults[callCount]
 			}


### PR DESCRIPTION
- When no adapter is configured for a particular call to Check, Mixer now returns a
ValidUseCount of 10000 and a ValidDuration of 1 minute. This allows the proxy to cache
in this case.

- We were losing error during instance creation. They were being overwritten in some situations
by later error codes. They are now plumbed through the whole way.