### PR TITLE
Remove listeners for newer services when conflicts occur.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:69cbc3e07e29f392a861895651adad124e7b169e70ed77898ba2b34d0c646000"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
@@ -11,105 +12,133 @@
     "logging/internal",
     "logging/logadmin",
     "monitoring/apiv3",
-    "trace/apiv2"
+    "trace/apiv2",
   ]
+  pruneopts = "NUT"
   revision = "0fd7230b2a7505833d5f69b75cbd6c9582401479"
   version = "v0.23.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:af67bcc86941b71716daf8d05575d149209e93533b88314d8473fe6a583d6687"
   name = "code.cloudfoundry.org/copilot"
   packages = [
     ".",
     "api",
-    "testhelpers"
+    "testhelpers",
   ]
+  pruneopts = "NUT"
   revision = "1e7e324f8366ded261140272c9e44d0ee681bdbf"
 
 [[projects]]
+  digest = "1:0a7b52c5d11037c41b6e80e72a87a0ee974096434769d347bb960a9317526af0"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b98abe41e381c878749ef1aa9eb0798616afbb43"
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:afba31ae00ba20bbad534fda5f2eae6d73f195770384f4f21e2609c295b9d417"
   name = "github.com/Azure/go-autorest"
   packages = [
     "autorest",
     "autorest/adal",
     "autorest/azure",
-    "autorest/date"
+    "autorest/date",
   ]
+  pruneopts = "NUT"
   revision = "fc3b03a2d2d1f43fad3007038bd16f044f870722"
   version = "v9.10.0"
 
 [[projects]]
+  digest = "1:e0499b93857a1b91efbdc0c21e26f1130685de98035008f3b01eeeb0713798cb"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:3c2d61d5664a67de3359803cf539cf07aa72902da32e44f78df8c74d7a08749f"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
+  pruneopts = "NUT"
   revision = "9487d3a9d3be5bf3cf60b86ae810b97926964515"
   version = "2.0.0"
 
 [[projects]]
+  digest = "1:44ba3152ffe15e49d62050dffc6e68543a0d641e4dcf94ee715ad687c3a648ed"
   name = "github.com/Masterminds/semver"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "15d8430ab86497c5c0da827b748823945e1cf1e1"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:488fed6de34b17a9126520d2681885360bba914cc5a4667c027aec85f46f418c"
   name = "github.com/Masterminds/sprig"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b217b9c388de2cacde4354c536e520c52c055563"
   version = "v2.14.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:68771094001642d63e4644678a795a83fdb35671976d9d457d45297f44a14cfa"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = "NUT"
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:fdd419e104ec26bb5bd63cc62637c640453ed2929a7453f3afadbd9a0223da66"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
   branch = "master"
+  digest = "1:d37ce795f31d36a50c9a702930268c5f307bb3a224a4cb270ed232d09893b0da"
   name = "github.com/alicebob/gopher-json"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5a6b3ba71ee69b77cf64febf8b5a7526ca5eaef0"
 
 [[projects]]
+  digest = "1:b52ee76223ebe52bce46e0bce06675a7fea92a8bb409cb44f0d0da947848ea07"
   name = "github.com/alicebob/miniredis"
   packages = [
     ".",
-    "server"
+    "server",
   ]
+  pruneopts = "NUT"
   revision = "9d52b1fc8da9c42dae29127fdc6f795ddcd4810f"
   version = "2.3.2"
 
 [[projects]]
+  digest = "1:975108e8d4f5dab096fc991326e96a5716ee8d02e5e7386bb4796171afc4ab9a"
   name = "github.com/aokoli/goutils"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3391d3790d23d03408670993e957e8f408993c34"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:c7282bcb2f709745669782e047a7b4165809792eb266da2ad69b84495a2e59f6"
   name = "github.com/apache/thrift"
   packages = ["lib/go/thrift"]
+  pruneopts = "NUT"
   revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
   version = "0.10.0"
 
 [[projects]]
+  digest = "1:da11949fcbb5aae4c85905235a239f4ce9fd0b191d0ce6c8561aac9ed295fc09"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -139,120 +168,152 @@
     "private/protocol/xml/xmlutil",
     "service/cloudwatch",
     "service/cloudwatch/cloudwatchiface",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "NUT"
   revision = "4b5324816e154564ef4e490842c2e40560971f75"
   version = "v1.13.24"
 
 [[projects]]
   branch = "master"
+  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
   branch = "master"
+  digest = "1:e60ea12cc6af851334368f7df0e3e7f6827189a482324c9e3e9772f279a24df2"
   name = "github.com/bradfitz/slice"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d9036e2120b5ddfa53f3ebccd618c4af275f47da"
 
 [[projects]]
+  digest = "1:cad9bc2b0642bdd28650b794c023cb85ccc46a9949ce10b5c00df7b62dd819d4"
   name = "github.com/cactus/go-statsd-client"
   packages = [
     "statsd",
-    "statsd/statsdtest"
+    "statsd/statsdtest",
   ]
+  pruneopts = "NUT"
   revision = "138b925ccdf617776955904ba7759fce64406cec"
   version = "v3.1.1"
 
 [[projects]]
+  digest = "1:97b8422f271b83e760ce1279715d0f5d124f267459b56806306a64a0f82721c9"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:4de637283dc65619ec3b61bdf7b01179b4145a850e372be5e8e1c587b7c6145b"
   name = "github.com/circonus-labs/circonus-gometrics"
   packages = [
     ".",
     "api",
     "api/config",
-    "checkmgr"
+    "checkmgr",
   ]
+  pruneopts = "NUT"
   revision = "b5b9c6e8f93c67411193a170108e951e642c453c"
   version = "v2.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e225898a44ed568e2f5a43ea14be7b11fd3e71c0a6bf6e5b7fd8405c3222b10e"
   name = "github.com/circonus-labs/circonusllhist"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1e65893c445875524c5610f2a58aef24e30ef98a"
 
 [[projects]]
   branch = "master"
+  digest = "1:8ecb89af7dfe3ac401bdb0c9390b134ef96a97e85f732d2b0604fb7b3977839f"
   name = "github.com/codahale/hdrhistogram"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
   branch = "v2"
+  digest = "1:c91a5363a19174cb0181832821a7bb9da0aeefb5e2180724614b1005c2269712"
   name = "github.com/coreos/go-oidc"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "065b426bd41667456c1a924468f507673629c46b"
 
 [[projects]]
+  digest = "1:7cb4fdca4c251b3ef8027c90ea35f70c7b661a593b9eeae34753c65499098bb1"
   name = "github.com/cpuguy83/go-md2man"
   packages = ["md2man"]
+  pruneopts = "NUT"
   revision = "20f5889cbdc3c73dbd2862796665e7c465ade7d1"
   version = "v1.0.8"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:d897569dc1fa0997991cf2a8705fa61031a3f106d83f95623261bdd73240a06d"
   name = "github.com/dchest/siphash"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "4ebf1de738443ea7f45f02dc394c4df1942a126d"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9f5e5fe15b95106e3b79c9d3cd9467a580b28ab44b2ccc07f617076d736ebdc2"
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
-    "reference"
+    "reference",
   ]
+  pruneopts = "NUT"
   revision = "83389a148052d74ac602f5f1d62f86ff2f3c4aa5"
 
 [[projects]]
   branch = "master"
+  digest = "1:ff6b9b62a30f2237a6f4f8fbe5e89ec522db652998b00f9ded76bd63c1f284fb"
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy"
+    "spdy",
   ]
+  pruneopts = "NUT"
   revision = "bc6354cbbc295e925e4c611ffe90c1f287ee54db"
 
 [[projects]]
+  digest = "1:d9e273c079993d57deb3465f5252f039681fe0b4bb5a6c43c08589b0187f196a"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = "NUT"
   revision = "26b41036311f2da8242db402557a0dbd09dc83da"
   version = "v2.6.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f138a0aeba37ce443490e8ac903362bdd0c8fd4a2c1d328320b8a15bbc53705a"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
     "envoy/admin/v2alpha",
@@ -283,44 +344,56 @@
     "pkg/cache",
     "pkg/log",
     "pkg/server",
-    "pkg/util"
+    "pkg/util",
   ]
+  pruneopts = "T"
   revision = "8da69c22276922e7f517b8b04d474f799f5cae1c"
 
 [[projects]]
+  digest = "1:ad32dc29f37281bacb5dcedff17c9461dc1739dc8a5f63a71ab491c6e92edf8d"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "afac545df32f2287a079e2dfb7ba2745a643747e"
   version = "v3.0.0"
 
 [[projects]]
+  digest = "1:1a1fda2eefc60b9b047b3812b26be4779352aa80cab966b77e6fe77b157a7a4b"
   name = "github.com/fluent/fluent-logger-golang"
   packages = ["fluent"]
+  pruneopts = "NUT"
   revision = "8bbc2356beaf021b04c9bd5cdc76ea5a7ccb40ec"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:f26133af0db0007ccbd4830a033f7124c38cbab8afecd06452f17c6b7fd4c3a9"
   name = "github.com/garyburd/redigo"
   packages = [
     "internal",
-    "redis"
+    "redis",
   ]
+  pruneopts = "NUT"
   revision = "a69d19351219b6dd56f274f96d85a7014a2ec34e"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:27b7ff77d8f9de0ca6f1e821e09246aaa83132d07b8606ca0ed1dcacdcc1dded"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6333e38ac20b8949a8dd68baa3650f4dee8f39f0"
   version = "v1.33.0"
 
 [[projects]]
