### PR TITLE
add nodeagent cert to sdsConfig/ca root cert to validatecontext

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -18,8 +18,10 @@ RUN chmod 2755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
-ADD nodeagent-sds-cert.pem /etc/istio/nodeagent-sds-cert.pem
-ADD ca-root-cert.pem /etc/istio/ca-root-cert.pem
+
+ADD nodeagent-sds-cert.pem /etc/certs/nodeagent-sds-cert.pem
+ADD ca-root-cert.pem /etc/certs/ca-root-cert.pem
+
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -29,11 +29,11 @@ import (
 )
 
 const (
-	// SDSDummyCertPath is the path of dummy cert that envoy uses to communicate with SDS service through secure gPRC.
-	SDSDummyCertPath = "/etc/istio/nodeagent-sds-cert.pem"
+	// SDSCertPath is the path of cert that envoy uses to communicate with SDS service through secure gPRC.
+	SDSCertPath = "/etc/certs/nodeagent-sds-cert.pem"
 
 	// CARootCertPath is the path of ca root cert that envoy uses to validate cert got from SDS service.
-	CARootCertPath = "/etc/istio/ca-root-cert.pem"
+	CARootCertPath = "/etc/certs/ca-root-cert.pem"
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.
@@ -81,7 +81,7 @@ func ConstructSdsSecretConfig(serviceAccount string, refreshDuration *time.Durat
 											SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
 												CertChain: &core.DataSource{
 													Specifier: &core.DataSource_Filename{
-														Filename: SDSDummyCertPath,
+														Filename: SDSCertPath,
 													},
 												},
 											},

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -28,8 +28,13 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-// SDSDummyCertPath is the path of dummy cert that envoy uses to communicate with SDS service through secure gPRC.
-const SDSDummyCertPath = "/etc/istio/nodeagent-sds-cert.pem"
+const (
+	// SDSDummyCertPath is the path of dummy cert that envoy uses to communicate with SDS service through secure gPRC.
+	SDSDummyCertPath = "/etc/istio/nodeagent-sds-cert.pem"
+
+	// CARootCertPath is the path of ca root cert that envoy uses to validate cert got from SDS service.
+	CARootCertPath = "/etc/istio/ca-root-cert.pem"
+)
 
 // JwtKeyResolver resolves JWT public key and JwksURI.
 var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
@@ -87,6 +92,19 @@ func ConstructSdsSecretConfig(serviceAccount string, refreshDuration *time.Durat
 						},
 					},
 					RefreshDelay: refreshDuration,
+				},
+			},
+		},
+	}
+}
+
+// ConstructValidationContext constructs ValidationContext in CommonTlsContext.
+func ConstructValidationContext(rootCAFilePath string) *auth.CommonTlsContext_ValidationContext {
+	return &auth.CommonTlsContext_ValidationContext{
+		ValidationContext: &auth.CertificateValidationContext{
+			TrustedCa: &core.DataSource{
+				Specifier: &core.DataSource_Filename{
+					Filename: rootCAFilePath,
 				},
 			},
 		},

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -28,6 +28,9 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
+// SDSDummyCertPath is the path of dummy cert that envoy uses to communicate with SDS service through secure gPRC.
+const SDSDummyCertPath = "/etc/istio/nodeagent-sds-cert.pem"
+
 // JwtKeyResolver resolves JWT public key and JwksURI.
 var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
@@ -68,6 +71,17 @@ func ConstructSdsSecretConfig(serviceAccount string, refreshDuration *time.Durat
 							TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 								GoogleGrpc: &core.GrpcService_GoogleGrpc{
 									TargetUri: sdsUdsPath,
+									ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+										CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{
+											SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
+												CertChain: &core.DataSource{
+													Specifier: &core.DataSource_Filename{
+														Filename: SDSDummyCertPath,
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -145,7 +145,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 													SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
 														CertChain: &core.DataSource{
 															Specifier: &core.DataSource_Filename{
-																Filename: SDSDummyCertPath,
+																Filename: SDSCertPath,
 															},
 														},
 													},

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -140,6 +140,17 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 									TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 										GoogleGrpc: &core.GrpcService_GoogleGrpc{
 											TargetUri: "/tmp/sdsuds.sock",
+											ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+												CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{
+													SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
+														CertChain: &core.DataSource{
+															Specifier: &core.DataSource_Filename{
+																Filename: SDSDummyCertPath,
+															},
+														},
+													},
+												},
+											},
 										},
 									},
 								},

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -447,14 +447,14 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings, 
 		}
 	case networking.TLSSettings_MUTUAL, networking.TLSSettings_ISTIO_MUTUAL:
 		cluster.TlsContext = &auth.UpstreamTlsContext{
-			CommonTlsContext: &auth.CommonTlsContext{
-				ValidationContextType: &auth.CommonTlsContext_ValidationContext{
-					ValidationContext: certValidationContext,
-				},
-			},
-			Sni: tls.Sni,
+			CommonTlsContext: &auth.CommonTlsContext{},
+			Sni:              tls.Sni,
 		}
 		if meshConfig.SdsUdsPath == "" || tls.Mode == networking.TLSSettings_MUTUAL {
+			cluster.TlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{
+				ValidationContext: certValidationContext,
+			}
+
 			cluster.TlsContext.CommonTlsContext.TlsCertificates = []*auth.TlsCertificate{
 				{
 					CertificateChain: &core.DataSource{
@@ -470,6 +470,7 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings, 
 				},
 			}
 		} else {
+			cluster.TlsContext.CommonTlsContext.ValidationContextType = model.ConstructValidationContext(model.CARootCertPath)
 			cluster.TlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{}
 			// tls.SubjectAltNames is set to upstreamServiceAccount for mTLS case.
 			refreshDuration, _ := ptypes.Duration(meshConfig.SdsRefreshDelay)

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -943,7 +943,7 @@ func TestBuildSidecarListenerTLSContex(t *testing.T) {
 																SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
 																	CertChain: &core.DataSource{
 																		Specifier: &core.DataSource_Filename{
-																			Filename: model.SDSDummyCertPath,
+																			Filename: model.SDSCertPath,
 																		},
 																	},
 																},

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -963,7 +963,7 @@ func TestBuildSidecarListenerTLSContex(t *testing.T) {
 						ValidationContext: &auth.CertificateValidationContext{
 							TrustedCa: &core.DataSource{
 								Specifier: &core.DataSource_Filename{
-									Filename: "/etc/certs/root-cert.pem",
+									Filename: model.CARootCertPath,
 								},
 							},
 						},

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -938,6 +938,17 @@ func TestBuildSidecarListenerTLSContex(t *testing.T) {
 												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
 													GoogleGrpc: &core.GrpcService_GoogleGrpc{
 														TargetUri: "/tmp/sdsuds.sock",
+														ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+															CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials{
+																SslCredentials: &core.GrpcService_GoogleGrpc_SslCredentials{
+																	CertChain: &core.DataSource{
+																		Specifier: &core.DataSource_Filename{
+																			Filename: model.SDSDummyCertPath,
+																		},
+																	},
+																},
+															},
+														},
 													},
 												},
 											},


### PR DESCRIPTION
https://github.com/istio/istio/issues/6411

This change includes:
1. use nodeagent cert to construct sdsConfig for secure communication with nodeAgent
2. use ca root cert to construct validatecontext to validate cert from sds service. 