### PR TITLE
Normalize GO_TOP by striping the last slash to meet the condition of check-tree,and thus prevent the 'Not building in expected path' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ GOPATH ?= $(shell cd ${ISTIO_GO}/../../..; pwd)
 export GOPATH
 
 # If GOPATH is made up of several paths, use the first one for our targets in this Makefile
-GO_TOP := $(shell echo ${GOPATH} | cut -d ':' -f1)
+GO_TOP := $(shell realpath ${GOPATH} | cut -d ':' -f1)
 export GO_TOP
 
 # Note that disabling cgo here adversely affects go get.  Instead we'll rely on this

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ GOPATH ?= $(shell cd ${ISTIO_GO}/../../..; pwd)
 export GOPATH
 
 # If GOPATH is made up of several paths, use the first one for our targets in this Makefile
-GO_TOP := $(shell realpath ${GOPATH} | cut -d ':' -f1)
+GO_TOP := $(realpath ${GOPATH} | cut -d ':' -f1)
 export GO_TOP
 
 # Note that disabling cgo here adversely affects go get.  Instead we'll rely on this


### PR DESCRIPTION
Normalize GO_TOP by striping the last slash to meet the condition of check-tree,and thus prevent the build error:`Not building in expected path 'GOPATH/src/istio.io/istio'. Make sure to clone Istio into that path. ...`, in the case  GOPATH is end with a slash.
