### PR TITLE
force to use proxyv2 for istio-telemetry pod

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -130,7 +130,7 @@
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: istio-proxy
-        image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy.image }}:{{ $.Values.global.tag }}"
+        image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
         - containerPort: 9091


### PR DESCRIPTION
telemetry pod proxy version should be forced v2 to be consistent with [policy pod](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml#L36) and [pilot pod](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml#L74)  