### PR TITLE
mixer: change network fail policy to fail close.

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -189,6 +189,8 @@ func buildTransport(mesh *meshconfig.MeshConfig, uid attribute) *mccpb.Transport
 		ReportCluster: model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(telemetry), port),
 		// internal telemetry forwarding
 		AttributesForMixerProxy: &mpb.Attributes{Attributes: attributes{"source.uid": uid}},
+		// TODO(yangminzhu): Make this configurable in mesh config.
+		NetworkFailPolicy: &mccpb.NetworkFailPolicy{Policy: mccpb.FAIL_CLOSE},
 	}
 }
 


### PR DESCRIPTION
Tested manually:
1. Install Istio without this change, create a denier rule in mixer for app2
2. Access app2 from app1 and confirmed the access is denied by the denier rule with error message: `PERMISSION_DENIED:ymzhu-app-handler.denier.default:Not allowed`
3. Shutdown the istio-policy container and repeat step 2, confirmed the access is not denied (fail open)
4. Update pilot pod to use the image with this change
5. Repeat step 2 and confirmed the access is denied with a different message: `UNAVAILABLE:no healthy upstream` (fail close)

Background: #3960