### PR TITLE
returns error when revision is not exists in istioctl replace command

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -206,9 +206,10 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 				// fill up revision
 				if config.ResourceVersion == "" {
 					current, exists := configClient.Get(config.Type, config.Name, config.Namespace)
-					if exists {
-						config.ResourceVersion = current.ResourceVersion
+					if !exists {
+						return errors.New("revision is required")
 					}
+					config.ResourceVersion = current.ResourceVersion
 				}
 
 				var newRev string


### PR DESCRIPTION
When ``config.ResourceVersion`` is empty, we will try to get current config. 

If ``current.ResourceVersion`` is still empty,  we can return  ``revision is required`` error directly because `` configClient.Update(config)`` will also return the error.