### PR TITLE
Avoid returning empty strings from k8s env adapter

### DIFF
--- a/mixer/template/sample/template.gen.go
+++ b/mixer/template/sample/template.gen.go
@@ -437,6 +437,9 @@ var (
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
 						if len(field) != len(name) {
+							if !out.WasSet(field) {
+								return nil, false
+							}
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/template/template.gen.go
+++ b/mixer/template/template.gen.go
@@ -328,6 +328,9 @@ var (
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
 						if len(field) != len(name) {
+							if !out.WasSet(field) {
+								return nil, false
+							}
 							switch field {
 
 							case "source_pod_ip":

--- a/mixer/test/spyAdapter/template/template.gen.go
+++ b/mixer/test/spyAdapter/template/template.gen.go
@@ -237,6 +237,9 @@ var (
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
 						if len(field) != len(name) {
+							if !out.WasSet(field) {
+								return nil, false
+							}
 							switch field {
 
 							case "int64Primitive":

--- a/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
+++ b/mixer/tools/codegen/pkg/bootstrapgen/template/bootstrapTemplate.go
@@ -339,6 +339,9 @@ var (
                 func(name string) (value interface{}, found bool) {
                     field := strings.TrimPrefix(name, fullOutName)
                     if len(field) != len(name) {
+                        if !out.WasSet(field) {
+                           return nil, false
+                        }
                         switch field {
                             {{range .OutputTemplateMessage.Fields}}
                             case "{{.ProtoName}}":

--- a/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
+++ b/mixer/tools/codegen/pkg/bootstrapgen/testdata/template.gen.go.golden
@@ -465,6 +465,9 @@ var (
 					func(name string) (value interface{}, found bool) {
 						field := strings.TrimPrefix(name, fullOutName)
 						if len(field) != len(name) {
+							if !out.WasSet(field) {
+								return nil, false
+							}
 							switch field {
 
 							case "int64Primitive":


### PR DESCRIPTION
If the attributes are not derivable from k8s env adapter, it should leave the attributes unset, instead of returning default empty values.