### PR TITLE
Fixed a flaky controller test

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -90,7 +90,7 @@ func TestServices(t *testing.T) {
 			}
 		}
 		ep, anotherErr := sds.InstancesByPort(hostname, 80, nil)
-		if anotherErr != nil || len(ep) > 0 {
+		if anotherErr != nil || len(ep) == 2 {
 			return true
 		}
 		return false

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -82,15 +82,20 @@ func TestServices(t *testing.T) {
 		}
 		log.Infof("Services: %#v", out)
 
+		serviceFound := false
 		for _, item := range out {
 			if item.Hostname == hostname &&
 				len(item.Ports) == 1 &&
 				item.Ports[0].Protocol == model.ProtocolHTTP {
-				return true
+				serviceFound = true
 			}
 		}
 		ep, anotherErr := sds.InstancesByPort(hostname, 80, nil)
-		if anotherErr != nil || len(ep) == 2 {
+		if anotherErr != nil {
+			t.Errorf("error gettings instance by port: %v", anotherErr)
+			return false
+		}
+		if serviceFound && len(ep) == 2 {
 			return true
 		}
 		return false


### PR DESCRIPTION
The Kube ServiceRegistry controller test was very flaky and often fails in tests with:

```sh
--- FAIL: TestServices (0.63s)
	controller_test.go:120: Invalid response for GetInstancesByPort []
FAIL
FAIL	istio.io/istio/pilot/pkg/serviceregistry/kube	0.704s
```

The reason is that the test continued immediately after the matching service was found and before waiting for the endpoints to propagate correctly.