### PR TITLE
Revert "Use downstream protocol by default (#6158)"

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -476,12 +476,7 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings) 
 }
 
 func setUpstreamProtocol(cluster *v2.Cluster, port *model.Port) {
-	switch port.Protocol {
-	case model.ProtocolHTTP:
-		cluster.ProtocolSelection = v2.Cluster_USE_DOWNSTREAM_PROTOCOL
-	case model.ProtocolGRPC:
-		fallthrough
-	case model.ProtocolHTTP2:
+	if port.Protocol.IsHTTP2() {
 		cluster.Http2ProtocolOptions = &core.Http2ProtocolOptions{
 			// Envoy default value of 100 is too low for data path.
 			MaxConcurrentStreams: &types.UInt32Value{

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -153,8 +153,8 @@ func updateCluster(clusterName string, edsCluster *EdsCluster) error {
 	var err error
 
 	// This is a gross hack but Costin will insist on supporting everything from ancient Greece
-	//new style cluster names
-	if strings.Index(clusterName, "outbound") == 0 || strings.Index(clusterName, "inbound") == 0 {
+	if strings.Index(clusterName, "outbound") == 0 ||
+		strings.Index(clusterName, "inbound") == 0 { //new style cluster names
 		var p int
 		var subsetName string
 		_, subsetName, hostname, p = model.ParseSubsetKey(clusterName)


### PR DESCRIPTION
It's forcing HTTP protocol version negotiated on the downstream to all
the peers along the way, even though there is no guarantee that any of
them supports it.

This reverts commit ef5ad4659269609b5e0ef32272566248bbd8d70e.

Fixes #6421.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>