### PR TITLE
Update Proxy SHA to latest (release-1.0).

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "817e3f93a1e4d97788fc838910fb2f9e0503650b"
+		"lastStableSHA": "121faee7273322465a0f51e1a976ae628416b60a"
 	}
 ]

--- a/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
+++ b/mixer/test/client/disable_tcp_check_calls/disable_tcp_check_calls_test.go
@@ -22,7 +22,26 @@ import (
 )
 
 // Report attributes from a good POST request
-const reportAttributesOkPost = `
+const reportAttributesOkPostOpen = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "connection.mtls": false,
+  "connection.received.bytes": "*",
+  "connection.received.bytes_total": "*",
+  "connection.sent.bytes": "*",
+  "connection.sent.bytes_total": "*",
+  "connection.id": "*",
+  "connection.event": "open"
+}
+`
+const reportAttributesOkPostClose = `
 {
   "context.protocol": "tcp",
   "context.time": "*",
@@ -52,7 +71,7 @@ var expectedStats = map[string]int{
 	"tcp_mixer_filter.total_remote_check_calls":          0,
 	"tcp_mixer_filter.total_remote_quota_calls":          0,
 	"tcp_mixer_filter.total_remote_report_calls":         1,
-	"tcp_mixer_filter.total_report_calls":                1,
+	"tcp_mixer_filter.total_report_calls":                2,
 }
 
 func TestDisableTCPCheckCalls(t *testing.T) {
@@ -74,6 +93,6 @@ func TestDisableTCPCheckCalls(t *testing.T) {
 		t.Errorf("Failed in request %s: %v", tag, err)
 	}
 	s.VerifyCheckCount(tag, 0)
-	s.VerifyReport(tag, reportAttributesOkPost)
+	s.VerifyTwoReports(tag, reportAttributesOkPostOpen, reportAttributesOkPostClose)
 	s.VerifyStats(expectedStats)
 }

--- a/mixer/test/client/tcp_filter/tcp_filter_test.go
+++ b/mixer/test/client/tcp_filter/tcp_filter_test.go
@@ -33,13 +33,33 @@ const checkAttributesOkPost = `
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "connection.mtls": false,
-  "connection.id": "*",
-  "connection.event": "open"
+  "connection.id": "*"
 }
 `
 
 // Report attributes from a good POST request
-const reportAttributesOkPost = `
+const reportAttributesOkPostOpen = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "connection.mtls": false,
+  "check.cache_hit": false,
+  "quota.cache_hit": false,
+  "connection.received.bytes": "*",
+  "connection.received.bytes_total": "*",
+  "connection.sent.bytes": "*",
+  "connection.sent.bytes_total": "*",
+  "connection.id": "*",
+  "connection.event": "open"
+}
+`
+const reportAttributesOkPostClose = `
 {
   "context.protocol": "tcp",
   "context.time": "*",
@@ -97,7 +117,7 @@ var expectedStats = map[string]int{
 	"tcp_mixer_filter.total_remote_check_calls":          2,
 	"tcp_mixer_filter.total_remote_quota_calls":          0,
 	"tcp_mixer_filter.total_remote_report_calls":         2,
-	"tcp_mixer_filter.total_report_calls":                2,
+	"tcp_mixer_filter.total_report_calls":                3,
 }
 
 func TestTCPMixerFilter(t *testing.T) {
@@ -116,7 +136,7 @@ func TestTCPMixerFilter(t *testing.T) {
 		t.Errorf("Failed in request %s: %v", tag, err)
 	}
 	s.VerifyCheck(tag, checkAttributesOkPost)
-	s.VerifyReport(tag, reportAttributesOkPost)
+	s.VerifyTwoReports(tag, reportAttributesOkPostOpen, reportAttributesOkPostClose)
 
 	tag = "MixerFail"
 	s.SetMixerCheckStatus(rpc.Status{

--- a/mixer/test/client/tcp_filter_periodical_report/tcp_filter_periodical_report_test.go
+++ b/mixer/test/client/tcp_filter_periodical_report/tcp_filter_periodical_report_test.go
@@ -22,6 +22,27 @@ import (
 )
 
 // Report attributes from a good POST request
+const openReportAttributesOkPost = `
+{
+  "context.protocol": "tcp",
+  "context.time": "*",
+  "mesh1.ip": "[1 1 1 1]",
+  "source.ip": "[127 0 0 1]",
+  "target.uid": "POD222",
+  "target.namespace": "XYZ222",
+  "destination.ip": "[127 0 0 1]",
+  "destination.port": "*",
+  "connection.mtls": false,
+  "check.cache_hit": false,
+  "quota.cache_hit": false,
+  "connection.received.bytes": 191,
+  "connection.received.bytes_total": 191,
+  "connection.sent.bytes": 0,
+  "connection.sent.bytes_total": 0,
+  "connection.id": "*",
+  "connection.event": "open"
+}
+`
 const deltaReportAttributesOkPost = `
 {
   "context.protocol": "tcp",
@@ -74,8 +95,8 @@ var expectedStats = map[string]int{
 	"tcp_mixer_filter.total_quota_calls":                 0,
 	"tcp_mixer_filter.total_remote_check_calls":          1,
 	"tcp_mixer_filter.total_remote_quota_calls":          0,
-	"tcp_mixer_filter.total_remote_report_calls":         2,
-	"tcp_mixer_filter.total_report_calls":                2,
+	"tcp_mixer_filter.total_remote_report_calls":         3,
+	"tcp_mixer_filter.total_report_calls":                3,
 }
 
 func TestTCPMixerFilterPeriodicalReport(t *testing.T) {
@@ -99,6 +120,7 @@ func TestTCPMixerFilterPeriodicalReport(t *testing.T) {
 		t.Errorf("Failed in request %s: %v", tag, err)
 	}
 
+	s.VerifyReport("openReport", openReportAttributesOkPost)
 	s.VerifyReport("deltaReport", deltaReportAttributesOkPost)
 	s.VerifyReport("finalReport", finalReportAttributesOkPost)
 


### PR DESCRIPTION
This pulls the latest Istio Proxy changes without Envoy update.