### PR TITLE
Do not run schema validation when parsing resources for istioctl command

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -203,6 +203,7 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 				return fmt.Errorf("create takes no arguments")
 			}
 			varr, others, err := readInputs()
+
 			if err != nil {
 				return err
 			}
@@ -728,7 +729,7 @@ func readInputs() ([]model.Config, []crd.IstioKind, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return crd.ParseInputs(string(input))
+	return crd.ParseInputsWithoutValidation(string(input))
 }
 
 // Print a simple list of names

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -203,7 +203,6 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 				return fmt.Errorf("create takes no arguments")
 			}
 			varr, others, err := readInputs()
-
 			if err != nil {
 				return err
 			}

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -184,6 +184,7 @@ func parseInputsImpl(inputs string, withValidate bool) ([]model.Config, []IstioK
 
 	return varr, others, nil
 }
+
 // ParseInputs reads multiple documents from `kubectl` output and checks with
 // the schema. It also returns the list of unrecognized kinds as the second
 // response.

--- a/pilot/pkg/config/kube/crd/conversion.go
+++ b/pilot/pkg/config/kube/crd/conversion.go
@@ -140,15 +140,7 @@ func CamelCaseToKabobCase(s string) string {
 	}
 }
 
-// ParseInputs reads multiple documents from `kubectl` output and checks with
-// the schema. It also returns the list of unrecognized kinds as the second
-// response.
-//
-// NOTE: This function only decodes a subset of the complete k8s
-// ObjectMeta as identified by the fields in model.ConfigMeta. This
-// would typically only be a problem if a user dumps an configuration
-// object with kubectl and then re-ingests it.
-func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
+func parseInputsImpl(inputs string, withValidate bool) ([]model.Config, []IstioKind, error) {
 	var varr []model.Config
 	var others []IstioKind
 	reader := bytes.NewReader([]byte(inputs))
@@ -181,12 +173,30 @@ func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
 			return nil, nil, fmt.Errorf("cannot parse proto message: %v", err)
 		}
 
-		if err := schema.Validate(config.Name, config.Namespace, config.Spec); err != nil {
-			return nil, nil, fmt.Errorf("configuration is invalid: %v", err)
+		if withValidate {
+			if err := schema.Validate(config.Name, config.Namespace, config.Spec); err != nil {
+				return nil, nil, fmt.Errorf("configuration is invalid: %v", err)
+			}
 		}
 
 		varr = append(varr, *config)
 	}
 
 	return varr, others, nil
+}
+// ParseInputs reads multiple documents from `kubectl` output and checks with
+// the schema. It also returns the list of unrecognized kinds as the second
+// response.
+//
+// NOTE: This function only decodes a subset of the complete k8s
+// ObjectMeta as identified by the fields in model.ConfigMeta. This
+// would typically only be a problem if a user dumps an configuration
+// object with kubectl and then re-ingests it.
+func ParseInputs(inputs string) ([]model.Config, []IstioKind, error) {
+	return parseInputsImpl(inputs, true)
+}
+
+// ParseInputsWithoutValidation same as ParseInputs, but do not apply schema validation.
+func ParseInputsWithoutValidation(inputs string) ([]model.Config, []IstioKind, error) {
+	return parseInputsImpl(inputs, false)
 }


### PR DESCRIPTION
At this stage, config might not have the namespace fully resolved, thus validation doesn't work properly.

Also, validation still run at later stage, e.g [create](https://github.com/istio/istio/blob/d1b5573dfa0df7cee4262a3279c0522e11ab2e67/pilot/pkg/config/kube/crd/client.go#L384), [update](https://github.com/istio/istio/blob/d1b5573dfa0df7cee4262a3279c0522e11ab2e67/pilot/pkg/config/kube/crd/client.go#L417) so this call is redundant anyway.

Issue: https://github.com/istio/istio/issues/6620