### PR TITLE
Added annotaion of `scheduler.alpha.kubernetes.io/critical-pod: ""`.

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         istio: citadel
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-citadel-service-account
       containers:

--- a/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         istio: sidecar-injector
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         istio: galley
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-galley-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
         {{- end }}
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: {{ $key }}-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: grafana
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         istio: ingress
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-ingress-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       name: kiali
       labels:
         app: kiali
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: kiali-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -188,6 +188,7 @@ spec:
         istio-mixer-type: {{ $mname }}
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
 {{- if eq $mname "policy"}}
 {{- template "policy_container" $ }}
 {{- else }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app: pilot
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-pilot-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: prometheus
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: prometheus
       containers:

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         istio: citadel
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-citadel-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: servicegraph
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       containers:
         - name: servicegraph

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
     metadata:
       labels:
         istio: sidecar-injector
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-sidecar-injector-service-account
       containers:

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
         app: jaeger
       annotations:
         sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       containers:
         - name: jaeger


### PR DESCRIPTION
This can make sure the pod will not be preempted after it was deployed
on one node.