### PR TITLE
Increase health probe interval

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 - /usr/local/bin/galley
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
           readinessProbe:
@@ -55,7 +55,7 @@ spec:
                 - /usr/local/bin/galley
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
           resources:

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
                 - /usr/local/bin/sidecar-injector
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
           readinessProbe:
@@ -56,7 +56,7 @@ spec:
                 - /usr/local/bin/sidecar-injector
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
           resources:

--- a/install/kubernetes/templates/istio-sidecar-injector.yaml.tmpl
+++ b/install/kubernetes/templates/istio-sidecar-injector.yaml.tmpl
@@ -62,7 +62,7 @@ spec:
                 - /usr/local/bin/sidecar-injector
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
           readinessProbe:
@@ -71,7 +71,7 @@ spec:
                 - /usr/local/bin/sidecar-injector
                 - probe
                 - --probe-path=/health
-                - --interval=2s
+                - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
       volumes:


### PR DESCRIPTION
Health check file write interval is currently the same as the probe interval (2s). If the probe happens to be closely aligned with the write, this could lead to failures due to small delays in the write.
This PR increases the probe interval to give enough buffer to avoid this.
It could be the cause for https://github.com/istio/istio/issues/6553 and/or https://github.com/istio/old_issues_repo/issues/383