### PR TITLE
End pilot-agent when the last epoch of Agent terminates normally (#6324)

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -240,12 +240,15 @@ var (
 			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry)
 			watcher := envoy.NewWatcher(proxyConfig, agent, role, certs, pilotSAN)
 			ctx, cancel := context.WithCancel(context.Background())
-			go watcher.Run(ctx)
 
-			stop := make(chan struct{})
-			cmd.WaitSignal(stop)
-			<-stop
-			cancel()
+			go func (){
+				defer cancel()
+				stop := make(chan struct{})
+				cmd.WaitSignal(stop)
+				<-stop
+			}()
+
+			watcher.Run(ctx)
 			return nil
 		},
 	}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -241,7 +241,7 @@ var (
 			watcher := envoy.NewWatcher(proxyConfig, agent, role, certs, pilotSAN)
 			ctx, cancel := context.WithCancel(context.Background())
 
-			go func (){
+			go func() {
 				defer cancel()
 				stop := make(chan struct{})
 				cmd.WaitSignal(stop)

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -100,7 +100,10 @@ const (
 
 func (w *watcher) Run(ctx context.Context) {
 	// agent consumes notifications from the controller
-	go w.agent.Run(ctx)
+	agentStop := make(chan error)
+	go func(stop chan<- error) {
+		stop <- w.agent.Run(ctx)
+	}(agentStop)
 
 	// kickstart the proxy with partial state (in case there are no notifications coming)
 	w.Reload()
@@ -111,10 +114,18 @@ func (w *watcher) Run(ctx context.Context) {
 		certDirs = append(certDirs, cert.Directory)
 	}
 
-	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.Reload)
-	go w.retrieveAZ(ctx, azRetryInterval, azRetryAttempts)
+	watchingCtx, cancelWatching := context.WithCancel(ctx)
+	go watchCerts(watchingCtx, certDirs, watchFileEvents, defaultMinDelay, w.Reload)
+	go w.retrieveAZ(watchingCtx, azRetryInterval, azRetryAttempts)
 
-	<-ctx.Done()
+	select {
+	case err := <-agentStop:
+		if err != nil {
+			log.Errora(err)
+		}
+	case <-ctx.Done():
+	}
+	cancelWatching()
 }
 
 func (w *watcher) Reload() {
@@ -335,6 +346,7 @@ func (proxy envoy) Run(config interface{}, epoch int, abort <-chan error) error 
 	go func() {
 		done <- cmd.Wait()
 	}()
+
 
 	select {
 	case err := <-abort:

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -347,7 +347,6 @@ func (proxy envoy) Run(config interface{}, epoch int, abort <-chan error) error 
 		done <- cmd.Wait()
 	}()
 
-
 	select {
 	case err := <-abort:
 		log.Warnf("Aborting epoch %d", epoch)

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -44,8 +44,9 @@ func (ta TestAgent) ScheduleConfigUpdate(config interface{}) {
 	ta.schedule(config)
 }
 
-func (ta TestAgent) Run(ctx context.Context) {
+func (ta TestAgent) Run(ctx context.Context) error {
 	<-ctx.Done()
+	return nil
 }
 
 func TestRunReload(t *testing.T) {


### PR DESCRIPTION
It fixes #6324 

I looked through both envoy and pilot-agent and could notice [Agent waits until the next 'config update'](https://github.com/istio/istio/blob/a4df8f85dcf3c32d4fd944e69f662a51b1eb43da/pilot/pkg/proxy/agent.go#L185), if the last epoch terminates normally. I think in case of 'config update' Istio users do not explicitly terminate epochs, since it supports hot-reloading. So the main purpose of the normal termination of the last epoch would be closer to the pilot-agent termination.

With this assumption, the PR does graceful shutdown of the pilot-agent on the last normal epoch termination. I think it can reduce the chance of being a zombie agent in not only /quitquitquit but also other normal envoy terminations.

I hope the PR saves you guys’ time for this issue.