### PR TITLE
Add proxy version info to envoy metadata

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -123,6 +123,8 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_ISTIO_PROXY_VERSION
+          value: {{ .Values.global.istioProxyVersion }}
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: ISTIO_META_ISTIO_PROXY_VERSION
+            value: {{ .Values.global.istioProxyVersion }}
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -119,6 +119,8 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: ISTIO_META_ISTIO_PROXY_VERSION
+          value: {{ .Values.global.istioProxyVersion }}
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -136,6 +136,7 @@ type Params struct {
 	DebugMode       bool                   `json:"debugMode"`
 	Mesh            *meshconfig.MeshConfig `json:"-"`
 	ImagePullPolicy string                 `json:"imagePullPolicy"`
+	IstioProxyVersion string                 `json:"istioProxyVersion"`
 	// Comma separated list of IP ranges in CIDR form. If set, only redirect outbound traffic to Envoy for these IP
 	// ranges. All outbound traffic can be redirected with the wildcard character "*". Defaults to "*".
 	IncludeIPRanges string `json:"includeIPRanges"`

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -133,6 +133,12 @@ containers:
     valueFrom:
       fieldRef:
         fieldPath: status.podIP
+  - name: ISTIO_META_ISTIO_PROXY_VERSION
+    {{ if eq .IstioProxyVersion "" -}}
+    value: "0.8.0"
+    {{ else -}}
+    value: {{ .IstioProxyVersion }}
+    {{ end -}}
   - name: ISTIO_META_POD_NAME
     valueFrom:
       fieldRef:

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -184,11 +184,6 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	opts["refresh_delay"] = fmt.Sprintf("{\"seconds\": %d, \"nanos\": %d}", config.DiscoveryRefreshDelay.Seconds, config.DiscoveryRefreshDelay.Nanos)
 	opts["connect_timeout"] = fmt.Sprintf("{\"seconds\": %d, \"nanos\": %d}", config.ConnectTimeout.Seconds, config.ConnectTimeout.Nanos)
 
-	// Failsafe for EDSv2. In case of bugs of problems, the injection template can be modified to
-	// add this env variable. This is short lived, EDSv1 will be deprecated/removed.
-	if os.Getenv("USE_EDS_V1") == "1" {
-		opts["edsv1"] = "1"
-	}
 	opts["cluster"] = config.ServiceCluster
 	opts["nodeID"] = node
 


### PR DESCRIPTION
To allow smooth upgrades from 1.0 to future versions.
I need help to determine the places where this needs to be plugged in.

cc @sdake @costinm @ayj

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>