### PR TITLE
Stackdriver Context Graph adapter: support regional GKE clusters

### DIFF
--- a/mixer/adapter/stackdriver/contextgraph/workload.go
+++ b/mixer/adapter/stackdriver/contextgraph/workload.go
@@ -83,8 +83,12 @@ func (wi workloadInstance) Reify(logger adapter.Logger) ([]entity, []edge) {
 		[4]string{meshUID, workloadNamespace, workloadName, ""},
 	}
 	// TODO: Figure out what the container is for non-GCE clusters.
-	clusterContainer := fmt.Sprintf("//container.googleapis.com/projects/%s/zones/%s/clusters/%s",
-		wi.clusterProject, wi.clusterLocation, wi.clusterName)
+	clusterLocationType := "locations"
+	if strings.Count(clusterLocation, "-") == 2 {
+		clusterLocationType = "zones"
+	}
+	clusterContainer := fmt.Sprintf("//container.googleapis.com/projects/%s/%s/%s/clusters/%s",
+		wi.clusterProject, clusterLocationType, wi.clusterLocation, wi.clusterName)
 
 	var ownerK8sFullName string
 	t := strings.Split(wi.owner, "/")

--- a/mixer/adapter/stackdriver/contextgraph/workload_test.go
+++ b/mixer/adapter/stackdriver/contextgraph/workload_test.go
@@ -14,7 +14,10 @@
 
 package contextgraph
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestWorkloadInstanceReify(t *testing.T) {
 	wi := workloadInstance{
@@ -84,7 +87,7 @@ func TestWorkloadInstanceReify(t *testing.T) {
 		}, {
 			sourceFullName: "//istio.io/projects/org:project/meshes/mesh%2F1/clusterProjects/org2:project2/" +
 				"locations/pangea/clusters/global-mesh/owners/kubernetes%3A%2F%2Fapis%2Fextensions%2Fv1beta1%2Fnamespaces%2Fistio-system%2Fdeployments%2Fistio-policy",
-			destinationFullName: "//container.googleapis.com/projects/org2:project2/zones/pangea/clusters/global-mesh/" +
+			destinationFullName: "//container.googleapis.com/projects/org2:project2/locations/pangea/clusters/global-mesh/" +
 				"k8s/namespaces/istio-system/extensions/deployments/istio-policy",
 			typeName: "google.cloud.contextgraph.Membership",
 		},
@@ -95,6 +98,48 @@ func TestWorkloadInstanceReify(t *testing.T) {
 	for i, e := range edges {
 		if i < len(wantEdges) && e != wantEdges[i] {
 			t.Errorf("edge %d = %#v, want %#v", i, e, wantEdges[i])
+		}
+	}
+}
+
+func TestWorkloadInstanceClusterLocation(t *testing.T) {
+	wi := workloadInstance{
+		meshUID:           "mesh/1",
+		istioProject:      "org:project",
+		clusterProject:    "org2:project2",
+		clusterName:       "global-mesh",
+		uid:               "kubernetes://istio-system/istio-telemetry-65db5b46fc-r7qhq",
+		owner:             "kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-policy",
+		workloadName:      "istio-policy",
+		workloadNamespace: "istio-system",
+	}
+
+	for _, test := range []struct {
+		location, wantFullName string
+	}{
+		{"pangea",
+			"//container.googleapis.com/projects/org2:project2/locations/pangea/" +
+				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+		{"us-central1-a",
+			"//container.googleapis.com/projects/org2:project2/zones/us-central1-a/" +
+				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+		{"us-central1",
+			"//container.googleapis.com/projects/org2:project2/locations/us-central1/" +
+				"clusters/global-mesh/k8s/namespaces/istio-system/extensions/deployments/istio-policy"},
+	} {
+		wi.clusterLocation = test.location
+		_, edges := wi.Reify(mockLogger{})
+		var fullName string
+		for _, e := range edges {
+			if strings.HasPrefix(e.destinationFullName, "//container.googleapis.com/") {
+				if fullName != "" {
+					t.Errorf("Found two container destinations: %q and %q", fullName, e.destinationFullName)
+				}
+				fullName = e.destinationFullName
+			}
+		}
+		if fullName != test.wantFullName {
+			t.Errorf("for location %q, got %q, want %q", test.location, fullName, test.wantFullName)
 		}
 	}
 }


### PR DESCRIPTION
Regional and zonal GKE clusters sadly have different paths; this checks to see if the location is a zone or a region and supplies the correct path in the Stackdriver Context Graph adapter