### PR TITLE
Enhance the metadata model of Galley and add support for all known CRDs.

### DIFF
--- a/galley/pkg/kube/converter/converter.go
+++ b/galley/pkg/kube/converter/converter.go
@@ -1,0 +1,57 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package converter
+
+import (
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
+
+// Fn is a conversion function that converts the given unstructured CRD into the destination resource.
+type Fn func(destination resource.Info, u *unstructured.Unstructured) (proto.Message, error)
+
+var converters = map[string]Fn{
+	"identity":           identity,
+	"old-mixer-adapter":  mixerAdapter,
+	"old-mixer-template": mixerTemplate,
+}
+
+// Get returns the named converter function, or panics if it is not found.
+func Get(name string) Fn {
+	fn, found := converters[name]
+	if !found {
+		panic(fmt.Sprintf("converter.Get: converter not found: %s", name))
+	}
+
+	return fn
+}
+
+func identity(destination resource.Info, u *unstructured.Unstructured) (proto.Message, error) {
+	return toProto(destination, u.Object["spec"])
+}
+
+func mixerTemplate(destination resource.Info, u *unstructured.Unstructured) (proto.Message, error) {
+	// TODO
+	panic("mixer instance converter NYI")
+}
+
+func mixerAdapter(destination resource.Info, u *unstructured.Unstructured) (proto.Message, error) {
+	// TODO
+	panic("mixer instance converter NYI")
+}

--- a/galley/pkg/kube/converter/proto.go
+++ b/galley/pkg/kube/converter/proto.go
@@ -12,27 +12,23 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package kube
+package converter
 
 import (
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/protobuf/jsonpb"
 	yaml2 "gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"istio.io/istio/galley/pkg/runtime/resource"
 )
 
-// toProto reads a proto.Message from the given unstructured data.
-func toProto(s ResourceSpec, u *unstructured.Unstructured) (proto.Message, error) {
-	return specToProto(s, u.Object["spec"])
-}
-
-func specToProto(s ResourceSpec, spec interface{}) (proto.Message, error) {
+func toProto(info resource.Info, data interface{}) (proto.Message, error) {
 
 	var result proto.Message
-	js, err := toJSON(spec)
+	js, err := toJSON(data)
 	if err == nil {
-		pb := s.Target.NewProtoInstance()
+		pb := info.NewProtoInstance()
 		if err = jsonpb.UnmarshalString(js, pb); err == nil {
 			result = pb
 		}

--- a/galley/pkg/kube/converter/proto_test.go
+++ b/galley/pkg/kube/converter/proto_test.go
@@ -12,36 +12,26 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package kube
+package converter
 
 import (
 	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"istio.io/istio/galley/pkg/runtime/resource"
 )
 
 func TestToProto(t *testing.T) {
-	cr := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"name":            "foo",
-				"resourceVersion": "rv",
-			},
-			"spec": map[string]interface{}{},
-		},
+	spec := map[string]interface{}{}
+
+	i := resource.Info{
+		MessageName: "google.protobuf.Empty",
+		IsGogo:      true,
 	}
 
-	s := ResourceSpec{
-		Target: resource.Info{
-			MessageName: "google.protobuf.Empty",
-		},
-	}
-
-	p, err := toProto(s, cr)
+	p, err := toProto(i, spec)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/galley/pkg/kube/interfaces.go
+++ b/galley/pkg/kube/interfaces.go
@@ -111,7 +111,7 @@ func addTypeToScheme(s *runtime.Scheme, gv schema.GroupVersion, kind, listKind s
 		}
 
 		c := &unstructured.UnstructuredList{}
-		o.SetAPIVersion(gv.Group)
+		o.SetAPIVersion(gv.Version)
 		o.SetKind(listKind)
 		s.AddKnownTypeWithName(gvk, c)
 

--- a/galley/pkg/kube/resourcespec.go
+++ b/galley/pkg/kube/resourcespec.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	sc "k8s.io/apimachinery/pkg/runtime/schema"
 
+	"istio.io/istio/galley/pkg/kube/converter"
 	"istio.io/istio/galley/pkg/runtime/resource"
 )
 
@@ -45,6 +46,9 @@ type ResourceSpec struct {
 
 	// Target resource type of the resource
 	Target resource.Info
+
+	// The converter to use
+	Converter converter.Fn
 }
 
 // APIResource generated from this type.

--- a/galley/pkg/kube/source.go
+++ b/galley/pkg/kube/source.go
@@ -97,7 +97,7 @@ func (s *sourceImpl) process(l *listener, kind resource.EventKind, key, version 
 		Kind: kind,
 	}
 	if u != nil {
-		item, err := toProto(l.spec, u)
+		item, err := l.spec.Converter(l.spec.Target, u)
 		if err != nil {
 			log.Errorf("Unable to convert unstructured to proto: %s/%s", key, version)
 			return

--- a/galley/pkg/kube/source_test.go
+++ b/galley/pkg/kube/source_test.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic/fake"
 	dtesting "k8s.io/client-go/testing"
 
+	"istio.io/istio/galley/pkg/kube/converter"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/testing/mock"
 )
@@ -92,7 +94,9 @@ func TestSource_BasicEvents(t *testing.T) {
 			Plural:   "foos",
 			Target: resource.Info{
 				MessageName: "google.protobuf.Empty",
+				IsGogo:      true,
 			},
+			Converter: converter.Get("identity"),
 		},
 	}
 
@@ -157,6 +161,10 @@ func TestSource_ProtoConversionError(t *testing.T) {
 			Plural:   "foos",
 			Target: resource.Info{
 				MessageName: "google.protobuf.Empty",
+				IsGogo:      true,
+			},
+			Converter: func(info resource.Info, u *unstructured.Unstructured) (proto.Message, error) {
+				return nil, fmt.Errorf("cant convert")
 			},
 		},
 	}

--- a/galley/pkg/kube/types.go
+++ b/galley/pkg/kube/types.go
@@ -18,29 +18,29 @@ func init() {
 		Singular:  "policy",
 		Plural:    "policies",
 		Version:   "v1alpha1",
-		Group:     "authentication",
+		Group:     "authentication.istio.io",
 		Target:    getTargetFor("istio.authentication.v1alpha1.Policy"),
 		Converter: converter.Get("identity"),
 	})
 
 	Types.add(ResourceSpec{
-		Kind:      "AuthenticationMeshPolicy",
-		ListKind:  "AuthenticationMeshPolicyList",
-		Singular:  "mesh-policy",
-		Plural:    "mesh-policies",
+		Kind:      "MeshPolicy",
+		ListKind:  "MeshPolicyList",
+		Singular:  "meshpolicy",
+		Plural:    "meshpolicies",
 		Version:   "v1alpha1",
-		Group:     "authentication",
+		Group:     "authentication.istio.io",
 		Target:    getTargetFor("istio.authentication.v1alpha1.Policy"),
 		Converter: converter.Get("identity"),
 	})
 
 	Types.add(ResourceSpec{
-		Kind:      "servicecontrol",
-		ListKind:  "servicecontrolList",
-		Singular:  "servicecontrol",
-		Plural:    "servicecontrols",
+		Kind:      "signalfx",
+		ListKind:  "signalfxList",
+		Singular:  "signalfx",
+		Plural:    "signalfxs",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -51,7 +51,7 @@ func init() {
 		Singular:  "fluentd",
 		Plural:    "fluentds",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -62,7 +62,7 @@ func init() {
 		Singular:  "opa",
 		Plural:    "opas",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -73,84 +73,7 @@ func init() {
 		Singular:  "circonus",
 		Plural:    "circonuses",
 		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "statsd",
-		ListKind:  "statsdList",
-		Singular:  "statsd",
-		Plural:    "statsds",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "bypass",
-		ListKind:  "bypassList",
-		Singular:  "bypass",
-		Plural:    "bypasses",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "adapter",
-		ListKind:  "adapterList",
-		Singular:  "adapter",
-		Plural:    "adapters",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-template"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "prometheus",
-		ListKind:  "prometheusList",
-		Singular:  "prometheus",
-		Plural:    "prometheuses",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "denier",
-		ListKind:  "denierList",
-		Singular:  "denier",
-		Plural:    "deniers",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "stdio",
-		ListKind:  "stdioList",
-		Singular:  "stdio",
-		Plural:    "stdios",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "rbac",
-		ListKind:  "rbacList",
-		Singular:  "rbac",
-		Plural:    "rbacs",
-		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -161,7 +84,73 @@ func init() {
 		Singular:  "kubernetesenv",
 		Plural:    "kubernetesenvs",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "statsd",
+		ListKind:  "statsdList",
+		Singular:  "statsd",
+		Plural:    "statsds",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "bypass",
+		ListKind:  "bypassList",
+		Singular:  "bypass",
+		Plural:    "bypasses",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "adapter",
+		ListKind:  "adapterList",
+		Singular:  "adapter",
+		Plural:    "adapters",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "prometheus",
+		ListKind:  "prometheusList",
+		Singular:  "prometheus",
+		Plural:    "prometheuses",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "denier",
+		ListKind:  "denierList",
+		Singular:  "denier",
+		Plural:    "deniers",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "stdio",
+		ListKind:  "stdioList",
+		Singular:  "stdio",
+		Plural:    "stdios",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -172,7 +161,18 @@ func init() {
 		Singular:  "listchecker",
 		Plural:    "listcheckers",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "servicecontrol",
+		ListKind:  "servicecontrolList",
+		Singular:  "servicecontrol",
+		Plural:    "servicecontrols",
+		Version:   "v1alpha2",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -183,7 +183,7 @@ func init() {
 		Singular:  "stackdriver",
 		Plural:    "stackdrivers",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -194,18 +194,7 @@ func init() {
 		Singular:  "solarwinds",
 		Plural:    "solarwindses",
 		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
-		Converter: converter.Get("old-mixer-adapter"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "signalfx",
-		ListKind:  "signalfxList",
-		Singular:  "signalfx",
-		Plural:    "signalfxs",
-		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -216,7 +205,7 @@ func init() {
 		Singular:  "noop",
 		Plural:    "noops",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -227,7 +216,7 @@ func init() {
 		Singular:  "memquota",
 		Plural:    "memquotas",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
 		Converter: converter.Get("old-mixer-adapter"),
 	})
@@ -238,7 +227,7 @@ func init() {
 		Singular:  "tracespan",
 		Plural:    "tracespans",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -249,7 +238,7 @@ func init() {
 		Singular:  "apikey",
 		Plural:    "apikeys",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -260,7 +249,7 @@ func init() {
 		Singular:  "authorization",
 		Plural:    "authorizations",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -271,7 +260,7 @@ func init() {
 		Singular:  "template",
 		Plural:    "templates",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -282,7 +271,7 @@ func init() {
 		Singular:  "checknothing",
 		Plural:    "checknothings",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -293,7 +282,7 @@ func init() {
 		Singular:  "logentry",
 		Plural:    "logentries",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -304,7 +293,7 @@ func init() {
 		Singular:  "metric",
 		Plural:    "metrics",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -315,7 +304,7 @@ func init() {
 		Singular:  "quota",
 		Plural:    "quotas",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -326,7 +315,7 @@ func init() {
 		Singular:  "reportnothing",
 		Plural:    "reportnothings",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -337,7 +326,7 @@ func init() {
 		Singular:  "servicecontrolreport",
 		Plural:    "servicecontrolreports",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -348,7 +337,7 @@ func init() {
 		Singular:  "kubernetes",
 		Plural:    "kuberneteses",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -359,7 +348,7 @@ func init() {
 		Singular:  "listentry",
 		Plural:    "listentries",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
 		Converter: converter.Get("old-mixer-template"),
 	})
@@ -367,10 +356,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "HTTPAPISpec",
 		ListKind:  "HTTPAPISpecList",
-		Singular:  "http-api-spec",
-		Plural:    "http-api-specs",
+		Singular:  "httpapispec",
+		Plural:    "httpapispecs",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.v1.config.client.HTTPAPISpec"),
 		Converter: converter.Get("identity"),
 	})
@@ -378,10 +367,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "HTTPAPISpecBinding",
 		ListKind:  "HTTPAPISpecBindingList",
-		Singular:  "http-api-spec-binding",
-		Plural:    "http-api-spec-bindings",
+		Singular:  "httpapispecbinding",
+		Plural:    "httpapispecbindings",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.v1.config.client.HTTPAPISpecBinding"),
 		Converter: converter.Get("identity"),
 	})
@@ -389,10 +378,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "QuotaSpec",
 		ListKind:  "QuotaSpecList",
-		Singular:  "quota-spec",
-		Plural:    "quota-specs",
+		Singular:  "quotaspec",
+		Plural:    "quotaspecs",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.v1.config.client.QuotaSpec"),
 		Converter: converter.Get("identity"),
 	})
@@ -400,10 +389,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "QuotaSpecBinding",
 		ListKind:  "QuotaSpecBindingList",
-		Singular:  "quota-spec-binding",
-		Plural:    "quota-spec-bindings",
+		Singular:  "quotaspecbinding",
+		Plural:    "quotaspecbindings",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.mixer.v1.config.client.QuotaSpecBinding"),
 		Converter: converter.Get("identity"),
 	})
@@ -411,10 +400,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "DestinationRule",
 		ListKind:  "DestinationRuleList",
-		Singular:  "destination-rule",
-		Plural:    "destination-rules",
+		Singular:  "destinationrule",
+		Plural:    "destinationrules",
 		Version:   "v1alpha3",
-		Group:     "networking",
+		Group:     "networking.istio.io",
 		Target:    getTargetFor("istio.networking.v1alpha3.DestinationRule"),
 		Converter: converter.Get("identity"),
 	})
@@ -422,10 +411,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "EnvoyFilter",
 		ListKind:  "EnvoyFilterList",
-		Singular:  "envoy-filter",
-		Plural:    "envoy-filters",
+		Singular:  "envoyfilter",
+		Plural:    "envoyfilters",
 		Version:   "v1alpha3",
-		Group:     "networking",
+		Group:     "networking.istio.io",
 		Target:    getTargetFor("istio.networking.v1alpha3.EnvoyFilter"),
 		Converter: converter.Get("identity"),
 	})
@@ -436,7 +425,7 @@ func init() {
 		Singular:  "gateway",
 		Plural:    "gateways",
 		Version:   "v1alpha3",
-		Group:     "networking",
+		Group:     "networking.istio.io",
 		Target:    getTargetFor("istio.networking.v1alpha3.Gateway"),
 		Converter: converter.Get("identity"),
 	})
@@ -444,10 +433,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "ServiceEntry",
 		ListKind:  "ServiceEntryList",
-		Singular:  "service-entry",
-		Plural:    "service-entries",
+		Singular:  "serviceentry",
+		Plural:    "serviceentries",
 		Version:   "v1alpha3",
-		Group:     "networking",
+		Group:     "networking.istio.io",
 		Target:    getTargetFor("istio.networking.v1alpha3.ServiceEntry"),
 		Converter: converter.Get("identity"),
 	})
@@ -455,10 +444,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "VirtualService",
 		ListKind:  "VirtualServiceList",
-		Singular:  "virtual-service",
-		Plural:    "virtual-services",
+		Singular:  "virtualservice",
+		Plural:    "virtualservices",
 		Version:   "v1alpha3",
-		Group:     "networking",
+		Group:     "networking.istio.io",
 		Target:    getTargetFor("istio.networking.v1alpha3.VirtualService"),
 		Converter: converter.Get("identity"),
 	})
@@ -469,7 +458,7 @@ func init() {
 		Singular:  "attributemanifest",
 		Plural:    "attributemanifests",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.policy.v1beta1.AttributeManifest"),
 		Converter: converter.Get("identity"),
 	})
@@ -480,7 +469,7 @@ func init() {
 		Singular:  "handler",
 		Plural:    "handlers",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.policy.v1beta1.Handler"),
 		Converter: converter.Get("identity"),
 	})
@@ -491,7 +480,7 @@ func init() {
 		Singular:  "instance",
 		Plural:    "instances",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.policy.v1beta1.Instance"),
 		Converter: converter.Get("identity"),
 	})
