### PR TITLE
[DO NOT MERGE] add sidecar install job

### DIFF
--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/clusterrole.yaml
@@ -14,3 +14,7 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
   verbs: ["get", "list", "watch", "patch"]
+- apiGroups: [ ""]
+  resources: ["namespaces"]
+  resourceNames: [ "kube-system", {{ .Release.Namespace | quote }} ]
+  verbs: ["get", "patch" ]

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         istio: sidecar-injector
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
       containers:
@@ -78,3 +80,4 @@ spec:
             path: config
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
+---

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
@@ -1,36 +1,97 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: istio-sidecar-injector
+  name: istio-sidecar-injector-pre-instanll
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
   labels:
-    app: istio-sidecar-injector
+    app: istio-security
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-webhooks:
-  - name: sidecar-injector.istio.io
-    clientConfig:
-      service:
-        name: istio-sidecar-injector
-        namespace: {{ .Release.Namespace }}
-        path: "/inject"
-      caBundle: ""
-    rules:
-      - operations: [ "CREATE" ]
-        apiGroups: [""]
-        apiVersions: ["v1"]
-        resources: ["pods"]
-    failurePolicy: Fail
-    namespaceSelector:
-{{- if .Values.enableNamespacesByDefault }}
-      matchExpressions:
-      - key: istio-injection
-        operator: NotIn
-        values:
-        - disabled
-{{- else }}
-      matchLabels:
-        istio-injection: enabled
-{{- end }}
-
+spec:
+  template:
+    metadata:
+      name: istio-sidecar-injector-pre-install
+      labels:
+        app: istio-sidecar-injector-pre-install
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-sidecar-injector-service-account
+      containers:
+      - name: hyperkube
+        image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+        command: [ "/bin/entrypoint.sh" ]
+        args: [ "/mutatingwebhookconfiguration.yaml" ]
+        volumeMounts:
+        - name: entrypoint
+          mountPath: /bin/entrypoint.sh
+          readOnly: true
+          subPath: entrypoint.sh
+        - name: config
+          mountPath: /mutatingwebhookconfiguration.yaml
+          readOnly: true
+          subPath: mutatingwebhookconfiguration.yaml
+      volumes:
+      - name: entrypoint
+        configMap:
+          defaultMode: 0700
+          name: istio-sidecar-injector-pre-install
+      - name: config
+        configMap:
+          name: istio-sidecar-injector-pre-install
+      restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-sidecar-injector-pre-install
+  namespace: {{ .Release.Namespace }}
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -ex
+    [ "$#" -ne 1 ] && echo "first argument must be path to mutatingwebhookconfiguration.yaml" && exit 1
+    /kubectl label --overwrite namespace kube-system istio-injection=disabled
+    /kubectl label --overwrite namespace {{ .Release.Namespace }} istio-injection=disabled
+    /kubectl apply -f ${1}
+  mutatingwebhookconfiguration.yaml: |-
+    apiVersion: admissionregistration.k8s.io/v1beta1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: istio-sidecar-injector
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: istio-sidecar-injector
+        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+    webhooks:
+      - name: sidecar-injector.istio.io
+        clientConfig:
+          service:
+            name: istio-sidecar-injector
+            namespace: {{ .Release.Namespace }}
+            path: "/inject"
+          caBundle: ""
+        rules:
+          - operations: [ "CREATE" ]
+            apiGroups: [""]
+            apiVersions: ["v1"]
+            resources: ["pods"]
+        failurePolicy: Fail
+        namespaceSelector:
+    {{- if .Values.enableNamespacesByDefault }}
+          matchExpressions:
+          - key: istio-injection
+            operator: NotIn
+            values:
+            - disabled
+    {{- else }}
+          matchLabels:
+            istio-injection: enabled
+    {{- end }}
+---


### PR DESCRIPTION
To support opt-out sidecar injection configuration the `kube-system` and `istio-system` namespaces must be labeled with `istio-injection=disabled`. AFAICT, helm does not provide a built-in option to label namespaces. Adding the namespace resources (w/labels) directly to our help templates risk accidental deletion of system namespaces in the case istio is uninstalled (via kubectl delete -f istio.yaml). 

As an alternative, create a pre-install job to label the namespaces. The mutatingwebhookconfiguration is also created from the pre-install job to avoid ordering issues, e.g. configuration is created before istio-system namespace is labeled with `disabled`. The downside to this approach is that `kubectl delete -f istio.yaml` no longer deletes the mutatingwebhookconfiguration. For that, we may want to consider a proper installer/uninstaller and/or operator to orchestrate install/unstall/upgrades.