### PR TITLE
Make plugins optional

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -104,7 +104,7 @@ func init() {
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Namespace, "namespace", "n", "",
 		"Select a namespace where the controller resides. If not set, uses ${POD_NAMESPACE} environment variable")
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Plugins, "plugins", bootstrap.DefaultPlugins,
-		"comma separated list of plugins to enable")
+		"comma separated list of networking plugins to enable")
 
 	// Config Controller options
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -103,6 +103,8 @@ func init() {
 		fmt.Sprintf("File name for Istio mesh configuration. If not specified, a default mesh will be used."))
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Namespace, "namespace", "n", "",
 		"Select a namespace where the controller resides. If not set, uses ${POD_NAMESPACE} environment variable")
+	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Plugins, "plugins", bootstrap.DefaultPlugins,
+		"comma separated list of plugins to enable")
 
 	// Config Controller options
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -102,6 +102,8 @@ var (
 	// Visible for tests - at runtime can be set by PILOT_CERT_DIR environment variable.
 	PilotCertDir = "/etc/certs/"
 
+	// DefaultPlugins is the default list of plugins to enable, when no plugin(s)
+	// is specified through the command line
 	DefaultPlugins = []string{
 		plugin.Authn,
 		plugin.Authz,

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -49,6 +49,7 @@ import (
 	configmonitor "istio.io/istio/pilot/pkg/config/monitor"
 	"istio.io/istio/pilot/pkg/model"
 	istio_networking "istio.io/istio/pilot/pkg/networking/core"
+	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	envoyv2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -74,9 +75,7 @@ const (
 var (
 	// FilepathWalkInterval dictates how often the file system is walked for config
 	FilepathWalkInterval = 100 * time.Millisecond
-)
 
-var (
 	// ConfigDescriptor describes all supported configuration kinds.
 	// TODO: use model.IstioConfigTypes once model.IngressRule is deprecated
 	ConfigDescriptor = model.ConfigDescriptor{
@@ -102,6 +101,14 @@ var (
 	// PilotCertDir is the default location for mTLS certificates used by pilot
 	// Visible for tests - at runtime can be set by PILOT_CERT_DIR environment variable.
 	PilotCertDir = "/etc/certs/"
+
+	DefaultPlugins = []string{
+		plugin.Authn,
+		plugin.Authz,
+		plugin.Envoyfilter,
+		plugin.Health,
+		plugin.Mixer,
+	}
 )
 
 // MeshArgs provide configuration options for the mesh. If ConfigFile is provided, an attempt will be made to
@@ -156,6 +163,7 @@ type PilotArgs struct {
 	Service          ServiceArgs
 	MeshConfig       *meshconfig.MeshConfig
 	CtrlZOptions     *ctrlz.Options
+	Plugins          []string
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -783,7 +791,8 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 
 	// For now we create the gRPC server sourcing data from Pilot's older data model.
 	s.initGrpcServer()
-	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(environment, istio_networking.NewConfigGenerator())
+
+	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(environment, istio_networking.NewConfigGenerator(args.Plugins))
 	// TODO: decouple v2 from the cache invalidation, use direct listeners.
 	envoy.V2ClearCache = s.EnvoyXdsServer.ClearCacheFunc()
 	s.EnvoyXdsServer.Register(s.grpcServer)

--- a/pilot/pkg/networking/core/configgen.go
+++ b/pilot/pkg/networking/core/configgen.go
@@ -37,6 +37,6 @@ type ConfigGenerator interface {
 }
 
 // NewConfigGenerator creates a new instance of the dataplane configuration generator
-func NewConfigGenerator() ConfigGenerator {
-	return v1alpha3.NewConfigGenerator(registry.NewPlugins())
+func NewConfigGenerator(plugins []string) ConfigGenerator {
+	return v1alpha3.NewConfigGenerator(registry.NewPlugins(plugins))
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -16,12 +16,15 @@ package mixer
 
 import (
 	"fmt"
+	"net"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
 	mccpb "istio.io/api/mixer/v1/config/client"
@@ -29,7 +32,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/log"
-	"net"
 )
 
 type mixerplugin struct{}

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -16,15 +16,12 @@ package mixer
 
 import (
 	"fmt"
-	"net"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	"github.com/gogo/protobuf/types"
-
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"
 	mccpb "istio.io/api/mixer/v1/config/client"
@@ -32,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/log"
+	"net"
 )
 
 type mixerplugin struct{}

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -33,12 +33,16 @@ const (
 	// ListenerProtocolHTTP is an HTTP listener.
 	ListenerProtocolHTTP
 
-	// Available plugin names that can be specified through command line
-	Authn       = "authn"
-	Authz       = "authz"
+	// Authn is the name of the authentication plugin passed through the command line
+	Authn = "authn"
+	// Authz is the name of the rbac plugin passed through the command line
+	Authz = "authz"
+	// Envoyfilter is the name of the envoyfilter plugin passed through the command line
 	Envoyfilter = "envoyfilter"
-	Health      = "health"
-	Mixer       = "mixer"
+	// Health is the name of the health plugin passed through the command line
+	Health = "health"
+	// Mixer is the name of the mixer plugin passed through the command line
+	Mixer = "mixer"
 )
 
 // ModelProtocolToListenerProtocol converts from a model.Protocol to its corresponding plugin.ListenerProtocol

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -32,6 +32,13 @@ const (
 	ListenerProtocolTCP
 	// ListenerProtocolHTTP is an HTTP listener.
 	ListenerProtocolHTTP
+
+	// Available plugin names that can be specified through command line
+	Authn       = "authn"
+	Authz       = "authz"
+	Envoyfilter = "envoyfilter"
+	Health      = "health"
+	Mixer       = "mixer"
 )
 
 // ModelProtocolToListenerProtocol converts from a model.Protocol to its corresponding plugin.ListenerProtocol

--- a/pilot/pkg/networking/plugin/registry/registry.go
+++ b/pilot/pkg/networking/plugin/registry/registry.go
@@ -26,12 +26,21 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin/mixer"
 )
 
+var availablePlugins = map[string]plugin.Plugin{
+	plugin.Authn:       authn.NewPlugin(),
+	plugin.Authz:       authz.NewPlugin(),
+	plugin.Envoyfilter: envoyfilter.NewPlugin(),
+	plugin.Health:      health.NewPlugin(),
+	plugin.Mixer:       mixer.NewPlugin(),
+}
+
 // NewPlugins returns a slice of default Plugins.
-func NewPlugins() []plugin.Plugin {
-	return []plugin.Plugin{
-		authn.NewPlugin(),
-		authz.NewPlugin(),
-		envoyfilter.NewPlugin(),
-		health.NewPlugin(),
-		mixer.NewPlugin()}
+func NewPlugins(in []string) []plugin.Plugin {
+	var plugins []plugin.Plugin
+	for _, pl := range in {
+		if p, exist := availablePlugins[pl]; exist {
+			plugins = append(plugins, p)
+		}
+	}
+	return plugins
 }

--- a/pilot/pkg/networking/plugin/registry/registry_test.go
+++ b/pilot/pkg/networking/plugin/registry/registry_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package registry_test
 
 import (

--- a/pilot/pkg/networking/plugin/registry/registry_test.go
+++ b/pilot/pkg/networking/plugin/registry/registry_test.go
@@ -1,0 +1,38 @@
+package registry_test
+
+import (
+	"reflect"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/networking/plugin"
+	"istio.io/istio/pilot/pkg/networking/plugin/envoyfilter"
+	"istio.io/istio/pilot/pkg/networking/plugin/health"
+	"istio.io/istio/pilot/pkg/networking/plugin/mixer"
+	"istio.io/istio/pilot/pkg/networking/plugin/registry"
+)
+
+func TestPlugins(t *testing.T) {
+	expectedPlugins := []string{"mixer", "health", "envoyfilter"}
+	plugins := registry.NewPlugins(expectedPlugins)
+	if len(plugins) != len(expectedPlugins) {
+		t.Errorf("expected length of plugins to be %d, but got %d", len(expectedPlugins), len(plugins))
+	}
+
+	var checkPluginType = func(i int, p func() plugin.Plugin) {
+		if reflect.TypeOf(plugins[i]) != reflect.TypeOf(p()) {
+			t.Errorf("expected type of plugin to be %s, but got %s", reflect.TypeOf(plugins[i]), reflect.TypeOf(p()))
+		}
+	}
+
+	checkPluginType(0, mixer.NewPlugin)
+	checkPluginType(1, health.NewPlugin)
+	checkPluginType(2, envoyfilter.NewPlugin)
+}
+
+func TestPluginsNonValid(t *testing.T) {
+	expectedPlugins := []string{"abc"}
+	plugins := registry.NewPlugins(expectedPlugins)
+	if len(plugins) != 0 {
+		t.Errorf("expected length of plugins to be %d, but got %d", 0, len(plugins))
+	}
+}


### PR DESCRIPTION
This allows to specify a list of comma separated plugins through a
 command line argument --plugins.