### PR TITLE
Gateway TLS

### DIFF
--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -825,6 +825,19 @@ func (store *istioConfigStore) VirtualServices(gateways map[string]bool) []Confi
 				w.Destination.Host = ResolveShortnameToFQDN(w.Destination.Host, r.ConfigMeta).String()
 			}
 		}
+		//resolve host in tls route.destination
+		for _, tls := range rule.Tls {
+			for _, m := range tls.Match {
+				for i, g := range m.Gateways {
+					if g != IstioMeshGateway {
+						m.Gateways[i] = ResolveShortnameToFQDN(g, r.ConfigMeta).String()
+					}
+				}
+			}
+			for _, w := range tls.Route {
+				w.Destination.Host = ResolveShortnameToFQDN(w.Destination.Host, r.ConfigMeta).String()
+			}
+		}
 	}
 
 	return out

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -503,7 +503,7 @@ func l4Match(meta model.ConfigMeta, predicates []*networking.L4MatchAttributes, 
 		gatewayMatch := len(match.Gateways) == 0
 		if len(match.Gateways) > 0 {
 			for _, gateway := range match.Gateways {
-				fqdn := model.ResolveShortnameToFQDN(gateway, meta)
+				fqdn := model.ResolveShortnameToFQDN(gateway, meta).String()
 				gatewayMatch = gatewayMatch || gatewayNames[fqdn]
 			}
 		}
@@ -535,7 +535,7 @@ func tlsMatch(meta model.ConfigMeta, predicates []*networking.TLSMatchAttributes
 		gatewayMatch := len(match.Gateways) == 0
 		if len(match.Gateways) > 0 {
 			for _, gateway := range match.Gateways {
-				fqdn := model.ResolveShortnameToFQDN(gateway, meta)
+				fqdn := model.ResolveShortnameToFQDN(gateway, meta).String()
 				gatewayMatch = gatewayMatch || gatewayNames[fqdn]
 			}
 		}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -531,9 +531,10 @@ func tlsMatch(meta model.ConfigMeta, predicates []*networking.TLSMatchAttributes
 	// This means we can return as soon as we get any match of an entire predicate.
 	for _, match := range predicates {
 		// TODO: implement more matches, like CIDR ranges, etc.
-		if len(match.SniHosts) > 0 && len(pickMatchingGatewayHosts(gatewayHosts, match.SniHosts)) == 0 {
-			// the match's sni hosts don't include hosts advertised by server
-			continue
+		sniHostsMatch := len(match.SniHosts) == 0
+		if len(match.SniHosts) > 0 {
+			// the match's sni hosts includes hosts advertised by server
+			sniHostsMatch = len(pickMatchingGatewayHosts(gatewayHosts, match.SniHosts)) > 0
 		}
 
 		// if there's no port predicate, portMatch is true; otherwise we evaluate the port predicate against the server's port
@@ -551,7 +552,7 @@ func tlsMatch(meta model.ConfigMeta, predicates []*networking.TLSMatchAttributes
 			}
 		}
 
-		if portMatch && gatewayMatch {
+		if sniHostsMatch && portMatch && gatewayMatch {
 			return true
 		}
 	}


### PR DESCRIPTION
Adds logic to gather destinations from the TLS blocks as well as the TCP blocks. Also fixes a bug where the gateway matches were not being resolved to FQDNs. 