### PR TITLE
Revert "Test cases for 'istioctl version'"

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -539,32 +539,3 @@ func TestKubeInject(t *testing.T) {
 		})
 	}
 }
-
-func TestVersion(t *testing.T) {
-	cases := []testCase{
-		{ // case 0
-			configs: []model.Config{},
-			args:    strings.Split("version", " "),
-			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\n" +
-				"User: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9\\.]+)\n" +
-				"BuildStatus: unknown\n"),
-		},
-		{ // case 1 short output
-			configs:        []model.Config{},
-			args:           strings.Split("version -s", " "),
-			expectedOutput: "unknown@unknown-unknown-unknown-unknown-unknown\n",
-		},
-		{ // case 2 bogus arg
-			configs:        []model.Config{},
-			args:           strings.Split("version --typo", " "),
-			expectedOutput: "Error: unknown flag: --typo\n",
-			wantException:  true,
-		},
-	}
-
-	for i, c := range cases {
-		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
-			verifyOutput(t, c)
-		})
-	}
-}

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -15,6 +15,8 @@
 package version
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +29,9 @@ func CobraCommand() *cobra.Command {
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if short {
-				cmd.Println(Info)
+				fmt.Println(Info)
 			} else {
-				cmd.Println(Info.LongForm())
+				fmt.Println(Info.LongForm())
 			}
 		},
 	}


### PR DESCRIPTION
Reverts istio/istio#6543

This has broken the release test as istioctl now prints to stderr.
https://storage.googleapis.com/istio-prow/pull/istio-releases_daily-release/714/daily-e2e-bookinfoTests/7/build-log.txt