### PR TITLE
Remove the clusterregistry configmap usage in favor of labelled secret

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -653,7 +653,7 @@ func (k *KubeInfo) deployIstio() error {
 			return err
 		}
 		// Create the local secrets and configmap to start pilot
-		if err := util.CreateMultiClusterSecrets(k.Namespace, k.KubeClient, k.RemoteKubeConfig, k.KubeConfig); err != nil {
+		if err := util.CreateMultiClusterSecrets(k.Namespace, k.RemoteKubeConfig, k.KubeConfig); err != nil {
 			log.Errorf("Unable to create secrets on local cluster %s", err.Error())
 			return err
 		}

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -29,14 +29,9 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/sync/errgroup"
 	multierror "github.com/hashicorp/go-multierror"
 	"golang.org/x/net/context/ctxhttp"
-	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 
 	"istio.io/istio/pkg/log"
 )
@@ -762,60 +757,26 @@ func CheckPodRunning(n, name string, kubeconfig string) error {
 }
 
 // CreateMultiClusterSecrets will create the secrets and configmap associated with the remote cluster
-func CreateMultiClusterSecrets(namespace string, KubeClient kubernetes.Interface, RemoteKubeConfig string, localKubeConfig string) error {
+func CreateMultiClusterSecrets(namespace string, RemoteKubeConfig string, localKubeConfig string) error {
 	const (
-		secretName    = "remote-cluster"
-		configMapName = "clusterregistry"
+		secretLabel = "istio/multiCluster"
+		labelValue  = "true"
 	)
-	_, err := ShellMuteOutput("kubectl create secret generic %s --from-file %s -n %s --kubeconfig=%s", secretName, RemoteKubeConfig, namespace, localKubeConfig)
-	// The cluster name is derived from the filename used to create the secret we will need it for the configmap
 	filename := filepath.Base(RemoteKubeConfig)
+
+	_, err := ShellMuteOutput("kubectl create secret generic %s --from-file %s -n %s --kubeconfig=%s", filename, RemoteKubeConfig, namespace, localKubeConfig)
 	if err != nil {
 		return err
 	}
-	log.Infof("Secret remote-cluster created\n")
-	remoteCluster := &v1.ConfigMap{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      configMapName,
-			Namespace: namespace,
-		},
-	}
+	log.Infof("Secret %s created\n", filename)
 
-	remoteClusterData := v1alpha1.Cluster{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "Cluster",
-			APIVersion: "clusterregistry.k8s.io/v1alpha1",
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name:      secretName,
-			Namespace: namespace,
-			Annotations: map[string]string{"config.istio.io/accessConfigSecret": secretName,
-				"config.istio.io/accessConfigSecretNamespace": namespace,
-				"config.istio.io/platform":                    "Kubernetes"},
-			ClusterName: "",
-		},
-		Spec: v1alpha1.ClusterSpec{
-			KubernetesAPIEndpoints: v1alpha1.KubernetesAPIEndpoints{
-				ServerEndpoints: nil,
-				CABundle:        nil,
-			},
-			AuthInfo: v1alpha1.AuthInfo{},
-		},
-	}
-
-	dataBytes, err1 := yaml.Marshal(remoteClusterData)
-	if err1 != nil {
-		return err1
-	}
-
-	data := map[string]string{}
-	data[filename] = string(dataBytes)
-	remoteCluster.Data = data
-
-	_, err = KubeClient.CoreV1().ConfigMaps(namespace).Create(remoteCluster)
+	// label the secret for use as istio/multiCluster config
+	_, err = ShellMuteOutput("kubectl label secret %s %s=%s -n %s --kubeconfig=%s",
+		filename, secretLabel, labelValue, namespace, localKubeConfig)
 	if err != nil {
 		return err
 	}
-	log.Infof("Configmap created\n")
+
+	log.Infof("Secret %s labelled with %s=%s\n", filename, secretLabel, labelValue)
 	return nil
 }


### PR DESCRIPTION
- creates a secret with the remote cluster's kubeconfig and label it for pilot multicluster usage
- this aligns with current docs & preferred remote cluster config
  reference.
- this removes the pilot e2e multicluster configuring the clusterregistry configmap.

Fixes: https://github.com/istio/istio/issues/6072
