### PR TITLE
Switching secretcontroller to use envoyv2

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -599,7 +599,7 @@ func (s *Server) initMultiClusterController(args *PilotArgs) (err error) {
 		err = clusterregistry.StartSecretController(s.kubeClient,
 			s.clusterStore,
 			s.ServiceController,
-			s.discoveryService,
+			s.EnvoyXdsServer,
 			args.Config.ClusterRegistriesNamespace,
 			args.Config.ControllerOptions.ResyncPeriod,
 			args.Config.ControllerOptions.WatchedNamespace,


### PR DESCRIPTION
Original secret controller was using envoy v1 api. This PR switches to envoy v2 api.
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>