### PR TITLE
Add namespace to kiali chart secrets

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/secrets.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kiali
+  namespace: {{ .Release.Namespace }}
   labels:
     app: kiali
 


### PR DESCRIPTION
Replaces #6926, being based on the release-1.0 branch.
