### PR TITLE
Revert #6801 - breaks upgrade from 0.8

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -551,7 +551,6 @@ func getRouteOperation(in *route.Route, vsName string, port int) string {
 	// Otherwise there are multiple destination clusters and destination host is not clear. For that case
 	// return virtual serivce name:port/uri as substitute.
 	if c := in.GetRoute().GetCluster(); model.IsValidSubsetKey(c) {
-		log.Infof("cluster name %s", c)
 		// Parse host and port from cluster name.
 		_, _, h, p := model.ParseSubsetKey(c)
 		return fmt.Sprintf("%s:%d%s", h, p, path)

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -336,18 +336,19 @@ func addDestinationServiceAttributes(attrs attributes, discovery model.ServiceDi
 	attrs["destination.service"] = attrStringValue(destinationHostname.String()) // DEPRECATED. Remove when fully out of use.
 	attrs["destination.service.host"] = attrStringValue(destinationHostname.String())
 
-	serviceAttributes, err := discovery.GetServiceAttributes(destinationHostname)
-	if err == nil && serviceAttributes != nil {
-		if serviceAttributes.Name != "" {
-			attrs["destination.service.name"] = attrStringValue(serviceAttributes.Name)
-		}
-		if serviceAttributes.Namespace != "" {
-			attrs["destination.service.namespace"] = attrStringValue(serviceAttributes.Namespace)
-		}
-		if serviceAttributes.UID != "" {
-			attrs["destination.service.uid"] = attrStringValue(serviceAttributes.UID)
-		}
-	}
+	// Not compatible with Istio 0.8 - can be added back only if version 1.0+ is detected or post 1.0
+	//serviceAttributes, err := discovery.GetServiceAttributes(destinationHostname)
+	//if err == nil && serviceAttributes != nil {
+	//	if serviceAttributes.Name != "" {
+	//		attrs["destination.service.name"] = attrStringValue(serviceAttributes.Name)
+	//	}
+	//	if serviceAttributes.Namespace != "" {
+	//		attrs["destination.service.namespace"] = attrStringValue(serviceAttributes.Namespace)
+	//	}
+	//	if serviceAttributes.UID != "" {
+	//		attrs["destination.service.uid"] = attrStringValue(serviceAttributes.UID)
+	//	}
+	//}
 	return attrs
 }
 


### PR DESCRIPTION
Reverts change breaking 0.8 upgrade test:

```
[2018-07-04 14:53:43.296][25][warning][config] bazel-out/k8-opt/bin/external/envoy/source/common/config/_virtual_includes/grpc_mux_subscription_lib/common/config/grpc_mux_subscription_impl.h:70] gRPC config for type.googleapis.com/envoy.api.v2.RouteConfiguration rejected: Unable to parse JSON as proto (INVALID_ARGUMENT:: Cannot find field.): {"mixer_attributes":{"attributes":{"destination.service.host":{"string_value":"istio-pilot.istio-system.svc.cluster.local"},"destination.service":{"string_value":"istio-pilot.istio-system.svc.cluster.local"}}},"disable_check_calls":true,"forward_attributes":{"attributes":{"destination.service":{"string_value":"istio-pilot.istio-system.svc.cluster.local"},"destination.service.host":{"string_value":"istio-pilot.istio-system.svc.cluster.local"}}}}
```

Can be added back in 1.1 or with some detection or in a backward-compatible way.