### PR TITLE
Fix errors when trying to enable Kiali in Helm installation

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -8,7 +8,6 @@ metadata:
     version: master
 rules:
 - apiGroups: ["","apps", "autoscaling"]
-  attributeRestrictions: null
   resources:
   - configmaps
   - namespaces
@@ -24,7 +23,6 @@ rules:
   - list
   - watch
 - apiGroups: ["config.istio.io"]
-  attributeRestrictions: null
   resources:
   - routerules
   - destinationpolicies
@@ -58,7 +56,6 @@ rules:
   - list
   - watch
 - apiGroups: ["networking.istio.io"]
-  attributeRestrictions: null
   resources:
   - virtualservices
   - destinationrules


### PR DESCRIPTION
The `attributeRestrictions` aren't documented in the `PolicyRule` API reference.
Specifying those generates errors.

Fixes #6583 