### PR TITLE
Remove e2e_mixer_run from the e2e_suite 

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -121,7 +121,7 @@ e2e_version_skew_run: out_dir
 	go test -v -timeout 20m ./tests/e2e/tests/upgrade -args --smooth_check=true ${E2E_ARGS} ${EXTRA_E2E_ARGS} ${UPGRADE_E2E_ARGS}
 
 e2e_all_run: out_dir
-	$(MAKE) --keep-going e2e_simple_run e2e_mixer_run e2e_bookinfo_run e2e_dashboard_run e2e_upgrade_run e2e_version_skew_run
+	$(MAKE) --keep-going e2e_simple_run e2e_bookinfo_run e2e_dashboard_run e2e_upgrade_run e2e_version_skew_run
 
 JUNIT_E2E_XML ?= $(ISTIO_OUT)/junit.xml
 TARGET ?= e2e_all


### PR DESCRIPTION
now that it runs as a separate job.

And the mixer job is passing.
https://k8s-gubernator.appspot.com/build/istio-prow/e2e-mixer-no_auth/14/