### PR TITLE
Mixer Conditional Quota

### DIFF
--- a/mixer/pkg/runtime/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher_test.go
@@ -380,7 +380,7 @@ ident                         : dest.istio-system
 	},
 
 	{
-		name: "BasicQuotaError2",
+		name: "QuotaRequestUnknownQuota",
 		config: []string{
 			data.HandlerAQuota1,
 			data.InstanceQuota1,
@@ -391,9 +391,36 @@ ident                         : dest.istio-system
 			Quota:           "XXX",
 			BestEffort:      true,
 			DeduplicationID: "42",
-			Amount:          64,
+			Amount:          10697,
 		},
-		err: `requested quota 'XXX' is invalid`,
+		expectedQuotaResult: adapter.QuotaResult{
+			Amount:        10697,
+			ValidDuration: time.Minute,
+		},
+	},
+
+	{
+		name: "QuotaRequestConditionalUnmatchedQuota",
+		config: []string{
+			data.HandlerAQuota1,
+			data.InstanceQuota1WithSpec,
+			data.RuleQuota1Conditional,
+		},
+		variety: tpb.TEMPLATE_VARIETY_QUOTA,
+		qma: &QuotaMethodArgs{
+			Quota:           "iquota1",
+			BestEffort:      true,
+			DeduplicationID: "42",
+			Amount:          10697,
+		},
+		attr: map[string]interface{}{
+			"attr.string": "XXX",
+			"ident":       "dest.istio-system",
+		},
+		expectedQuotaResult: adapter.QuotaResult{
+			Amount:        10697,
+			ValidDuration: time.Minute,
+		},
 	},
 
 	{

--- a/mixer/pkg/runtime/dispatcher/session.go
+++ b/mixer/pkg/runtime/dispatcher/session.go
@@ -17,11 +17,10 @@ package dispatcher
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/gogo/googleapis/google/rpc"
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -143,20 +142,29 @@ func (s *session) dispatch() error {
 		}
 
 		for _, group := range destination.InstanceGroups {
-			if !group.Matches(s.bag) {
-				continue
+			groupMatched := group.Matches(s.bag)
+
+			if groupMatched {
+				ndestinations++
 			}
-			ndestinations++
 
 			for j, input := range group.Builders {
 				if s.variety == tpb.TEMPLATE_VARIETY_QUOTA {
 					// only dispatch instances with a matching name
-
 					if !strings.EqualFold(input.InstanceShortName, s.quotaArgs.Quota) {
 						continue
 					}
-
+					if !groupMatched {
+						// This is a conditional quota and it does not apply to the requester
+						// return what was requested
+						s.quotaResult.Amount = s.quotaArgs.Amount
+						s.quotaResult.ValidDuration = defaultValidDuration
+					}
 					foundQuota = true
+				}
+
+				if !groupMatched {
+					continue
 				}
 
 				var instance interface{}
@@ -194,8 +202,11 @@ func (s *session) dispatch() error {
 	s.waitForDispatched()
 
 	if s.variety == tpb.TEMPLATE_VARIETY_QUOTA && !foundQuota {
-		log.Errorf("Requested quota '%s' is invalid", s.quotaArgs.Quota)
-		s.err = multierror.Append(s.err, fmt.Errorf("requested quota '%s' is invalid", s.quotaArgs.Quota))
+		// If quota is not found it is very likely that quotaSpec / quotaSpecBinding was applied first
+		// We still err on the side of allowing access, but warn about the fact that quota was not found.
+		s.quotaResult.Amount = s.quotaArgs.Amount
+		s.quotaResult.ValidDuration = defaultValidDuration
+		log.Warnf("Requested quota '%s' is not configured", s.quotaArgs.Quota)
 	}
 
 	return nil

--- a/mixer/pkg/runtime/testing/data/data.go
+++ b/mixer/pkg/runtime/testing/data/data.go
@@ -510,6 +510,21 @@ spec:
     - iquota1.tquota.istio-system
 `
 
+// RuleQuota1Conditional conditionally selects iquota1
+var RuleQuota1Conditional = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: rquota1
+  namespace: istio-system
+spec:
+  match: attr.string == "select"
+  actions:
+  - handler: hquota1.aquota
+    instances:
+    - iquota1.tquota.istio-system
+`
+
 // RuleQuota2 references iquota1 and hquota1.
 var RuleQuota2 = `
 apiVersion: "config.istio.io/v1alpha2"


### PR DESCRIPTION
This PR implements conditional quota in the new dispatcher.
This fixes a regression caused when quota moved to the new dispatcher.

1. If a conditional quota does not apply to the request, Mixer returns what was requested.
2. If a quota is not found on Mixer, mixer still returns what was requested but logs a warning.
    It is expected that quotaSpec, quotaSpecBindings and Mixer rules are applied in various order. We should not deny traffic in the interim.