@@ -502,18 +491,18 @@ func init() {
 		Singular:  "rule",
 		Plural:    "rules",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.policy.v1beta1.Rule"),
 		Converter: converter.Get("identity"),
 	})
 
 	Types.add(ResourceSpec{
-		Kind:      "RbacConfig",
-		ListKind:  "RbacConfigList",
-		Singular:  "rbac-config",
-		Plural:    "rbac-configs",
+		Kind:      "Rbac",
+		ListKind:  "rbacList",
+		Singular:  "rbac",
+		Plural:    "rbacs",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.rbac.v1alpha1.RbacConfig"),
 		Converter: converter.Get("identity"),
 	})
@@ -521,10 +510,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "ServiceRole",
 		ListKind:  "ServiceRoleList",
-		Singular:  "service-role",
-		Plural:    "service-roles",
+		Singular:  "servicerole",
+		Plural:    "serviceroles",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.rbac.v1alpha1.ServiceRole"),
 		Converter: converter.Get("identity"),
 	})
@@ -532,10 +521,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "ServiceRoleBinding",
 		ListKind:  "ServiceRoleBindingList",
-		Singular:  "service-role-binding",
-		Plural:    "service-role-bindings",
+		Singular:  "servicerolebinding",
+		Plural:    "servicerolebindings",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.rbac.v1alpha1.ServiceRoleBinding"),
 		Converter: converter.Get("identity"),
 	})
