### PR TITLE
Add galley config validation metrics and improved loggings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,7 @@ mixs:
 $(MIXER_GO_BINS):
 	bin/gobuild.sh $@ ./mixer/cmd/$(@F)
 
+.PHONY: galley
 GALLEY_GO_BINS:=${ISTIO_OUT}/galley
 galley:
 	bin/gobuild.sh ${ISTIO_OUT}/galley ./galley/cmd/galley

--- a/galley/pkg/crd/validation/monitoring.go
+++ b/galley/pkg/crd/validation/monitoring.go
@@ -22,23 +22,23 @@ import (
 )
 
 var (
-	metricCertKeyUpdate = prometheus.NewGauge(prometheus.GaugeOpts{
+	metricCertKeyUpdate = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "galley_validation_cert_key_updates",
 		Help: "Galley validation webhook certiticate updates",
 	})
-	metricCertKeyUpdateError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	metricCertKeyUpdateError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "galley_validation_cert_key_update_errors",
 		Help: "Galley validation webhook certiticate updates errors",
 	}, []string{"error"})
-	metricValidationPassed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	metricValidationPassed = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "galley_validation_passed",
 		Help: "Resource is valid",
 	}, []string{"group", "version", "resource"})
-	metricValidationFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	metricValidationFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "galley_validation_failed",
 		Help: "Resource validation failed",
 	}, []string{"group", "version", "resource", "reason"})
-	metricValidationHTTPError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	metricValidationHTTPError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "galley_validation_http_error",
 		Help: "Resource validation http serve errors",
 	}, []string{"status"})

--- a/galley/pkg/crd/validation/monitoring.go
+++ b/galley/pkg/crd/validation/monitoring.go
@@ -1,0 +1,85 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+)
+
+var (
+	metricCertKeyUpdate = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "galley_validation_cert_key_updates",
+		Help: "Galley validation webhook certiticate updates",
+	})
+	metricCertKeyUpdateError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "galley_validation_cert_key_update_errors",
+		Help: "Galley validation webhook certiticate updates errors",
+	}, []string{"error"})
+	metricValidationPassed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "galley_validation_passed",
+		Help: "Resource is valid",
+	}, []string{"group", "version", "resource"})
+	metricValidationFailed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "galley_validation_failed",
+		Help: "Resource validation failed",
+	}, []string{"group", "version", "resource", "reason"})
+	metricValidationHTTPError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "galley_validation_http_error",
+		Help: "Resource validation http serve errors",
+	}, []string{"status"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		metricCertKeyUpdate,
+		metricCertKeyUpdateError,
+		metricValidationPassed,
+		metricValidationFailed,
+		metricValidationHTTPError)
+}
+
+func reportValidationFailed(request *admissionv1beta1.AdmissionRequest, reason string) {
+	metricValidationFailed.With(prometheus.Labels{
+		"group":    request.Resource.Group,
+		"version":  request.Resource.Version,
+		"resource": request.Resource.Resource,
+		"reason":   reason,
+	}).Add(1)
+}
+
+func reportValidationPass(request *admissionv1beta1.AdmissionRequest) {
+	metricValidationPassed.With(prometheus.Labels{
+		"group":    request.Resource.Group,
+		"version":  request.Resource.Version,
+		"resource": request.Resource.Resource,
+	}).Add(1)
+}
+
+func reportValidationHTTPError(status int) {
+	metricValidationHTTPError.With(prometheus.Labels{
+		"status": strconv.Itoa(status),
+	}).Add(1)
+}
+
+const (
+	reasonUnsupportedOperation = "unsupported_operation"
+	reasonYamlDecodeError      = "yaml_decode_error"
+	reasonUnknownType          = "unknown_type"
+	reasonCRDConversionError   = "crd_conversion_error"
+	reasonInvalidConfig        = "invalid_resource"
+)

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
           - containerPort: 443
+          - containerPort: 9093
           command:
           - /usr/local/bin/galley
           - validator

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -8,5 +8,8 @@ metadata:
 spec:
   ports:
   - port: 443
+    name: https-validation
+  - port: 9093
+    name: http-monitoring
   selector:
     istio: galley

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -82,6 +82,20 @@ data:
         action: keep
         regex: {{ .Release.Namespace }};istio-pilot;http-monitoring
 
+    - job_name: 'galley'
+      # Override the global default and scrape targets from this job every 5 seconds.
+      scrape_interval: 5s
+      # metrics_path defaults to '/metrics'
+      # scheme defaults to 'http'.
+
+      kubernetes_sd_configs:
+      - role: endpoints
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: {{ .Release.Namespace }};istio-galley;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:


### PR DESCRIPTION
Add metrics and improved logging for configuration validation. Copied from #6762 (against master) which didn't make the 1.0 merge window.