### PR TITLE
Add keepalive

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -88,6 +88,11 @@
         "max_requests": "100000"
       }]
     },
+    "upstream_connection_options": {
+      "tcp_keepalive": {
+        "keepalive_time": 300
+      }
+    },
     "http2_protocol_options": { }
     }
 

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -88,6 +88,11 @@
         "max_requests": "100000"
       }]
     },
+    "upstream_connection_options": {
+      "tcp_keepalive": {
+        "keepalive_time": 300
+      }
+    },
     "http2_protocol_options": { }
     }
 

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -66,6 +66,11 @@
         "max_requests": "100000"
       }]
     },
+    "upstream_connection_options": {
+      "tcp_keepalive": {
+        "keepalive_time": 300
+      }
+    },
     "http2_protocol_options": { }
     }
 

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -97,6 +97,11 @@
         "max_requests": "100000"
       }]
     },
+    "upstream_connection_options": {
+      "tcp_keepalive": {
+        "keepalive_time": 300
+      }
+    },
     "http2_protocol_options": { }
     }
 


### PR DESCRIPTION
Issue #7296

Root cause seems to be a 'silent close' - sidecars believed that the pilot is alive and are waiting for a push
(netstat shows the connection active on client side).

Didn't find any option to turn h2 keep alive - and they obviously are not active, or they would have detected the close. TCP keepalive would do the same. 

Side-effect - extra traffic, but it's handled by kernel.