### PR TITLE
WIP: Add ingressgateway for grafana

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
               secretKeyRef:
                 name: grafana
                 key: password
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "false"
+          - name: GF_AUTH_DISABLE_LOGIN_FORM
+            value: "false"
 {{- else }}            
           - name: GF_AUTH_BASIC_ENABLED
             value: "false"

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -34,12 +34,25 @@ spec:
           env:
           - name: GRAFANA_PORT
             value: {{ .Values.service.internalPort | quote }}
+{{- if .Values.security.enabled }}
+          - name: GF_SECURITY_ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: username
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: grafana
+                key: password
+{{- else }}            
           - name: GF_AUTH_BASIC_ENABLED
             value: "false"
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_ROLE
             value: Admin
+{{- end}}
           - name: GF_PATHS_DATA
             value: /data/grafana
           resources:

--- a/install/kubernetes/helm/istio/charts/grafana/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/gateway.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingressgateway.enabled -}}
+{{- $serviceName := include "grafana.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: grafana-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "{{- .Values.ingressgateway.host }}"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: grafana
+spec:
+  host: {{ template "grafana.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: DISABLE
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: fortio
+spec:
+  hosts:
+  - "{{- .Values.ingressgateway.host }}"
+  gateways:
+  - grafana-gateway
+  http:
+  - route:
+    - destination:
+        port:
+          number: {{ $servicePort }}
+        host: {{ template "grafana.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+{{- end}}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.security.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+type: Opaque
+data:
+  username: {{ .Values.security.adminUser | b64enc | quote }}
+  password: {{ .Values.security.adminPassword | b64enc | quote }}
+{{- end -}}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -350,8 +350,7 @@ grafana:
       #     - grafana.local
   ingressgateway:
     enabled: true
-    hosts:
-      - grafana.local
+    host: "grafana.local"
     
 
 prometheus:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -330,7 +330,12 @@ grafana:
     type: ClusterIP
     externalPort: 3000
     internalPort: 3000
+  security:
+    enabled: true
+    adminUser: admin
+    adminPassword: admin
   ingress:
+    # DEPRECATED. DO NOT USE.
     enabled: false
     # Used to create an Ingress record.
     hosts:
@@ -343,6 +348,11 @@ grafana:
       # - secretName: grafana-tls
       #   hosts:
       #     - grafana.local
+  ingressgateway:
+    enabled: true
+    hosts:
+      - grafana.local
+    
 
 prometheus:
   enabled: true


### PR DESCRIPTION
This PR makes it possible to configure an ingress gateway for accessing the grafana dashboard. As part of adding the gateway, the PR also enables the ability to add user/pass for grafana (by enabling security). This allows restricting access while exposing grafana.

cc: @costinm

/hold