### PR TITLE
Update Bookinfo code

### DIFF
--- a/samples/bookinfo/build_push_update_images.sh
+++ b/samples/bookinfo/build_push_update_images.sh
@@ -23,8 +23,13 @@ if [ "$#" -ne 1 ]; then
 fi
 
 VERSION=$1
-src/build-services.sh $VERSION
-IMAGES=$(docker images -f reference=istio/examples-bookinfo*:$VERSION --format "{{.Repository}}:$VERSION")
-for IMAGE in $IMAGES; do docker push $IMAGE; done
-sed -i "s/\(istio\/examples-bookinfo-.*\):[[:digit:]]\.[[:digit:]]\.[[:digit:]]/\1:$VERSION/g" */bookinfo*.yaml
+src/build-services.sh "${VERSION}"
+
+for v in ${VERSION} "latest"
+do
+  IMAGES+=$(docker images -f reference=istio/examples-bookinfo*:"$v" --format "{{.Repository}}:$v")
+done
+
+for IMAGE in ${IMAGES}; do docker push "${IMAGE}"; done
+sed -i "s/\\(istio\\/examples-bookinfo-.*\\):[[:digit:]]\\.[[:digit:]]\\.[[:digit:]]/\\1:$VERSION/g" -- */bookinfo*.yaml
 

--- a/samples/bookinfo/consul/bookinfo.yaml
+++ b/samples/bookinfo/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.5.0
+    image: istio/examples-bookinfo-details-v1:1.6.0
     networks:
       istiomesh:
     dns:
@@ -32,7 +32,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.5.0
+    image: istio/examples-bookinfo-ratings-v1:1.6.0
     networks:
       istiomesh:
     dns:
@@ -48,7 +48,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.5.0
+    image: istio/examples-bookinfo-reviews-v1:1.6.0
     networks:
       istiomesh:
     dns:
@@ -65,7 +65,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.5.0
+    image: istio/examples-bookinfo-reviews-v2:1.6.0
     networks:
       istiomesh:
     dns:
@@ -82,7 +82,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.5.0
+    image: istio/examples-bookinfo-reviews-v3:1.6.0
     networks:
       istiomesh:
     dns:
@@ -99,7 +99,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.5.0
+    image: istio/examples-bookinfo-productpage-v1:1.6.0
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/consul/bookinfo.yaml
+++ b/samples/bookinfo/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.6.0
+    image: istio/examples-bookinfo-details-v1:1.7.0
     networks:
       istiomesh:
     dns:
@@ -32,7 +32,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.6.0
+    image: istio/examples-bookinfo-ratings-v1:1.7.0
     networks:
       istiomesh:
     dns:
@@ -48,7 +48,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.6.0
+    image: istio/examples-bookinfo-reviews-v1:1.7.0
     networks:
       istiomesh:
     dns:
@@ -65,7 +65,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.6.0
+    image: istio/examples-bookinfo-reviews-v2:1.7.0
     networks:
       istiomesh:
     dns:
@@ -82,7 +82,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.6.0
+    image: istio/examples-bookinfo-reviews-v3:1.7.0
     networks:
       istiomesh:
     dns:
@@ -99,7 +99,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.6.0
+    image: istio/examples-bookinfo-productpage-v1:1.7.0
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/eureka/bookinfo.yaml
+++ b/samples/bookinfo/eureka/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.5.0
+    image: istio/examples-bookinfo-details-v1:1.6.0
     networks:
       default:
         aliases:
@@ -28,7 +28,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.5.0
+    image: istio/examples-bookinfo-ratings-v1:1.6.0
     networks:
       default:
         aliases:
@@ -40,7 +40,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.5.0
+    image: istio/examples-bookinfo-reviews-v1:1.6.0
     networks:
       default:
         aliases:
@@ -53,7 +53,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.5.0
+    image: istio/examples-bookinfo-reviews-v2:1.6.0
     networks:
       default:
         aliases:
@@ -66,7 +66,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.5.0
+    image: istio/examples-bookinfo-reviews-v3:1.6.0
     networks:
       default:
         aliases:
@@ -79,7 +79,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.5.0
+    image: istio/examples-bookinfo-productpage-v1:1.6.0
     networks:
       default:
         aliases:

--- a/samples/bookinfo/eureka/bookinfo.yaml
+++ b/samples/bookinfo/eureka/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.6.0
+    image: istio/examples-bookinfo-details-v1:1.7.0
     networks:
       default:
         aliases:
@@ -28,7 +28,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.6.0
+    image: istio/examples-bookinfo-ratings-v1:1.7.0
     networks:
       default:
         aliases:
@@ -40,7 +40,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.6.0
+    image: istio/examples-bookinfo-reviews-v1:1.7.0
     networks:
       default:
         aliases:
