### PR TITLE
remove unused service account name and templates.

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "security.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "security.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -53,7 +53,6 @@ global:
 # security configuration
 #
 security:
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: citadel
   resources: {}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
       volumes:
       - name: certs
         secret:
+{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-galley-service-account
+{{- else }}
+          secretName: istio.default
+{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "mixer.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "mixer.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/charts/security/templates/_helpers.tpl
@@ -14,14 +14,3 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Service account name.
-*/}}
-{{- define "security.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "security.fullname" . -}}-service-account
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}-service-account
-{{- end -}}
-{{- end -}}

--- a/install/kubernetes/helm/istio/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/templates/_helpers.tpl
@@ -16,17 +16,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Service account name.
-*/}}
-{{- define "istio.serviceAccountName" -}}
-{{- if .Values.global.rbacEnabled -}}
-{{- template "istio.fullname" . -}}
-{{- else }}
-{{- .Values.serviceAccountName | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Create a fully qualified configmap name.
 */}}
 {{- define "istio.configmap.fullname" -}}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -27,7 +27,6 @@ global:
     # istio-sidecar-injector configmap stores configuration for sidecar injection.
     # This config map is used by istioctl kube-inject and the injector webhook.
     enableCoreDump: false
-    serviceAccountName: default # used only if RBAC is not enabled
     replicaCount: 1
 
     # istio egress capture whitelist
@@ -113,7 +112,6 @@ istiotesting:
 #
 ingress:
   enabled: true
-  serviceAccountName: default
   replicaCount: 1
   autoscaleMin: 1
   autoscaleMax: 1
@@ -220,7 +218,6 @@ sidecarInjectorWebhook:
 #
 galley:
   enabled: true
-  serviceAccountName: default
   replicaCount: 1
   image: galley
   resources: {}
@@ -236,7 +233,6 @@ galley:
 #
 mixer:
   enabled: true
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: mixer
   resources: {}
@@ -257,7 +253,6 @@ mixer:
 #
 pilot:
   enabled: true
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: pilot
   resources: {}
@@ -272,7 +267,6 @@ pilot:
 # security configuration
 #
 security:
-  serviceAccountName: default # used only if RBAC is not enabled
   replicaCount: 1
   image: citadel
   resources: {}


### PR DESCRIPTION
Remove unused service account name and templates since they haven't been used in yaml templates.
Fix chart deploy issue when rbac is disabled.