### PR TITLE
Add a logic to remove stale clusters

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -321,7 +321,12 @@ func (s *DiscoveryServer) pushEds(con *XdsConnection) error {
 	empty := []string{}
 
 	for _, clusterName := range con.Clusters {
-		c := s.getOrAddEdsCluster(clusterName)
+		c := s.getEdsCluster(clusterName)
+		if c == nil {
+			adsLog.Errorf("cluster %s was nil skipping it.", clusterName)
+			continue
+		}
+
 		l := loadAssignment(c)
 		if l == nil { // fresh cluster
 			if err := updateCluster(clusterName, c); err != nil {


### PR DESCRIPTION
When an istio service with an associated endpoint is removed, Pilot seem to
have kept the stale cluster(s) in StreamAggregatedResources, part of the problem
was the initial check was only looking for the length equality of the clusters
from service discovery and the ones that Envoy knows about. This change performs
a deep equality check on both cluster sets. If both sets are equal no
changes made, otherwise we refresh clusters that envoy knows about with
the new set.