### PR TITLE
Correcting duplication of annotations field in values.yaml

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -136,7 +136,6 @@ ingress:
     annotations: {}
     loadBalancerIP: ""
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-    annotations: {}
     ports:
     - port: 80
       name: http


### PR DESCRIPTION
The duplication causes an error when using the script that auto-generates the docs table of possible installation options.