### PR TITLE
Change mixer-post-install job name to indicate release version

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -60,7 +60,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-mixer-post-install
+  name: istio-mixer-post-install-1.0
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install


### PR DESCRIPTION
Post install job should have unique names per official release.
This ensures that during upgrades post-install and new post-install jobs do not collide.