### PR TITLE
Restore e2e_dashboard to working state

### DIFF
--- a/addons/grafana/dashboards/istio-mesh-dashboard.json
+++ b/addons/grafana/dashboards/istio-mesh-dashboard.json
@@ -60,7 +60,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
@@ -976,7 +976,7 @@
           "refId": "E"
         },
         {
-          "expr": "label_replace(sum(irate(istio_request_count{response_code!~\"5.*\"}[1m])) by (destination_service)/ sum(irate(istio_request_count[1m]) > 0) by (destination_service), \"destination_service\", \"$1\", \"destination_service\", \"(.*).svc.cluster.local\")",
+          "expr": "label_replace(sum(irate(istio_request_count{response_code!~\"5.*\"}[1m])) by (destination_service)/ sum(irate(istio_request_count[1m]) > bool 0) by (destination_service), \"destination_service\", \"$1\", \"destination_service\", \"(.*).svc.cluster.local\")",
           "format": "table",
           "instant": true,
           "interval": "",

--- a/addons/grafana/dashboards/mixer-dashboard.json
+++ b/addons/grafana/dashboards/mixer-dashboard.json
@@ -14,25 +14,25 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-beta2"
+      "version": "5.0.4"
     },
     {
       "type": "panel",
       "id": "graph",
       "name": "Graph",
-      "version": ""
+      "version": "5.0.0"
     },
     {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": "1.0.0"
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "text",
       "name": "Text",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
   "annotations": {
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1520470122238,
+  "iteration": 1529808982599,
   "links": [],
   "panels": [
     {
@@ -534,20 +534,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(envoy_cluster_mixer_check_server_upstream_rq_total[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "envoy (Check)",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(envoy_cluster_mixer_report_server_upstream_rq_total[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "envoy (Report)",
-          "refId": "D"
-        },
-        {
           "expr": "sum(rate(grpc_server_handled_total[1m]))",
           "format": "time_series",
           "hide": false,
@@ -556,7 +542,7 @@
           "refId": "B"
         },
         {
-          "expr": "rate(grpc_server_handled_total[1m])",
+          "expr": "sum(rate(grpc_server_handled_total[1m])) by (grpc_method)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "mixer ({{ grpc_method }})",
@@ -640,20 +626,6 @@
       "stack": false,
       "steppedLine": false,
       "targets": [
-        {
-          "expr": "envoy_cluster_mixer_check_server_upstream_rq_time",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }} (envoy Check)",
-          "refId": "A"
-        },
-        {
-          "expr": "envoy_cluster_mixer_report_server_upstream_rq_time",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }} (envoy Report)",
-          "refId": "E"
-        },
         {
           "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{}[1m])) by (grpc_method, le)) * 1000",
           "format": "time_series",
@@ -749,20 +721,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(envoy_cluster_mixer_check_server_upstream_rq_5xx[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Envoy Check",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(envoy_cluster_mixer_report_server_upstream_rq_5xx[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Envoy Report",
-          "refId": "C"
-        },
-        {
           "expr": "sum(rate(grpc_server_handled_total{grpc_code=~\"Unknown|Unimplemented|Internal|DataLoss\"}[1m])) by (grpc_method)",
           "format": "time_series",
           "intervalFactor": 2,
@@ -843,20 +801,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_4xx[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Envoy Check",
-          "refId": "A"
-        },
-        {
-          "expr": "irate(envoy_cluster_mixer_report_server_upstream_rq_4xx[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Envoy Report",
-          "refId": "C"
-        },
-        {
           "expr": "sum(irate(grpc_server_handled_total{grpc_code!=\"OK\",grpc_service=~\".*Mixer\"}[1m])) by (grpc_method)",
           "format": "time_series",
           "intervalFactor": 2,
@@ -901,419 +845,12 @@
       ]
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 19
-      },
-      "id": 10,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "envoy_cluster_mixer_check_server_upstream_cx_active",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Active  (mixer_check_server)",
-          "refId": "B"
-        },
-        {
-          "expr": "envoy_cluster_mixer_report_server_upstream_cx_active",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Active  (mixer_report_server)",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Connections",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 19
-      },
-      "id": 1,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "envoy_cluster_mixer_check_server_membership_healthy",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Healthy (mixer_check_server)",
-          "refId": "A"
-        },
-        {
-          "expr": "envoy_cluster_mixer_check_server_membership_total",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Total (mixer_check_server)",
-          "refId": "B"
-        },
-        {
-          "expr": "envoy_cluster_mixer_report_server_membership_healthy",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Healthy (mixer_report_server)",
-          "refId": "C"
-        },
-        {
-          "expr": "envoy_cluster_mixer_report_server_membership_total",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 2,
-          "legendFormat": "Total (mixer_report_server)",
-          "refId": "D"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Cluster Membership",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 19
-      },
-      "id": 35,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "rate(envoy_cluster_mixer_check_server_outlier_detection_ejections_enforced_total[1m])",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Total Ejections (mixer_check_server)",
-          "refId": "A"
-        },
-        {
-          "expr": "rate(envoy_cluster_mixer_check_server_outlier_detection_ejections_overflow[1m])",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Overflow Ejections (mixer_check_server)",
-          "refId": "B"
-        },
-        {
-          "expr": "envoy_cluster_mixer_check_server_outlier_detection_ejections_active",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Active Ejections (mixer_check_server)",
-          "refId": "C"
-        },
-        {
-          "expr": "rate(envoy_cluster_mixer_report_server_outlier_detection_ejections_enforced_total[1m])",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Total Ejections (mixer_report_server)",
-          "refId": "D"
-        },
-        {
-          "expr": "rate(envoy_cluster_mixer_report_server_outlier_detection_ejections_overflow[1m])",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Overflow Ejections (mixer_report_server)",
-          "refId": "E"
-        },
-        {
-          "expr": "envoy_cluster_mixer_report_server_outlier_detection_ejections_active",
-          "format": "time_series",
-          "instant": false,
-          "intervalFactor": 2,
-          "legendFormat": "Active Ejections (mixer_report_server)",
-          "refId": "F"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Outliers",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 19
-      },
-      "id": 36,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Total (mixer_check_server)",
-          "refId": "A"
-        },
-        {
-          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry_success[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Success  (mixer_check_server)",
-          "refId": "B"
-        },
-        {
-          "expr": "irate(envoy_cluster_mixer_check_server_upstream_rq_retry_overflow[1m])",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Overflow  (mixer_check_server)",
-          "refId": "C"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Client Retries",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
       "content": "<center><h2>Adapters and Config</h2></center>",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 19
       },
       "id": 28,
       "links": [],
@@ -1333,7 +870,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 29
+        "y": 22
       },
       "id": 13,
       "legend": {
@@ -1413,7 +950,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 29
+        "y": 22
       },
       "id": 14,
       "legend": {
@@ -1507,7 +1044,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 36
+        "y": 29
       },
       "id": 60,
       "legend": {
@@ -1608,7 +1145,7 @@
         "h": 7,
         "w": 6,
         "x": 6,
-        "y": 36
+        "y": 29
       },
       "id": 56,
       "legend": {
@@ -1688,7 +1225,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 36
+        "y": 29
       },
       "id": 54,
       "legend": {
@@ -1768,7 +1305,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 36
+        "y": 29
       },
       "id": 58,
       "legend": {
@@ -1844,7 +1381,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 36
       },
       "id": 23,
       "links": [],
@@ -1859,7 +1396,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 39
       },
       "id": 46,
       "panels": [],
@@ -1878,7 +1415,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 40
       },
       "id": 17,
       "legend": {
@@ -1958,7 +1495,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 40
       },
       "id": 18,
       "legend": {
@@ -2071,8 +1608,8 @@
     ]
   },
   "time": {
-    "from": "now-5m",
-    "to": "now"
+    "from": "now/d",
+    "to": "now/d"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -2102,5 +1639,5 @@
   "timezone": "",
   "title": "Mixer Dashboard",
   "uid": "2",
-  "version": 9
+  "version": 3
 }

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -14,25 +14,25 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-beta2"
+      "version": "5.0.4"
     },
     {
       "type": "panel",
       "id": "graph",
       "name": "Graph",
-      "version": ""
+      "version": "5.0.0"
     },
     {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": "1.0.0"
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "text",
       "name": "Text",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
   "annotations": {
@@ -517,7 +517,7 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 13
       },
@@ -598,8 +598,8 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 8,
         "y": 13
       },
       "id": 12,
