### PR TITLE
Patch MixerReportToMixer test to reflect source.service removal

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -933,9 +933,9 @@ func TestMixerReportingToMixer(t *testing.T) {
 		t.Fatalf("Expected ValVector from prometheus, got %T", value)
 	}
 
-	if vec := value.(model.Vector); len(vec) < 2 {
+	if vec := value.(model.Vector); len(vec) < 1 {
 		t.Logf("Values for istio_request_count:\n%s", promDump(promAPI, "istio_request_count"))
-		t.Errorf("Expected at least two metrics with 'istio-policy' as the destination (srcs: istio-ingress, productpage), got %d", len(vec))
+		t.Errorf("Expected at least one metric with 'istio-policy' as the destination, got %d", len(vec))
 	}
 
 	t.Logf("Validating metrics with 'istio-telemetry' have been generated... ")
@@ -950,9 +950,9 @@ func TestMixerReportingToMixer(t *testing.T) {
 		t.Fatalf("Expected ValVector from prometheus, got %T", value)
 	}
 
-	if vec := value.(model.Vector); len(vec) < 2 {
+	if vec := value.(model.Vector); len(vec) < 1 {
 		t.Logf("Values for istio_request_count:\n%s", promDump(promAPI, "istio_request_count"))
-		t.Errorf("Expected at least two metrics with 'istio-telemetry' as the destination (srcs: istio-ingress, productpage), got %d", len(vec))
+		t.Errorf("Expected at least one metric with 'istio-telemetry' as the destination, got %d", len(vec))
 	}
 
 	mixerPod, err := podID("istio-mixer-type=telemetry")


### PR DESCRIPTION
This PR updates the error conditions being checked for the `TestMixerReportingToMixer` test
(part of the `e2e_mixer` suite). This reflects the move away from `source_service` labeling
on metrics and within the attributes. A follow-on PR will be needed when `source_workload`
labels are added / available.

Fixes part of #6247.

Logs from local e2e test run:

```
--- PASS: TestMixerReportingToMixer (36.16s)
	mixer_test.go:924: Validating metrics with 'istio-policy' have been generated...
	mixer_test.go:926: Prometheus query: sum(istio_request_count{destination_service="istio-policy.mixer-test-0dc124f7d2564ea78553348238.svc.cluster.local"}) by (source_service)
	mixer_test.go:941: Validating metrics with 'istio-telemetry' have been generated...
	mixer_test.go:943: Prometheus query: sum(istio_request_count{destination_service="istio-telemetry.mixer-test-0dc124f7d2564ea78553348238.svc.cluster.local"}) by (source_service)
	mixer_test.go:963: Validating Mixer access logs show Check() and Report() calls...
```