### PR TITLE
Add proxy version to the proxy-status command

### DIFF
--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -67,7 +67,7 @@ func (s *StatusWriter) PrintSingle(statuses map[string][]byte, proxyName string)
 
 func (s *StatusWriter) setupStatusPrint(statuses map[string][]byte) (*tabwriter.Writer, []*writerStatus, error) {
 	w := new(tabwriter.Writer).Init(s.Writer, 0, 8, 5, ' ', 0)
-	fmt.Fprintln(w, "PROXY\tCDS\tLDS\tEDS\tRDS\tPILOT")
+	fmt.Fprintln(w, "PROXY\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
 	fullStatus := []*writerStatus{}
 	for pilot, status := range statuses {
 		ss := []*writerStatus{}
@@ -91,8 +91,8 @@ func statusPrintln(w io.Writer, status *writerStatus) error {
 	listenerSynced := xdsStatus(status.ListenerSent, status.ListenerAcked)
 	routeSynced := xdsStatus(status.RouteSent, status.RouteAcked)
 	endpointSynced := xdsStatus(status.EndpointSent, status.EndpointAcked)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\n",
-		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot)
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v (%v%%)\t%v\t%v\t%v\n",
+		status.ProxyID, clusterSynced, listenerSynced, endpointSynced, status.EndpointPercent, routeSynced, status.pilot, status.ProxyVersion)
 	return nil
 }
 

--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -149,6 +149,7 @@ func statusInput1() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
 			ProxyID:         "proxy1",
+			ProxyVersion:    "1.0",
 			ClusterSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			ClusterAcked:    "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
 			ListenerSent:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
@@ -164,6 +165,7 @@ func statusInput2() []v2.SyncStatus {
 	return []v2.SyncStatus{
 		{
 			ProxyID:       "proxy2",
+			ProxyVersion:  "1.0",
 			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			ClusterAcked:  "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
 			ListenerSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,3 +1,3 @@
-PROXY      CDS       LDS        EDS               RDS          PILOT
-proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1
-proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot2
+PROXY      CDS       LDS        EDS               RDS          PILOT      VERSION
+proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
+proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot2     1.0

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-PROXY      CDS       LDS        EDS               RDS          PILOT
-proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1
-proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot1
+PROXY      CDS       LDS        EDS               RDS          PILOT      VERSION
+proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
+proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot1     1.0

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-PROXY      CDS       LDS        EDS            RDS        PILOT
-proxy2     STALE     SYNCED     STALE (0%)     SYNCED     pilot2
+PROXY      CDS       LDS        EDS            RDS        PILOT      VERSION
+proxy2     STALE     SYNCED     STALE (0%)     SYNCED     pilot2     1.0

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -82,6 +82,7 @@ func NewMemServiceDiscovery(services map[model.Hostname]*model.Service, versions
 // SyncStatus is the synchronization status between Pilot and a given Envoy
 type SyncStatus struct {
 	ProxyID         string `json:"proxy,omitempty"`
+	ProxyVersion    string `json:"proxy_version,omitempty"`
 	ClusterSent     string `json:"cluster_sent,omitempty"`
 	ClusterAcked    string `json:"cluster_acked,omitempty"`
 	ListenerSent    string `json:"listener_sent,omitempty"`
@@ -102,8 +103,10 @@ func Syncz(w http.ResponseWriter, req *http.Request) {
 	for _, con := range adsClients {
 		con.mu.RLock()
 		if con.modelNode != nil {
+			proxyVersion, _ := con.modelNode.GetProxyVersion()
 			syncz = append(syncz, SyncStatus{
 				ProxyID:         con.modelNode.ID,
+				ProxyVersion:    proxyVersion,
 				ClusterSent:     con.ClusterNonceSent,
 				ClusterAcked:    con.ClusterNonceAcked,
 				ListenerSent:    con.ListenerNonceSent,

--- a/pilot/pkg/proxy/envoy/v2/debug_test.go
+++ b/pilot/pkg/proxy/envoy/v2/debug_test.go
@@ -135,6 +135,9 @@ func verifySyncStatus(t *testing.T, gotStatus []v2.SyncStatus, nodeID string, wa
 	// This makes this test contaminated by others
 	for _, ss := range gotStatus {
 		if ss.ProxyID == nodeID {
+			if ss.ProxyVersion == "" {
+				t.Errorf("ProxyVersion should always be set for %v", nodeID)
+			}
 			if (ss.ClusterSent != "") != wantSent {
 				t.Errorf("wanted ClusterSent set %v got %v for %v", wantSent, ss.ClusterSent, nodeID)
 			}

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -28,6 +28,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/gogo/googleapis/google/rpc"
+	proto "github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -35,6 +36,10 @@ import (
 	"istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/tests/util"
 )
+
+var nodeMetadata = &proto.Struct{Fields: map[string]*proto.Value{
+	"ISTIO_PROXY_VERSION": &proto.Value{Kind: &proto.Value_StringValue{StringValue: "1.0"}}, // actual value doesn't matter
+}}
 
 // Extract cluster load assignment from a discovery response.
 func getLoadAssignment(res1 *xdsapi.DiscoveryResponse) (*xdsapi.ClusterLoadAssignment, error) {
@@ -136,7 +141,8 @@ func sendEDSReq(clusters []string, node string, edsstr ads.AggregatedDiscoverySe
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:       v2.EndpointType,
 		ResourceNames: clusters,
@@ -152,7 +158,8 @@ func sendEDSNack(clusters []string, node string, edsstr ads.AggregatedDiscoveryS
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.EndpointType,
 		ErrorDetail: &rpc.Status{Message: "NOPE!"},
@@ -170,7 +177,8 @@ func sendEDSNack(clusters []string, node string, edsstr ads.AggregatedDiscoveryS
 func sendEDSReqReconnect(clusters []string, edsstr ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient, res *xdsapi.DiscoveryResponse) error {
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		Node: &core.Node{
-			Id: sidecarId(app3Ip, "app3"),
+			Id:       sidecarId(app3Ip, "app3"),
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:       v2.EndpointType,
 		ResponseNonce: res.Nonce,
@@ -187,7 +195,8 @@ func sendLDSReq(node string, ldsstr ads.AggregatedDiscoveryService_StreamAggrega
 	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl: v2.ListenerType})
 	if err != nil {
@@ -201,7 +210,8 @@ func sendLDSNack(node string, ldsstr ads.AggregatedDiscoveryService_StreamAggreg
 	err := ldsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.ListenerType,
 		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
@@ -216,7 +226,8 @@ func sendRDSReq(node string, routes []string, rdsstr ads.AggregatedDiscoveryServ
 	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:       v2.RouteType,
 		ResourceNames: routes})
@@ -231,7 +242,8 @@ func sendRDSNack(node string, routes []string, rdsstr ads.AggregatedDiscoverySer
 	err := rdsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl:     v2.RouteType,
 		ErrorDetail: &rpc.Status{Message: "NOPE!"}})
@@ -246,7 +258,8 @@ func sendCDSReq(node string, edsstr ads.AggregatedDiscoveryService_StreamAggrega
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		TypeUrl: v2.ClusterType})
 	if err != nil {
@@ -260,7 +273,8 @@ func sendCDSNack(node string, edsstr ads.AggregatedDiscoveryService_StreamAggreg
 	err := edsstr.Send(&xdsapi.DiscoveryRequest{
 		ResponseNonce: time.Now().String(),
 		Node: &core.Node{
-			Id: node,
+			Id:       node,
+			Metadata: nodeMetadata,
 		},
 		ErrorDetail: &rpc.Status{Message: "NOPE!"},
 		TypeUrl:     v2.ClusterType})


### PR DESCRIPTION
Not sure if this should be in the default response or we should add a `-o wide` similar to kube. Typically this value is just going to be the same for every proxy.