### PR TITLE
Update servicegraph reporter query label (fix servicegraph)

### DIFF
--- a/addons/servicegraph/promgen/promgen.go
+++ b/addons/servicegraph/promgen/promgen.go
@@ -30,8 +30,8 @@ import (
 	"istio.io/istio/addons/servicegraph"
 )
 
-const reqsFmt = "sum(rate(istio_requests_total{reporter=\"server\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
-const tcpFmt = "sum(rate(istio_tcp_received_bytes_total{reporter=\"server\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const reqsFmt = "sum(rate(istio_requests_total{reporter=\"destination\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
+const tcpFmt = "sum(rate(istio_tcp_received_bytes_total{reporter=\"destination\"}[%s])) by (source_workload, destination_workload, source_app, destination_app)"
 const emptyFilter = " > 0"
 
 type genOpts struct {


### PR DESCRIPTION
#7034 updated the metric label for 'server' and 'client' to be 'destination' and 'source' respectively.

The servicegraph query was not updated however, so service graph does not work out of the box with the latest HEAD of Istio.

This PR fixes servicegraph 😄

Fixes #7414 
Replaces #7378 