### PR TITLE
bookinfo fixes

### DIFF
--- a/samples/CONFIG-MIGRATION.md
+++ b/samples/CONFIG-MIGRATION.md
@@ -194,8 +194,8 @@ spec:
   precedence: 2
   match:
     httpHeaders:
-      cookie:
-        regex: "^(.*?;)?(user=jason)(;.*)?$"
+      end-user:
+        exact: jason
   route:
   - tags:
       version: v1
@@ -218,8 +218,8 @@ spec:
   match:
     request:
       headers:
-        cookie:
-          regex: ^(.*?;)?(user=jason)(;.*)?$
+        end-user:
+          exact: jason
   route:
   - labels:
       version: v1

--- a/samples/bookinfo/networking/virtual-service-ratings-test-abort.yaml
+++ b/samples/bookinfo/networking/virtual-service-ratings-test-abort.yaml
@@ -8,8 +8,8 @@ spec:
   http:
   - match:
     - headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
     fault:
       abort:
         percent: 100

--- a/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
+++ b/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
@@ -8,8 +8,8 @@ spec:
   http:
   - match:
     - headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
     fault:
       delay:
         percent: 100

--- a/samples/bookinfo/networking/virtual-service-reviews-jason-v2-v3.yaml
+++ b/samples/bookinfo/networking/virtual-service-reviews-jason-v2-v3.yaml
@@ -8,8 +8,8 @@ spec:
   http:
   - match:
     - headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
     route:
     - destination:
         host: reviews

--- a/samples/bookinfo/networking/virtual-service-reviews-test-v2.yaml
+++ b/samples/bookinfo/networking/virtual-service-reviews-test-v2.yaml
@@ -8,8 +8,8 @@ spec:
   http:
   - match:
     - headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
     route:
     - destination:
         host: reviews

--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: krancour/examples-bookinfo-details-v1:1.8.0
+    image: krancour/examples-bookinfo-details-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -32,7 +32,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: krancour/examples-bookinfo-ratings-v1:1.8.0
+    image: krancour/examples-bookinfo-ratings-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -48,7 +48,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: krancour/examples-bookinfo-reviews-v1:1.8.0
+    image: krancour/examples-bookinfo-reviews-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -65,7 +65,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: krancour/examples-bookinfo-reviews-v2:1.8.0
+    image: krancour/examples-bookinfo-reviews-v2:1.9.0
     networks:
       istiomesh:
     dns:
@@ -82,7 +82,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: krancour/examples-bookinfo-reviews-v3:1.8.0
+    image: krancour/examples-bookinfo-reviews-v3:1.9.0
     networks:
       istiomesh:
     dns:
@@ -99,7 +99,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: krancour/examples-bookinfo-productpage-v1:1.8.0
+    image: krancour/examples-bookinfo-productpage-v1:1.9.0
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/platform/consul/route-rule-ratings-test-abort.yaml
+++ b/samples/bookinfo/platform/consul/route-rule-ratings-test-abort.yaml
@@ -10,8 +10,8 @@ spec:
   match:
     request:
       headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
   route:
   - labels:
       version: v1

--- a/samples/bookinfo/platform/consul/route-rule-ratings-test-delay.yaml
+++ b/samples/bookinfo/platform/consul/route-rule-ratings-test-delay.yaml
@@ -10,8 +10,8 @@ spec:
   match:
     request:
       headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
   route:
   - labels:
       version: v1

--- a/samples/bookinfo/platform/consul/route-rule-reviews-test-v2.yaml
+++ b/samples/bookinfo/platform/consul/route-rule-reviews-test-v2.yaml
@@ -10,8 +10,8 @@ spec:
   match:
     request:
       headers:
-        cookie:
-          regex: "^(.*?;)?(user=jason)(;.*)?$"
+        end-user:
+          exact: jason
   route:
   - labels:
       version: v2

