### PR TITLE
Revert "bump bookinfo version to 1.8.0"

### DIFF
--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.8.0
+    image: krancour/examples-bookinfo-details-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -32,7 +32,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.8.0
+    image: krancour/examples-bookinfo-ratings-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -48,7 +48,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.8.0
+    image: krancour/examples-bookinfo-reviews-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -65,7 +65,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.8.0
+    image: krancour/examples-bookinfo-reviews-v2:1.9.0
     networks:
       istiomesh:
     dns:
@@ -82,7 +82,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.8.0
+    image: krancour/examples-bookinfo-reviews-v3:1.9.0
     networks:
       istiomesh:
     dns:
@@ -99,7 +99,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.8.0
+    image: krancour/examples-bookinfo-productpage-v1:1.9.0
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.8.0
+        image: krancour/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        image: krancour/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: istio/examples-bookinfo-mongodb:1.8.0
+        image: krancour/examples-bookinfo-mongodb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v2:1.8.0
+        image: krancour/examples-bookinfo-details-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.8.0
+        image: krancour/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.8.0
+        image: krancour/examples-bookinfo-mysqldb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: krancour/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.8.0
+        image: krancour/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.8.0
+        image: krancour/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.8.0
+        image: krancour/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.8.0
+        image: krancour/examples-bookinfo-reviews-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: krancour/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        image: krancour/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.8.0
+        image: krancour/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080


### PR DESCRIPTION
Reverts istio/istio#7195

`prow/e2e-bookInfoTests-v1alpha3.sh Skipped`
was failing and prow marked it as skipped and passed. I hadn't noticed it then. (FYI @sebastienvas - this is the result of that bug)
Somehow, it seemed to pass with @krancour's image but the test continues to fail even when I reproduced it locally on a ubuntu machine. Also built image on mac and tried with it. Same issue.

