### PR TITLE
add httpAuthority attribute to the accesslog

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -228,6 +228,7 @@ spec:
     sentBytes: response.total_size | 0
     referer: request.referer | ""
     xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
+    requestHost: request.host | ""
   monitored_resource_type: '"global"'
 ---
 apiVersion: "config.istio.io/v1alpha2"

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -228,7 +228,7 @@ spec:
     sentBytes: response.total_size | 0
     referer: request.referer | ""
     xForwardedFor: request.headers["x-forwarded-for"] | "0.0.0.0"
-    requestHost: request.host | ""
+    httpAuthority: request.host | ""
   monitored_resource_type: '"global"'
 ---
 apiVersion: "config.istio.io/v1alpha2"


### PR DESCRIPTION
It could be useful to log the value of the Host header as was sent by the client. The use case is especially important in case of the gateways, when a request is sent to a gateway, with Host header containing the original destination (not the URL of the gateway). I propose to add requestHost to the default `accesslog` log entry. 