### PR TITLE
Add another type parameter to the tracing to control the UI service type

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -35,6 +35,7 @@ items:
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
   spec:
+    type: {{ .Values.service.uiType }}
     ports:
       - name: http-query
         port: 80

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -429,6 +429,7 @@ tracing:
     annotations: {}
     name: http
     type: ClusterIP
+    uiType: ClusterIP
     externalPort: 9411
     internalPort: 9411
     uiPort: 16686


### PR DESCRIPTION
While tracing parameters should be better organised within the category imho I'm keeping this change minimal to fix the issue of missing service type.

Fixes #7243