### PR TITLE
Allow for case-insensitive matching for Mixer quotas

### DIFF
--- a/mixer/pkg/runtime/dispatcher/session.go
+++ b/mixer/pkg/runtime/dispatcher/session.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gogo/googleapis/google/rpc"
 	multierror "github.com/hashicorp/go-multierror"
@@ -147,7 +148,7 @@ func (s *session) dispatch() error {
 				if s.variety == tpb.TEMPLATE_VARIETY_QUOTA {
 					// only dispatch instances with a matching name
 
-					if input.InstanceShortName != s.quotaArgs.Quota {
+					if !strings.EqualFold(input.InstanceShortName, s.quotaArgs.Quota) {
 						continue
 					}
 

--- a/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/kube/mixer-rule-ratings-ratelimit.yaml
@@ -60,7 +60,7 @@ spec:
   rules:
   - quotas:
     - charge: 1
-      quota: RequestCount
+      quota: requestcount
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpecBinding


### PR DESCRIPTION
This PR updates the quota name comparision to be case-insensitive for mixer quota dispatch.

In debugging the `e2e_mixer` failures for `TestMetricsAndRateLimitAndRulesAndBookinfo`,
I discovered that there were errors related to matching the quota names. I tried making
the name comparison use `strings.EqualFold()` instead of a basic `==`, and all of a 
sudden the test passed with flying colors.

During a failed run of the test, I saw logs full of entries like:

```
2018-06-14T02:03:01.085077Z	error	Requested quota 'RequestCount' is invalid
2018-06-14T02:03:01.085814Z	error	api	Quota failure:performing quota alloc failed: 1 error occurred:

* requested quota 'RequestCount' is invalid
```

With these changes, a run of the test produces:

```
$ make e2e_mixer E2E_ARGS="--use_local_cluster --test.run=TestMetricsAndRateLimitAndRulesAndBookinfo --skip_cleanup" HUB=localhost:5000 TAG=latest
...
--- PASS: TestMetricsAndRateLimitAndRulesAndBookinfo (166.12s)
	mixer_test.go:742: Establishing metrics baseline for test...
	mixer_test.go:744: prometheus query: istio_request_count{destination_service="ratings.mixer-test-9acd242a092b4eeea1eaf87f9e.svc.cluster.local"}
	mixer_test.go:752: error getting prior 429s, using 0 as value (msg: value not found for map[string]string{"response_code":"429"})
	mixer_test.go:758: error getting prior 200s, using 0 as value (msg: value not found for map[string]string{"response_code":"200"})
	mixer_test.go:761: Baseline established: prior200s = 0.000000, prior429s = 0.000000
	mixer_test.go:767: Warming traffic...
	mixer_test.go:742: Establishing metrics baseline for test...
	mixer_test.go:744: prometheus query: istio_request_count{destination_service="ratings.mixer-test-9acd242a092b4eeea1eaf87f9e.svc.cluster.local"}
	mixer_test.go:761: Baseline established: prior200s = 16.000000, prior429s = 133.000000
	mixer_test.go:767: Sending traffic...
	mixer_test.go:835: Fortio Summary: 300 reqs (9.962538 rps, 300.000000 200s (9.962538 rps), 0 400s - map[200:300])
	mixer_test.go:847: Expected Totals: 200s: 30.112809 (1.000000 rps), 429s: 269.887191 (8.962538 rps)
	mixer_test.go:742: Establishing metrics baseline for test...
	mixer_test.go:744: prometheus query: istio_request_count{destination_service="ratings.mixer-test-9acd242a092b4eeea1eaf87f9e.svc.cluster.local"}
	mixer_test.go:761: Baseline established: prior200s = 44.000000, prior429s = 406.000000
	mixer_test.go:872: Actual 429s: 273.000000 (9.065909 rps)
	mixer_test.go:889: Actual 200s: 28.000000 (0.929837 rps), expecting ~1 rps
PASS
...
ok  	istio.io/istio/tests/e2e/tests/mixer	389.282s
```

I don't believe that it is intentional to have case sensitivity in the quota selection.