### PR TITLE
Avoid assigning uname if LOCAL_OS exists

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -45,20 +45,19 @@ export ISTIO_BIN=${ISTIO_BIN:-${GOPATH}/bin}
 export GOARCH=${GOARCH:-'amd64'}
 
 # Determine the OS. Matches logic in the Makefile.
-LOCAL_OS="`uname`"
+LOCAL_OS=${LOCAL_OS:-"`uname`"}
 case $LOCAL_OS in
   'Linux')
-    LOCAL_OS='linux'
+    export GOOS=${GOOS:-"linux"}
     ;;
   'Darwin')
-    LOCAL_OS='darwin'
+    export GOOS=${GOOS:-"darwin"}
     ;;
   *)
     echo "This system's OS ${LOCAL_OS} isn't recognized/supported"
     exit 1
     ;;
 esac
-export GOOS=${GOOS:-${LOCAL_OS}}
 
 # test scripts seem to like to run this script directly rather than use make
 export ISTIO_OUT=${ISTIO_OUT:-${ISTIO_BIN}}
@@ -123,7 +122,7 @@ if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; 
     # Download debug envoy binary.
     mkdir -p $ISTIO_ENVOY_DEBUG_DIR
     pushd $ISTIO_ENVOY_DEBUG_DIR
-    if [ "$LOCAL_OS" == "darwin" ] && [ "$GOOS" != "linux" ]; then
+    if [ "$LOCAL_OS" == "Darwin" ] && [ "$GOOS" != "linux" ]; then
        ISTIO_ENVOY_DEBUG_URL=${ISTIO_ENVOY_MAC_RELEASE_URL}
     fi
     echo "Downloading envoy debug artifact: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_DEBUG_URL}"
@@ -135,7 +134,7 @@ if [ ! -f "$ISTIO_ENVOY_DEBUG_PATH" ] || [ ! -f "$ISTIO_ENVOY_RELEASE_PATH" ] ; 
     # Download release envoy binary.
     mkdir -p $ISTIO_ENVOY_RELEASE_DIR
     pushd $ISTIO_ENVOY_RELEASE_DIR
-    if [ "$LOCAL_OS" == "darwin" ] && [ "$GOOS" != "linux" ]; then
+    if [ "$LOCAL_OS" == "Darwin" ] && [ "$GOOS" != "linux" ]; then
        ISTIO_ENVOY_RELEASE_URL=${ISTIO_ENVOY_MAC_RELEASE_URL}
     fi
     echo "Downloading envoy release artifact: ${DOWNLOAD_COMMAND} ${ISTIO_ENVOY_RELEASE_URL}"
@@ -149,7 +148,7 @@ mkdir -p ${ISTIO_OUT}
 mkdir -p ${ISTIO_BIN}
 
 # copy debug envoy binary used for local tests such as ones in mixer/test/clients
-if [ "$LOCAL_OS" == "darwin" ]; then
+if [ "$LOCAL_OS" == "Darwin" ]; then
     # Download darwin envoy binary.
     DARWIN_ENVOY_DIR=$(mktemp -d)
     pushd $DARWIN_ENVOY_DIR


### PR DESCRIPTION
This minor script change is first trying to get existing `LOCAL_OS` before assigning it  \`uname\`.
This is useful for MacOS users (like me) who wish to build/push docker images. Without this fix, when building docker image, the scripts uses the MacOS envoy for the images.

The change has no affect on existing build flows.