@@ -53,7 +53,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.6.0
+    image: istio/examples-bookinfo-reviews-v2:1.7.0
     networks:
       default:
         aliases:
@@ -66,7 +66,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.6.0
+    image: istio/examples-bookinfo-reviews-v3:1.7.0
     networks:
       default:
         aliases:
@@ -79,7 +79,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.6.0
+    image: istio/examples-bookinfo-productpage-v1:1.7.0
     networks:
       default:
         aliases:

--- a/samples/bookinfo/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/kube/bookinfo-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.5.0
+        image: istio/examples-bookinfo-productpage-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.5.0
+        image: istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.5.0
+        image: istio/examples-bookinfo-reviews-v3:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/kube/bookinfo-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.6.0
+        image: istio/examples-bookinfo-productpage-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.6.0
+        image: istio/examples-bookinfo-reviews-v2:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.6.0
+        image: istio/examples-bookinfo-reviews-v3:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/kube/bookinfo-db.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: istio/examples-bookinfo-mongodb:1.5.0
+        image: istio/examples-bookinfo-mongodb:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/kube/bookinfo-db.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: istio/examples-bookinfo-mongodb:1.6.0
+        image: istio/examples-bookinfo-mongodb:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v2:1.5.0
+        image: istio/examples-bookinfo-details-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -36,3 +36,4 @@ spec:
         env:
         - name: DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS
           value: "true"
+----

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -34,6 +34,6 @@ spec:
         ports:
         - containerPort: 9080
         env:
-        - name: DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS
+        - name: DO_NOT_ENCRYPT
           value: "true"
 ---

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -36,4 +36,4 @@ spec:
         env:
         - name: DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS
           value: "true"
-----
+---

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v2:1.6.0
+        image: istio/examples-bookinfo-details-v2:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -33,3 +33,6 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
+        env:
+        - name: DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS
+          value: "true"

--- a/samples/bookinfo/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-details-v2.yaml
@@ -33,7 +33,3 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
-        env:
-        - name: WITH_ISTIO
-          value: "true"
----

--- a/samples/bookinfo/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/kube/bookinfo-details.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.5.0
+        image: istio/examples-bookinfo-details-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/kube/bookinfo-details.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.6.0
+        image: istio/examples-bookinfo-details-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/kube/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.5.0
+        image: istio/examples-bookinfo-mysqldb:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/kube/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.6.0
+        image: istio/examples-bookinfo-mysqldb:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: gcr.io/istio-testing/examples-bookinfo-ratings-v2:0.2.8
+        image: istio/examples-bookinfo-ratings-v2:1.6.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.6.0
+        image: istio/examples-bookinfo-ratings-v2:1.7.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: gcr.io/istio-testing/examples-bookinfo-ratings-v2:0.2.8
+        image: istio/examples-bookinfo-ratings-v2:1.6.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.6.0
+        image: istio/examples-bookinfo-ratings-v2:1.7.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.5.0
+        image: istio/examples-bookinfo-ratings-v2:1.6.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings-v2.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.6.0
+        image: istio/examples-bookinfo-ratings-v2:1.7.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.5.0
+        image: istio/examples-bookinfo-ratings-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/kube/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.6.0
+        image: istio/examples-bookinfo-ratings-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-reviews-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.5.0
+        image: istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/kube/bookinfo-reviews-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.6.0
+        image: istio/examples-bookinfo-reviews-v2:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo.yaml
+++ b/samples/bookinfo/kube/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.5.0
+        image: istio/examples-bookinfo-details-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.5.0
+        image: istio/examples-bookinfo-ratings-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.5.0
+        image: istio/examples-bookinfo-reviews-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.5.0
+        image: istio/examples-bookinfo-reviews-v2:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.5.0
+        image: istio/examples-bookinfo-reviews-v3:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.5.0
+        image: istio/examples-bookinfo-productpage-v1:1.6.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/kube/bookinfo.yaml
+++ b/samples/bookinfo/kube/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.6.0
+        image: istio/examples-bookinfo-details-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.6.0
+        image: istio/examples-bookinfo-ratings-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.6.0
+        image: istio/examples-bookinfo-reviews-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.6.0
+        image: istio/examples-bookinfo-reviews-v2:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.6.0
+        image: istio/examples-bookinfo-reviews-v3:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.6.0
+        image: istio/examples-bookinfo-productpage-v1:1.7.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -26,14 +26,14 @@ VERSION=$1
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 pushd $SCRIPTDIR/productpage
-  docker build -t istio/examples-bookinfo-productpage-v1:${VERSION} .
+  docker build -t istio/examples-bookinfo-productpage-v1:${VERSION} -t istio/examples-bookinfo-productpage-v1:latest .
 popd
 
 pushd $SCRIPTDIR/details
   #plain build -- no calling external book service to fetch topics
