### PR TITLE
add rule specific for consul

### DIFF
--- a/samples/bookinfo/platform/consul/destination-rule-all.yaml
+++ b/samples/bookinfo/platform/consul/destination-rule-all.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: productpage
+spec:
+  host: productpage.service.consul
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: reviews
+spec:
+  host: reviews.service.consul
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+  - name: v3
+    labels:
+      version: v3
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ratings
+spec:
+  host: ratings.service.consul
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: details
+spec:
+  host: details.service.consul
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---

--- a/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
+++ b/samples/bookinfo/platform/consul/templates/bookinfo.sidecars.yaml.tmpl
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_details-v1_1"
@@ -34,7 +34,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster details-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   ratings-v1-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_ratings-v1_1"
@@ -52,7 +52,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster ratings-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   productpage-v1-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_productpage-v1_1"
@@ -70,7 +70,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster productpage-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v1-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v1_1"
@@ -88,7 +88,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v1 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v2-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v2_1"
@@ -106,7 +106,7 @@ services:
       - -c
       - "/usr/local/bin/pilot-agent proxy --serviceregistry Consul --serviceCluster reviews-v2 --zipkinAddress zipkin:9411 --configPath /var/lib/istio >/tmp/envoy.log"
   reviews-v3-init:
-    image: {PROXY_HUB}/proxy_init:{PROXY_TAG}
+    image: docker.io/istio/proxy_init:0.7.1
     cap_add:
       - NET_ADMIN
     network_mode: "container:consul_reviews-v3_1"

--- a/samples/bookinfo/platform/consul/virtual-service-all-v1.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-all-v1.yaml
@@ -1,0 +1,52 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: productpage
+spec:
+  hosts:
+  - productpage.service.consul
+  http:
+  - route:
+    - destination:
+        host: productpage.service.consul
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+  - reviews.service.consul
+  http:
+  - route:
+    - destination:
+        host: reviews.service.consul
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings.service.consul
+  http:
+  - route:
+    - destination:
+        host: ratings.service.consul
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: details
+spec:
+  hosts:
+  - details.service.consul
+  http:
+  - route:
+    - destination:
+        host: details.service.consul
+        subset: v1
+---

--- a/samples/bookinfo/platform/consul/virtual-service-ratings-test-abort.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-ratings-test-abort.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings.service.consul
+  http:
+  - match:
+    - headers:
+        end-user:
+          exact: jason
+    fault:
+      abort:
+        percent: 100
+        httpStatus: 500
+    route:
+    - destination:
+        host: ratings.service.consul
+        subset: v1
+  - route:
+    - destination:
+        host: ratings.service.consul
+        subset: v1

--- a/samples/bookinfo/platform/consul/virtual-service-ratings-test-delay.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-ratings-test-delay.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: ratings
+spec:
+  hosts:
+  - ratings.service.consul
+  http:
+  - match:
+    - headers:
+        end-user:
+          exact: jason
+    fault:
+      delay:
+        percent: 100
+        fixedDelay: 7s
+    route:
+    - destination:
+        host: ratings.service.consul
+        subset: v1
+  - route:
+    - destination:
+        host: ratings.service.consul
+        subset: v1

--- a/samples/bookinfo/platform/consul/virtual-service-reviews-50-v3.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-reviews-50-v3.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews.service.consul
+  http:
+  - route:
+    - destination:
+        host: reviews.service.consul
+        subset: v1
+      weight: 50
+    - destination:
+        host: reviews.service.consul
+        subset: v3
+      weight: 50

--- a/samples/bookinfo/platform/consul/virtual-service-reviews-test-v2.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-reviews-test-v2.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews.service.consul
+  http:
+  - match:
+    - headers:
+        end-user:
+          exact: jason
+    route:
+    - destination:
+        host: reviews.service.consul
+        subset: v2
+  - route:
+    - destination:
+        host: reviews.service.consul
+        subset: v1

--- a/samples/bookinfo/platform/consul/virtual-service-reviews-v2-v3.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-reviews-v2-v3.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews.service.consul
+  http:
+  - route:
+    - destination:
+        host: reviews.service.consul
+        subset: v2
+      weight: 50
+    - destination:
+        host: reviews.service.consul
+        subset: v3
+      weight: 50

--- a/samples/bookinfo/platform/consul/virtual-service-reviews-v3.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-reviews-v3.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews
+spec:
+  hosts:
+    - reviews.service.consul
+  http:
+  - route:
+    - destination:
+        host: reviews.service.consul
+        subset: v3


### PR DESCRIPTION
istioctl can't create rules for domain/namespace `.service.consul` and in pilot if a host field is not a FQDN, it appends <host>.svc.<meta.domain>
https://github.com/istio/istio/blob/release-1.0/pilot/pkg/model/config.go#L548

so for now cannot use the same rules in the bookinfo example for both consul and k8s