+  digest = "1:17a3e1bcb1d09ad7a3d1ca4eaf22d9c45fa5cd9848c964a9b3945e57fd69c1e8"
   name = "github.com/go-redis/redis"
   packages = [
     ".",
@@ -330,12 +403,14 @@
     "internal/pool",
     "internal/proto",
     "internal/singleflight",
-    "internal/util"
+    "internal/util",
   ]
+  pruneopts = "NUT"
   revision = "877867d2845fbaf86798befe410b6ceb6f5c29a3"
   version = "v6.10.2"
 
 [[projects]]
+  digest = "1:c34b254950cbbcfc71edaec88d329f1cf56902ec47de568417549a418879674c"
   name = "github.com/gobwas/glob"
   packages = [
     ".",
@@ -345,21 +420,25 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings"
+    "util/strings",
   ]
+  pruneopts = "NUT"
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
   version = "v0.2.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:14b8346469495ac03923026eb8ee5cb48f9873ee472e239f7208d4f5a20cd884"
   name = "github.com/gogo/googleapis"
   packages = [
     "google/api",
-    "google/rpc"
+    "google/rpc",
   ]
+  pruneopts = "T"
   revision = "0cd9801be74a10d5ac39d69626eac8255ffcd502"
 
 [[projects]]
+  digest = "1:2a1db9bae44464f781d3637b67df38e896c6e1b9c902e27d24ee9037cb50f23b"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
@@ -367,30 +446,38 @@
     "proto",
     "protoc-gen-gogo/descriptor",
     "sortkeys",
-    "types"
+    "types",
   ]
+  pruneopts = "T"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:93dfbd1ff3309dcd3573c7fec6ae3db24cba9a2373bcf303008ed8e8262b57e0"
   name = "github.com/gogo/status"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d60b5acac426cb52f7e28124c6aaa862d9f339f5"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0f096f9332ad5f84341de82db69fd098864b17c668333a1fbbffd1b846dcc2b"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2cc4b790554d1a0c48fcc3aeb891e3de70cf8de0"
   source = "github.com/istio/glog"
 
 [[projects]]
   branch = "master"
+  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = "NUT"
   revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
 
 [[projects]]
+  digest = "1:f06f5af7cd9a366aa7f3efd821df2e42a68c6371eb7313d460ee3c51f39cbe47"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -403,65 +490,83 @@
     "ptypes/empty",
     "ptypes/struct",
     "ptypes/timestamp",
-    "ptypes/wrappers"
+    "ptypes/wrappers",
   ]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9413ddbde906f91f062fda0dfa9a7cff43458cd1b2282c0fa25c61d89300b116"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "github.com/golang/sync"
   packages = ["errgroup"]
+  pruneopts = "NUT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
+  digest = "1:51bee9f1987dcdb9f9a1b4c20745d78f6bf6f5f14ad4e64ca883eb64df4c0045"
   name = "github.com/google/go-github"
   packages = ["github"]
+  pruneopts = "NUT"
   revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
   version = "v15.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = "NUT"
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:1bb197a3b5db4e06e00b7560f8e89836c486627f2a0338332ed37daa003d259e"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
+  digest = "1:fe852c57b4fc4d11e6ef79bce1e930ee2f2f7d148b370afef8f8d012a80960ea"
   name = "github.com/googleapis/gax-go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:1326ee75d625e65c37f388f2dc058083418f07a529adf4c2792015dd1bbc6780"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "NUT"
   revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a4d08bac611acf00142f2a31c9bac2a6bbb08bc55ee010c8cacf38858a5452ec"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -470,93 +575,121 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/utils",
-    "pagination"
+    "pagination",
   ]
+  pruneopts = "NUT"
   revision = "2daf3049f2a9913e6e5bf54926fd90efb1f9a0f0"
 
 [[projects]]
+  digest = "1:dbd86d229eacaa86a98b10f8fb3e3fc69a1913e0f4e010e7cc1f92bf12edca92"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:eced3d718020962f1cc6ac109b840ba17dc817a291062b5948ba7aecc8c6665d"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:3b708ebf63bfa9ba3313bedb8526bc0bb284e51474e65e958481476a9d4a12aa"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:6dfcf03e0fc46617c6e2eaca1a792a072a2adf9a6a33f958a4f87ac3fe9149b9"
   name = "github.com/grpc-ecosystem/go-grpc-middleware"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "aed189ae50cf2ee326c1de8c083f3187e574e0d8"
 
 [[projects]]
+  digest = "1:96c558cff0532e2e9ffc0b6d7c8c7431c592d781b109343aa51e27f9fd9a6b82"
   name = "github.com/grpc-ecosystem/go-grpc-prometheus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6b7015e65d366bf3f19b2b2a000a831940f0f7e0"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:5fe0eca2183ce87ed273e9e8e0ea415bc1164599bf938092bdd5c2e9be8a9ace"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
+  pruneopts = "NUT"
   revision = "0e7658f8ee99ee5aa683e2a032b8880091b7a055"
 
 [[projects]]
+  digest = "1:bc96aad31f2a5f3bdae5edb9d33b4c1a35e42acf8d56c065bfcc6bd469037bb1"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
+  pruneopts = "NUT"
   revision = "9a494b5fb9c86180a5702e29c485df1507a47198"
   version = "v1.0.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0d9d74edbd40fdeada436d5ac9cb5197407899af3fef85ff0137077ffe8ae19"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:a5d940c38bf56f121721bfa747c66356df387cb9d5318c570c6d4170aab62862"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:4d55897d00e9b53c1c716e8fe504de3d21bec8edba0a330bfaa87902695e46e2"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
   branch = "master"
+  digest = "1:dc4366a15678a34f62f5806a6c3eca43aaaae6e6e7a4539bc7efcaf3b6028958"
   name = "github.com/hashicorp/go-retryablehttp"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "794af36148bf63c118d6db80eb902a136b907e71"
 
 [[projects]]
   branch = "master"
+  digest = "1:21017d4f73bafd34ac326337d60bc431e9d736d1f4ef90fc5b464b58dba3c8a3"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
   branch = "master"
+  digest = "1:13e2fa5735a82a5fb044f290cfd0dba633d1c5e516b27da0509e0dbb3515a18e"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NUT"
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
+  digest = "1:9e86f696cf1e38e2e71d42a4a6fb0807e8038ce00bcad32b1ba51117ae51cba0"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -567,130 +700,170 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "NUT"
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:8926b09bc7e669ef6aec95f6ad5abb7240f232cc217f3841f9097d5c8c482666"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
+  pruneopts = "NUT"
   revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:8f4d123953b43699018f24ac5000818af8abb180528f14d803fe6fb8002bf6c5"
   name = "github.com/hashicorp/vault"
   packages = [
     "api",
     "helper/compressutil",
     "helper/jsonutil",
     "helper/parseutil",
-    "helper/strutil"
+    "helper/strutil",
   ]
+  pruneopts = "NUT"
   revision = "5dd7f25f5c4b541f2da62d70075b6f82771a650d"
   version = "v0.10.0"
 
 [[projects]]
+  digest = "1:002e717d1aba87b3b5d85f50c7f4755679866edb6297a46679cbd2b7c74a084c"
   name = "github.com/howeyc/fsnotify"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "441bbc86b167f3c1f4786afae9931403b99fdacf"
   version = "v0.9.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b7f860847a1d71f925ba9385ed95f1ebc0abfeb418a78e219ab61f48fdfeffad"
   name = "github.com/howeyc/gopass"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  digest = "1:f5db19d350bd0b542d17f7e7cf4e7068bac416c08adb6a129b3c6d1db8211051"
   name = "github.com/huandu/xstrings"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "2bf18b218c51864a87384c06996e40ff9dcff8e1"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:cf327083982a19eae01f70be6663a935a02bac3a2dc79efbc19668c8378bfbb3"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "163f41321a19dd09362d4c63cc2489db2015f1f4"
   version = "0.3.2"
 
 [[projects]]
+  digest = "1:406338ad39ab2e37b7f4452906442a3dbf0eb3379dd1f06aafb5c07e769a5fbb"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:ea0e9c42fc8bbc0b5d8e88df4550dc6737e1a1ae2074884a6f3a46082ca872d2"
   name = "github.com/istio/tools"
   packages = ["protoc-gen-docs"]
+  pruneopts = "NUT"
   revision = "ca7e3cf34b0ed739c37e2ff50b6ae0632da9911e"
 
 [[projects]]
+  digest = "1:ac6d01547ec4f7f673311b4663909269bfb8249952de3279799289467837c3cc"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:42c47ace7ccb114261ef7e0d418d274921514ab50a3bf6bdb9e51c3dde8ce13d"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
   version = "1.1.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:f91bb67d051a94cf6ab2cf07eee0550432afc31655838d42cdec258db4b348f0"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:e361d686ef1e70b8bd268cfb3953fcc0d59b43d4e5b6ad9a80112b06bff6cb2b"
   name = "github.com/lyft/protoc-gen-validate"
   packages = ["validate"]
+  pruneopts = "NUT"
   revision = "930a67cf7ba41b9d9436ad7a1be70a5d5ff6e1fc"
   version = "v0.0.6"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NUT"
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b62c4f18ad6eb454ac5253e7791ded3d7867330015ca4b37b6336e57f514585e"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
   branch = "master"
