### PR TITLE
Change pre/post install jobs restart to OnFailure

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -88,4 +88,4 @@ spec:
         - name: tmp-configmap-mixer
           configMap:
             name: istio-mixer-custom-resources
-      restartPolicy: Never # CRD might take some time till they are available to consume
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -76,9 +76,11 @@ spec:
       containers:
         - name: hyperkube
           image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
-          command: ["/bin/bash","-c",
-            "sleep 30 && \
-            ./kubectl apply -f /tmp/mixer/custom-resources.yaml"]
+          command:
+            - ./kubectl
+            - apply
+            - -f
+            - /tmp/mixer/custom-resources.yaml
           volumeMounts:
             - mountPath: "/tmp/mixer"
               name: tmp-configmap-mixer

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-old-ca.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-old-ca.yaml
@@ -37,5 +37,5 @@ spec:
               if [[ $? = 0 ]]; then ./kubectl delete serviceaccount istio-ca-service-account $NS; fi;
               ./kubectl get service istio-ca-ilb $NS;
               if [[ $? = 0 ]]; then ./kubectl delete service istio-ca-ilb $NS; fi
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -97,4 +97,4 @@ spec:
                 name=$(echo $entry | awk '{print $2}');
                 kubectl delete secret $name -n $ns;
               done
-      restartPolicy: Never
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -83,5 +83,5 @@ spec:
         - name: tmp-configmap-security
           configMap:
             name: istio-security-custom-resources
-      restartPolicy: Never # CRD might take some time till they are available to consume
+      restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
    Change pre/post install jobs restart to OnFailure
    
    The pre/post install jobs fail consistently during startup.  They
    depend on services being available, and as these services are not
    available, the post install jobs specifically restart and leave
    the dead pod behind.  This mode removes the dead pod and restarts
    the install job correctly.
    
    Jason Young offered up the solution.