### PR TITLE
Long-running testing improvements

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -12,14 +12,17 @@ data:
   mesh: |-
     # Set the following variable to true to disable policy checks by the Mixer.
     # Note that metrics will still be reported to the Mixer.
-    disablePolicyChecks: false
+    disablePolicyChecks: {{ .Values.global.disablePolicyChecks }}
+
     # Set enableTracing to false to disable request tracing.
-    enableTracing: true
+    enableTracing: {{ .Values.global.enableTracing }}
+
     # Set accessLogFile to empty string to disable access log.
-    accessLogFile: "/dev/stdout"
+    accessLogFile: "{{ .Values.global.proxy.accessLogFile }}"
     #
     # To disable the mixer completely (including metrics), comment out
     # the following lines
+    # Deprecated: mixer is using EDS
     mixerCheckServer: istio-policy.{{ .Release.Namespace }}.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.{{ .Release.Namespace }}.svc.cluster.local:15004
     # This is the ingress service name, update if you used a different name
@@ -30,6 +33,7 @@ data:
     # from istio Pilot. Lower refresh delay results in higher CPU
     # utilization and potential performance loss in exchange for faster
     # convergence. Tweak this value according to your setup.
+    # Deprecated: using push.
     rdsRefreshDelay: {{ .Values.global.refreshInterval }}
 
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
@@ -44,6 +48,7 @@ data:
       # NOTE: If you change any values in this section, make sure to make
       # the same changes in start up args in istio-ingress pods.
       # See rdsRefreshDelay for explanation about this setting.
+      # Deprecated: using push.
       discoveryRefreshDelay: {{ .Values.global.refreshInterval }}
       #
       # TCP connection timeout between Envoy & the application, and between Envoys.

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -11,7 +11,7 @@ metadata:
     istio: sidecar-injector
 data:
   config: |-
-    policy: {{ .Values.global.proxy.policy }}
+    policy: {{ .Values.global.proxy.autoinject }}
     template: |-
       initContainers:
       - name: istio-init

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -8,19 +8,22 @@ global:
   # Default repository for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Daily builds from prow are on gcr.io, and nightly builds from circle on
-  # docker.io/istionightly
-  hub: docker.io/istio
+  hub: docker.io/istionightly
+  #hub: docker.io/istio
 
   # Default tag for Istio images.
-  # Should track latest released version in the branch.
-  tag: 0.8.latest
+  tag: nightly-master
+  #tag: 1.0.latest
+
   proxy:
     image: proxyv2
 
-    # istio-sidecar-injector configmap stores configuration for sidecar injection.
-    # This config map is used by istioctl kube-inject and the injector webhook.
+    # Configures the access log for each sidecar. Setting it to an empty string will
+    # disable access log for sidecar.
+    accessLogFile: "/dev/stdout"
+
+    # If set, newly injected sidecars will have core dumps enabled.
     enableCoreDump: false
-    replicaCount: 1
 
     # istio egress capture whitelist
     # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly
@@ -37,7 +40,9 @@ global:
     #     Redirect only selected ports:            --includeInboundPorts="80,8080"
     includeInboundPorts: "*"
     excludeInboundPorts: ""
-    policy: enabled
+
+    # This controls the 'policy' in the sidecar injector.
+    autoinject: enabled
 
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
     # would be <host>:<port>).
@@ -63,6 +68,13 @@ global:
   # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
   # propagated, not recommended for tests.
   controlPlaneSecurityEnabled: false
+
+  # disablePolicyChecks disables mixer policy checks.
+  # Will set the value with same name in istio config map - pilot needs to be restarted to take effect.
+  disablePolicyChecks: false
+
+  # EnableTracing sets the value with same name in istio config map, requires pilot restart to take effect.
+  enableTracing: true
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:
@@ -151,7 +163,15 @@ gateways:
       istio: ingressgateway
     replicaCount: 1
     autoscaleMin: 1
-    autoscaleMax: 1
+    autoscaleMax: 5
+    resources: {}
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      #requests:
+      #  cpu: 1800m
+      #  memory: 256Mi
+
     loadBalancerIP: ""
     serviceAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be

--- a/tests/helm/iperf3-noistio.yaml
+++ b/tests/helm/iperf3-noistio.yaml
@@ -1,55 +1,54 @@
----
-
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: iperf3
+  name: iperfraw
 spec:
   hosts:
