### PR TITLE
Delayed start for the istio-mixer-post-install job

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -77,11 +77,9 @@ spec:
       containers:
         - name: hyperkube
           image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
-          command:
-            - ./kubectl
-            - apply
-            - -f
-            - /tmp/mixer/custom-resources.yaml
+          command: ["/bin/bash","-c",
+            "sleep 30 && \
+            ./kubectl apply -f /tmp/mixer/custom-resources.yaml"]
           volumeMounts:
             - mountPath: "/tmp/mixer"
               name: tmp-configmap-mixer


### PR DESCRIPTION
Added a delayed start for the `istio-mixer-post-install` hooked job to overcome a timeout on first try due to system still busy bringing up relevant services.

As we are currently using `hyperkube` with `kubectl v1.7.6` the request timeout flag is still not available. Once we have a new kubectl we can replace this delay with a longer timeout.

Fixes #6470 