### PR TITLE
Fix racetest following #6890

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ jobs:
             make sync
             make localTestEnv
             set -o pipefail
-            make -k pilot-racetest mixer-racetest broker-racetest security-racetest T=-v | tee -a /go/out/tests/build-log.txt
+            make -k pilot-racetest mixer-racetest security-racetest T=-v | tee -a /go/out/tests/build-log.txt
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - <<: *markJobFinishesOnGCS


### PR DESCRIPTION
In #6890 by @ayj the broker code got removed.
It was removed from the `racetest` make file but not from CircleCI's config which makes the test to fail since then.

Add to #6730 