### PR TITLE
simplify fmt script

### DIFF
--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -19,12 +19,8 @@ cd $ROOTDIR
 export GOPATH=$(cd $ROOTDIR/../../..; pwd)
 export PATH=$GOPATH/bin:$PATH
 
-if which goimports; then
-  goimports=`which goimports`
-else
-  go get golang.org/x/tools/cmd/goimports
-  goimports=${GOPATH}/bin/goimports
-fi
+go get -u golang.org/x/tools/cmd/goimports
+goimports=${GOPATH}/bin/goimports
 
 PKGS=${PKGS:-"."}
 if [[ -z ${GO_FILES} ]];then

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -34,39 +34,14 @@ fi
 UX=$(uname)
 
 if [ $check = false ]; then
-  #remove blank lines so gofmt / goimports can do their job
-  for fl in ${GO_FILES}; do
-    if [[ ${UX} == "Darwin" ]]; then
-      sed -i '' -e "/^import[[:space:]]*(/,/)/{ /^\s*$/d;}" $fl
-    else
-      sed -i -e "/^import[[:space:]]*(/,/)/{ /^\s*$/d;}" $fl
-    fi
-  done
-
-  gofmt -s -w ${GO_FILES}
   $goimports -w -local istio.io ${GO_FILES}
   exit $?
 fi
 
-#check mode
-#remove blank lines so gofmt / goimports can do their job
-tf="/tmp/~output.go"
-ec=0
 for fl in ${GO_FILES}; do
-  if [[ ${UX} == "Darwin" ]]; then
-    sed -e "/^import[[:space:]]*(/,/)/{ /^\s*$/d;}" $fl > $tf
-  else
-    sed -e "/^import[[:space:]]*(/,/)/{ /^\s*$/d;}" $fl > $tf
-  fi
-
-  gofmt -s -w $tf
-  $goimports -w -local istio.io $tf
-  if [[ $(diff $tf $fl) ]]; then
-    echo "File $fl needs formatting. Please run bin/fmt.sh"
-    diff $tf $fl
-    ec=1
+  file_needs_formatting=$($goimports -l -local istio.io $fl)
+  if [[ ! -z "$file_needs_formatting" ]]; then
+    echo "please run bin/fmt.sh against: $file_needs_formatting"
+    exit 1
   fi
 done
-
-rm $tf
-exit $ec

--- a/broker/pkg/platform/kube/crd/client.go
+++ b/broker/pkg/platform/kube/crd/client.go
@@ -33,6 +33,7 @@ import (
 
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/log"
+
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic

--- a/galley/pkg/kube/interfaces.go
+++ b/galley/pkg/kube/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )

--- a/galley/pkg/runtime/resource/schema_test.go
+++ b/galley/pkg/runtime/resource/schema_test.go
@@ -22,6 +22,7 @@ import (
 
 	pgogo "github.com/gogo/protobuf/proto"
 	plang "github.com/golang/protobuf/proto"
+
 	// Pull in gogo & golang Empty
 	_ "github.com/gogo/protobuf/types"
 	_ "github.com/golang/protobuf/ptypes/empty"

--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -25,6 +25,7 @@ import (
 
 	mcp "istio.io/api/config/mcp/v1alpha1"
 	"istio.io/istio/galley/pkg/mcp/client"
+
 	// Import the resource package to pull in all proto types.
 	_ "istio.io/istio/galley/pkg/runtime/resource"
 )

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+
 	// import all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"

--- a/mixer/adapter/circonus/circonus.go
+++ b/mixer/adapter/circonus/circonus.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log" //nolint:adapterlinter
+
 	"net/url"
 	"time"
 

--- a/mixer/pkg/config/crd/init.go
+++ b/mixer/pkg/config/crd/init.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/wait"
+
 	// import GKE cluster authentication plugin
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	// import OIDC cluster authentication plugin, e.g. for Tectonic

--- a/pilot/pkg/config/monitor/fakes/copilot_client.go
+++ b/pilot/pkg/config/monitor/fakes/copilot_client.go
@@ -7,6 +7,7 @@ import (
 	"code.cloudfoundry.org/copilot/api"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	// manually added this space to satisfy goimports -d --local istio.io
 	"istio.io/istio/pilot/pkg/config/monitor"
 )

--- a/security/pkg/caclient/protocol/protocol.go
+++ b/security/pkg/caclient/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	//"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/platform"
 	pb "istio.io/istio/security/proto"

--- a/security/tests/integration/kubernetes_utils.go
+++ b/security/tests/integration/kubernetes_utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // to avoid 'No Auth Provider found for name "gcp"'
+
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/pkg/log"


### PR DESCRIPTION
- goimports is a superset of gofmt
- shouldn't need to remove spaces
- now utilizing -l flag to tell us if there is a diff
- update goimports so we are getting all the good formatting.