### PR TITLE
mixer: allow configuring mixer ports

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -731,7 +731,7 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     portLevelSettings:
     - port:
-        name: grpc-mixer-mtls
+        number: 15004
       tls:
         mode: ISTIO_MUTUAL
     {{- end}}
@@ -751,7 +751,7 @@ spec:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     portLevelSettings:
     - port:
-        name: grpc-mixer-mtls
+        number: 15004
       tls:
         mode: ISTIO_MUTUAL
     {{- end}}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -22,8 +22,13 @@ data:
     #
     # Deprecated: mixer is using EDS
     {{- if .Values.mixer.enabled }}
+    {{- if .Values.global.controlPlaneSecurityEnabled }}
     mixerCheckServer: istio-policy.{{ .Release.Namespace }}.svc.cluster.local:15004
     mixerReportServer: istio-telemetry.{{ .Release.Namespace }}.svc.cluster.local:15004
+    {{- else }}
+    mixerCheckServer: istio-policy.{{ .Release.Namespace }}.svc.cluster.local:9091
+    mixerReportServer: istio-telemetry.{{ .Release.Namespace }}.svc.cluster.local:9091
+    {{- end }}
     {{- end }}
 
     # This is the ingress service name, update if you used a different name

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -17,6 +17,7 @@ package mixer
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -42,13 +43,6 @@ type attribute = *mpb.Attributes_AttributeValue
 type attributes map[string]attribute
 
 const (
-	//mixerPortName       = "grpc-mixer"
-	// defined in install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
-	mixerPortNumber = 9091
-
-	//mixerMTLSPortName   = "grpc-mixer-mtls"
-	mixerMTLSPortNumber = 15004
-
 	// mixer filter name
 	mixer = "mixer"
 
@@ -180,18 +174,16 @@ func (mixerplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConf
 	}
 }
 
+func buildUpstreamName(address string) string {
+	host, port, _ := net.SplitHostPort(address)
+	v, _ := strconv.Atoi(port)
+	return model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(host), v)
+}
+
 func buildTransport(mesh *meshconfig.MeshConfig, node *model.Proxy) *mccpb.TransportConfig {
-	policy, _, _ := net.SplitHostPort(mesh.MixerCheckServer)
-	telemetry, _, _ := net.SplitHostPort(mesh.MixerReportServer)
-
-	port := mixerPortNumber
-	if mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS {
-		port = mixerMTLSPortNumber
-	}
-
 	res := &mccpb.TransportConfig{
-		CheckCluster:      model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(policy), port),
-		ReportCluster:     model.BuildSubsetKey(model.TrafficDirectionOutbound, "", model.Hostname(telemetry), port),
+		CheckCluster:      buildUpstreamName(mesh.MixerCheckServer),
+		ReportCluster:     buildUpstreamName(mesh.MixerReportServer),
 		NetworkFailPolicy: &mccpb.NetworkFailPolicy{Policy: mccpb.FAIL_CLOSE},
 		// internal telemetry forwarding
 		AttributesForMixerProxy: &mpb.Attributes{Attributes: attributes{"source.uid": attrUID(node)}},


### PR DESCRIPTION
Removes the hack of hard-coded port numbers.

Signed-off-by: Kuat Yessenov <kuat@google.com>