### PR TITLE
fix kubeconfig client merging logic

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -610,8 +610,7 @@
 [[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
-  version = "0.3.2"
+  revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -1605,6 +1604,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b1b9b8e8b201a43956fc265f8a6bb4f6b020d0a3c5df3065c7f7df2901910b25"
+  inputs-digest = "9685749234e1dda2f52784e4221c6670fb34bd9d6bed2ba63680b4e5faa7690d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -361,3 +361,7 @@ ignored = [
 [[constraint]]
   name = "github.com/gogo/status"
   revision = "d60b5acac426cb52f7e28124c6aaa862d9f339f5"
+
+[[override]]
+  name = "github.com/imdario/mergo"
+  revision = "6633656539c1639d9d78127b7d47c622b5d7b6dc"

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -45,7 +45,11 @@ func BuildClientConfig(kubeconfig, context string) (*rest.Config, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
 	loadingRules.ExplicitPath = kubeconfig
-	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: context}
+	configOverrides := &clientcmd.ConfigOverrides{
+		ClusterDefaults: clientcmd.ClusterDefaults,
+		CurrentContext:  context,
+	}
+
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
 }
 

--- a/vendor/github.com/imdario/mergo/merge.go
+++ b/vendor/github.com/imdario/mergo/merge.go
@@ -8,35 +8,14 @@
 
 package mergo
 
-import "reflect"
-
-func hasExportedField(dst reflect.Value) (exported bool) {
-	for i, n := 0, dst.NumField(); i < n; i++ {
-		field := dst.Type().Field(i)
-		if field.Anonymous && dst.Field(i).Kind() == reflect.Struct {
-			exported = exported || hasExportedField(dst.Field(i))
-		} else {
-			exported = exported || len(field.PkgPath) == 0
-		}
-	}
-	return
-}
-
-type config struct {
-	overwrite    bool
-	transformers transformers
-}
-
-type transformers interface {
-	Transformer(reflect.Type) func(dst, src reflect.Value) error
-}
+import (
+	"reflect"
+)
 
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *config) (err error) {
-	overwrite := config.overwrite
-
+func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int) (err error) {
 	if !src.IsValid() {
 		return
 	}
@@ -53,167 +32,68 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		// Remember, remember...
 		visited[h] = &visit{addr, typ, seen}
 	}
-
-	if config.transformers != nil && !isEmptyValue(dst) {
-		if fn := config.transformers.Transformer(dst.Type()); fn != nil {
-			err = fn(dst, src)
-			return
-		}
-	}
-
 	switch dst.Kind() {
 	case reflect.Struct:
-		if hasExportedField(dst) {
-			for i, n := 0, dst.NumField(); i < n; i++ {
-				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
-					return
-				}
-			}
-		} else {
-			if dst.CanSet() && !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
-				dst.Set(src)
+		for i, n := 0, dst.NumField(); i < n; i++ {
+			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1); err != nil {
+				return
 			}
 		}
 	case reflect.Map:
-		if len(src.MapKeys()) == 0 && !src.IsNil() && len(dst.MapKeys()) == 0 {
-			dst.Set(reflect.MakeMap(dst.Type()))
-			return
-		}
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {
 				continue
 			}
 			dstElement := dst.MapIndex(key)
-			switch srcElement.Kind() {
-			case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
-				if srcElement.IsNil() {
-					continue
-				}
+			switch reflect.TypeOf(srcElement.Interface()).Kind() {
+			case reflect.Struct:
 				fallthrough
-			default:
-				if !srcElement.CanInterface() {
-					continue
-				}
-				switch reflect.TypeOf(srcElement.Interface()).Kind() {
-				case reflect.Struct:
-					fallthrough
-				case reflect.Ptr:
-					fallthrough
-				case reflect.Map:
-					if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
-						return
-					}
-				case reflect.Slice:
-					srcSlice := reflect.ValueOf(srcElement.Interface())
-
-					var dstSlice reflect.Value
-					if !dstElement.IsValid() || dstElement.IsNil() {
-						dstSlice = reflect.MakeSlice(srcSlice.Type(), 0, srcSlice.Len())
-					} else {
-						dstSlice = reflect.ValueOf(dstElement.Interface())
-					}
-
-					dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
-					dst.SetMapIndex(key, dstSlice)
+			case reflect.Map:
+				if err = deepMerge(dstElement, srcElement, visited, depth+1); err != nil {
+					return
 				}
 			}
-			if dstElement.IsValid() && reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map {
-				continue
-			}
-
-			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
-				if dst.IsNil() {
-					dst.Set(reflect.MakeMap(dst.Type()))
-				}
+			if !dstElement.IsValid() {
 				dst.SetMapIndex(key, srcElement)
 			}
 		}
