### PR TITLE
Use post install job to enable mTLS

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-security-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: security
+data:
+  custom-resources.yaml: |-
+    {{- include "security-default.yaml.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.global.mtls.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-security-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-security-post-install-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.istio.io"] # needed to create security destination rules
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-security-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-security-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-security-post-install-account
+    namespace: {{ .Release.Namespace }}
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-security-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-security-post-install
+      labels:
+        app: istio-security
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-security-post-install-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          command:
+            - ./kubectl
+            - apply
+            - -f
+            - /tmp/security/custom-resources.yaml
+          volumeMounts:
+            - mountPath: "/tmp/security"
+              name: tmp-configmap-security
+      volumes:
+        - name: tmp-configmap-security
+          configMap:
+            name: istio-security-custom-resources
+      restartPolicy: Never # CRD might take some time till they are available to consume
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.mtls.enabled }}
+{{ define "security-default.yaml.tpl" }}
 # These policy and destination rules effectively enable mTLS for all services in the mesh. For now,
 # they are added to Istio installation yaml for backward compatible. In future, they should be in
 # a separated yaml file so that customer can enable mTLS independent from installation.
@@ -8,6 +8,11 @@ apiVersion: "authentication.istio.io/v1alpha1"
 kind: "MeshPolicy"
 metadata:
   name: "default"
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   peers:
   - mtls: {}
@@ -18,6 +23,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   host: "*.local"
   trafficPolicy:
@@ -30,6 +40,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   host: "kubernetes.default.svc.cluster.local"
   trafficPolicy:


### PR DESCRIPTION
`helm install` command cannot submit customer resources (i.e the default authentication policy and destination rules to enable mTLS) directly. This PR uses a post-install job to add those.