### PR TITLE
Enable coredump by default

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -28,7 +28,7 @@ global:
     accessLogFile: "/dev/stdout"
 
     # If set, newly injected sidecars will have core dumps enabled.
-    enableCoreDump: false
+    enableCoreDump: true
 
     # istio egress capture whitelist
     # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -21,6 +21,10 @@ data:
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
 {{- end }}
         args:
+{{- if eq .Values.global.proxy.enableCoreDump true }}
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+{{- end }}
         - "-p"
         - {{ "[[ .MeshConfig.ProxyListenPort ]]" }}
         - "-u"
@@ -57,19 +61,6 @@ data:
             - NET_ADMIN
           privileged: true
         restartPolicy: Always
-      {{ if eq .Values.global.proxy.enableCoreDump true }}
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
-        command:
-          - /bin/sh
-        image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
-      {{ end }}
       containers:
       - name: istio-proxy
         image: {{ "[[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\") -]]" }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -25,7 +25,7 @@ global:
     accessLogFile: "/dev/stdout"
 
     # If set, newly injected sidecars will have core dumps enabled.
-    enableCoreDump: false
+    enableCoreDump: true
 
     # istio egress capture whitelist
     # https://istio.io/docs/tasks/traffic-management/egress.html#calling-external-services-directly

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -85,6 +85,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -105,6 +105,8 @@ items:
             readOnly: true
         initContainers:
         - args:
+          - -c
+          - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
           - -p
           - "15001"
           - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -90,6 +90,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -105,6 +105,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -87,6 +87,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -88,6 +88,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u
@@ -210,6 +212,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -107,6 +107,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -84,6 +84,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -106,6 +106,8 @@ items:
             readOnly: true
         initContainers:
         - args:
+          - -c
+          - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
           - -p
           - "15001"
           - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -90,6 +90,8 @@ items:
             readOnly: true
         initContainers:
         - args:
+          - -c
+          - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
           - -p
           - "15001"
           - -u
@@ -211,6 +213,8 @@ items:
             readOnly: true
         initContainers:
         - args:
+          - -c
+          - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
           - -p
           - "15001"
           - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -101,6 +101,8 @@ spec:
         name: init-two
         resources: {}
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -84,6 +84,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -86,6 +86,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -90,6 +90,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -89,6 +89,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -89,6 +89,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -89,6 +89,8 @@ spec:
           readOnly: true
       initContainers:
       - args:
+        - -c
+        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         - -p
         - "15001"
         - -u


### PR DESCRIPTION
Core dump should be on by default until we are really confident.