### PR TITLE
Do not allow short names in gateway hosts

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -408,7 +408,7 @@ func validateServer(server *networking.Server) (errs error) {
 		for _, host := range server.Hosts {
 			// short name hosts are not allowed in gateways
 			if host != "*" && !strings.Contains(host, ".") {
-				errs = appendErrors(errs, fmt.Errorf("short names (non FQDN) are not allowed in Gateway server hosts", host))
+				errs = appendErrors(errs, fmt.Errorf("short names (non FQDN) are not allowed in Gateway server hosts"))
 			}
 			if err := ValidateWildcardDomain(host); err != nil {
 				errs = appendErrors(errs, err)

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -406,6 +406,10 @@ func validateServer(server *networking.Server) (errs error) {
 		errs = appendErrors(errs, fmt.Errorf("server config must contain at least one host"))
 	} else {
 		for _, host := range server.Hosts {
+			// short name hosts are not allowed in gateways
+			if !strings.Contains(host, ".") {
+				errs = appendErrors(errs, fmt.Errorf("short names (non FQDN) are not allowed in Gateway server hosts"))
+			}
 			if err := ValidateWildcardDomain(host); err != nil {
 				errs = appendErrors(errs, err)
 			}

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -407,8 +407,8 @@ func validateServer(server *networking.Server) (errs error) {
 	} else {
 		for _, host := range server.Hosts {
 			// short name hosts are not allowed in gateways
-			if !strings.Contains(host, ".") {
-				errs = appendErrors(errs, fmt.Errorf("short names (non FQDN) are not allowed in Gateway server hosts"))
+			if host != "*" && !strings.Contains(host, ".") {
+				errs = appendErrors(errs, fmt.Errorf("short names (non FQDN) are not allowed in Gateway server hosts", host))
 			}
 			if err := ValidateWildcardDomain(host); err != nil {
 				errs = appendErrors(errs, err)

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -1119,6 +1119,12 @@ func TestValidateServer(t *testing.T) {
 				Port:  &networking.Port{Number: 7, Name: "http", Protocol: "http"},
 			},
 			"domain"},
+		{"invalid short name host",
+			&networking.Server{
+				Hosts: []string{"foo"},
+				Port:  &networking.Port{Number: 7, Name: "http", Protocol: "http"},
+			},
+			"short names"},
 		{"invalid port",
 			&networking.Server{
 				Hosts: []string{"foo.bar.com"},


### PR DESCRIPTION
cc @ZackButcher
This should solve some of the issues that Arun Gupta as seeing.
Also addresses error reporting in https://github.com/istio/istio/issues/7284

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>