### PR TITLE
add cert manager integration example

### DIFF
--- a/samples/bookinfo/kube/bookinfo-certificate.yaml
+++ b/samples/bookinfo/kube/bookinfo-certificate.yaml
@@ -2,10 +2,10 @@
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
-  name: istio-ingress-certs
+  name: istio-ingressgateway-certs
   namespace: istio-system
 spec:
-  secretName: istio-ingress-certs
+  secretName: istio-ingressgateway-certs
   issuerRef:
     name: letsencrypt-staging
     kind: ClusterIssuer

--- a/samples/bookinfo/kube/bookinfo-certificate.yaml
+++ b/samples/bookinfo/kube/bookinfo-certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: istio-ingress-certs
+  namespace: istio-system
+spec:
+  secretName: istio-ingress-certs
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  commonName: bookinfo.example.com
+  dnsNames:
+  - bookinfo.example.com
+  acme:
+    config:
+    - http01:
+        ingressClass: none
+      domains:
+      - bookinfo.example.com

--- a/samples/bookinfo/kube/cert-manager.yaml
+++ b/samples/bookinfo/kube/cert-manager.yaml
@@ -103,13 +103,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cm-acme-http-solver
-  namespace: cert-system
+  namespace: istio-system # expose certificate issuer pod
   annotations:
     auth.istio.io/8089: NONE
 spec:
   ports:
   - port: 8089
     name: http-certingr
+  selector:
+    certmanager.k8s.io/domain: bookinfo.example.com
 ---
 apiVersion: apps/v1beta1
 kind: Deployment

--- a/samples/bookinfo/kube/cert-manager.yaml
+++ b/samples/bookinfo/kube/cert-manager.yaml
@@ -1,12 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
- name: cert-system
- labels:
-    istio-injection: enabled
----
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -57,7 +49,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-manager
-  namespace: cert-system
+  namespace: istio-system
   labels:
     app: cert-manager
 ---
@@ -95,7 +87,7 @@ roleRef:
   name: cert-manager
 subjects:
   - name: cert-manager
-    namespace: cert-system
+    namespace: istio-system
     kind: ServiceAccount
 
 ---
@@ -117,7 +109,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cert-manager
-  namespace: cert-system
+  namespace: istio-system
   labels:
     app: cert-manager
     version: v0.3.0
@@ -126,12 +118,10 @@ spec:
   selector:
     matchLabels:
       app: cert-manager
-      version: v0.3.0
   template:
     metadata:
       labels:
         app: cert-manager
-        version: v0.3.0
     spec:
       serviceAccountName: cert-manager
       containers:
@@ -161,7 +151,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
-  namespace: cert-system
+  namespace: istio-system
 spec:
   acme:
     # The ACME server URL
@@ -178,7 +168,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging
-  namespace: cert-system
+  namespace: istio-system
 spec:
   acme:
     # The ACME server URL

--- a/samples/bookinfo/kube/cert-manager.yaml
+++ b/samples/bookinfo/kube/cert-manager.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: cert-system
+ labels:
+    istio-injection: enabled
+---
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+---
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: cert-system
+  labels:
+    app: cert-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cert-manager
+  labels:
+    app: cert-manager
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager
+  labels:
+    app: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager
+subjects:
+  - name: cert-manager
+    namespace: cert-system
+    kind: ServiceAccount
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cm-acme-http-solver
+  namespace: cert-system
+  annotations:
+    auth.istio.io/8089: NONE
+spec:
+  ports:
+  - port: 8089
+    name: http-certingr
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cert-manager
+  namespace: cert-system
+  labels:
+    app: cert-manager
+    version: v0.3.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cert-manager
+      version: v0.3.0
+  template:
+    metadata:
+      labels:
+        app: cert-manager
+        version: v0.3.0
+    spec:
+      serviceAccountName: cert-manager
+      containers:
+        - name: cert-manager
+          image: quay.io/jetstack/cert-manager-controller:v0.3.0
+          imagePullPolicy: IfNotPresent
+          args:
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=$(POD_NAMESPACE)
+          - --default-issuer-name=letsencrypt-prod
+          - --default-issuer-kind=ClusterIssuer
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          resources:
+            limits:
+             cpu: 1
+             memory: 256Mi
+            requests:
+             cpu: 0.01
+             memory: 32Mi
+---
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  namespace: cert-system
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: prod@istio.io
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    http01: {}
+---
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  namespace: cert-system
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: stage@istio.io
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    http01: {}

