### PR TITLE
Force usage of envoyv2 ports in bootstrap.go by consuming config option for discoveryAddress

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -88,12 +88,12 @@ data:
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15005
+      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15011
     {{- else }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15007
+      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15010
     {{- end }}

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -219,13 +219,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	}
 	StoreHostPort(h, p, "pilot_address", opts)
 
-	// Default values for the grpc address.
-	// TODO: take over the DiscoveryAddress or add a separate mesh config option
-	// Default value
-	grpcPort := "15010"
-	if config.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-		grpcPort = "15011"
-	}
+	grpcPort := p // Use pilot port
 	grpcHost := h // Use pilot host
 
 	grpcAddress := opts["pilot_grpc"]

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -108,7 +108,7 @@
 
     "hosts": [
     {
-    "socket_address": {"address": "mypilot", "port_value": 15011}
+    "socket_address": {"address": "mypilot", "port_value": 1001}
     }
     ],
     "circuit_breakers": {

--- a/pkg/bootstrap/testdata/auth.proto
+++ b/pkg/bootstrap/testdata/auth.proto
@@ -3,7 +3,7 @@ binary_path:             "/usr/local/bin/envoy"
 service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 2}
 parent_shutdown_duration: {seconds: 3}
-discovery_address:       "istio-pilot:15005"
+discovery_address:       "istio-pilot:15011"
 discovery_refresh_delay:  {seconds: 1}
 zipkin_address:           ""
 connect_timeout:          {seconds: 1}

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -74,7 +74,7 @@
 
       "hosts": [
           {
-            "socket_address": {"address": "istio-pilot", "port_value": 15005}
+            "socket_address": {"address": "istio-pilot", "port_value": 15011}
           }
         ]
 

--- a/pkg/bootstrap/testdata/default.proto
+++ b/pkg/bootstrap/testdata/default.proto
@@ -3,7 +3,7 @@ binary_path:             "/usr/local/bin/envoy"
 service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 2}
 parent_shutdown_duration: {seconds: 3}
-discovery_address:       "istio-pilot:15007"
+discovery_address:       "istio-pilot:15010"
 discovery_refresh_delay:  {seconds: 1}
 zipkin_address:           ""
 connect_timeout:          {seconds: 1}

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -53,7 +53,7 @@
 
       "hosts": [
           {
-            "socket_address": {"address": "istio-pilot", "port_value": 15007}
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
           }
         ]
 


### PR DESCRIPTION
The Helm chart has v1 proxy ports which is incorrect.