### PR TITLE
[WIP] Add test case for accessing external service with sni

### DIFF
--- a/tests/e2e/tests/pilot/externalservice_test.go
+++ b/tests/e2e/tests/pilot/externalservice_test.go
@@ -64,6 +64,18 @@ func TestServiceEntry(t *testing.T) {
 			url:               "https://google.com",
 			shouldBeReachable: false,
 		},
+		{
+			name:              "REACHABLE_google.com_over_google_sni",
+			config:            "testdata/networking/v1alpha3/service-entry-google-sni.yaml",
+			url:               "https://www.google.com",
+			shouldBeReachable: true,
+		},
+		{
+			name:              "UNREACHABLE_wikipedia.org_over_google_sni",
+			config:            "testdata/networking/v1alpha3/service-entry-google-sni.yaml",
+			url:               "https://wikipedia.org",
+			shouldBeReachable: false,
+		},
 	}
 
 	var cfgs *deployableConfig

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/service-entry-google-sni.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/service-entry-google-sni.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: service-entry-google
+spec:
+  hosts:
+    - www.google.com
+  ports:
+  - number: 443
+    name: https
+    protocol: TLS
+  - number: 80
+    name: http
+    protocol: http
+  resolution: DNS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: google
+spec:
+  hosts:
+  - www.google.com
+  gateways:
+  - mesh
+  tls:
+  - match:
+    - gateways:
+      - mesh
+      port: 443
+      sni_hosts:
+      - www.google.com
+    route:
+    - destination:
+        host: www.google.com
+        port:
+          number: 443
+      weight: 100


### PR DESCRIPTION
This PR adds a test case to pilot's e2e tests that checks the access of an application to an external service using sni.