### PR TITLE
tests: switch mixer to v1alpha3

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -79,8 +79,8 @@ type testConfig struct {
 var (
 	tc        *testConfig
 	testFlags = &framework.TestFlags{
-		V1alpha1: true,  //implies envoyv1
-		V1alpha3: false, //implies envoyv2
+		V1alpha1: false, //implies envoyv1
+		V1alpha3: true,  //implies envoyv2
 		Ingress:  true,
 		Egress:   true,
 	}


### PR DESCRIPTION
Prow has been using v1alpha1, which was a false positive.
