### PR TITLE
use Gateway and VirtualService for bookinfo

### DIFF
--- a/samples/bookinfo/kube/bookinfo-gateway.yaml
+++ b/samples/bookinfo/kube/bookinfo-gateway.yaml
@@ -13,32 +13,45 @@
 #   limitations under the License.
 
 ###########################################################################
-# Ingress resource (gateway)
-##########################################################################
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: gateway
-  annotations:
-    kubernetes.io/ingress.class: "istio"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /productpage
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /login
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /logout
-        backend:
-          serviceName: productpage
-          servicePort: 9080
-      - path: /api/v1/products.*
-        backend:
-          serviceName: productpage
-          servicePort: 9080
+# Gateway and VirtualService
+###########################################################################
+
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: bookinfo
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: bookinfo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - bookinfo-gateway
+  http:
+  - match:
+    - uri:
+        prefix: "/productpage"
+    - uri:
+        prefix: "/login"
+    - uri:
+        prefix: "/api/v1/products.*"
+
+    route:
+    - destination:
+        host: productpage
+        port:
+          number: 9080


### PR DESCRIPTION
I was testing **bookinfo** application on my cluster and seems like `Ingress` resources are not working anymore. Switching to `v1alpha3` routing API makes the app working.