+  digest = "1:eeb1f466766c40a4656b090593e103d2ce327b914329232bc1d4632dae17fc4f"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
 
 [[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:314a5881fab303a80d6d2e35a77000f2224bb50f09ef63a9aa4c1f9eaef985d8"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:80c34337e8a734e190f2d1b716cae774cca74db98315166f92074434e9af0227"
   name = "github.com/natefinch/lumberjack"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
   version = "v2.1"
 
 [[projects]]
+  digest = "1:bb9042d54ccbd35f6f91584e8f1729d319d2c80b0031f66c62bea9a451dac744"
   name = "github.com/onsi/ginkgo"
   packages = ["config"]
+  pruneopts = "NUT"
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:32b6e270bb2709e5dee469d2319b90ee73137eb2b153b33f8093bd170aa1b999"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -706,12 +879,14 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = "NUT"
   revision = "003f63b7f4cff3fc95357005358af2de0f5fe152"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:6e84b99a796a98598b0de4c99376ed1b22860140529d307b80503a379c7c622d"
   name = "github.com/open-policy-agent/opa"
   packages = [
     "ast",
@@ -722,160 +897,204 @@
     "topdown",
     "topdown/builtins",
     "types",
-    "util"
+    "util",
   ]
+  pruneopts = "NUT"
   revision = "688594c3786b0805d061a0de387f6a265a7fa9d0"
   version = "v0.7.1"
 
 [[projects]]
+  digest = "1:e0cc8395ea893c898ff5eb0850f4d9851c1f57c78c232304a026379a47a552d0"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
   branch = "master"
+  digest = "1:61820d62888624679de099adf44bb6cf2fd55b7f9e8f4f8d320d9d9d28bee938"
   name = "github.com/openshift/api"
   packages = ["apps/v1"]
+  pruneopts = "NUT"
   revision = "dca24d1902afee9d2be02425a2d7c9f910063631"
 
 [[projects]]
+  digest = "1:7fea98b6541d058ba0ae5496d57d420d396a3f121a0aec64b4ec2171b0a93846"
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
   ]
+  pruneopts = "NUT"
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:cce3a18fb0b96b5015cd8ca03a57d20a662679de03c4dc4b6ff5f17ea2050fa6"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:44c66ad69563dbe3f8e76d7d6cad21a03626e53f1875b5ab163ded419e01ca7a"
   name = "github.com/philhofer/fwd"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "bb6d471dc95d4fe11e432687f8b70ff496cf3136"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d7a105e63e6268ccf865aa680c419d905a92cdddff1394409a554c0f1f22072b"
   name = "github.com/pquerna/cachecontrol"
   packages = [
     ".",
-    "cacheobject"
+    "cacheobject",
   ]
+  pruneopts = "NUT"
   revision = "525d0eb5f91d30e3b1548de401b7ef9ea6898520"
 
 [[projects]]
+  digest = "1:cef42830c5d06beae276a5f8ea263fc9af140567f2ddcc2d9a4c71c3c0d8d97d"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
     "api/prometheus/v1",
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NUT"
   revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
   version = "v0.9.0-pre1"
 
 [[projects]]
   branch = "master"
+  digest = "1:53a76eb11bdc815fcf0c757a9648fda0ab6887da13f07587181ff2223b67956c"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:961880ec9eb36ddb61f4c512e600ee0a94c5f0b20840d5e04ee1d4aae607776a"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
     "log",
-    "model"
+    "model",
   ]
+  pruneopts = "NUT"
   revision = "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a"
 
 [[projects]]
   branch = "master"
+  digest = "1:604744be795a5d7b32f64c8d6b78c11514335f0b66991f63ce8a0476ac51a576"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NUT"
   revision = "780932d4fbbe0e69b84c34c20f5c8d0981e109ea"
 
 [[projects]]
   branch = "master"
+  digest = "1:dd44fe8710ad4ed088feee198935587ae26de0f8e2731a7b5a54bc4e98a0edbb"
   name = "github.com/prometheus/prom2json"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "daa2bca1c13fce65dabc24d4fbd5054d50cf66d9"
 
 [[projects]]
   branch = "master"
+  digest = "1:89948a031cefb021d77be478c260502337228ad35eb5e8c811eb16f0a759b9ae"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "8732c616f52954686704c8645fe1a9d59e9df7c1"
 
 [[projects]]
+  digest = "1:bcfa8e184764796499312e55cd8a5fff63896eca0d6faff6b6e43ac6a98a498a"
   name = "github.com/russross/blackfriday"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "55d61fa8aa702f59229e6cff85793c22e580eaf5"
   version = "v1.5.1"
 
 [[projects]]
+  digest = "1:cb24eec7a9478395847671abfbea162885f0be9c7ff6ef20b699dc20804ae1a4"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
   name = "github.com/satori/go.uuid"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:45010b961ea5349797980f57e2b7cd54b398d71ec3aba056a6bf2916d7cce024"
   name = "github.com/sethgrid/pester"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ed9870dad3170c0b25ab9b11830cc57c3a7798fb"
 
 [[projects]]
   branch = "master"
+  digest = "1:debf1a119378d059b68925f1796851b6855bfc2f55419a50d634ecce3eabd8e8"
   name = "github.com/shurcooL/sanitized_anchor_name"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "86672fcb3f950f35f2e675df2240550f2a50762f"
 
 [[projects]]
   branch = "master"
+  digest = "1:74a468852019b3440166581a31d8c4c8b44a8c8ae05979277c441ba9b6b53be3"
   name = "github.com/signalfx/com_signalfx_metrics_protobuf"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "93e507b42f43f458a109ca278d1542a26a0b87fc"
 
 [[projects]]
   branch = "master"
+  digest = "1:e3e4baeb39e30cfbe15396d38cb3780f2d1788ebf2663d198ce041411dc04f37"
   name = "github.com/signalfx/gohistogram"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "1ccfd2ff508314074672f4450a917011a2060408"
 
 [[projects]]
+  digest = "1:6d2568c2224155c27d78497d7bd3d9bba6559eb8ca5e3cbff2f2965365565515"
   name = "github.com/signalfx/golib"
   packages = [
     "datapoint",
@@ -885,57 +1104,73 @@
     "log",
     "sfxclient",
     "timekeeper",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "b1be94c3ec8d1fdeccd62735b851489f0b3798e0"
   version = "v1.1.6"
 
 [[projects]]
+  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:f6511f6d3b472aa9a56703ffb09f073a4dd6fc0c83d78103e2a60466a47f1eea"
   name = "github.com/spf13/cobra"
   packages = [
     ".",
-    "doc"
+    "doc",
   ]
+  pruneopts = "NUT"
   revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
   version = "v0.0.2"
 
 [[projects]]
+  digest = "1:3ab855aa584d08db6541ce99dad60c12bd6a328ecb8a7358363887f85c976347"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:5e11bbce28350eb595975f090b0b0f1eebc494f8073ebe79ea14dd172283d972"
   name = "github.com/square/certstrap"
   packages = ["pkix"]
+  pruneopts = "NUT"
   revision = "fa1359e6e510efcf9cd67bc0edbe43d7300a7833"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:a852b1ad03ca063d2c57866d9f94dcb1cb2e111415c5902ce0586fc2d207221b"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:eaa6698f44de8f2977e93c9b946e60a8af75f565058658aad2df8032b55c84e5"
   name = "github.com/tinylib/msgp"
   packages = ["msgp"]
+  pruneopts = "NUT"
   revision = "b2b6a672cf1e5b90748f79b8b81fc8c5cf0571a1"
   version = "1.0.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:1e4c6579336a71d60c374c18fefca05377a3b241d5e0b246caa6efd37a1d1369"
   name = "github.com/tv42/httpunix"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b75d8614f926c077e48d85f1f8f7885b758c6225"
 
 [[projects]]
+  digest = "1:b666d32353a1d6bf7a783d4d0dc94c9790f318516b4a38984ea503a79c5d2d28"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -950,35 +1185,43 @@
     "transport",
     "transport/zipkin",
     "utils",
-    "zipkin"
+    "zipkin",
   ]
+  pruneopts = "NUT"
   revision = "c107110d057826281414cb964f167bce5be17588"
   version = "v2.12.0"
 
 [[projects]]
+  digest = "1:0da2810678a062e0567c3215911869b0423da0e497c56683ff8e87e7a6952597"
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
+  pruneopts = "NUT"
   revision = "4267858c0679cd4e47cefed8d7f70fd386cfb567"
   version = "v1.4.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c6ef772d4fbc609fa153c0bb3dbe633b221130dae7cf9a61ccce8ac112f57170"
   name = "github.com/yashtewari/glob-intersection"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "7af743e8ec8480fee1932a737a406f7ec817f910"
 
 [[projects]]
   branch = "master"
+  digest = "1:f82afe3b9f4175f8d737257ffb0b16f72b0bf054cd7e967839ab9271279e51e8"
   name = "github.com/yuin/gopher-lua"
   packages = [
     ".",
     "ast",
     "parse",
-    "pm"
+    "pm",
   ]
+  pruneopts = "NUT"
   revision = "84ea3a3c79b3c4b3b39606cc96f255cd63635ce0"
 
 [[projects]]
+  digest = "1:b038bdba39feddf53cd499a9732108607534724aa1b034dfd0cf003da2283ed5"
   name = "go.opencensus.io"
   packages = [
     "exporter/stackdriver/propagation",
@@ -993,24 +1236,30 @@
     "tag",
     "trace",
     "trace/internal",
-    "trace/propagation"
+    "trace/propagation",
   ]
+  pruneopts = "NUT"
   revision = "c3ed530f775d85e577ca652cb052a52c078aad26"
   version = "v0.11.0"
 
 [[projects]]
