### PR TITLE
A few improvements to ControlZ

### DIFF
--- a/pkg/ctrlz/ctrlz.go
+++ b/pkg/ctrlz/ctrlz.go
@@ -36,12 +36,14 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"sync"
+
 	"istio.io/istio/pkg/ctrlz/fw"
 	"istio.io/istio/pkg/ctrlz/topics"
 	"istio.io/istio/pkg/log"
 )
 
-var allTopics = []fw.Topic{
+var coreTopics = []fw.Topic{
 	topics.ScopeTopic(),
 	topics.MemTopic(),
 	topics.EnvTopic(),
@@ -50,6 +52,13 @@ var allTopics = []fw.Topic{
 	topics.VersionTopic(),
 	topics.MetricsTopic(),
 }
+
+var allTopics []fw.Topic
+var topicMutex sync.Mutex
+var server *http.Server
+var shutdown sync.WaitGroup
+var shutdownMutex sync.Mutex
+var abort = false
 
 func augmentLayout(layout *template.Template, page string) *template.Template {
 	return template.Must(layout.Parse(string(MustAsset(page))))
@@ -87,24 +96,46 @@ type topic struct {
 }
 
 func getTopics() []topic {
-	topics := []topic{}
+	var topics []topic
+
+	topicMutex.Lock()
 	for _, t := range allTopics {
 		topics = append(topics, topic{Name: t.Title(), URL: "/" + t.Prefix() + "z/"})
 	}
+	topicMutex.Unlock()
 
 	return topics
 }
 
+// RegisterTopic registers a new Control-Z topic for the current process.
+func RegisterTopic(t fw.Topic) {
+	topicMutex.Lock()
+	allTopics = append(allTopics, t)
+	topicMutex.Unlock()
+}
+
 // Run starts up the ControlZ listeners.
+//
+// ControlZ uses the set of standard core topics, the
+// supplied custom topics, as well as any topics registered
+// via the RegisterTopic function.
 func Run(o *Options, customTopics []fw.Topic) {
 	if o.Port == 0 {
 		// disabled
 		return
 	}
 
+	topicMutex.Lock()
+
+	for _, t := range coreTopics {
+		allTopics = append(allTopics, t)
+	}
+
 	for _, t := range customTopics {
 		allTopics = append(allTopics, t)
 	}
+
+	topicMutex.Unlock()
 
 	exec, _ := os.Executable()
 	instance := exec + " - " + getLocalIP()
@@ -133,14 +164,50 @@ func Run(o *Options, customTopics []fw.Topic) {
 		addr = ""
 	}
 
-	s := &http.Server{
-		Addr:           fmt.Sprintf("%s:%d", addr, o.Port),
-		Handler:        router,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
-		MaxHeaderBytes: 1 << 20,
+	shutdownMutex.Lock()
+
+	if abort {
+		// reset to default state in case Run is called again
+		abort = false
+	} else {
+		server = &http.Server{
+			Addr:           fmt.Sprintf("%s:%d", addr, o.Port),
+			Handler:        router,
+			ReadTimeout:    10 * time.Second,
+			WriteTimeout:   10 * time.Second,
+			MaxHeaderBytes: 1 << 20,
+		}
+		shutdown.Add(1)
 	}
 
-	log.Infof("ControlZ available at %s:%d", getLocalIP(), o.Port)
-	s.ListenAndServe()
+	shutdownMutex.Unlock()
+
+	if server != nil {
+		log.Infof("ControlZ available at %s:%d", getLocalIP(), o.Port)
+		server.ListenAndServe()
+		log.Infof("ControlZ terminated")
+		shutdown.Done()
+		server = nil
+	}
+}
+
+// Stop terminates ControlZ.
+//
+// Stop is hot normally used by programs that expose ControlZ, it is primarily intended to be
+// used by tests.
+func Stop() {
+	wait := false
+
+	shutdownMutex.Lock()
+	if server != nil {
+		server.Close()
+		wait = true
+	} else {
+		abort = true
+	}
+	shutdownMutex.Unlock()
+
+	if wait {
+		shutdown.Wait()
+	}
 }

--- a/pkg/ctrlz/ctrlz.go
+++ b/pkg/ctrlz/ctrlz.go
@@ -99,10 +99,11 @@ func getTopics() []topic {
 	var topics []topic
 
 	topicMutex.Lock()
+	defer topicMutex.Unlock()
+
 	for _, t := range allTopics {
 		topics = append(topics, topic{Name: t.Title(), URL: "/" + t.Prefix() + "z/"})
 	}
-	topicMutex.Unlock()
 
 	return topics
 }
@@ -110,8 +111,9 @@ func getTopics() []topic {
 // RegisterTopic registers a new Control-Z topic for the current process.
 func RegisterTopic(t fw.Topic) {
 	topicMutex.Lock()
+	defer topicMutex.Unlock()
+
 	allTopics = append(allTopics, t)
-	topicMutex.Unlock()
 }
 
 // Run starts up the ControlZ listeners.
@@ -193,7 +195,7 @@ func Run(o *Options, customTopics []fw.Topic) {
 
 // Stop terminates ControlZ.
 //
-// Stop is hot normally used by programs that expose ControlZ, it is primarily intended to be
+// Stop is not normally used by programs that expose ControlZ, it is primarily intended to be
 // used by tests.
 func Stop() {
 	wait := false
@@ -203,6 +205,7 @@ func Stop() {
 		server.Close()
 		wait = true
 	} else {
+		// prevent any in-progress calls to Run from succeeding
 		abort = true
 	}
 	shutdownMutex.Unlock()

--- a/pkg/ctrlz/ctrlz_test.go
+++ b/pkg/ctrlz/ctrlz_test.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctrlz
+
+import "testing"
+
+func TestStartStop(t *testing.T) {
+	o := DefaultOptions()
+	go Run(o, nil)
+	Stop()
+}


### PR DESCRIPTION
- Add the RegisterTopic function which makes it possible to have packages register themselves into
ControlZ in a manner similar to how we support registering logging scopes.

- Add the Stop function which makes it possible to kill ControlZ wtihin a process. This is mainly useful
for test scenarios.