### PR TITLE
Use mesh-level authentication policy and destination rules to enable mesh mTLS

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
@@ -122,6 +122,18 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
+metadata:
+  name: meshpolicies.authentication.istio.io
+spec:
+  group: authentication.istio.io
+  names:
+    kind: MeshPolicy
+    listKind: MeshPolicyList
+    plural: meshpolicies
+    singular: meshpolicy
+  scope: Cluster
+  version: v1alpha1
+---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
@@ -122,6 +122,8 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: meshpolicies.authentication.istio.io
 spec:

--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.global.mtls.enabled }}
+# These policy and destination rules effectively enable mTLS for all services in the mesh. For now,
+# they are added to Istio installation yaml for backward compatible. In future, they should be in
+# a separated yaml file so that customer can enable mTLS independent from installation.
+
+# Authentication policy to enable mutual TLS for all services (that have sidecar) in the mesh.
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}
+---
+# Corresponding destination rule to configure client side to use mutual TLS when talking to
+# any service (host) in the mesh.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: "default"
+spec:
+  host: "*.local"
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+---
+# Destination rule to dislabe (m)TLS when talking to API server, as API server doesn't have sidecar.
+# Customer should add similar destination rules for other services that dont' have sidecar.
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: "api-server"
+spec:
+  host: "kubernetes.default.svc.cluster.local"
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -10,11 +10,6 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   mesh: |-
-  {{- if .Values.global.mtls.enabled }}
-    # Mutual TLS between proxies
-    authPolicy: MUTUAL_TLS
-  {{- end }}
-
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.
     disablePolicyChecks: false
@@ -77,14 +72,14 @@ data:
       proxyAdminPort: 15000
       #
       # Zipkin trace collector
-      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411    
+      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
       statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
     {{- end }}
-    
+
     {{- if .Values.global.controlPlaneSecurityEnabled }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -45,6 +45,7 @@ func TestMTlsWithAuthNPolicy(t *testing.T) {
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)
 	}
+	defer globalCfg.Teardown()
 	defer cfgs.Teardown()
 
 	srcPods := []string{"a", "t"}

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -21,25 +21,21 @@ import (
 )
 
 func TestMTlsWithAuthNPolicy(t *testing.T) {
-	// This policy will enable mTLS globally. Policy should be in 'istio-global-config' namespace
-	globalCfg := &deployableConfig{
-		Namespace:  "", // Use blank for cluster CRD.
-		YamlFiles:  []string{"testdata/authn/v1alpha1/global-mtls.yaml.tmpl"},
-		kubeconfig: tc.Kube.KubeConfig,
+	if tc.Kube.AuthEnabled {
+		// mTLS is now enabled via CRDs, so this test is no longer needed (and could cause trouble due
+		// to conflicts of policies)
+		// The whole authn test suites should be rewritten after PR #TBD for better consistency.
+		t.Skipf("Skipping %s: authn=true", t.Name())
 	}
-	// This policy disable mTLS for c and d:80.
+	// This policy will enable mTLS for all namespace, and disable mTLS for c and d:80.
 	cfgs := &deployableConfig{
 		Namespace:  tc.Kube.Namespace,
 		YamlFiles:  []string{"testdata/authn/v1alpha1/authn-policy.yaml.tmpl", "testdata/authn/destination-rule.yaml.tmpl"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
-	if err := globalCfg.Setup(); err != nil {
-		t.Fatal(err)
-	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)
 	}
-	defer globalCfg.Teardown()
 	defer cfgs.Teardown()
 
 	srcPods := []string{"a", "t"}

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -27,11 +27,20 @@ func TestMTlsWithAuthNPolicy(t *testing.T) {
 		// The whole authn test suites should be rewritten after PR #TBD for better consistency.
 		t.Skipf("Skipping %s: authn=true", t.Name())
 	}
+	// This policy will enable mTLS globally. Policy should be in 'istio-global-config' namespace
+	globalCfg := &deployableConfig{
+		Namespace:  "", // Use blank for cluster CRD.
+		YamlFiles:  []string{"testdata/authn/v1alpha1/global-mtls.yaml.tmpl"},
+		kubeconfig: tc.Kube.KubeConfig,
+	}
 	// This policy will enable mTLS for all namespace, and disable mTLS for c and d:80.
 	cfgs := &deployableConfig{
 		Namespace:  tc.Kube.Namespace,
 		YamlFiles:  []string{"testdata/authn/v1alpha1/authn-policy.yaml.tmpl", "testdata/authn/destination-rule.yaml.tmpl"},
 		kubeconfig: tc.Kube.KubeConfig,
+	}
+	if err := globalCfg.Setup(); err != nil {
+		t.Fatal(err)
 	}
 	if err := cfgs.Setup(); err != nil {
 		t.Fatal(err)

--- a/tests/e2e/tests/pilot/authn_policy_test.go
+++ b/tests/e2e/tests/pilot/authn_policy_test.go
@@ -27,13 +27,13 @@ func TestMTlsWithAuthNPolicy(t *testing.T) {
 		// The whole authn test suites should be rewritten after PR #TBD for better consistency.
 		t.Skipf("Skipping %s: authn=true", t.Name())
 	}
-	// This policy will enable mTLS globally. Policy should be in 'istio-global-config' namespace
+	// This policy will enable mTLS globally (mesh policy)
 	globalCfg := &deployableConfig{
 		Namespace:  "", // Use blank for cluster CRD.
 		YamlFiles:  []string{"testdata/authn/v1alpha1/global-mtls.yaml.tmpl"},
 		kubeconfig: tc.Kube.KubeConfig,
 	}
-	// This policy will enable mTLS for all namespace, and disable mTLS for c and d:80.
+	// This policy disable mTLS for c and d:80.
 	cfgs := &deployableConfig{
 		Namespace:  tc.Kube.Namespace,
 		YamlFiles:  []string{"testdata/authn/v1alpha1/authn-policy.yaml.tmpl", "testdata/authn/destination-rule.yaml.tmpl"},


### PR DESCRIPTION
istio-auth.yaml (and its variants) will contain these resources to turn on mTLS for the whole mesh. This has equivalent effect as setting `authPolicy` in mesh configmap to `MUTUAL_TLS`.

```yalm
apiVersion: "authentication.istio.io/v1alpha1"
kind: "MeshPolicy"
metadata:
  name: "default"
spec:
  peers:
  - mtls: {}
---
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: "default"
spec:
  host: "*.local"
  trafficPolicy:
    tls:
      mode: ISTIO_MUTUAL
---
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: "api-server"
spec:
  host: "kubernetes.default.svc.cluster.local"
  trafficPolicy:
    tls:
      mode: DISABLE
```

In future, these resources may be moved out to a separate yaml file so that customer can enable mTLS independent of Istio installation.

Issue https://github.com/istio/istio/issues/5900