### PR TITLE
Fix istio-remote yaml indentation error

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
@@ -1,8 +1,8 @@
-  kind: ClusterRole
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: istio-reader
-  rules:
-    - apiGroups: ['']
-      resources: ['nodes', 'pods', 'services', 'endpoints']
-      verbs: ['get', 'watch', 'list']
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: istio-reader
+rules:
+  - apiGroups: ['']
+    resources: ['nodes', 'pods', 'services', 'endpoints']
+    verbs: ['get', 'watch', 'list']


### PR DESCRIPTION
Seems like there are a few more YAML indentation errors in the istio-remote chart, similar to #7260 