### PR TITLE
Force namespace-wide authn policy name to be "default"

### DIFF
--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -561,7 +561,7 @@ func TestAuthenticationPolicyConfig(t *testing.T) {
 	store := model.MakeIstioStore(memory.Make(model.IstioConfigTypes))
 
 	authNPolicies := map[string]*authn.Policy{
-		"all": {},
+		model.DefaultAuthenticationPolicyName: {},
 		"hello": {
 			Targets: []*authn.TargetSelector{{
 				Name: "hello",
@@ -627,7 +627,7 @@ func TestAuthenticationPolicyConfig(t *testing.T) {
 		{
 			hostname: "world.default.svc.cluster.local",
 			port:     8080,
-			expected: "all",
+			expected: "default",
 		},
 		{
 			hostname: "world.another-galaxy.svc.cluster.local",
@@ -683,7 +683,7 @@ func TestAuthenticationPolicyConfigWithGlobal(t *testing.T) {
 			policy: &globalPolicy,
 		},
 		{
-			name:      "namespace-policy",
+			name:      model.DefaultAuthenticationPolicyName,
 			namespace: "default",
 			policy:    &namespacePolicy,
 		},

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1703,6 +1703,13 @@ func ValidateAuthenticationPolicy(name, namespace string, msg proto.Message) err
 	var errs error
 
 	if !clusterScoped {
+		if len(in.Targets) == 0 && name != DefaultAuthenticationPolicyName {
+			errs = appendErrors(errs, fmt.Errorf("authentication policy with no target rules  must be named %q, found %q",
+				DefaultAuthenticationPolicyName, name))
+		}
+		if len(in.Targets) > 0 && name == DefaultAuthenticationPolicyName {
+			errs = appendErrors(errs, fmt.Errorf("authentication policy with name %q must not have any target rules", name))
+		}
 		for _, target := range in.Targets {
 			errs = appendErrors(errs, validateAuthNPolicyTarget(target))
 		}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3133,16 +3133,35 @@ func TestValidateServiceEntries(t *testing.T) {
 func TestValidateAuthenticationPolicy(t *testing.T) {
 	cases := []struct {
 		name  string
+		configName string
 		in    proto.Message
 		valid bool
 	}{
 		{
-			name:  "empty",
+			name:  "empty policy with namespace-wise policy name",
+			configName: DefaultAuthenticationPolicyName,
 			in:    &authn.Policy{},
 			valid: true,
 		},
 		{
-			name: "empty-with-destination",
+			name:  "empty policy with non-default name",
+			configName: someName,
+			in:    &authn.Policy{},
+			valid: false,
+		},
+		{
+			name: "service-specific policy with namespace-wise name",
+			configName: DefaultAuthenticationPolicyName,
+			in: &authn.Policy{
+				Targets: []*authn.TargetSelector{{
+					Name: "foo",
+				}},
+			},
+			valid: false,
+		},
+		{
+			name: "Targets only policy",
+			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{{
 					Name: "foo",
@@ -3152,6 +3171,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Source mTLS",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
 					Params: &authn.PeerAuthenticationMethod_Mtls{},
@@ -3161,6 +3181,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Source JWT",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
 					Params: &authn.PeerAuthenticationMethod_Jwt{
@@ -3176,13 +3197,14 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Origin",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
 					{
 						Jwt: &authn.Jwt{
 							Issuer:     "istio.io",
 							JwksUri:    "https://secure.istio.io/oauth/v1/certs",
-							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+			                                JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
 						},
 					},
 				},
@@ -3191,6 +3213,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Bad JkwsURI",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
 					{
@@ -3206,6 +3229,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Bad JkwsURI Port",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
 					{
@@ -3221,6 +3245,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Duplicate Jwt issuers",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
 					Params: &authn.PeerAuthenticationMethod_Jwt{
@@ -3245,6 +3270,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Just binding",
+			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				PrincipalBinding: authn.PrincipalBinding_USE_ORIGIN,
 			},
@@ -3252,6 +3278,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Bad target name",
+			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{
 					{
@@ -3263,6 +3290,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 		{
 			name: "Good target name",
+			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{
 					{
@@ -3274,7 +3302,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if got := ValidateAuthenticationPolicy(someName, someNamespace, c.in); (got == nil) != c.valid {
+		if got := ValidateAuthenticationPolicy(c.configName, someNamespace, c.in); (got == nil) != c.valid {
 			t.Errorf("ValidateAuthenticationPolicy(%v): got(%v) != want(%v): %v\n", c.name, got == nil, c.valid, got)
 		}
 	}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3132,25 +3132,25 @@ func TestValidateServiceEntries(t *testing.T) {
 
 func TestValidateAuthenticationPolicy(t *testing.T) {
 	cases := []struct {
-		name  string
+		name       string
 		configName string
-		in    proto.Message
-		valid bool
+		in         proto.Message
+		valid      bool
 	}{
 		{
-			name:  "empty policy with namespace-wise policy name",
+			name:       "empty policy with namespace-wise policy name",
 			configName: DefaultAuthenticationPolicyName,
-			in:    &authn.Policy{},
-			valid: true,
+			in:         &authn.Policy{},
+			valid:      true,
 		},
 		{
-			name:  "empty policy with non-default name",
+			name:       "empty policy with non-default name",
 			configName: someName,
-			in:    &authn.Policy{},
-			valid: false,
+			in:         &authn.Policy{},
+			valid:      false,
 		},
 		{
-			name: "service-specific policy with namespace-wise name",
+			name:       "service-specific policy with namespace-wise name",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{{
@@ -3160,7 +3160,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Targets only policy",
+			name:       "Targets only policy",
 			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{{
@@ -3170,7 +3170,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Source mTLS",
+			name:       "Source mTLS",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
@@ -3180,7 +3180,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Source JWT",
+			name:       "Source JWT",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
@@ -3196,7 +3196,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Origin",
+			name:       "Origin",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
@@ -3204,7 +3204,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 						Jwt: &authn.Jwt{
 							Issuer:     "istio.io",
 							JwksUri:    "https://secure.istio.io/oauth/v1/certs",
-			                                JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
+							JwtHeaders: []string{"x-goog-iap-jwt-assertion"},
 						},
 					},
 				},
@@ -3212,7 +3212,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Bad JkwsURI",
+			name:       "Bad JkwsURI",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
@@ -3228,7 +3228,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Bad JkwsURI Port",
+			name:       "Bad JkwsURI Port",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Origins: []*authn.OriginAuthenticationMethod{
@@ -3244,7 +3244,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Duplicate Jwt issuers",
+			name:       "Duplicate Jwt issuers",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Peers: []*authn.PeerAuthenticationMethod{{
@@ -3269,7 +3269,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Just binding",
+			name:       "Just binding",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				PrincipalBinding: authn.PrincipalBinding_USE_ORIGIN,
@@ -3277,7 +3277,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "Bad target name",
+			name:       "Bad target name",
 			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{
@@ -3289,7 +3289,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid: false,
 		},
 		{
-			name: "Good target name",
+			name:       "Good target name",
 			configName: someName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3138,7 +3138,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 		valid      bool
 	}{
 		{
-			name:       "empty policy with namespace-wise policy name",
+			name:       "empty policy with namespace-wide policy name",
 			configName: DefaultAuthenticationPolicyName,
 			in:         &authn.Policy{},
 			valid:      true,
@@ -3150,7 +3150,7 @@ func TestValidateAuthenticationPolicy(t *testing.T) {
 			valid:      false,
 		},
 		{
-			name:       "service-specific policy with namespace-wise name",
+			name:       "service-specific policy with namespace-wide name",
 			configName: DefaultAuthenticationPolicyName,
 			in: &authn.Policy{
 				Targets: []*authn.TargetSelector{{


### PR DESCRIPTION
This PR enforce the name for authentication policy that have no target selector rules (i.e namespace-wide policy) must be `default`. This is to avoid having conflicts namespace-wide policies, as well as be more consistent with mesh-wide policy name.