--- a/samples/bookinfo/routing/cert-manager-egress-rules.yaml
+++ b/samples/bookinfo/routing/cert-manager-egress-rules.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: kubernetesapis
+  namespace: cert-system
+spec:
+  hosts:
+  - kubernetes.default.svc.cluster.local
+  location: MESH_INTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: NONE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: kubernetesapis
+  namespace: cert-system
+spec:
+  host: kubernetes.default.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: letsencryptapis
+  namespace: cert-system
+spec:
+  hosts:
+  - "*.api.letsencrypt.org"
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: NONE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: letsencryptapis
+  namespace: cert-system
+spec:
+  host: "*.api.letsencrypt.org"

--- a/samples/bookinfo/routing/cert-manager-egress-rules.yaml
+++ b/samples/bookinfo/routing/cert-manager-egress-rules.yaml
@@ -1,46 +1,11 @@
 ---
 apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: kubernetesapis
-  namespace: cert-system
-spec:
-  hosts:
-  - kubernetes.default.svc.cluster.local
-  location: MESH_INTERNAL
-  ports:
-  - number: 443
-    name: https
-    protocol: HTTPS
-  resolution: NONE
----
-apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: kubernetesapis
-  namespace: cert-system
+  namespace: istio-system
 spec:
   host: kubernetes.default.svc.cluster.local
----
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: letsencryptapis
-  namespace: cert-system
-spec:
-  hosts:
-  - "*.api.letsencrypt.org"
-  location: MESH_EXTERNAL
-  ports:
-  - number: 443
-    name: https
-    protocol: HTTPS
-  resolution: NONE
----
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: letsencryptapis
-  namespace: cert-system
-spec:
-  host: "*.api.letsencrypt.org"
+  trafficPolicy:
+    tls:
+      mode: DISABLE

--- a/samples/bookinfo/routing/cert-manager-gateway.yaml
+++ b/samples/bookinfo/routing/cert-manager-gateway.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cert-manager-gateway
+  namespace: cert-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: cert-manager
+  namespace: cert-system
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - cert-manager-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /.well-known/acme-challenge/
+    route:
+    - destination:
+        host: cert-manager-resolver
+        port:
+          number: 8089
+

--- a/samples/bookinfo/routing/cert-manager-gateway.yaml
+++ b/samples/bookinfo/routing/cert-manager-gateway.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: cert-manager-gateway
-  namespace: cert-system
+  namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
@@ -18,7 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: cert-manager
-  namespace: cert-system
+  namespace: istio-system
 spec:
   hosts:
   - "*"


### PR DESCRIPTION
Istio 0.8.0 and Cert Manager 0.3.0 integration example.

```shell
# deploy cert manager 
kubectl apply -f samples/bookinfo/kube/cert-manager.yaml

# add egress rules for cert manager
istioctl create -f samples/bookinfo/routing/cert-manager-egress-rules.yaml

# add cert manager gateway
istioctl create -f samples/bookinfo/routing/cert-manager-gateway.yaml

# issue a certificate for bookinfo ingress
kubectl apply -f samples/bookinfo/kube/bookinfo-certificate.yaml
```

This example has an issue with **cm-acme-http-solver-xxxx**, which is not in mesh, because it will be created from cert-manager instance via k8s api without `sidecar.istio.io/inject: "true"` annotation.

Related to https://github.com/istio/istio/issues/6486