### PR TITLE
Add tracing ingress

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+{{- $servicePort := .Values.service.uiPort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: jaeger-query
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: jaeger
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    {{- range $key, $value := .Values.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: jaeger-query
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -3,7 +3,6 @@
 apiVersion: v1
 kind: List
 items:
-{{- if .Values.ingress.enabled }}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -22,13 +21,11 @@ items:
   spec:
     ports:
       - name: query-http
-        port: 80
+        port: {{ .Values.service.uiPort }}
         protocol: TCP
         targetPort: {{ .Values.service.uiPort }}
     selector:
       app: jaeger
-    type: LoadBalancer
-{{- end }}
 - apiVersion: v1
   kind: Service
   metadata:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -419,15 +419,15 @@ tracing:
     enabled: false
     # Used to create an Ingress record.
     hosts:
-      - zipkin.local
+      - tracing.local
     annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     tls:
       # Secrets must be manually created in the namespace.
-      # - secretName: zipkin-tls
+      # - secretName: tracing-tls
       #   hosts:
-      #     - zipkin.local
+      #     - tracing.local
 
 kiali:
   enabled: false


### PR DESCRIPTION
This PR brings the tracing chart in line with the other 'add-on' charts in the way they define their ingress.

The issue with the existing chart is that it does not install the jaeger-query service if the ingress property is not enabled - whereas this service maybe required independent of whether an ingress is defined.

Related to #6923