### PR TITLE
Move "repository" to "hub" and hardcode image name

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: istio-grafana-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.hyperkube.repository }}/hyperkube:{{ .Values.hyperkube.tag }}"
+          image: "{{ .Values.global.hyperkube.repository }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/grafana/run.sh", "/tmp/grafana/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/grafana"

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: istio-grafana-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          image: "{{ .Values.hyperkube.repository }}/hyperkube:{{ .Values.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/grafana/run.sh", "/tmp/grafana/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/grafana"

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: istio-grafana-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.global.hyperkube.repository }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/grafana/run.sh", "/tmp/grafana/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/grafana"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       serviceAccountName: kiali-service-account
       containers:
-      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      - image: "{{ .Values.hub }}/kiali:{{ .Values.tag }}"
         name: kiali
         command:
         - "/opt/kiali/kiali"

--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: istio-mixer-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/mixer/run.sh", "/tmp/mixer/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/mixer"

--- a/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/create-custom-resources-job.yaml
@@ -81,7 +81,7 @@ spec:
       serviceAccountName: istio-mixer-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/mixer/run.sh", "/tmp/mixer/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/mixer"

--- a/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
@@ -50,7 +50,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ $statsdname }}
-        image: "{{ $.Values.prometheusStatsdExporter.repository }}:{{ $.Values.prometheusStatsdExporter.tag}}"
+        image: "{{ $.Values.prometheusStatsdExporter.hub }}/statsd-exporter:{ $.Values.prometheusStatsdExporter.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         ports:
         - containerPort: 9102

--- a/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/statsdtoprom.yaml
@@ -50,7 +50,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ $statsdname }}
-        image: "{{ $.Values.prometheusStatsdExporter.hub }}/statsd-exporter:{ $.Values.prometheusStatsdExporter.tag }}"
+        image: "{{ $.Values.prometheusStatsdExporter.hub }}/statsd-exporter:{{ $.Values.prometheusStatsdExporter.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         ports:
         - containerPort: 9102

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
             - '--storage.tsdb.retention=6h'

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -87,7 +87,7 @@ spec:
       serviceAccountName: istio-cleanup-secrets-service-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
           command:
           - /bin/bash
           - -c

--- a/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/cleanup-secrets.yaml
@@ -87,7 +87,7 @@ spec:
       serviceAccountName: istio-cleanup-secrets-service-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
           command:
           - /bin/bash
           - -c

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: istio-security-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.global.hyperkube.repository }}:{{ .Values.global.hyperkube.tag }}"
+          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/security"

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -76,7 +76,7 @@ spec:
       serviceAccountName: istio-security-post-install-account
       containers:
         - name: hyperkube
-          image: "{{ .Values.hyperkube.hub }}/hyperkube:{{ .Values.hyperkube.tag }}"
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
           command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]
           volumeMounts:
             - mountPath: "/tmp/security"

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: jaeger
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.hub }}/all-in-one:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -1,6 +1,6 @@
 # Common settings.
 global:
-  # Default repository for Istio images.
+  # Default hub for Istio images.
   # Releases are published to docker hub under 'istio' project.
   # Daily builds from prow are on gcr.io, and nightly builds from circle on docker.io/istionightly
   hub: gcr.io/istio-release
@@ -62,11 +62,6 @@ global:
   # local tests require IfNotPresent, to avoid uploading to dockerhub.
   # TODO: Switch to Always as default, and override in the local tests.
   imagePullPolicy: IfNotPresent
-
-  # Not recommended for user to configure this. Hyperkube image to use when creating custom resources
-  hyperkube:
-    repository: quay.io/coreos/hyperkube
-    tag: v1.7.6_coreos.0
 
   # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
   # propagated, not recommended for tests.
@@ -302,7 +297,7 @@ mixer:
   image: mixer
 
   prometheusStatsdExporter:
-    repository: prom/statsd-exporter
+    hub: docker.io/prom
     tag: latest
 
 #
@@ -354,9 +349,9 @@ grafana:
 prometheus:
   enabled: true
   replicaCount: 1
-  image:
-    repository: docker.io/prom/prometheus
-    tag: latest
+  hub: docker.io/prom
+  tag: latest
+
   ingress:
     enabled: false
     # Used to create an Ingress record.
@@ -422,9 +417,8 @@ tracing:
         #   hosts:
         #     - jaeger.local
   replicaCount: 1
-  image:
-    repository: jaegertracing/all-in-one
-    tag: 1.5
+  hub: docker.io/jaegertracing
+  tag: 1.5
   service:
     annotations: {}
     name: http
@@ -449,9 +443,8 @@ tracing:
 kiali:
   enabled: false
   replicaCount: 1
-  image:
-    repository: kiali/kiali
-    tag: v0.5.0
+  hub: docker.io/kiali
+  tag: v0.5.0
   ingress:
     enabled: false
     ## Used to create an Ingress record.
@@ -481,3 +474,8 @@ certmanager:
   hub: quay.io/jetstack
   tag: v0.3.1
   resources: {}
+
+  # Not recommended for user to configure this. Hyperkube image to use when creating custom resources
+hyperkube:
+  hub: quay.io/coreos
+  tag: v1.7.6_coreos.0

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -123,6 +123,12 @@ global:
     #   cpu: 100m
     #   memory: 128Mi
 
+
+  # Not recommended for user to configure this. Hyperkube image to use when creating custom resources
+  hyperkube:
+    hub: quay.io/coreos
+    tag: v1.7.6_coreos.0
+
 # Any customization for istio testing should be here
 istiotesting:
   oneNameSpace: false
@@ -474,8 +480,3 @@ certmanager:
   hub: quay.io/jetstack
   tag: v0.3.1
   resources: {}
-
-  # Not recommended for user to configure this. Hyperkube image to use when creating custom resources
-hyperkube:
-  hub: quay.io/coreos
-  tag: v1.7.6_coreos.0


### PR DESCRIPTION
The imagename hard code comes from the pattern laid down in certmanager.
I'm not super keen on this as it makes determining the image names for airgapped
installs a bit more difficult.  The good news is we can always add an "image"
field for each service if we want to expose that information in values.yaml
or just document it appropriately.