+  digest = "1:8eff4c694254322268936dc162805ff95ac846435e909f011ba43805bb9b4e0f"
   name = "go.uber.org/atomic"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "8474b86a5a6f79c443ce4b2992817ff32cf208b8"
   version = "v1.3.1"
 
 [[projects]]
+  digest = "1:58ca93bdf81bac106ded02226b5395a0595d5346cdc4caa8d9c1f3a5f8f9976e"
   name = "go.uber.org/multierr"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:93ca63fc5341f2dd07216941f51d990e0fbc3ea6e35b7c153c0409ca411b83be"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -1019,31 +1268,37 @@
     "internal/color",
     "internal/exit",
     "zapcore",
-    "zapgrpc"
+    "zapgrpc",
   ]
+  pruneopts = "NUT"
   revision = "35aad584952c3e7020db7b839f6b102de6271f89"
   version = "v1.7.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5791bbafb386740ff5ad5b3259ea6a9290e97ca1a7dff3f8dbe3bfaf261910"
   name = "go4.org"
   packages = ["reflectutil"]
+  pruneopts = "NUT"
   revision = "9599cf28b011184741f249bd9f9330756b506cbc"
 
 [[projects]]
   branch = "master"
+  digest = "1:19d1141ec7245db886df0d6c8e134f6204a7da780d68b56570f7461ec631035b"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
     "ed25519/internal/edwards25519",
     "pbkdf2",
     "scrypt",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = "NUT"
   revision = "88942b9c40a4c9d203b82b3731787b672d6e809b"
 
 [[projects]]
   branch = "master"
+  digest = "1:b84f2fcf8e506e4592ab192fdc9a3bb8c7567bdcb39d6e973a1aaaaabbdbaf87"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -1056,40 +1311,48 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
   ]
+  pruneopts = "NUT"
   revision = "6078986fec03a1dcc236c34816c71b0e05018fda"
 
 [[projects]]
   branch = "master"
+  digest = "1:46d51403ff2c42fce53d789fa91252a9737c37be95f77edfc609656c9dbb4751"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = "NUT"
   revision = "fdc9e635145ae97e6c2cb777c48305600cf515cb"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0140c0c868c6e0f01c0380865194592c011fe521d6e12d78bfd33e756fe018a"
   name = "golang.org/x/sync"
   packages = ["semaphore"]
+  pruneopts = "NUT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:5fbc1827a937001bd5ada54907c053791ed946195515abdbb98395276b149eb7"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
     "windows/registry",
-    "windows/svc/eventlog"
+    "windows/svc/eventlog",
   ]
+  pruneopts = "NUT"
   revision = "378d26f46672a356c46195c28f61bdb4c0a781dd"
 
 [[projects]]
+  digest = "1:662ba4579f5a6cd02a6d54c8e99517f1166fda9fee60519258e1e2f64d232b78"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -1117,28 +1380,34 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:51a479a09b7ed06b7be5a854e27fcc328718ae0e5ad159f9ddeef12d0326c2e7"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NUT"
   revision = "26559e0f760e39c24d730d3224364aef164ee23f"
 
 [[projects]]
   branch = "master"
+  digest = "1:b622ec8798492f8225ad6b03f942844c8aea43cf7748a3415763dd79332274c7"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
-    "imports"
+    "imports",
   ]
+  pruneopts = "NUT"
   revision = "77106db15f689a60e7d4e085d967ac557b918fb2"
 
 [[projects]]
   branch = "master"
+  digest = "1:eb7f28ba6e3a772ccf9bce19464f7a0ead6ecf91c969f3f9c3fe52cd8b99a524"
   name = "google.golang.org/api"
   packages = [
     "gensupport",
@@ -1152,11 +1421,13 @@
     "support/bundler",
     "transport",
     "transport/grpc",
-    "transport/http"
+    "transport/http",
   ]
+  pruneopts = "NUT"
   revision = "dbbc13f71100fa6ece308335445fca6bb0dd5c2f"
 
 [[projects]]
+  digest = "1:820b35d8dcca07fedbe257fd224c3d1b9ea85e6dbc3c0fbbf3df2f28c4a38f45"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -1170,13 +1441,15 @@
     "internal/socket",
     "internal/urlfetch",
     "socket",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "NUT"
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:85f8f3fe32639472b7c046b2b51771ab03182cbbdcb52c9e95c0915471a5e790"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
@@ -1191,11 +1464,13 @@
     "googleapis/logging/v2",
     "googleapis/monitoring/v3",
     "googleapis/rpc/status",
-    "protobuf/field_mask"
+    "protobuf/field_mask",
   ]
+  pruneopts = "NUT"
   revision = "ab0870e398d5dd054b868c0db1481ab029b9a9f2"
 
 [[projects]]
+  digest = "1:fcd35d1e9b9f34a41d343e860db4268b5944f8b718bdbb7e3f7faff03f130bd8"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -1227,71 +1502,91 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "NUT"
   revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
   version = "v1.12.0"
 
 [[projects]]
+  digest = "1:22b2dee6f30bc8601f087449a2a819df8388e54e9547349c658f14d8f8c590f2"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [[projects]]
+  digest = "1:b543ccca3ea7427f4e10dd96d1031d92539e634a9ce8b63cecdb93a19d34700c"
   name = "gopkg.in/d4l3k/messagediff.v1"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "29f32d820d112dbd66e58492a6ffb7cc3106312b"
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:341a7df38da99fe91ed40e4008c13cc5d02dcc98ed1a094360cb7d5df26d6d26"
   name = "gopkg.in/logfmt.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:4e5a9cf82174cea34d2a04859fa7c22444d0f597c6666ebe32397d648c03c60a"
   name = "gopkg.in/russross/blackfriday.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "cadec560ec52d93835bf2f15bd794700d3a2473b"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:5ad9c049c7b40ffdda4332ade4602424b093c2f5136091b953a1b6fe29d8b61e"
   name = "gopkg.in/square/go-jose.v2"
   packages = [
     ".",
     "cipher",
-    "json"
+    "json",
   ]
+  pruneopts = "NUT"
   revision = "76dd09796242edb5b897103a75df2645c028c960"
   version = "v2.1.6"
 
 [[projects]]
+  digest = "1:a1efdbc2762667c8a41cbf02b19a0549c846bf2c1d08cad4f445e3344089f1f0"
   name = "gopkg.in/stack.v1"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:1ab6db2d2bd353449c5d1e976ba7a92a0ece6e83aaab3e6674f8f2f1faebb85a"
   name = "gopkg.in/validator.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "59c90c7046f643cbe0d4e7c8776c42a84ce75910"
 
 [[projects]]
+  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:24c9fdc0fd1d3a9bdfb28afff78157394ac858d2406bc7add94784b0376b7be5"
   name = "istio.io/api"
   packages = [
     "authentication/v1alpha1",
@@ -1306,11 +1601,13 @@
     "networking/v1alpha3",
     "policy/v1beta1",
     "rbac/v1alpha1",
-    "routing/v1alpha1"
+    "routing/v1alpha1",
   ]
+  pruneopts = "T"
   revision = "2d182f5d150eaa9ac276347df8f0154f209973dc"
 
 [[projects]]
+  digest = "1:737dc897c386ed456eaf3bef1b1b1f6eb89a3c965e492b883758a839a3d650a8"
   name = "istio.io/fortio"
   packages = [
     ".",
@@ -1322,13 +1619,14 @@
     "periodic",
     "stats",
     "ui",
-    "version"
+    "version",
   ]
+  pruneopts = "T"
   revision = "b508c4b471a13fbe9f2e219ab6091e8f688b9836"
   version = "v1.0.0"
 
 [[projects]]
-  branch = "release-1.10"
+  digest = "1:9901e970bf9e2a578e722d5731c324f0d09a72de13aa10efb397891f5561299b"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -1359,11 +1657,14 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NUT"
   revision = "8b7507fac302640dd5f1efbf9643199952cc58db"
+  version = "kubernetes-1.10.4"
 
 [[projects]]
+  digest = "1:a2be8ed9249dfc0b602b506bfa7eac89ae769446dbe726a4a2ff08996e90cb70"
   name = "k8s.io/apiextensions-apiserver"
   packages = [
     "pkg/apis/apiextensions",
@@ -1371,12 +1672,14 @@
     "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
-    "pkg/features"
+    "pkg/features",
   ]
+  pruneopts = "NUT"
   revision = "8e7f43002fec5394a8d96ebca781aa9d4b37aaef"
   version = "kubernetes-1.10.4"
 
 [[projects]]
+  digest = "1:46ff67de7914d41f6b214de2bbe519d05ace9807a050b0dbacb70242b77062ea"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -1424,22 +1727,26 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NUT"
   revision = "17529ec7eadb8de8e7dc835201455f53571f655a"
   version = "kubernetes-1.10.4"
 
 [[projects]]
   branch = "master"
+  digest = "1:b2424188db3a007c63cb54f0318adf4fd7173a1f54e57dec3c9d0d5270ef94b2"
   name = "k8s.io/apiserver"
   packages = [
     "pkg/features",
-    "pkg/util/feature"
+    "pkg/util/feature",
   ]
+  pruneopts = "NUT"
   revision = "f4a9d31325865f18b8023622a564578f079d582b"
 
 [[projects]]
   branch = "release-7.0"
+  digest = "1:ce8a4f1991a780921e582b0a8cb8b7761cf2dac99c6e1046eec3058884040d1c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1542,17 +1849,21 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NUT"
   revision = "26a26f55b28aa1b338fbaf6fbbe0bcd76aed05e0"
 
 [[projects]]
