### PR TITLE
Tighten the Galley metadata model

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -273,10 +273,10 @@
     "envoy/config/trace/v2",
     "envoy/service/discovery/v2",
     "envoy/type",
+    "envoy/type/matcher",
     "pkg/cache",
     "pkg/log",
     "pkg/server",
-    "envoy/type/matcher",
     "pkg/util"
   ]
   revision = "8da69c22276922e7f517b8b04d474f799f5cae1c"
@@ -1589,6 +1589,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f63c021ef6669cfc784723c46a26533edcd1fe57276a95a9dae05331a410f224"
+  inputs-digest = "0e3e9fcc9d7504defd0d51f36b5b3b1a6c59964c20d00b2223238f9e0d91f92a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/galley/pkg/kube/schema.go
+++ b/galley/pkg/kube/schema.go
@@ -35,7 +35,7 @@ func (e *Schema) All() []ResourceSpec {
 }
 
 func getTargetFor(name string) resource.Info {
-	rInfo, ok := resource.Types.LookupByMessageName(resource.MessageName(name))
+	rInfo, ok := resource.Types.LookupByMessageName(name)
 	if !ok {
 		panic(fmt.Sprintf("Corresponding resource spec not found for: %s", name))
 	}

--- a/galley/pkg/kube/source_test.go
+++ b/galley/pkg/kube/source_test.go
@@ -32,6 +32,14 @@ import (
 	"istio.io/istio/galley/pkg/testing/mock"
 )
 
+var emptyInfo resource.Info
+
+func init() {
+	schema := resource.NewSchema()
+	schema.Register("google.protobuf.Empty", true)
+	emptyInfo, _ = schema.LookupByMessageName("google.protobuf.Empty")
+}
+
 func TestNewSource(t *testing.T) {
 	k := &mock.Kube{}
 	for i := 0; i < 100; i++ {
@@ -89,13 +97,10 @@ func TestSource_BasicEvents(t *testing.T) {
 
 	entries := []ResourceSpec{
 		{
-			Kind:     "foo",
-			Singular: "foo",
-			Plural:   "foos",
-			Target: resource.Info{
-				MessageName: "google.protobuf.Empty",
-				IsGogo:      true,
-			},
+			Kind:      "foo",
+			Singular:  "foo",
+			Plural:    "foos",
+			Target:    emptyInfo,
 			Converter: converter.Get("identity"),
 		},
 	}
@@ -159,10 +164,7 @@ func TestSource_ProtoConversionError(t *testing.T) {
 			Kind:     "foo",
 			Singular: "foo",
 			Plural:   "foos",
-			Target: resource.Info{
-				MessageName: "google.protobuf.Empty",
-				IsGogo:      true,
-			},
+			Target:   emptyInfo,
 			Converter: func(info resource.Info, u *unstructured.Unstructured) (proto.Message, error) {
 				return nil, fmt.Errorf("cant convert")
 			},

--- a/galley/pkg/mcp/snapshot/inmemory.go
+++ b/galley/pkg/mcp/snapshot/inmemory.go
@@ -14,7 +14,14 @@
 
 package snapshot
 
-import mcp "istio.io/api/config/mcp/v1alpha1"
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	mcp "istio.io/api/config/mcp/v1alpha1"
+)
 
 // InMemory Snapshot implementation
 type InMemory struct {
@@ -57,4 +64,33 @@ func (s *InMemory) Set(typ string, version string, resources []*mcp.Envelope) {
 // Freeze the snapshot, so that it won't get mutated anymore.
 func (s *InMemory) Freeze() {
 	s.frozen = true
+}
+
+func (s *InMemory) String() string {
+	var b bytes.Buffer
+
+	var messages []string
+	for message := range s.envelopes {
+		messages = append(messages, message)
+	}
+	sort.Strings(messages)
+
+	for i, n := range messages {
+		fmt.Fprintf(&b, "[%d] (%s @%s)\n", i, n, s.versions[n])
+
+		envs := s.envelopes[n]
+
+		// Avoid mutating the original data
+		entries := make([]*mcp.Envelope, len(envs))
+		copy(entries, envs)
+		sort.Slice(entries, func(i, j int) bool {
+			return strings.Compare(entries[i].Metadata.Name, entries[j].Metadata.Name) == -1
+		})
+
+		for j, entry := range entries {
+			fmt.Fprintf(&b, "  [%d] (%s)\n", j, entry.Metadata.Name)
+		}
+	}
+
+	return b.String()
 }

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -166,6 +166,7 @@ func (p *Processor) processEvent(e resource.Event) bool {
 	scope.Debugf("Incoming source event: %v", e)
 
 	if e.Kind == resource.FullSync {
+		scope.Infof("Synchronization is complete, starting distribution.")
 		p.distribute = true
 		return true
 	}
@@ -175,6 +176,6 @@ func (p *Processor) processEvent(e resource.Event) bool {
 
 func (p *Processor) publish() {
 	sn := p.state.buildSnapshot()
-	// TODO: The appropriate name for publishing
+	// TODO: Set the appropriate name for publishing
 	p.distributor.SetSnapshot("", sn)
 }

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -62,7 +62,7 @@ func TestProcessor_Start_Error(t *testing.T) {
 
 func TestProcessor_Stop(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty", false)
+	schema.Register("google.protobuf.Empty", true)
 
 	src := NewInMemorySource()
 	distributor := snapshot.New()
@@ -83,8 +83,8 @@ func TestProcessor_Stop(t *testing.T) {
 
 func TestProcessor_EventAccumulation(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty", false)
-	emptyMessageName := resource.MessageName("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", true)
+	info, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()
 	distributor := NewInMemoryDistributor()
@@ -97,7 +97,7 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	k1 := resource.Key{MessageName: emptyMessageName, FullName: "r1"}
+	k1 := resource.Key{MessageName: info.MessageName, FullName: "r1"}
 	src.Set(k1, &types.Empty{})
 
 	// Wait "long enough"
@@ -110,8 +110,8 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 
 func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty", false)
-	emptyMessageName := resource.MessageName("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", true)
+	info, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()
 	distributor := NewInMemoryDistributor()
@@ -124,7 +124,7 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	k1 := resource.Key{MessageName: emptyMessageName, FullName: "r1"}
+	k1 := resource.Key{MessageName: info.MessageName, FullName: "r1"}
 	src.Set(k1, &types.Empty{})
 
 	// Wait "long enough"
@@ -137,8 +137,8 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 
 func TestProcessor_Publishing(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("google.protobuf.Empty", false)
-	emptyMessageName := resource.MessageName("google.protobuf.Empty")
+	schema.Register("google.protobuf.Empty", true)
+	info, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	src := NewInMemorySource()
 	distributor := NewInMemoryDistributor()
@@ -156,7 +156,7 @@ func TestProcessor_Publishing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	k1 := resource.Key{MessageName: emptyMessageName, FullName: "r1"}
+	k1 := resource.Key{MessageName: info.MessageName, FullName: "r1"}
 	src.Set(k1, &types.Empty{})
 
 	processCallCount.Wait()

--- a/galley/pkg/runtime/resource/proto.go
+++ b/galley/pkg/runtime/resource/proto.go
@@ -12,31 +12,28 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package converter
+package resource
 
 import (
 	"reflect"
-	"testing"
 
-	"github.com/gogo/protobuf/types"
-
-	"istio.io/istio/galley/pkg/runtime/resource"
+	prgogo "github.com/gogo/protobuf/proto"
+	prlang "github.com/golang/protobuf/proto"
 )
 
-func TestToProto(t *testing.T) {
-	spec := map[string]interface{}{}
+// getProtoMessageType returns the Go lang type of the proto with the specified name.
+func getProtoMessageType(protoMessageName string, isGogo bool) reflect.Type {
+	var t reflect.Type
 
-	s := resource.NewSchema()
-	s.Register("google.protobuf.Empty", true)
-	i, _ := s.LookupByMessageName("google.protobuf.Empty")
-
-	p, err := toProto(i, spec)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if isGogo {
+		t = prgogo.MessageType(protoMessageName)
+	} else {
+		t = prlang.MessageType(protoMessageName)
 	}
 
-	var expected = &types.Empty{}
-	if !reflect.DeepEqual(p, expected) {
-		t.Fatalf("Mismatch\nExpected:\n%+v\nActual:\n%+v\n", expected, p)
+	if t == nil {
+		return nil
 	}
+
+	return t.Elem()
 }

--- a/galley/pkg/runtime/resource/resource_test.go
+++ b/galley/pkg/runtime/resource/resource_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 func TestKind_Equality_True(t *testing.T) {
-	k1 := MessageName("a")
-	k2 := MessageName("a")
+	k1 := MessageName{"a"}
+	k2 := MessageName{"a"}
 
 	if k1 != k2 {
 		t.Fatalf("Expected to be equal: %v == %v", k1, k2)
@@ -31,8 +31,8 @@ func TestKind_Equality_True(t *testing.T) {
 }
 
 func TestKind_Equality_False(t *testing.T) {
-	k1 := MessageName("a")
-	k2 := MessageName("v")
+	k1 := MessageName{"a"}
+	k2 := MessageName{"v"}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -57,8 +57,8 @@ func TestVersion_Equality_False(t *testing.T) {
 	}
 }
 func TestKey_Equality_True(t *testing.T) {
-	k1 := Key{MessageName: MessageName("a"), FullName: "ks"}
-	k2 := Key{MessageName: MessageName("a"), FullName: "ks"}
+	k1 := Key{MessageName: MessageName{"a"}, FullName: "ks"}
+	k2 := Key{MessageName: MessageName{"a"}, FullName: "ks"}
 
 	if k1 != k2 {
 		t.Fatalf("Expected to be equal: %v == %v", k1, k2)
@@ -66,8 +66,8 @@ func TestKey_Equality_True(t *testing.T) {
 }
 
 func TestKey_Equality_False_DifferentKind(t *testing.T) {
-	k1 := Key{MessageName: MessageName("a"), FullName: "ks"}
-	k2 := Key{MessageName: MessageName("b"), FullName: "ks"}
+	k1 := Key{MessageName: MessageName{"a"}, FullName: "ks"}
+	k2 := Key{MessageName: MessageName{"b"}, FullName: "ks"}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -75,8 +75,8 @@ func TestKey_Equality_False_DifferentKind(t *testing.T) {
 }
 
 func TestKey_Equality_False_DifferentName(t *testing.T) {
-	k1 := Key{MessageName: MessageName("a"), FullName: "ks"}
-	k2 := Key{MessageName: MessageName("a"), FullName: "otherks"}
+	k1 := Key{MessageName: MessageName{"a"}, FullName: "ks"}
+	k2 := Key{MessageName: MessageName{"a"}, FullName: "otherks"}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -84,16 +84,16 @@ func TestKey_Equality_False_DifferentName(t *testing.T) {
 }
 
 func TestKey_String(t *testing.T) {
-	k1 := Key{MessageName: MessageName("a"), FullName: "ks"}
+	k1 := Key{MessageName: MessageName{"a"}, FullName: "ks"}
 	// Ensure that it doesn't crash
 	_ = k1.String()
 }
 
 func TestVersionedKey_Equality_True(t *testing.T) {
 	k1 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 	k2 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 
 	if k1 != k2 {
 		t.Fatalf("Expected to be equal: %v == %v", k1, k2)
@@ -102,9 +102,9 @@ func TestVersionedKey_Equality_True(t *testing.T) {
 
 func TestVersionedKey_Equality_False_DifferentKind(t *testing.T) {
 	k1 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 	k2 := VersionedKey{
-		Key: Key{MessageName: MessageName("b"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"b"}, FullName: "ks"}, Version: Version("v1")}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -113,9 +113,9 @@ func TestVersionedKey_Equality_False_DifferentKind(t *testing.T) {
 
 func TestVersionedKey_Equality_False_DifferentName(t *testing.T) {
 	k1 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 	k2 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "otherks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "otherks"}, Version: Version("v1")}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -124,9 +124,9 @@ func TestVersionedKey_Equality_False_DifferentName(t *testing.T) {
 
 func TestVersionedKey_Equality_False_DifferentVersion(t *testing.T) {
 	k1 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 	k2 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v2")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v2")}
 
 	if k1 == k2 {
 		t.Fatalf("Expected to be not equal: %v == %v", k1, k2)
@@ -135,7 +135,7 @@ func TestVersionedKey_Equality_False_DifferentVersion(t *testing.T) {
 
 func TestVersionedKey_String(t *testing.T) {
 	k1 := VersionedKey{
-		Key: Key{MessageName: MessageName("a"), FullName: "ks"}, Version: Version("v1")}
+		Key: Key{MessageName: MessageName{"a"}, FullName: "ks"}, Version: Version("v1")}
 	// Ensure that it doesn't crash
 	_ = k1.String()
 }
@@ -153,13 +153,10 @@ func TestResource_IsEmpty(t *testing.T) {
 }
 
 func TestInfo_newProtoInstance_Success(t *testing.T) {
-	i := Info{}
-	p := i.newProtoInstance(
-		func(_ string) reflect.Type {
-			return reflect.PtrTo(reflect.TypeOf(types.Empty{}))
-		}, func(_ string) reflect.Type {
-			return reflect.PtrTo(reflect.TypeOf(types.Empty{}))
-		})
+	i := Info{
+		goType: reflect.TypeOf(types.Empty{}),
+	}
+	p := i.NewProtoInstance()
 
 	if p == nil || reflect.TypeOf(p) != reflect.PtrTo(reflect.TypeOf(types.Empty{})) {
 		t.Fatalf("Unexpected proto type returned: %v", p)
@@ -173,29 +170,10 @@ func TestInfo_newProtoInstance_PanicAtNil(t *testing.T) {
 		}
 	}()
 
-	i := Info{}
-	_ = i.newProtoInstance(
-		func(_ string) reflect.Type {
-			return nil
-		}, func(_ string) reflect.Type {
-			return nil
-		})
-}
-
-func TestInfo_newProtoInstance_PanicAtNonPtr(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("Expected panic not found")
-		}
-	}()
-
-	i := Info{}
-	_ = i.newProtoInstance(
-		func(_ string) reflect.Type {
-			return reflect.TypeOf(types.Empty{})
-		}, func(_ string) reflect.Type {
-			return reflect.TypeOf(types.Empty{})
-		})
+	i := Info{
+		goType: nil,
+	}
+	_ = i.NewProtoInstance()
 }
 
 func TestInfo_newProtoInstance_PanicAtNonProto(t *testing.T) {
@@ -205,19 +183,16 @@ func TestInfo_newProtoInstance_PanicAtNonProto(t *testing.T) {
 		}
 	}()
 
-	i := Info{}
-	_ = i.newProtoInstance(
-		func(_ string) reflect.Type {
-			return reflect.PtrTo(reflect.TypeOf(Info{}))
-		}, func(_ string) reflect.Type {
-			return reflect.PtrTo(reflect.TypeOf(Info{}))
-		})
+	i := Info{
+		goType: reflect.TypeOf(""),
+	}
+	_ = i.NewProtoInstance()
 }
 
 func TestInfo_String(t *testing.T) {
 	i := Info{
 		TypeURL:     "http://foo.bar.com",
-		MessageName: "foo",
+		MessageName: MessageName{"foo"},
 	}
 	// Ensure that it doesn't crash
 	_ = i.String()

--- a/galley/pkg/runtime/resource/schema.go
+++ b/galley/pkg/runtime/resource/schema.go
@@ -16,39 +16,71 @@ package resource
 
 import (
 	"fmt"
+	"reflect"
 )
 
 // BaseTypeURL contains the common scheme & domain parts of all type urls.
 const BaseTypeURL = "types.googleapis.com"
 
+// injectable function for overriding proto.MessageType, for testing purposes.
+type messageTypeFn func(name string, isGogo bool) reflect.Type
+
 // Schema contains metadata about configuration resources.
 type Schema struct {
-	byName map[MessageName]Info
+	byName map[string]Info
 	byURL  map[string]Info
+
+	messageTypeFn messageTypeFn
 }
 
 // NewSchema returns a new instance of Schema.
 func NewSchema() *Schema {
+	return newSchema(getProtoMessageType)
+}
+
+// NewSchema returns a new instance of Schema.
+func newSchema(messageTypeFn messageTypeFn) *Schema {
 	return &Schema{
-		byName: make(map[MessageName]Info),
-		byURL:  make(map[string]Info),
+		byName:        make(map[string]Info),
+		byURL:         make(map[string]Info),
+		messageTypeFn: messageTypeFn,
 	}
 }
 
 // Register a proto into the schema.
 func (s *Schema) Register(protoMessageName string, isGogo bool) {
-	info := Info{
-		MessageName: MessageName(protoMessageName),
-		IsGogo:      isGogo,
-		TypeURL:     fmt.Sprintf("%s/%s", BaseTypeURL, protoMessageName),
+	if _, found := s.byName[protoMessageName]; found {
+		panic(fmt.Sprintf("Schema.Register: Proto type is registered multiple times: %q", protoMessageName))
 	}
 
-	s.byName[info.MessageName] = info
+	// Before registering, ensure that the proto type is actually reachable.
+	goType := s.messageTypeFn(protoMessageName, isGogo)
+	if goType == nil {
+		panic(fmt.Sprintf("Schema.Register: Proto type not found: %q, isGogo: %v", protoMessageName, isGogo))
+	}
+
+	info := Info{
+		MessageName: MessageName{protoMessageName},
+		IsGogo:      isGogo,
+		TypeURL:     fmt.Sprintf("%s/%s", BaseTypeURL, protoMessageName),
+		goType:      goType,
+	}
+
+	s.byName[info.MessageName.string] = info
 	s.byURL[info.TypeURL] = info
 }
 
+// Info looks up a resource.Info by its message name. It panics if the expected entry not found.
+func (s *Schema) Info(name MessageName) Info {
+	i, ok := s.byName[name.string]
+	if !ok {
+		panic(fmt.Sprintf("Schema.Info: MessageName %q not found", name))
+	}
+	return i
+}
+
 // LookupByMessageName looks up a resource.Info by its message name.
-func (s *Schema) LookupByMessageName(name MessageName) (Info, bool) {
+func (s *Schema) LookupByMessageName(name string) (Info, bool) {
 	i, ok := s.byName[name]
 	return i, ok
 }

--- a/galley/pkg/runtime/resource/schema_test.go
+++ b/galley/pkg/runtime/resource/schema_test.go
@@ -22,37 +22,83 @@ import (
 
 	pgogo "github.com/gogo/protobuf/proto"
 	plang "github.com/golang/protobuf/proto"
+	// Pull in gogo & golang Empty
+	_ "github.com/gogo/protobuf/types"
+	_ "github.com/golang/protobuf/ptypes/empty"
 )
 
 func TestSchema_All(t *testing.T) {
 	// Test Schema.All in isolation, as the rest of the tests depend on it.
 	s := Schema{
-		byName: make(map[MessageName]Info),
+		byName: make(map[string]Info),
 		byURL:  make(map[string]Info),
 	}
 
-	s.Register("bar", false)
-	s.Register("foo", false)
+	foo := Info{MessageName: MessageName{"foo"}, IsGogo: false, TypeURL: "zoo.tar.com/foo"}
+	bar := Info{MessageName: MessageName{"bar"}, IsGogo: false, TypeURL: "zoo.tar.com/bar"}
+	s.byName[foo.MessageName.string] = foo
+	s.byName[bar.MessageName.string] = bar
+	s.byURL[foo.TypeURL] = foo
+	s.byURL[bar.TypeURL] = bar
 
 	infos := s.All()
 	sort.Slice(infos, func(i, j int) bool {
-		return strings.Compare(string(infos[i].MessageName), string(infos[j].MessageName)) < 0
+		return strings.Compare(infos[i].MessageName.String(), infos[j].MessageName.String()) < 0
 	})
 
 	expected := []Info{
 		{
-			MessageName: MessageName("bar"),
-			TypeURL:     BaseTypeURL + "/bar",
+			MessageName: MessageName{"bar"},
+			TypeURL:     "zoo.tar.com/bar",
 		},
 		{
-			MessageName: MessageName("foo"),
-			TypeURL:     BaseTypeURL + "/foo",
+			MessageName: MessageName{"foo"},
+			TypeURL:     "zoo.tar.com/foo",
 		},
 	}
 
 	if !reflect.DeepEqual(expected, infos) {
 		t.Fatalf("Mismatch.\nExpected:\n%v\nActual:\n%v\n", expected, infos)
 	}
+}
+
+func TestRegister_Success(t *testing.T) {
+	s := NewSchema()
+
+	s.Register("google.protobuf.Empty", false)
+	if _, found := s.byName["google.protobuf.Empty"]; !found {
+		t.Fatalf("Empty type should have been registered")
+	}
+
+	s = NewSchema()
+
+	s.Register("google.protobuf.Empty", true)
+	if _, found := s.byName["google.protobuf.Empty"]; !found {
+		t.Fatalf("Empty type should have been registered")
+	}
+}
+
+func TestRegister_DoubleRegistrationPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("should have panicked")
+		}
+	}()
+
+	s := NewSchema()
+	s.Register("google.protobuf.Empty", true)
+	s.Register("google.protobuf.Empty", true)
+}
+
+func TestRegister_UnknownProto_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("should have panicked")
+		}
+	}()
+
+	s := NewSchema()
+	s.Register("unknown", true)
 }
 
 func TestSchema_NewProtoInstance(t *testing.T) {
@@ -64,24 +110,32 @@ func TestSchema_NewProtoInstance(t *testing.T) {
 		} else {
 			name = plang.MessageName(p)
 		}
-		if name != string(info.MessageName) {
+		if name != info.MessageName.String() {
 			t.Fatalf("Name/MessageName mismatch: MessageName:%v, Name:%v", info.MessageName, name)
 		}
 	}
 }
 
-func TestSchema_LookupByKind(t *testing.T) {
-	for _, info := range Types.All() {
-		i, found := Types.LookupByMessageName(info.MessageName)
+func TestSchema_Info(t *testing.T) {
+	s := NewSchema()
+	s.Register("google.protobuf.Empty", true)
+	i, _ := s.LookupByMessageName("google.protobuf.Empty")
 
-		if !found {
-			t.Fatalf("Expected info not found: %v", info)
-		}
-
-		if i != info {
-			t.Fatalf("Lookup mismatch. Expected:%v, Actual:%v", info, i)
-		}
+	info := s.Info(i.MessageName)
+	if info.MessageName.String() != "google.protobuf.Empty" {
+		t.Fatalf("Unexpected info found: %v", info)
 	}
+}
+
+func TestSchema_Info_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic not found")
+		}
+	}()
+
+	s := NewSchema()
+	s.Info(MessageName{"unknown"})
 }
 
 func TestSchema_LookupByTypeURL(t *testing.T) {

--- a/galley/pkg/runtime/resource/types_test.go
+++ b/galley/pkg/runtime/resource/types_test.go
@@ -1,0 +1,43 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package resource
+
+import "testing"
+
+func TestTypes_Info(t *testing.T) {
+	for _, info := range Types.All() {
+		i := Types.Info(info.MessageName)
+
+		if i != info {
+			t.Fatalf("Lookup mismatch. Expected:%v, Actual:%v", info, i)
+		}
+	}
+}
+
+func TestTypes_LookupByMessageName(t *testing.T) {
+	for _, info := range Types.All() {
+		if _, found := Types.LookupByMessageName(info.MessageName.string); !found {
+			t.Fatalf("expected info not found for: %s", info.MessageName.string)
+		}
+	}
+}
+
+func TestTypes_LookupByTypeURL(t *testing.T) {
+	for _, info := range Types.All() {
+		if _, found := Types.LookupByTypeURL(info.TypeURL); !found {
+			t.Fatalf("expected info not found for: %s", info.MessageName.string)
+		}
+	}
+}

--- a/galley/pkg/runtime/source_test.go
+++ b/galley/pkg/runtime/source_test.go
@@ -24,6 +24,14 @@ import (
 	"istio.io/istio/galley/pkg/runtime/resource"
 )
 
+var emptyInfo resource.Info
+
+func init() {
+	schema := resource.NewSchema()
+	schema.Register("google.protobuf.Empty", true)
+	emptyInfo, _ = schema.LookupByMessageName("google.protobuf.Empty")
+}
+
 func TestInMemory_Start_Empty(t *testing.T) {
 	i := NewInMemorySource()
 	ch, err := i.Start()
@@ -42,7 +50,7 @@ func TestInMemory_Start_Empty(t *testing.T) {
 
 func TestInMemory_Start_WithItem(t *testing.T) {
 	i := NewInMemorySource()
-	i.Set(resource.Key{MessageName: "foo", FullName: "n1/f1"}, &types.Empty{})
+	i.Set(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"}, &types.Empty{})
 
 	ch, err := i.Start()
 	if err != nil {
@@ -51,7 +59,7 @@ func TestInMemory_Start_WithItem(t *testing.T) {
 
 	actual := logChannelOutput(ch, 2)
 	expected := strings.TrimSpace(`
-[Event](Added: [VKey](foo:n1/f1 @v1))
+[Event](Added: [VKey](google.protobuf.Empty:n1/f1 @v1))
 [Event](FullSync: [VKey](: @))`)
 	if actual != expected {
 		t.Fatalf("Channel mismatch:\nActual:\n%v\nExpected:\n%v\n", actual, expected)
@@ -83,14 +91,14 @@ func TestInMemory_Set(t *testing.T) {
 	}
 
 	// One Register one update
-	i.Set(resource.Key{MessageName: "foo", FullName: "n1/f1"}, &types.Empty{})
-	i.Set(resource.Key{MessageName: "foo", FullName: "n1/f1"}, &types.Empty{})
+	i.Set(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"}, &types.Empty{})
+	i.Set(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"}, &types.Empty{})
 
 	actual := logChannelOutput(ch, 3)
 	expected := strings.TrimSpace(`
 [Event](FullSync: [VKey](: @))
-[Event](Added: [VKey](foo:n1/f1 @v1))
-[Event](Updated: [VKey](foo:n1/f1 @v2))`)
+[Event](Added: [VKey](google.protobuf.Empty:n1/f1 @v1))
+[Event](Updated: [VKey](google.protobuf.Empty:n1/f1 @v2))`)
 	if actual != expected {
 		t.Fatalf("Channel mismatch:\nActual:\n%v\nExpected:\n%v\n", actual, expected)
 	}
@@ -103,16 +111,16 @@ func TestInMemory_Delete(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	i.Set(resource.Key{MessageName: "foo", FullName: "n1/f1"}, &types.Empty{})
+	i.Set(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"}, &types.Empty{})
 	// Two deletes
-	i.Delete(resource.Key{MessageName: "foo", FullName: "n1/f1"})
-	i.Delete(resource.Key{MessageName: "foo", FullName: "n1/f1"})
+	i.Delete(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"})
+	i.Delete(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"})
 
 	actual := logChannelOutput(ch, 3)
 	expected := strings.TrimSpace(`
 [Event](FullSync: [VKey](: @))
-[Event](Added: [VKey](foo:n1/f1 @v1))
-[Event](Deleted: [VKey](foo:n1/f1 @v2))`)
+[Event](Added: [VKey](google.protobuf.Empty:n1/f1 @v1))
+[Event](Deleted: [VKey](google.protobuf.Empty:n1/f1 @v2))`)
 	if actual != expected {
 		t.Fatalf("Channel mismatch:\nActual:\n%v\nExpected:\n%v\n", actual, expected)
 	}
@@ -120,14 +128,14 @@ func TestInMemory_Delete(t *testing.T) {
 
 func TestInMemory_Get(t *testing.T) {
 	i := NewInMemorySource()
-	i.Set(resource.Key{MessageName: "foo", FullName: "n1/f1"}, &types.Empty{})
+	i.Set(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"}, &types.Empty{})
 
-	r, _ := i.Get(resource.Key{MessageName: "foo", FullName: "n1/f1"})
+	r, _ := i.Get(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f1"})
 	if r.IsEmpty() {
 		t.Fatal("Get should have been non empty")
 	}
 
-	r, _ = i.Get(resource.Key{MessageName: "foo", FullName: "n1/f2"})
+	r, _ = i.Get(resource.Key{MessageName: emptyInfo.MessageName, FullName: "n1/f2"})
 	if !r.IsEmpty() {
 		t.Fatalf("Get should have been empty: %v", r)
 	}

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -15,7 +15,9 @@
 package runtime
 
 import (
+	"bytes"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -55,11 +57,6 @@ func newState(schema *resource.Schema) *State {
 }
 
 func (s *State) apply(event resource.Event) bool {
-	if _, ok := s.schema.LookupByMessageName(event.ID.MessageName); !ok {
-		scope.Errorf("Received an source event for unknown message name: %v", event)
-		return false
-	}
-
 	pks := s.getResourceTypeState(event.ID.MessageName)
 
 	switch event.Kind {
@@ -93,6 +90,8 @@ func (s *State) apply(event resource.Event) bool {
 	s.versionCounter++
 	pks.version = s.versionCounter
 
+	scope.Debugf("In-memory state has changed:\n%v\n", s)
+
 	return true
 }
 
@@ -125,7 +124,8 @@ func (s *State) buildSnapshot() snapshot.Snapshot {
 		}
 
 		version := fmt.Sprintf("%d", state.version)
-		sn.Set(string(name), version, entries)
+		typeURL := s.schema.Info(name).TypeURL
+		sn.Set(typeURL, version, entries)
 	}
 
 	sn.Freeze()
@@ -134,7 +134,7 @@ func (s *State) buildSnapshot() snapshot.Snapshot {
 }
 
 func (s *State) envelopeResource(event resource.Event) (*mcp.Envelope, bool) {
-	info, _ := s.schema.LookupByMessageName(event.ID.MessageName)
+	info := s.schema.Info(event.ID.MessageName)
 
 	serialized, err := proto.Marshal(event.Item)
 	if err != nil {
@@ -153,4 +153,22 @@ func (s *State) envelopeResource(event resource.Event) (*mcp.Envelope, bool) {
 	}
 
 	return entry, true
+}
+
+// String implements fmt.Stringer
+func (s *State) String() string {
+	var b bytes.Buffer
+
+	var messages []string
+	for k := range s.entries {
+		messages = append(messages, k.String())
+	}
+	sort.Strings(messages)
+
+	fmt.Fprintf(&b, "[State @%v]\n", s.versionCounter)
+
+	sn := s.buildSnapshot()
+	fmt.Fprintf(&b, "%v", sn)
+
+	return b.String()
 }

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -17,7 +17,6 @@ package runtime
 import (
 	"bytes"
 	"fmt"
-	"sort"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -158,12 +157,6 @@ func (s *State) envelopeResource(event resource.Event) (*mcp.Envelope, bool) {
 // String implements fmt.Stringer
 func (s *State) String() string {
 	var b bytes.Buffer
-
-	var messages []string
-	for k := range s.entries {
-		messages = append(messages, k.String())
-	}
-	sort.Strings(messages)
 
 	fmt.Fprintf(&b, "[State @%v]\n", s.versionCounter)
 

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -167,7 +167,7 @@ func (s *State) String() string {
 
 	fmt.Fprintf(&b, "[State @%v]\n", s.versionCounter)
 
-	sn := s.buildSnapshot()
+	sn := s.buildSnapshot().(*snapshot.InMemory)
 	fmt.Fprintf(&b, "%v", sn)
 
 	return b.String()

--- a/galley/pkg/runtime/state_test.go
+++ b/galley/pkg/runtime/state_test.go
@@ -20,17 +20,20 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/galley/pkg/runtime/resource"
+	// Pull in gogo & golang Empty
+	_ "github.com/golang/protobuf/ptypes/empty"
 )
 
 func TestState_Apply_Add(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 
@@ -40,11 +43,11 @@ func TestState_Apply_Add(t *testing.T) {
 	}
 
 	sn := s.buildSnapshot()
-	r := sn.Resources("mn")
+	r := sn.Resources(einfo.TypeURL)
 	if len(r) != 1 {
 		t.Fatal("Entry should have been registered in snapshot")
 	}
-	v := sn.Version("mn")
+	v := sn.Version(einfo.TypeURL)
 	if v == "" {
 		t.Fatal("Version should have been available")
 	}
@@ -52,13 +55,14 @@ func TestState_Apply_Add(t *testing.T) {
 
 func TestState_Apply_Update(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 
@@ -69,7 +73,7 @@ func TestState_Apply_Update(t *testing.T) {
 
 	e = resource.Event{
 		Kind: resource.Updated,
-		ID:   resource.VersionedKey{Version: "v2", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v2", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 	changed = s.apply(e)
@@ -78,11 +82,11 @@ func TestState_Apply_Update(t *testing.T) {
 	}
 
 	sn := s.buildSnapshot()
-	r := sn.Resources("mn")
+	r := sn.Resources(einfo.TypeURL)
 	if len(r) != 1 {
 		t.Fatal("Entry should have been registered in snapshot")
 	}
-	v := sn.Version("mn")
+	v := sn.Version(einfo.TypeURL)
 	if v == "" {
 		t.Fatal("Version should have been available")
 	}
@@ -90,13 +94,14 @@ func TestState_Apply_Update(t *testing.T) {
 
 func TestState_Apply_Update_SameVersion(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 
@@ -107,7 +112,7 @@ func TestState_Apply_Update_SameVersion(t *testing.T) {
 
 	e = resource.Event{
 		Kind: resource.Updated,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 	s.apply(e)
@@ -120,13 +125,14 @@ func TestState_Apply_Update_SameVersion(t *testing.T) {
 
 func TestState_Apply_Delete(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 
@@ -137,7 +143,7 @@ func TestState_Apply_Delete(t *testing.T) {
 
 	e = resource.Event{
 		Kind: resource.Deleted,
-		ID:   resource.VersionedKey{Version: "v2", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v2", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 	}
 	s.apply(e)
 
@@ -155,36 +161,14 @@ func TestState_Apply_Delete(t *testing.T) {
 
 func TestState_Apply_UnknownEventKind(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.EventKind(42),
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
-		Item: &types.Any{},
-	}
-	changed := s.apply(e)
-	if changed {
-		t.Fatal("calling apply should not have changed state.")
-	}
-
-	sn := s.buildSnapshot()
-	r := sn.Resources("mn")
-	if len(r) != 0 {
-		t.Fatal("Entry should have not been in snapshot")
-	}
-}
-
-func TestState_Apply_UnknownResourceKind(t *testing.T) {
-	schema := resource.NewSchema()
-	schema.Register("mn", false)
-
-	s := newState(schema)
-
-	e := resource.Event{
-		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "unknown", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: &types.Any{},
 	}
 	changed := s.apply(e)
@@ -201,13 +185,14 @@ func TestState_Apply_UnknownResourceKind(t *testing.T) {
 
 func TestState_Apply_BrokenProto(t *testing.T) {
 	schema := resource.NewSchema()
-	schema.Register("mn", false)
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
 
 	s := newState(schema)
 
 	e := resource.Event{
 		Kind: resource.Added,
-		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: "mn", FullName: "fn"}},
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
 		Item: nil,
 	}
 	changed := s.apply(e)
@@ -216,8 +201,26 @@ func TestState_Apply_BrokenProto(t *testing.T) {
 	}
 
 	sn := s.buildSnapshot()
-	r := sn.Resources("mn")
+	r := sn.Resources(einfo.TypeURL)
 	if len(r) != 0 {
 		t.Fatal("Entry should have not been in snapshot")
 	}
+}
+
+func TestState_String(t *testing.T) {
+	schema := resource.NewSchema()
+	schema.Register("google.protobuf.Empty", false)
+	einfo, _ := schema.LookupByMessageName("google.protobuf.Empty")
+
+	s := newState(schema)
+
+	e := resource.Event{
+		Kind: resource.Added,
+		ID:   resource.VersionedKey{Version: "v1", Key: resource.Key{MessageName: einfo.MessageName, FullName: "fn"}},
+		Item: nil,
+	}
+	_ = s.apply(e)
+
+	// Should not crash
+	_ = s.String()
 }


### PR DESCRIPTION
+ Tighten the metadata model and disallow naked type conversions from/to resource.MessageName.
+ Refactor the runtime/resource code, so that test injection is made at the top-level.
+ Match the tests to the new model, and add some new tests.
+ Fix a bug where MCP Snapshot was being created with message names, instead of Type URLs.
