### PR TITLE
fix 0.8-to-1.0 upgrade issue with istio-mixer-post-install

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -60,7 +60,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-mixer-post-install
+  name: istio-mixer-post-install-v1.0.0
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install


### PR DESCRIPTION
The istio-mixer-post-install job was changed between 0.8 to 1.0 to address CRD install issues. However, hob template specs are immutable. Upgrading from 0.8 to 1.0 produces the following error when the modified job is applied. 

```bash
The Job "istio-mixer-post-install" is invalid: spec.template: Invalid value: core.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"istio-mixer-post-install", GenerateName:"", Namespace:"", SelfLin
k:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSecon
ds:(*int64)(nil), Labels:map[string]string{"app":"mixer", "controller-uid":"7990ff1d-86b8-11e8-8e71-42010a8000b7", "job-name":"istio-mixer-post-install", "release":"RELEASE-NAME"}, Annotations:m
ap[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:core.PodSpec{Volumes:[]core.Volume{core.Vol
ume{Name:"tmp-configmap-mixer", VolumeSource:core.VolumeSource{HostPath:(*core.HostPathVolumeSource)(nil), EmptyDir:(*core.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*core.GCEPersistentDiskV
olumeSource)(nil), AWSElasticBlockStore:(*core.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*core.GitRepoVolumeSource)(nil), Secret:(*core.SecretVolumeSource)(nil), NFS:(*core.NFSVolumeSourc
e)(nil), ISCSI:(*core.ISCSIVolumeSource)(nil), Glusterfs:(*core.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*core.PersistentVolumeClaimVolumeSource)(nil), RBD:(*core.RBDVolumeSource)(nil
), Quobyte:(*core.QuobyteVolumeSource)(nil), FlexVolume:(*core.FlexVolumeSource)(nil), Cinder:(*core.CinderVolumeSource)(nil), CephFS:(*core.CephFSVolumeSource)(nil), Flocker:(*core.FlockerVolum
eSource)(nil), DownwardAPI:(*core.DownwardAPIVolumeSource)(nil), FC:(*core.FCVolumeSource)(nil), AzureFile:(*core.AzureFileVolumeSource)(nil), ConfigMap:(*core.ConfigMapVolumeSource)(0xc43d75330
0), VsphereVolume:(*core.VsphereVirtualDiskVolumeSource)(nil), AzureDisk:(*core.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*core.PhotonPersistentDiskVolumeSource)(nil), Projected:(*core.
ProjectedVolumeSource)(nil), PortworxVolume:(*core.PortworxVolumeSource)(nil), ScaleIO:(*core.ScaleIOVolumeSource)(nil), StorageOS:(*core.StorageOSVolumeSource)(nil)}}}, InitContainers:[]core.Co
ntainer(nil), Containers:[]core.Container{core.Container{Name:"hyperkube", Image:"quay.io/coreos/hyperkube:v1.7.6_coreos.0", Command:[]string{"/bin/bash", "/tmp/mixer/run.sh", "/tmp/mixer/custom
-resources.yaml"}, Args:[]string(nil), WorkingDir:"", Ports:[]core.ContainerPort(nil), EnvFrom:[]core.EnvFromSource(nil), Env:[]core.EnvVar(nil), Resources:core.ResourceRequirements{Limits:core.
ResourceList(nil), Requests:core.ResourceList(nil)}, VolumeMounts:[]core.VolumeMount{core.VolumeMount{Name:"tmp-configmap-mixer", ReadOnly:false, MountPath:"/tmp/mixer", SubPath:"", MountPropaga
tion:(*core.MountPropagationMode)(nil)}}, VolumeDevices:[]core.VolumeDevice(nil), LivenessProbe:(*core.Probe)(nil), ReadinessProbe:(*core.Probe)(nil), Lifecycle:(*core.Lifecycle)(nil), Terminati
onMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*core.SecurityContext)(nil), Stdin:false, StdinOnce:false, TTY:false}}, Re
startPolicy:"OnFailure", TerminationGracePeriodSeconds:(*int64)(0xc42f069080), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountN
ame:"istio-mixer-post-install-account", AutomountServiceAccountToken:(*bool)(nil), NodeName:"", SecurityContext:(*core.PodSecurityContext)(0xc440dc3a40), ImagePullSecrets:[]core.LocalObjectRefer
ence(nil), Hostname:"", Subdomain:"", Affinity:(*core.Affinity)(nil), SchedulerName:"default-scheduler", Tolerations:[]core.Toleration(nil), HostAliases:[]core.HostAlias(nil), PriorityClassName:
"", Priority:(*int32)(nil), DNSConfig:(*core.PodDNSConfig)(nil)}}: field is immutable 
```

Creating a new version of the job fixes the issue. However, the 0.8 istio-mixer-post-install job is still left around and needs to be manually cleaned up. 