### PR TITLE
Remove broken cluster for pilot dashboard

### DIFF
--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -989,52 +989,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(envoy_cluster_manager_cds_update_attempt[1m]))",
+          "expr": "sum(irate(envoy_cluster_xds_grpc_update_success[1m]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "CDS Attempts",
-          "refId": "F"
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_manager_cds_update_success[1m]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "CDS Successes",
-          "refId": "A"
-        },
-        {
-          "expr": "sum(irate(envoy_listener_manager_lds_update_attempt[1m]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "LDS Attempts",
-          "refId": "E"
-        },
-        {
-          "expr": "sum(irate(envoy_listener_manager_lds_update_success[1m]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "LDS Successes",
-          "refId": "B"
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_rds_update_attempt[1m]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "RDS Attempts",
-          "refId": "G"
-        },
-        {
-          "expr": "sum(irate(envoy_cluster_rds_update_success[1m]))",
-          "format": "time_series",
-          "hide": false,
-          "intervalFactor": 1,
-          "legendFormat": "RDS Successes",
-          "refId": "I"
+          "legendFormat": "XDS GRPC Successes",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -1110,27 +1070,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(rate(envoy_cluster_manager_cds_update_attempt[1m])) - sum(rate(envoy_cluster_manager_cds_update_success[1m])))",
+          "expr": "round(sum(rate(envoy_cluster_xds_grpc_update_attempt[1m])) - sum(rate(envoy_cluster_xds_grpc_update_success[1m])))",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "CDS",
+          "legendFormat": "XDS GRPC ",
           "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "round(sum(rate(envoy_listener_manager_lds_update_attempt[1m])) - sum(rate(envoy_listener_manager_lds_update_success[1m])))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "LDS",
-          "refId": "B",
-          "step": 2
-        },
-        {
-          "expr": "round(sum(rate(envoy_cluster_rds_update_attempt[1m])) - sum(rate(envoy_cluster_rds_update_success[1m])))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "RDS",
-          "refId": "C",
           "step": 2
         }
       ],
@@ -1207,10 +1151,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_rds_upstream_cx_active)",
+          "expr": "sum(envoy_cluster_xds_grpc_upstream_cx_active)",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "Pilot (RDS)",
+          "legendFormat": "Pilot (XDS GRPC)",
           "refId": "C",
           "step": 2
         }
@@ -1291,5 +1235,5 @@
   "timezone": "browser",
   "title": "Pilot Dashboard",
   "uid": "3",
-  "version": 3
+  "version": 2
 }

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -804,7 +804,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_rds_membership_healthy)",
+          "expr": "sum(envoy_cluster_xds_grpc_membership_healthy)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Pilot (healthy)",
@@ -812,7 +812,7 @@
           "step": 2
         },
         {
-          "expr": "sum(envoy_cluster_rds_membership_total)",
+          "expr": "sum(envoy_cluster_xds_grpc_membership_total)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Pilot (total)",
@@ -893,7 +893,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(envoy_cluster_rds_upstream_rq_time) by (quantile)",
+          "expr": "sum(envoy_cluster_xds_grpc_upstream_rq_time) by (quantile)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -493,457 +493,12 @@
       ]
     },
     {
-      "content": "<center><h2>Pilot Overview</h2></center>",
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "height": "40px",
-      "id": 30,
-      "links": [],
-      "mode": "html",
-      "title": "",
-      "transparent": true,
-      "type": "text"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 13
-      },
-      "id": 9,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(rate(pilot_discovery_calls[1m])) by (method)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ method }}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Discovery Calls",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ops",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 13
-      },
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(irate(pilot_discovery_errors[1m])) by (method)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ method }}",
-          "refId": "A",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Discovery Errors",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 13
-      },
-      "id": 39,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "histogram_quantile(0.5, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ method }} -  p50",
-          "refId": "A",
-          "step": 2
-        },
-        {
-          "expr": "histogram_quantile(0.9, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ method }} -  p90",
-          "refId": "B",
-          "step": 2
-        },
-        {
-          "expr": "histogram_quantile(0.99, sum(irate(pilot_discovery_resources_bucket[1m])) by (le, method))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ method }} -  p99",
-          "refId": "C",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Discovery Returned Resource Counts",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 20
-      },
-      "id": 45,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_xds_grpc_membership_healthy)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Pilot (healthy)",
-          "refId": "E",
-          "step": 2
-        },
-        {
-          "expr": "sum(envoy_cluster_xds_grpc_membership_total)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "Pilot (total)",
-          "refId": "F",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Cluster Membership",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 20
-      },
-      "id": 50,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(envoy_cluster_xds_grpc_upstream_rq_time) by (quantile)",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "C",
-          "step": 2
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Request Latency",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "ms",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
-    },
-    {
       "content": "<center><h2>xDS</h2></center>",
       "gridPos": {
         "h": 3,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 10
       },
       "id": 28,
       "links": [],
@@ -963,7 +518,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 13
       },
       "id": 40,
       "legend": {
@@ -1016,7 +571,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ops",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1024,12 +579,12 @@
           "show": true
         },
         {
-          "format": "short",
+          "format": "ops",
           "label": null,
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1044,7 +599,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 30
+        "y": 13
       },
       "id": 42,
       "legend": {
@@ -1097,7 +652,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ops",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1110,7 +665,7 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": true
+          "show": false
         }
       ]
     },
@@ -1125,7 +680,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 30
+        "y": 13
       },
       "id": 41,
       "legend": {
@@ -1235,5 +790,5 @@
   "timezone": "browser",
   "title": "Pilot Dashboard",
   "uid": "3",
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
This PR attempts to fix the `e2e_dashboard` broken by a recent PR and changes to envoy->Pilot comm protocol.

I have not tested this locally. 