### PR TITLE
depreciate istioctl create, get, replace, and delete subcommands in favor of kubectl

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -172,45 +172,46 @@ func TestGet(t *testing.T) {
 		{
 			configs: []model.Config{},
 			args:    strings.Split("get destinationrules", " "),
-			expectedOutput: `No resources found.
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+No resources found.
 `,
 		},
 		{
 			configs: testGateways,
 			args:    strings.Split("get gateways -n default", " "),
-			expectedOutput: `GATEWAY NAME       HOSTS     NAMESPACE   AGE
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+GATEWAY NAME       HOSTS     NAMESPACE   AGE
 bookinfo-gateway   *         default     0s
 `,
 		},
 		{
 			configs: testVirtualServices,
 			args:    strings.Split("get virtualservices -n default", " "),
-			expectedOutput: `VIRTUAL-SERVICE NAME   GATEWAYS           HOSTS     #HTTP     #TCP      NAMESPACE   AGE
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+VIRTUAL-SERVICE NAME   GATEWAYS           HOSTS     #HTTP     #TCP      NAMESPACE   AGE
 bookinfo               bookinfo-gateway   *             1        0      default     0s
 `,
 		},
 		{
-			configs:        []model.Config{},
-			args:           strings.Split("get invalid", " "),
-			expectedRegexp: regexp.MustCompile("^Usage:.*"),
-			wantException:  true, // "istioctl get invalid" should fail
-		},
-		{
-			configs:        []model.Config{},
-			args:           strings.Split("get all", " "),
-			expectedOutput: "No resources found.\n",
+			configs: []model.Config{},
+			args:    strings.Split("get all", " "),
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+No resources found.
+`,
 		},
 		{
 			configs: testDestinationRules,
 			args:    strings.Split("get destinationrules", " "),
-			expectedOutput: `DESTINATION-RULE NAME   HOST               SUBSETS   NAMESPACE   AGE
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+DESTINATION-RULE NAME   HOST               SUBSETS   NAMESPACE   AGE
 googleapis              *.googleapis.com             default     0s
 `,
 		},
 		{
 			configs: testServiceEntries,
 			args:    strings.Split("get serviceentries", " "),
-			expectedOutput: `SERVICE-ENTRY NAME   HOSTS              PORTS      NAMESPACE   AGE
+			expectedOutput: `Command "get" is deprecated, Use ` + "`kubectl get`" + ` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)
+SERVICE-ENTRY NAME   HOSTS              PORTS      NAMESPACE   AGE
 googleapis           *.googleapis.com   HTTP/443   default     0s
 `,
 		},
@@ -228,7 +229,7 @@ func TestCreate(t *testing.T) {
 		{ // invalid doesn't provide -f filename
 			configs:        []model.Config{},
 			args:           strings.Split("create virtualservice", " "),
-			expectedRegexp: regexp.MustCompile("^Usage:.*"),
+			expectedRegexp: regexp.MustCompile("^Command \"create\" is deprecated, Use `kubectl create` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)*"),
 			wantException:  true,
 		},
 	}
@@ -245,7 +246,7 @@ func TestReplace(t *testing.T) {
 		{ // invalid doesn't provide -f
 			configs:        []model.Config{},
 			args:           strings.Split("replace virtualservice", " "),
-			expectedRegexp: regexp.MustCompile("^Usage:.*"),
+			expectedRegexp: regexp.MustCompile("^Command \"replace\" is deprecated, Use `kubectl apply` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)*"),
 			wantException:  true,
 		},
 	}
@@ -261,14 +262,8 @@ func TestDelete(t *testing.T) {
 	cases := []testCase{
 		{
 			configs:        []model.Config{},
-			args:           strings.Split("delete destinationrule unknown", " "),
-			expectedRegexp: regexp.MustCompile("^Error: 1 error occurred:\n\n\\* cannot delete unknown: item not found\n$"),
-			wantException:  true,
-		},
-		{
-			configs:        []model.Config{},
 			args:           strings.Split("delete all foo", " "),
-			expectedRegexp: regexp.MustCompile("^Error: configuration type all not found"),
+			expectedRegexp: regexp.MustCompile("^Command \"delete\" is deprecated, Use `kubectl delete` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)*"),
 			wantException:  true,
 		},
 	}

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -143,26 +143,17 @@ var (
 		Short:             "Istio control interface",
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
-		Long: `
-Istio configuration command line utility.
-
-Create, list, modify, and delete configuration resources in the Istio
-system.
-
-Available routing and traffic management configuration types:
-
-	[virtualservice gateway destinationrule serviceentry httpapispec httpapispecbinding quotaspec quotaspecbinding servicerole servicerolebinding policy]
-
-See https://istio.io/docs/reference/ for an overview of Istio routing.
-
+		Long: `Istio configuration command line utility for service operators to
+debug and diagnose their Istio mesh.
 `,
 		PersistentPreRunE: istioPersistentPreRunE,
 	}
 
 	postCmd = &cobra.Command{
-		Use:     "create",
-		Short:   "Create policies and rules",
-		Example: "istioctl create -f example-routing.yaml",
+		Use:        "create",
+		Deprecated: "Use `kubectl create` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)",
+		Short:      "Create policies and rules",
+		Example:    "istioctl create -f example-routing.yaml",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				c.Println(c.UsageString())
@@ -230,9 +221,10 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 	}
 
 	putCmd = &cobra.Command{
-		Use:     "replace",
-		Short:   "Replace existing policies and rules",
-		Example: "istioctl replace -f example-routing.yaml",
+		Use:        "replace",
+		Deprecated: "Use `kubectl apply` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)",
+		Short:      "Replace existing policies and rules",
+		Example:    "istioctl replace -f example-routing.yaml",
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				c.Println(c.UsageString())
@@ -323,8 +315,9 @@ See https://istio.io/docs/reference/ for an overview of Istio routing.
 	}
 
 	getCmd = &cobra.Command{
-		Use:   "get <type> [<name>]",
-		Short: "Retrieve policies and rules",
+		Use:        "get <type> [<name>]",
+		Deprecated: "Use `kubectl get` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)",
+		Short:      "Retrieve policies and rules",
 		Example: `# List all virtual services
 istioctl get virtualservices
 
@@ -413,8 +406,9 @@ istioctl get virtualservice bookinfo
 	}
 
 	deleteCmd = &cobra.Command{
-		Use:   "delete <type> <name> [<name2> ... <nameN>]",
-		Short: "Delete policies or rules",
+		Use:        "delete <type> <name> [<name2> ... <nameN>]",
+		Deprecated: "Use `kubectl delete` instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl)",
+		Short:      "Delete policies or rules",
 		Example: `# Delete a rule using the definition in example-routing.yaml.
 istioctl delete -f example-routing.yaml
 
@@ -515,7 +509,13 @@ istioctl delete virtualservice bookinfo
 	}
 
 	contextCmd = &cobra.Command{
-		Use:   "context-create --api-server http://<ip>:<port>",
+		Use: "context-create --api-server http://<ip>:<port>",
+		Deprecated: `Use kubectl instead (see https://kubernetes.io/docs/tasks/tools/install-kubectl), e.g.
+
+	$ kubectl config set-context istio --cluster=istio
+	$ kubectl config set-cluster istio --server=http://localhost:8080
+	$ kubectl config use-context istio
+`,
 		Short: "Create a kubeconfig file suitable for use with istioctl in a non kubernetes environment",
 		Example: `# Create a config file for the api server.
 istioctl context-create --api-server http://127.0.0.1:8080


### PR DESCRIPTION
istio.io docs have been updated to use kubectl for all crud operations. Mark the istioctl crud operations as deprecated to give users an advanced warning that they will be removed at a later date (1.1 timeframe?).

xref: https://github.com/istio/istio.github.io/pull/2002

cc @frankbu @geeknoid @linsun 