### PR TITLE
add reporterKind attribute to accesslog and tcpaccesslog

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -228,6 +228,7 @@ spec:
     sentBytes: response.total_size | 0
     referer: request.referer | ""
     xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
+    reporterKind: context.reporter.kind | "unknown"
   monitored_resource_type: '"global"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -263,6 +264,7 @@ spec:
     sentBytes: connection.sent.bytes | 0
     totalReceivedBytes: connection.received.bytes_total | 0
     totalSentBytes: connection.sent.bytes_total | 0
+    reporterKind: context.reporter.kind | "unknown"
   monitored_resource_type: '"global"'
 ---
 apiVersion: "config.istio.io/v1alpha2"


### PR DESCRIPTION
Since both the source and the destination sidecar proxies report on each request, we have two almost identical access entries in the logs. We need to distinguish between the two entries in the logs, `context.reporter.kind` is the way to do it. I propose to add `reporterKind` attribute to the default `accesslog` and `tcpaccesslog` log entries. 