+  digest = "1:58ab731bcfa98d0eb090bdde8a05275e7cc27957d21538b12527c659c3d372c3"
   name = "k8s.io/cluster-registry"
   packages = ["pkg/apis/clusterregistry/v1alpha1"]
+  pruneopts = "NUT"
   revision = "423735c7f10cbbc83ccee14d62b266ddcf9709dd"
   version = "v0.0.6"
 
 [[projects]]
+  digest = "1:7cf5966b13d204189456804f06f1b727a4bc2c52fdd3d555746d410cdcd3eb9e"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
@@ -1562,12 +1873,14 @@
     "pkg/proto/hapi/version",
     "pkg/sympath",
     "pkg/timeconv",
-    "pkg/version"
+    "pkg/version",
   ]
+  pruneopts = "NUT"
   revision = "a80231648a1473929271764b920a8e346f6de844"
   version = "v2.8.2"
 
 [[projects]]
+  digest = "1:0c90432acd2171fd5150bb618539f6ffcccba28f0e2df73f8dddbefaaa6644db"
   name = "k8s.io/ingress"
   packages = [
     "core/pkg/ingress/annotations/class",
@@ -1577,18 +1890,22 @@
     "core/pkg/ingress/store",
     "core/pkg/k8s",
     "core/pkg/strings",
-    "core/pkg/task"
+    "core/pkg/task",
   ]
+  pruneopts = "NUT"
   revision = "fe19ebb09ee22f90d60ba3111ae0a9db6027e675"
   version = "0.9.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:e0d6dcb28c42a53c7243bb6380badd17f92fbd8488a075a07e984f91a07c0d23"
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
+  pruneopts = "NUT"
   revision = "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
 
 [[projects]]
+  digest = "1:d76101903ea467a9b4a4415e7c3a7d603bdb499b3b2fa90a3fb6a0b8284e4d8d"
   name = "k8s.io/kubernetes"
   packages = [
     "pkg/apis/autoscaling",
@@ -1598,14 +1915,246 @@
     "pkg/apis/networking",
     "pkg/features",
     "pkg/util/parsers",
-    "pkg/util/pointer"
+    "pkg/util/pointer",
   ]
+  pruneopts = "NUT"
   revision = "5ca598b4ba5abb89bb773071ce452e33fb66339d"
   version = "v1.10.4"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "70f66277068be52e07b9b2e40c6959ddae2b8708745af55a9a22cac843b99210"
+  input-imports = [
+    "cloud.google.com/go/compute/metadata",
+    "cloud.google.com/go/logging",
+    "cloud.google.com/go/logging/logadmin",
+    "cloud.google.com/go/monitoring/apiv3",
+    "code.cloudfoundry.org/copilot",
+    "code.cloudfoundry.org/copilot/api",
+    "code.cloudfoundry.org/copilot/testhelpers",
+    "contrib.go.opencensus.io/exporter/stackdriver",
+    "github.com/DataDog/datadog-go/statsd",
+    "github.com/alicebob/miniredis",
+    "github.com/alicebob/miniredis/server",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/ec2metadata",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/awstesting/unit",
+    "github.com/aws/aws-sdk-go/service/cloudwatch",
+    "github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface",
+    "github.com/bradfitz/slice",
+    "github.com/cactus/go-statsd-client/statsd",
+    "github.com/cactus/go-statsd-client/statsd/statsdtest",
+    "github.com/cenkalti/backoff",
+    "github.com/circonus-labs/circonus-gometrics",
+    "github.com/circonus-labs/circonus-gometrics/checkmgr",
+    "github.com/coreos/go-oidc",
+    "github.com/davecgh/go-spew/spew",
+    "github.com/emicklei/go-restful",
+    "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/core",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener",
+    "github.com/envoyproxy/go-control-plane/envoy/api/v2/route",
+    "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/fault/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/fault/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/health_check/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mongo_proxy/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha",
+    "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/type/matcher",
+    "github.com/envoyproxy/go-control-plane/pkg/cache",
+    "github.com/envoyproxy/go-control-plane/pkg/server",
+    "github.com/envoyproxy/go-control-plane/pkg/util",
+    "github.com/evanphx/json-patch",
+    "github.com/fluent/fluent-logger-golang/fluent",
+    "github.com/ghodss/yaml",
+    "github.com/go-redis/redis",
+    "github.com/gogo/googleapis/google/rpc",
+    "github.com/gogo/protobuf/gogoproto",
+    "github.com/gogo/protobuf/jsonpb",
+    "github.com/gogo/protobuf/proto",
+    "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
+    "github.com/gogo/protobuf/sortkeys",
+    "github.com/gogo/protobuf/types",
+    "github.com/gogo/status",
+    "github.com/golang/glog",
+    "github.com/golang/protobuf/jsonpb",
+    "github.com/golang/protobuf/proto",
+    "github.com/golang/protobuf/ptypes",
+    "github.com/golang/protobuf/ptypes/any",
+    "github.com/golang/protobuf/ptypes/duration",
+    "github.com/golang/protobuf/ptypes/empty",
+    "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/protobuf/ptypes/wrappers",
+    "github.com/golang/sync/errgroup",
+    "github.com/google/go-github/github",
+    "github.com/google/uuid",
+    "github.com/googleapis/gax-go",
+    "github.com/gorilla/mux",
+    "github.com/gorilla/websocket",
+    "github.com/grpc-ecosystem/go-grpc-middleware",
+    "github.com/grpc-ecosystem/go-grpc-prometheus",
+    "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc",
+    "github.com/hashicorp/consul/api",
+    "github.com/hashicorp/go-multierror",
+    "github.com/hashicorp/vault/api",
+    "github.com/howeyc/fsnotify",
+    "github.com/istio/tools/protoc-gen-docs",
+    "github.com/natefinch/lumberjack",
+    "github.com/onsi/gomega",
+    "github.com/onsi/gomega/gbytes",
+    "github.com/onsi/gomega/gexec",
+    "github.com/open-policy-agent/opa/ast",
+    "github.com/open-policy-agent/opa/rego",
+    "github.com/openshift/api/apps/v1",
+    "github.com/opentracing/opentracing-go",
+    "github.com/opentracing/opentracing-go/ext",
+    "github.com/opentracing/opentracing-go/log",
+    "github.com/pborman/uuid",
+    "github.com/pkg/errors",
+    "github.com/pmezard/go-difflib/difflib",
+    "github.com/prometheus/client_golang/api",
+    "github.com/prometheus/client_golang/api/prometheus/v1",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/client_model/go",
+    "github.com/prometheus/common/model",
+    "github.com/prometheus/prom2json",
+    "github.com/satori/go.uuid",
+    "github.com/signalfx/com_signalfx_metrics_protobuf",
+    "github.com/signalfx/golib/datapoint",
+    "github.com/signalfx/golib/errors",
+    "github.com/signalfx/golib/sfxclient",
+    "github.com/spf13/cobra",
+    "github.com/spf13/cobra/doc",
+    "github.com/spf13/pflag",
+    "github.com/stretchr/testify/assert",
+    "github.com/uber/jaeger-client-go",
+    "github.com/uber/jaeger-client-go/transport",
+    "github.com/uber/jaeger-client-go/transport/zipkin",
+    "github.com/uber/jaeger-client-go/zipkin",
+    "go.opencensus.io/plugin/ochttp",
+    "go.opencensus.io/plugin/ochttp/propagation/b3",
+    "go.opencensus.io/trace",
+    "go.uber.org/atomic",
+    "go.uber.org/multierr",
+    "go.uber.org/zap",
+    "go.uber.org/zap/zapcore",
+    "go.uber.org/zap/zapgrpc",
+    "golang.org/x/net/context",
+    "golang.org/x/net/context/ctxhttp",
+    "golang.org/x/net/idna",
+    "golang.org/x/oauth2",
+    "golang.org/x/oauth2/google",
+    "golang.org/x/time/rate",
+    "golang.org/x/tools/imports",
+    "google.golang.org/api/googleapi",
+    "google.golang.org/api/option",
+    "google.golang.org/api/servicecontrol/v1",
+    "google.golang.org/genproto/googleapis/api/distribution",
+    "google.golang.org/genproto/googleapis/api/label",
+    "google.golang.org/genproto/googleapis/api/metric",
+    "google.golang.org/genproto/googleapis/api/monitoredres",
+    "google.golang.org/genproto/googleapis/monitoring/v3",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/balancer",
+    "google.golang.org/grpc/codes",
+    "google.golang.org/grpc/credentials",
+    "google.golang.org/grpc/encoding/gzip",
+    "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/peer",
+    "google.golang.org/grpc/reflection",
+    "google.golang.org/grpc/status",
+    "gopkg.in/d4l3k/messagediff.v1",
+    "gopkg.in/validator.v2",
+    "gopkg.in/yaml.v2",
+    "istio.io/api/authentication/v1alpha1",
+    "istio.io/api/broker/dev",
+    "istio.io/api/config/mcp/v1alpha1",
+    "istio.io/api/envoy/config/filter/http/authn/v2alpha1",
+    "istio.io/api/envoy/config/filter/http/jwt_auth/v2alpha1",
+    "istio.io/api/mesh/v1alpha1",
+    "istio.io/api/mixer/adapter/model/v1beta1",
+    "istio.io/api/mixer/v1",
+    "istio.io/api/mixer/v1/config/client",
+    "istio.io/api/networking/v1alpha3",
+    "istio.io/api/policy/v1beta1",
+    "istio.io/api/rbac/v1alpha1",
+    "istio.io/api/routing/v1alpha1",
+    "istio.io/fortio",
+    "istio.io/fortio/fhttp",
+    "istio.io/fortio/periodic",
+    "k8s.io/api/admission/v1beta1",
+    "k8s.io/api/admissionregistration/v1beta1",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/apps/v1beta1",
+    "k8s.io/api/apps/v1beta2",
+    "k8s.io/api/batch/v1",
+    "k8s.io/api/batch/v2alpha1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/extensions/v1beta1",
+    "k8s.io/api/rbac/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/fields",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/strategicpatch",
+    "k8s.io/apimachinery/pkg/util/uuid",
+    "k8s.io/apimachinery/pkg/util/wait",
+    "k8s.io/apimachinery/pkg/util/yaml",
+    "k8s.io/apimachinery/pkg/watch",
+    "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
+    "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/dynamic/fake",
+    "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/fake",
+    "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
+    "k8s.io/client-go/kubernetes/typed/core/v1",
+    "k8s.io/client-go/plugin/pkg/client/auth",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "k8s.io/client-go/plugin/pkg/client/auth/oidc",
+    "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
+    "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/clientcmd/api/v1",
+    "k8s.io/client-go/tools/portforward",
+    "k8s.io/client-go/tools/remotecommand",
+    "k8s.io/client-go/transport/spdy",
+    "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/workqueue",
+    "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1",
+    "k8s.io/helm/pkg/chartutil",
+    "k8s.io/helm/pkg/engine",
+    "k8s.io/helm/pkg/proto/hapi/chart",
+    "k8s.io/helm/pkg/timeconv",
+    "k8s.io/ingress/core/pkg/ingress/annotations/class",
+    "k8s.io/ingress/core/pkg/ingress/status",
+    "k8s.io/ingress/core/pkg/ingress/store",
+    "k8s.io/kubernetes/pkg/apis/core",
+    "k8s.io/kubernetes/pkg/apis/core/v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -47,16 +47,6 @@ type testCase struct {
 	wantException bool
 }
 
