### PR TITLE
Add app label to gateways

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -166,6 +166,7 @@ gateways:
   istio-ingressgateway:
     enabled: true
     labels:
+      app: istio-ingressgateway
       istio: ingressgateway
     replicaCount: 1
     autoscaleMin: 1
@@ -212,6 +213,7 @@ gateways:
   istio-egressgateway:
     enabled: true
     labels:
+      app: istio-egressgateway
       istio: egressgateway
     replicaCount: 1
     autoscaleMin: 1
@@ -236,6 +238,7 @@ gateways:
   istio-ilbgateway:
       enabled: false
       labels:
+        app: istio-ilbgateway
         istio: ilbgateway
       replicaCount: 1
       autoscaleMin: 1


### PR DESCRIPTION
This PR adds `app` labels to the gateways via helm.

It is entirely focused on improving the UX for various monitoring solutions (including the servicegraph), as `labels["app"]` is used as an expression in various places. This moves these values from being `"unknown"` to properly reflecting their purpose.