-	case reflect.Slice:
-		dst.Set(reflect.AppendSlice(dst, src))
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
 		if src.IsNil() {
 			break
-		}
-		if src.Kind() != reflect.Interface {
-			if dst.IsNil() || overwrite {
-				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
-					dst.Set(src)
-				}
-			} else if src.Kind() == reflect.Ptr {
-				if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
-					return
-				}
-			} else if dst.Elem().Type() == src.Type() {
-				if err = deepMerge(dst.Elem(), src, visited, depth+1, config); err != nil {
-					return
-				}
-			} else {
-				return ErrDifferentArgumentsTypes
-			}
-			break
-		}
-		if dst.IsNil() || overwrite {
-			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+		} else if dst.IsNil() {
+			if dst.CanSet() && isEmptyValue(dst) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, config); err != nil {
+		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1); err != nil {
 			return
 		}
 	default:
-		if dst.CanSet() && !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
+		if dst.CanSet() && !isEmptyValue(src) {
 			dst.Set(src)
 		}
 	}
 	return
 }
 
-// Merge will fill any empty for value type attributes on the dst struct using corresponding
-// src attributes if they themselves are not empty. dst and src must be valid same-type structs
-// and dst must be a pointer to struct.
-// It won't merge unexported (private) fields and will do recursively any exported field.
-func Merge(dst, src interface{}, opts ...func(*config)) error {
-	return merge(dst, src, opts...)
-}
-
-// MergeWithOverwrite will do the same as Merge except that non-empty dst attributes will be overriden by
-// non-empty src attribute values.
-// Deprecated: use Merge(…) with WithOverride
-func MergeWithOverwrite(dst, src interface{}, opts ...func(*config)) error {
-	return merge(dst, src, append(opts, WithOverride)...)
-}
-
-// WithTransformers adds transformers to merge, allowing to customize the merging of some types.
-func WithTransformers(transformers transformers) func(*config) {
-	return func(config *config) {
-		config.transformers = transformers
-	}
-}
-
-// WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
-func WithOverride(config *config) {
-	config.overwrite = true
-}
-
-func merge(dst, src interface{}, opts ...func(*config)) error {
+// Merge sets fields' values in dst from src if they have a zero
+// value of their type.
+// dst and src must be valid same-type structs and dst must be
+// a pointer to struct.
+// It won't merge unexported (private) fields and will do recursively
+// any exported field.
+func Merge(dst, src interface{}) error {
 	var (
 		vDst, vSrc reflect.Value
 		err        error
 	)
-
-	config := &config{}
-
-	for _, opt := range opts {
-		opt(config)
-	}
-
 	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
 		return err
 	}
 	if vDst.Type() != vSrc.Type() {
 		return ErrDifferentArgumentsTypes
 	}
-	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, config)
+	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0)
 }

--- a/vendor/github.com/imdario/mergo/mergo.go
+++ b/vendor/github.com/imdario/mergo/mergo.go
@@ -32,7 +32,7 @@ type visit struct {
 	next *visit
 }
 
-// From src/pkg/encoding/json/encode.go.
+// From src/pkg/encoding/json.
 func isEmptyValue(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
@@ -45,10 +45,8 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr, reflect.Func:
+	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
-	case reflect.Invalid:
-		return true
 	}
 	return false
 }

--- a/vendor/github.com/imdario/mergo/testdata/license.yml
+++ b/vendor/github.com/imdario/mergo/testdata/license.yml
@@ -1,4 +1,3 @@
 import: ../../../../fossene/db/schema/thing.yml
 fields:
     site: string
-    author: root


### PR DESCRIPTION
This change aligns the istioctl client config merging logic with
kubectl. kubectl uses an older version of github.com/imdario/mergo
where the Merge() function overwrites existing values. istioctl uses a
newer version which doesn't (see linked issues below). This manifests
in the k8s client loading code with multiple config sources not being
merged properly.

Longer term fix would be to update kubectl and k8s.io/client-go to use
the latest version of github.com/imdario/mergo.

Fixes https://github.com/istio/istio/issues/4938

Related upstream kubernetes issues:
- https://github.com/imdario/mergo/issues/33#issuecomment-357105051
- https://github.com/kubernetes/kubernetes/issues/27543
- https://github.com/kubernetes/kubernetes/pull/23789