--- a/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: krancour/examples-bookinfo-productpage-v1:1.8.0
+        image: krancour/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v3:1.8.0
+        image: krancour/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: krancour/examples-bookinfo-mongodb:1.8.0
+        image: krancour/examples-bookinfo-mongodb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: krancour/examples-bookinfo-details-v2:1.8.0
+        image: krancour/examples-bookinfo-details-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: krancour/examples-bookinfo-details-v1:1.8.0
+        image: krancour/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: krancour/examples-bookinfo-mysqldb:1.8.0
+        image: krancour/examples-bookinfo-mysqldb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: krancour/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: krancour/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: krancour/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: krancour/examples-bookinfo-ratings-v1:1.8.0
+        image: krancour/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: krancour/examples-bookinfo-details-v1:1.8.0
+        image: krancour/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: krancour/examples-bookinfo-ratings-v1:1.8.0
+        image: krancour/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v1:1.8.0
+        image: krancour/examples-bookinfo-reviews-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: krancour/examples-bookinfo-reviews-v3:1.8.0
+        image: krancour/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: krancour/examples-bookinfo-productpage-v1:1.8.0
+        image: krancour/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/src/build-services.sh
+++ b/samples/bookinfo/src/build-services.sh
@@ -39,7 +39,7 @@ popd
 
 pushd $SCRIPTDIR/reviews
   #java build the app.
-  docker run --rm -v $(PWD):/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
+  docker run --rm -v `pwd`:/home/gradle/project -w /home/gradle/project gradle:4.8.1 gradle clean build
   pushd reviews-wlpcfg
     #plain build -- no ratings
     docker build -t istio/examples-bookinfo-reviews-v1:${VERSION} -t istio/examples-bookinfo-reviews-v1:latest --build-arg service_version=v1 .

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -21,7 +21,6 @@ import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
 import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.CookieParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -33,7 +32,6 @@ import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.ResponseProcessingException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -84,7 +82,7 @@ public class LibertyRestEndpoint extends Application {
     	return result;
     }
     
