### PR TITLE
Fix front-matter output.

### DIFF
--- a/pkg/collateral/cobra.go
+++ b/pkg/collateral/cobra.go
@@ -38,7 +38,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 				c.EmitBashCompletion = true
 				c.EmitManPages = true
 				c.EmitMarkdown = true
-				c.EmitJekyllHTML = true
+				c.EmitHTMLFragmentWithFrontMatter = true
 			}
 
 			return EmitCollateral(root, &c)
@@ -51,7 +51,8 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd.Flags().BoolVarP(&c.EmitManPages, "man", "", c.EmitManPages, "Produce man pages")
 	cmd.Flags().BoolVarP(&c.EmitBashCompletion, "bash", "", c.EmitBashCompletion, "Produce bash completion files")
 	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
-	cmd.Flags().BoolVarP(&c.EmitJekyllHTML, "jekyll_html", "", c.EmitJekyllHTML, "Produce a Jekyll-friendly HTML documentation file")
+	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
+		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
 
 	return cmd
 }

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -45,8 +45,8 @@ type Control struct {
 	// EmitMarkdown controls whether to produce mankdown documentation files.
 	EmitMarkdown bool
 
-	// EmitJeyllHTML controls whether to produce Jekyll-friendly HTML documentation files.
-	EmitJekyllHTML bool
+	// EmitHTMLFragmentWithFrontMatter controls whether to produce HTML fragments with Jekyll/Hugo front matter.
+	EmitHTMLFragmentWithFrontMatter bool
 
 	// ManPageInfo provides extra information necessary when emitting man pages.
 	ManPageInfo doc.GenManHeader
@@ -68,9 +68,9 @@ func EmitCollateral(root *cobra.Command, c *Control) error {
 		}
 	}
 
-	if c.EmitJekyllHTML {
-		if err := genJekyllHTML(root, c.OutputDir+"/"+root.Name()+".html"); err != nil {
-			return fmt.Errorf("unable to output Jekyll HTML file: %v", err)
+	if c.EmitHTMLFragmentWithFrontMatter {
+		if err := genHTMLFragment(root, c.OutputDir+"/"+root.Name()+".html"); err != nil {
+			return fmt.Errorf("unable to output HTML fragment file: %v", err)
 		}
 	}
 
@@ -112,7 +112,7 @@ func findCommands(commands map[string]*cobra.Command, cmd *cobra.Command) {
 
 const help = "help"
 
-func genJekyllHTML(cmd *cobra.Command, path string) error {
+func genHTMLFragment(cmd *cobra.Command, path string) error {
 	commands := make(map[string]*cobra.Command)
 	findCommands(commands, cmd)
 
@@ -159,7 +159,7 @@ func genJekyllHTML(cmd *cobra.Command, path string) error {
 func (g *generator) genFileHeader(root *cobra.Command, numEntries int) {
 	g.emit("---")
 	g.emit("title: ", root.Name())
-	g.emit("description: ", html.EscapeString(root.Short))
+	g.emit("description: ", root.Short)
 	g.emit("generator: pkg-collateral-docs")
 	g.emit("number_of_entries: ", strconv.Itoa(numEntries))
 	g.emit("---")


### PR DESCRIPTION
- Front-matter is not HTML and shouldn't undergo HTML escaping.

- Rename the --jekyll_html option to --html_fragment_with_front_matter, which matches
the name used in the protoc-gen-docs tool.