### PR TITLE
Avoid adding APA attributes into ingress check cache key

### DIFF
--- a/mixer/template/sample/template.gen.go
+++ b/mixer/template/sample/template.gen.go
@@ -436,7 +436,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) && out.WasSet(field) {
+						if len(field) != len(name) {
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -327,7 +327,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) && out.WasSet(field) {
+						if len(field) != len(name) {
 							switch field {
 
 							case "source_pod_ip":

--- a/mixer/test/spyAdapter/template/template.gen.go
+++ b/mixer/test/spyAdapter/template/template.gen.go
@@ -236,7 +236,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) && out.WasSet(field) {
+						if len(field) != len(name) {
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -338,7 +338,7 @@ var (
             outBag := newWrapperAttrBag(
                 func(name string) (value interface{}, found bool) {
                     field := strings.TrimPrefix(name, fullOutName)
-                    if len(field) != len(name) && out.WasSet(field) {
+                    if len(field) != len(name) {
                         switch field {
                             {{range .OutputTemplateMessage.Fields}}
                             case "{{.ProtoName}}":

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -464,7 +464,7 @@ var (
 				outBag := newWrapperAttrBag(
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
-						if len(field) != len(name) && out.WasSet(field) {
+						if len(field) != len(name) {
 							switch field {
 
 							case "int64Primitive":


### PR DESCRIPTION
Right now APA attributes will present in Ingress proxy's check cache even though the proxy does not have any knowledge about it. The reason is that there is no env attributes generated for source of ingress calls, while the wrapper bag `get` logic will still try to find those generated attributes in the organic attributes bag after failing to find them in generated bag. This PR fixes this problem.

cc @kyessenov @geeknoid 