### PR TITLE
Add prometheus scrape information to probe list, so that envoy does n…

### DIFF
--- a/pilot/pkg/networking/plugin/health/health.go
+++ b/pilot/pkg/networking/plugin/health/health.go
@@ -61,7 +61,9 @@ func buildHealthCheckFilters(filterChain *plugin.FilterChain, probes model.Probe
 		// Check that the probe matches the listener port. If not, then the probe will be handled
 		// as a management port and not traced. If the port does match, then we need to add a
 		// health check filter for the probe path, to ensure that health checks are not traced.
-		if probe.Port.Port == endpoint.Port {
+		// If no probe port is defined, then port has not specifically been defined, so assume filter
+		// needs to be applied.
+		if probe.Port == nil || probe.Port.Port == endpoint.Port {
 			filter := buildHealthCheckFilter(probe)
 			if !containsHTTPFilter(filterChain.HTTP, filter) {
 				filterChain.HTTP = append(filterChain.HTTP, filter)

--- a/pilot/pkg/networking/plugin/health/health_test.go
+++ b/pilot/pkg/networking/plugin/health/health_test.go
@@ -65,6 +65,35 @@ func TestBuildHealthCheckFilters(t *testing.T) {
 				},
 			},
 		},
+		// No probe port, so filter should be created
+		{
+			probes: model.ProbeList{
+				&model.Probe{
+					Path: "/health",
+				},
+			},
+			endpoint: &model.NetworkEndpoint{
+				Port: 8080,
+			},
+			expected: plugin.FilterChain{
+				HTTP: []*http_conn.HttpFilter{
+					{
+						Name: "envoy.health_check",
+						Config: util.MessageToStruct(&hcfilter.HealthCheck{
+							PassThroughMode: &types.BoolValue{
+								Value: true,
+							},
+							Headers: []*envoy_api_v2_route.HeaderMatcher{
+								{
+									Name:  ":path",
+									Value: "/health",
+								},
+							},
+						}),
+					},
+				},
+			},
+		},
 		{
 			probes: model.ProbeList{
 				&model.Probe{

--- a/pilot/pkg/serviceregistry/kube/cache_test.go
+++ b/pilot/pkg/serviceregistry/kube/cache_test.go
@@ -37,9 +37,9 @@ func TestPodCache(t *testing.T) {
 		{
 			name: "Should find all addresses in the map",
 			pods: []*v1.Pod{
-				generatePod("pod1", "nsA", "", "", map[string]string{"app": "test-app"}),
-				generatePod("pod2", "nsA", "", "", map[string]string{"app": "prod-app-1"}),
-				generatePod("pod3", "nsB", "", "", map[string]string{"app": "prod-app-2"}),
+				generatePod("pod1", "nsA", "", "", map[string]string{"app": "test-app"}, map[string]string{}),
+				generatePod("pod2", "nsA", "", "", map[string]string{"app": "prod-app-1"}, map[string]string{}),
+				generatePod("pod3", "nsB", "", "", map[string]string{"app": "prod-app-2"}, map[string]string{}),
 			},
 			keys: map[string]string{
 				"128.0.0.1": "nsA/pod1",


### PR DESCRIPTION
…ot trace the scrape requests.

Follow on from #6068, to include prometheus scrape requests in the list of probes that Envoy should not trace.
