### PR TITLE
'istioctl version' should write to stdout, not stderr

### DIFF
--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -15,6 +15,8 @@
 package version
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +29,9 @@ func CobraCommand() *cobra.Command {
 		Short: "Prints out build version information",
 		Run: func(cmd *cobra.Command, args []string) {
 			if short {
-				cmd.Println(Info)
+				fmt.Fprintln(cmd.OutOrStdout(), Info)
 			} else {
-				cmd.Println(Info.LongForm())
+				fmt.Fprintln(cmd.OutOrStdout(), Info.LongForm())
 			}
 		},
 	}


### PR DESCRIPTION
Alternate fix for the bug I introduced writing CLI version output to stderr.

The reason for the change was to be able to use Cobra's capture facility for unit tests.
Unfortunately I used the variant that writes to stderr instead of the variant that writes to stdout and supports the Cobra capture facility.