### PR TITLE
Change tracing chart to use tracing.provider to select backend

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.jaeger.ingress.enabled -}}
-{{- if .Values.jaeger.enabled -}}
+{{ if (.Values.jaeger.ingress.enabled) and eq .Values.provider "jaeger" }}
 {{- $servicePort := .Values.service.uiPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -30,5 +29,4 @@ spec:
   tls:
 {{ toYaml .Values.jaeger.ingress.tls | indent 4 }}
   {{- end -}}
-{{- end -}}
 {{- end -}}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jaeger.enabled }}
+{{ if eq .Values.provider "jaeger" }}
 
 apiVersion: v1
 kind: List

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -403,8 +403,8 @@ zipkin:
 
 tracing:
   enabled: false
+  provider: jaeger
   jaeger:
-    enabled: false
     memory:
       max_traces: 50000
     ingress:


### PR DESCRIPTION
Currently the `jaeger-query` and `jaeger-collector` services are not deployed by default when `tracing.enabled=true` is set when using the helm chart. The users need to include `tracing.jaeger.enabled`.  I've seen a few situations in recent days where users are expecting the `jaeger-query` service to be available - so thinking it may be better to have these enabled by default (it is only adding two more services, no additional deployments).

Additional, when originally working on the helm chart for tracing there were [discussions about supporting multiple backends](https://github.com/istio/istio/pull/5670#issuecomment-389882420), and using a mechanism that would ensure only one backend was deployed. This PR changes from using `tracing.jaeger.enabled` to a property `tracing.provider` with default value of `jaeger`.

As getting close to the 1.0 release, was wondering whether we wanted to consider making this change now to make it easier to add other providers in the future?