### PR TITLE
mixer: add sidecar health probe

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -85,6 +85,12 @@
           readOnly: true
         - name: uds-socket
           mountPath: /sock
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: 19093
+          initialDelaySeconds: 5
+          periodSeconds: 5
 {{- end }}
 
 {{- define "telemetry_container" }}
@@ -176,6 +182,12 @@
           readOnly: true
         - name: uds-socket
           mountPath: /sock
+        livenessProbe:
+          httpGet:
+            path: /version
+            port: 19093
+          initialDelaySeconds: 5
+          periodSeconds: 5
 {{- end }}
 
 

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -141,6 +141,32 @@ static_resources:
 {{- end }}
     name: "15004"
   - address:
+      socker_address:
+        address: 0.0.0.0
+        port_value: 19093
+    filter_chains:
+    - filters:
+      - config:
+          codec_type: HTTP
+          generate_request_id: false
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: health
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: health
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: in.9092
+                  timeout: 0.000s
+          stat_prefix: health
+        name: envoy.http_connection_manager
+    name: health
+  - address:
       socket_address:
         address: 0.0.0.0
         port_value: 9091

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -109,6 +109,32 @@ static_resources:
 {{- end }}
     name: "15004"
   - address:
+      socker_address:
+        address: 0.0.0.0
+        port_value: 19093
+    filter_chains:
+    - filters:
+      - config:
+          codec_type: HTTP
+          generate_request_id: false
+          http_filters:
+          - name: envoy.router
+          route_config:
+            name: health
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: health
+              routes:
+              - match:
+                  prefix: /
+                route:
+                  cluster: in.9092
+                  timeout: 0.000s
+          stat_prefix: health
+        name: envoy.http_connection_manager
+    name: health
+  - address:
       socket_address:
         address: 0.0.0.0
         port_value: 9091


### PR DESCRIPTION
Mixer sidecar health probe is a passthrough to mixer health endpoint. This way we can tie in the container health statuses, and force pod restarts instead of individual container restarts.

Follow-up to https://github.com/istio/proxy/pull/1851

/assign @mandarjog @douglas-reid 

Signed-off-by: Kuat Yessenov <kuat@google.com>