-type testCaseGoldenFile struct {
-	configs []model.Config
-	args    []string
-
-	filename       string         // Expected constant output
-	expectedRegexp *regexp.Regexp // Expected regexp output
-
-	wantException bool
-}
-
 var (
 	testRouteRules = []model.Config{
 		{
@@ -250,24 +240,24 @@ func TestGet(t *testing.T) {
 			configs: testRouteRules,
 			args:    strings.Split("get routerules --all-namespaces", " "),
 			expectedOutput: `NAME      KIND                        NAMESPACE      AGE
-a         RouteRule.config.v1alpha2   default        <unknown>
-b         RouteRule.config.v1alpha2   default        <unknown>
-c         RouteRule.config.v1alpha2   istio-system   <unknown>
-d         RouteRule.config.v1alpha2   default        <unknown>
+a         RouteRule.config.v1alpha2   default        0s
+b         RouteRule.config.v1alpha2   default        0s
+c         RouteRule.config.v1alpha2   istio-system   0s
+d         RouteRule.config.v1alpha2   default        0s
 `,
 		},
 		{ // case 2
 			configs: testGateways,
 			args:    strings.Split("get gateways -n default", " "),
 			expectedOutput: `GATEWAY NAME       HOSTS     NAMESPACE   AGE
-bookinfo-gateway   *         default     <unknown>
+bookinfo-gateway   *         default     0s
 `,
 		},
 		{ // case 3
 			configs: testVirtualServices,
 			args:    strings.Split("get virtualservices -n default", " "),
 			expectedOutput: `VIRTUAL-SERVICE NAME   GATEWAYS           HOSTS     #HTTP     #TCP      NAMESPACE   AGE
-bookinfo               bookinfo-gateway   *             1        0      default     <unknown>
+bookinfo               bookinfo-gateway   *             1        0      default     0s
 `,
 		},
 		{ // case 4 invalid type
@@ -280,13 +270,13 @@ bookinfo               bookinfo-gateway   *             1        0      default 
 			configs: append(testRouteRules, testVirtualServices...),
 			args:    strings.Split("get all", " "),
 			expectedOutput: `VIRTUAL-SERVICE NAME   GATEWAYS           HOSTS     #HTTP     #TCP      NAMESPACE   AGE
-bookinfo               bookinfo-gateway   *             1        0      default     <unknown>
+bookinfo               bookinfo-gateway   *             1        0      default     0s
 
 NAME      KIND                        NAMESPACE      AGE
-a         RouteRule.config.v1alpha2   default        <unknown>
-b         RouteRule.config.v1alpha2   default        <unknown>
-c         RouteRule.config.v1alpha2   istio-system   <unknown>
-d         RouteRule.config.v1alpha2   default        <unknown>
+a         RouteRule.config.v1alpha2   default        0s
+b         RouteRule.config.v1alpha2   default        0s
+c         RouteRule.config.v1alpha2   istio-system   0s
+d         RouteRule.config.v1alpha2   default        0s
 `,
 		},
 		{ // case 6 all with no data
@@ -298,14 +288,14 @@ d         RouteRule.config.v1alpha2   default        <unknown>
 			configs: testDestinationRules,
 			args:    strings.Split("get destinationrules", " "),
 			expectedOutput: `DESTINATION-RULE NAME   HOST               SUBSETS   NAMESPACE   AGE
-googleapis              *.googleapis.com             default     <unknown>
+googleapis              *.googleapis.com             default     0s
 `,
 		},
 		{ // case 8
 			configs: testServiceEntries,
 			args:    strings.Split("get serviceentries", " "),
 			expectedOutput: `SERVICE-ENTRY NAME   HOSTS              PORTS      NAMESPACE   AGE
-googleapis           *.googleapis.com   HTTP/443   default     <unknown>
+googleapis           *.googleapis.com   HTTP/443   default     0s
 `,
 		},
 	}

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -132,7 +132,14 @@ func (cr *store) Create(config model.Config) (string, error) {
 	_, exists = ns.Load(config.Name)
 
 	if !exists {
-		config.ResourceVersion = time.Now().String()
+		tnow := time.Now()
+		config.ResourceVersion = tnow.String()
+
+		// Set the creation timestamp, if not provided.
+		if config.CreationTimestamp.Time.IsZero() {
+			config.CreationTimestamp.Time = tnow
+		}
+
 		ns.Store(config.Name, config)
 		return config.ResourceVersion, nil
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
 	authn "istio.io/api/authentication/v1alpha1"
 )
 
@@ -84,6 +86,9 @@ type Service struct {
 	// or use the passthrough model (i.e. proxy will forward the traffic to the network endpoint requested
 	// by the caller)
 	Resolution Resolution
+
+	// CreationTime records the time this service was created, if available.
+	CreationTime time.Time `json:"creationTime,omitempty"`
 }
 
 // Resolution indicates how the service instances need to be resolved before routing

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -102,14 +102,6 @@ func (configgen *ConfigGeneratorImpl) BuildListeners(env model.Environment, node
 	return nil, nil
 }
 
-// sortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
-func sortServicesByCreationTime(services []*model.Service) []*model.Service {
-	sort.SliceStable(services, func(i, j int) bool {
-		return services[i].CreationTime.Before(services[j].CreationTime)
-	})
-	return services
-}
-
 // buildSidecarListeners produces a list of listeners for sidecar proxies
 func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env model.Environment, node model.Proxy) ([]*xdsapi.Listener, error) {
 
@@ -125,9 +117,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env model.Environmen
 	if err != nil {
 		return nil, err
 	}
-
-	// Sort the services in order of creation.
-	services = sortServicesByCreationTime(services)
 
 	listeners := make([]*xdsapi.Listener, 0)
 
@@ -363,6 +352,14 @@ func handleOutboundListenerConflict(service *model.Service, servicePort *model.P
 		servicePort.Protocol)
 }
 
+// sortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
+func sortServicesByCreationTime(services []*model.Service) []*model.Service {
+	sort.SliceStable(services, func(i, j int) bool {
+		return services[i].CreationTime.Before(services[j].CreationTime)
+	})
+	return services
+}
+
 // buildSidecarOutboundListeners generates http and tcp listeners for outbound connections from the service instance
 // TODO(github.com/istio/pilot/issues/237)
 //
@@ -379,6 +376,9 @@ func handleOutboundListenerConflict(service *model.Service, servicePort *model.P
 // IPs and ports, but requires that ports of non-load balanced service be unique.
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.Environment, node model.Proxy,
 	proxyInstances []*model.ServiceInstance, services []*model.Service) []*xdsapi.Listener {
+
+	// Sort the services in order of creation.
+	services = sortServicesByCreationTime(services)
 
 	var proxyLabels model.LabelsCollection
 	for _, w := range proxyInstances {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1,0 +1,170 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+	"time"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+)
+
+var (
+	tnow  = time.Now()
+	tzero = time.Time{}
+	proxy = model.Proxy{
+		Type:      model.Sidecar,
+		IPAddress: "1.1.1.1",
+		ID:        "v0.default",
+		Domain:    "default.example.org",
+	}
+)
+
+func TestOutboundListenerConflict_HTTP(t *testing.T) {
+	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
+	// storing the services out of time order to test that it's being sorted properly.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolHTTP, tnow.Add(1*time.Second)),
+		buildService(model.ProtocolTCP, tnow),
+		buildService(model.ProtocolHTTP, tnow.Add(2*time.Second)))
+}
+
+func TestOutboundListenerConflict_TCP(t *testing.T) {
+	// The oldest service port is HTTP.  We should encounter conflicts when attempting to add the TCP ports. Purposely
+	// storing the services out of time order to test that it's being sorted properly.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolTCP, tnow.Add(1*time.Second)),
+		buildService(model.ProtocolHTTP, tnow),
+		buildService(model.ProtocolTCP, tnow.Add(2*time.Second)))
+}
+
+func TestOutboundListenerConflict_Unordered(t *testing.T) {
+	// Ensure that the order is preserved when all the times match. The first service in the list wins.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolHTTP, tzero),
+		buildService(model.ProtocolTCP, tzero),
+		buildService(model.ProtocolTCP, tzero))
+}
+
+func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
+	t.Helper()
+
+	p := &fakePlugin{}
+	configgen := NewConfigGenerator([]plugin.Plugin{p})
+
+	env := buildListenerEnv()
+
+	var oldestService *model.Service
+	instances := make([]*model.ServiceInstance, len(services))
+	for i, s := range services {
+		instances[i] = &model.ServiceInstance{
+			Service: s,
+		}
+		if oldestService == nil || s.CreationTime.Before(oldestService.CreationTime) {
+			oldestService = s
+		}
+	}
+	listeners := configgen.buildSidecarOutboundListeners(env, proxy, instances, services)
+	if len(listeners) != 1 {
+		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+	}
+
+	oldestProtocol := oldestService.Ports[0].Protocol
+	if oldestProtocol != model.ProtocolHTTP && isHTTPListener(listeners[0]) {
+		t.Fatal("expected TCP listener, found HTTP")
+	} else if oldestProtocol == model.ProtocolHTTP && !isHTTPListener(listeners[0]) {
+		t.Fatal("expected HTTP listener, found TCP")
+	}
+
+	if len(p.outboundListenerParams) != 1 {
+		t.Fatalf("expected %d listener params, found %d", 1, len(p.outboundListenerParams))
+	}
+
+	if p.outboundListenerParams[0].Service != oldestService {
+		t.Fatalf("listener conflict failed to preserve listener for the oldest service")
+	}
+}
+
+type fakePlugin struct {
+	outboundListenerParams []*plugin.InputParams
+}
+
+func (p *fakePlugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	p.outboundListenerParams = append(p.outboundListenerParams, in)
+	return nil
+}
+
+func (p *fakePlugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	return nil
+}
+
+func (p *fakePlugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
+	cluster *xdsapi.Cluster) {
+}
+
+func (p *fakePlugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
+	cluster *xdsapi.Cluster) {
+}
+
+func (p *fakePlugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+}
+
+func (p *fakePlugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+}
+
+func isHTTPListener(listener *xdsapi.Listener) bool {
+	if len(listener.FilterChains) > 0 && len(listener.FilterChains[0].Filters) > 0 {
+		return listener.FilterChains[0].Filters[0].Name == "envoy.http_connection_manager"
+	}
+	return false
+}
+
+func buildService(protocol model.Protocol, creationTime time.Time) *model.Service {
+	return &model.Service{
+		CreationTime: creationTime,
+		Hostname:     "*.example.org",
+		Address:      "1.1.1.1",
+		ClusterVIPs:  make(map[string]string),
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "default",
+				Port:     8080,
+				Protocol: protocol,
+			},
+		},
+		Resolution: model.Passthrough,
+	}
+}
+
+func buildListenerEnv() model.Environment {
+	serviceDiscovery := &fakes.ServiceDiscovery{}
+
+	configStore := &fakes.IstioConfigStore{}
+
+	mesh := model.DefaultMeshConfig()
+	env := model.Environment{
+		ServiceDiscovery: serviceDiscovery,
+		ServiceAccounts:  &fakes.ServiceAccounts{},
+		IstioConfigStore: configStore,
+		Mesh:             &mesh,
+		MixerSAN:         []string{},
+	}
+
+	return env
+}

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
@@ -188,8 +190,11 @@ func convertPortNameToProtocol(name string) model.Protocol {
 	return model.ParseProtocol(prefix)
 }
 