-  docker build -t istio/examples-bookinfo-details-v1:${VERSION} --build-arg service_version=v1 .
+  docker build -t istio/examples-bookinfo-details-v1:${VERSION} -t istio/examples-bookinfo-details-v1:latest --build-arg service_version=v1 .
   #with calling external book service to fetch topic for the book
-  docker build -t istio/examples-bookinfo-details-v2:${VERSION} --build-arg service_version=v2 \
+  docker build -t istio/examples-bookinfo-details-v2:${VERSION} -t istio/examples-bookinfo-details-v2:latest --build-arg service_version=v2 \
 	 --build-arg enable_external_book_service=true .
 popd
 
@@ -42,25 +42,25 @@ pushd $SCRIPTDIR/reviews
   docker run --rm -v $(PWD):/home/gradle/project -w /home/gradle/project gradle gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
-    docker build -t istio/examples-bookinfo-reviews-v1:${VERSION} --build-arg service_version=v1 .
+    docker build -t istio/examples-bookinfo-reviews-v1:${VERSION} -t istio/examples-bookinfo-reviews-v1:latest --build-arg service_version=v1 .
     #with ratings black stars
-    docker build -t istio/examples-bookinfo-reviews-v2:${VERSION} --build-arg service_version=v2 \
+    docker build -t istio/examples-bookinfo-reviews-v2:${VERSION} -t istio/examples-bookinfo-reviews-v2:latest --build-arg service_version=v2 \
 	   --build-arg enable_ratings=true .
     #with ratings red stars
-    docker build -t istio/examples-bookinfo-reviews-v3:${VERSION} --build-arg service_version=v3 \
+    docker build -t istio/examples-bookinfo-reviews-v3:${VERSION} -t istio/examples-bookinfo-reviews-v3:latest --build-arg service_version=v3 \
 	   --build-arg enable_ratings=true --build-arg star_color=red .
   popd
 popd
 
 pushd $SCRIPTDIR/ratings
-  docker build -t istio/examples-bookinfo-ratings-v1:${VERSION} --build-arg service_version=v1 .
-  docker build -t istio/examples-bookinfo-ratings-v2:${VERSION} --build-arg service_version=v2 .
+  docker build -t istio/examples-bookinfo-ratings-v1:${VERSION} -t istio/examples-bookinfo-ratings-v1:latest --build-arg service_version=v1 .
+  docker build -t istio/examples-bookinfo-ratings-v2:${VERSION} -t istio/examples-bookinfo-ratings-v2:latest --build-arg service_version=v2 .
 popd
 
 pushd $SCRIPTDIR/mysql
-  docker build -t istio/examples-bookinfo-mysqldb:${VERSION} .
+  docker build -t istio/examples-bookinfo-mysqldb:${VERSION} -t istio/examples-bookinfo-mysqldb:latest .
 popd
 
 pushd $SCRIPTDIR/mongodb
-  docker build -t istio/examples-bookinfo-mongodb:${VERSION} .
+  docker build -t istio/examples-bookinfo-mongodb:${VERSION} -t istio/examples-bookinfo-mongodb:latest .
 popd

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -39,7 +39,7 @@ popd
 
 pushd $SCRIPTDIR/reviews
   #java build the app.
-  docker run --rm -v `pwd`:/usr/bin/app:rw niaquinto/gradle clean build
+  docker run --rm -v $(PWD):/home/gradle/project -w /home/gradle/project gradle gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
     docker build -t istio/examples-bookinfo-reviews-v1:${VERSION} --build-arg service_version=v1 .

--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -82,13 +82,13 @@ def fetch_details_from_external_service(isbn, id, headers)
     http = Net::HTTP.new(uri.host, uri.port)
     http.read_timeout = 5 # seconds
 
-    # DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS means that the app must access external services
-    # without TLS, using unencrypted traffic protocols like HTTP. The TLS origination will be
+    # DO_NOT_ENCRYPT means that the app must access external services without TLS,
+    # using unencrypted traffic protocols like HTTP. The TLS origination will be
     # performed if needed, elsewhere, e.g. by a sidecar proxy.
     #
     # If this environment variable is false, the app must use TLS, e.g. HTTPS, to access
     # external services.
-    unless ENV['DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS'] === 'true' then
+    unless ENV['DO_NOT_ENCRYPT'] === 'true' then
       http.use_ssl = true
     end
 

--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -82,12 +82,12 @@ def fetch_details_from_external_service(isbn, id, headers)
     http = Net::HTTP.new(uri.host, uri.port)
     http.read_timeout = 5 # seconds
 
