### PR TITLE
Disable current broken integration test (example and security) 

### DIFF
--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -43,5 +43,3 @@ fi
 # Upload images - needed by the subsequent tests
 time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
 
-# Run security e2e test
-CERT_DIR=$(make where-is-docker-temp) ${ROOT}/security/bin/e2e.sh --hub "gcr.io/istio-testing" --tag "${GIT_SHA}"

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -43,8 +43,5 @@ fi
 # Upload images - needed by the subsequent tests
 time ISTIO_DOCKER_HUB="gcr.io/istio-testing" make push HUB="gcr.io/istio-testing" TAG="${GIT_SHA}"
 
-# Run integration framework sample
-./tests/integration/example/integration.sh
-
 # Run security e2e test
 CERT_DIR=$(make where-is-docker-temp) ${ROOT}/security/bin/e2e.sh --hub "gcr.io/istio-testing" --tag "${GIT_SHA}"


### PR DESCRIPTION
Since Oz and Nathan are building a better framework, we have a plan to retire these anyway. 