-func makeService(hostname model.Hostname, address string, ports map[string]int, external bool, resolution model.Resolution) *model.Service {
+func makeService(hostname model.Hostname, address string, ports map[string]int, external bool, resolution model.Resolution,
+	creationTime time.Time) *model.Service {
+
 	svc := &model.Service{
+		CreationTime: creationTime,
 		Hostname:     hostname,
 		Address:      address,
 		MeshExternal: external,
@@ -213,13 +218,13 @@ func makeService(hostname model.Hostname, address string, ports map[string]int, 
 }
 
 func makeInstance(serviceEntry *networking.ServiceEntry, address string, port int,
-	svcPort *networking.Port, labels map[string]string) *model.ServiceInstance {
+	svcPort *networking.Port, labels map[string]string, creationTime time.Time) *model.ServiceInstance {
 	family := model.AddressFamilyTCP
 	if port == 0 {
 		family = model.AddressFamilyUnix
 	}
 
-	services := convertServices(serviceEntry)
+	services := convertServices(serviceEntry, creationTime)
 	svc := services[0] // default
 	for _, s := range services {
 		if s.Hostname.String() == address {
@@ -244,6 +249,7 @@ func makeInstance(serviceEntry *networking.ServiceEntry, address string, port in
 }
 
 func TestConvertService(t *testing.T) {
+	tnow := time.Now()
 	serviceTests := []struct {
 		externalSvc *networking.ServiceEntry
 		services    []*model.Service
@@ -252,21 +258,21 @@ func TestConvertService(t *testing.T) {
 			// service entry http
 			externalSvc: httpNone,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-number": 80, "http2-number": 8080}, true, model.Passthrough),
+				map[string]int{"http-number": 80, "http2-number": 8080}, true, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry tcp
 			externalSvc: tcpNone,
 			services: []*model.Service{makeService("tcpnone.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, true, model.Passthrough),
+				map[string]int{"tcp-444": 444}, true, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry http  static
 			externalSvc: httpStatic,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideLB),
+				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideLB, tnow),
 			},
 		},
 		{
@@ -274,44 +280,44 @@ func TestConvertService(t *testing.T) {
 			externalSvc: httpDNSnoEndpoints,
 			services: []*model.Service{
 				makeService("google.com", model.UnspecifiedIP,
-					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 				makeService("www.wikipedia.org", model.UnspecifiedIP,
-					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry dns
 			externalSvc: httpDNS,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
 			services: []*model.Service{makeService("tcpdns.com", model.UnspecifiedIP,
-				map[string]int{"tcp-444": 444}, true, model.DNSLB),
+				map[string]int{"tcp-444": 444}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry tcp static
 			externalSvc: tcpStatic,
 			services: []*model.Service{makeService("tcpstatic.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+				map[string]int{"tcp-444": 444}, true, model.ClientSideLB, tnow),
 			},
 		},
 		{
 			// service entry http internal
 			externalSvc: httpNoneInternal,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-number": 80, "http2-number": 8080}, false, model.Passthrough),
+				map[string]int{"http-number": 80, "http2-number": 8080}, false, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry tcp internal
 			externalSvc: tcpNoneInternal,
 			services: []*model.Service{makeService("tcpinternal.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, false, model.Passthrough),
+				map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 			},
 		},
 		{
@@ -319,19 +325,19 @@ func TestConvertService(t *testing.T) {
 			externalSvc: multiAddrInternal,
 			services: []*model.Service{
 				makeService("tcp1.com", "1.1.1.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp1.com", "2.2.2.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp2.com", "1.1.1.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp2.com", "2.2.2.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 			},
 		},
 	}
 
 	for _, tt := range serviceTests {
-		services := convertServices(tt.externalSvc)
+		services := convertServices(tt.externalSvc, tnow)
 		if err := compare(t, services, tt.services); err != nil {
 			t.Error(err)
 		}
@@ -339,6 +345,7 @@ func TestConvertService(t *testing.T) {
 }
 
 func TestConvertInstances(t *testing.T) {
+	tnow := time.Now()
 	serviceInstanceTests := []struct {
 		externalSvc *networking.ServiceEntry
 		out         []*model.ServiceInstance
@@ -359,64 +366,64 @@ func TestConvertInstances(t *testing.T) {
 			// service entry static
 			externalSvc: httpStatic,
 			out: []*model.ServiceInstance{
-				makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Ports[0], nil),
-				makeInstance(httpStatic, "2.2.2.2", 18080, httpStatic.Ports[1], nil),
-				makeInstance(httpStatic, "3.3.3.3", 1080, httpStatic.Ports[0], nil),
-				makeInstance(httpStatic, "3.3.3.3", 8080, httpStatic.Ports[1], nil),
-				makeInstance(httpStatic, "4.4.4.4", 1080, httpStatic.Ports[0], map[string]string{"foo": "bar"}),
-				makeInstance(httpStatic, "4.4.4.4", 8080, httpStatic.Ports[1], map[string]string{"foo": "bar"}),
+				makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Ports[0], nil, tnow),
+				makeInstance(httpStatic, "2.2.2.2", 18080, httpStatic.Ports[1], nil, tnow),
+				makeInstance(httpStatic, "3.3.3.3", 1080, httpStatic.Ports[0], nil, tnow),
+				makeInstance(httpStatic, "3.3.3.3", 8080, httpStatic.Ports[1], nil, tnow),
+				makeInstance(httpStatic, "4.4.4.4", 1080, httpStatic.Ports[0], map[string]string{"foo": "bar"}, tnow),
+				makeInstance(httpStatic, "4.4.4.4", 8080, httpStatic.Ports[1], map[string]string{"foo": "bar"}, tnow),
 			},
 		},
 		{
 			// service entry DNS with no endpoints
 			externalSvc: httpDNSnoEndpoints,
 			out: []*model.ServiceInstance{
-				makeInstance(httpDNSnoEndpoints, "google.com", 80, httpDNSnoEndpoints.Ports[0], nil),
-				makeInstance(httpDNSnoEndpoints, "google.com", 8080, httpDNSnoEndpoints.Ports[1], nil),
-				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 80, httpDNSnoEndpoints.Ports[0], nil),
-				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 8080, httpDNSnoEndpoints.Ports[1], nil),
+				makeInstance(httpDNSnoEndpoints, "google.com", 80, httpDNSnoEndpoints.Ports[0], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "google.com", 8080, httpDNSnoEndpoints.Ports[1], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 80, httpDNSnoEndpoints.Ports[0], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 8080, httpDNSnoEndpoints.Ports[1], nil, tnow),
 			},
 		},
 		{
 			// service entry dns
 			externalSvc: httpDNS,
 			out: []*model.ServiceInstance{
-				makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-				makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil),
-				makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-				makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil),
-				makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
-				makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}),
+				makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+				makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil, tnow),
+				makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+				makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil, tnow),
+				makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
+				makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}, tnow),
 			},
 		},
 		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
 			out: []*model.ServiceInstance{
-				makeInstance(tcpDNS, "lon.google.com", 444, tcpDNS.Ports[0], nil),
-				makeInstance(tcpDNS, "in.google.com", 444, tcpDNS.Ports[0], nil),
+				makeInstance(tcpDNS, "lon.google.com", 444, tcpDNS.Ports[0], nil, tnow),
+				makeInstance(tcpDNS, "in.google.com", 444, tcpDNS.Ports[0], nil, tnow),
 			},
 		},
 		{
 			// service entry tcp static
 			externalSvc: tcpStatic,
 			out: []*model.ServiceInstance{
-				makeInstance(tcpStatic, "1.1.1.1", 444, tcpStatic.Ports[0], nil),
-				makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil),
+				makeInstance(tcpStatic, "1.1.1.1", 444, tcpStatic.Ports[0], nil, tnow),
+				makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil, tnow),
 			},
 		},
 		{
 			// service entry unix domain socket static
 			externalSvc: udsLocal,
 			out: []*model.ServiceInstance{
-				makeInstance(udsLocal, "/test/sock", 0, udsLocal.Ports[0], nil),
+				makeInstance(udsLocal, "/test/sock", 0, udsLocal.Ports[0], nil, tnow),
 			},
 		},
 	}
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(strings.Join(tt.externalSvc.Hosts, "_"), func(t *testing.T) {
-			instances := convertInstances(tt.externalSvc)
+			instances := convertInstances(tt.externalSvc, tnow)
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -20,20 +20,25 @@ import (
 	"sort"
 	"testing"
 
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func createServiceEntries(serviceEntries []*networking.ServiceEntry, store model.IstioConfigStore, t *testing.T) {
+func createServiceEntries(serviceEntries []*networking.ServiceEntry, store model.IstioConfigStore, t *testing.T, creationTime time.Time) {
 	t.Helper()
 	for _, svc := range serviceEntries {
 		config := model.Config{
 			ConfigMeta: model.ConfigMeta{
-				Type:      model.ServiceEntry.Type,
-				Name:      svc.Hosts[0],
-				Namespace: "default",
-				Domain:    "cluster.local",
+				Type:              model.ServiceEntry.Type,
+				Name:              svc.Hosts[0],
+				Namespace:         "default",
+				Domain:            "cluster.local",
+				CreationTimestamp: meta_v1.Time{creationTime},
 			},
 			Spec: svc,
 		}
@@ -66,12 +71,13 @@ func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
+	tnow := time.Now()
 	expectedServices := []*model.Service{
-		makeService("*.google.com", model.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
-		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+		makeService("*.google.com", model.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
+		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideLB, tnow),
 	}
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	services, err := sd.Services()
 	if err != nil {
@@ -91,7 +97,8 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	service, err := sd.GetService(model.Hostname(hostDNE))
 	if err != nil {
@@ -117,9 +124,10 @@ func TestServiceDiscoveryGetServiceAttributes(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
-	tcpStaticSvc := convertServices(tcpStatic)
+	tcpStaticSvc := convertServices(tcpStatic, tnow)
 	for _, svc := range tcpStaticSvc {
 		expect := model.ServiceAttributes{
 			Name:      svc.Hostname.String(),
@@ -129,7 +137,7 @@ func TestServiceDiscoveryGetServiceAttributes(t *testing.T) {
 			t.Errorf("GetServiceAttributes(%q) => %v, want %v", svc.Hostname, *attr, expect)
 		}
 	}
-	tcpDNSSvc := convertServices(tcpDNS)
+	tcpDNSSvc := convertServices(tcpDNS, tnow)
 	for _, svc := range tcpDNSSvc {
 		if attr, _ := sd.GetServiceAttributes(svc.Hostname); attr != nil {
 			t.Errorf(`GetServiceAttributes("tcpDNSSvc") => %q, want nil`, attr.Namespace)
@@ -141,7 +149,8 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpStatic, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpStatic, tcpStatic}, store, t, tnow)
 
 	_, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddress: "2.2.2.2"})
 	if err != nil {
@@ -154,15 +163,16 @@ func TestServiceDiscoveryInstances(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
-		makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
+		makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}, tnow),
 	}
 
 	instances, err := sd.InstancesByPort("*.google.com", 0, nil)
@@ -181,12 +191,13 @@ func TestServiceDiscoveryInstances1Port(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
 	}
 
 	instances, err := sd.InstancesByPort("*.google.com", 80, nil)
@@ -205,12 +216,14 @@ func TestNonServiceConfig(t *testing.T) {
 	defer stopFn()
 
 	// Create a non-service configuration element. This should not affect the service registry at all.
+	tnow := time.Now()
 	config := model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Type:      model.DestinationRule.Type,
-			Name:      "fakeDestinationRule",
-			Namespace: "default",
-			Domain:    "cluster.local",
+			Type:              model.DestinationRule.Type,
+			Name:              "fakeDestinationRule",
+			Namespace:         "default",
+			Domain:            "cluster.local",
+			CreationTimestamp: meta_v1.Time{tnow},
 		},
 		Spec: &networking.DestinationRule{
 			Host: "fakehost",
@@ -222,11 +235,11 @@ func TestNonServiceConfig(t *testing.T) {
 	}
 
 	// Now create some service entries and verify that it's added to the registry.
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
 	}
 	instances, err := sd.InstancesByPort("*.google.com", 80, nil)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -112,6 +112,7 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 		LoadBalancingDisabled: loadBalancingDisabled,
 		MeshExternal:          meshExternal,
 		Resolution:            resolution,
+		CreationTime:          svc.CreationTimestamp.Time,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"time"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -70,6 +72,7 @@ func TestServiceConversion(t *testing.T) {
 
 	ip := "10.0.0.1"
 
+	tnow := time.Now()
 	localSvc := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -79,6 +82,7 @@ func TestServiceConversion(t *testing.T) {
 				CanonicalServiceAccountsOnVMAnnotation: saC + "," + saD,
 				"other/annotation":                     "test",
 			},
+			CreationTimestamp: metav1.Time{tnow},
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP: ip,
@@ -100,6 +104,10 @@ func TestServiceConversion(t *testing.T) {
 	service := convertService(localSvc, domainSuffix)
 	if service == nil {
 		t.Errorf("could not convert service")
+	}
+
+	if service.CreationTime != tnow {
+		t.Errorf("incorrect creation time => %v, want %v", service.CreationTime, tnow)
 	}
 
 	if len(service.Ports) != len(localSvc.Spec.Ports) {

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"net"
 
+	"time"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -37,8 +39,9 @@ func NewDiscovery(services map[model.Hostname]*model.Service, versions int) *Ser
 // MakeService creates a memory service
 func MakeService(hostname model.Hostname, address string) *model.Service {
 	return &model.Service{
-		Hostname: hostname,
-		Address:  address,
+		CreationTime: time.Now(),
+		Hostname:     hostname,
+		Address:      address,
 		Ports: []*model.Port{
 			{
 				Name:     PortHTTPName,
@@ -68,6 +71,7 @@ func MakeService(hostname model.Hostname, address string) *model.Service {
 // MakeExternalHTTPService creates memory external service
 func MakeExternalHTTPService(hostname, external model.Hostname, address string) *model.Service {
 	return &model.Service{
+		CreationTime: time.Now(),
 		Hostname:     hostname,
 		Address:      address,
 		ExternalName: external,
@@ -82,6 +86,7 @@ func MakeExternalHTTPService(hostname, external model.Hostname, address string) 
 // MakeExternalHTTPSService creates memory external service
 func MakeExternalHTTPSService(hostname, external model.Hostname, address string) *model.Service {
 	return &model.Service{
+		CreationTime: time.Now(),
 		Hostname:     hostname,
 		Address:      address,
 		ExternalName: external,


### PR DESCRIPTION
This PR adds the CreationTime to the service struct and populates it
in the k8s service registry. When available, services will be sorted
by their creation time. Conflicts will cause the listeners for newer
services to be dropped.

Partial fix for #5992