### PR TITLE
Multicluster make zipkin conditional

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -76,7 +76,7 @@ data:
     {{- if .Values.global.remoteZipkinAddress }}
       #
       # Zipkin trace collector
-      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
+      zipkinAddress: {{ .Values.global.remoteZipkinAddress }}:9411
     {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -94,8 +94,10 @@ data:
         - {{ "[[ .ProxyConfig.DiscoveryAddress ]]" }}
         - --discoveryRefreshDelay
         - {{ "[[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]" }}
+      {{- if .Values.global.zipkinAddress }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
+      {{- end }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}
       {{- if .Values.global.proxy.envoyStatsd.enabled }}


### PR DESCRIPTION
This change makes the zipkin argument in
the sidecar configmap to be conditional
based on zipkin being used in remote clusters.