### PR TITLE
Fix multicluster e2e test setup to use helm chart template

### DIFF
--- a/tests/e2e/framework/app_manager.go
+++ b/tests/e2e/framework/app_manager.go
@@ -90,7 +90,7 @@ func (am *AppManager) deploy(a *App) error {
 			log.Errorf("CreateTempfile failed %v", err)
 			return err
 		}
-		if err = am.istioctl.KubeInject(a.AppYaml, finalYaml); err != nil {
+		if err = am.istioctl.KubeInject(a.AppYaml, finalYaml, am.Kubeconfig); err != nil {
 			log.Errorf("KubeInject failed for yaml %s: %v", a.AppYaml, err)
 			return err
 		}

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -107,6 +107,7 @@ func NewCommonConfigWithVersion(testID, version string) (*CommonConfig, error) {
 	c.Cleanup.RegisterCleanable(c.Kube.Istioctl)
 	c.Cleanup.RegisterCleanable(c.Kube.AppManager)
 	if c.Kube.RemoteKubeConfig != "" {
+		c.Cleanup.RegisterCleanable(c.Kube.RemoteAppManager.istioctl)
 		c.Cleanup.RegisterCleanable(c.Kube.RemoteAppManager)
 	}
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -465,12 +465,6 @@ func (k *KubeInfo) Teardown() error {
 				log.Errorf("Failed to delete namespace %s", k.Namespace)
 				return err
 			}
-			if *multiClusterDir != "" {
-				if err := util.DeleteNamespace(k.Namespace, k.RemoteKubeConfig); err != nil {
-					log.Errorf("Failed to delete namespace %s on remote cluster", k.Namespace)
-					return err
-				}
-			}
 
 			// ClusterRoleBindings are not namespaced and need to be deleted separately
 			if _, err := util.Shell("kubectl get --kubeconfig=%s clusterrolebinding -o jsonpath={.items[*].metadata.name}"+
@@ -487,6 +481,11 @@ func (k *KubeInfo) Teardown() error {
 				log.Errorf("Failed to delete clusterroles associated with namespace %s", k.Namespace)
 				return err
 			}
+		}
+	}
+	if *multiClusterDir != "" {
+		if err := util.DeleteNamespace(k.Namespace, k.RemoteKubeConfig); err != nil {
+			log.Errorf("Failed to delete namespace %s on remote cluster", k.Namespace)
 		}
 	}
 

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -662,10 +662,8 @@ func (k *KubeInfo) deployIstio() error {
 			log.Infof("Failed to create Cacerts with namespace %s in remote cluster", k.Namespace)
 		}
 
-		yamlDir := filepath.Join(istioInstallDir, mcRemoteInstallFile)
-		baseIstioYaml := filepath.Join(k.ReleaseDir, yamlDir)
 		testIstioYaml := filepath.Join(k.TmpDir, "yaml", mcRemoteInstallFile)
-		if err := k.generateRemoteIstio(baseIstioYaml, testIstioYaml); err != nil {
+		if err := k.generateRemoteIstio(testIstioYaml); err != nil {
 			log.Errorf("Generating Remote yaml %s failed", testIstioYaml)
 			return err
 		}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -325,13 +325,6 @@ func (k *KubeInfo) Setup() error {
 				log.Error("Failed to deploy Istio.")
 				return err
 			}
-
-			if k.InstallAddons {
-				if err = k.deployAddons(); err != nil {
-					log.Error("Failed to deploy istio addons")
-					return err
-				}
-			}
 		}
 		// Create the ingress secret.
 		certDir := util.GetResourcePath("./tests/testdata/certs")
@@ -644,6 +637,13 @@ func (k *KubeInfo) deployIstio() error {
 	if err := util.KubeApply(k.Namespace, testIstioYaml, k.KubeConfig); err != nil {
 		log.Errorf("Istio core %s deployment failed", testIstioYaml)
 		return err
+	}
+
+	if k.InstallAddons {
+		if err := k.deployAddons(); err != nil {
+			log.Error("Failed to deploy istio addons")
+			return err
+		}
 	}
 
 	if *multiClusterDir != "" {

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -183,7 +183,7 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		}
 	}
 	yamlDir := filepath.Join(tmpDir, "yaml")
-	i, err := NewIstioctl(yamlDir, *namespace, *namespace, *proxyHub, *proxyTag, *imagePullPolicy)
+	i, err := NewIstioctl(yamlDir, *namespace, *namespace, *proxyHub, *proxyTag, *imagePullPolicy, "")
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +231,16 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		if remoteKubeClient, err = kube.CreateInterface(remoteKubeConfig); err != nil {
 			return nil, err
 		}
-
-		aRemote = NewAppManager(tmpDir, *namespace, i, remoteKubeConfig)
+		// Create Istioctl for remote using injectConfigMap on remote (not the same as master cluster's)
+		remoteI, err := NewIstioctl(yamlDir, *namespace, *namespace, *proxyHub, *proxyTag, *imagePullPolicy, "istio-sidecar-injector")
+		if err != nil {
+			return nil, err
+		}
+		if baseVersion != "" {
+			remoteI.localPath = filepath.Join(releaseDir, "/bin/istioctl")
+			remoteI.defaultProxy = true
+		}
+		aRemote = NewAppManager(tmpDir, *namespace, remoteI, remoteKubeConfig)
 	}
 
 	a := NewAppManager(tmpDir, *namespace, i, kubeConfig)