-    private JsonObject getRatings(String productId, Cookie user, String xreq, String xtraceid, String xspanid,
+    private JsonObject getRatings(String productId, String user, String xreq, String xtraceid, String xspanid,
                                   String xparentspanid, String xsampled, String xflags, String xotspan){
       ClientBuilder cb = ClientBuilder.newBuilder();
       String timeout = star_color.equals("black") ? "10000" : "2500";
@@ -115,7 +113,7 @@ public class LibertyRestEndpoint extends Application {
         builder.header("x-ot-span-context",xotspan);
       }
       if(user!=null) {
-        builder.cookie(user);
+        builder.header("end-user", user);
       }
       Response r = builder.get();
       int statusCode = r.getStatusInfo().getStatusCode();
@@ -140,7 +138,7 @@ public class LibertyRestEndpoint extends Application {
     @GET
     @Path("/reviews/{productId}")
     public Response bookReviewsById(@PathParam("productId") int productId,
-                                    @CookieParam("user") Cookie user,
+                                    @HeaderParam("end-user") String user,
                                     @HeaderParam("x-request-id") String xreq,
                                     @HeaderParam("x-b3-traceid") String xtraceid,
                                     @HeaderParam("x-b3-spanid") String xspanid,

--- a/tests/e2e/tests/bookinfo/demo_test.go
+++ b/tests/e2e/tests/bookinfo/demo_test.go
@@ -27,8 +27,13 @@ import (
 	"istio.io/istio/tests/util"
 )
 
+type user struct {
+	username      string
+	sessionCookie string
+}
+
 type userVersion struct {
-	user    string
+	user    user
 	version string
 	model   string
 }
@@ -176,8 +181,8 @@ func testVersionMigrationRule(t *testing.T, configVersion string, rule migration
 			Value: "bar",
 		},
 		{
-			Name:  "user",
-			Value: "normal-user",
+			Name:  "session",
+			Value: u1.sessionCookie,
 		},
 	}
 
@@ -248,7 +253,7 @@ func doTestDbRoutingMongo(t *testing.T, configVersion string, rules []string) {
 
 	respExpr := "glyphicon-star" // not great test for v2 or v3 being alive
 
-	_, err = checkHTTPResponse(u1, getIngressOrFail(t, configVersion), respExpr, 10)
+	_, err = checkHTTPResponse(getIngressOrFail(t, configVersion), respExpr, 10)
 	inspect(
 		err, fmt.Sprintf("Failed database routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", respExpr), t)
@@ -272,7 +277,7 @@ func doTestDbRoutingMysql(t *testing.T, configVersion string, rules []string) {
 
 	respExpr := "glyphicon-star" // not great test for v2 or v3 being alive
 
-	_, err = checkHTTPResponse(u1, getIngressOrFail(t, configVersion), respExpr, 10)
+	_, err = checkHTTPResponse(getIngressOrFail(t, configVersion), respExpr, 10)
 	inspect(
 		err, fmt.Sprintf("Failed database routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", respExpr), t)
@@ -318,7 +323,7 @@ func doTestExternalDetailsService(t *testing.T, configVersion string, rules []st
 
 	isbnFetchedFromExternalService := "0486424618"
 
-	_, err = checkHTTPResponse(u1, getIngressOrFail(t, configVersion), isbnFetchedFromExternalService, 1)
+	_, err = checkHTTPResponse(getIngressOrFail(t, configVersion), isbnFetchedFromExternalService, 1)
 	inspect(
 		err, fmt.Sprintf("Failed external details routing! %s in v1", u1),
 		fmt.Sprintf("Success! Response matches with expected! %s", isbnFetchedFromExternalService), t)

--- a/tests/e2e/tests/bookinfo/main_test.go
+++ b/tests/e2e/tests/bookinfo/main_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 const (
-	u1                                 = "normal-user"
-	u2                                 = "test-user"
 	bookinfoSampleDir                  = "samples/bookinfo"
 	yamlExtension                      = "yaml"
 	deploymentDir                      = "platform/kube"
@@ -65,6 +63,14 @@ const (
 )
 
 var (
+	u1 = user{
+		username:      "normal-user",
+		sessionCookie: "eyJ1c2VyIjoibm9ybWFsLXVzZXIifQ.Di_G8A.9xNK4BEiyV0-vPOB3mWF6_PXKrw",
+	}
+	u2 = user{
+		username:      "test-user",
+		sessionCookie: "eyJ1c2VyIjoidGVzdC11c2VyIn0.Di_NWg.BQ9nq-xSfqKqsT2Rd-Uh2Hg4b0I",
+	}
 	tc *testConfig
 	tf = &framework.TestFlags{
 		Ingress: true,
@@ -136,7 +142,7 @@ func preprocessRule(t *testConfig, version, rule string) error {
 		return err
 	}
 	content := string(ori)
-	content = strings.Replace(content, "jason", u2, -1)
+	content = strings.Replace(content, "jason", u2.username, -1)
 
 	err = os.MkdirAll(filepath.Dir(dest), 0700)
 	if err != nil {
@@ -235,7 +241,7 @@ func setUpDefaultRouting() error {
 	return nil
 }
 
-func checkRoutingResponse(user, version, gateway, modelFile string) (int, error) {
+func checkRoutingResponse(user user, version, gateway, modelFile string) (int, error) {
 	startT := time.Now()
 	cookies := []http.Cookie{
 		{
@@ -243,8 +249,8 @@ func checkRoutingResponse(user, version, gateway, modelFile string) (int, error)
 			Value: "bar",
 		},
 		{
-			Name:  "user",
-			Value: user,
+			Name:  "session",
+			Value: user.sessionCookie,
 		},
 	}
 	resp, err := getWithCookie(fmt.Sprintf("%s/productpage", gateway), cookies)
@@ -268,7 +274,7 @@ func checkRoutingResponse(user, version, gateway, modelFile string) (int, error)
 	return duration, err
 }
 
-func checkHTTPResponse(user, gateway, expr string, count int) (int, error) {
+func checkHTTPResponse(gateway, expr string, count int) (int, error) {
 	resp, err := http.Get(fmt.Sprintf("%s/productpage", gateway))
 	if err != nil {
 		return -1, err

--- a/tests/e2e/tests/upgrade/upgrade_test.go
+++ b/tests/e2e/tests/upgrade/upgrade_test.go
@@ -34,8 +34,6 @@ import (
 )
 
 const (
-	u1              = "normal-user"
-	u2              = "test-user"
 	bookinfoYaml    = "samples/bookinfo/platform/kube/bookinfo.yaml"
 	bookinfoGateway = "bookinfo-gateway.yaml"
 	modelDir        = "tests/apps/bookinfo/output"
@@ -46,6 +44,14 @@ const (
 )
 
 var (
+	u1 = user{
+		username:      "normal-user",
+		sessionCookie: "eyJ1c2VyIjoibm9ybWFsLXVzZXIifQ.Di_G8A.9xNK4BEiyV0-vPOB3mWF6_PXKrw",
+	}
+	u2 = user{
+		username:      "test-user",
+		sessionCookie: "eyJ1c2VyIjoidGVzdC11c2VyIn0.Di_NWg.BQ9nq-xSfqKqsT2Rd-Uh2Hg4b0I",
+	}
 	tc                *testConfig
 	baseConfig        *framework.CommonConfig
 	targetConfig      *framework.CommonConfig
@@ -54,6 +60,11 @@ var (
 	flagTargetVersion = flag.String("target_version", "0.5.1", "Target version to upgrade to.")
 	flagSmoothCheck   = flag.Bool("smooth_check", false, "Whether to check the upgrade is smooth.")
 )
+
+type user struct {
+	username      string
+	sessionCookie string
+}
 
 type testConfig struct {
 	*framework.CommonConfig
@@ -72,7 +83,7 @@ func (t *testConfig) Setup() error {
 			return err
 		}
 		content := string(ori)
-		content = strings.Replace(content, "jason", u2, -1)
+		content = strings.Replace(content, "jason", u2.username, -1)
 		err = ioutil.WriteFile(dest, []byte(content), 0600)
 		if err != nil {
 			log.Errorf("Failed to write into new rule file %s", dest)
@@ -175,7 +186,7 @@ func setUpDefaultRouting() error {
 	return probeGateway(testRetryTimes)
 }
 
-func checkRoutingResponse(user, version, gateway, modelFile string) (int, error) {
+func checkRoutingResponse(user user, version, gateway, modelFile string) (int, error) {
 	startT := time.Now()
 	cookies := []http.Cookie{
 		{
@@ -183,8 +194,8 @@ func checkRoutingResponse(user, version, gateway, modelFile string) (int, error)
 			Value: "bar",
 		},
 		{
-			Name:  "user",
-			Value: user,
+			Name:  "session",
+			Value: user.sessionCookie,
 		},
 	}
 	resp, err := getWithCookie(fmt.Sprintf("%s/productpage", gateway), cookies)


### PR DESCRIPTION
Fixes #7047 

Important: requires #7098 to be merged first since that make some critical fixes to the bookinfo sample app's build process, which fails in its current state.

This PR corrects unrealistic behavior in the sample app.

Currently, the productpage app stores user identity in a cookie that is neither encrypted nor signed. It is easily tampered with by even the most novice attacker. Additionally, the productpage app _forwards_ that same cookie to the downstream reviews service. This is also bad. Both of these, however, were obviously done to facilitate an impactful demo that shows request routing decisions being done on the basis of user identity.

This PR transforms the example to use more realistic behavior without compromising on the demo's impact. The cookie is now encoded and digitally signed (the flask framework automatically encodes any session data that is kept in a cookie-based session store). It can be decoded, but tampering with it (successfully) is not possible due to the signature. The productinfo page also ceases to share this cookie with the downstream review service. Instead, it injects the end-user's username into a custom `end-user` header on the outbound requests to the reviews service. The end result is that there is _still_ a plain text header present that routing decisions can be based on, but from start to finish, we didn't have to compromise on security to make that possible.

All sample routing rules (used by tasks in the documentation) are also updated by this PR.

Note that the images referenced in the various `yaml` files do not exist yet in dockerhub because I don't have permissions to push them and, as far as I can tell, there isn't any _automated_ build/push process for those. So someone else needs to build and push these, I guess?

Will open a complementary PR in the docs repo momentarily.