### PR TITLE
Xds test refactors

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/README.md
+++ b/pilot/pkg/proxy/envoy/v2/README.md
@@ -21,7 +21,7 @@ curl $PILOT/debug/cdsz
 
 ```
 
-Each handler takes an extra parameter, "debug=0|1" which flips the verbosity of the 
+Each handler takes an extra parameter, "debug=0|1" which flips the verbosity of the
 messages for that component (similar with envoy).
 
 An extra parameter "push=1" triggers a config push to all connected endpoints.
@@ -57,7 +57,7 @@ Example for EDS:
    // Cluster
    "echosrv.istio-system.svc.cluster.local|grpc-ping": {
     "EdsClients": {
-      // One for each connected envoy. 
+      // One for each connected envoy.
       "sidecar~172.17.0.8~echosrv-deployment-5b7878cc9-dlm8j.istio-system~istio-system.svc.cluster.local-116": {
         // Should match the info in the node (this is the real remote address)
         "PeerAddr": "172.17.0.8:42044",
@@ -111,30 +111,30 @@ Example for EDS:
 # Log messages
 
 Verbose messages for v2 is controlled by env variables PILOT_DEBUG_{EDS,CDS,LDS}.
-Setting it to "0" disables debug, setting it to "1" enables - debug is currently 
+Setting it to "0" disables debug, setting it to "1" enables - debug is currently
 enabled by default, since it is not very verbose.
 
-Messages are prefixed with EDS/LDS/CDS. 
+Messages are prefixed with EDS/LDS/CDS.
 
 What we log and how to use it:
-- sidecar connecting to pilot: "EDS/CSD/LDS: REQ ...". This includes the node, IP and the discovery 
+- sidecar connecting to pilot: "EDS/CSD/LDS: REQ ...". This includes the node, IP and the discovery
 request proto. Should show up when the sidecar starts up.
 - sidecar disconnecting from pilot: xDS: close. This happens when a pod is stopped.
 - push events - whenever we push a config the the sidecar.
-- "XDS: Registry event..." - indicates a registry event, should be followed by PUSH messages for 
-each endpoint. 
-- "EDS: no instances": pay close attention to this event, it indicates that Envoy asked for 
+- "XDS: Registry event..." - indicates a registry event, should be followed by PUSH messages for
+each endpoint.
+- "EDS: no instances": pay close attention to this event, it indicates that Envoy asked for
 a cluster but pilot doesn't have any valid instance. At some point after, when the instance eventually
 shows up you should see an EDS PUSH message.
 
-In addition, the registry has slightly more verbose messages about the events, so it is 
+In addition, the registry has slightly more verbose messages about the events, so it is
 possible to map an event in the registry to config pushes.
 
 
 # Example requests and responses
 
 
-EDS: 
+EDS:
 
 ```bash
 

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -14,25 +14,12 @@
 package v2_test
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/binary"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"sync"
 	"testing"
 	"time"
-
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/gogo/googleapis/google/rpc"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 
 	pilotbootstrap "istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
@@ -40,189 +27,6 @@ import (
 	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/tests/util"
 )
