### PR TITLE
Fix caps in ratelimit quota config for v1alpha3

### DIFF
--- a/samples/bookinfo/routing/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/routing/mixer-rule-ratings-ratelimit.yaml
@@ -60,7 +60,7 @@ spec:
   rules:
   - quotas:
     - charge: 1
-      quota: RequestCount
+      quota: requestcount
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpecBinding


### PR DESCRIPTION
There are reports of `TestMetricsAndRateLimitAndRulesAndBookinfo ` failing in CircleCI with v1alpha3 tests.

This PR corrects a minor caps issue in the config used by that test. Running locally, I
see the tests passing:

```
$ make test/local/noauth/e2e_mixer_envoyv2 E2E_ARGS="--use_local_cluster --test.run=TestMetricsAndRateLimitAndRulesAndBookinfo --skip_cleanup" HUB=localhost:5000 TAG=latest

set -o pipefail; ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 20m ./tests/e2e/tests/mixer \
	--skip_cleanup --auth_enable=false --v1alpha3=true --egress=false --ingress=false --rbac_enable=false \
	--v1alpha1=false --cluster_wide --use_local_cluster --test.run=TestMetricsAndRateLimitAndRulesAndBookinfo --skip_cleanup   --istioctl=/Users/dougreid/work/go/out/darwin_amd64/release/istioctl --mixer_tag=latest --pilot_tag=latest --proxy_tag=latest --ca_tag=latest --galley_tag=latest --mixer_hub=localhost:5000 --pilot_hub=localhost:5000 --proxy_hub=localhost:5000 --ca_hub=localhost:5000 --galley_hub=localhost:5000 | tee -a /Users/dougreid/work/go/out/tests/build-log.txt

2018-06-14T18:55:03.132118Z	info	Command output:
memquota "handler" deleted
quota "requestcount" deleted
rule "quota" deleted
quotaspec "request-count" deleted
quotaspecbinding "request-count" deleted
--- PASS: TestMetricsAndRateLimitAndRulesAndBookinfo (166.13s)
	mixer_test.go:745: Establishing metrics baseline for test...
	mixer_test.go:747: prometheus query: istio_request_count{destination_service="ratings.istio-system.svc.cluster.local"}
	mixer_test.go:755: error getting prior 429s, using 0 as value (msg: value not found for map[string]string{"response_code":"429"})
	mixer_test.go:761: error getting prior 200s, using 0 as value (msg: value not found for map[string]string{"response_code":"200"})
	mixer_test.go:764: Baseline established: prior200s = 0.000000, prior429s = 0.000000
	mixer_test.go:770: Warming traffic...
	mixer_test.go:745: Establishing metrics baseline for test...
	mixer_test.go:747: prometheus query: istio_request_count{destination_service="ratings.istio-system.svc.cluster.local"}
	mixer_test.go:764: Baseline established: prior200s = 16.000000, prior429s = 133.000000
	mixer_test.go:770: Sending traffic...
	mixer_test.go:838: Fortio Summary: 300 reqs (9.955791 rps, 300.000000 200s (9.955791 rps), 0 400s - map[200:300])
	mixer_test.go:850: Expected Totals: 200s: 30.133215 (1.000000 rps), 429s: 269.866785 (8.955791 rps)
	mixer_test.go:745: Establishing metrics baseline for test...
	mixer_test.go:747: prometheus query: istio_request_count{destination_service="ratings.istio-system.svc.cluster.local"}
	mixer_test.go:764: Baseline established: prior200s = 43.000000, prior429s = 406.000000
	mixer_test.go:875: Actual 429s: 273.000000 (9.059770 rps)
	mixer_test.go:892: Actual 200s: 27.000000 (0.896021 rps), expecting ~1 rps
PASS
...
ok  	istio.io/istio/tests/e2e/tests/mixer	402.218s
```

cc: @hklai 