### PR TITLE
Data race fix in discovery

### DIFF
--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -504,8 +504,9 @@ func (ds *DiscoveryService) clearCache() {
 
 		if !clearCacheTimerSet {
 			clearCacheTimerSet = true
+			startDebounce := lastClearCacheEvent
 			time.AfterFunc(DebounceAfter, func() {
-				debouncePush(lastClearCacheEvent)
+				debouncePush(startDebounce)
 			})
 		} // else: debunce in progress - it'll keep delaying the push
 


### PR DESCRIPTION
PR fixes a new data race that fails `racetest` in recent builds.
I also believe the logic was incorrect as `debouncePush` func was actually comparing time since itself (always 0).

Fixes #7307