### PR TITLE
Avoid CRD leftover

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
@@ -654,6 +654,27 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
+  name: rbacconfigs.config.istio.io
+  labels:
+    app: {{ template "mixer.name" . }}
+    package: istio.io.mixer
+    istio: rbac
+spec:
+  group: config.istio.io
+  names:
+    kind: RbacConfig
+    plural: rbacconfigs
+    singular: rbacconfig
+    categories:
+    - istio-io
+    - rbac-istio-io
+  scope: Namespaced
+  version: v1alpha2
+---
+
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
   name: serviceroles.config.istio.io
   labels:
     app: {{ template "mixer.name" . }}


### PR DESCRIPTION
The `rbacconfigs.config.istio.io` is the only CRD not created by Helm but programatically.
Therefore, as it's not managed by Helm, uninstalling Istio with `helm delete istio --purge` won't remove the CRD.

Fixes #7124 