### PR TITLE
Add listeners by creation time and cleanup error reports for conflicts

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -46,16 +46,6 @@ type testCase struct {
 	wantException bool
 }
 
-type testCaseGoldenFile struct {
-	configs []model.Config
-	args    []string
-
-	filename       string         // Expected constant output
-	expectedRegexp *regexp.Regexp // Expected regexp output
-
-	wantException bool
-}
-
 var (
 	testGateways = []model.Config{
 		{
@@ -189,14 +179,14 @@ func TestGet(t *testing.T) {
 			configs: testGateways,
 			args:    strings.Split("get gateways -n default", " "),
 			expectedOutput: `GATEWAY NAME       HOSTS     NAMESPACE   AGE
-bookinfo-gateway   *         default     <unknown>
+bookinfo-gateway   *         default     0s
 `,
 		},
 		{
 			configs: testVirtualServices,
 			args:    strings.Split("get virtualservices -n default", " "),
 			expectedOutput: `VIRTUAL-SERVICE NAME   GATEWAYS           HOSTS     #HTTP     #TCP      NAMESPACE   AGE
-bookinfo               bookinfo-gateway   *             1        0      default     <unknown>
+bookinfo               bookinfo-gateway   *             1        0      default     0s
 `,
 		},
 		{
@@ -214,14 +204,14 @@ bookinfo               bookinfo-gateway   *             1        0      default 
 			configs: testDestinationRules,
 			args:    strings.Split("get destinationrules", " "),
 			expectedOutput: `DESTINATION-RULE NAME   HOST               SUBSETS   NAMESPACE   AGE
-googleapis              *.googleapis.com             default     <unknown>
+googleapis              *.googleapis.com             default     0s
 `,
 		},
 		{
 			configs: testServiceEntries,
 			args:    strings.Split("get serviceentries", " "),
 			expectedOutput: `SERVICE-ENTRY NAME   HOSTS              PORTS      NAMESPACE   AGE
-googleapis           *.googleapis.com   HTTP/443   default     <unknown>
+googleapis           *.googleapis.com   HTTP/443   default     0s
 `,
 		},
 	}

--- a/pilot/pkg/config/memory/config.go
+++ b/pilot/pkg/config/memory/config.go
@@ -132,7 +132,14 @@ func (cr *store) Create(config model.Config) (string, error) {
 	_, exists = ns.Load(config.Name)
 
 	if !exists {
-		config.ResourceVersion = time.Now().String()
+		tnow := time.Now()
+		config.ResourceVersion = tnow.String()
+
+		// Set the creation timestamp, if not provided.
+		if config.CreationTimestamp.Time.IsZero() {
+			config.CreationTimestamp.Time = tnow
+		}
+
 		ns.Store(config.Name, config)
 		return config.ResourceVersion, nil
 	}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -29,6 +29,8 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
 	authn "istio.io/api/authentication/v1alpha1"
 )
 
@@ -84,6 +86,9 @@ type Service struct {
 	// or use the passthrough model (i.e. proxy will forward the traffic to the network endpoint requested
 	// by the caller)
 	Resolution Resolution
+
+	// CreationTime records the time this service was created, if available.
+	CreationTime time.Time `json:"creationTime,omitempty"`
 }
 
 // Resolution indicates how the service instances need to be resolved before routing

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -30,7 +30,7 @@ import (
 	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	"github.com/envoyproxy/go-control-plane/envoy/type"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -337,6 +337,46 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 	return listeners
 }
 
+type listenerEntry struct {
+	service *model.Service
+	servicePort *model.Port
+	listener *xdsapi.Listener
+}
+
+func getServiceName(env model.Environment, service *model.Service) string {
+	attrs, err := env.GetServiceAttributes(service.Hostname)
+	if err != nil || attrs == nil || attrs.Name == "" {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s/%s", attrs.Namespace, attrs.Name)
+}
+
+func getClusterName(service *model.Service, servicePort *model.Port) string {
+	return model.BuildSubsetKey(model.TrafficDirectionOutbound, "",
+		service.Hostname, servicePort.Port)
+}
+
+func handleOutboundListenerConflict(env model.Environment, service *model.Service, servicePort *model.Port, current listenerEntry, listenerMapKey string) {
+	conflictingOutbound.Add(1)
+	log.Warnf("buildSidecarOutboundListener: Omitting listener for service '%s' due to conflict with service '%s'. "+
+		"Outbound listener '%s' for cluster '%s' on key '%s'. Current Protocol: %s, incoming service protocol %s",
+		getServiceName(env, service),
+		getServiceName(env, current.service),
+		current.listener.Name,
+		getClusterName(service, servicePort),
+		listenerMapKey,
+		current.servicePort.Protocol,
+		servicePort.Protocol)
+}
+
+// sortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
+func sortServicesByCreationTime(services []*model.Service) []*model.Service {
+	sort.SliceStable(services, func(i, j int) bool {
+		return services[i].CreationTime.Before(services[j].CreationTime)
+	})
+	return services
+}
+
 // buildSidecarOutboundListeners generates http and tcp listeners for outbound connections from the service instance
 // TODO(github.com/istio/pilot/issues/237)
 //
@@ -354,6 +394,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env model.Env
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.Environment, node model.Proxy,
 	proxyInstances []*model.ServiceInstance, services []*model.Service) []*xdsapi.Listener {
 
+	// Sort the services in order of creation.
+	services = sortServicesByCreationTime(services)
+
 	var proxyLabels model.LabelsCollection
 	for _, w := range proxyInstances {
 		proxyLabels = append(proxyLabels, w.Labels)
@@ -364,13 +407,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 
 	var tcpListeners, httpListeners []*xdsapi.Listener
 	var currentListener *xdsapi.Listener
-	listenerTypeMap := make(map[string]model.Protocol)
-	listenerMap := make(map[string]*xdsapi.Listener)
+	listenerMap := make(map[string]listenerEntry)
 	for _, service := range services {
 		for _, servicePort := range service.Ports {
-			clusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, "",
-				service.Hostname, servicePort.Port)
-
 			listenAddress := WildcardAddress
 			var addresses []string
 			var listenerMapKey string
@@ -388,11 +427,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 			switch plugin.ModelProtocolToListenerProtocol(servicePort.Protocol) {
 			case plugin.ListenerProtocolHTTP:
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
-				if l, exists := listenerMap[listenerMapKey]; exists {
-					if !listenerTypeMap[listenerMapKey].IsHTTP() {
-						conflictingOutbound.Add(1)
-						log.Warnf("buildSidecarOutboundListeners: listener conflict (%v current and new %v) on %s, destination:%s, current Listener: (%s %v)",
-							servicePort.Protocol, listenerTypeMap[listenerMapKey], listenerMapKey, clusterName, l.Name, l)
+				if current, exists := listenerMap[listenerMapKey]; exists {
+					if !current.servicePort.Protocol.IsHTTP() {
+						handleOutboundListenerConflict(env, service, servicePort, current, listenerMapKey)
 					}
 					// Skip building listener for the same http port
 					continue
@@ -418,15 +455,14 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 				}
 
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
-				var exists bool
-				if currentListener, exists = listenerMap[listenerMapKey]; exists {
+				currentListener = nil
+				if current, exists := listenerMap[listenerMapKey]; exists {
+					currentListener = current.listener
 					// Check for port collisions between TCP/TLS and HTTP.
 					// If configured correctly, TCP/TLS ports may not collide.
 					// We'll need to do additional work to find out if there is a collision within TCP/TLS.
-					if !listenerTypeMap[listenerMapKey].IsTCP() {
-						conflictingOutbound.Add(1)
-						log.Warnf("buildSidecarOutboundListeners: listener conflict (%v current and new %v) on %s, destination:%s, current Listener: (%s %v)",
-							servicePort.Protocol, listenerTypeMap[listenerMapKey], listenerMapKey, clusterName, currentListener.Name, currentListener)
+					if !current.servicePort.Protocol.IsTCP() {
+						handleOutboundListenerConflict(env, service, servicePort, current, listenerMapKey)
 						continue
 					}
 				}
@@ -476,8 +512,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 				newFilterChains = append(newFilterChains, mutable.Listener.FilterChains...)
 				currentListener.FilterChains = newFilterChains
 			} else {
-				listenerMap[listenerMapKey] = mutable.Listener
-				listenerTypeMap[listenerMapKey] = servicePort.Protocol
+				listenerMap[listenerMapKey] = listenerEntry{
+					service: service,
+					servicePort: servicePort,
+					listener: mutable.Listener,
+				}
 			}
 
 			if log.DebugEnabled() && len(mutable.Listener.FilterChains) > 1 || currentListener != nil {
@@ -493,16 +532,15 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env model.En
 	}
 
 	for name, l := range listenerMap {
-		ltype := listenerTypeMap[name]
-		if err := l.Validate(); err != nil {
-			log.Warnf("buildSidecarOutboundListeners: error validating listener %s (type %v): %v", name, ltype, err)
+		if err := l.listener.Validate(); err != nil {
+			log.Warnf("buildSidecarOutboundListeners: error validating listener %s (type %v): %v", name, l.servicePort.Protocol, err)
 			invalidOutboundListeners.Add(1)
 			continue
 		}
-		if ltype.IsTCP() {
-			tcpListeners = append(tcpListeners, l)
+		if l.servicePort.Protocol.IsTCP() {
+			tcpListeners = append(tcpListeners, l.listener)
 		} else {
-			httpListeners = append(httpListeners, l)
+			httpListeners = append(httpListeners, l.listener)
 		}
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -1,0 +1,170 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+	"time"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/fakes"
+	"istio.io/istio/pilot/pkg/networking/plugin"
+)
+
+var (
+	tnow  = time.Now()
+	tzero = time.Time{}
+	proxy = model.Proxy{
+		Type:      model.Sidecar,
+		IPAddress: "1.1.1.1",
+		ID:        "v0.default",
+		Domain:    "default.example.org",
+	}
+)
+
+func TestOutboundListenerConflict_HTTP(t *testing.T) {
+	// The oldest service port is TCP.  We should encounter conflicts when attempting to add the HTTP ports. Purposely
+	// storing the services out of time order to test that it's being sorted properly.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolHTTP, tnow.Add(1*time.Second)),
+		buildService(model.ProtocolTCP, tnow),
+		buildService(model.ProtocolHTTP, tnow.Add(2*time.Second)))
+}
+
+func TestOutboundListenerConflict_TCP(t *testing.T) {
+	// The oldest service port is HTTP.  We should encounter conflicts when attempting to add the TCP ports. Purposely
+	// storing the services out of time order to test that it's being sorted properly.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolTCP, tnow.Add(1*time.Second)),
+		buildService(model.ProtocolHTTP, tnow),
+		buildService(model.ProtocolTCP, tnow.Add(2*time.Second)))
+}
+
+func TestOutboundListenerConflict_Unordered(t *testing.T) {
+	// Ensure that the order is preserved when all the times match. The first service in the list wins.
+	testOutboundListenerConflict(t,
+		buildService(model.ProtocolHTTP, tzero),
+		buildService(model.ProtocolTCP, tzero),
+		buildService(model.ProtocolTCP, tzero))
+}
+
+func testOutboundListenerConflict(t *testing.T, services ...*model.Service) {
+	t.Helper()
+
+	p := &fakePlugin{}
+	configgen := NewConfigGenerator([]plugin.Plugin{p})
+
+	env := buildListenerEnv()
+
+	var oldestService *model.Service
+	instances := make([]*model.ServiceInstance, len(services))
+	for i, s := range services {
+		instances[i] = &model.ServiceInstance{
+			Service: s,
+		}
+		if oldestService == nil || s.CreationTime.Before(oldestService.CreationTime) {
+			oldestService = s
+		}
+	}
+	listeners := configgen.buildSidecarOutboundListeners(env, proxy, instances, services)
+	if len(listeners) != 1 {
+		t.Fatalf("expected %d listeners, found %d", 1, len(listeners))
+	}
+
+	oldestProtocol := oldestService.Ports[0].Protocol
+	if oldestProtocol != model.ProtocolHTTP && isHTTPListener(listeners[0]) {
+		t.Fatal("expected TCP listener, found HTTP")
+	} else if oldestProtocol == model.ProtocolHTTP && !isHTTPListener(listeners[0]) {
+		t.Fatal("expected HTTP listener, found TCP")
+	}
+
+	if len(p.outboundListenerParams) != 1 {
+		t.Fatalf("expected %d listener params, found %d", 1, len(p.outboundListenerParams))
+	}
+
+	if p.outboundListenerParams[0].Service != oldestService {
+		t.Fatalf("listener conflict failed to preserve listener for the oldest service")
+	}
+}
+
+type fakePlugin struct {
+	outboundListenerParams []*plugin.InputParams
+}
+
+func (p *fakePlugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	p.outboundListenerParams = append(p.outboundListenerParams, in)
+	return nil
+}
+
+func (p *fakePlugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
+	return nil
+}
+
+func (p *fakePlugin) OnOutboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
+	cluster *xdsapi.Cluster) {
+}
+
+func (p *fakePlugin) OnInboundCluster(env model.Environment, node model.Proxy, service *model.Service, servicePort *model.Port,
+	cluster *xdsapi.Cluster) {
+}
+
+func (p *fakePlugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+}
+
+func (p *fakePlugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
+}
+
+func isHTTPListener(listener *xdsapi.Listener) bool {
+	if len(listener.FilterChains) > 0 && len(listener.FilterChains[0].Filters) > 0 {
+		return listener.FilterChains[0].Filters[0].Name == "envoy.http_connection_manager"
+	}
+	return false
+}
+
+func buildService(protocol model.Protocol, creationTime time.Time) *model.Service {
+	return &model.Service{
+		CreationTime: creationTime,
+		Hostname:     "*.example.org",
+		Address:      "1.1.1.1",
+		ClusterVIPs:  make(map[string]string),
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "default",
+				Port:     8080,
+				Protocol: protocol,
+			},
+		},
+		Resolution: model.Passthrough,
+	}
+}
+
+func buildListenerEnv() model.Environment {
+	serviceDiscovery := &fakes.ServiceDiscovery{}
+
+	configStore := &fakes.IstioConfigStore{}
+
+	mesh := model.DefaultMeshConfig()
+	env := model.Environment{
+		ServiceDiscovery: serviceDiscovery,
+		ServiceAccounts:  &fakes.ServiceAccounts{},
+		IstioConfigStore: configStore,
+		Mesh:             &mesh,
+		MixerSAN:         []string{},
+	}
+
+	return env
+}

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -61,6 +61,7 @@ func convertServices(serviceEntry *networking.ServiceEntry, creationTime time.Ti
 						newAddress = ip.String()
 					}
 					out = append(out, &model.Service{
+						CreationTime: creationTime,
 						MeshExternal: serviceEntry.Location == networking.ServiceEntry_MESH_EXTERNAL,
 						Hostname:     model.Hostname(host),
 						Address:      newAddress,

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"time"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"
@@ -188,8 +190,11 @@ func convertPortNameToProtocol(name string) model.Protocol {
 	return model.ParseProtocol(prefix)
 }
 
-func makeService(hostname model.Hostname, address string, ports map[string]int, external bool, resolution model.Resolution) *model.Service {
+func makeService(hostname model.Hostname, address string, ports map[string]int, external bool, resolution model.Resolution,
+	creationTime time.Time) *model.Service {
+
 	svc := &model.Service{
+		CreationTime: creationTime,
 		Hostname:     hostname,
 		Address:      address,
 		MeshExternal: external,
@@ -213,13 +218,13 @@ func makeService(hostname model.Hostname, address string, ports map[string]int, 
 }
 
 func makeInstance(serviceEntry *networking.ServiceEntry, address string, port int,
-	svcPort *networking.Port, labels map[string]string) *model.ServiceInstance {
+	svcPort *networking.Port, labels map[string]string, creationTime time.Time) *model.ServiceInstance {
 	family := model.AddressFamilyTCP
 	if port == 0 {
 		family = model.AddressFamilyUnix
 	}
 
-	services := convertServices(serviceEntry)
+	services := convertServices(serviceEntry, creationTime)
 	svc := services[0] // default
 	for _, s := range services {
 		if s.Hostname.String() == address {
@@ -244,6 +249,7 @@ func makeInstance(serviceEntry *networking.ServiceEntry, address string, port in
 }
 
 func TestConvertService(t *testing.T) {
+	tnow := time.Now()
 	serviceTests := []struct {
 		externalSvc *networking.ServiceEntry
 		services    []*model.Service
@@ -252,21 +258,21 @@ func TestConvertService(t *testing.T) {
 			// service entry http
 			externalSvc: httpNone,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-number": 80, "http2-number": 8080}, true, model.Passthrough),
+				map[string]int{"http-number": 80, "http2-number": 8080}, true, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry tcp
 			externalSvc: tcpNone,
 			services: []*model.Service{makeService("tcpnone.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, true, model.Passthrough),
+				map[string]int{"tcp-444": 444}, true, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry http  static
 			externalSvc: httpStatic,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideLB),
+				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.ClientSideLB, tnow),
 			},
 		},
 		{
@@ -274,44 +280,44 @@ func TestConvertService(t *testing.T) {
 			externalSvc: httpDNSnoEndpoints,
 			services: []*model.Service{
 				makeService("google.com", model.UnspecifiedIP,
-					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 				makeService("www.wikipedia.org", model.UnspecifiedIP,
-					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+					map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry dns
 			externalSvc: httpDNS,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
+				map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
 			services: []*model.Service{makeService("tcpdns.com", model.UnspecifiedIP,
-				map[string]int{"tcp-444": 444}, true, model.DNSLB),
+				map[string]int{"tcp-444": 444}, true, model.DNSLB, tnow),
 			},
 		},
 		{
 			// service entry tcp static
 			externalSvc: tcpStatic,
 			services: []*model.Service{makeService("tcpstatic.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+				map[string]int{"tcp-444": 444}, true, model.ClientSideLB, tnow),
 			},
 		},
 		{
 			// service entry http internal
 			externalSvc: httpNoneInternal,
 			services: []*model.Service{makeService("*.google.com", model.UnspecifiedIP,
-				map[string]int{"http-number": 80, "http2-number": 8080}, false, model.Passthrough),
+				map[string]int{"http-number": 80, "http2-number": 8080}, false, model.Passthrough, tnow),
 			},
 		},
 		{
 			// service entry tcp internal
 			externalSvc: tcpNoneInternal,
 			services: []*model.Service{makeService("tcpinternal.com", "172.217.0.0/16",
-				map[string]int{"tcp-444": 444}, false, model.Passthrough),
+				map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 			},
 		},
 		{
@@ -319,19 +325,19 @@ func TestConvertService(t *testing.T) {
 			externalSvc: multiAddrInternal,
 			services: []*model.Service{
 				makeService("tcp1.com", "1.1.1.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp1.com", "2.2.2.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp2.com", "1.1.1.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 				makeService("tcp2.com", "2.2.2.0/16",
-					map[string]int{"tcp-444": 444}, false, model.Passthrough),
+					map[string]int{"tcp-444": 444}, false, model.Passthrough, tnow),
 			},
 		},
 	}
 
 	for _, tt := range serviceTests {
-		services := convertServices(tt.externalSvc)
+		services := convertServices(tt.externalSvc, tnow)
 		if err := compare(t, services, tt.services); err != nil {
 			t.Error(err)
 		}
@@ -339,6 +345,7 @@ func TestConvertService(t *testing.T) {
 }
 
 func TestConvertInstances(t *testing.T) {
+	tnow := time.Now()
 	serviceInstanceTests := []struct {
 		externalSvc *networking.ServiceEntry
 		out         []*model.ServiceInstance
@@ -359,64 +366,64 @@ func TestConvertInstances(t *testing.T) {
 			// service entry static
 			externalSvc: httpStatic,
 			out: []*model.ServiceInstance{
-				makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Ports[0], nil),
-				makeInstance(httpStatic, "2.2.2.2", 18080, httpStatic.Ports[1], nil),
-				makeInstance(httpStatic, "3.3.3.3", 1080, httpStatic.Ports[0], nil),
-				makeInstance(httpStatic, "3.3.3.3", 8080, httpStatic.Ports[1], nil),
-				makeInstance(httpStatic, "4.4.4.4", 1080, httpStatic.Ports[0], map[string]string{"foo": "bar"}),
-				makeInstance(httpStatic, "4.4.4.4", 8080, httpStatic.Ports[1], map[string]string{"foo": "bar"}),
+				makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Ports[0], nil, tnow),
+				makeInstance(httpStatic, "2.2.2.2", 18080, httpStatic.Ports[1], nil, tnow),
+				makeInstance(httpStatic, "3.3.3.3", 1080, httpStatic.Ports[0], nil, tnow),
+				makeInstance(httpStatic, "3.3.3.3", 8080, httpStatic.Ports[1], nil, tnow),
+				makeInstance(httpStatic, "4.4.4.4", 1080, httpStatic.Ports[0], map[string]string{"foo": "bar"}, tnow),
+				makeInstance(httpStatic, "4.4.4.4", 8080, httpStatic.Ports[1], map[string]string{"foo": "bar"}, tnow),
 			},
 		},
 		{
 			// service entry DNS with no endpoints
 			externalSvc: httpDNSnoEndpoints,
 			out: []*model.ServiceInstance{
-				makeInstance(httpDNSnoEndpoints, "google.com", 80, httpDNSnoEndpoints.Ports[0], nil),
-				makeInstance(httpDNSnoEndpoints, "google.com", 8080, httpDNSnoEndpoints.Ports[1], nil),
-				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 80, httpDNSnoEndpoints.Ports[0], nil),
-				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 8080, httpDNSnoEndpoints.Ports[1], nil),
+				makeInstance(httpDNSnoEndpoints, "google.com", 80, httpDNSnoEndpoints.Ports[0], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "google.com", 8080, httpDNSnoEndpoints.Ports[1], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 80, httpDNSnoEndpoints.Ports[0], nil, tnow),
+				makeInstance(httpDNSnoEndpoints, "www.wikipedia.org", 8080, httpDNSnoEndpoints.Ports[1], nil, tnow),
 			},
 		},
 		{
 			// service entry dns
 			externalSvc: httpDNS,
 			out: []*model.ServiceInstance{
-				makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-				makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil),
-				makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-				makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil),
-				makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
-				makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}),
+				makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+				makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil, tnow),
+				makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+				makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil, tnow),
+				makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
+				makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}, tnow),
 			},
 		},
 		{
 			// service entry tcp DNS
 			externalSvc: tcpDNS,
 			out: []*model.ServiceInstance{
-				makeInstance(tcpDNS, "lon.google.com", 444, tcpDNS.Ports[0], nil),
-				makeInstance(tcpDNS, "in.google.com", 444, tcpDNS.Ports[0], nil),
+				makeInstance(tcpDNS, "lon.google.com", 444, tcpDNS.Ports[0], nil, tnow),
+				makeInstance(tcpDNS, "in.google.com", 444, tcpDNS.Ports[0], nil, tnow),
 			},
 		},
 		{
 			// service entry tcp static
 			externalSvc: tcpStatic,
 			out: []*model.ServiceInstance{
-				makeInstance(tcpStatic, "1.1.1.1", 444, tcpStatic.Ports[0], nil),
-				makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil),
+				makeInstance(tcpStatic, "1.1.1.1", 444, tcpStatic.Ports[0], nil, tnow),
+				makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil, tnow),
 			},
 		},
 		{
 			// service entry unix domain socket static
 			externalSvc: udsLocal,
 			out: []*model.ServiceInstance{
-				makeInstance(udsLocal, "/test/sock", 0, udsLocal.Ports[0], nil),
+				makeInstance(udsLocal, "/test/sock", 0, udsLocal.Ports[0], nil, tnow),
 			},
 		},
 	}
 
 	for _, tt := range serviceInstanceTests {
 		t.Run(strings.Join(tt.externalSvc.Hosts, "_"), func(t *testing.T) {
-			instances := convertInstances(tt.externalSvc)
+			instances := convertInstances(tt.externalSvc, tnow)
 			sortServiceInstances(instances)
 			sortServiceInstances(tt.out)
 			if err := compare(t, instances, tt.out); err != nil {

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -20,20 +20,25 @@ import (
 	"sort"
 	"testing"
 
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 )
 
-func createServiceEntries(serviceEntries []*networking.ServiceEntry, store model.IstioConfigStore, t *testing.T) {
+func createServiceEntries(serviceEntries []*networking.ServiceEntry, store model.IstioConfigStore, t *testing.T, creationTime time.Time) {
 	t.Helper()
 	for _, svc := range serviceEntries {
 		config := model.Config{
 			ConfigMeta: model.ConfigMeta{
-				Type:      model.ServiceEntry.Type,
-				Name:      svc.Hosts[0],
-				Namespace: "default",
-				Domain:    "cluster.local",
+				Type:              model.ServiceEntry.Type,
+				Name:              svc.Hosts[0],
+				Namespace:         "default",
+				Domain:            "cluster.local",
+				CreationTimestamp: meta_v1.Time{creationTime},
 			},
 			Spec: svc,
 		}
@@ -66,12 +71,13 @@ func TestServiceDiscoveryServices(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
+	tnow := time.Now()
 	expectedServices := []*model.Service{
-		makeService("*.google.com", model.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB),
-		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideLB),
+		makeService("*.google.com", model.UnspecifiedIP, map[string]int{"http-port": 80, "http-alt-port": 8080}, true, model.DNSLB, tnow),
+		makeService("tcpstatic.com", "172.217.0.0/16", map[string]int{"tcp-444": 444}, true, model.ClientSideLB, tnow),
 	}
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	services, err := sd.Services()
 	if err != nil {
@@ -91,7 +97,8 @@ func TestServiceDiscoveryGetService(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	service, err := sd.GetService(model.Hostname(hostDNE))
 	if err != nil {
@@ -117,9 +124,10 @@ func TestServiceDiscoveryGetServiceAttributes(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
-	tcpStaticSvc := convertServices(tcpStatic)
+	tcpStaticSvc := convertServices(tcpStatic, tnow)
 	for _, svc := range tcpStaticSvc {
 		expect := model.ServiceAttributes{
 			Name:      svc.Hostname.String(),
@@ -129,7 +137,7 @@ func TestServiceDiscoveryGetServiceAttributes(t *testing.T) {
 			t.Errorf("GetServiceAttributes(%q) => %v, want %v", svc.Hostname, *attr, expect)
 		}
 	}
-	tcpDNSSvc := convertServices(tcpDNS)
+	tcpDNSSvc := convertServices(tcpDNS, tnow)
 	for _, svc := range tcpDNSSvc {
 		if attr, _ := sd.GetServiceAttributes(svc.Hostname); attr != nil {
 			t.Errorf(`GetServiceAttributes("tcpDNSSvc") => %q, want nil`, attr.Namespace)
@@ -141,7 +149,8 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpStatic, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpStatic, tcpStatic}, store, t, tnow)
 
 	_, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddress: "2.2.2.2"})
 	if err != nil {
@@ -154,15 +163,16 @@ func TestServiceDiscoveryInstances(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
-		makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "us.google.com", 18080, httpDNS.Ports[1], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 8080, httpDNS.Ports[1], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
+		makeInstance(httpDNS, "de.google.com", 8080, httpDNS.Ports[1], map[string]string{"foo": "bar"}, tnow),
 	}
 
 	instances, err := sd.InstancesByPort("*.google.com", 0, nil)
@@ -181,12 +191,13 @@ func TestServiceDiscoveryInstances1Port(t *testing.T) {
 	store, sd, stopFn := initServiceDiscovery()
 	defer stopFn()
 
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	tnow := time.Now()
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
 	}
 
 	instances, err := sd.InstancesByPort("*.google.com", 80, nil)
@@ -205,12 +216,14 @@ func TestNonServiceConfig(t *testing.T) {
 	defer stopFn()
 
 	// Create a non-service configuration element. This should not affect the service registry at all.
+	tnow := time.Now()
 	config := model.Config{
 		ConfigMeta: model.ConfigMeta{
-			Type:      model.DestinationRule.Type,
-			Name:      "fakeDestinationRule",
-			Namespace: "default",
-			Domain:    "cluster.local",
+			Type:              model.DestinationRule.Type,
+			Name:              "fakeDestinationRule",
+			Namespace:         "default",
+			Domain:            "cluster.local",
+			CreationTimestamp: meta_v1.Time{tnow},
 		},
 		Spec: &networking.DestinationRule{
 			Host: "fakehost",
@@ -222,11 +235,11 @@ func TestNonServiceConfig(t *testing.T) {
 	}
 
 	// Now create some service entries and verify that it's added to the registry.
-	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t)
+	createServiceEntries([]*networking.ServiceEntry{httpDNS, tcpStatic}, store, t, tnow)
 	expectedInstances := []*model.ServiceInstance{
-		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil),
-		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}),
+		makeInstance(httpDNS, "us.google.com", 7080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "uk.google.com", 1080, httpDNS.Ports[0], nil, tnow),
+		makeInstance(httpDNS, "de.google.com", 80, httpDNS.Ports[0], map[string]string{"foo": "bar"}, tnow),
 	}
 	instances, err := sd.InstancesByPort("*.google.com", 80, nil)
 	if err != nil {

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -112,6 +112,7 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 		LoadBalancingDisabled: loadBalancingDisabled,
 		MeshExternal:          meshExternal,
 		Resolution:            resolution,
+		CreationTime:          svc.CreationTimestamp.Time,
 	}
 }
 

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"time"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -70,6 +72,7 @@ func TestServiceConversion(t *testing.T) {
 
 	ip := "10.0.0.1"
 
+	tnow := time.Now()
 	localSvc := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
@@ -79,6 +82,7 @@ func TestServiceConversion(t *testing.T) {
 				CanonicalServiceAccountsOnVMAnnotation: saC + "," + saD,
 				"other/annotation":                     "test",
 			},
+			CreationTimestamp: metav1.Time{tnow},
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP: ip,
@@ -100,6 +104,10 @@ func TestServiceConversion(t *testing.T) {
 	service := convertService(localSvc, domainSuffix)
 	if service == nil {
 		t.Errorf("could not convert service")
+	}
+
+	if service.CreationTime != tnow {
+		t.Errorf("incorrect creation time => %v, want %v", service.CreationTime, tnow)
 	}
 
 	if len(service.Ports) != len(localSvc.Spec.Ports) {

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"net"
 
+	"time"
+
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -37,8 +39,9 @@ func NewDiscovery(services map[model.Hostname]*model.Service, versions int) *Ser
 // MakeService creates a memory service
 func MakeService(hostname model.Hostname, address string) *model.Service {
 	return &model.Service{
-		Hostname: hostname,
-		Address:  address,
+		CreationTime: time.Now(),
+		Hostname:     hostname,
+		Address:      address,
 		Ports: []*model.Port{
 			{
 				Name:     PortHTTPName,
@@ -68,6 +71,7 @@ func MakeService(hostname model.Hostname, address string) *model.Service {
 // MakeExternalHTTPService creates memory external service
 func MakeExternalHTTPService(hostname, external model.Hostname, address string) *model.Service {
 	return &model.Service{
+		CreationTime: time.Now(),
 		Hostname:     hostname,
 		Address:      address,
 		ExternalName: external,
@@ -82,6 +86,7 @@ func MakeExternalHTTPService(hostname, external model.Hostname, address string) 
 // MakeExternalHTTPSService creates memory external service
 func MakeExternalHTTPSService(hostname, external model.Hostname, address string) *model.Service {
 	return &model.Service{
+		CreationTime: time.Now(),
 		Hostname:     hostname,
 		Address:      address,
 		ExternalName: external,


### PR DESCRIPTION
This PR adds the CreationTime to the service struct and populates it
in the k8s service registry. When available, services will be sorted
by their creation time. Conflicts will cause the listeners for newer
services to be dropped.

Partial fix for #5992