### PR TITLE
improves sort performance

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -488,18 +488,35 @@ func (h Hostname) String() string {
 //  Hostname("*.com").Matches("foo.com")     = true
 //  Hostname("*.foo.com").Matches("foo.com") = false
 func (h Hostname) Matches(o Hostname) bool {
-	if !strings.Contains(string(h), "*") && !strings.Contains(string(o), "*") {
+	if len(h) == 0 && len(o) == 0 {
+		return true
+	}
+
+	hWildcard := string(h[0]) == "*"
+	if hWildcard && len(o) == 0 {
+		return true
+	}
+
+	oWildcard := string(o[0]) == "*"
+	if !hWildcard && !oWildcard {
+		// both are non-wildcards, so do normal string comparison
 		return h == o
 	}
-	la, sa := strings.Contains(string(h), "*"), strings.Contains(string(o), "*")
-	longer, shorter := strings.TrimLeft(string(h), "*"), strings.TrimLeft(string(o), "*")
+
+	longer, shorter := string(h), string(o)
+	if hWildcard {
+		longer = string(h[1:])
+	}
+	if oWildcard {
+		shorter = string(o[1:])
+	}
 	if len(longer) < len(shorter) {
 		longer, shorter = shorter, longer
-		la, sa = sa, la
+		hWildcard, oWildcard = oWildcard, hWildcard
 	}
 
 	matches := strings.HasSuffix(longer, shorter)
-	if matches && la && !sa && strings.TrimSuffix(longer, shorter) == "." {
+	if matches && hWildcard && !oWildcard && strings.TrimSuffix(longer, shorter) == "." {
 		// we match, but the longer is a wildcard and the shorter is not; we need to ensure we don't match input
 		// like `*.foo.com` to `foo.com` in that case (to avoid matching a domain literal to a wildcard subdomain)
 		return false
@@ -524,8 +541,9 @@ func (h Hostnames) Less(i, j int) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true // doesn't matter, they're both the empty string
 	}
+
 	// we sort longest to shortest, alphabetically, with wildcards last
-	ai, aj := strings.Contains(a.String(), "*"), strings.Contains(b.String(), "*")
+	ai, aj := string(a[0]) == "*", string(b[0]) == "*"
 	if ai && !aj {
 		// h[i] is a wildcard, but h[j] isn't; therefore h[j] < h[i]
 		return false
@@ -533,10 +551,12 @@ func (h Hostnames) Less(i, j int) bool {
 		// h[j] is a wildcard, but h[i] isn't; therefore h[i] < h[j]
 		return true
 	}
+
 	// they're either both wildcards, or both not; in either case we sort them longest to shortest, alphabetically
 	if len(a) == len(b) {
 		return a < b
 	}
+
 	return len(a) > len(b)
 }
 

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -262,6 +262,31 @@ func TestHostnameMatches(t *testing.T) {
 	}
 }
 
+func BenchmarkMatch(b *testing.B) {
+	tests := []struct {
+		a, z    Hostname
+		matches bool
+	}{
+		{"foo.com", "foo.com", true},
+		{"*.com", "foo.com", true},
+		{"*.foo.com", "bar.foo.com", true},
+		{"*", "foo.com", true},
+		{"*", "*.com", true},
+		{"*", "", true},
+		{"*.com", "*.foo.com", true},
+		{"foo.com", "*.foo.com", false},
+		{"*.foo.bar.baz", "baz", true},
+	}
+	for n := 0; n < b.N; n++ {
+		for _, test := range tests {
+			doesMatch := test.a.Matches(test.z)
+			if doesMatch != test.matches {
+				b.Fatalf("does not match")
+			}
+		}
+	}
+}
+
 func TestHostnamesSortOrder(t *testing.T) {
 	tests := []struct {
 		in, want Hostnames
@@ -310,5 +335,15 @@ func TestHostnamesSortOrder(t *testing.T) {
 				t.Fatalf("sort.Sort(%v) = %v, want %v", tmp, tt.in, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkSort(b *testing.B) {
+	unsorted := Hostnames{"foo.com", "bar.com", "*.com", "*.foo.com", "*", "baz.bar.com"}
+
+	for n := 0; n < b.N; n++ {
+		given := make(Hostnames, len(unsorted))
+		copy(given, unsorted)
+		sort.Sort(given)
 	}
 }


### PR DESCRIPTION
This is just the sort improvements (minus dropping the String() method)

Here is the before and after bench:

```
BenchmarkMatch-8         1000000              1036 ns/op
BenchmarkSort-8          5000000               387 ns/op
PASS
ok      istio.io/istio/pilot/pkg/model  4.930s
```

```
BenchmarkMatch-8        10000000               195 ns/op
BenchmarkSort-8          5000000               318 ns/op
PASS
ok      istio.io/istio/pilot/pkg/model  5.646s
```

The bench is also part of the `service_test` now. If you want to run it on your machine just cd down into the service directory and run `go test bench=.`