### PR TITLE
Add useful warnings when quota specs do not match

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -21,7 +21,6 @@ import (
 
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pkg/log"
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -27,7 +27,6 @@ import (
 	mccpb "istio.io/api/mixer/v1/config/client"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model/test"
-	"istio.io/istio/pkg/log"
 )
 
 const (
@@ -195,6 +194,7 @@ type ConfigStoreCache interface {
 type ConfigDescriptor []ProtoSchema
 
 // ProtoSchema provides description of the configuration schema and its key function
+// nolint: maligned
 type ProtoSchema struct {
 	// ClusterScoped is true for resource in cluster-level.
 	ClusterScoped bool
@@ -825,47 +825,123 @@ func (store *istioConfigStore) HTTPAPISpecByDestination(instance *ServiceInstanc
 	return out
 }
 
-// QuotaSpecByDestination selects Mixerclient quota specifications
-// associated with destination service instances.
-func (store *istioConfigStore) QuotaSpecByDestination(instance *ServiceInstance) []Config {
-	bindings, err := store.List(QuotaSpecBinding.Type, NamespaceAll)
-	if err != nil {
-		return nil
-	}
-	specs, err := store.List(QuotaSpec.Type, NamespaceAll)
-	if err != nil {
-		return nil
+// matchWildcardService returns true if wildcard matches the destination service
+// checked values are
+//     '*' which matches everything
+//     '*.ns.*' which matches anything in the same namespace
+//		strings of any other form are not matched.
+func matchWildcardService(destinationHost string, svc string) bool {
+	if len(svc) == 0 || !strings.Contains(svc, "*") {
+		return false
 	}
 
-	// Create a set key from a reference's name and namespace.
-	key := func(name, namespace string) string { return name + "/" + namespace }
+	if svc == "*" {
+		return true
+	}
 
+	// check for namespace match with svc like '*.ns.*'
+	// extract match substring by dropping '*'
+	if strings.HasPrefix(svc, "*") && strings.HasSuffix(svc, "*") {
+		return strings.Contains(destinationHost, svc[1:len(svc)-1])
+	}
+
+	log.Warnf("Wildcard pattern '%s' is not allowed. Only '*' or '*.<ns>.*' is allowed.", svc)
+
+	return false
+}
+
+// MatchesDestHost returns true if the service instance matches the given IstioService
+// 2018-07-17T23:44:08.916032Z	debug	model	model/config.go:850
+// MatchesDestHost binding host(details.istio-system.svc.cluster.local) ?= instance(reviews.default.svc.cluster.local)
+func MatchesDestHost(destinationHost string, meta ConfigMeta, svc *mccpb.IstioService) bool {
+	if matchWildcardService(destinationHost, svc.Service) {
+		return true
+	}
+
+	// try exact matches
+	hostname := string(ResolveHostname(meta, svc))
+	if destinationHost == hostname {
+		return true
+	}
+	shortName := hostname[0:strings.Index(hostname, ".")]
+	if strings.HasPrefix(destinationHost, shortName) {
+		log.Warnf("Quota excluded. service: %v only matches binding shortname: %s with %s",
+			destinationHost, shortName, hostname)
+	}
+
+	return false
+}
+
+func recordSpecRef(refs map[string]bool, bindingNamespace string, quotas []*mccpb.QuotaSpecBinding_QuotaSpecReference) {
+	for _, spec := range quotas {
+		namespace := spec.Namespace
+		if namespace == "" {
+			namespace = bindingNamespace
+		}
+		refs[key(spec.Name, namespace)] = true
+	}
+}
+
+// key creates a key from a reference's name and namespace.
+func key(name, namespace string) string {
+	return name + "/" + namespace
+}
+
+// findQuotaSpecRefs returns a set of quotaSpec reference names
+func findQuotaSpecRefs(instance *ServiceInstance, bindings []Config) map[string]bool {
 	// Build the set of quota spec references bound to the service instance.
-	refs := make(map[string]struct{})
+	refs := make(map[string]bool)
 	for _, binding := range bindings {
 		b := binding.Spec.(*mccpb.QuotaSpecBinding)
 		for _, service := range b.Services {
-			hostname := ResolveHostname(binding.ConfigMeta, service)
-			if hostname == instance.Service.Hostname {
-				for _, spec := range b.QuotaSpecs {
-					namespace := spec.Namespace
-					if namespace == "" {
-						namespace = binding.Namespace
-					}
-					refs[key(spec.Name, namespace)] = struct{}{}
-				}
+			if MatchesDestHost(string(instance.Service.Hostname), binding.ConfigMeta, service) {
+				recordSpecRef(refs, binding.Namespace, b.QuotaSpecs)
+				// found a binding that matches the instance.
+				break
 			}
 		}
 	}
 
+	return refs
+}
+
+// QuotaSpecByDestination selects Mixerclient quota specifications
+// associated with destination service instances.
+func (store *istioConfigStore) QuotaSpecByDestination(instance *ServiceInstance) []Config {
+	log.Debugf("QuotaSpecByDestination(%v)", instance)
+	bindings, err := store.List(QuotaSpecBinding.Type, NamespaceAll)
+	if err != nil {
+		log.Warnf("Unable to fetch QuotaSpecBindings: %v", err)
+		return nil
+	}
+
+	log.Debugf("QuotaSpecByDestination bindings[%d] %v", len(bindings), bindings)
+	specs, err := store.List(QuotaSpec.Type, NamespaceAll)
+	if err != nil {
+		log.Warnf("Unable to fetch QuotaSpecs: %v", err)
+		return nil
+	}
+
+	log.Debugf("QuotaSpecByDestination specs[%d] %v", len(specs), specs)
+
+	// Build the set of quota spec references bound to the service instance.
+	refs := findQuotaSpecRefs(instance, bindings)
+	log.Debugf("QuotaSpecByDestination refs:%v", refs)
+
 	// Append any spec that is in the set of references.
+	// Remove matching specs from refs so refs only contains dangling references.
 	var out []Config
 	for _, spec := range specs {
-		if _, ok := refs[key(spec.ConfigMeta.Name, spec.ConfigMeta.Namespace)]; ok {
+		refkey := key(spec.ConfigMeta.Name, spec.ConfigMeta.Namespace)
+		if refs[refkey] {
 			out = append(out, spec)
+			delete(refs, refkey)
 		}
 	}
 
+	if len(refs) > 0 {
+		log.Warnf("Some matched QuotaSpecs were not found: %v", refs)
+	}
 	return out
 }
 

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -825,12 +825,12 @@ func (store *istioConfigStore) HTTPAPISpecByDestination(instance *ServiceInstanc
 	return out
 }
 
-// matchWildcardService returns true if wildcard matches the destination service
-// checked values are
-//     '*' which matches everything
-//     '*.ns.*' which matches anything in the same namespace
+// matchWildcardService matches destinationHost to a wildcarded svc.
+// checked values for svc
+//     '*'  matches everything
+//     '*.ns.*'  matches anything in the same namespace
 //		strings of any other form are not matched.
-func matchWildcardService(destinationHost string, svc string) bool {
+func matchWildcardService(destinationHost, svc string) bool {
 	if len(svc) == 0 || !strings.Contains(svc, "*") {
 		return false
 	}
@@ -851,8 +851,7 @@ func matchWildcardService(destinationHost string, svc string) bool {
 }
 
 // MatchesDestHost returns true if the service instance matches the given IstioService
-// 2018-07-17T23:44:08.916032Z	debug	model	model/config.go:850
-// MatchesDestHost binding host(details.istio-system.svc.cluster.local) ?= instance(reviews.default.svc.cluster.local)
+// ex: binding host(details.istio-system.svc.cluster.local) ?= instance(reviews.default.svc.cluster.local)
 func MatchesDestHost(destinationHost string, meta ConfigMeta, svc *mccpb.IstioService) bool {
 	if matchWildcardService(destinationHost, svc.Service) {
 		return true
@@ -865,7 +864,7 @@ func MatchesDestHost(destinationHost string, meta ConfigMeta, svc *mccpb.IstioSe
 	}
 	shortName := hostname[0:strings.Index(hostname, ".")]
 	if strings.HasPrefix(destinationHost, shortName) {
-		log.Warnf("Quota excluded. service: %v only matches binding shortname: %s with %s",
+		log.Warnf("Quota excluded. service: %s matches binding shortname: %s, but does not match fqdn: %s",
 			destinationHost, shortName, hostname)
 	}
 

--- a/pilot/pkg/model/config_test.go
+++ b/pilot/pkg/model/config_test.go
@@ -15,7 +15,6 @@
 package model_test
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -313,32 +312,6 @@ func TestResolveHostname(t *testing.T) {
 			t.Errorf("ResolveHostname(%v, %v) => got %q, want %q", test.meta, test.svc, got, test.want)
 		}
 	}
-}
-
-type errorStore struct{}
-
-func (errorStore) ConfigDescriptor() model.ConfigDescriptor {
-	return model.IstioConfigTypes
-}
-
-func (errorStore) Get(typ, name, namespace string) (*model.Config, bool) {
-	return nil, false
-}
-
-func (errorStore) List(typ, namespace string) ([]model.Config, error) {
-	return nil, errors.New("fail")
-}
-
-func (errorStore) Create(config model.Config) (string, error) {
-	return "", errors.New("fail more")
-}
-
-func (errorStore) Update(config model.Config) (string, error) {
-	return "", errors.New("yes, fail again")
-}
-
-func (errorStore) Delete(typ, name, namespace string) error {
-	return errors.New("just keep failing")
 }
 
 func TestAuthenticationPolicyConfig(t *testing.T) {
@@ -705,5 +678,126 @@ func addRbacConfigToStore(configType, name, namespace string, store model.IstioC
 	}
 	if _, err := store.Create(config); err != nil {
 		t.Error(err)
+	}
+}
+
+type fakeStore struct {
+	model.ConfigStore
+	cfg map[string][]model.Config
+	err error
+}
+
+func (l *fakeStore) List(typ, namespace string) ([]model.Config, error) {
+	ret := l.cfg[typ]
+	return ret, l.err
+}
+
+func TestIstioConfigStore_QuotaSpecByDestination(t *testing.T) {
+	ns := "ns1"
+	l := &fakeStore{
+		cfg: map[string][]model.Config{
+			model.QuotaSpecBinding.Type: {
+				{
+					ConfigMeta: model.ConfigMeta{
+						Namespace: ns,
+						Domain:    "cluster.local",
+					},
+					Spec: &mccpb.QuotaSpecBinding{
+						Services: []*mccpb.IstioService{
+							{
+								Name:      "a",
+								Namespace: ns,
+							},
+						},
+						QuotaSpecs: []*mccpb.QuotaSpecBinding_QuotaSpecReference{
+							{
+								Name: "request-count",
+							},
+							{
+								Name: "does-not-exist",
+							},
+						},
+					},
+				},
+			},
+			model.QuotaSpec.Type: {
+				{
+					ConfigMeta: model.ConfigMeta{
+						Name:      "request-count",
+						Namespace: ns,
+					},
+					Spec: &mccpb.QuotaSpec{
+						Rules: []*mccpb.QuotaRule{
+							{
+								Quotas: []*mccpb.Quota{
+									{
+										Quota:  "requestcount",
+										Charge: 100,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ii := model.MakeIstioStore(l)
+	cfgs := ii.QuotaSpecByDestination(&model.ServiceInstance{
+		Service: &model.Service{
+			Hostname: model.Hostname("a." + ns + ".svc.cluster.local"),
+		},
+	})
+
+	if len(cfgs) != 1 {
+		t.Fatalf("did not find 1 matched quota")
+	}
+}
+
+func TestMatchesDestHost(t *testing.T) {
+	for _, tst := range []struct {
+		destinationHost string
+		svc             string
+		ans             bool
+	}{
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "myhost.ns.cluster.local",
+			ans:             true,
+		},
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "*",
+			ans:             true,
+		},
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "*.ns.*",
+			ans:             true,
+		},
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "*.ns2.*",
+			ans:             false,
+		},
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "myhost.ns2.cluster.local",
+			ans:             false,
+		},
+		{
+			destinationHost: "myhost.ns.cluster.local",
+			svc:             "ns.*.svc.cluster",
+			ans:             false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%s-%s", tst.destinationHost, tst.svc), func(t *testing.T) {
+			ans := model.MatchesDestHost(tst.destinationHost, model.ConfigMeta{}, &mccpb.IstioService{
+				Service: tst.svc,
+			})
+			if ans != tst.ans {
+				t.Fatalf("want: %v, got: %v", tst.ans, ans)
+			}
+		})
 	}
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -26,7 +26,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
-	"istio.io/istio/pkg/log"
 )
 
 // Environment provides an aggregate environmental API for Pilot

--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	networking "istio.io/api/networking/v1alpha3"
-	"istio.io/istio/pkg/log"
 )
 
 // MergedGateway describes a set of gateways for a workload merged into a single logical gateway.

--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -29,7 +29,6 @@ import (
 
 	authn "istio.io/api/authentication/v1alpha1"
 	"istio.io/istio/pkg/cache"
-	"istio.io/istio/pkg/log"
 )
 
 const (

--- a/pilot/pkg/model/log.go
+++ b/pilot/pkg/model/log.go
@@ -1,0 +1,21 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	istiolog "istio.io/istio/pkg/log"
+)
+
+var log = istiolog.RegisterScope("model", "model", 0)

--- a/pilot/pkg/model/push_status.go
+++ b/pilot/pkg/model/push_status.go
@@ -15,15 +15,11 @@
 package model
 
 import (
+	"encoding/json"
 	"sync"
-
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-
-	"encoding/json"
-
-	"istio.io/istio/pkg/log"
 )
 
 // PushStatus tracks the status of a mush - metrics and errors.
@@ -32,7 +28,7 @@ import (
 // The struct is exposed in a debug endpoint - fields public to allow
 // easy serialization as json.
 type PushStatus struct {
-	mutex sync.Mutex `json:"-"`
+	mutex sync.Mutex
 
 	// ProxyStatus is keyed by the error code, and holds a map keyed
 	// by the ID.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -28,7 +28,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
 	"time"
 
 	authn "istio.io/api/authentication/v1alpha1"

--- a/pilot/pkg/model/trace.go
+++ b/pilot/pkg/model/trace.go
@@ -17,8 +17,6 @@ package model
 import (
 	"os"
 	"strconv"
-
-	"istio.io/istio/pkg/log"
 )
 
 // Default trace sampling, if not provided in env var.


### PR DESCRIPTION
1. Add useful warning when quota specs do not match
2. Add a `model` scoped logger
3. Add previously omitted wildcard match so bound services do not have to be enumerated.
4. Add tests for QuotaSpecByDestination code.