### PR TITLE
Test cases for 'istioctl version'

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -545,7 +545,7 @@ func TestVersion(t *testing.T) {
 		{ // case 0
 			configs:        []model.Config{},
 			args:           strings.Split("version", " "),
-			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\nUser: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9]+)\nBuildStatus: unknown\n"),
+			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\nUser: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9\\.]+)\nBuildStatus: unknown\n"),
 		},
 		{ // case 1 short output
 			configs:        []model.Config{},

--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -543,9 +543,11 @@ func TestKubeInject(t *testing.T) {
 func TestVersion(t *testing.T) {
 	cases := []testCase{
 		{ // case 0
-			configs:        []model.Config{},
-			args:           strings.Split("version", " "),
-			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\nUser: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9\\.]+)\nBuildStatus: unknown\n"),
+			configs: []model.Config{},
+			args:    strings.Split("version", " "),
+			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\n" +
+				"User: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9\\.]+)\n" +
+				"BuildStatus: unknown\n"),
 		},
 		{ // case 1 short output
 			configs:        []model.Config{},

--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -539,3 +539,30 @@ func TestKubeInject(t *testing.T) {
 		})
 	}
 }
+
+func TestVersion(t *testing.T) {
+	cases := []testCase{
+		{ // case 0
+			configs:        []model.Config{},
+			args:           strings.Split("version", " "),
+			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\nUser: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9]+)\nBuildStatus: unknown\n"),
+		},
+		{ // case 1 short output
+			configs:        []model.Config{},
+			args:           strings.Split("version -s", " "),
+			expectedOutput: "unknown@unknown-unknown-unknown-unknown-unknown\n",
+		},
+		{ // case 2 bogus arg
+			configs:        []model.Config{},
+			args:           strings.Split("version --typo", " "),
+			expectedOutput: "Error: unknown flag: --typo\n",
+			wantException:  true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
+			verifyOutput(t, c)
+		})
+	}
+}

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -15,8 +15,6 @@
 package version
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,9 +27,9 @@ func CobraCommand() *cobra.Command {
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if short {
-				fmt.Println(Info)
+				cmd.Println(Info)
 			} else {
-				fmt.Println(Info.LongForm())
+				cmd.Println(Info.LongForm())
 			}
 		},
 	}


### PR DESCRIPTION
Before adding `istioctl version` enhancements to show server versions for Issue https://github.com/istio/istio/issues/2491 and Issue https://github.com/istio/istio/issues/5308 I want tests for the current output.