### PR TITLE
fix panic when initial validation configuration is invalid

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -35,11 +35,16 @@ import (
 )
 
 func (wh *Webhook) createOrUpdateWebhookConfig() {
+	if wh.webhookConfiguration == nil {
+		log.Error("validatingwebhookconfiguration update failed: no configuration loaded")
+		reportValidationConfigUpdateError(errors.New("no configuration loaded"))
+		return
+	}
+
 	client := wh.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 	updated, err := createOrUpdateWebhookConfigHelper(client, wh.webhookConfiguration)
 	if err != nil {
-		log.Errorf("%v validatingwebhookconfiguration update failed: %v",
-			wh.webhookConfiguration.Name, err)
+		log.Errorf("%v validatingwebhookconfiguration update failed: %v", wh.webhookConfiguration.Name, err)
 		reportValidationConfigUpdateError(err)
 	} else if updated {
 		log.Infof("%v validatingwebhookconfiguration updated", wh.webhookConfiguration.Name)
@@ -85,8 +90,7 @@ func (wh *Webhook) rebuildWebhookConfig() error {
 		wh.ownerRefs)
 	if err != nil {
 		reportValidationConfigLoadError(err)
-		log.Errorf("%v validatingwebhookconfiguration (re)load failed: %v",
-			wh.webhookConfiguration.Name, err)
+		log.Errorf("validatingwebhookconfiguration (re)load failed: %v", err)
 		return err
 	}
 	wh.webhookConfiguration = webhookConfig

--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -367,3 +367,20 @@ func TestLoadCaCertPem(t *testing.T) {
 		})
 	}
 }
+
+func TestInitialConfigLoadError(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("configuration should not panic on invalid configuration: %v", r)
+		}
+	}()
+
+	wh, cleanup := createTestWebhook(t, fake.NewSimpleClientset(), dummyConfig)
+	defer cleanup()
+
+	wh.webhookConfigFile = ""
+	wh.webhookConfiguration = nil
+	if err := wh.rebuildWebhookConfig(); err == nil {
+		t.Fatal("unexpected success: rebuildWebhookConfig() should have failed given invalid config files")
+	}
+}


### PR DESCRIPTION
The validation webhook panics during the error reporting path if the
initial webhook configuration or ca file is invalid (see stack trace
below).

This commit makes the error reporting more robust in case of
misconfiguration. The root cause for why configuration is invalid
still unknown.

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x121e091]
    goroutine 1 [running]:
    istio.io/istio/galley/pkg/crd/validation.(*Webhook).rebuildWebhookConfig(0xc4203a3560, 0x2c, 0x0)
        /workspace/istio-master/go/src/istio.io/istio/galley/pkg/crd/validation/config.go:89 +0x271
    istio.io/istio/galley/pkg/crd/validation.NewWebhook(0x1cf7b00, 0xc420401fa0, 0x28e19a0, 0xe, 0xe, 0x0, 0x0, 0x1bb, 0x7ffc9d9f0000, 0x1f, ...)
        /workspace/istio-master/go/src/istio.io/istio/galley/pkg/crd/validation/webhook.go:205 +0xabf
    istio.io/istio/galley/cmd/galley/cmd.validatorCmd.func1(0xc4202a0f00, 0xc4203fc9b0, 0x0, 0x5)
        /workspace/istio-master/go/src/istio.io/istio/galley/cmd/galley/cmd/validator.go:138 +0x498
    istio.io/istio/vendor/github.com/spf13/cobra.(*Command).execute(0xc4202a0f00, 0xc4203fc910, 0x5, 0x5, 0xc4202a0f00, 0xc4203fc910)
        /workspace/istio-master/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:760 +0x2c1
    istio.io/istio/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4202a0a00, 0x0, 0x1b540a6, 0x13)
        /workspace/istio-master/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:846 +0x30a
    istio.io/istio/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4202a0a00, 0x6, 0x6)
        /workspace/istio-master/go/src/istio.io/istio/vendor/github.com/spf13/cobra/command.go:794 +0x2b
    main.main()
        /workspace/istio-master/go/src/istio.io/istio/galley/cmd/galley/main.go:27 +0x8x