### PR TITLE
Fix image tag for helm install

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -13,7 +13,7 @@ global:
 
   # Default tag for Istio images.
   # Should track latest released version in the branch.
-  tag: 0.8.latest
+  tag: 0.8.0
   proxy:
     image: proxyv2
     resources:


### PR DESCRIPTION
Following https://istio.io/docs/setup/kubernetes/quick-start/#download-and-prepare-for-the-installation

When installing istio with helm, images can't be pulled because the tag has been changed from `0.8.latest` to `0.8.0`

```
❯ docker pull docker.io/istio/citadel:0.8.latest
Error response from daemon: manifest for istio/citadel:0.8.latest not found
```