### PR TITLE
Remove the post-install hooks when they were completed successfully

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -64,7 +64,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: {{ template "mixer.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -59,7 +59,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: istio-security
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
An installation of Istio with mTLS enabled will result in the following state:

```sh
NAME                                       READY     STATUS      RESTARTS   AGE
istio-citadel-85fcc767fc-wpz5q             1/1       Running     0          1m
istio-egressgateway-867bc6b594-2shzs       1/1       Running     0          1m
istio-galley-5f5f9b9676-2q7zs              1/1       Running     0          1m
istio-ingress-787bb7c94b-zpxrz             1/1       Running     0          1m
istio-ingressgateway-6df8678998-6bgjh      1/1       Running     0          1m
istio-mixer-post-install-rfwxk             0/1       Completed   0          1m
istio-pilot-6db8d59464-zdj55               2/2       Running     0          1m
istio-policy-7b978cf7df-dc596              2/2       Running     0          1m
istio-security-post-install-vzlx4          0/1       Completed   0          51s
istio-sidecar-injector-855f88c954-p6lkp    1/1       Running     0          1m
istio-statsd-prom-bridge-59b45fd6d-kfk86   1/1       Running     0          1m
istio-telemetry-7dfcc797b6-hnvnh           2/2       Running     0          1m
prometheus-ffd95f9f6-fcmrj                 1/1       Running     0          1m
```

Although completed, the Mixer and Security post-install jobs are lingering until next install.
This PR remove them upon successful completion leaving the environment a bit cleaner.