### PR TITLE
Added `priorityClassName` to Istio chart.

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-citadel-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: citadel
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         istio: sidecar-injector
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: sidecar-injector-webhook
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -129,6 +129,13 @@ global:
     #   cpu: 100m
     #   memory: 128Mi
 
+  # Kubernetes >=v1.11.0 will create two PriorityClass, including system-cluster-critical and
+  # system-node-critical, it is better to configure this in order to make sure your Istio pods
+  # will not be killed because of low prioroty class.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  # for more detail.
+  priorityClassName: ""
+
 #
 # sidecar-injector webhook configuration
 #

--- a/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: certmanager
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: certmanager
           image: "{{ .Values.hub }}/cert-manager-controller:{{ .Values.tag }}"

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         istio: galley
     spec:
       serviceAccountName: istio-galley-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: validator
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: {{ $key }}-service-account
+{{- if $.Values.global.priorityClassName }}
+      priorityClassName: "{{ $.Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ $spec.labels.istio }}
           image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-ingress-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: {{ template "istio.name" . }}
           image: "{{ .Values.global.hub }}/proxyv2:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         app: kiali
     spec:
       serviceAccountName: kiali-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
       - image: "{{ .Values.hub }}/kiali:{{ .Values.tag }}"
         name: kiali

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -1,6 +1,9 @@
 {{- define "policy_container" }}
     spec:
       serviceAccountName: istio-mixer-service-account
+{{- if $.Values.global.priorityClassName }}
+      priorityClassName: "{{ $.Values.global.priorityClassName }}"
+{{- end }}
       volumes:
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-pilot-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: prometheus
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: prometheus
           image: "{{ .Values.hub }}/prometheus:{{ .Values.tag }}"

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-citadel-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: citadel
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: servicegraph
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
         istio: sidecar-injector
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
+ {{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: sidecar-injector-webhook
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
         - name: jaeger
           image: "{{ .Values.hub }}/all-in-one:{{ .Values.tag }}"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -129,6 +129,13 @@ global:
     hub: quay.io/coreos
     tag: v1.7.6_coreos.0
 
+  # Kubernetes >=v1.11.0 will create two PriorityClass, including system-cluster-critical and
+  # system-node-critical, it is better to configure this in order to make sure your Istio pods
+  # will not be killed because of low prioroty class.
+  # Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  # for more detail.
+  priorityClassName: ""
+
 # Any customization for istio testing should be here
 istiotesting:
   oneNameSpace: false


### PR DESCRIPTION
Kubernetes >=v1.11.0 will create two PriorityClass, including
system-cluster-critical and system-node-critical, it is better
to configure this in order to make sure your Istio pods will
not be killed because of low prioroty class.

Refer to https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
for more detail.

/cc @sdake @costinm 