### PR TITLE
Add label for reporter to metrics

### DIFF
--- a/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
@@ -116,7 +116,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "round(sum(irate(istio_requests_total{destination_workload=~\"$workload\"}[1m])), 0.001)",
+          "expr": "round(sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m])), 0.001)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -198,7 +198,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(istio_requests_total{destination_workload=~\"$workload\",response_code!~\"5.*\"}[1m])) / sum(rate(istio_requests_total{destination_workload=~\"$workload\"}[1m]))",
+          "expr": "sum(rate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\",response_code!~\"5.*\"}[1m])) / sum(rate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -281,7 +281,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(istio_requests_total{destination_workload=~\"$workload\", response_code=~\"4.*\"}[1m])) ",
+          "expr": "sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\", response_code=~\"4.*\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -363,7 +363,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(istio_requests_total{destination_workload=~\"$workload\", response_code=~\"5.*\"}[1m])) ",
+          "expr": "sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\", response_code=~\"5.*\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -422,7 +422,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(istio_requests_total{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, response_code), 0.001)",
+          "expr": "round(sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, response_code), 0.001)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ source_workload }} -> {{destination_workload}} : {{ response_code }}",
@@ -507,7 +507,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(istio_requests_total{destination_workload=~\"$workload\",response_code!~\"5.*\"}[1m])) by (source_workload, destination_workload) / sum(irate(istio_requests_total{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload)",
+          "expr": "sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\",response_code!~\"5.*\"}[1m])) by (source_workload, destination_workload) / sum(irate(istio_requests_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -593,7 +593,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(irate(istio_request_duration_seconds_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.50, sum(irate(istio_request_duration_seconds_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -602,7 +602,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_seconds_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_seconds_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -611,7 +611,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_seconds_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_seconds_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -620,7 +620,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -705,7 +705,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.50, sum(irate(istio_response_bytes_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -714,7 +714,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.90, sum(irate(istio_response_bytes_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -723,7 +723,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.95, sum(irate(istio_response_bytes_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -732,7 +732,7 @@
           "step": 2
         },
         {
-          "expr": "histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
+          "expr": "histogram_quantile(0.99, sum(irate(istio_response_bytes_bucket{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload, le))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,

--- a/addons/grafana/dashboards/istio-mesh-dashboard.json
+++ b/addons/grafana/dashboards/istio-mesh-dashboard.json
@@ -140,7 +140,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "round(sum(irate(istio_requests_total[1m])), 0.001)",
+          "expr": "round(sum(irate(istio_requests_total{reporter=\"server\"}[1m])), 0.001)",
           "intervalFactor": 1,
           "refId": "A",
           "step": 4
@@ -221,7 +221,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(istio_requests_total{response_code!~\"5.*\"}[1m])) / sum(rate(istio_requests_total[1m]))",
+          "expr": "sum(rate(istio_requests_total{reporter=\"server\", response_code!~\"5.*\"}[1m])) / sum(rate(istio_requests_total[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -303,7 +303,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(istio_requests_total{response_code=~\"4.*\"}[1m])) ",
+          "expr": "sum(irate(istio_requests_total{reporter=\"server\", response_code=~\"4.*\"}[1m])) ",
           "intervalFactor": 1,
           "refId": "A",
           "step": 4
@@ -384,7 +384,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(irate(istio_requests_total{response_code=~\"5.*\"}[1m])) ",
+          "expr": "sum(irate(istio_requests_total{reporter=\"server\", response_code=~\"5.*\"}[1m])) ",
           "intervalFactor": 1,
           "refId": "A",
           "step": 4
@@ -594,7 +594,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(istio_requests_total{response_code=\"200\"}[1m])) by (destination_workload, destination_namespace, destination_app)",
+          "expr": "sum(rate(istio_requests_total{reporter=\"server\", response_code=\"200\"}[1m])) by (destination_workload, destination_namespace, destination_app)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -603,7 +603,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(istio_requests_total{response_code!~\"2.*\"}[1m])) by (destination_workload, destination_namespace)",
+          "expr": "sum(rate(istio_requests_total{reporter=\"server\", response_code!~\"2.*\"}[1m])) by (destination_workload, destination_namespace)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -612,7 +612,7 @@
           "refId": "C"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket[1m])) by (le, destination_workload, destination_namespace))",
+          "expr": "histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{reporter=\"server\"}[1m])) by (le, destination_workload, destination_namespace))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -621,7 +621,7 @@
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.90, sum(rate(istio_request_duration_seconds_bucket[1m])) by (le, destination_workload, destination_namespace))",
+          "expr": "histogram_quantile(0.90, sum(rate(istio_request_duration_seconds_bucket{reporter=\"server\"}[1m])) by (le, destination_workload, destination_namespace))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -630,7 +630,7 @@
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket[1m])) by (le, destination_workload, destination_namespace))",
+          "expr": "histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{reporter=\"server\"}[1m])) by (le, destination_workload, destination_namespace))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -639,7 +639,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(rate(istio_requests_total{response_code!~\"5.*\"}[1m])) by (destination_workload, destination_namespace) / sum(rate(istio_requests_total[1m])) by (destination_workload, destination_namespace)",
+          "expr": "sum(rate(istio_requests_total{reporter=\"server\", response_code!~\"5.*\"}[1m])) by (destination_workload, destination_namespace) / sum(rate(istio_requests_total[1m])) by (destination_workload, destination_namespace)",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -777,7 +777,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(istio_tcp_received_bytes_total[1m])) by (destination_workload, destination_namespace, destination_app)",
+          "expr": "sum(rate(istio_tcp_received_bytes_total{reporter=\"server\"}[1m])) by (destination_workload, destination_namespace, destination_app)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -786,7 +786,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(rate(istio_tcp_sent_bytes_total[1m])) by (destination_workload, destination_namespace)",
+          "expr": "sum(rate(istio_tcp_sent_bytes_total{reporter=\"server\"}[1m])) by (destination_workload, destination_namespace)",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
@@ -86,7 +86,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(istio_tcp_received_bytes_total{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload), 0.001)",
+          "expr": "round(sum(irate(istio_tcp_received_bytes_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload), 0.001)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ source_workload }} -> {{ destination_workload }}",
@@ -167,7 +167,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(istio_tcp_sent_bytes_total{destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload), 0.001)",
+          "expr": "round(sum(irate(istio_tcp_sent_bytes_total{reporter=\"server\", destination_workload=~\"$workload\"}[1m])) by (source_workload, destination_workload), 0.001)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ destination_workload }} -> {{ source_workload }} ",

--- a/addons/servicegraph/promgen/promgen.go
+++ b/addons/servicegraph/promgen/promgen.go
@@ -30,8 +30,8 @@ import (
 	"istio.io/istio/addons/servicegraph"
 )
 
-const reqsFmt = "sum(rate(istio_requests_total[%s])) by (source_workload, destination_workload, source_app, destination_app)"
-const tcpFmt = "sum(rate(istio_tcp_received_bytes_total[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const reqsFmt = "sum(rate(istio_requests_total{reporter=\"server\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const tcpFmt = "sum(rate(istio_tcp_received_bytes_total{reporter=\"server\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
 const emptyFilter = " > 0"
 
 type genOpts struct {

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -245,6 +245,7 @@ metadata:
 spec:
   value: "1"
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -273,6 +274,7 @@ metadata:
 spec:
   value: response.duration | "0ms"
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -301,6 +303,7 @@ metadata:
 spec:
   value: request.size | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -329,6 +332,7 @@ metadata:
 spec:
   value: response.size | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -359,6 +363,7 @@ metadata:
 spec:
   value: connection.sent.bytes | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -387,6 +392,7 @@ metadata:
 spec:
   value: connection.received.bytes | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -416,6 +422,7 @@ spec:
     instance_name: requestcount.metric.{{ .Release.Namespace }}
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -438,6 +445,7 @@ spec:
     instance_name: requestduration.metric.{{ .Release.Namespace }}
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -463,6 +471,7 @@ spec:
     instance_name: requestsize.metric.{{ .Release.Namespace }}
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -490,6 +499,7 @@ spec:
     instance_name: responsesize.metric.{{ .Release.Namespace }}
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -517,6 +527,7 @@ spec:
     instance_name: tcpbytesent.metric.{{ .Release.Namespace }}
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -537,6 +548,7 @@ spec:
     instance_name: tcpbytereceived.metric.{{ .Release.Namespace }}
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -212,14 +212,14 @@ func metrics(promAPI promv1.API, workload string) (workloadMetrics, error) {
 		wns = parts[1]
 	}
 
-	rpsQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*"}[1m]))`, reqTot, wlabel, wname, wnslabel, wns)
-	errRPSQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*",response_code!="200"}[1m]))`, reqTot, wlabel, wname, wnslabel, wns)
-	p50LatencyQuery :=
-		fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*"}[1m])) by (le))`, 0.5, reqDur, wlabel, wname, wnslabel, wns)
-	p90LatencyQuery :=
-		fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*"}[1m])) by (le))`, 0.9, reqDur, wlabel, wname, wnslabel, wns)
-	p99LatencyQuery :=
-		fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*"}[1m])) by (le))`, 0.99, reqDur, wlabel, wname, wnslabel, wns)
+	rpsQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*",reporter=\"server\"}[1m]))`, reqTot, wlabel, wname, wnslabel, wns)
+	errRPSQuery := fmt.Sprintf(`sum(rate(%s{%s=~"%s.*", %s=~"%s.*",reporter=\"server\",response_code!="200"}[1m]))`, reqTot, wlabel, wname, wnslabel, wns)
+	p50LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*,"reporter=\"server\"}[1m])) by (le))`,
+		0.5, reqDur, wlabel, wname, wnslabel, wns)
+	p90LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*"reporter=\"server\"}[1m])) by (le))`,
+		0.9, reqDur, wlabel, wname, wnslabel, wns)
+	p99LatencyQuery := fmt.Sprintf(`histogram_quantile(%f, sum(rate(%s_bucket{%s=~"%s.*", %s=~"%s.*",reporter=\"server\"}[1m])) by (le))`,
+		0.99, reqDur, wlabel, wname, wnslabel, wns)
 
 	var me *multierror.Error
 	var err error

--- a/mixer/pkg/lang/externs.go
+++ b/mixer/pkg/lang/externs.go
@@ -33,21 +33,22 @@ import (
 
 // Externs contains the list of standard external functions used during evaluation.
 var Externs = map[string]interpreter.Extern{
-	"ip":              interpreter.ExternFromFn("ip", externIP),
-	"ip_equal":        interpreter.ExternFromFn("ip_equal", externIPEqual),
-	"timestamp":       interpreter.ExternFromFn("timestamp", externTimestamp),
-	"timestamp_equal": interpreter.ExternFromFn("timestamp_equal", externTimestampEqual),
-	"dnsName":         interpreter.ExternFromFn("dnsName", externDNSName),
-	"dnsName_equal":   interpreter.ExternFromFn("dnsName_equal", externDNSNameEqual),
-	"email":           interpreter.ExternFromFn("email", externEmail),
-	"email_equal":     interpreter.ExternFromFn("email_equal", externEmailEqual),
-	"uri":             interpreter.ExternFromFn("uri", externURI),
-	"uri_equal":       interpreter.ExternFromFn("uri_equal", externURIEqual),
-	"match":           interpreter.ExternFromFn("match", externMatch),
-	"matches":         interpreter.ExternFromFn("matches", externMatches),
-	"startsWith":      interpreter.ExternFromFn("startsWith", externStartsWith),
-	"endsWith":        interpreter.ExternFromFn("endsWith", externEndsWith),
-	"emptyStringMap":  interpreter.ExternFromFn("emptyStringMap", externEmptyStringMap),
+	"ip":                interpreter.ExternFromFn("ip", externIP),
+	"ip_equal":          interpreter.ExternFromFn("ip_equal", externIPEqual),
+	"timestamp":         interpreter.ExternFromFn("timestamp", externTimestamp),
+	"timestamp_equal":   interpreter.ExternFromFn("timestamp_equal", externTimestampEqual),
+	"dnsName":           interpreter.ExternFromFn("dnsName", externDNSName),
+	"dnsName_equal":     interpreter.ExternFromFn("dnsName_equal", externDNSNameEqual),
+	"email":             interpreter.ExternFromFn("email", externEmail),
+	"email_equal":       interpreter.ExternFromFn("email_equal", externEmailEqual),
+	"uri":               interpreter.ExternFromFn("uri", externURI),
+	"uri_equal":         interpreter.ExternFromFn("uri_equal", externURIEqual),
+	"match":             interpreter.ExternFromFn("match", externMatch),
+	"matches":           interpreter.ExternFromFn("matches", externMatches),
+	"startsWith":        interpreter.ExternFromFn("startsWith", externStartsWith),
+	"endsWith":          interpreter.ExternFromFn("endsWith", externEndsWith),
+	"emptyStringMap":    interpreter.ExternFromFn("emptyStringMap", externEmptyStringMap),
+	"conditionalString": interpreter.ExternFromFn("conditionalString", externConditionalString),
 }
 
 // ExternFunctionMetadata is the type-metadata about externs. It gets used during compilations.
@@ -107,6 +108,11 @@ var ExternFunctionMetadata = []ast.FunctionMetadata{
 		Name:          "emptyStringMap",
 		ReturnType:    config.STRING_MAP,
 		ArgumentTypes: []config.ValueType{},
+	},
+	{
+		Name:          "conditionalString",
+		ReturnType:    config.STRING,
+		ArgumentTypes: []config.ValueType{config.BOOL, config.STRING, config.STRING},
 	},
 }
 
@@ -320,4 +326,11 @@ func externEndsWith(str string, suffix string) bool {
 
 func externEmptyStringMap() map[string]string {
 	return map[string]string{}
+}
+
+func externConditionalString(condition bool, trueStr, falseStr string) string {
+	if condition {
+		return trueStr
+	}
+	return falseStr
 }

--- a/mixer/pkg/lang/externs_test.go
+++ b/mixer/pkg/lang/externs_test.go
@@ -487,3 +487,11 @@ func TestExternEmptyStringMap(t *testing.T) {
 		t.Errorf("emptyStringMap() returned non-empty map: %#v", m)
 	}
 }
+
+func TestExternConditionalString(t *testing.T) {
+	boolExpr := true
+	got := externConditionalString(boolExpr, "yes", "no")
+	if got != "yes" {
+		t.Errorf("externIfElse(%t, \"yes\", \"no\") => %s, wanted: %s", boolExpr, got, "yes")
+	}
+}

--- a/mixer/testdata/config/metrics.yaml
+++ b/mixer/testdata/config/metrics.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   value: "1"
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -34,6 +35,7 @@ metadata:
 spec:
   value: response.duration | "0ms"
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -62,6 +64,7 @@ metadata:
 spec:
   value: request.size | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -90,6 +93,7 @@ metadata:
 spec:
   value: response.size | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"

--- a/mixer/testdata/config/prometheus.yaml
+++ b/mixer/testdata/config/prometheus.yaml
@@ -9,6 +9,7 @@ spec:
     instance_name: requestcount.metric.istio-system
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -31,6 +32,7 @@ spec:
     instance_name: requestduration.metric.istio-system
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -56,6 +58,7 @@ spec:
     instance_name: requestsize.metric.istio-system
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -83,6 +86,7 @@ spec:
     instance_name: responsesize.metric.istio-system
     kind: DISTRIBUTION
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -110,6 +114,7 @@ spec:
     instance_name: tcpbytesent.metric.istio-system
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal
@@ -130,6 +135,7 @@ spec:
     instance_name: tcpbytereceived.metric.istio-system
     kind: COUNTER
     label_names:
+    - reporter
     - source_app
     - source_namespace
     - source_principal

--- a/mixer/testdata/config/tcpmetrics.yaml
+++ b/mixer/testdata/config/tcpmetrics.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   value: connection.sent.bytes | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
@@ -36,6 +37,7 @@ metadata:
 spec:
   value: connection.received.bytes | 0
   dimensions:
+    reporter: conditionalString((context.reporter.uid | "n/a") == (source.uid | ""), "client", "server")
     source_namespace: source.namespace | "unknown"
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"


### PR DESCRIPTION
This PR adds a label to distinguish metrics derived from client-side reporting
from metrics derived from server-side reporting (avoiding double-counting).

This PR is needed as recent changes in Istio have lead to a full support for client-
side reporting.

As part of this labeling, this PR updates the dashboard queries to only use
*server*-side reports for graphs (client-side report displays will follow).

This PR also introduces a `conditionalString` fn to the Mixer expression language.

/hold