### PR TITLE
Release 1 0 fix mcp client test crash

### DIFF
--- a/galley/pkg/mcp/client/client_test.go
+++ b/galley/pkg/mcp/client/client_test.go
@@ -234,7 +234,8 @@ func TestSingleTypeCases(t *testing.T) {
 	defer ts.close()
 
 	c := New(ts, supportedMessageNames, ts, key, metadata)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go c.Run(ctx)
 
 	makeRequest := func(typeURL, version, nonce string, errorCode codes.Code) *mcp.MeshConfigRequest {


### PR DESCRIPTION
The unit test server uses channels to mock a bidirectional grpc
stream. The channels were closed but the client-under-test was not
stopped, resulting in writing to a closed channel.

_NOTE_: This PR is pushed to 1.0 because the unit-test failure may result in false positive for other critical P0 PRs. The fix is low-risk because (1) it only touches a unit test file and (2) mcp is alpha and disabled by default for 1.0.