### PR TITLE
move ca root cert to different path in proxyv2 image

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -19,7 +19,7 @@ ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 
-ADD ca-root-cert.pem /etc/certs/ca-root-cert.pem
+ADD ca-root-cert.pem /etc/istio/certs/ca-root-cert.pem
 
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// CARootCertPath is the path of ca root cert that envoy uses to validate cert got from SDS service.
-	CARootCertPath = "/etc/certs/ca-root-cert.pem"
+	CARootCertPath = "/etc/istio/certs/ca-root-cert.pem"
 
 	// SDSStatPrefix is the human readable prefix to use when emitting statistics for the SDS service.
 	SDSStatPrefix = "sdsstat"


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

integration shows ca cert is flushed(most likely by citadel) in previous path(/etc/certs/), so move it to different folder