### PR TITLE
Fix istio-remote sidecar-injector-configmap rendered yaml parse error

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -129,16 +129,16 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
-            capabilities:
-              add:
-              - NET_ADMIN
-            runAsGroup: 1337
-            {{ "[[ else -]]" }}
-            runAsUser: 1337
-            {{ "[[ end -]]" }}
+          privileged: false
+          readOnlyRootFilesystem: true
+          {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsGroup: 1337
+          {{ "[[ else -]]" }}
+          runAsUser: 1337
+          {{ "[[ end -]]" }}
         restartPolicy: Always
         resources:
           {{ "[[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyCPU\") -]]" }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -131,16 +131,16 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
-            capabilities:
-              add:
-              - NET_ADMIN
-            runAsGroup: 1337
-            {{ "[[ else -]]" }}
-            runAsUser: 1337
-            {{ "[[ end -]]" }}
+          privileged: false
+          readOnlyRootFilesystem: true
+          {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
+          capabilities:
+            add:
+            - NET_ADMIN
+          runAsGroup: 1337
+          {{ "[[ else -]]" }}
+          runAsUser: 1337
+          {{ "[[ end -]]" }}
         restartPolicy: Always
         resources:
           {{ "[[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyCPU\") -]]" }}


### PR DESCRIPTION
Another whitespace error in this template.

 This is like https://github.com/istio/istio/issues/7239 and https://github.com/istio/istio/issues/7244, but they're lines 11 and 85 respectively, mine error was reporting line 102 (though of course that's subject to the first round of (Helm) templating, so it might well fix 7244)