### PR TITLE
Add filter query parameters for servicegraph

### DIFF
--- a/addons/servicegraph/README.md
+++ b/addons/servicegraph/README.md
@@ -37,6 +37,19 @@ All endpoints take these query parameters:
 - `filter_empty=true` will restrict the nodes and edges shown to only
   those that reflect non-zero traffic levels during the specified
   `time_horizon`. Deafult is `false`.
+  
+- `destination_namespace` will filter the nodes and edges show to only 
+  those where the destination workload is in the given namespace.
+  
+- `destination_workload` will filter the nodes and edges show to only 
+  those where the destination workload is with the given name.
+
+- `source_namespace` will filter the nodes and edges show to only 
+  those where the source workload is in the given namespace. 
+
+- `source_workload` will filter the nodes and edges show to only 
+  those where the source workload is with the given name.
+
 
 # Demosvc service
 Defined in `servicegraph/cmd/demosvc`, this provides a simple HTTP

--- a/addons/servicegraph/force/forcegraph.js
+++ b/addons/servicegraph/force/forcegraph.js
@@ -101,6 +101,7 @@ var endpoint = "/d3graph";
 
 (function(){
     var query={};
+    var params = [];
     var i=0;
     var tele;
     var search_values=location.search.replace('\?','').split('&');
@@ -108,14 +109,14 @@ var endpoint = "/d3graph";
         telem=search_values[i].split('=');
         query[telem[0]]=telem[1];
     }
-
-    if (query.time_horizon != undefined && query.filter_empty != undefined) {
-        endpoint = endpoint + "?time_horizon=" + query.time_horizon +
-            "&filter_empty=" + query.filter_empty;
-    } else if (query.time_horizon != undefined) {
-        endpoint = endpoint + "?time_horizon=" + query.time_horizon;
-    } else if (query.filter_empty != undefined) {
-        endpoint = endpoint + "?filter_empty=" + query.filter_empty;
+    for (var k in query) {
+        if (query.hasOwnProperty(k)) {
+            params.push(k + "=" + query[k]);
+        }
+    }
+    var queryParams = params.join("&");
+    if (queryParams !== "") {
+        endpoint = endpoint + "?" + queryParams;
     }
 }());
 

--- a/addons/servicegraph/promgen/promgen.go
+++ b/addons/servicegraph/promgen/promgen.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -30,13 +31,17 @@ import (
 	"istio.io/istio/addons/servicegraph"
 )
 
-const reqsFmt = "sum(rate(istio_requests_total{reporter=\"destination\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
-const tcpFmt = "sum(rate(istio_tcp_received_bytes_total{reporter=\"destination\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const reqsFmt = "sum(rate(istio_requests_total{reporter=\"destination\"%s}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const tcpFmt = "sum(rate(istio_tcp_received_bytes_total{reporter=\"destination\"%s}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
 const emptyFilter = " > 0"
 
 type genOpts struct {
-	timeHorizon string
-	filterEmpty bool
+	timeHorizon  string
+	filterEmpty  bool
+	dstNamespace string
+	dstWorkload  string
+	srcNamespace string
+	srcWorkload  string
 }
 
 type promHandler struct {
@@ -61,12 +66,24 @@ func (p *promHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if filterEmptyStr == "true" {
 		filterEmpty = true
 	}
+
+	dstNamespace := r.URL.Query().Get("destination_namespace")
+	dstWorkload := r.URL.Query().Get("destination_workload")
+	srcNamespace := r.URL.Query().Get("source_namespace")
+	srcWorkload := r.URL.Query().Get("source_workload")
 	// validate time_horizon
 	if _, err := model.ParseDuration(timeHorizon); err != nil {
 		writeError(w, fmt.Errorf("could not parse time_horizon: %v", err))
 		return
 	}
-	g, err := p.generate(genOpts{timeHorizon, filterEmpty})
+	g, err := p.generate(genOpts{
+		timeHorizon,
+		filterEmpty,
+		dstNamespace,
+		dstWorkload,
+		srcNamespace,
+		srcWorkload,
+	})
 	g.Merge(p.static)
 	if err != nil {
 		writeError(w, err)
@@ -92,7 +109,8 @@ func (p *promHandler) generate(opts genOpts) (*servicegraph.Dynamic, error) {
 		return nil, err
 	}
 	api := v1.NewAPI(client)
-	query := fmt.Sprintf(reqsFmt, opts.timeHorizon)
+	serviceFilter := generateServiceFilter(opts)
+	query := fmt.Sprintf(reqsFmt, serviceFilter, opts.timeHorizon)
 	if opts.filterEmpty {
 		query += emptyFilter
 	}
@@ -100,7 +118,7 @@ func (p *promHandler) generate(opts genOpts) (*servicegraph.Dynamic, error) {
 	if err != nil {
 		return nil, err
 	}
-	query = fmt.Sprintf(tcpFmt, opts.timeHorizon)
+	query = fmt.Sprintf(tcpFmt, serviceFilter, opts.timeHorizon)
 	if opts.filterEmpty {
 		query += emptyFilter
 	}
@@ -109,6 +127,27 @@ func (p *promHandler) generate(opts genOpts) (*servicegraph.Dynamic, error) {
 		return nil, err
 	}
 	return merge(graph, tcpGraph)
+}
+
+func generateServiceFilter(opts genOpts) string {
+	filterParams := make([]string, 0, 4)
+	if opts.dstNamespace != "" {
+		filterParams = append(filterParams, "destination_namespace=\""+opts.dstNamespace+"\"")
+	}
+	if opts.dstWorkload != "" {
+		filterParams = append(filterParams, "destination_workload=\""+opts.dstWorkload+"\"")
+	}
+	if opts.srcNamespace != "" {
+		filterParams = append(filterParams, "source_namespace=\""+opts.srcNamespace+"\"")
+	}
+	if opts.srcWorkload != "" {
+		filterParams = append(filterParams, "source_workload=\""+opts.srcWorkload+"\"")
+	}
+	filterStr := strings.Join(filterParams, ", ")
+	if filterStr != "" {
+		filterStr = ", " + filterStr
+	}
+	return filterStr
 }
 
 func merge(g1, g2 *servicegraph.Dynamic) (*servicegraph.Dynamic, error) {


### PR DESCRIPTION
Fix #6588 
Add the filter query parameters to filter by metric labels:
- destination_namespace
- destination_workload
- source_namespace
- source_workload