### PR TITLE
[Important Fix] Add release name (NS) to the Statsd address in mesh config

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -82,7 +82,7 @@ data:
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.
-      statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
+      statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd.host }}.{{ .Release.Namespace }}:{{ .Values.global.proxy.envoyStatsd.port }}
     {{- end }}
     
     {{- if .Values.global.controlPlaneSecurityEnabled }}


### PR DESCRIPTION
In recent PR of mine (#6133) I moved the statsd address to the global values.
The value in the configmap should be with the NS because otherwise pods with injected `istio-proxy` outside of the `istio-system` namespace won't be able to connect to the statsd destination causing the istio-proxy container to crash.