### PR TITLE
Helm chart: allow mapping for statsd-prom-bridge

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/configmap.yaml
@@ -11,3 +11,4 @@ metadata:
     istio: mixer
 data:
   mapping.conf: |-
+{{ toYaml .Values.prometheusStatsdExporter.mapping | indent 4 }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -360,6 +360,10 @@ mixer:
     hub: docker.io/prom
     tag: v0.6.0
 
+    # Configuration to be included as the statsd_exporter mapping configuration.
+    # See https://github.com/prometheus/statsd_exporter/tree/master#metric-mapping-and-configuration
+    mapping: {}
+
 #
 # pilot configuration
 #


### PR DESCRIPTION
#3984

This is a much less interesting alternative to #5069. Instead of declaring a list of mappings, this just makes it possible to declare your own mappings in your helm configuration.

Eg, in your own values:
```yaml
mixer:
  prometheusStatsdExporter:
    mapping:
      mappings:
       - match: envoy\.cluster\.(.*)\|(.*)\|\|(.*)\.(.*)\.svc\.cluster\.local\.(.*)
         match_type: regex
         name: envoy_${5}
         labels:
           direction: "$1"
           port: "$2"
           service_name: "$3"
           namespace: "$4"
           job: envoy
```

The above will map things like:
`envoy.cluster.outbound|portnum||my-service.my-namespace.svc.cluster.local.some_metric`
to
`envoy_some_metric{direction="outbound", port="portnum", service_name="my-service", namespace="my-namespace", job="envoy"}`
which is far more useful in prometheus.

Further, doing so is (I believe) necessary if you are then using Prometheus with http://github.com/directXMan12/k8s-prometheus-adapter/ to drive your HorizontalPodAutoscalers.