### PR TITLE
Create the grafana policy at post-install

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-grafana-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: grafana
+data:
+  custom-resources.yaml: |-
+    {{- include "grafana-default.yaml.tpl" . | indent 4}}
+  run.sh: |-
+    {{- include "install-custom-resources.sh.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.global.mtls.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-grafana-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-grafana-post-install-{{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-grafana-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-grafana-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-grafana-post-install-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-grafana-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-grafana-post-install
+      labels:
+        app: istio-grafana
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-grafana-post-install-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          command: [ "/bin/bash", "/tmp/grafana/run.sh", "/tmp/grafana/custom-resources.yaml" ]
+          volumeMounts:
+            - mountPath: "/tmp/grafana"
+              name: tmp-configmap-grafana
+      volumes:
+        - name: tmp-configmap-grafana
+          configMap:
+            name: istio-grafana-custom-resources
+      restartPolicy: OnFailure
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.global.mtls.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -76,4 +75,3 @@ spec:
           configMap:
             name: istio-grafana-custom-resources
       restartPolicy: OnFailure
-{{- end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/grafana-ports-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/grafana-ports-mtls.yaml
@@ -1,0 +1,12 @@
+{{ define "grafana-default.yaml.tpl" }}
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: grafana-ports-mtls-disabled
+  namespace: {{ .Release.Namespace }}
+spec:
+  targets:
+  - name: grafana
+    ports:
+    - number: {{ .Values.service.externalPort }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
@@ -21,15 +21,3 @@ spec:
       name: {{ .Values.service.name }}
   selector:
     app: grafana
----
-apiVersion: authentication.istio.io/v1alpha1
-kind: Policy
-metadata:
-  name: grafana-ports-mtls-disabled
-  namespace: {{ .Release.Namespace }}
-spec:
-  targets:
-  - name: grafana
-    ports:
-    - number: {{ .Values.service.externalPort }}
----


### PR DESCRIPTION
This is to avoid an error when installing Istio from scratch using Helm with the grafana enabled.

Fixes #6238