### PR TITLE
Regenerate the Citadel templates

### DIFF
--- a/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
@@ -1,0 +1,50 @@
+################################
+# Citadel with plug-in key/certs. Run this after istio-auth.yaml
+################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: istio-citadel
+  namespace: {ISTIO_NAMESPACE}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: citadel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+      - name: citadel
+        image: {CITADEL_HUB}/citadel:{CITADEL_TAG}
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --append-dns-names=true
+          - --citadel-storage-namespace={ISTIO_NAMESPACE}
+          - --grpc-port=8060
+          - --grpc-hostname=citadel
+          - --self-signed-ca=false
+          - --signing-cert=/etc/cacerts/ca-cert.pem
+          - --signing-key=/etc/cacerts/ca-key.pem
+          - --root-cert=/etc/cacerts/root-cert.pem
+          - --cert-chain=/etc/cacerts/cert-chain.pem
+        volumeMounts:
+        - name: cacerts
+          mountPath: /etc/cacerts
+          readOnly: true
+      volumes:
+      - name: cacerts
+        secret:
+          secretName: cacerts
+          optional: true
+---

--- a/install/kubernetes/citadel_extras/istio-citadel-standalone.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-standalone.yaml.tmpl
@@ -1,0 +1,94 @@
+################################
+# Deploy Citadel as a stand alone service in a cluster
+################################
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: istio-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-citadel-{ISTIO_NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "get", "watch", "list", "update", "delete"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+---
+# Grant permissions to Citadel.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-citadel-role-binding-{ISTIO_NAMESPACE}
+subjects:
+- kind: ServiceAccount
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: istio-citadel-{ISTIO_NAMESPACE}
+  apiGroup: rbac.authorization.k8s.io
+---
+# Service account for Citadel
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+---
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: istio-standalone-citadel
+  namespace: {ISTIO_NAMESPACE}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: standalone-citadel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+      - name: citadel
+        image: {CITADEL_HUB}/citadel:{CITADEL_TAG}
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --citadel-storage-namespace={ISTIO_NAMESPACE}
+          - --grpc-port=8060
+          - --grpc-host-identities=istio-standalone-citadel
+          - --self-signed-ca=true
+          - --self-signed-ca-org=test-org
+          - --self-signed-ca-cert-ttl=24000h
+          - --sign-ca-certs=true # Whether Citadel issues certs for other Citadels.
+          - --workload-cert-ttl=21h
+          - --logtostderr
+          - --stderrthreshold
+          - INFO
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standalone-citadel-ilb
+  namespace: istio-system
+  annotations:
+    cloud.google.com/load-balancer-type: "internal"
+  labels:
+    istio: standalone-citadel
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8060
+    protocol: TCP
+  selector:
+    istio: standalone-citadel

--- a/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
@@ -1,0 +1,64 @@
+################################
+# Citadel cluster-wide
+################################
+# Service account for Citadel
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-citadel-service-account
+  namespace: {ISTIO_NAMESPACE}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-citadel
+  namespace: istio-system
+  labels:
+    istio: citadel
+spec:
+  ports:
+    - port: 8060
+  selector:
+    istio: citadel
+---
+# Citadel watching all namespaces
+apiVersion: v1
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: istio-citadel
+  namespace: {ISTIO_NAMESPACE}
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        istio: citadel
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-citadel-service-account
+      containers:
+      - name: citadel
+        image: {CITADEL_HUB}/citadel:{CITADEL_TAG}
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/local/bin/istio_ca"]
+        args:
+          - --append-dns-names=true
+          - --citadel-storage-namespace={ISTIO_NAMESPACE}
+          - --grpc-port=8060
+          - --grpc-hostname=citadel
+          - --self-signed-ca=true
+          - --liveness-probe-path=/tmp/ca.liveness # path to the liveness health check status file
+          - --liveness-probe-interval=60s # interval for health check file update
+          - --probe-check-interval=15s    # interval for health status check
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/istio_ca
+            - probe
+            - --probe-path=/tmp/ca.liveness # path to the liveness health check status file
+            - --interval=125s               # the maximum time gap allowed between the file mtime and the current sys clock.
+          initialDelaySeconds: 60
+          periodSeconds: 60
+---

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -220,6 +220,17 @@ function gen_platforms_files() {
     done
 }
 
+function gen_citadel_extra_files() {
+    SRC_DIR=$ROOT/install/kubernetes/citadel_extras
+    DEST=$DEST_DIR/install/kubernetes
+    sed -e "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|;s|image: {CITADEL_HUB}/\(.*\):{CITADEL_TAG}|image: ${CITADEL_HUB}/\1:${CITADEL_TAG}|" \
+    $SRC_DIR/istio-citadel-plugin-certs.yaml.tmpl > $DEST/istio-citadel-plugin-certs.yaml
+    sed -e "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|;s|image: {CITADEL_HUB}/\(.*\):{CITADEL_TAG}|image: ${CITADEL_HUB}/\1:${CITADEL_TAG}|" \
+    $SRC_DIR/istio-citadel-with-health-check.yaml.tmpl > $DEST/istio-citadel-with-health-check.yaml
+    sed -e "s|{ISTIO_NAMESPACE}|${ISTIO_NAMESPACE}|;s|image: {CITADEL_HUB}/\(.*\):{CITADEL_TAG}|image: ${CITADEL_HUB}/\1:${CITADEL_TAG}|" \
+    $SRC_DIR/istio-citadel-standalone.yaml.tmpl > $DEST/istio-citadel-standalone.yaml
+}
+
 #
 # Script work begins here
 #
@@ -250,3 +261,6 @@ gen_istio_files
 
 # Generate platform files (consul)
 gen_platforms_files
+
+# Generate extra Citadel files from their templates
+gen_citadel_extra_files


### PR DESCRIPTION
This is to resolve doc issues due to missing Citadel yaml files in the released package.
Specifically:
- `istio-citadel-plugin-certs.yaml`
- `istio-citadel-standalone.yaml`
- `istio-citadel-with-health-check.yaml`

The PR adds back the templates and re-generates them upon running the `updateVersion.sh` so that it will be included in the next release.

Can replace #6961 in fixing #6922.
Fixes https://github.com/istio/istio.github.io/issues/1836