### PR TITLE
Add stalebot configuration for pruning old prs and issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,43 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# General configuration
+# Label to use when marking as stale
+staleLabel: stale
+
+# Pull request specific configuration
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 7
+  # Number of days of inactivity before a stale Issue or Pull Request is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 7
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in the last 7 days. It will be closed in 7 days if no further activity occurs. Please
+    feel free to give a status update now, ping for review, or re-open when it's ready.
+    Thank you for your contributions!
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+     This pull request has been automatically closed because it has not had
+     activity in the last 14 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+     Thank you for your contributions!
+  # Limit the number of actions per hour, from 1-30. Default is 30
+  limitPerRun: 1
+
+# Issue specific configuration
+issues:
+  # TODO: Consider increasing the limitPerRun once we are satisfied with the bot's performance
+  limitPerRun: 1
+  daysUntilStale: 30
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity in the
+    last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or other activity
+    occurs. Thank you for your contributions.
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the
+    last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
+    Thank you for your contributions.
+  exemptLabels:
+    - help wanted


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

We have been using a Github apps hosted version of this stalebot for the envoyproxy/envoy repository. So far it has worked well. 

cc @louiscryan @sebastienvas 

I transferred the same config file that we are using in Envoy, but I'm not sure what should be marked for exemptLabels as it relates to Istio. Envoy ignores issues marked `help wanted` , but I'm not sure how diligent we have been with Istio lately.