### PR TITLE
Take the latest available GKE version instead of specific one

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -8,7 +8,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ properties['gkeClusterName'] }}
-      initialClusterVersion: 1.9.6-gke.1
+      initialClusterVersion: 1.9
       legacyAbac:
         enabled: false
       initialNodeCount: {{ properties['initialNodeCount'] }}


### PR DESCRIPTION
GKE version updated to supported one as suggested in the related issue.
`1.9` will request the latest minor version available for 1.9.

I re-opened #6540 for `release-1.0` because I think it's important to have a valid GKE value.

Fixes #6520