### PR TITLE
Add health check flag to the Citadel

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -38,6 +38,20 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           {{- end }}
+          {{- if .Values.healthCheckEnabled }}
+            - --liveness-probe-path=/tmp/ca.liveness # path to the liveness health check status file
+            - --liveness-probe-interval=60s # interval for health check file update
+            - --probe-check-interval=15s    # interval for health status check
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/istio_ca
+              - probe
+              - --probe-path=/tmp/ca.liveness # path to the liveness health check status file
+              - --interval=125s               # the maximum time gap allowed between the file mtime and the current sys clock.
+            initialDelaySeconds: 60
+            periodSeconds: 60
+          {{- end }}
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -316,6 +316,8 @@ security:
   image: citadel
   selfSigned: true # indicate if self-signed CA is used.
   cleanUpOldCA: true
+  # Enabled Health Check will add the livenessProbe to the Citadel container
+  healthCheckEnabled: false
 
 #
 # addons configuration


### PR DESCRIPTION
Enables adding the `livenessProbe` to the Citadel container.

Fixes #6922