-
-func connectADS(t *testing.T, url string) ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
-	conn, err := grpc.Dial(url, grpc.WithInsecure())
-	if err != nil {
-		t.Fatal("Connection failed", err)
-	}
-
-	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamAggregatedResources(context.Background())
-	if err != nil {
-		t.Fatal("Rpc failed", err)
-	}
-	return edsstr
-}
-
-func connectADSS(t *testing.T, url string) ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
-	certDir := util.IstioSrc + "/tests/testdata/certs/default/"
-
-	clientCert, err := tls.LoadX509KeyPair(certDir+model.CertChainFilename,
-		certDir+model.KeyFilename)
-	if err != nil {
-		t.Fatal("Can't load client certs ", err)
-		return nil
-	}
-
-	serverCABytes, err := ioutil.ReadFile(certDir + model.RootCertFilename)
-	if err != nil {
-		t.Fatal("Can't load client certs ", err)
-		return nil
-	}
-	serverCAs := x509.NewCertPool()
-	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
-		t.Fatal("Can't load client certs ", err)
-		return nil
-	}
-
-	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		RootCAs:      serverCAs,
-		ServerName:   "istio-pilot.istio-system.svc",
-	}
-
-	creds := credentials.NewTLS(tlsCfg)
-
-	opts := []grpc.DialOption{
-		// Verify Pilot cert and service account
-		grpc.WithTransportCredentials(creds),
-	}
-	conn, err := grpc.Dial(url, opts...)
-	if err != nil {
-		t.Fatal("Connection failed", err)
-	}
-
-	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamAggregatedResources(context.Background())
-	if err != nil {
-		t.Fatal("Rpc failed", err)
-	}
-	return edsstr
-}
-
-func sendEDSReq(t *testing.T, clusters []string, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl:       v2.EndpointType,
-		ResourceNames: clusters,
-	})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendEDSNack(t *testing.T, clusters []string, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl:     v2.EndpointType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"},
-	})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-// If pilot is reset, envoy will connect with a nonce/version info set on the previous
-// connection to pilot. In HA case this may be a different pilot. This is a regression test for
-// reconnect problems.
-func sendEDSReqReconnect(t *testing.T, clusters []string,
-	edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient,
-	res *xdsapi.DiscoveryResponse) {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
-			Id: sidecarId(app3Ip, "app3"),
-		},
-		TypeUrl:       v2.EndpointType,
-		ResponseNonce: res.Nonce,
-		VersionInfo:   res.VersionInfo,
-		ResourceNames: clusters})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendLDSReq(t *testing.T, node string, ldsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl: v2.ListenerType})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendLDSNack(t *testing.T, node string, ldsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl:     v2.ListenerType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendRDSReq(t *testing.T, node string, routes []string, rdsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl:       v2.RouteType,
-		ResourceNames: routes})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-
-}
-func sendRDSNack(t *testing.T, node string, routes []string, rdsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl:     v2.RouteType,
-		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendCDSReq(t *testing.T, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		TypeUrl: v2.ClusterType})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
-
-func sendCDSNack(t *testing.T, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
-	err := edsstr.Send(&xdsapi.DiscoveryRequest{
-		ResponseNonce: time.Now().String(),
-		Node: &envoy_api_v2_core1.Node{
-			Id: node,
-		},
-		ErrorDetail: &rpc.Status{Message: "NOPE!"},
-		TypeUrl:     v2.ClusterType})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-}
 
 // Regression for envoy restart and overlapping connections
 func TestAdsReconnectWithNonce(t *testing.T) {
@@ -290,23 +94,6 @@ func TestTLS(t *testing.T) {
 		t.Fatal("Failed to checkin", err)
 	}
 	t.Log("AZ:", c.AvailabilityZone)
-}
-
-func adsReceive(ads ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient, to time.Duration) (*xdsapi.DiscoveryResponse, error) {
-	done := make(chan int, 1)
-	t := time.NewTimer(to)
-	defer func() {
-		done <- 1
-	}()
-	go func() {
-		select {
-		case <-t.C:
-			_ = ads.CloseSend() // will result in adsRecv closing as well, interrupting the blocking recv
-		case <-done:
-			_ = t.Stop()
-		}
-	}()
-	return ads.Recv()
 }
 
 func TestAdsClusterUpdate(t *testing.T) {
@@ -414,34 +201,9 @@ func TestAdsUpdate(t *testing.T) {
 }
 
 // Make a direct EDS grpc request to pilot, verify the result is as expected.
-func TestAdsEds(t *testing.T) {
+func TestAdsMultiple(t *testing.T, server *pilotbootstrap.Server) {
 	server := initLocalPilotTestEnv(t)
-	testAdsMultiple(t, server)
-}
 
-// Extract cluster load assignment from a discovery response.
-func getLoadAssignment(res1 *xdsapi.DiscoveryResponse) (*xdsapi.ClusterLoadAssignment, error) {
-	if res1.TypeUrl != "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment" {
-		return nil, errors.New("Invalid typeURL" + res1.TypeUrl)
-	}
-	if res1.Resources[0].TypeUrl != "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment" {
-		return nil, errors.New("Invalid resource typeURL" + res1.Resources[0].TypeUrl)
-	}
-	cla := &xdsapi.ClusterLoadAssignment{}
-	err := cla.Unmarshal(res1.Resources[0].Value)
-	if err != nil {
-		return nil, err
-	}
-	return cla, nil
-}
-
-func testIp(id uint32) string {
-	ipb := []byte{0, 0, 0, 0}
-	binary.BigEndian.PutUint32(ipb, id)
-	return net.IP(ipb).String()
-}
-
-func testAdsMultiple(t *testing.T, server *pilotbootstrap.Server) {
 	wg := &sync.WaitGroup{}
 	wgConnect := &sync.WaitGroup{}
 

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	pilotbootstrap "istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/bootstrap"
@@ -201,7 +200,7 @@ func TestAdsUpdate(t *testing.T) {
 }
 
 // Make a direct EDS grpc request to pilot, verify the result is as expected.
-func TestAdsMultiple(t *testing.T, server *pilotbootstrap.Server) {
+func TestAdsMultiple(t *testing.T) {
 	server := initLocalPilotTestEnv(t)
 
 	wg := &sync.WaitGroup{}

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -24,8 +24,15 @@ import (
 func TestCDS(t *testing.T) {
 	initLocalPilotTestEnv(t)
 
-	cdsr := connectADS(t, util.MockPilotGrpcAddr)
-	sendCDSReq(t, sidecarId(app3Ip, "app3"), cdsr)
+	cdsr, err := connectADS(util.MockPilotGrpcAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = sendCDSReq(sidecarId(app3Ip, "app3"), cdsr)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	res, err := cdsr.Recv()
 	if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -26,21 +26,41 @@ import (
 	"istio.io/istio/tests/util"
 )
 
-func Test_Syncz(t *testing.T) {
+func TestSyncz(t *testing.T) {
 	t.Run("return the sent and ack status of adsClient connections", func(t *testing.T) {
 		initLocalPilotTestEnv(t)
-		adsstr := connectADS(t, util.MockPilotGrpcAddr)
+		adsstr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
 		defer adsstr.CloseSend()
 
 		// Need to send two of each so that the second sends an Ack that is picked up
-		sendEDSReq(t, []string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendEDSReq(t, []string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendCDSReq(t, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendCDSReq(t, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendLDSReq(t, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendLDSReq(t, sidecarId(app3Ip, "syncApp"), adsstr)
-		sendRDSReq(t, sidecarId(app3Ip, "syncApp"), []string{"80", "8080"}, adsstr)
-		sendRDSReq(t, sidecarId(app3Ip, "syncApp"), []string{"80", "8080"}, adsstr)
+		if err := sendEDSReq([]string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendEDSReq([]string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendCDSReq(sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendCDSReq(sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendLDSReq(sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendLDSReq(sidecarId(app3Ip, "syncApp"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendRDSReq(sidecarId(app3Ip, "syncApp"), []string{"80", "8080"}, adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendRDSReq(sidecarId(app3Ip, "syncApp"), []string{"80", "8080"}, adsstr); err != nil {
+			t.Fatal(err)
+		}
+
 		for i := 0; i < 4; i++ {
 			_, err := adsReceive(adsstr, 5*time.Second)
 			if err != nil {
@@ -52,17 +72,36 @@ func Test_Syncz(t *testing.T) {
 	})
 	t.Run("sync status not set when Nackd", func(t *testing.T) {
 		initLocalPilotTestEnv(t)
-		adsstr := connectADS(t, util.MockPilotGrpcAddr)
+		adsstr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
 		defer adsstr.CloseSend()
 
-		sendEDSReq(t, []string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendEDSNack(t, []string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendCDSReq(t, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendCDSNack(t, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendLDSReq(t, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendLDSNack(t, sidecarId(app3Ip, "syncApp2"), adsstr)
-		sendRDSReq(t, sidecarId(app3Ip, "syncApp2"), []string{"80", "8080"}, adsstr)
-		sendRDSNack(t, sidecarId(app3Ip, "syncApp2"), []string{"80", "8080"}, adsstr)
+		if err := sendEDSReq([]string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendEDSNack([]string{"outbound|9080||app2.default.svc.cluster.local"}, sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendCDSReq(sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendCDSNack(sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendLDSReq(sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendLDSNack(sidecarId(app3Ip, "syncApp2"), adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendRDSReq(sidecarId(app3Ip, "syncApp2"), []string{"80", "8080"}, adsstr); err != nil {
+			t.Fatal(err)
+		}
+		if err := sendRDSNack(sidecarId(app3Ip, "syncApp2"), []string{"80", "8080"}, adsstr); err != nil {
+			t.Fatal(err)
+		}
 		for i := 0; i < 5; i++ {
 			_, err := adsReceive(adsstr, 5*time.Second)
 			if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -218,8 +218,15 @@ func multipleRequest(server *bootstrap.Server, t *testing.T) {
 
 	// Bad client - will not read any response. This triggers Write to block, which should
 	// be detected
-	ads := connectADS(t, util.MockPilotGrpcAddr)
-	sendCDSReq(t, sidecarId(testIp(0x0a120001), "app3"), ads)
+	ads, err := connectADS(util.MockPilotGrpcAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = sendCDSReq(sidecarId(testIp(0x0a120001), "app3"), ads)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// 1000 clients * 100 pushes = ~4 sec
 	n := 10 // clients

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -1,0 +1,259 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v2_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/binary"
+	"errors"
+	"io/ioutil"
+	"net"
+	"testing"
+	"time"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+
+	"github.com/gogo/googleapis/google/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/proxy/envoy/v2"
+	"istio.io/istio/tests/util"
+)
+
+// Extract cluster load assignment from a discovery response.
+func getLoadAssignment(res1 *xdsapi.DiscoveryResponse) (*xdsapi.ClusterLoadAssignment, error) {
+	if res1.TypeUrl != "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment" {
+		return nil, errors.New("Invalid typeURL" + res1.TypeUrl)
+	}
+	if res1.Resources[0].TypeUrl != "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment" {
+		return nil, errors.New("Invalid resource typeURL" + res1.Resources[0].TypeUrl)
+	}
+	cla := &xdsapi.ClusterLoadAssignment{}
+	err := cla.Unmarshal(res1.Resources[0].Value)
+	if err != nil {
+		return nil, err
+	}
+	return cla, nil
+}
+
+func testIp(id uint32) string {
+	ipb := []byte{0, 0, 0, 0}
+	binary.BigEndian.PutUint32(ipb, id)
+	return net.IP(ipb).String()
+}
+
+func connectADS(t *testing.T, url string) ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
+	conn, err := grpc.Dial(url, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal("Connection failed", err)
+	}
+
+	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
+	edsstr, err := xds.StreamAggregatedResources(context.Background())
+	if err != nil {
+		t.Fatal("Rpc failed", err)
+	}
+	return edsstr
+}
+
+func connectADSS(t *testing.T, url string) ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient {
+	certDir := util.IstioSrc + "/tests/testdata/certs/default/"
+
+	clientCert, err := tls.LoadX509KeyPair(certDir+model.CertChainFilename,
+		certDir+model.KeyFilename)
+	if err != nil {
+		t.Fatal("Can't load client certs ", err)
+		return nil
+	}
+
+	serverCABytes, err := ioutil.ReadFile(certDir + model.RootCertFilename)
+	if err != nil {
+		t.Fatal("Can't load client certs ", err)
+		return nil
+	}
+	serverCAs := x509.NewCertPool()
+	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
+		t.Fatal("Can't load client certs ", err)
+		return nil
+	}
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      serverCAs,
+		ServerName:   "istio-pilot.istio-system.svc",
+	}
+
+	creds := credentials.NewTLS(tlsCfg)
+
+	opts := []grpc.DialOption{
+		// Verify Pilot cert and service account
+		grpc.WithTransportCredentials(creds),
+	}
+	conn, err := grpc.Dial(url, opts...)
+	if err != nil {
+		t.Fatal("Connection failed", err)
+	}
+
+	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
+	edsstr, err := xds.StreamAggregatedResources(context.Background())
+	if err != nil {
+		t.Fatal("Rpc failed", err)
+	}
+	return edsstr
+}
+
+func adsReceive(ads ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient, to time.Duration) (*xdsapi.DiscoveryResponse, error) {
+	done := make(chan int, 1)
+	t := time.NewTimer(to)
+	defer func() {
+		done <- 1
+	}()
+	go func() {
+		select {
+		case <-t.C:
+			_ = ads.CloseSend() // will result in adsRecv closing as well, interrupting the blocking recv
+		case <-done:
+			_ = t.Stop()
+		}
+	}()
+	return ads.Recv()
+}
+
+func sendEDSReq(t *testing.T, clusters []string, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl:       v2.EndpointType,
+		ResourceNames: clusters,
+	})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendEDSNack(t *testing.T, clusters []string, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl:     v2.EndpointType,
+		ErrorDetail: &rpc.Status{Message: "NOPE!"},
+	})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+// If pilot is reset, envoy will connect with a nonce/version info set on the previous
+// connection to pilot. In HA case this may be a different pilot. This is a regression test for
+// reconnect problems.
+func sendEDSReqReconnect(t *testing.T, clusters []string,
+	edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient,
+	res *xdsapi.DiscoveryResponse) {
+	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+		Node: &envoy_api_v2_core1.Node{
+			Id: sidecarId(app3Ip, "app3"),
+		},
+		TypeUrl:       v2.EndpointType,
+		ResponseNonce: res.Nonce,
+		VersionInfo:   res.VersionInfo,
+		ResourceNames: clusters})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendLDSReq(t *testing.T, node string, ldsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl: v2.ListenerType})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendLDSNack(t *testing.T, node string, ldsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl:     v2.ListenerType,
+		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendRDSReq(t *testing.T, node string, routes []string, rdsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl:       v2.RouteType,
+		ResourceNames: routes})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+
+}
+func sendRDSNack(t *testing.T, node string, routes []string, rdsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl:     v2.RouteType,
+		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendCDSReq(t *testing.T, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		TypeUrl: v2.ClusterType})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}
+
+func sendCDSNack(t *testing.T, node string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient) {
+	err := edsstr.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &envoy_api_v2_core1.Node{
+			Id: node,
+		},
+		ErrorDetail: &rpc.Status{Message: "NOPE!"},
+		TypeUrl:     v2.ClusterType})
+	if err != nil {
+		t.Fatal("Send failed", err)
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -26,8 +26,14 @@ func TestLDS(t *testing.T) {
 	initLocalPilotTestEnv(t)
 
 	t.Run("sidecar", func(t *testing.T) {
-		ldsr := connectADS(t, util.MockPilotGrpcAddr)
-		sendLDSReq(t, sidecarId(app3Ip, "app3"), ldsr)
+		ldsr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = sendLDSReq(sidecarId(app3Ip, "app3"), ldsr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		res, err := ldsr.Recv()
 		if err != nil {
@@ -45,13 +51,18 @@ func TestLDS(t *testing.T) {
 
 	// 'router' or 'gateway' type of listener
 	t.Run("gateway", func(t *testing.T) {
-		ldsr := connectADS(t, util.MockPilotGrpcAddr)
-		sendLDSReq(t, gatewayId(gatewayIP), ldsr)
+		ldsr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = sendLDSReq(gatewayId(gatewayIP), ldsr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		res, err := ldsr.Recv()
 		if err != nil {
 			t.Fatal("Failed to receive LDS", err)
-			return
 		}
 
 		strResponse, _ := model.ToJSONWithIndent(res, " ")
@@ -64,8 +75,15 @@ func TestLDS(t *testing.T) {
 	})
 
 	t.Run("ingress", func(t *testing.T) {
-		ldsr := connectADS(t, util.MockPilotGrpcAddr)
-		sendLDSReq(t, ingressId(ingressIP), ldsr)
+		ldsr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = sendLDSReq(ingressId(ingressIP), ldsr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		res, err := ldsr.Recv()
 		if err != nil {

--- a/pilot/pkg/proxy/envoy/v2/rds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/rds_test.go
@@ -26,13 +26,18 @@ func TestRDS(t *testing.T) {
 	initLocalPilotTestEnv(t)
 
 	t.Run("sidecar", func(t *testing.T) {
-		rdsr := connectADS(t, util.MockPilotGrpcAddr)
-		sendRDSReq(t, sidecarId(app3Ip, "app3"), []string{"80", "8080"}, rdsr)
+		rdsr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = sendRDSReq(sidecarId(app3Ip, "app3"), []string{"80", "8080"}, rdsr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		res, err := rdsr.Recv()
 		if err != nil {
 			t.Fatal("Failed to receive RDS", err)
-			return
 		}
 
 		strResponse, _ := model.ToJSONWithIndent(res, " ")
@@ -44,8 +49,14 @@ func TestRDS(t *testing.T) {
 	})
 
 	t.Run("gateway", func(t *testing.T) {
-		rdsr := connectADS(t, util.MockPilotGrpcAddr)
-		sendRDSReq(t, gatewayId(gatewayIP), []string{"http.80", "https.443.https"}, rdsr)
+		rdsr, err := connectADS(util.MockPilotGrpcAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = sendRDSReq(gatewayId(gatewayIP), []string{"http.80", "https.443.https"}, rdsr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		res, err := rdsr.Recv()
 		if err != nil {


### PR DESCRIPTION
TEST CHANGES ONLY.

This was all started by the fact that you cannot call `t.Fatal` from a goroutine that is not your test goroutine. I've refactored to now capture the errors and stop passing the `testing.T` around in a bunch of spots.

I've also gone ahead and extracted most but not all of the helpers - makes the tests easier to read.

Dropped some white space as well.