### PR TITLE
Add optional enable coredump to gateway

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -29,6 +29,23 @@ spec:
 {{- if $.Values.global.priorityClassName }}
       priorityClassName: "{{ $.Values.global.priorityClassName }}"
 {{- end }}
+{{- if eq $.Values.global.proxy.enableCoreDump true }}
+      initContainers:
+        - name: enable-core-dump
+{{- if contains "/" $.Values.global.proxy_init.image }}
+          image: "{{ $.Values.global.proxy_init.image }}"
+{{- else }}
+          image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy_init.image }}:{{ $.Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+          securityContext:
+            privileged: true
+{{- end }}
       containers:
         - name: {{ $spec.labels.istio }}
           image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"


### PR DESCRIPTION
Coredumps are currently only available on sidecars, this adds the same option to gateway.