### PR TITLE
Normalize shebangs in shell scripts

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Exit immediately for non zero status
 set -e

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 set -u
 

--- a/bin/envsetup.sh
+++ b/bin/envsetup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # Setup and document common environment variables used for building and testing Istio
 # User-specific settings can be added to .istiorc in the project workspace or $HOME/.istiorc
 # This may include dockerhub settings or other customizations.

--- a/bin/mixer_codegen.sh
+++ b/bin/mixer_codegen.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 die () {
   echo "ERROR: $*. Aborting." >&2

--- a/bin/perfcheck.sh
+++ b/bin/perfcheck.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #
 # Shell script for checking go benchmarks against baseline files.

--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo pipefail
 

--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 export K8S_VER=${K8S_VER:-v1.9.2}
 export MINIKUBE_VER=${MINIKUBE_VER:-v0.25.0}

--- a/downloadIstio.sh
+++ b/downloadIstio.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Early version of a downloader/installer for Istio
 #

--- a/galley/tools/gen-meta/gen-meta.sh
+++ b/galley/tools/gen-meta/gen-meta.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/install/tools/setupMeshEx.sh
+++ b/install/tools/setupMeshEx.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Copyright 2017 Istio Authors. All Rights Reserved.
 #

--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # Early version of a downloader/installer for Istio
 #

--- a/samples/bookinfo/src/mongodb/script.sh
+++ b/samples/bookinfo/src/mongodb/script.sh
@@ -1,3 +1,3 @@
-#! /bin/sh 
+#!/bin/sh
 set -e
 mongoimport --host localhost --db test --collection ratings --drop --file /app/data/ratings_data.json

--- a/samples/rawvm/demo.sh
+++ b/samples/rawvm/demo.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -x
 set -e

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 #
 # Sets up a cluster for perf testing - GCP/GKE
 #   tools/setup_perf_cluster.sh

--- a/tools/update_all
+++ b/tools/update_all
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 # update and rebuild from source
 set -e
 set -x


### PR DESCRIPTION
First step in enabling linter checks to every shell script

Note that using /usr/env/bash allows bash to exist at a different path than /bin/bash, but /bin/bash is depended on by other scripts and, as far as I can tell, is actually more standard than the existence of /usr/env/bash.

/assign @mandarjog
