### PR TITLE
Enforce Kubernetes RBAC at all times

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -18,4 +17,3 @@ rules:
 - apiGroups: [""]
   resources: ["services"]
   verbs: ["get", "watch", "list"]
-{{- end }}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +15,3 @@ subjects:
   - kind: ServiceAccount
     name: istio-citadel-service-account
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -32,9 +32,6 @@ global:
   # imagePullPolicy is applied to istio control plane components.
   imagePullPolicy: IfNotPresent
 
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
   imagePullSecrets:
     # - private-registry-key

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -15,4 +14,3 @@ rules:
 - apiGroups: ["config.istio.io"] # istio mixer CRD watcher
   resources: ["*"]
   verbs: ["get", "list", "watch"]
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +15,3 @@ subjects:
   - kind: ServiceAccount
     name: istio-galley-service-account
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -16,9 +16,7 @@ spec:
       labels:
         istio: galley
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-galley-service-account
-{{- end }}
       containers:
         - name: validator
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
@@ -63,10 +61,6 @@ spec:
       volumes:
       - name: certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-galley-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/clusterrole.yaml
@@ -1,7 +1,6 @@
 {{- range $key, $spec := .Values }}
 {{- if and (ne $key "global") (ne $key "enabled") }}
 {{- if $spec.enabled }}