@@ -663,7 +671,7 @@ func (k *KubeInfo) deployIstio() error {
 		}
 
 		testIstioYaml := filepath.Join(k.TmpDir, "yaml", mcRemoteInstallFile)
-		if err := k.generateRemoteIstio(testIstioYaml); err != nil {
+		if err := k.generateRemoteIstio(testIstioYaml, *useAutomaticInjection, *proxyHub, *proxyTag); err != nil {
 			log.Errorf("Generating Remote yaml %s failed", testIstioYaml)
 			return err
 		}

--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -68,7 +68,7 @@ func TestGateway_HTTPIngress(t *testing.T) {
 			for _, elt := range resp.Version {
 				count[elt] = count[elt] + 1
 			}
-			log.Infof("request counts %v", count)
+			log.Infof("request counts %+v", count)
 			if count["v2"] >= 95 {
 				return nil
 			}
@@ -103,7 +103,7 @@ func TestGateway_HTTPSIngress(t *testing.T) {
 			for _, elt := range resp.Version {
 				count[elt] = count[elt] + 1
 			}
-			log.Infof("request counts %v", count)
+			log.Infof("request counts %+v", count)
 			if count["v2"] >= 95 {
 				return nil
 			}
@@ -138,7 +138,7 @@ func TestGateway_TCPIngress(t *testing.T) {
 			for _, elt := range resp.Version {
 				count[elt] = count[elt] + 1
 			}
-			log.Infof("request counts %v", count)
+			log.Infof("request counts %+v", count)
 			if count["v1"] >= 95 {
 				return nil
 			}
@@ -254,7 +254,7 @@ cleanup:
 			}
 			if count["200"] != len(resp.Code) {
 				// have entries other than 200
-				t.Errorf("Got non 200 status code while changing rules: %v", count)
+				t.Errorf("Got non 200 status code while changing rules: %+v", count)
 			} else {
 				log.Infof("No 503s were encountered while changing rules (total %d requests)", len(resp.Code))
 			}

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -192,6 +192,14 @@ func HelmInstall(chartDir, chartName, namespace, setValue string) error {
 	return err
 }
 
+// HelmTemplate helm template from a chart for a given namespace
+//      --set stringArray        set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+func HelmTemplate(chartDir, chartName, namespace, setValue, outfile string) error {
+	_, err := Shell("helm template %s --name %s --namespace %s %s > %s", chartDir,
+		chartName, namespace, setValue, outfile)
+	return err
+}
+
 // HelmDelete helm del --purge a chart
 func HelmDelete(chartName string) error {
 	_, err := Shell("helm del --purge %s", chartName)


### PR DESCRIPTION
 
    - istio-remote helm chart: Add istio-ingressgateway service and endpoints option
    - Make the multicluster e2e tests always setup istio-remote via helm template with
      passed args.
    - Fix crash in getEndpointIPForService method

    -  e2e test install addons prior to remote cluster install
 
Update e2e framework to work with istio-remote helm chart created configmap

- istio-remote changes removed selectorless service/endpoint setup so DNS
  for istio control plane services won't resolve on remote.  Sidecar
  injection configmap setup on remote uses the IP addresses of services
  directly.
  - change istioctl in e2e framework to allow use of sidecar inject
    configmap on remote rather than default settings.
- enable/disable sidecar injection in remote based on test flag
- misc. fix zipkin address in istio-remote configmap