@@ -543,10 +532,10 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "DestinationPolicy",
 		ListKind:  "DestinationPolicyList",
-		Singular:  "destination-policy",
-		Plural:    "destination-policies",
+		Singular:  "destinationpolicy",
+		Plural:    "destinationpolicies",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.routing.v1alpha1.DestinationPolicy"),
 		Converter: converter.Get("identity"),
 	})
@@ -554,32 +543,21 @@ func init() {
 	Types.add(ResourceSpec{
 		Kind:      "EgressRule",
 		ListKind:  "EgressRuleList",
-		Singular:  "egress-rule",
-		Plural:    "egress-rules",
+		Singular:  "egressrule",
+		Plural:    "egressrules",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.routing.v1alpha1.EgressRule"),
-		Converter: converter.Get("identity"),
-	})
-
-	Types.add(ResourceSpec{
-		Kind:      "IngressRule",
-		ListKind:  "IngressRuleList",
-		Singular:  "ingress-rule",
-		Plural:    "ingress-rules",
-		Version:   "v1alpha2",
-		Group:     "config",
-		Target:    getTargetFor("istio.routing.v1alpha1.IngressRule"),
 		Converter: converter.Get("identity"),
 	})
 
 	Types.add(ResourceSpec{
 		Kind:      "RouteRule",
 		ListKind:  "RouteRuleList",
-		Singular:  "route-rule",
-		Plural:    "route-rules",
+		Singular:  "routerule",
+		Plural:    "routerules",
 		Version:   "v1alpha2",
-		Group:     "config",
+		Group:     "config.istio.io",
 		Target:    getTargetFor("istio.routing.v1alpha1.RouteRule"),
 		Converter: converter.Get("identity"),
 	})

--- a/galley/pkg/kube/types.go
+++ b/galley/pkg/kube/types.go
@@ -1,41 +1,587 @@
-//  Copyright 2018 Istio Authors
+// GENERATED FILE -- DO NOT EDIT
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+//go:generate $GOPATH/src/istio.io/istio/galley/tools/gen-meta/gen-meta.sh kube pkg/kube/types.go
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
 
 package kube
+
+import "istio.io/istio/galley/pkg/kube/converter"
 
 // Types in the schema.
 var Types = Schema{}
 
 func init() {
-	// TODO: Full set of Schema.
+
 	Types.add(ResourceSpec{
-		Kind:     "Rule",
-		ListKind: "RuleList",
-		Singular: "rule",
-		Plural:   "rules",
-		Version:  "v1beta1",
-		Group:    "config.istio.io",
-		Target:   getTargetFor("istio.policy.v1beta1.Rule"),
+		Kind:      "AuthenticationPolicy",
+		ListKind:  "AuthenticationPolicyList",
+		Singular:  "policy",
+		Plural:    "policies",
+		Version:   "v1alpha1",
+		Group:     "authentication",
+		Target:    getTargetFor("istio.authentication.v1alpha1.Policy"),
+		Converter: converter.Get("identity"),
 	})
 
 	Types.add(ResourceSpec{
-		Kind:     "DestinationRule",
-		ListKind: "DestinationRuleList",
-		Singular: "destinationrule",
-		Plural:   "destinationrules",
-		Version:  "v1alpha3",
-		Group:    "config.istio.io",
-		Target:   getTargetFor("istio.networking.v1alpha3.DestinationRule"),
+		Kind:      "AuthenticationMeshPolicy",
+		ListKind:  "AuthenticationMeshPolicyList",
+		Singular:  "mesh-policy",
+		Plural:    "mesh-policies",
+		Version:   "v1alpha1",
+		Group:     "authentication",
+		Target:    getTargetFor("istio.authentication.v1alpha1.Policy"),
+		Converter: converter.Get("identity"),
 	})
+
+	Types.add(ResourceSpec{
+		Kind:      "servicecontrol",
+		ListKind:  "servicecontrolList",
+		Singular:  "servicecontrol",
+		Plural:    "servicecontrols",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "fluentd",
+		ListKind:  "fluentdList",
+		Singular:  "fluentd",
+		Plural:    "fluentds",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "opa",
+		ListKind:  "opaList",
+		Singular:  "opa",
+		Plural:    "opas",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "circonus",
+		ListKind:  "circonusList",
+		Singular:  "circonus",
+		Plural:    "circonuses",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "statsd",
+		ListKind:  "statsdList",
+		Singular:  "statsd",
+		Plural:    "statsds",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "bypass",
+		ListKind:  "bypassList",
+		Singular:  "bypass",
+		Plural:    "bypasses",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "adapter",
+		ListKind:  "adapterList",
+		Singular:  "adapter",
+		Plural:    "adapters",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "prometheus",
+		ListKind:  "prometheusList",
+		Singular:  "prometheus",
+		Plural:    "prometheuses",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "denier",
+		ListKind:  "denierList",
+		Singular:  "denier",
+		Plural:    "deniers",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "stdio",
+		ListKind:  "stdioList",
+		Singular:  "stdio",
+		Plural:    "stdios",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "rbac",
+		ListKind:  "rbacList",
+		Singular:  "rbac",
+		Plural:    "rbacs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "kubernetesenv",
+		ListKind:  "kubernetesenvList",
+		Singular:  "kubernetesenv",
+		Plural:    "kubernetesenvs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "listchecker",
+		ListKind:  "listcheckerList",
+		Singular:  "listchecker",
+		Plural:    "listcheckers",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "stackdriver",
+		ListKind:  "stackdriverList",
+		Singular:  "stackdriver",
+		Plural:    "stackdrivers",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "solarwinds",
+		ListKind:  "solarwindsList",
+		Singular:  "solarwinds",
+		Plural:    "solarwindses",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "signalfx",
+		ListKind:  "signalfxList",
+		Singular:  "signalfx",
+		Plural:    "signalfxs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "noop",
+		ListKind:  "noopList",
+		Singular:  "noop",
+		Plural:    "noops",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "memquota",
+		ListKind:  "memquotaList",
+		Singular:  "memquota",
+		Plural:    "memquotas",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Info"),
+		Converter: converter.Get("old-mixer-adapter"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "tracespan",
+		ListKind:  "tracespanList",
+		Singular:  "tracespan",
+		Plural:    "tracespans",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "apikey",
+		ListKind:  "apikeyList",
+		Singular:  "apikey",
+		Plural:    "apikeys",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "authorization",
+		ListKind:  "authorizationList",
+		Singular:  "authorization",
+		Plural:    "authorizations",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "template",
+		ListKind:  "templateList",
+		Singular:  "template",
+		Plural:    "templates",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "checknothing",
+		ListKind:  "checknothingList",
+		Singular:  "checknothing",
+		Plural:    "checknothings",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "logentry",
+		ListKind:  "logentryList",
+		Singular:  "logentry",
+		Plural:    "logentries",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "metric",
+		ListKind:  "metricList",
+		Singular:  "metric",
+		Plural:    "metrics",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "quota",
+		ListKind:  "quotaList",
+		Singular:  "quota",
+		Plural:    "quotas",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "reportnothing",
+		ListKind:  "reportnothingList",
+		Singular:  "reportnothing",
+		Plural:    "reportnothings",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "servicecontrolreport",
+		ListKind:  "servicecontrolreportList",
+		Singular:  "servicecontrolreport",
+		Plural:    "servicecontrolreports",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "kubernetes",
+		ListKind:  "kubernetesList",
+		Singular:  "kubernetes",
+		Plural:    "kuberneteses",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "listentry",
+		ListKind:  "listentryList",
+		Singular:  "listentry",
+		Plural:    "listentries",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.adapter.model.v1beta1.Template"),
+		Converter: converter.Get("old-mixer-template"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "HTTPAPISpec",
+		ListKind:  "HTTPAPISpecList",
+		Singular:  "http-api-spec",
+		Plural:    "http-api-specs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.v1.config.client.HTTPAPISpec"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "HTTPAPISpecBinding",
+		ListKind:  "HTTPAPISpecBindingList",
+		Singular:  "http-api-spec-binding",
+		Plural:    "http-api-spec-bindings",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.v1.config.client.HTTPAPISpecBinding"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "QuotaSpec",
+		ListKind:  "QuotaSpecList",
+		Singular:  "quota-spec",
+		Plural:    "quota-specs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.v1.config.client.QuotaSpec"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "QuotaSpecBinding",
+		ListKind:  "QuotaSpecBindingList",
+		Singular:  "quota-spec-binding",
+		Plural:    "quota-spec-bindings",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.mixer.v1.config.client.QuotaSpecBinding"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "DestinationRule",
+		ListKind:  "DestinationRuleList",
+		Singular:  "destination-rule",
+		Plural:    "destination-rules",
+		Version:   "v1alpha3",
+		Group:     "networking",
+		Target:    getTargetFor("istio.networking.v1alpha3.DestinationRule"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "EnvoyFilter",
+		ListKind:  "EnvoyFilterList",
+		Singular:  "envoy-filter",
+		Plural:    "envoy-filters",
+		Version:   "v1alpha3",
+		Group:     "networking",
+		Target:    getTargetFor("istio.networking.v1alpha3.EnvoyFilter"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "Gateway",
+		ListKind:  "GatewayList",
+		Singular:  "gateway",
+		Plural:    "gateways",
+		Version:   "v1alpha3",
+		Group:     "networking",
+		Target:    getTargetFor("istio.networking.v1alpha3.Gateway"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "ServiceEntry",
+		ListKind:  "ServiceEntryList",
+		Singular:  "service-entry",
+		Plural:    "service-entries",
+		Version:   "v1alpha3",
+		Group:     "networking",
+		Target:    getTargetFor("istio.networking.v1alpha3.ServiceEntry"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "VirtualService",
+		ListKind:  "VirtualServiceList",
+		Singular:  "virtual-service",
+		Plural:    "virtual-services",
+		Version:   "v1alpha3",
+		Group:     "networking",
+		Target:    getTargetFor("istio.networking.v1alpha3.VirtualService"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "attributemanifest",
+		ListKind:  "attributemanifestList",
+		Singular:  "attributemanifest",
+		Plural:    "attributemanifests",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.policy.v1beta1.AttributeManifest"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "handler",
+		ListKind:  "handlerList",
+		Singular:  "handler",
+		Plural:    "handlers",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.policy.v1beta1.Handler"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "instance",
+		ListKind:  "instanceList",
+		Singular:  "instance",
+		Plural:    "instances",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.policy.v1beta1.Instance"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "rule",
+		ListKind:  "ruleList",
+		Singular:  "rule",
+		Plural:    "rules",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.policy.v1beta1.Rule"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "RbacConfig",
+		ListKind:  "RbacConfigList",
+		Singular:  "rbac-config",
+		Plural:    "rbac-configs",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.rbac.v1alpha1.RbacConfig"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "ServiceRole",
+		ListKind:  "ServiceRoleList",
+		Singular:  "service-role",
+		Plural:    "service-roles",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.rbac.v1alpha1.ServiceRole"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "ServiceRoleBinding",
+		ListKind:  "ServiceRoleBindingList",
+		Singular:  "service-role-binding",
+		Plural:    "service-role-bindings",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.rbac.v1alpha1.ServiceRoleBinding"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "DestinationPolicy",
+		ListKind:  "DestinationPolicyList",
+		Singular:  "destination-policy",
+		Plural:    "destination-policies",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.routing.v1alpha1.DestinationPolicy"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "EgressRule",
+		ListKind:  "EgressRuleList",
+		Singular:  "egress-rule",
+		Plural:    "egress-rules",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.routing.v1alpha1.EgressRule"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "IngressRule",
+		ListKind:  "IngressRuleList",
+		Singular:  "ingress-rule",
+		Plural:    "ingress-rules",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.routing.v1alpha1.IngressRule"),
+		Converter: converter.Get("identity"),
+	})
+
+	Types.add(ResourceSpec{
+		Kind:      "RouteRule",
+		ListKind:  "RouteRuleList",
+		Singular:  "route-rule",
+		Plural:    "route-rules",
+		Version:   "v1alpha2",
+		Group:     "config",
+		Target:    getTargetFor("istio.routing.v1alpha1.RouteRule"),
+		Converter: converter.Get("identity"),
+	})
+
 }

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -62,7 +62,7 @@ func TestProcessor_Start_Error(t *testing.T) {
 
 func TestProcessor_Stop(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", false)
 
 	src := NewInMemorySource()
 	distributor := snapshot.New()
@@ -83,7 +83,7 @@ func TestProcessor_Stop(t *testing.T) {
 
 func TestProcessor_EventAccumulation(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", false)
 	emptyMessageName := resource.MessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()
@@ -110,7 +110,7 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 
 func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", false)
 	emptyMessageName := resource.MessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()
@@ -137,7 +137,7 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 
 func TestProcessor_Publishing(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", false)
 	emptyMessageName := resource.MessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()

--- a/galley/pkg/runtime/resource/resource_test.go
+++ b/galley/pkg/runtime/resource/resource_test.go
@@ -154,9 +154,12 @@ func TestResource_IsEmpty(t *testing.T) {
 
 func TestInfo_newProtoInstance_Success(t *testing.T) {
 	i := Info{}
-	p := i.newProtoInstance(func(_ string) reflect.Type {
-		return reflect.PtrTo(reflect.TypeOf(types.Empty{}))
-	})
+	p := i.newProtoInstance(
+		func(_ string) reflect.Type {
+			return reflect.PtrTo(reflect.TypeOf(types.Empty{}))
+		}, func(_ string) reflect.Type {
+			return reflect.PtrTo(reflect.TypeOf(types.Empty{}))
+		})
 
 	if p == nil || reflect.TypeOf(p) != reflect.PtrTo(reflect.TypeOf(types.Empty{})) {
 		t.Fatalf("Unexpected proto type returned: %v", p)
@@ -171,9 +174,12 @@ func TestInfo_newProtoInstance_PanicAtNil(t *testing.T) {
 	}()
 
 	i := Info{}
-	_ = i.newProtoInstance(func(_ string) reflect.Type {
-		return nil
-	})
+	_ = i.newProtoInstance(
+		func(_ string) reflect.Type {
+			return nil
+		}, func(_ string) reflect.Type {
+			return nil
+		})
 }
 
 func TestInfo_newProtoInstance_PanicAtNonPtr(t *testing.T) {
@@ -184,9 +190,12 @@ func TestInfo_newProtoInstance_PanicAtNonPtr(t *testing.T) {
 	}()
 
 	i := Info{}
-	_ = i.newProtoInstance(func(_ string) reflect.Type {
-		return reflect.TypeOf(types.Empty{})
-	})
+	_ = i.newProtoInstance(
+		func(_ string) reflect.Type {
+			return reflect.TypeOf(types.Empty{})
+		}, func(_ string) reflect.Type {
+			return reflect.TypeOf(types.Empty{})
+		})
 }
 
 func TestInfo_newProtoInstance_PanicAtNonProto(t *testing.T) {
@@ -197,9 +206,12 @@ func TestInfo_newProtoInstance_PanicAtNonProto(t *testing.T) {
 	}()
 
 	i := Info{}
-	_ = i.newProtoInstance(func(_ string) reflect.Type {
-		return reflect.PtrTo(reflect.TypeOf(Info{}))
-	})
+	_ = i.newProtoInstance(
+		func(_ string) reflect.Type {
+			return reflect.PtrTo(reflect.TypeOf(Info{}))
+		}, func(_ string) reflect.Type {
+			return reflect.PtrTo(reflect.TypeOf(Info{}))
+		})
 }
 
 func TestInfo_String(t *testing.T) {

--- a/galley/pkg/runtime/resource/schema.go
+++ b/galley/pkg/runtime/resource/schema.go
@@ -36,9 +36,10 @@ func NewSchema() *Schema {
 }
 
 // Register a proto into the schema.
-func (s *Schema) Register(protoMessageName string) {
+func (s *Schema) Register(protoMessageName string, isGogo bool) {
 	info := Info{
 		MessageName: MessageName(protoMessageName),
+		IsGogo:      isGogo,
 		TypeURL:     fmt.Sprintf("%s/%s", BaseTypeURL, protoMessageName),
 	}
 

--- a/galley/pkg/runtime/resource/schema_test.go
+++ b/galley/pkg/runtime/resource/schema_test.go
@@ -20,7 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
+	pgogo "github.com/gogo/protobuf/proto"
+	plang "github.com/golang/protobuf/proto"
 )
 
 func TestSchema_All(t *testing.T) {
@@ -30,8 +31,8 @@ func TestSchema_All(t *testing.T) {
 		byURL:  make(map[string]Info),
 	}
 
-	s.Register("bar")
-	s.Register("foo")
+	s.Register("bar", false)
+	s.Register("foo", false)
 
 	infos := s.All()
 	sort.Slice(infos, func(i, j int) bool {
@@ -57,7 +58,12 @@ func TestSchema_All(t *testing.T) {
 func TestSchema_NewProtoInstance(t *testing.T) {
 	for _, info := range Types.All() {
 		p := info.NewProtoInstance()
-		name := proto.MessageName(p)
+		var name string
+		if info.IsGogo {
+			name = pgogo.MessageName(p)
+		} else {
+			name = plang.MessageName(p)
+		}
 		if name != string(info.MessageName) {
 			t.Fatalf("Name/MessageName mismatch: MessageName:%v, Name:%v", info.MessageName, name)
 		}

--- a/galley/pkg/runtime/resource/types.go
+++ b/galley/pkg/runtime/resource/types.go
@@ -1,31 +1,46 @@
-//  Copyright 2018 Istio Authors
+// GENERATED FILE -- DO NOT EDIT
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+//go:generate $GOPATH/src/istio.io/istio/galley/tools/gen-meta/gen-meta.sh runtime pkg/runtime/resource/types.go
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
 
 package resource
 
 import (
 	// Pull in all the known proto types to ensure we get their types registered.
+	_ "istio.io/api/authentication/v1alpha1"
+	_ "istio.io/api/mixer/adapter/model/v1beta1"
+	_ "istio.io/api/mixer/v1/config/client"
 	_ "istio.io/api/networking/v1alpha3"
 	_ "istio.io/api/policy/v1beta1"
+	_ "istio.io/api/rbac/v1alpha1"
+	_ "istio.io/api/routing/v1alpha1"
 )
 
 // Types of known resources.
 var Types = NewSchema()
 
 func init() {
-	// TODO: Rest
-	// Register known kinds here
-	Types.Register("istio.policy.v1beta1.Rule")
-	Types.Register("istio.networking.v1alpha3.DestinationRule")
+	Types.Register("istio.authentication.v1alpha1.Policy", true)
+	Types.Register("istio.mixer.adapter.model.v1beta1.Info", true)
+	Types.Register("istio.mixer.adapter.model.v1beta1.Template", true)
+	Types.Register("istio.mixer.v1.config.client.HTTPAPISpec", true)
+	Types.Register("istio.mixer.v1.config.client.HTTPAPISpecBinding", true)
+	Types.Register("istio.mixer.v1.config.client.QuotaSpec", true)
+	Types.Register("istio.mixer.v1.config.client.QuotaSpecBinding", true)
+	Types.Register("istio.networking.v1alpha3.DestinationRule", true)
+	Types.Register("istio.networking.v1alpha3.EnvoyFilter", true)
+	Types.Register("istio.networking.v1alpha3.Gateway", true)
+	Types.Register("istio.networking.v1alpha3.ServiceEntry", true)
+	Types.Register("istio.networking.v1alpha3.VirtualService", true)
+	Types.Register("istio.policy.v1beta1.AttributeManifest", true)
+	Types.Register("istio.policy.v1beta1.Handler", true)
+	Types.Register("istio.policy.v1beta1.Instance", true)
+	Types.Register("istio.policy.v1beta1.Rule", true)
+	Types.Register("istio.rbac.v1alpha1.RbacConfig", false)
+	Types.Register("istio.rbac.v1alpha1.ServiceRole", false)
+	Types.Register("istio.rbac.v1alpha1.ServiceRoleBinding", false)
+	Types.Register("istio.routing.v1alpha1.DestinationPolicy", false)
+	Types.Register("istio.routing.v1alpha1.EgressRule", false)
+	Types.Register("istio.routing.v1alpha1.IngressRule", false)
+	Types.Register("istio.routing.v1alpha1.RouteRule", false)
 }

--- a/galley/pkg/runtime/resource/types.go
+++ b/galley/pkg/runtime/resource/types.go
@@ -41,6 +41,5 @@ func init() {
 	Types.Register("istio.rbac.v1alpha1.ServiceRoleBinding", false)
 	Types.Register("istio.routing.v1alpha1.DestinationPolicy", false)
 	Types.Register("istio.routing.v1alpha1.EgressRule", false)
-	Types.Register("istio.routing.v1alpha1.IngressRule", false)
 	Types.Register("istio.routing.v1alpha1.RouteRule", false)
 }

--- a/galley/pkg/runtime/state_test.go
+++ b/galley/pkg/runtime/state_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestState_Apply_Add(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -52,7 +52,7 @@ func TestState_Apply_Add(t *testing.T) {
 
 func TestState_Apply_Update(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -90,7 +90,7 @@ func TestState_Apply_Update(t *testing.T) {
 
 func TestState_Apply_Update_SameVersion(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -120,7 +120,7 @@ func TestState_Apply_Update_SameVersion(t *testing.T) {
 
 func TestState_Apply_Delete(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -155,7 +155,7 @@ func TestState_Apply_Delete(t *testing.T) {
 
 func TestState_Apply_UnknownEventKind(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -178,7 +178,7 @@ func TestState_Apply_UnknownEventKind(t *testing.T) {
 
 func TestState_Apply_UnknownResourceKind(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 
@@ -201,7 +201,7 @@ func TestState_Apply_UnknownResourceKind(t *testing.T) {
 
 func TestState_Apply_BrokenProto(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn")
+	schema.Register("mn", false)
 
 	s := newState(schema)
 

--- a/galley/tools/gen-meta/gen-meta.sh
+++ b/galley/tools/gen-meta/gen-meta.sh
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+go run ${DIR}/main.go ${DIR}/gen-metadata-defs ${1} ${DIR}/metadata.yaml ${DIR}/../../${2}
+goimports -w -local istio.io ${DIR}/../../${2}

--- a/galley/tools/gen-meta/main.go
+++ b/galley/tools/gen-meta/main.go
@@ -1,0 +1,235 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+const usage = `
+
+gen-meta [runtime|kube] <input-yaml-path> <output-go-path> 
+
+`
+
+var knownProtoTypes = map[string]struct{}{
+	"google.protobuf.Struct": {},
+}
+
+type metadata struct {
+	Items         []*entry   `json:"items"`
+	ProtoPackages []string   `json:"-"`
+	ProtoDefs     []protoDef `json:"-"`
+}
+
+type entry struct {
+	Kind      string `json:"kind"`
+	Singular  string `json:"singular"`
+	Plural    string `json:"plural"`
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Proto     string `json:"proto"`
+	Gogo      bool   `json:"gogo"`
+	Converter string `json:"converter"`
+}
+
+type protoDef struct {
+	MessageName string `json:"-"`
+	Gogo        bool   `json:"-"`
+}
+
+func main() {
+	if len(os.Args) != 5 {
+		fmt.Printf(usage)
+		fmt.Printf("%v\n", os.Args)
+		os.Exit(-1)
+	}
+
+	isRuntime := false
+	switch os.Args[2] {
+	case "kube":
+		isRuntime = false
+	case "runtime":
+		isRuntime = true
+	default:
+		fmt.Printf("Unknown target: %v", os.Args[2])
+		fmt.Printf(usage)
+		os.Exit(-1)
+	}
+
+	input := os.Args[3]
+	output := os.Args[4]
+
+	m, err := readMetadata(input)
+	if err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(-2)
+	}
+
+	var contents []byte
+	if isRuntime {
+		contents, err = applyTemplate(runtimeTemplate, m)
+	} else {
+		contents, err = applyTemplate(kubeTemplate, m)
+	}
+
+	if err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(-3)
+	}
+
+	if err = ioutil.WriteFile(output, contents, os.ModePerm); err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(-4)
+	}
+}
+
+func readMetadata(path string) (*metadata, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read input file: %v", err)
+	}
+
+	var m metadata
+
+	if err = yaml.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("error marshalling input file: %v", err)
+	}
+
+	// Stable sort based on message name.
+	sort.Slice(m.Items, func(i, j int) bool {
+		return strings.Compare(m.Items[i].Proto, m.Items[j].Proto) < 0
+	})
+
+	// Calculate the Go packages
+	names := make(map[string]struct{})
+	for _, e := range m.Items {
+		if _, found := knownProtoTypes[e.Proto]; e.Proto == "" || found {
+			continue
+		}
+
+		parts := strings.Split(e.Proto, ".")
+		// Remove the first "istio", and the Proto itself
+		parts = parts[1 : len(parts)-1]
+
+		p := strings.Join(parts, "/")
+		p = fmt.Sprintf("istio.io/api/%s", p)
+		names[p] = struct{}{}
+	}
+
+	for k := range names {
+		m.ProtoPackages = append(m.ProtoPackages, k)
+	}
+	sort.Strings(m.ProtoPackages)
+
+	// Calculate the proto types
+	// First, single instance the proto defs
+	protoDefs := make(map[string]protoDef)
+	for _, e := range m.Items {
+		if _, found := knownProtoTypes[e.Proto]; e.Proto == "" || found {
+			continue
+		}
+		defn := protoDef{MessageName: e.Proto, Gogo: e.Gogo}
+
+		if prevDefn, ok := protoDefs[e.Proto]; ok && defn != prevDefn {
+			return nil, fmt.Errorf("proto definitions do not match: %+v != %+v", defn, prevDefn)
+		}
+		protoDefs[e.Proto] = defn
+	}
+
+	for _, v := range protoDefs {
+		m.ProtoDefs = append(m.ProtoDefs, v)
+	}
+
+	// Stable sort based on message name.
+	sort.Slice(m.ProtoDefs, func(i, j int) bool {
+		return strings.Compare(m.ProtoDefs[i].MessageName, m.ProtoDefs[j].MessageName) < 0
+	})
+
+	return &m, nil
+}
+
+const runtimeTemplate = `
+// GENERATED FILE -- DO NOT EDIT
+//
+//go:generate $GOPATH/src/istio.io/istio/galley/tools/gen-meta/gen-meta.sh runtime pkg/runtime/resource/types.go
+//
+
+package resource
+
+import (
+// Pull in all the known proto types to ensure we get their types registered.
+{{range .ProtoPackages}}	_ "{{.}}"
+{{end}}
+)
+
+// Types of known resources.
+var Types = NewSchema()
+
+func init() {
+{{range .ProtoDefs}}	Types.Register("{{.MessageName}}", {{.Gogo}})
+{{end}}}
+`
+
+const kubeTemplate = `
+// GENERATED FILE -- DO NOT EDIT
+//
+//go:generate $GOPATH/src/istio.io/istio/galley/tools/gen-meta/gen-meta.sh kube pkg/kube/types.go
+//
+
+package kube
+
+// Types in the schema.
+var Types = Schema{}
+
+func init() {
+{{range .Items}}
+	Types.add(ResourceSpec{
+		Kind:       "{{.Kind}}",
+		ListKind:   "{{.Kind}}List",
+		Singular:   "{{.Singular}}",
+		Plural:     "{{.Plural}}",
+		Version:    "{{.Version}}",
+		Group:      "{{.Group}}",
+		Target:     getTargetFor("{{.Proto}}"),
+		Converter:  converter.Get("{{ if .Converter }}{{.Converter}}{{ else }}identity{{end}}"),
+    })
+{{end}}
+}
+`
+
+func applyTemplate(tmpl string, m *metadata) ([]byte, error) {
+	t := template.New("tmpl")
+
+	t2, err := t.Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	var b bytes.Buffer
+	if err = t2.Execute(&b, m); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}

--- a/galley/tools/gen-meta/metadata.yaml
+++ b/galley/tools/gen-meta/metadata.yaml
@@ -2,16 +2,16 @@
 items:
 # Types from Pilot
   - kind:        "RouteRule"
-    singular:    "route-rule"
-    plural:      "route-rules"
-    group:       "config"
+    singular:    "routerule"
+    plural:      "routerules"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.routing.v1alpha1.RouteRule"
 
   - kind:        "VirtualService"
-    singular:    "virtual-service"
-    plural:      "virtual-services"
-    group:       "networking"
+    singular:    "virtualservice"
+    plural:      "virtualservices"
+    group:       "networking.istio.io"
     version:     "v1alpha3"
     proto:       "istio.networking.v1alpha3.VirtualService"
     gogo:        true
@@ -19,84 +19,77 @@ items:
   - kind:        "Gateway"
     singular:    "gateway"
     plural:      "gateways"
-    group:       "networking"
+    group:       "networking.istio.io"
     version:     "v1alpha3"
     proto:       "istio.networking.v1alpha3.Gateway"
     gogo:        true
 
-  - kind:        "IngressRule"
-    singular:    "ingress-rule"
-    plural:      "ingress-rules"
-    group:       "config"
-    version:     "v1alpha2"
-    proto:       "istio.routing.v1alpha1.IngressRule"
-
   - kind:        "EgressRule"
-    singular:    "egress-rule"
-    plural:      "egress-rules"
-    group:       "config"
+    singular:    "egressrule"
+    plural:      "egressrules"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.routing.v1alpha1.EgressRule"
 
   - kind:        "ServiceEntry"
-    singular:    "service-entry"
-    plural:      "service-entries"
-    group:       "networking"
+    singular:    "serviceentry"
+    plural:      "serviceentries"
+    group:       "networking.istio.io"
     version:     "v1alpha3"
     proto:       "istio.networking.v1alpha3.ServiceEntry"
     gogo:        true
 
   - kind:        "DestinationPolicy"
-    singular:    "destination-policy"
-    plural:      "destination-policies"
-    group:       "config"
+    singular:    "destinationpolicy"
+    plural:      "destinationpolicies"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.routing.v1alpha1.DestinationPolicy"
 
   - kind:        "DestinationRule"
-    singular:    "destination-rule"
-    plural:      "destination-rules"
-    group:       "networking"
+    singular:    "destinationrule"
+    plural:      "destinationrules"
+    group:       "networking.istio.io"
     version:     "v1alpha3"
     proto:       "istio.networking.v1alpha3.DestinationRule"
     gogo:        true
 
   - kind:        "EnvoyFilter"
-    singular:    "envoy-filter"
-    plural:      "envoy-filters"
-    group:       "networking"
+    singular:    "envoyfilter"
+    plural:      "envoyfilters"
+    group:       "networking.istio.io"
     version:     "v1alpha3"
     proto:       "istio.networking.v1alpha3.EnvoyFilter"
     gogo:        true
 
   - kind:        "HTTPAPISpec"
-    singular:    "http-api-spec"
-    plural:      "http-api-specs"
-    group:       "config"
+    singular:    "httpapispec"
+    plural:      "httpapispecs"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.v1.config.client.HTTPAPISpec"
     gogo:        true
 
   - kind:        "HTTPAPISpecBinding"
-    singular:    "http-api-spec-binding"
-    plural:      "http-api-spec-bindings"
-    group:       "config"
+    singular:    "httpapispecbinding"
+    plural:      "httpapispecbindings"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.v1.config.client.HTTPAPISpecBinding"
     gogo:        true
 
   - kind:        "QuotaSpec"
-    singular:    "quota-spec"
-    plural:      "quota-specs"
-    group:       "config"
+    singular:    "quotaspec"
+    plural:      "quotaspecs"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.v1.config.client.QuotaSpec"
     gogo:        true
 
   - kind:        "QuotaSpecBinding"
-    singular:    "quota-spec-binding"
-    plural:      "quota-spec-bindings"
-    group:       "config"
+    singular:    "quotaspecbinding"
+    plural:      "quotaspecbindings"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.v1.config.client.QuotaSpecBinding"
     gogo:        true
@@ -104,39 +97,40 @@ items:
   - kind:        "AuthenticationPolicy"
     singular:    "policy"
     plural:      "policies"
-    group:       "authentication"
+    group:       "authentication.istio.io"
     version:     "v1alpha1"
     proto:       "istio.authentication.v1alpha1.Policy"
     gogo:        true
 
-  - kind:        "AuthenticationMeshPolicy"
+  - kind:          "MeshPolicy"
     clusterScoped: true
-    singular:      "mesh-policy"
-    plural:        "mesh-policies"
-    group:       "authentication"
-    version:     "v1alpha1"
+    singular:      "meshpolicy"
+    plural:        "meshpolicies"
+    group:         "authentication.istio.io"
+    version:       "v1alpha1"
     proto:         "istio.authentication.v1alpha1.Policy"
-    gogo:        true
+    gogo:          true
 
   - kind:        "ServiceRole"
-    singular:    "service-role"
-    plural:      "service-roles"
-    group:       "config"
+    singular:    "servicerole"
+    plural:      "serviceroles"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.rbac.v1alpha1.ServiceRole"
 
   - kind:        "ServiceRoleBinding"
     clusterScoped: false
-    singular:      "service-role-binding"
-    plural:        "service-role-bindings"
-    group:       "config"
+    singular:      "servicerolebinding"
+    plural:        "servicerolebindings"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:         "istio.rbac.v1alpha1.ServiceRoleBinding"
 
-  - kind:        "RbacConfig"
-    singular:    "rbac-config"
-    plural:      "rbac-configs"
-    group:       "config"
+  - kind:        "Rbac"
+    listKind:    "rbacList"
+    singular:    "rbac"
+    plural:      "rbacs"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.rbac.v1alpha1.RbacConfig"
 
@@ -145,7 +139,7 @@ items:
   - kind:        "rule"
     singular:    "rule"
     plural:      "rules"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.policy.v1beta1.Rule"
     gogo:        true
@@ -153,7 +147,7 @@ items:
   - kind:        "attributemanifest"
     singular:    "attributemanifest"
     plural:      "attributemanifests"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.policy.v1beta1.AttributeManifest"
     gogo:        true
@@ -161,7 +155,7 @@ items:
   - kind:        "instance"
     singular:    "instance"
     plural:      "instances"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.policy.v1beta1.Instance"
     gogo:        true
@@ -169,7 +163,7 @@ items:
   - kind:        "handler"
     singular:    "handler"
     plural:      "handlers"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.policy.v1beta1.Handler"
     gogo:        true
@@ -177,7 +171,7 @@ items:
   - kind:        "template"
     singular:    "template"
     plural:      "templates"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -186,7 +180,7 @@ items:
   - kind:        "adapter"
     singular:    "adapter"
     plural:      "adapters"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -197,7 +191,7 @@ items:
   - kind:        "bypass"
     singular:    "bypass"
     plural:      "bypasses"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -206,7 +200,7 @@ items:
   - kind:        "circonus"
     singular:    "circonus"
     plural:      "circonuses"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -215,7 +209,7 @@ items:
   - kind:        "denier"
     singular:    "denier"
     plural:      "deniers"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -224,7 +218,7 @@ items:
   - kind:        "fluentd"
     singular:    "fluentd"
     plural:      "fluentds"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -233,7 +227,7 @@ items:
   - kind:        "kubernetesenv"
     singular:    "kubernetesenv"
     plural:      "kubernetesenvs"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -242,7 +236,7 @@ items:
   - kind:        "listchecker"
     singular:    "listchecker"
     plural:      "listcheckers"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -251,7 +245,7 @@ items:
   - kind:        "memquota"
     singular:    "memquota"
     plural:      "memquotas"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -260,7 +254,7 @@ items:
   - kind:        "noop"
     singular:    "noop"
     plural:      "noops"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -269,7 +263,7 @@ items:
   - kind:        "opa"
     singular:    "opa"
     plural:      "opas"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -278,16 +272,7 @@ items:
   - kind:        "prometheus"
     singular:    "prometheus"
     plural:      "prometheuses"
-    group:       "config"
-    version:     "v1alpha2"
-    proto:       "istio.mixer.adapter.model.v1beta1.Info"
-    gogo:        true
-    converter:   "old-mixer-adapter"
-
-  - kind:        "rbac"
-    singular:    "rbac"
-    plural:      "rbacs"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -296,14 +281,14 @@ items:
   - kind:        "servicecontrol"
     singular:    "servicecontrol"
     plural:      "servicecontrols"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
     converter:   "old-mixer-adapter"
 
   - kind:        "signalfx"
-    group:       "config"
+    group:       "config.istio.io"
     plural:      "signalfxs"
     singular:    "signalfx"
     version:     "v1alpha2"
@@ -314,7 +299,7 @@ items:
   - kind:        "solarwinds"
     singular:    "solarwinds"
     plural:      "solarwindses"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -323,7 +308,7 @@ items:
   - kind:        "stackdriver"
     singular:    "stackdriver"
     plural:      "stackdrivers"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -332,7 +317,7 @@ items:
   - kind:        "statsd"
     singular:    "statsd"
     plural:      "statsds"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -341,7 +326,7 @@ items:
   - kind:        "stdio"
     singular:    "stdio"
     plural:      "stdios"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Info"
     gogo:        true
@@ -350,7 +335,7 @@ items:
   - kind:        "apikey"
     singular:    "apikey"
     plural:      "apikeys"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -359,7 +344,7 @@ items:
   - kind:        "authorization"
     singular:    "authorization"
     plural:      "authorizations"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -368,7 +353,7 @@ items:
   - kind:        "checknothing"
     singular:    "checknothing"
     plural:      "checknothings"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -377,7 +362,7 @@ items:
   - kind:        "kubernetes"
     singular:    "kubernetes"
     plural:      "kuberneteses"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -386,7 +371,7 @@ items:
   - kind:        "listentry"
     singular:    "listentry"
     plural:      "listentries"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -395,7 +380,7 @@ items:
   - kind:        "logentry"
     singular:    "logentry"
     plural:      "logentries"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -404,7 +389,7 @@ items:
   - kind:        "metric"
     singular:    "metric"
     plural:      "metrics"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -413,7 +398,7 @@ items:
   - kind:        "quota"
     singular:    "quota"
     plural:      "quotas"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -422,7 +407,7 @@ items:
   - kind:        "reportnothing"
     singular:    "reportnothing"
     plural:      "reportnothings"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -431,7 +416,7 @@ items:
   - kind:        "servicecontrolreport"
     singular:    "servicecontrolreport"
     plural:      "servicecontrolreports"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
@@ -440,26 +425,8 @@ items:
   - kind:        "tracespan"
     singular:    "tracespan"
     plural:      "tracespans"
-    group:       "config"
+    group:       "config.istio.io"
     version:     "v1alpha2"
     proto:       "istio.mixer.adapter.model.v1beta1.Template"
     gogo:        true
     converter:   "old-mixer-template"
-
-# TODO
-#  - kind:        "ServiceRole"
-#    singular:    "servicerole"
-#    plural:      "serviceroles"
-#    group:       "config"
-#    version:     "v1alpha2"
-#    proto:       "istio.mixer.adapter.model.v1beta1.Template"
-#    gogo:        true
-
-# TODO
-#  - kind:        "ServiceRoleBinding"
-#    singular:    "servicerolebinding"
-#    plural:      "servicerolebindings"
-#    group:       "config"
-#    version:     "v1alpha2"
-#    proto:       "istio.mixer.adapter.model.v1beta1.Template"
-#    gogo:        true

--- a/galley/tools/gen-meta/metadata.yaml
+++ b/galley/tools/gen-meta/metadata.yaml
@@ -1,0 +1,465 @@
+# TODO: We should be obtaining this metadata directly from the api repository.
+items:
+# Types from Pilot
+  - kind:        "RouteRule"
+    singular:    "route-rule"
+    plural:      "route-rules"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.routing.v1alpha1.RouteRule"
+
+  - kind:        "VirtualService"
+    singular:    "virtual-service"
+    plural:      "virtual-services"
+    group:       "networking"
+    version:     "v1alpha3"
+    proto:       "istio.networking.v1alpha3.VirtualService"
+    gogo:        true
+
+  - kind:        "Gateway"
+    singular:    "gateway"
+    plural:      "gateways"
+    group:       "networking"
+    version:     "v1alpha3"
+    proto:       "istio.networking.v1alpha3.Gateway"
+    gogo:        true
+
+  - kind:        "IngressRule"
+    singular:    "ingress-rule"
+    plural:      "ingress-rules"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.routing.v1alpha1.IngressRule"
+
+  - kind:        "EgressRule"
+    singular:    "egress-rule"
+    plural:      "egress-rules"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.routing.v1alpha1.EgressRule"
+
+  - kind:        "ServiceEntry"
+    singular:    "service-entry"
+    plural:      "service-entries"
+    group:       "networking"
+    version:     "v1alpha3"
+    proto:       "istio.networking.v1alpha3.ServiceEntry"
+    gogo:        true
+
+  - kind:        "DestinationPolicy"
+    singular:    "destination-policy"
+    plural:      "destination-policies"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.routing.v1alpha1.DestinationPolicy"
+
+  - kind:        "DestinationRule"
+    singular:    "destination-rule"
+    plural:      "destination-rules"
+    group:       "networking"
+    version:     "v1alpha3"
+    proto:       "istio.networking.v1alpha3.DestinationRule"
+    gogo:        true
+
+  - kind:        "EnvoyFilter"
+    singular:    "envoy-filter"
+    plural:      "envoy-filters"
+    group:       "networking"
+    version:     "v1alpha3"
+    proto:       "istio.networking.v1alpha3.EnvoyFilter"
+    gogo:        true
+
+  - kind:        "HTTPAPISpec"
+    singular:    "http-api-spec"
+    plural:      "http-api-specs"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.v1.config.client.HTTPAPISpec"
+    gogo:        true
+
+  - kind:        "HTTPAPISpecBinding"
+    singular:    "http-api-spec-binding"
+    plural:      "http-api-spec-bindings"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.v1.config.client.HTTPAPISpecBinding"
+    gogo:        true
+
+  - kind:        "QuotaSpec"
+    singular:    "quota-spec"
+    plural:      "quota-specs"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.v1.config.client.QuotaSpec"
+    gogo:        true
+
+  - kind:        "QuotaSpecBinding"
+    singular:    "quota-spec-binding"
+    plural:      "quota-spec-bindings"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.v1.config.client.QuotaSpecBinding"
+    gogo:        true
+
+  - kind:        "AuthenticationPolicy"
+    singular:    "policy"
+    plural:      "policies"
+    group:       "authentication"
+    version:     "v1alpha1"
+    proto:       "istio.authentication.v1alpha1.Policy"
+    gogo:        true
+
+  - kind:        "AuthenticationMeshPolicy"
+    clusterScoped: true
+    singular:      "mesh-policy"
+    plural:        "mesh-policies"
+    group:       "authentication"
+    version:     "v1alpha1"
+    proto:         "istio.authentication.v1alpha1.Policy"
+    gogo:        true
+
+  - kind:        "ServiceRole"
+    singular:    "service-role"
+    plural:      "service-roles"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.rbac.v1alpha1.ServiceRole"
+
+  - kind:        "ServiceRoleBinding"
+    clusterScoped: false
+    singular:      "service-role-binding"
+    plural:        "service-role-bindings"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:         "istio.rbac.v1alpha1.ServiceRoleBinding"
+
+  - kind:        "RbacConfig"
+    singular:    "rbac-config"
+    plural:      "rbac-configs"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.rbac.v1alpha1.RbacConfig"
+
+# Types from Mixer
+
+  - kind:        "rule"
+    singular:    "rule"
+    plural:      "rules"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.policy.v1beta1.Rule"
+    gogo:        true
+
+  - kind:        "attributemanifest"
+    singular:    "attributemanifest"
+    plural:      "attributemanifests"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.policy.v1beta1.AttributeManifest"
+    gogo:        true
+
+  - kind:        "instance"
+    singular:    "instance"
+    plural:      "instances"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.policy.v1beta1.Instance"
+    gogo:        true
+
+  - kind:        "handler"
+    singular:    "handler"
+    plural:      "handlers"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.policy.v1beta1.Handler"
+    gogo:        true
+
+  - kind:        "template"
+    singular:    "template"
+    plural:      "templates"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "adapter"
+    singular:    "adapter"
+    plural:      "adapters"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+## Mixer Adapter Types
+
+  - kind:        "bypass"
+    singular:    "bypass"
+    plural:      "bypasses"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "circonus"
+    singular:    "circonus"
+    plural:      "circonuses"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "denier"
+    singular:    "denier"
+    plural:      "deniers"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "fluentd"
+    singular:    "fluentd"
+    plural:      "fluentds"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "kubernetesenv"
+    singular:    "kubernetesenv"
+    plural:      "kubernetesenvs"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "listchecker"
+    singular:    "listchecker"
+    plural:      "listcheckers"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "memquota"
+    singular:    "memquota"
+    plural:      "memquotas"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "noop"
+    singular:    "noop"
+    plural:      "noops"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "opa"
+    singular:    "opa"
+    plural:      "opas"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "prometheus"
+    singular:    "prometheus"
+    plural:      "prometheuses"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "rbac"
+    singular:    "rbac"
+    plural:      "rbacs"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "servicecontrol"
+    singular:    "servicecontrol"
+    plural:      "servicecontrols"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "signalfx"
+    group:       "config"
+    plural:      "signalfxs"
+    singular:    "signalfx"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "solarwinds"
+    singular:    "solarwinds"
+    plural:      "solarwindses"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "stackdriver"
+    singular:    "stackdriver"
+    plural:      "stackdrivers"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "statsd"
+    singular:    "statsd"
+    plural:      "statsds"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "stdio"
+    singular:    "stdio"
+    plural:      "stdios"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Info"
+    gogo:        true
+    converter:   "old-mixer-adapter"
+
+  - kind:        "apikey"
+    singular:    "apikey"
+    plural:      "apikeys"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "authorization"
+    singular:    "authorization"
+    plural:      "authorizations"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "checknothing"
+    singular:    "checknothing"
+    plural:      "checknothings"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "kubernetes"
+    singular:    "kubernetes"
+    plural:      "kuberneteses"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "listentry"
+    singular:    "listentry"
+    plural:      "listentries"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "logentry"
+    singular:    "logentry"
+    plural:      "logentries"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "metric"
+    singular:    "metric"
+    plural:      "metrics"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "quota"
+    singular:    "quota"
+    plural:      "quotas"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "reportnothing"
+    singular:    "reportnothing"
+    plural:      "reportnothings"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "servicecontrolreport"
+    singular:    "servicecontrolreport"
+    plural:      "servicecontrolreports"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+  - kind:        "tracespan"
+    singular:    "tracespan"
+    plural:      "tracespans"
+    group:       "config"
+    version:     "v1alpha2"
+    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+    gogo:        true
+    converter:   "old-mixer-template"
+
+# TODO
+#  - kind:        "ServiceRole"
+#    singular:    "servicerole"
+#    plural:      "serviceroles"
+#    group:       "config"
+#    version:     "v1alpha2"
+#    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+#    gogo:        true
+
+# TODO
+#  - kind:        "ServiceRoleBinding"
+#    singular:    "servicerolebinding"
+#    plural:      "servicerolebindings"
+#    group:       "config"
+#    version:     "v1alpha2"
+#    proto:       "istio.mixer.adapter.model.v1beta1.Template"
+#    gogo:        true


### PR DESCRIPTION
- Move CRD => Proto conversion code into its own package.
- Introduce the notion of converters, identity being the default one. (This is used to perform conversions for context specific things (i.e. old mixer instances to the new ones)
- Introduce support for Gogo protos
- Add go:generate tool to generate metadata glue code for Galley