### PR TITLE
Allow 0 HTTP retries

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1622,8 +1622,8 @@ func validateHTTPRetry(retries *networking.HTTPRetry) (errs error) {
 		return
 	}
 
-	if retries.Attempts <= 0 {
-		errs = multierror.Append(errs, errors.New("attempts must be positive"))
+	if retries.Attempts < 0 {
+		errs = multierror.Append(errs, errors.New("attempts must be non-zero"))
 	}
 	if retries.PerTryTimeout != nil {
 		errs = appendErrors(errs, ValidateDurationGogo(retries.PerTryTimeout))

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -500,7 +500,7 @@ func translateHeaderMatch(name string, in *networking.StringMatch) route.HeaderM
 
 // translateRetryPolicy translates retry policy
 func translateRetryPolicy(in *networking.HTTPRetry) *route.RouteAction_RetryPolicy {
-	if in != nil && in.Attempts > 0 {
+	if in != nil {
 		d := util.GogoDurationToDuration(in.PerTryTimeout)
 		return &route.RouteAction_RetryPolicy{
 			NumRetries:    &types.UInt32Value{Value: uint32(in.GetAttempts())},


### PR DESCRIPTION
@frankbu reported that we are defaulting to 1 retry, and we do not allow the users to explicitly set 0 retries. This changes the validation to allow the user to explicitly set 0 retries.

Will verify before merging...