### PR TITLE
Expose the accessLogFile in Mesh config

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -20,6 +20,8 @@ data:
     disablePolicyChecks: false
     # Set enableTracing to false to disable request tracing.
     enableTracing: true
+    # Set accessLogFile to empty string to disable access log.
+    accessLogFile: "/dev/stdout"
     #
     # To disable the mixer completely (including metrics), comment out
     # the following lines


### PR DESCRIPTION
Following a [user question](https://groups.google.com/forum/#!topic/istio-users/PJQlbf5gFaI) about how to disable the proxy access log I exposed the relevant parameters to make it easier for users to disable or set alternative log destination. 