### PR TITLE
Mixer: delete unix socket before calling listen

### DIFF
--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -26,6 +26,8 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 
+	"os"
+
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/api"
@@ -153,6 +155,14 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 		} else {
 			network = a.APIAddress[:idx]
 			address = a.APIAddress[idx+3:]
+		}
+	}
+
+	if network == "unix" {
+		// remove Unix socket before use.
+		if err = os.Remove(address); err != nil && !os.IsNotExist(err) {
+			// Anything other than "file not found" is an error.
+			return nil, fmt.Errorf("unable to remove unix://%s: %v", address, err)
 		}
 	}
 


### PR DESCRIPTION
Mixer listens on a unix socket. If Mixer is restarted, if the UDS file is not removed mixer fails to start with ```Unable to initialize Mixer: unable to listen: listen unix /sock/mixer.socket: bind: address already in use```
Fixes #7050 