-{{- if $.Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -16,7 +15,6 @@ rules:
   resources: ["thirdpartyresources", "virtualservices", "destinationrules", "gateways"]
   verbs: ["get", "watch", "list", "update"]
 ---
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/clusterrolebindings.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/clusterrolebindings.yaml
@@ -1,7 +1,6 @@
 {{- range $key, $spec := .Values }}
 {{- if and (ne $key "global") (ne $key "enabled") }}
 {{- if $spec.enabled }}
-{{- if $.Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -15,7 +14,6 @@ subjects:
     name: {{ $key }}-service-account
     namespace: {{ $.Release.Namespace }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -25,9 +25,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if $.Values.global.rbacEnabled }}
       serviceAccountName: {{ $key }}-service-account
-{{- end }}
       containers:
         - name: {{ $spec.labels.istio }}
           image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
@@ -104,11 +102,7 @@ spec:
       volumes:
       - name: istio-certs
         secret:
-{{- if $.Values.global.rbacEnabled }}
           secretName: istio.{{ $key }}-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
           optional: true
       {{- range $spec.secretVolumes }}
       - name: {{ .name }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/serviceaccount.yaml
@@ -1,7 +1,6 @@
 {{- range $key, $spec := .Values }}
 {{- if and (ne $key "global") (ne $key "enabled") }}
 {{- if $spec.enabled }}
-{{- if $.Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if $.Values.global.imagePullSecrets }}
@@ -19,7 +18,6 @@ metadata:
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
 ---
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -15,4 +14,3 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps", "pods", "endpoints", "services"]
   verbs: ["get", "watch", "list"]
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +10,3 @@ subjects:
   - kind: ServiceAccount
     name: istio-ingress-service-account
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -18,9 +18,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-ingress-service-account
-{{- end }}
       containers:
         - name: {{ template "istio.name" . }}
           image: "{{ .Values.global.hub }}/proxyv2:{{ .Values.global.tag }}"
@@ -90,11 +88,7 @@ spec:
       volumes:
       - name: istio-certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-ingress-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
           optional: true
       - name: ingress-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/ingress/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -64,4 +63,3 @@ rules:
   - get
   - list
   - watch
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +15,3 @@ subjects:
 - kind: ServiceAccount
   name: kiali-service-account
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       labels:
         app: kiali
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: kiali-service-account
-{{ end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         name: kiali

--- a/install/kubernetes/helm/istio/charts/kiali/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -24,4 +23,3 @@ rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
   verbs: ["get", "list", "watch"]
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/clusterrolebinding.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +15,3 @@ subjects:
   - kind: ServiceAccount
     name: istio-mixer-service-account
     namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -1,8 +1,6 @@
 {{- define "policy_container" }}
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-mixer-service-account
-{{- end }}
       volumes:
       - name: istio-certs
         secret:
@@ -77,9 +75,7 @@
 
 {{- define "telemetry_container" }}
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-mixer-service-account
-{{- end }}
       volumes:
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/clusterrolebinding.yaml
@@ -13,9 +13,5 @@ roleRef:
   name: istio-pilot-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-pilot-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -21,9 +21,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-pilot-service-account
-{{- end }}
       containers:
         - name: discovery
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
@@ -116,10 +114,6 @@ spec:
           name: istio
       - name: istio-certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-pilot-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +14,3 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -18,4 +17,3 @@ rules:
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-{{ end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrolebindings.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/clusterrolebindings.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -11,4 +10,3 @@ subjects:
 - kind: ServiceAccount
   name: prometheus
   namespace: {{ .Release.Namespace }}
-{{ end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -21,9 +21,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: prometheus
-{{ end }}
       containers:
         - name: prometheus
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -10,4 +9,3 @@ imagePullSecrets:
 metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-old-ca.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-old-ca.yaml
@@ -20,9 +20,7 @@ spec:
         app: {{ template "security.name" . }}
         release: {{ .Release.Name }}
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-cleanup-old-ca-service-account
-{{- end }}
       containers:
         - name: hyperkube
           image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"

--- a/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/clusterrolebinding.yaml
@@ -13,11 +13,7 @@ roleRef:
   name: istio-citadel-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-citadel-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
 
 {{- if $.Values.cleanUpOldCA }}
@@ -38,10 +34,6 @@ roleRef:
   name: istio-cleanup-old-ca-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-cleanup-old-ca-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -19,9 +19,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-citadel-service-account
-{{- end }}
       containers:
         - name: citadel
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -34,5 +33,4 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrolebinding.yaml
@@ -13,9 +13,5 @@ roleRef:
   name: istio-sidecar-injector-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-{{- if .Values.global.rbacEnabled }}
     name: istio-sidecar-injector-service-account
-{{- else }}
-    name: default
-{{- end }}
     namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -16,9 +16,7 @@ spec:
       labels:
         istio: sidecar-injector
     spec:
-{{- if .Values.global.rbacEnabled }}
       serviceAccountName: istio-sidecar-injector-service-account
-{{- end }}
       containers:
         - name: sidecar-injector-webhook
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
@@ -67,11 +65,7 @@ spec:
           name: istio
       - name: certs
         secret:
-{{- if .Values.global.rbacEnabled }}
           secretName: istio.istio-sidecar-injector-service-account
-{{- else }}
-          secretName: istio.default
-{{- end }}
       - name: inject-config
         configMap:
           name: istio-sidecar-injector

--- a/install/kubernetes/helm/istio/values-istio-auth-galley.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth-galley.yaml
@@ -9,9 +9,6 @@ global:
     # destination rules or service annotations.
     enabled: true
 
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values-istio-galley.yaml
+++ b/install/kubernetes/helm/istio/values-istio-galley.yaml
@@ -9,9 +9,6 @@ global:
     # destination rules or service annotations.
     enabled: false
 
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
@@ -9,9 +9,6 @@ global:
     # destination rules or service annotations.
     enabled: true
 
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
@@ -9,10 +9,6 @@ global:
     # destination rules or service annotations.
     enabled: false
 
-
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with privte docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -77,9 +77,6 @@ global:
     # destination rules or service annotations.
     enabled: false
 
-  # create RBAC resources. Must be set for any cluster configured with rbac.
-  rbacEnabled: true
-
   # ImagePullSecrets for all ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.
   # Must be set for any clustser configured with privte docker registry.


### PR DESCRIPTION
This removes the capability of disabling Kubernetes RBAC
in the deployment of Istio.  The reason this option was
originally added is that RBAC was pretty rough around the
edges in Kubernetes 1.6 and 1.7.  In later Kubernetes
versions, RBAC worked well and is completely integrated with
Istio.

RBAC has been enabled since Istio 0.8.  This PR forces
RBAC to enabled by removing the conditional for RBAC disablement.