### PR TITLE
update proxy sha.

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "00a9969d37a05acb5fe0cd4554c92394d3f66572"
+		"lastStableSHA": "302e712df1da2bc5e7a7d054381fcb7aaca4b3ae"
 	}
 ]


### PR DESCRIPTION
This includes the latest RBAC filter support in Envoy.
For #6377 