### PR TITLE
WIP: istioctl mesh-dump implementation

### DIFF
--- a/istioctl/cmd/istioctl/meshdump.go
+++ b/istioctl/cmd/istioctl/meshdump.go
@@ -29,8 +29,6 @@ import (
 
 var (
 	outMeshDumpFilename string
-	dumpPilot           bool
-	dumpEnvoy           bool
 
 	meshDumpCmd = &cobra.Command{
 		Use:   "mesh-dump",

--- a/istioctl/cmd/istioctl/meshdump.go
+++ b/istioctl/cmd/istioctl/meshdump.go
@@ -138,6 +138,6 @@ func writeToTar(out *tar.Writer, name string, body []byte) error {
 }
 
 func dumpAll() bool {
-	// If nothing has been explicity requested, dump everything
+	// If nothing has been explicitly requested, dump everything
 	return !dumpPilot && !dumpEnvoy
 }

--- a/istioctl/cmd/istioctl/meshdump.go
+++ b/istioctl/cmd/istioctl/meshdump.go
@@ -1,0 +1,132 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"istio.io/istio/istioctl/pkg/kubernetes"
+	"istio.io/istio/pkg/log"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+)
+
+var (
+	outMeshDumpFilename string
+
+	meshDumpCmd = &cobra.Command{
+		Use:   "mesh-dump",
+		Short: "Creates an archive of mesh information for debugging purposes [kube only]",
+		Long: `
+Creates an archive of mesh information required for debugging.
+`,
+		Example: `# Create archive of mesh information for debugging
+    istioctl mesh-dump
+`,
+		Aliases: []string{"md"},
+		RunE: func(c *cobra.Command, args []string) error {
+			kubeClient, err := newExecClient(kubeconfig, configContext)
+			if err != nil {
+				return err
+			}
+
+			filename := "istio-dump.tgz"
+			if outMeshDumpFilename != "" {
+				filename = outMeshDumpFilename
+			}
+
+			f, err := os.Create(filename)
+			if err != nil {
+				return err
+			}
+
+			zipper := gzip.NewWriter(f)
+			tarWriter := tar.NewWriter(zipper)
+			defer func() {
+				tarWriter.Close()
+				zipper.Close()
+				f.Close()
+			}()
+
+			var errs error
+			pilotADSz, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", "/debug/adsz", nil)
+			if err != nil {
+				log.Errorf("error retrieving adsz from Pilots: %v", err)
+			}
+			log.Debugf("Finished AllPilotsDiscoveryDo with %d pilots", len(pilotADSz))
+			for pilot, adsz := range pilotADSz {
+				fname := filepath.Join("pilot", pilot+".json")
+				// if err = ioutil.WriteFile(filepath.Join(tmp, "pilot", pilot+".json"), adsz, 0777); err != nil {
+				if err = writeToTar(tarWriter, fname, adsz); err != nil {
+					errs = multierror.Append(errs, err)
+				}
+			}
+
+			pods, err := kubeClient.GetPods("", "")
+			if err != nil {
+				errs = multierror.Append(errs, err)
+			}
+			for _, pod := range pods {
+				_, err := kubernetes.GetPilotAgentContainer(pod)
+				if err != nil {
+					continue // Ignore pods that have no pilot-agent
+				}
+				log.Debugf("Querying pod %s/%s", pod.Namespace, pod.Name)
+				out, err := kubeClient.EnvoyDo(pod.Name, pod.Namespace, "GET", "/config_dump", nil)
+				if err != nil {
+					errs = multierror.Append(errs, err)
+				}
+				if len(out) > 0 {
+					fname := filepath.Join("pod", pod.Namespace, fmt.Sprintf("%s.json", pod.Name))
+					if err = writeToTar(tarWriter, fname, out); err != nil {
+						errs = multierror.Append(errs, err)
+					}
+				}
+			}
+
+			c.Printf("Wrote %d pilot configurations and %d pod configurations to %s\n", len(pilotADSz), len(pods), filename)
+
+			return errs
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(meshDumpCmd)
+	meshDumpCmd.PersistentFlags().StringVarP(&outMeshDumpFilename, "output", "o", "", "Output .tgz filename")
+}
+
+// writeToTar writes a single file to a tar/tgz archive.
+func writeToTar(out *tar.Writer, name string, body []byte) error {
+	h := &tar.Header{
+		Name:    name,
+		Size:    int64(len(body)),
+		Mode:    0444,
+		ModTime: time.Now(),
+	}
+	if err := out.WriteHeader(h); err != nil {
+		return err
+	}
+	if _, err := out.Write(body); err != nil {
+		return err
+	}
+	return nil
+}

--- a/istioctl/cmd/istioctl/meshdump.go
+++ b/istioctl/cmd/istioctl/meshdump.go
@@ -27,10 +27,13 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
+	"k8s.io/api/core/v1"
 )
 
 var (
 	outMeshDumpFilename string
+	dumpPilot           bool
+	dumpEnvoy           bool
 
 	meshDumpCmd = &cobra.Command{
 		Use:   "mesh-dump",
@@ -48,12 +51,7 @@ Creates an archive of mesh information required for debugging.
 				return err
 			}
 
-			filename := "istio-dump.tgz"
-			if outMeshDumpFilename != "" {
-				filename = outMeshDumpFilename
-			}
-
-			f, err := os.Create(filename)
+			f, err := os.Create(outMeshDumpFilename)
 			if err != nil {
 				return err
 			}
@@ -67,42 +65,48 @@ Creates an archive of mesh information required for debugging.
 			}()
 
 			var errs error
-			pilotADSz, err := kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", "/debug/adsz", nil)
-			if err != nil {
-				log.Errorf("error retrieving adsz from Pilots: %v", err)
-			}
-			log.Debugf("Finished AllPilotsDiscoveryDo with %d pilots", len(pilotADSz))
-			for pilot, adsz := range pilotADSz {
-				fname := filepath.Join("pilot", pilot+".json")
-				// if err = ioutil.WriteFile(filepath.Join(tmp, "pilot", pilot+".json"), adsz, 0777); err != nil {
-				if err = writeToTar(tarWriter, fname, adsz); err != nil {
-					errs = multierror.Append(errs, err)
-				}
-			}
-
-			pods, err := kubeClient.GetPods("", "")
-			if err != nil {
-				errs = multierror.Append(errs, err)
-			}
-			for _, pod := range pods {
-				_, err := kubernetes.GetPilotAgentContainer(pod)
+			var pilotADSz map[string][]byte
+			if dumpPilot || dumpAll() {
+				pilotADSz, err = kubeClient.AllPilotsDiscoveryDo(istioNamespace, "GET", "/debug/adsz", nil)
 				if err != nil {
-					continue // Ignore pods that have no pilot-agent
+					log.Errorf("error retrieving adsz from Pilots: %v", err)
 				}
-				log.Debugf("Querying pod %s/%s", pod.Namespace, pod.Name)
-				out, err := kubeClient.EnvoyDo(pod.Name, pod.Namespace, "GET", "/config_dump", nil)
-				if err != nil {
-					errs = multierror.Append(errs, err)
-				}
-				if len(out) > 0 {
-					fname := filepath.Join("pod", pod.Namespace, fmt.Sprintf("%s.json", pod.Name))
-					if err = writeToTar(tarWriter, fname, out); err != nil {
+				log.Debugf("Finished AllPilotsDiscoveryDo with %d pilots", len(pilotADSz))
+				for pilot, adsz := range pilotADSz {
+					fname := filepath.Join("pilot", pilot+".json")
+					if err = writeToTar(tarWriter, fname, adsz); err != nil {
 						errs = multierror.Append(errs, err)
 					}
 				}
 			}
 
-			c.Printf("Wrote %d pilot configurations and %d pod configurations to %s\n", len(pilotADSz), len(pods), filename)
+			var pods []v1.Pod
+			if dumpEnvoy || dumpAll() {
+				pods, err = kubeClient.GetPods("", "")
+				if err != nil {
+					errs = multierror.Append(errs, err)
+				}
+				for _, pod := range pods {
+					_, err := kubernetes.GetPilotAgentContainer(pod)
+					if err != nil {
+						log.Debugf("Skipping pod %s/%s which has no agent-container", pod.Namespace, pod.Name)
+						continue // Ignore pods that have no pilot-agent
+					}
+					log.Debugf("Querying pod %s/%s", pod.Namespace, pod.Name)
+					out, err := kubeClient.EnvoyDo(pod.Name, pod.Namespace, "GET", "/config_dump", nil)
+					if err != nil {
+						errs = multierror.Append(errs, err)
+					}
+					if len(out) > 0 {
+						fname := filepath.Join("pod", pod.Namespace, fmt.Sprintf("%s.json", pod.Name))
+						if err = writeToTar(tarWriter, fname, out); err != nil {
+							errs = multierror.Append(errs, err)
+						}
+					}
+				}
+			}
+
+			c.Printf("Wrote %d pilot configurations and %d pod configurations to %s\n", len(pilotADSz), len(pods), outMeshDumpFilename)
 
 			return errs
 		},
@@ -110,8 +114,10 @@ Creates an archive of mesh information required for debugging.
 )
 
 func init() {
-	rootCmd.AddCommand(meshDumpCmd)
-	meshDumpCmd.PersistentFlags().StringVarP(&outMeshDumpFilename, "output", "o", "", "Output .tgz filename")
+	experimentalCmd.AddCommand(meshDumpCmd)
+	meshDumpCmd.PersistentFlags().StringVarP(&outMeshDumpFilename, "output", "o", "istio-dump.tgz", "Output .tgz filename")
+	meshDumpCmd.PersistentFlags().BoolVar(&dumpPilot, "pilot", false, "Mesh Dump of Pilot status")
+	meshDumpCmd.PersistentFlags().BoolVar(&dumpEnvoy, "envoy", false, "Mesh Dump of Envoy status")
 }
 
 // writeToTar writes a single file to a tar/tgz archive.
@@ -129,4 +135,9 @@ func writeToTar(out *tar.Writer, name string, body []byte) error {
 		return err
 	}
 	return nil
+}
+
+func dumpAll() bool {
+	// If nothing has been explicity requested, dump everything
+	return !dumpPilot && !dumpEnvoy
 }

--- a/istioctl/cmd/istioctl/proxyconfig_test.go
+++ b/istioctl/cmd/istioctl/proxyconfig_test.go
@@ -23,6 +23,8 @@ import (
 
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/test/util"
+
+	"k8s.io/api/core/v1"
 )
 
 type execTestCase struct {
@@ -180,4 +182,9 @@ func (client mockExecConfig) PilotDiscoveryDo(pilotNamespace, method, path strin
 		return results, nil
 	}
 	return nil, fmt.Errorf("unable to find any Pilot instances")
+}
+
+func (client mockExecConfig) GetPods(namespace, labelSelector string) ([]v1.Pod, error) {
+	// This mock implemention never finds any pods
+	return nil, nil
 }

--- a/istioctl/cmd/istioctl/proxyconfig_test.go
+++ b/istioctl/cmd/istioctl/proxyconfig_test.go
@@ -23,8 +23,6 @@ import (
 
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/test/util"
-
-	"k8s.io/api/core/v1"
 )
 
 type execTestCase struct {
@@ -182,9 +180,4 @@ func (client mockExecConfig) PilotDiscoveryDo(pilotNamespace, method, path strin
 		return results, nil
 	}
 	return nil, fmt.Errorf("unable to find any Pilot instances")
-}
-
-func (client mockExecConfig) GetPods(namespace, labelSelector string) ([]v1.Pod, error) {
-	// This mock implemention never finds any pods
-	return nil, nil
 }

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -45,8 +45,6 @@ type ExecClient interface {
 	EnvoyDo(podName, podNamespace, method, path string, body []byte) ([]byte, error)
 	// AllPilotsDiscoveryDo invokes "/usr/local/bin/pilot-agent request" on all Istio pilots
 	AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error)
-	// GetPods returns all pods optionally matching a namespace or label selector
-	GetPods(namespace, labelSelector string) ([]v1.Pod, error)
 }
 
 // NewClient is the contructor for the client wrapper

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -226,5 +226,5 @@ func GetPilotAgentContainer(pod v1.Pod) (string, error) {
 			return c.Name, nil
 		}
 	}
-	return "", fmt.Errorf("Pod %s has no pilot-agent container")
+	return "", fmt.Errorf("pod %s has no pilot-agent container")
 }

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -226,5 +226,5 @@ func GetPilotAgentContainer(pod v1.Pod) (string, error) {
 			return c.Name, nil
 		}
 	}
-	return "", fmt.Errorf("pod %s has no pilot-agent container")
+	return "", fmt.Errorf("pod %s has no pilot-agent container", pod.Name)
 }


### PR DESCRIPTION
Implementation of istioctl mesh-dump.  This is a troubleshooting command that captures Istio .json configuration into a file for later analysis.

This initial implementation captures the _/debug/adsz_ endpoint for all Pilots and the /config_dump endpoint for all Envoys.

For https://github.com/istio/istio/issues/6382