### PR TITLE
parse service account from SDS request

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -76,8 +76,8 @@ func NewSecretCache(cl ca.Client, secretTTL, rotationInterval, evictionDuration 
 // GetSecret gets secret from cache, this function is called by SDS.FetchSecret,
 // Since credential passing from client may change, regenerate secret every time
 // instread of reading from cache.
-func (sc *SecretCache) GetSecret(proxyID, token string) (*sds.SecretItem, error) {
-	ns, err := sc.generateSecret(token, time.Now())
+func (sc *SecretCache) GetSecret(proxyID, serviceAccount, token string) (*sds.SecretItem, error) {
+	ns, err := sc.generateSecret(token, serviceAccount, time.Now())
 	if err != nil {
 		log.Errorf("Failed to generate secret for proxy %q: %v", proxyID, err)
 		return nil, err
@@ -135,7 +135,7 @@ func (sc *SecretCache) rotate(t time.Time) {
 				// If token is still valid, re-generated the secret and push change to proxy.
 				// Most likey this code path may not necessary, since TTL of cert is much longer than token.
 				// When cert has expired, we could make it simple by assuming token has already expired.
-				ns, err := sc.generateSecret(e.Token, now)
+				ns, err := sc.generateSecret(e.Token, e.ServiceAccount, now)
 				if err != nil {
 					log.Errorf("Failed to generate secret for proxy %q: %v", proxyID, err)
 					return
@@ -156,9 +156,9 @@ func (sc *SecretCache) rotate(t time.Time) {
 	})
 }
 
-func (sc *SecretCache) generateSecret(token string, t time.Time) (*sds.SecretItem, error) {
+func (sc *SecretCache) generateSecret(token, serviceAccount string, t time.Time) (*sds.SecretItem, error) {
 	options := util.CertOptions{
-		Host:       "", //TODO(quanlin): figure out what to use here.
+		Host:       serviceAccount,
 		RSAKeySize: keySize,
 	}
 
@@ -176,6 +176,7 @@ func (sc *SecretCache) generateSecret(token string, t time.Time) (*sds.SecretIte
 	return &sds.SecretItem{
 		CertificateChain: certChainPER,
 		PrivateKey:       keyPEM,
+		ServiceAccount:   serviceAccount,
 		Token:            token,
 		CreatedTime:      t,
 	}, nil

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -26,7 +26,7 @@ var (
 	mockCertificateChain1st    = []byte{01}
 	mockCertificateChainRemain = []byte{02}
 
-	fakeServiceAccount = "spiffe://cluster.local/ns/bar/sa/foo"
+	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
 )
 
 func TestGetSecret(t *testing.T) {
@@ -39,7 +39,7 @@ func TestGetSecret(t *testing.T) {
 	}()
 
 	proxyID := "proxy1-id"
-	gotSecret, err := sc.GetSecret(proxyID, fakeServiceAccount, "jwtToken1" /*jwtToken*/)
+	gotSecret, err := sc.GetSecret(proxyID, fakeSpiffeID, "jwtToken1" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestGetSecret(t *testing.T) {
 	}
 
 	// Try to get secret again using different jwt token, verify secret is re-generated.
-	gotSecret, err = sc.GetSecret(proxyID, fakeServiceAccount, "newToken" /*jwtToken*/)
+	gotSecret, err = sc.GetSecret(proxyID, fakeSpiffeID, "newToken" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestRefreshSecret(t *testing.T) {
 		skipTokenExpireCheck = true
 	}()
 
-	_, err := sc.GetSecret("proxy1-id" /*proxyID*/, fakeServiceAccount, "jwtToken1" /*jwtToken*/)
+	_, err := sc.GetSecret("proxy1-id" /*proxyID*/, fakeSpiffeID, "jwtToken1" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -25,6 +25,8 @@ import (
 var (
 	mockCertificateChain1st    = []byte{01}
 	mockCertificateChainRemain = []byte{02}
+
+	fakeServiceAccount = "spiffe://cluster.local/ns/bar/sa/foo"
 )
 
 func TestGetSecret(t *testing.T) {
@@ -37,8 +39,7 @@ func TestGetSecret(t *testing.T) {
 	}()
 
 	proxyID := "proxy1-id"
-	jwtToken := "jwtToken1"
-	gotSecret, err := sc.GetSecret(proxyID, jwtToken)
+	gotSecret, err := sc.GetSecret(proxyID, fakeServiceAccount, "jwtToken1" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -55,8 +56,7 @@ func TestGetSecret(t *testing.T) {
 	}
 
 	// Try to get secret again using different jwt token, verify secret is re-generated.
-	jwtToken = "newToken"
-	gotSecret, err = sc.GetSecret(proxyID, jwtToken)
+	gotSecret, err = sc.GetSecret(proxyID, fakeServiceAccount, "newToken" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -91,9 +91,7 @@ func TestRefreshSecret(t *testing.T) {
 		skipTokenExpireCheck = true
 	}()
 
-	proxyID := "proxy1-id"
-	jwtToken := "jwtToken1"
-	_, err := sc.GetSecret(proxyID, jwtToken)
+	_, err := sc.GetSecret("proxy1-id" /*proxyID*/, fakeServiceAccount, "jwtToken1" /*jwtToken*/)
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,6 +45,9 @@ const (
 	// credentialTokenHeaderKey is the header key in gPRC header which is used to
 	// pass credential token from envoy to SDS.
 	credentialTokenHeaderKey = "authorization"
+
+	// uriScheme is the URI scheme for Istio identities.
+	uriScheme = "spiffe"
 )
 
 var (
@@ -131,19 +135,13 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				return receiveError
 			}
 
-			if discReq.Node.Id == "" {
-				log.Warnf("Discovery request %+v missing node id", discReq)
+			proxy, svcAccount, err := parseDiscoveryRequest(discReq)
+			if err != nil {
 				continue
 			}
-			proxy, err := model.ParseServiceNode(discReq.Node.Id)
-			if err != nil {
-				log.Errorf("Failed to parse service node from discovery request %+v: %v", discReq, err)
-				return err
-			}
-			proxy.Metadata = model.ParseMetadata(discReq.Node.Metadata)
-			con.proxy = &proxy
+			con.proxy = proxy
 
-			secret, err := s.st.GetSecret(discReq.Node.Id, token)
+			secret, err := s.st.GetSecret(discReq.Node.Id, svcAccount, token)
 			if err != nil {
 				log.Errorf("Failed to get secret for proxy %q from secret cache: %v", discReq.Node.Id, err)
 				return err
@@ -178,19 +176,12 @@ func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *xdsapi.Discovery
 		return nil, err
 	}
 
-	if discReq.Node.Id == "" {
-		log.Warnf("SDS discovery request %+v missing node id", discReq)
-		return nil, fmt.Errorf("SDS discovery request %+v missing node id", discReq)
-	}
-
-	proxy, err := model.ParseServiceNode(discReq.Node.Id)
+	proxy, svcAccount, err := parseDiscoveryRequest(discReq)
 	if err != nil {
-		log.Errorf("Failed to parse service node from discovery request %+v: %v", discReq, err)
 		return nil, err
 	}
-	proxy.Metadata = model.ParseMetadata(discReq.Node.Metadata)
 
-	secret, err := s.st.GetSecret(discReq.Node.Id, token)
+	secret, err := s.st.GetSecret(discReq.Node.Id, svcAccount, token)
 	if err != nil {
 		log.Errorf("Failed to get secret for proxy %q from secret cache: %v", discReq.Node.Id, err)
 		return nil, err
@@ -211,6 +202,26 @@ func NotifyProxy(proxyID string, secret *SecretItem) error {
 
 	cli.pushChannel <- &sdsEvent{}
 	return nil
+}
+
+func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (*model.Proxy, string, error) {
+	if discReq.Node.Id == "" {
+		return nil, "", fmt.Errorf("discovery request %+v missing node id", discReq)
+	}
+
+	if len(discReq.ResourceNames) != 1 || !strings.HasPrefix(discReq.ResourceNames[0], uriScheme) {
+		return nil, "", fmt.Errorf("discovery request has invalid resourceNames %+v", discReq.ResourceNames)
+	}
+	svcAccount := discReq.ResourceNames[0]
+
+	proxy, err := model.ParseServiceNode(discReq.Node.Id)
+	if err != nil {
+		log.Errorf("Failed to parse service node from discovery request %+v: %v", discReq, err)
+		return nil, "", err
+	}
+	proxy.Metadata = model.ParseMetadata(discReq.Node.Metadata)
+
+	return &proxy, svcAccount, nil
 }
 
 func getCredentialToken(ctx context.Context) (string, error) {
@@ -242,7 +253,7 @@ func removeConn(proxyID string) {
 }
 
 func pushSDS(con *sdsConnection) error {
-	response, err := sdsDiscoveryResponse(con.secret, *con.proxy)
+	response, err := sdsDiscoveryResponse(con.secret, con.proxy)
 	if err != nil {
 		log.Errorf("SDS: Failed to construct response %v", err)
 		return err
@@ -257,7 +268,7 @@ func pushSDS(con *sdsConnection) error {
 	return nil
 }
 
-func sdsDiscoveryResponse(s *SecretItem, proxy model.Proxy) (*xdsapi.DiscoveryResponse, error) {
+func sdsDiscoveryResponse(s *SecretItem, proxy *model.Proxy) (*xdsapi.DiscoveryResponse, error) {
 	//TODO(quanlin): use timestamp for versionInfo and nouce for now, may change later.
 	t := time.Now().String()
 	resp := &xdsapi.DiscoveryResponse{
@@ -272,8 +283,7 @@ func sdsDiscoveryResponse(s *SecretItem, proxy model.Proxy) (*xdsapi.DiscoveryRe
 	}
 
 	secret := &authapi.Secret{
-		//TODO(quanlin): better naming.
-		Name: "self-signed",
+		Name: s.ServiceAccount,
 		Type: &authapi.Secret_TlsCertificate{
 			TlsCertificate: &authapi.TlsCertificate{
 				CertificateChain: &core.DataSource{

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -39,6 +39,8 @@ var (
 	fakePushPrivateKey       = []byte{04}
 
 	fakeCredentialToken = "faketoken"
+
+	fakeServiceAccount = "spiffe://cluster.local/ns/bar/sa/foo"
 )
 
 func TestStreamSecrets(t *testing.T) {
@@ -67,7 +69,7 @@ func testHelper(t *testing.T, testSocket string, cb secretCallback) {
 
 	proxyID := "sidecar~127.0.0.1~id1~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{"test"},
+		ResourceNames: []string{fakeServiceAccount},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -105,7 +107,7 @@ func TestStreamSecretsPush(t *testing.T) {
 
 	proxyID := "sidecar~127.0.0.1~id2~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{"test"},
+		ResourceNames: []string{fakeServiceAccount},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -137,6 +139,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	if err = NotifyProxy(proxyID, &SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,
+		ServiceAccount:   fakeServiceAccount,
 	}); err != nil {
 		t.Errorf("failed to send push notificiation to proxy %q", proxyID)
 	}
@@ -162,24 +165,25 @@ func verifySDSSResponse(t *testing.T, resp *api.DiscoveryResponse, expectedPriva
 		t.Fatalf("UnmarshalAny SDS response failed: %v", err)
 	}
 
-	certificateChainGot := pb.GetTlsCertificate().GetCertificateChain()
-	certificateChainWant := &core.DataSource{
-		Specifier: &core.DataSource_InlineBytes{
-			InlineBytes: expectedCertChain,
+	expectedResponseSecret := authapi.Secret{
+		Name: fakeServiceAccount,
+		Type: &authapi.Secret_TlsCertificate{
+			TlsCertificate: &authapi.TlsCertificate{
+				CertificateChain: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: expectedCertChain,
+					},
+				},
+				PrivateKey: &core.DataSource{
+					Specifier: &core.DataSource_InlineBytes{
+						InlineBytes: expectedPrivateKey,
+					},
+				},
+			},
 		},
 	}
-	if !reflect.DeepEqual(certificateChainWant, certificateChainGot) {
-		t.Errorf("certificate Chain: got %+v, want %+v", certificateChainGot, certificateChainWant)
-	}
-
-	privateKeyGot := pb.GetTlsCertificate().GetPrivateKey()
-	privateKeyWant := &core.DataSource{
-		Specifier: &core.DataSource_InlineBytes{
-			InlineBytes: expectedPrivateKey,
-		},
-	}
-	if !reflect.DeepEqual(privateKeyWant, privateKeyGot) {
-		t.Errorf("private key: got %+v, want %+v", privateKeyGot, privateKeyWant)
+	if !reflect.DeepEqual(pb, expectedResponseSecret) {
+		t.Errorf("secret key: got %+v, want %+v", pb, expectedResponseSecret)
 	}
 }
 
@@ -245,13 +249,18 @@ func setupConnection(socket string) (*grpc.ClientConn, error) {
 type mockSecretStore struct {
 }
 
-func (*mockSecretStore) GetSecret(proxyID, token string) (*SecretItem, error) {
-	if token == fakeCredentialToken {
-		return &SecretItem{
-			CertificateChain: fakeCertificateChain,
-			PrivateKey:       fakePrivateKey,
-		}, nil
+func (*mockSecretStore) GetSecret(proxyID, serviceAccount, token string) (*SecretItem, error) {
+	if token != fakeCredentialToken {
+		return nil, fmt.Errorf("unexpected token %q", token)
 	}
 
-	return nil, fmt.Errorf("unexpected token %q", token)
+	if serviceAccount != fakeServiceAccount {
+		return nil, fmt.Errorf("unexpected service account %q", serviceAccount)
+	}
+
+	return &SecretItem{
+		CertificateChain: fakeCertificateChain,
+		PrivateKey:       fakePrivateKey,
+		ServiceAccount:   serviceAccount,
+	}, nil
 }

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -40,7 +40,7 @@ var (
 
 	fakeCredentialToken = "faketoken"
 
-	fakeServiceAccount = "spiffe://cluster.local/ns/bar/sa/foo"
+	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
 )
 
 func TestStreamSecrets(t *testing.T) {
@@ -69,7 +69,7 @@ func testHelper(t *testing.T, testSocket string, cb secretCallback) {
 
 	proxyID := "sidecar~127.0.0.1~id1~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{fakeServiceAccount},
+		ResourceNames: []string{fakeSpiffeID},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -107,7 +107,7 @@ func TestStreamSecretsPush(t *testing.T) {
 
 	proxyID := "sidecar~127.0.0.1~id2~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{fakeServiceAccount},
+		ResourceNames: []string{fakeSpiffeID},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -139,7 +139,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	if err = NotifyProxy(proxyID, &SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,
-		ServiceAccount:   fakeServiceAccount,
+		SpiffeID:         fakeSpiffeID,
 	}); err != nil {
 		t.Errorf("failed to send push notificiation to proxy %q", proxyID)
 	}
@@ -166,7 +166,7 @@ func verifySDSSResponse(t *testing.T, resp *api.DiscoveryResponse, expectedPriva
 	}
 
 	expectedResponseSecret := authapi.Secret{
-		Name: fakeServiceAccount,
+		Name: fakeSpiffeID,
 		Type: &authapi.Secret_TlsCertificate{
 			TlsCertificate: &authapi.TlsCertificate{
 				CertificateChain: &core.DataSource{
@@ -249,18 +249,18 @@ func setupConnection(socket string) (*grpc.ClientConn, error) {
 type mockSecretStore struct {
 }
 
-func (*mockSecretStore) GetSecret(proxyID, serviceAccount, token string) (*SecretItem, error) {
+func (*mockSecretStore) GetSecret(proxyID, spiffeID, token string) (*SecretItem, error) {
 	if token != fakeCredentialToken {
 		return nil, fmt.Errorf("unexpected token %q", token)
 	}
 
-	if serviceAccount != fakeServiceAccount {
-		return nil, fmt.Errorf("unexpected service account %q", serviceAccount)
+	if spiffeID != fakeSpiffeID {
+		return nil, fmt.Errorf("unexpected spiffeID %q", spiffeID)
 	}
 
 	return &SecretItem{
 		CertificateChain: fakeCertificateChain,
 		PrivateKey:       fakePrivateKey,
-		ServiceAccount:   serviceAccount,
+		SpiffeID:         spiffeID,
 	}, nil
 }

--- a/security/pkg/nodeagent/sds/secretmanager.go
+++ b/security/pkg/nodeagent/sds/secretmanager.go
@@ -18,7 +18,7 @@ import "time"
 
 // SecretManager defines secrets management interface which is used by SDS.
 type SecretManager interface {
-	GetSecret(proxyID, serviceAccount, token string) (*SecretItem, error)
+	GetSecret(proxyID, spiffeID, token string) (*SecretItem, error)
 }
 
 // SecretItem is the cached item in in-memory secret store.
@@ -26,8 +26,8 @@ type SecretItem struct {
 	CertificateChain []byte
 	PrivateKey       []byte
 
-	// ServiceAccount passed from envoy, in spiffe format.
-	ServiceAccount string
+	// SpiffeID passed from envoy.
+	SpiffeID string
 
 	// Credential token passed from envoy, caClient uses this token to send
 	// CSR to CA to sign certificate.

--- a/security/pkg/nodeagent/sds/secretmanager.go
+++ b/security/pkg/nodeagent/sds/secretmanager.go
@@ -18,13 +18,16 @@ import "time"
 
 // SecretManager defines secrets management interface which is used by SDS.
 type SecretManager interface {
-	GetSecret(proxyID, token string) (*SecretItem, error)
+	GetSecret(proxyID, serviceAccount, token string) (*SecretItem, error)
 }
 
 // SecretItem is the cached item in in-memory secret store.
 type SecretItem struct {
 	CertificateChain []byte
 	PrivateKey       []byte
+
+	// ServiceAccount passed from envoy, in spiffe format.
+	ServiceAccount string
 
 	// Credential token passed from envoy, caClient uses this token to send
 	// CSR to CA to sign certificate.


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

service account passed from client will be in spiffe format, SDSS uses it to
1. construct response to client
2. construct csr template