### PR TITLE
Istio-remote helm: allow setup pilot svc & endpoint for controlPlaneSecurity

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -85,18 +85,28 @@ data:
       statsdUdpAddress: {{ .Values.global.proxy.envoyStatsd.host }}:{{ .Values.global.proxy.envoyStatsd.port }}
     {{- end }}
 
+    {{- $defPilotHostname := printf "istio-pilot.%s" .Release.Namespace }}
+    {{- $pilotAddress := .Values.global.remotePilotAddress | default $defPilotHostname }}
     {{- if .Values.global.controlPlaneSecurityEnabled }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      discoveryAddress: {{ .Values.global.remotePilotAddress }}:15005
+      {{- if .Values.global.remotePilotCreateSvcEndpoint }}
+      discoveryAddress: {{ $defPilotHostname }}:15005
+      {{- else }}
+      discoveryAddress: {{ $pilotAddress }}:15005
+      {{- end }}
     {{- else }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
       #
       # Address where istio Pilot service is running
-      discoveryAddress: {{ .Values.global.remotePilotAddress }}:15007
+      {{- if .Values.global.remotePilotCreateSvcEndpoint }}
+      discoveryAddress: {{ $defPilotHostname }}:15007
+      {{- else }}
+      discoveryAddress: {{ $pilotAddress }}:15007
+      {{- end }}
     {{- end }}

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.global.remotePilotCreateSvcEndpoint }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: istio-pilot
+  namespace: {{ .Release.Namespace }}
+subsets:
+- addresses:
+  - ip: {{ .Values.global.remotePilotAddress }}
+  ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
+  - port: 15010
+    name: grpc-xds # direct
+  - port: 15011
+    name: https-xds # mTLS or non-mTLS depending on auth setting
+  - port: 8080
+    name: http-legacy-discovery # direct
+  - port: 9093
+    name: http-monitoring
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.remotePilotCreateSvcEndpoint }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 15003
+    name: http-old-discovery # mTLS or non-mTLS depending on auth setting
+  - port: 15005
+    name: https-discovery # always mTLS
+  - port: 15007
+    name: http-discovery # always plain-text
+  - port: 15010
+    name: grpc-xds # direct
+  - port: 15011
+    name: https-xds # mTLS or non-mTLS depending on auth setting
+  - port: 8080
+    name: http-legacy-discovery # direct
+  - port: 9093
+    name: http-monitoring
+  clusterIP: None
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -95,6 +95,9 @@ global:
   imagePullSecrets:
     # - private-registry-key
 
+  # If true, create a headless service and endpoint for istio-pilot with the remotePilotAddress and
+  # sets the MeshConfig configmap discoveryAddress to 'istio-pilot.<namespace>'
+  remotePilotCreateSvcEndpoint: false
 
   # Remote Istio endpoints. Can be hostnames or IP addresses
   # The Pilot address is required. The others are optional.


### PR DESCRIPTION
When controlPlaneSecurityEnabled the spiffe configured by sidecar injector
assumes that the pilot discoveryAddress is a hostname.namespace formatted
string.  This change makes the istio-remote helm chart setup a selectorless
service and endpoint from the pilotAddress when the remotePilotCreateSvcEndpoint
arg is true and sets the MeshConfig discoveryAddress to be the hostname
for istio-pilot.

Fixes: #7010 