### PR TITLE
Grafana 5.2.1

### DIFF
--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,13 +1,15 @@
-from grafana/grafana:5.0.4
+FROM grafana/grafana:5.2.1
 
-COPY grafana.ini /etc/grafana/
-RUN chmod 777 -R /etc/grafana/
+COPY --chown=grafana grafana.ini /etc/grafana/
+COPY --chown=grafana dashboards.yaml /etc/grafana/provisioning/dashboards/
+COPY --chown=grafana datasources.yaml /etc/grafana/provisioning/datasources/
 
-COPY dashboards.yaml /etc/grafana/provisioning/dashboards/
-RUN chmod 777 -R /etc/grafana/provisioning/dashboards/
+USER root
+RUN mkdir -p /var/lib/grafana/dashboards && \
+    chown grafana /var/lib/grafana/dashboards
 
-COPY datasources.yaml /etc/grafana/provisioning/datasources/
-RUN chmod 777 -R /etc/grafana/provisioning/datasources/
+RUN mkdir -p /data/grafana
+RUN chown grafana /data/grafana
+USER grafana
 
-COPY dashboards /var/lib/grafana/dashboards/
-RUN chmod 777 -R /var/lib/grafana/dashboards/
+COPY --chown=grafana dashboards /var/lib/grafana/dashboards/

--- a/addons/grafana/dashboards.yaml
+++ b/addons/grafana/dashboards.yaml
@@ -1,9 +1,9 @@
 apiVersion: 1
 
 providers:
-- name: 'default'
+- name: 'istio'
   orgId: 1
-  folder: ''
+  folder: 'istio'
   type: file
   options:
     path: /var/lib/grafana/dashboards

--- a/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
@@ -857,6 +857,6 @@
   },
   "timezone": "",
   "title": "Istio HTTP/GRPC Workload Dashboard",
-  "uid": "95DgGEWmz",
+  "uid": "istio-http-grpc-workload",
   "version": 4
 }

--- a/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-http-grpc-workload-dashboard.json
@@ -781,7 +781,7 @@
   "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["istio"],
   "templating": {
     "list": [
       {

--- a/addons/grafana/dashboards/istio-mesh-dashboard.json
+++ b/addons/grafana/dashboards/istio-mesh-dashboard.json
@@ -805,7 +805,7 @@
   "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["istio"],
   "templating": {
     "list": []
   },

--- a/addons/grafana/dashboards/istio-mesh-dashboard.json
+++ b/addons/grafana/dashboards/istio-mesh-dashboard.json
@@ -840,6 +840,6 @@
   },
   "timezone": "browser",
   "title": "Istio Mesh Dashboard",
-  "uid": "1",
+  "uid": "istio-mesh",
   "version": 9
 }

--- a/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
@@ -215,7 +215,7 @@
   "refresh": "10s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["istio"],
   "templating": {
     "list": [
       {

--- a/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
@@ -212,7 +212,7 @@
       ]
     }
   ],
-  "refresh": "10s",
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": ["istio"],

--- a/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
+++ b/addons/grafana/dashboards/istio-tcp-workload-dashboard.json
@@ -291,6 +291,6 @@
   },
   "timezone": "",
   "title": "Istio TCP Workload Dashboard",
-  "uid": "0G9AS34ik",
+  "uid": "istio-tcp-workload",
   "version": 6
 }

--- a/addons/grafana/dashboards/mixer-dashboard.json
+++ b/addons/grafana/dashboards/mixer-dashboard.json
@@ -1638,6 +1638,6 @@
   },
   "timezone": "",
   "title": "Mixer Dashboard",
-  "uid": "2",
+  "uid": "istio-mixer",
   "version": 3
 }

--- a/addons/grafana/dashboards/mixer-dashboard.json
+++ b/addons/grafana/dashboards/mixer-dashboard.json
@@ -1582,7 +1582,7 @@
   "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["istio"],
   "templating": {
     "list": [
       {

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -789,6 +789,6 @@
   },
   "timezone": "browser",
   "title": "Pilot Dashboard",
-  "uid": "3",
+  "uid": "istio-pilot",
   "version": 3
 }

--- a/addons/grafana/dashboards/pilot-dashboard.json
+++ b/addons/grafana/dashboards/pilot-dashboard.json
@@ -754,7 +754,7 @@
   "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
-  "tags": [],
+  "tags": ["istio"],
   "templating": {
     "list": []
   },

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
           volumeMounts:
           - name: data
             mountPath: /data/grafana
+      securityContext:
+        fsGroup: 472
+        runAsNonRoot: true
+        runAsUser: 472
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       volumes:


### PR DESCRIPTION
Hi @douglas-reid.
This PR is primarily about upgrading Grafana to 5.2.1, which changes the uid for grafana to `472`.

I've also done a few other tidy up bits whilst I was here:

  - Consistent uid's
  - Moved istio dashboards into a Folder (this is handy for us, as we inject a bunch of our own dashboards too)
  - Added istio tag to the istio dashboards
  - Ensured consistent refresh times across all boards
