### PR TITLE
Updating Kiali to v0.5.0 on Ansible Installer

### DIFF
--- a/install/ansible/istio/tasks/install_addons.yml
+++ b/install/ansible/istio/tasks/install_addons.yml
@@ -1,8 +1,8 @@
 - name: Install Kiali
   block:
-  
-  - set_fact: 
-      kiali_version: v0.4.0
+
+  - set_fact:
+      kiali_version: v0.5.0
 
   - name: Install Kiali on Openshift
     shell: |


### PR DESCRIPTION
Following https://github.com/istio/istio/pull/6930, https://github.com/istio/istio/pull/6929 and https://github.com/istio/istio/pull/7007,

Updating Kiali on Ansible Installer on release-1.0 branch

cc @gyliu513 
