### PR TITLE
Uniform stats prefixes in Envoy config

### DIFF
--- a/istioctl/pkg/writer/envoy/configdump/testdata/configdump.json
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/configdump.json
@@ -20,7 +20,7 @@
                                     {
                                         "name": "envoy.http_connection_manager",
                                         "config": {
-                                            "stat_prefix": "http",
+                                            "stat_prefix": "0.0.0.0_8080",
                                             "use_remote_address": false,
                                             "generate_request_id": true,
                                             "access_log": [

--- a/istioctl/pkg/writer/envoy/configdump/testdata/listenerdump.json
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/listenerdump.json
@@ -18,7 +18,7 @@
                             {
                                 "name": "envoy.http_connection_manager",
                                 "config": {
-                                    "stat_prefix": "http",
+                                    "stat_prefix": "0.0.0.0_8080",
                                     "use_remote_address": false,
                                     "generate_request_id": true,
                                     "access_log": [

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -45,12 +45,6 @@ const (
 
 	envoyHTTPConnectionManager = "envoy.http_connection_manager"
 
-	// HTTPStatPrefix indicates envoy stat prefix for http listeners
-	HTTPStatPrefix = "http"
-
-	// RDSName is the name of route-discovery-service (RDS) cluster
-	//RDSName = "rds"
-
 	// RDSHttpProxy is the special name for HTTP PROXY route
 	RDSHttpProxy = "http_proxy"
 
@@ -584,6 +578,9 @@ type httpListenerOpts struct {
 	direction        http_conn.HttpConnectionManager_Tracing_OperationName
 	// If set, use this as a basis
 	connectionManager *http_conn.HttpConnectionManager
+	// stat prefix for the http connection manager
+	// DO not set this field. Will be overridden by marshalFilters
+	statPrefix string
 }
 
 // filterChainOpts describes a filter chain: a set of filters with the same TLS context
@@ -624,7 +621,7 @@ func buildHTTPConnectionManager(env model.Environment, httpOpts *httpListenerOpt
 	connectionManager.CodecType = http_conn.AUTO
 	connectionManager.AccessLog = []*accesslog.AccessLog{}
 	connectionManager.HttpFilters = filters
-	connectionManager.StatPrefix = HTTPStatPrefix
+	connectionManager.StatPrefix = httpOpts.statPrefix
 	connectionManager.UseRemoteAddress = &google_protobuf.BoolValue{httpOpts.useRemoteAddress}
 
 	if httpOpts.rds != "" && !env.DisableRDS {
@@ -760,6 +757,7 @@ func marshalFilters(l *xdsapi.Listener, opts buildListenerOpts, chains []plugin.
 		}
 
 		if opt.httpOpts != nil {
+			opt.httpOpts.statPrefix = l.Name
 			connectionManager := buildHTTPConnectionManager(opts.env, opt.httpOpts, chain.HTTP)
 			l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, listener.Filter{
 				Name:   envoyHTTPConnectionManager,


### PR DESCRIPTION
TCP Proxy stats will be prefixed with cluster name.
Mongo proxy stats will be prefixed with cluster name (envoy appends mongo.stat_prefix)
HTTP connection manager stats will be prefixed with the listener name.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>