@@ -679,89 +679,8 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 13
-      },
-      "id": 38,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(pilot_discovery_cache_size) by (cache_name)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ cache_name }}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Discovery Cache Sizes",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "bytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
+        "w": 8,
+        "x": 16,
         "y": 13
       },
       "id": 39,
@@ -857,357 +776,9 @@
       "fill": 1,
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 0,
-        "y": 20
-      },
-      "id": 37,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(pilot_discovery_cache_hit{cache_name=\"cds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "Hits",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(pilot_discovery_cache_miss{cache_name=\"cds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "MIsses",
-          "refId": "B",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "CDS Cache",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 6,
-        "y": 20
-      },
-      "id": 46,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(pilot_discovery_cache_hit{cache_name=\"lds\"}[1m])) ",
-          "intervalFactor": 2,
-          "legendFormat": "Hits",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(pilot_discovery_cache_miss{cache_name=\"lds\"}[1m])) ",
-          "intervalFactor": 2,
-          "legendFormat": "Misses",
-          "refId": "B",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "LDS Cache",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 12,
-        "y": 20
-      },
-      "id": 47,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(pilot_discovery_cache_hit{cache_name=\"rds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "Hits",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(pilot_discovery_cache_miss{cache_name=\"rds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "Misses",
-          "refId": "B",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "RDS Cache",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 6,
-        "x": 18,
-        "y": 20
-      },
-      "id": 48,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(pilot_discovery_cache_hit{cache_name=\"sds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "Hits",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "sum(irate(pilot_discovery_cache_miss{cache_name=\"sds\"}[1m]))",
-          "intervalFactor": 2,
-          "legendFormat": "Misses",
-          "refId": "B",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "SDS Cache",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 20
       },
       "id": 45,
       "legend": {
@@ -1296,7 +867,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 20
       },
       "id": 50,
       "legend": {
@@ -1372,7 +943,7 @@
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 27
       },
       "id": 28,
       "links": [],
@@ -1392,7 +963,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 37
+        "y": 30
       },
       "id": 40,
       "legend": {
@@ -1513,7 +1084,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 37
+        "y": 30
       },
       "id": 42,
       "legend": {
@@ -1610,7 +1181,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 37
+        "y": 30
       },
       "id": 41,
       "legend": {
@@ -1720,5 +1291,5 @@
   "timezone": "browser",
   "title": "Pilot Dashboard",
   "uid": "3",
-  "version": 2
+  "version": 3
 }

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -109,7 +109,7 @@ e2e_galley_run: out_dir
 	go test -v -timeout 25m ./tests/e2e/tests/galley -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} -use_galley_config_validator -cluster_wide
 
 e2e_dashboard_run: out_dir
-	go test -v -timeout 25m ./tests/e2e/tests/dashboard -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
+	ISTIO_PROXY_IMAGE=proxyv2 go test -v -timeout 25m ./tests/e2e/tests/dashboard -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
 e2e_bookinfo_run: out_dir
 	go test -v -timeout 60m ./tests/e2e/tests/bookinfo -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}


### PR DESCRIPTION
This PR fixes a number of issues with the `e2e_dashboard` test that have resulted from
recent changes to Istio functionality across the codebase.

Primarily, it switches the proxy version being used for the test to `v2`. This allows
the test to actually execute.

Additionally, a number of changes to existing dashboards are made to match behavioral (and
otherwise) changes. This PR:
- removes all `mixer_check_server` and `mixer_report_server` metrics monitoring, as the cluster naming for those clusters has changed (and the mixer self-monitoring covers the same metrics).
- removes the pilot discovery cache monitoring, as the xDS cache metrics no longer appear to be generated with the v2 config
- fixes the success rate query logic to properly report NaN in cases of 0 total requests (preventing divide-by-zero scenarios).

Results from local testing:
```
$ make e2e_dashboard E2E_ARGS="--use_local_cluster" HUB=localhost:5000 TAG=latest
...
=== RUN   TestDashboards
=== RUN   TestDashboards/Istio
=== RUN   TestDashboards/HTTP_Service
=== RUN   TestDashboards/TCP_Service
=== RUN   TestDashboards/Mixer
=== RUN   TestDashboards/Pilot
--- PASS: TestDashboards (0.56s)
	dashboard_test.go:78: Validating prometheus in ready-state...
	dashboard_test.go:478: Waiting for prometheus metrics: 0s
	dashboard_test.go:485: Value found for: 'round(sum(irate(istio_request_count[1m])), 0.001)'
	dashboard_test.go:485: Value found for: 'sum(irate(istio_request_count{response_code=~"4.*"}[1m]))'
	dashboard_test.go:485: Value found for: 'sum(irate(istio_request_count{response_code=~"5.*"}[1m]))'
	dashboard_test.go:83: Sentinel metrics found in prometheus.
    --- PASS: TestDashboards/Istio (0.13s)
    	dashboard_test.go:108: For Istio, checking 20 queries.
    --- PASS: TestDashboards/HTTP_Service (0.06s)
    	dashboard_test.go:108: For HTTP Service, checking 14 queries.
    --- PASS: TestDashboards/TCP_Service (0.05s)
    	dashboard_test.go:108: For TCP Service, checking 14 queries.
    --- PASS: TestDashboards/Mixer (0.13s)
    	dashboard_test.go:108: For Mixer, checking 35 queries.
    --- PASS: TestDashboards/Pilot (0.17s)
    	dashboard_test.go:108: For Pilot, checking 30 queries.
PASS
...
ok  	istio.io/istio/tests/e2e/tests/dashboard	262.101s
```