### PR TITLE
Remove Namespaced CRD scope

### DIFF
--- a/install/kubernetes/helm/istio/charts/certmanager/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/crds.yaml
@@ -24,7 +24,6 @@ spec:
   names:
     kind: Issuer
     plural: issuers
-  scope: Namespaced
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -35,7 +34,6 @@ metadata:
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
-  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates

--- a/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/crds.yaml
@@ -16,7 +16,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -37,7 +36,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -58,7 +56,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -79,7 +76,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -100,7 +96,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -121,7 +116,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -142,7 +136,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -163,7 +156,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -184,7 +176,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -205,7 +196,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -226,7 +216,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -247,7 +236,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -268,7 +256,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -285,7 +272,6 @@ spec:
     kind: redisquota
     plural: redisquotas
     singular: redisquota
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -306,7 +292,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 
 ---
@@ -328,7 +313,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -349,7 +333,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -370,7 +353,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -391,7 +373,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -412,7 +393,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -433,7 +413,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -454,7 +433,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -475,7 +453,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -496,7 +473,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -517,7 +493,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -538,7 +513,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -559,7 +533,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -580,7 +553,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -601,7 +573,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -622,7 +593,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -643,7 +613,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -664,7 +633,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 
@@ -685,7 +653,6 @@ spec:
     categories:
     - istio-io
     - rbac-istio-io
-  scope: Namespaced
   version: v1alpha1
 ---
 
@@ -706,7 +673,6 @@ spec:
     categories:
     - istio-io
     - rbac-istio-io
-  scope: Namespaced
   version: v1alpha1
 ---
 
@@ -727,7 +693,6 @@ spec:
     categories:
     - istio-io
     - rbac-istio-io
-  scope: Namespaced
   version: v1alpha1
 ---
 kind: CustomResourceDefinition
@@ -747,7 +712,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -767,7 +731,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -787,7 +750,6 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -807,6 +769,5 @@ spec:
     categories:
     - istio-io
     - policy-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---

--- a/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/crds.yaml
@@ -14,7 +14,6 @@ spec:
     categories:
     - istio-io
     - networking-istio-io
-  scope: Namespaced
   version: v1alpha3
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -33,7 +32,6 @@ spec:
     categories:
     - istio-io
     - networking-istio-io
-  scope: Namespaced
   version: v1alpha3
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -52,7 +50,6 @@ spec:
     categories:
     - istio-io
     - networking-istio-io
-  scope: Namespaced
   version: v1alpha3
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -70,7 +67,6 @@ spec:
     categories:
     - istio-io
     - networking-istio-io
-  scope: Namespaced
   version: v1alpha3
 ---
 kind: CustomResourceDefinition
@@ -86,7 +82,6 @@ spec:
     categories:
     - istio-io
     - authentication-istio-io
-  scope: Namespaced
   version: v1alpha1
 ---
 kind: CustomResourceDefinition
@@ -119,7 +114,6 @@ spec:
     categories:
     - istio-io
     - apim-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -135,7 +129,6 @@ spec:
     categories:
     - istio-io
     - apim-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -151,7 +144,6 @@ spec:
     categories:
     - istio-io
     - apim-istio-io
-  scope: Namespaced
   version: v1alpha2
 ---
 kind: CustomResourceDefinition
@@ -167,7 +159,6 @@ spec:
     categories:
     - istio-io
     - apim-istio-io
-  scope: Namespaced
   version: v1alpha2
 
 ---
@@ -186,5 +177,4 @@ spec:
     categories:
     - istio-io
     - networking-istio-io
-  scope: Namespaced
   version: v1alpha3


### PR DESCRIPTION
Default scope for CRDs are `Namespaced` anyway.

The reason for removing the scope is to avoid errors as reported in #7270 where an exiting CRD has been programatically generated by previous versions in a `Cluster` scope. However, we moved all CRDs to the Helm charts to avoid having them "unmanaged" and be leftover after Helm deletion.

With this PR if a CRD already existed from a previous installation with either `Cluster` or `Namespaced` scope, the new one will be applied without the immutable error and the old scope will remain.
If it's a new installation, the new CRD will be created with the `Namespaced` scope (like they are prior to this change).

Fixes #7270