-  - "iperf.{{ .Values.domain }}"
+  - "iperf3raw.{{ .Values.domain }}"
   gateways:
   - istio-gateway
   tcp:
-  - match:
-    - port: 5201
-    route:
+  - route:
     - destination:
-        host: iperf3.test.svc.cluster.local
+        host: iperf3-raw.test.svc.cluster.local
         port:
-          number: 5201
+          number: 5202
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: iperf3
+  name: iperf3-raw
 spec:
   ports:
-  - name: tcp
-    port: 5201
-    targetPort: 5201
+  - name: tcp1
+    port: 5202
+    targetPort: 5202
   selector:
-    app: iperf3
-
+    app: iperf3-raw
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: iperf3
+  name: iperf3-raw
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: iperf3
+        app: iperf3-raw
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: docker.io/networkstatic/iperf3
         imagePullPolicy: IfNotPresent
-        name: iperf3
+        name: iperf3-raw
         ports:
-        - containerPort: 5201
+        - containerPort: 5202
         args:
         - '-s'
+        - '-p'
+        - '5202'
         resources:
           requests:
             cpu: 1000m

--- a/tests/helm/setup.sh
+++ b/tests/helm/setup.sh
@@ -8,7 +8,15 @@ function testIstioSystem() {
     --values tests/helm/values-istio-test.yaml \
     --set global.refreshInterval=30s \
     --set global.tag=$TAG \
+    --set global.proxy.accessLogFile="" \
+    --set global.proxy.resources.requests.cpu=1100m \
+    --set global.proxy.resources.requests.memory=256Mi \
+    --set global.imagePullPolicy=Always \
     --set global.hub=$HUB \
+    --set gateways.istio-ingressgateway.resources.requests.cpu=1900m \
+    --set gateways.istio-ingressgateway.resources.requests.memory=512Mi \
+    --set gateways.istio-ingressgateway.resources.limits.cpu=1900m \
+    --set gateways.istio-ingressgateway.resources.limits.memory=512Mi \
     install/kubernetes/helm/istio  | \
         kubectl apply -n istio-system -f -
    popd
@@ -20,11 +28,10 @@ function testInstall() {
     kubectl create ns istio-system
     testIstioSystem
 
-    kubectl -n test apply -f samples/httpbin/httpbin.yaml
-
     kubectl create ns test
     kubectl label namespace test istio-injection=enabled
 
+    kubectl -n test apply -f samples/httpbin/httpbin.yaml
     kubectl create ns bookinfo
     kubectl label namespace bookinfo istio-injection=enabled
     kubectl -n bookinfo apply -f samples/bookinfo/kube/bookinfo.yaml
@@ -33,7 +40,8 @@ function testInstall() {
 # Apply the helm template
 function testApply() {
    pushd $TOP/src/istio.io/istio
-   helm -n test template tests/helm |kubectl -n test apply -f -
+   helm -n test template \
+    tests/helm |kubectl -n test apply -f -
    popd
 }
 
@@ -46,17 +54,27 @@ function testCreateDNS() {
 
     gcloud dns --project=$DNS_PROJECT record-sets transaction start --zone=$DNS_ZONE
 
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=grafana.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=prom.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=fortio2.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=pilot.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=fortio.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=fortioraw.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=bookinfo.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=httpbin.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=citadel.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
-    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress08.$DNS_DOMAIN --name=mixer.v08.$DNS_DOMAIN --ttl=300 --type=CNAME --zone=$DNS_ZONE
+  #  gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=grafana.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=prom.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=fortio2.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=pilot.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=fortio.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=fortioraw.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=bookinfo.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=httpbin.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=citadel.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=mixer.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
 
     gcloud dns --project=$DNS_PROJECT record-sets transaction execute --zone=$DNS_ZONE
 }
 
+# Run this after adding a new name for ingress testing
+function testAddDNS() {
+    local N=$1
+
+    gcloud dns --project=$DNS_PROJECT record-sets transaction start --zone=$DNS_ZONE
+
+    gcloud dns --project=$DNS_PROJECT record-sets transaction add ingress10.${DNS_DOMAIN}. --name=${N}.v10.${DNS_DOMAIN}. --ttl=300 --type=CNAME --zone=$DNS_ZONE
+
+    gcloud dns --project=$DNS_PROJECT record-sets transaction execute --zone=$DNS_ZONE
+}

--- a/tests/helm/templates/fortio-080.yaml
+++ b/tests/helm/templates/fortio-080.yaml
@@ -1,0 +1,60 @@
+# Fortio with 0.8.0 sidecar
+apiVersion: v1
+kind: Service
+metadata:
+  name: fortio080
+spec:
+  ports:
+  - port: 8080
+    name: http-echo
+  - port: 8079
+    name: grpc-ping
+  selector:
+    app: fortiov080
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortiov080
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fortiov080
+        version: fortio080
+      annotations:
+        sidecar.istio.io/proxyImage: istio/proxyv2:0.8.0
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        ports:
+         - containerPort: 8080
+         - containerPort: 8079
+        args:
+          - server
+        resources:
+          requests:
+            cpu: 800m
+            memory: "1G"
+          limits:
+            cpu: 1000m
+            memory: "1G"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortio080
+spec:
+  hosts:
+  - "fortio080.{{.Values.domain}}"
+  gateways:
+  - istio-gateway
+  http:
+  - route:
+    - destination:
+        host: fortio080.test.svc.cluster.local
+        port:
+          number: 8080

--- a/tests/helm/templates/fortio-10rc1.yaml
+++ b/tests/helm/templates/fortio-10rc1.yaml
@@ -1,8 +1,8 @@
-# Fortio with alpha1/v1
+# Fortio with 1.0RC1 sidecar
 apiVersion: v1
 kind: Service
 metadata:
-  name: alpha1
+  name: fortio10rc1
 spec:
   ports:
   - port: 8080
@@ -10,20 +10,21 @@ spec:
   - port: 8079
     name: grpc-ping
   selector:
-    app: alpha1
+    app: fortio10rc1
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: alpha1
+  name: fortio10rc1
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: alpha1
+        app: fortio10rc1
+        version: fortio10rc1
       annotations:
-        sidecar.istio.io/proxyImage: istionightly/proxyv2:nightly-release-0.8
+        sidecar.istio.io/proxyImage: istio/proxyv2:1.0.0-snapshot.0
     spec:
       containers:
       - name: echosrv
@@ -41,3 +42,20 @@ spec:
           limits:
             cpu: 1000m
             memory: "1G"
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortio10rc1
+spec:
+  hosts:
+  - "fortio10rc1.{{.Values.domain}}"
+  gateways:
+  - istio-gateway
+  http:
+  - route:
+    - destination:
+        host: fortio10rc1.test.svc.cluster.local
+        port:
+          number: 8080

--- a/tests/helm/templates/fortio-cli.yaml
+++ b/tests/helm/templates/fortio-cli.yaml
@@ -1,13 +1,51 @@
+## Fortio clients generating traffic on different components.
+# Generally use the ingress gateway - to capture non-istio service as well.
+---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: fortio-cli1
+  name: cli-fortio-tls
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: fortio-cli1
+        app: cli-fortio-tls
+        version: v1-tls
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        args:
+          - load
+          - -t
+          - "0"
+          - -c
+          - "32"
+          - -qps
+          - "1000"
+          - http://fortiotls.{{ .Values.domain }}/echo?size=5000
+        resources:
+          requests:
+            cpu: 800m
+            memory: "1G"
+          limits:
+            cpu: 1000m
+            memory: "1G"
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortio-cli-raw
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fortio-cli-raw
         version: v1
       annotations:
         sidecar.istio.io/inject: "false"
@@ -24,7 +62,7 @@ spec:
           - "32"
           - -qps
           - "1000"
-          - http://fortio2.v08.istio.webinf.info/echo?size=5000
+          - http://fortionoistio.{{ .Values.domain }}/echo?size=5000
         resources:
           requests:
             cpu: 800m
@@ -59,7 +97,7 @@ spec:
           - "32"
           - -qps
           - "1000"
-          - http://fortio.v08.istio.webinf.info/echo?size=5000
+          - http://fortiomaster.{{ .Values.domain }}/echo?size=5000
         resources:
           requests:
             cpu: 800m
@@ -67,4 +105,75 @@ spec:
           limits:
             cpu: 1000m
             memory: "1G"
+
 ---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cli-fortio10rc1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cli-fortio10rc1
+        version: cli-fortio10rc1
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        args:
+          - load
+          - -t
+          - "0"
+          - -c
+          - "32"
+          - -qps
+          - "1000"
+          - http://fortio10rc1.{{ .Values.domain }}/echo?size=5000
+        resources:
+          requests:
+            cpu: 400m
+            memory: "1G"
+          limits:
+            cpu: 500m
+            memory: "1G"
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cli-fortio080
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cli-fortio080
+        version: cli-fortio080
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        args:
+          - load
+          - -t
+          - "0"
+          - -c
+          - "32"
+          - -qps
+          - "1000"
+          - http://fortio080.{{ .Values.domain }}/echo?size=5000
+        resources:
+          requests:
+            cpu: 400m
+            memory: "1G"
+          limits:
+            cpu: 500m
+            memory: "1G"

--- a/tests/helm/templates/fortio-master.yaml
+++ b/tests/helm/templates/fortio-master.yaml
@@ -1,0 +1,61 @@
+# Fortio with latest sidecar
+apiVersion: v1
+kind: Service
+metadata:
+  name: fortiomaster
+spec:
+  ports:
+  - port: 8080
+    name: http-echo
+  - port: 8079
+    name: grpc-ping
+  selector:
+    app: fortiomaster
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: fortiomaster
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fortiomaster
+        version: fortiomaster
+      annotations:
+        sidecar.istio.io/proxyImage: istionightly/proxyv2:nightly-master
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        ports:
+         - containerPort: 8080
+         - containerPort: 8079
+        args:
+          - server
+        resources:
+          requests:
+            cpu: 800m
+            memory: "1G"
+          limits:
+            cpu: 1000m
+            memory: "1G"
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortiomaster
+spec:
+  hosts:
+  - "fortiomaster.{{.Values.domain}}"
+  gateways:
+  - istio-gateway
+  http:
+  - route:
+    - destination:
+        host: fortiomaster.test.svc.cluster.local
+        port:
+          number: 8080

--- a/tests/helm/templates/fortio-noistio.yaml
+++ b/tests/helm/templates/fortio-noistio.yaml
@@ -1,22 +1,27 @@
 # 2 fortio servers, not istio injected (to baseline service-to-service without istio)
 # 0.8 CPU each.
-apiVersion: v1
-kind: Service
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
 metadata:
-  name: fortio-noistio1
+  name: fortionoistio
 spec:
-  ports:
-  - port: 8080
-    name: http-echo
-  - port: 8079
-    name: grpc-ping
-  selector:
-    name: fortio-noistio1
+  hosts:
+  - "fortionoistio.{{.Values.domain}}"
+  gateways:
+  - istio-gateway
+  http:
+  - route:
+    - destination:
+        host: fortionoistio.test.svc.cluster.local
+        port:
+          number: 8080
 ---
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: fortio-noistio2
+  name: fortionoistio
 spec:
   ports:
   - port: 8080
@@ -24,74 +29,20 @@ spec:
   - port: 8079
     name: grpc-ping
   selector:
-    name: fortio-noistio2
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: fortio-noistio
-spec:
-  ports:
-  - port: 8080
-    name: http-echo
-  - port: 8079
-    name: grpc-ping
-  selector:
-    app: fortio-noistio
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: fortio-noistio-headless
-spec:
-  clusterIP: None
-  ports:
-  - port: 8080
-    name: http-echo
-  - port: 8079
-    name: grpc-ping
-  selector:
-    app: fortio-noistio
+    name: fortionoistio
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: fortio-noistio1
+  name: fortionoistio
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: fortio-noistio
-        name: fortio-noistio1
-      annotations:
-        sidecar.istio.io/inject: "false"
-    spec:
-      containers:
-      - name: echosrv
-        image: istio/fortio:latest
-        imagePullPolicy: Always
-        args:
-          - server
-        resources:
-          requests:
-            cpu: 800m
-            memory: "1G"
-          limits:
-            cpu: 1000m
-            memory: "1G"
----
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: fortio-noistio2
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: fortio-noistio
-        name: fortio-noistio2
+        app: fortionoistio
+        name: fortionoistio
+        version: fortionoistio
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/tests/helm/templates/fortio-tls.yaml
+++ b/tests/helm/templates/fortio-tls.yaml
@@ -2,14 +2,14 @@
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
-  name: "fortio-mtls"
+  name: fortiotls
 spec:
   peers:
   - mtls: {}
   peer_is_optional: true
   targets:
   # Must be short name of service
-  - name: "fortio-tls"
+  - name: fortiotls
     # subsets: "v2"
     ports:
     # name also supported
@@ -19,9 +19,9 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: fortio-tls
+  name: fortiotls
 spec:
-  host:  fortio-tls.test.svc.cluster.local
+  host:  fortiotls.test.svc.cluster.local
   trafficPolicy:
     tls:
       # Equivalent with ISTIO_MUTUAL
@@ -37,7 +37,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fortio-tls
+  name: fortiotls
 spec:
   ports:
   - port: 8080
@@ -48,12 +48,12 @@ spec:
   - port: 8079
     name: grpc-ping
   selector:
-    app: fortio-tls
+    app: fortiotls
 ---
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: fortio-tls
+  name: fortiotls
 spec:
   replicas: 1
   template:
@@ -62,7 +62,7 @@ spec:
         sidecar.istio.io/controlPlaneAuthPolicy: MUTUAL_TLS
         sidecar.istio.io/discoveryAddress: istio-pilot.istio-system:15005
       labels:
-        app: fortio-tls
+        app: fortiotls
         version: tls
     spec:
       containers:
@@ -80,3 +80,21 @@ spec:
           limits:
             cpu: 1000m
             memory: "1G"
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortiotls
+spec:
+  hosts:
+  - "fortiotls.{{ .Values.domain }}"
+  gateways:
+  - istio-gateway
+  http:
+  - route:
+    - destination:
+        host: fortiotls.test.svc.cluster.local
+        port:
+          number: 8080

--- a/tests/helm/templates/gateway.yaml
+++ b/tests/helm/templates/gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: istio08-gateway
+  name: istio-gateway
 spec:
   selector:
     istio: ingressgateway
@@ -18,22 +18,26 @@ spec:
     - "pilot.{{ .Values.domain }}"
     - "fortio.{{ .Values.domain }}"
     - "fortio2.{{ .Values.domain }}"
-    - "fortioraw.{{ .Values.domain }}"
+    - "fortiotls.{{ .Values.domain }}"
+    - "fortionoistio.{{ .Values.domain }}"
     - "bookinfo.{{ .Values.domain }}"
     - "httpbin.{{ .Values.domain }}"
+    - "fortio080.{{ .Values.domain }}"
+    - "fortio10rc1.{{ .Values.domain }}"
+    - "fortiomaster.{{ .Values.domain }}"
+    - "fortiocli.{{ .Values.domain }}"
+  - port:
+      number: 5201
+      protocol: TCP
+      name: tcp-iperf3
+    hosts:
+    - "*"
   - port:
       number: 5203
       protocol: TCP
-      name: tcp-iperf
+      name: tcp-iperf-tls
     hosts:
     - "*"
-  - port:
-      number: 5202
-      protocol: TCP
-      name: tcp-iperfraw
-    hosts:
-    - "*"
-
 ---
 
 apiVersion: networking.istio.io/v1alpha3
@@ -44,7 +48,7 @@ spec:
   hosts:
   - "pilot.{{ .Values.domain }}"
   gateways:
-  - istio08-gateway
+  - istio-gateway
   http:
   - route:
     - destination:
@@ -62,7 +66,7 @@ spec:
   hosts:
   - "httpbin.{{ .Values.domain }}"
   gateways:
-  - istio08-gateway
+  - istio-gateway
   http:
   - route:
     - destination:
@@ -79,7 +83,7 @@ spec:
   hosts:
   - "grafana.{{ .Values.domain }}"
   gateways:
-  - istio08-gateway
+  - istio-gateway
   http:
   - route:
     - destination:
@@ -98,7 +102,7 @@ spec:
   hosts:
   - "prom.{{ .Values.domain }}"
   gateways:
-  - istio08-gateway
+  - istio-gateway
   http:
   - route:
     - destination:
@@ -115,85 +119,12 @@ spec:
   hosts:
   - "bookinfo.{{ .Values.domain }}"
   gateways:
-  - istio08-gateway
+  - istio-gateway
   http:
   - route:
     - destination:
         host: productpage.bookinfo.svc.cluster.local
         port:
           number: 9080
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: fortio
-spec:
-  hosts:
-  - "fortioraw.{{.Values.domain}}"
-  gateways:
-  - istio08-gateway
-  http:
-  - route:
-    - destination:
-        host: fortio-noistio.test.svc.cluster.local
-        port:
-          number: 8080
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: fortioistio
-spec:
-  hosts:
-  - "fortio.{{ .Values.domain }}"
-  gateways:
-  - istio08-gateway
-  http:
-  - route:
-    - destination:
-        host: fortiov1.test.svc.cluster.local
-        port:
-          number: 8080
-
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: fortio2istio
-spec:
-  hosts:
-  - "fortio2.{{ .Values.domain }}"
-  gateways:
-  - istio08-gateway
-  http:
-  - route:
-    - destination:
-        host: fortio-tls.test.svc.cluster.local
-        port:
-          number: 8080
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: iperf
-spec:
-  hosts:
-  - "iperf.{{ .Values.domain }}"
-  gateways:
-  - istio08-gateway
-  tcp:
-  - route:
-    - destination:
-        host: iperf3.test.svc.cluster.local
-        port:
-          number: 5202
 
 ---

--- a/tests/helm/templates/iperf3-tls.yaml
+++ b/tests/helm/templates/iperf3-tls.yaml
@@ -1,0 +1,109 @@
+
+#apiVersion: networking.istio.io/v1alpha3
+#kind: Gateway
+#metadata:
+#  name: istio-iperf-gateway
+#spec:
+#  selector:
+#    istio: ingressgateway
+#  servers:
+#  - port:
+#      number: 5203
+#      protocol: TCP
+#      name: tcp-iperf-tls
+#    hosts:
+#    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: iperf-tls
+spec:
+  hosts:
+  - "iperf-tls.{{ .Values.domain }}"
+  gateways:
+  - istio-gateway
+  tcp:
+  - match:
+    - port: 5203
+    route:
+    - destination:
+        host: iperf3-tls.test.svc.cluster.local
+        port:
+          number: 5203
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iperf3-tls
+spec:
+  ports:
+  - name: tcp
+    port: 5203
+    targetPort: 5203
+  selector:
+    app: iperf3-tls
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: iperf3-tls
+spec:
+  peers:
+  - mtls: {}
+  peer_is_optional: true
+  targets:
+  # Must be short name of service
+  - name: iperf3-tls
+    # subsets: "v2"
+    ports:
+    # name also supported
+    # TODO: this should be target port (container)
+    - number: 5203
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: iperf3tls
+spec:
+  host:  iperf3-tls.test.svc.cluster.local
+  trafficPolicy:
+    tls:
+      # Equivalent with ISTIO_MUTUAL
+      mode: MUTUAL
+      client_certificate: /etc/certs/cert-chain.pem
+      private_key: /etc/certs/key.pem
+      ca_certificates: /etc/certs/root-cert.pem
+      subject_alt_names:
+      - spiffe://cluster.local/ns/test/sa/default
+
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iperf3-tls
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: iperf3-tls
+    spec:
+      containers:
+      - image: docker.io/networkstatic/iperf3
+        imagePullPolicy: IfNotPresent
+        name: iperf3
+        ports:
+        - containerPort: 5203
+        args:
+        - '-s'
+        - '-p'
+        - '5203'
+        resources:
+          requests:
+            cpu: 1000m
+            memory: "1G"
+          limits:
+            cpu: 1000m
+            memory: "2G"

--- a/tests/helm/templates/virtual_service.yaml
+++ b/tests/helm/templates/virtual_service.yaml
@@ -23,31 +23,13 @@ metadata:
   name: fortiov1
 spec:
   hosts:
-  - fortio.v08.istio.webinf.info
+  - fortio.{{ .Values.domain }}
   - fortiov1.test.svc.cluster.local
   http:
   - route:
     # service selects multiple deployments, has 2 subsets
     - destination:
         host: fortiov1.test.svc.cluster.local
-        port:
-          number: 8080
-
----
-
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: fortiotls
-spec:
-  hosts:
-  - fortio2.v08.istio.webinf.info
-  #- fortio-tls.test.svc.cluster.local
-  http:
-  - route:
-    # service selects multiple deployments, has 2 subsets
-    - destination:
-        host: fortiov-tls.test.svc.cluster.local
         port:
           number: 8080
 

--- a/tests/helm/values.yaml
+++ b/tests/helm/values.yaml
@@ -2,7 +2,7 @@ healthPort: true
 testHub: docker.io/istionightly
 testTag: nightly-release-0.8
 
-domain: v08.istio.webinf.info
+domain: v10.istio.webinf.info
 
 # Namespace where istio control plane is installed.
 istioNamespace: istio-system


### PR DESCRIPTION
Cleaned up and fixed the stress testing. 
The previous version has been running for >1month on 0.8, in weekly cluster.
The new version is running in weekly10 cluster.

Still broken: 
- ingress TCP to mtls service (bug filed)
- Metrics are still off in some cases (via ingressgateway)
 