### PR TITLE
Make the error message when Istio is checked out into the wrong place less confusing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
 .PHONY: check-tree
 check-tree:
 	@if [ "$(ISTIO_GO)" != "$(GO_TOP)/src/istio.io/istio" ]; then \
-		echo Istio not found in GOPATH/src/istio.io. Make sure to clone Istio on that path. $(ISTIO_GO) not under $(GO_TOP) ; \
+		echo Not building in expected path \'GOPATH/src/istio.io/istio\'. Make sure to clone Istio into that path. Istio root=$(ISTIO_GO), GO_TOP=$(GO_TOP) ; \
 		exit 1; fi
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile


### PR DESCRIPTION
The old message says:

Istio not found in GOPATH/src/istio.io. Make sure to clone Istio on that path. /Users/ssuchter/go/src/istio.io not under /Users/ssuchter/go

I had checked out into /Users/ssuchter/go/src/istio.io, not /Users/ssuchter/go/src/istio.io/istio

I found this confusing in multiple ways:
1. Because the first letter was capitalized (I vs i), I thought it was meaning a proper noun, not the directory name (which should have a lower case i)
2. In the next sentence, it says 'on that path' which wasn't obvious that it meant to have a subdirectory called 'istio'
3. In the last sentence, is says that the first directory isn't under the second directory, and you can see it obviously is.

I reworded the error message to be like this:

Not building in expected path 'GOPATH/src/istio.io/istio'. Make sure to clone Istio into that path. Istio root=/Users/ssuchter/go/src/istio.io, GO_TOP=/Users/ssuchter/go