### PR TITLE
Fix the rbac sample files for Istio 1.0.

### DIFF
--- a/samples/bookinfo/platform/kube/rbac/details-reviews-policy.yaml
+++ b/samples/bookinfo/platform/kube/rbac/details-reviews-policy.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: default
 spec:
   subjects:
-  - user: "cluster.local/ns/default/sa/bookinfo-productpage"
+  - user: "spiffe://cluster.local/ns/default/sa/bookinfo-productpage"
   roleRef:
     kind: ServiceRole
     name: "details-reviews-viewer"

--- a/samples/bookinfo/platform/kube/rbac/ratings-policy.yaml
+++ b/samples/bookinfo/platform/kube/rbac/ratings-policy.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: default
 spec:
   subjects:
-  - user: "cluster.local/ns/default/sa/bookinfo-reviews"
+  - user: "spiffe://cluster.local/ns/default/sa/bookinfo-reviews"
   roleRef:
     kind: ServiceRole
     name: "ratings-viewer"


### PR DESCRIPTION
The user field is comparing to the original peer certificate which would have a "spiffe://" prefix for the identity.

For #6377.

/cc @liminw 