### PR TITLE
add service account, cluster role, and binding for remote clusters

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+  kind: ClusterRole
+  apiVersion: rbac.authorization.k8s.io/v1
+  metadata:
+    name: istio-reader
+  rules:
+    - apiGroups: ['']
+      resources: ['nodes', 'pods', 'services', 'endpoints']
+      verbs: ['get', 'watch', 'list']

--- a/install/kubernetes/helm/istio-remote/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-multi
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-reader
+subjects:
+- kind: ServiceAccount
+  name: istio-multi
+  namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio-remote/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-multi
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This adds a service account, cluster role, and binding to ease in multi-cluster setup. 

cc: @tiswanso 

related: #5516 #6366 