### PR TITLE
push to sidecars when detecting jwt pubkey change

### DIFF
--- a/pilot/pkg/model/jwks_resolver.go
+++ b/pilot/pkg/model/jwks_resolver.go
@@ -84,6 +84,9 @@ type jwksResolver struct {
 	// cache for jwksURI.
 	JwksURICache cache.ExpiringCache
 
+	// Callback function to invoke when detecting jwt public key change.
+	PushFunc func()
+
 	// cache for JWT public key.
 	// map key is jwksURI, map value is jwtPubKeyEntry.
 	keyEntries sync.Map
@@ -344,7 +347,10 @@ func (r *jwksResolver) refresh(t time.Time) {
 
 	if hasChange {
 		atomic.AddUint64(&r.keyChangedCount, 1)
-		// TODO(quanlin): send notification to update config and push config to sidecar.
+		// Push public key changes to sidecars.
+		if r.PushFunc != nil {
+			r.PushFunc()
+		}
 	}
 }
 

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -372,6 +372,9 @@ func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCach
 		return nil, err
 	}
 
+	// Flush cached discovery responses when detecting jwt public key change.
+	model.JwtKeyResolver.PushFunc = out.ClearCache
+
 	if configCache != nil {
 		// TODO: changes should not trigger a full recompute of LDS/RDS/CDS/EDS
 		// (especially mixerclient HTTP and quota)


### PR DESCRIPTION
Preeviously jwt pubkey change relies on pilot periodically to push to sidecars;
Recently seems [periodically push is disabled by default](https://github.com/istio/istio/blob/release-1.0/pilot/pkg/proxy/envoy/v2/discovery.go#L34), so add proactively push callback in jwtresolver 

complete https://github.com/istio/istio/issues/4917