### PR TITLE
Injector: Adds a [white|black]list mecanism for auto injection

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlDecoder "k8s.io/apimachinery/pkg/util/yaml"
@@ -230,6 +231,17 @@ type Config struct {
 	// Template is the templated version of `SidecarInjectionSpec` prior to
 	// expansion over the `SidecarTemplateData`.
 	Template string `json:"template"`
+
+	// NeverInjectSelector: Refuses the injection on pods whose labels match this selector.
+	// It's an array of label selectors, that will be OR'ed, meaning we will iterate
+	// over it and stop at the first match
+	// Takes precedence over AlwaysInjectSelector.
+	NeverInjectSelector []metav1.LabelSelector `json:"neverInjectSelector"`
+
+	// AlwaysInjectSelector: Forces the injection on pods whose labels match this selector.
+	// It's an array of label selectors, that will be OR'ed, meaning we will iterate
+	// over it and stop at the first match
+	AlwaysInjectSelector []metav1.LabelSelector `json:"alwaysInjectSelector"`
 }
 
 func validateCIDRList(cidrs string) error {
@@ -340,7 +352,7 @@ func validateUInt32(value string) error {
 	return err
 }
 
-func injectRequired(ignored []string, namespacePolicy InjectionPolicy, podSpec *corev1.PodSpec, metadata *metav1.ObjectMeta) bool { // nolint: lll
+func injectRequired(ignored []string, config *Config, podSpec *corev1.PodSpec, metadata *metav1.ObjectMeta) bool { // nolint: lll
 	// Skip injection when host networking is enabled. The problem is
 	// that the iptable changes are assumed to be within the pod when,
 	// in fact, they are changing the routing at the host level. This
@@ -373,11 +385,47 @@ func injectRequired(ignored []string, namespacePolicy InjectionPolicy, podSpec *
 		useDefault = true
 	}
 
+	// If an annotation is not explicitly given, check the LabelSelectors, starting with NeverInject
+	if useDefault {
+		for _, neverSelector := range config.NeverInjectSelector {
+			selector, err := metav1.LabelSelectorAsSelector(&neverSelector)
+			if err != nil {
+				log.Warnf("Invalid selector for NeverInjectSelector: %v (%v)", neverSelector, err)
+			} else {
+				if !selector.Empty() && selector.Matches(labels.Set(metadata.Labels)) {
+					log.Debugf("Explicitly disabling injection for pod %s/%s due to pod labels matching NeverInjectSelector config map entry.",
+						metadata.Namespace, potentialPodName(metadata))
+					inject = false
+					useDefault = false
+					break
+				}
+			}
+		}
+	}
+
+	// If there's no annotation nor a NeverInjectSelector, check the AlwaysInject one
+	if useDefault {
+		for _, alwaysSelector := range config.AlwaysInjectSelector {
+			selector, err := metav1.LabelSelectorAsSelector(&alwaysSelector)
+			if err != nil {
+				log.Warnf("Invalid selector for AlwaysInjectSelector: %v (%v)", alwaysSelector, err)
+			} else {
+				if !selector.Empty() && selector.Matches(labels.Set(metadata.Labels)) {
+					log.Debugf("Explicitly enabling injection for pod %s/%s due to pod labels matching AlwaysInjectSelector config map entry.",
+						metadata.Namespace, potentialPodName(metadata))
+					inject = true
+					useDefault = false
+					break
+				}
+			}
+		}
+	}
+
 	var required bool
-	switch namespacePolicy {
+	switch config.Policy {
 	default: // InjectionPolicyOff
 		log.Errorf("Illegal value for autoInject:%s, must be one of [%s,%s]. Auto injection disabled!",
-			namespacePolicy, InjectionPolicyDisabled, InjectionPolicyEnabled)
+			config.Policy, InjectionPolicyDisabled, InjectionPolicyEnabled)
 		required = false
 	case InjectionPolicyDisabled:
 		if useDefault {
@@ -403,7 +451,7 @@ func injectRequired(ignored []string, namespacePolicy InjectionPolicy, podSpec *
 		log.Debugf("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v required:%v %s",
 			metadata.Namespace,
 			potentialPodName(metadata),
-			namespacePolicy,
+			config,
 			useDefault,
 			inject,
 			required,

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -103,6 +103,8 @@ func loadConfig(injectFile, meshFile string) (*Config, *meshconfig.MeshConfig, e
 
 	log.Infof("New configuration: sha256sum %x", sha256.Sum256(data))
 	log.Infof("Policy: %v", c.Policy)
+	log.Infof("AlwaysInjectSelector: %v", c.AlwaysInjectSelector)
+	log.Infof("NeverInjectSelector: %v", c.NeverInjectSelector)
 	log.Infof("Template: |\n  %v", strings.Replace(c.Template, "\n", "\n  ", -1))
 
 	return &c, meshConfig, nil
@@ -500,7 +502,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 	log.Debugf("Object: %v", string(req.Object.Raw))
 	log.Debugf("OldObject: %v", string(req.OldObject.Raw))
 
-	if !injectRequired(ignoredNamespaces, wh.sidecarConfig.Policy, &pod.Spec, &pod.ObjectMeta) {
+	if !injectRequired(ignoredNamespaces, wh.sidecarConfig, &pod.Spec, &pod.ObjectMeta) {
 		log.Infof("Skipping %s/%s due to policy check", pod.ObjectMeta.Namespace, podName)
 		return &v1beta1.AdmissionResponse{
 			Allowed: true,

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -117,19 +117,30 @@ ZOQ5UvU=
 -----END CERTIFICATE-----`)
 )
 
+func parseToLabelSelector(t *testing.T, selector string) *metav1.LabelSelector {
+	result, err := metav1.ParseToLabelSelector(selector)
+	if err != nil {
+		t.Errorf("Invalid selector %v: %v", selector, err)
+	}
+
+	return result
+}
+
 func TestInjectRequired(t *testing.T) {
 	podSpec := &corev1.PodSpec{}
 	podSpecHostNetwork := &corev1.PodSpec{
 		HostNetwork: true,
 	}
 	cases := []struct {
-		policy  InjectionPolicy
+		config  *Config
 		podSpec *corev1.PodSpec
 		meta    *metav1.ObjectMeta
 		want    bool
 	}{
 		{
-			policy:  InjectionPolicyEnabled,
+			config: &Config{
+				Policy: InjectionPolicyEnabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "no-policy",
@@ -139,7 +150,9 @@ func TestInjectRequired(t *testing.T) {
 			want: true,
 		},
 		{
-			policy:  InjectionPolicyEnabled,
+			config: &Config{
+				Policy: InjectionPolicyEnabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:      "default-policy",
@@ -148,7 +161,9 @@ func TestInjectRequired(t *testing.T) {
 			want: true,
 		},
 		{
-			policy:  InjectionPolicyEnabled,
+			config: &Config{
+				Policy: InjectionPolicyEnabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "force-on-policy",
@@ -158,7 +173,9 @@ func TestInjectRequired(t *testing.T) {
 			want: true,
 		},
 		{
-			policy:  InjectionPolicyEnabled,
+			config: &Config{
+				Policy: InjectionPolicyEnabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "force-off-policy",
@@ -168,7 +185,9 @@ func TestInjectRequired(t *testing.T) {
 			want: false,
 		},
 		{
-			policy:  InjectionPolicyDisabled,
+			config: &Config{
+				Policy: InjectionPolicyDisabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "no-policy",
@@ -178,7 +197,9 @@ func TestInjectRequired(t *testing.T) {
 			want: false,
 		},
 		{
-			policy:  InjectionPolicyDisabled,
+			config: &Config{
+				Policy: InjectionPolicyDisabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:      "default-policy",
@@ -187,7 +208,9 @@ func TestInjectRequired(t *testing.T) {
 			want: false,
 		},
 		{
-			policy:  InjectionPolicyDisabled,
+			config: &Config{
+				Policy: InjectionPolicyDisabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "force-on-policy",
@@ -197,7 +220,9 @@ func TestInjectRequired(t *testing.T) {
 			want: true,
 		},
 		{
-			policy:  InjectionPolicyDisabled,
+			config: &Config{
+				Policy: InjectionPolicyDisabled,
+			},
 			podSpec: podSpec,
 			meta: &metav1.ObjectMeta{
 				Name:        "force-off-policy",
@@ -207,7 +232,9 @@ func TestInjectRequired(t *testing.T) {
 			want: false,
 		},
 		{
-			policy:  InjectionPolicyEnabled,
+			config: &Config{
+				Policy: InjectionPolicyEnabled,
+			},
 			podSpec: podSpecHostNetwork,
 			meta: &metav1.ObjectMeta{
 				Name:        "force-off-policy",
@@ -216,11 +243,273 @@ func TestInjectRequired(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			config: &Config{
+				Policy: "wrong_policy",
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:        "wrong-policy",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyEnabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-always-inject-no-labels",
+				Namespace: "test-namespace",
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyEnabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-always-inject-with-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "bar1"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-inject-no-labels",
+				Namespace: "test-namespace",
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-inject-with-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "bar"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyEnabled,
+				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-never-inject-no-labels",
+				Namespace: "test-namespace",
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyEnabled,
+				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-never-inject-with-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "bar"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyDisabled,
+				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-never-inject-no-labels",
+				Namespace: "test-namespace",
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyDisabled,
+				NeverInjectSelector: []metav1.LabelSelector{{MatchLabels: map[string]string{"foo": "bar"}}},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-never-inject-with-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "bar"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyEnabled,
+				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-never-inject-with-empty-label",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-inject-with-empty-label",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "always")},
+				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-never-inject-with-label-returns-true",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"always": "bar", "foo2": "bar2"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "always")},
+				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-never-inject-with-label-returns-false",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"never": "bar", "foo2": "bar2"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "always")},
+				NeverInjectSelector:  []metav1.LabelSelector{*parseToLabelSelector(t, "never")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-disabled-always-never-inject-with-both-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"always": "bar", "never": "bar2"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyEnabled,
+				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:        "policy-enabled-annotation-true-never-inject",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyEnabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:        "policy-enabled-annotation-false-always-inject",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:        "policy-disabled-annotation-false-always-inject",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyEnabled,
+				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo"), *parseToLabelSelector(t, "bar")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-never-inject-multiple-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"label1": "", "bar": "anything"},
+			},
+			want: false,
+		},
+		{
+			config: &Config{
+				Policy:               InjectionPolicyDisabled,
+				AlwaysInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo"), *parseToLabelSelector(t, "bar")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:      "policy-enabled-always-inject-multiple-labels",
+				Namespace: "test-namespace",
+				Labels:    map[string]string{"label1": "", "bar": "anything"},
+			},
+			want: true,
+		},
+		{
+			config: &Config{
+				Policy:              InjectionPolicyDisabled,
+				NeverInjectSelector: []metav1.LabelSelector{*parseToLabelSelector(t, "foo")},
+			},
+			podSpec: podSpec,
+			meta: &metav1.ObjectMeta{
+				Name:        "policy-disabled-annotation-true-never-inject",
+				Namespace:   "test-namespace",
+				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
+			},
+			want: true,
+		},
 	}
 
 	for _, c := range cases {
-		if got := injectRequired(ignoredNamespaces, c.policy, c.podSpec, c.meta); got != c.want {
-			t.Errorf("injectRequired(%v, %v) got %v want %v", c.policy, c.meta, got, c.want)
+		if got := injectRequired(ignoredNamespaces, c.config, c.podSpec, c.meta); got != c.want {
+			t.Errorf("injectRequired(%v, %v) got %v want %v", c.config, c.meta, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
There are cases where the user does not have the control of the pod
and thus cannot add or change any annotation/label on it, and he
might not want the auto-injection to happen on it, even if the namespace
is labelled for auto-injection.

For example, in Openshift, a user can have automatic injection enabled
for her namespace, and at the same time, she can use the Openshift Builder
feature, which automatically creates a pod for running a source code build.
This builder pod should not have the sidecar injected on it.

Then we could have a way of having such class of pods NOT having the
sidecar injected, while maintaining injection by default for others.

This patch adds the ability to white or black list pods that get automatic
injection based on labels the pod has.

Then users can tweak the Sidecar ConfigMap adding the LabelSelectors:

- AlwaysInjectSelector: Forces the injection on pods whose labels match this selector.
- NeverInjectSelector: Refuses the injection on pods whose labels match this selector.

Annotations still have priority. Those labels are only checked if
an annotation is not explicitly given.

If both Selectors are present, `NeverInjectSelector` has the priority.

Thus the order of evaluation is:
Annotations - NeverInjectSelector - AlwaysInjectSelector - Namespace Policy