-    # DO_NOT_ENCRYPT means that the app must access external services without TLS,
-    # using unencrypted traffic protocols like HTTP. The TLS origination will be
-    # performed if needed, elsewhere, e.g. by a sidecar proxy.
+    # DO_NOT_ENCRYPT is used to configure the details service to use either
+    # HTTP (true) or HTTPS (false, default) when calling the external service to
+    # retrieve the book information.
     #
-    # If this environment variable is false, the app must use TLS, e.g. HTTPS, to access
-    # external services.
+    # Unless this environment variable is set to true, the app will use TLS (HTTPS)
+    # to access external services.
     unless ENV['DO_NOT_ENCRYPT'] === 'true' then
       http.use_ssl = true
     end

--- a/samples/bookinfo/src/details/details.rb
+++ b/samples/bookinfo/src/details/details.rb
@@ -82,15 +82,13 @@ def fetch_details_from_external_service(isbn, id, headers)
     http = Net::HTTP.new(uri.host, uri.port)
     http.read_timeout = 5 # seconds
 
-    # WITH_ISTIO means that the details app runs with an Istio sidecar injected.
+    # DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS means that the app must access external services
+    # without TLS, using unencrypted traffic protocols like HTTP. The TLS origination will be
+    # performed if needed, elsewhere, e.g. by a sidecar proxy.
     #
-    # With the Istio sidecar injected, the requests must be sent by HTTP protocol (without TLS),
-    # while the sidecar proxy will perform TLS origination. An Egress Rule
-    # must be defined to enable the trafic to www.googleapis.com and to perform the TLS origination.
-    #
-    # Without the Istio sidecar injected, the TLS origination must be performed by the `http` object,
-    # by setting `use_ssl` field to true.
-    unless ENV['WITH_ISTIO'] === 'true' then
+    # If this environment variable is false, the app must use TLS, e.g. HTTPS, to access
+    # external services.
+    unless ENV['DO_NOT_USE_TLS_FOR_EXTERNAL_SERVICE_CALLS'] === 'true' then
       http.use_ssl = true
     end
 

--- a/samples/bookinfo/src/mysql/Dockerfile
+++ b/samples/bookinfo/src/mysql/Dockerfile
@@ -15,4 +15,4 @@
 FROM mysql:8
 # MYSQL_ROOT_PASSWORD must be supplied as an env var
 
-COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d/mysqldb-init.sql
+COPY ./mysqldb-init.sql /docker-entrypoint-initdb.d

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -22,6 +22,7 @@ import sys
 from json2html import *
 import logging
 import requests
+import os
 
 # These two lines enable debugging at httplib level (requests->urllib3->http.client)
 # You will see the REQUEST, including HEADERS and DATA, and RESPONSE with HEADERS but without DATA.
@@ -44,26 +45,28 @@ app.logger.setLevel(logging.DEBUG)
 from flask_bootstrap import Bootstrap
 Bootstrap(app)
 
+servicesDomain = "" if (os.environ.get("SERVICES_DOMAIN") == None) else "." + os.environ.get("SERVICES_DOMAIN")
+
 details = {
-    "name" : "http://details:9080",
+    "name" : "http://details{0}:9080".format(servicesDomain),
     "endpoint" : "details",
     "children" : []
 }
 
 ratings = {
-    "name" : "http://ratings:9080",
+    "name" : "http://ratings{0}:9080".format(servicesDomain),
     "endpoint" : "ratings",
     "children" : []
 }
 
 reviews = {
-    "name" : "http://reviews:9080",
+    "name" : "http://reviews{0}:9080".format(servicesDomain),
     "endpoint" : "reviews",
     "children" : [ratings]
 }
 
 productpage = {
-    "name" : "http://productpage:9080",
+    "name" : "http://details{0}:9080".format(servicesDomain),
     "endpoint" : "details",
     "children" : [details, reviews]
 }
@@ -243,6 +246,8 @@ class Writer(object):
 
     def write(self, data):
         self.file.write(data)
+
+    def flush(self):
         self.file.flush()
 
 if __name__ == '__main__':

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -42,13 +42,14 @@ public class LibertyRestEndpoint extends Application {
 
     private final static Boolean ratings_enabled = Boolean.valueOf(System.getenv("ENABLE_RATINGS"));
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
-    private final static String ratings_service = "http://ratings:9080/ratings";
-    
+    private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
+    private final static String ratings_service = "http://ratings" + services_domain + ":9080/ratings";
+
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
     	String result = "{";
     	result += "\"id\": \"" + productId + "\",";
     	result += "\"reviews\": [";
-    	
+
     	// reviewer 1:
     	result += "{";
     	result += "  \"reviewer\": \"Reviewer1\",";


### PR DESCRIPTION
Today, after TLS external services are supported without necessary TLS origination, https://istio.io/blog/2018/egress-https/ must be rewritten to show access with TLS origination and without it. The code of the details must be changed accordingly.