### PR TITLE
Remove the unnecessary 'creationTimestamp' fields in sample's yamls

### DIFF
--- a/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
@@ -53,7 +53,6 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpec
 metadata:
-  creationTimestamp: null
   name: request-count
   namespace: istio-system
 spec:
@@ -65,7 +64,6 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpecBinding
 metadata:
-  creationTimestamp: null
   name: request-count
   namespace: istio-system
 spec:

--- a/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota.yaml
+++ b/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota.yaml
@@ -55,7 +55,6 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpec
 metadata:
-  creationTimestamp: null
   name: request-count
   namespace: istio-system
 spec:
@@ -68,7 +67,6 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: QuotaSpecBinding
 metadata:
-  creationTimestamp: null
   name: request-count
   namespace: istio-system
 spec:


### PR DESCRIPTION
creationTimestamp will be created at runtime, so it's not necessary to define it in the yamls