### PR TITLE
Remove usages of mesh auth_policy flag

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -26,7 +26,7 @@ import (
 var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 // GetConsolidateAuthenticationPolicy returns the authentication policy for
-// service specified by hostname and port, if defined. It also tries to resolve JWKS URI if neccessary.
+// service specified by hostname and port, if defined. It also tries to resolve JWKS URI if necessary.
 func GetConsolidateAuthenticationPolicy(store IstioConfigStore, hostname Hostname, port *Port) *authn.Policy {
 	config := store.AuthenticationPolicyByDestination(hostname, port)
 	if config != nil {

--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -26,11 +26,7 @@ import (
 var JwtKeyResolver = newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
 // GetConsolidateAuthenticationPolicy returns the authentication policy for
-// service specified by hostname and port, if defined.
-// If not, it generates and output a policy that is equivalent to the legacy flag
-// and/or service annotation. Once these legacy flags/config deprecated,
-// this function can be placed by a call to store.AuthenticationPolicyByDestination
-// directly.
+// service specified by hostname and port, if defined. It also tries to resolve JWKS URI if neccessary.
 func GetConsolidateAuthenticationPolicy(store IstioConfigStore, hostname Hostname, port *Port) *authn.Policy {
 	config := store.AuthenticationPolicyByDestination(hostname, port)
 	if config != nil {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -17,9 +17,6 @@ package model
 import (
 	"reflect"
 	"testing"
-
-	authn "istio.io/api/authentication/v1alpha1"
-	meshconfig "istio.io/api/mesh/v1alpha1"
 )
 
 func TestParseJwksURI(t *testing.T) {
@@ -82,32 +79,6 @@ func TestParseJwksURI(t *testing.T) {
 					c.in, c.expectedHostname, c.expectedPort, c.expectedUseSSL,
 					host, port, useSSL)
 			}
-		}
-	}
-}
-
-func TestLegacyAuthenticationPolicyToPolicy(t *testing.T) {
-	cases := []struct {
-		in       meshconfig.MeshConfig_AuthPolicy
-		expected *authn.Policy
-	}{
-		{
-			in: meshconfig.MeshConfig_MUTUAL_TLS,
-			expected: &authn.Policy{
-				Peers: []*authn.PeerAuthenticationMethod{{
-					Params: &authn.PeerAuthenticationMethod_Mtls{&authn.MutualTls{}},
-				}},
-			},
-		},
-		{
-			in:       meshconfig.MeshConfig_NONE,
-			expected: nil,
-		},
-	}
-
-	for _, c := range cases {
-		if got := legacyAuthenticationPolicyToPolicy(c.in); !reflect.DeepEqual(got, c.expected) {
-			t.Errorf("legacyAuthenticationPolicyToPolicy(%v): got(%#v) != want(%#v)\n", c.in, got, c.expected)
 		}
 	}
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -237,7 +237,6 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		ConnectTimeout:        types.DurationProto(1 * time.Second),
 		IngressClass:          "istio",
 		IngressControllerMode: meshconfig.MeshConfig_STRICT,
-		AuthPolicy:            meshconfig.MeshConfig_NONE,
 		RdsRefreshDelay:       types.DurationProto(1 * time.Second),
 		EnableTracing:         true,
 		AccessLogFile:         "/dev/stdout",

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -806,12 +806,6 @@ func ValidateMeshConfig(mesh *meshconfig.MeshConfig) (errs error) {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid connect timeout:"))
 	}
 
-	switch mesh.AuthPolicy {
-	case meshconfig.MeshConfig_NONE, meshconfig.MeshConfig_MUTUAL_TLS:
-	default:
-		errs = multierror.Append(errs, fmt.Errorf("unrecognized auth policy %q", mesh.AuthPolicy))
-	}
-
 	if err := ValidateRefreshDelay(mesh.RdsRefreshDelay); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid rds refresh delay:"))
 	}

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -24,7 +24,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -100,8 +99,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 
 			if config != nil {
 				destinationRule := config.Spec.(*networking.DestinationRule)
-				// NOTE : this thing is modifying destination rules in place. Not a good idea
-				// when we start caching stuff.
 				convertIstioMutual(destinationRule, upstreamServiceAccounts)
 				applyTrafficPolicy(defaultCluster, destinationRule.TrafficPolicy, port)
 
@@ -117,11 +114,6 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 						p.OnOutboundCluster(env, proxy, push, service, port, subsetCluster)
 					}
 					clusters = append(clusters, subsetCluster)
-				}
-			} else {
-				// set TLSSettings if configmap global settings specifies MUTUAL_TLS, and we skip external destination.
-				if env.Mesh.AuthPolicy == meshconfig.MeshConfig_MUTUAL_TLS && !service.MeshExternal && proxy.Type == model.Sidecar {
-					applyUpstreamTLSSettings(defaultCluster, buildIstioMutualTLS(upstreamServiceAccounts, ""))
 				}
 			}
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -249,7 +249,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 
 		for _, p := range configgen.Plugins {
 			if authnPolicy, ok := p.(authn.Plugin); ok {
-				if authnPolicy.RequireTLSMultiplexing(env.Mesh, env.IstioConfigStore, instance.Service.Hostname, instance.Endpoint.ServicePort) {
+				if authnPolicy.RequireTLSMultiplexing(env.IstioConfigStore, instance.Service.Hostname, instance.Endpoint.ServicePort) {
 					listenerOpts.tlsMultiplexed = true
 					log.Infof("Uses TLS multiplexing for %v %v\n", string(instance.Service.Hostname), *instance.Endpoint.ServicePort)
 				}

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -29,7 +29,6 @@ import (
 	authn "istio.io/api/authentication/v1alpha1"
 	authn_filter "istio.io/api/envoy/config/filter/http/authn/v2alpha1"
 	jwtfilter "istio.io/api/envoy/config/filter/http/jwt_auth/v2alpha1"
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -336,7 +335,7 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableO
 
 func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	authnPolicy := model.GetConsolidateAuthenticationPolicy(
-		in.Env.Mesh, in.Env.IstioConfigStore, in.ServiceInstance.Service.Hostname, in.ServiceInstance.Endpoint.ServicePort)
+		in.Env.IstioConfigStore, in.ServiceInstance.Service.Hostname, in.ServiceInstance.Endpoint.ServicePort)
 
 	if mutable.Listener == nil || (len(mutable.Listener.FilterChains) != len(mutable.FilterChains)) {
 		return fmt.Errorf("expected same number of filter chains in listener (%d) and mutable (%d)", len(mutable.Listener.FilterChains), len(mutable.FilterChains))
@@ -362,8 +361,8 @@ func buildFilter(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 }
 
 // RequireTLSMultiplexing returns true if any one of MTLS mode is `PERMISSIVE`.
-func (Plugin) RequireTLSMultiplexing(mesh *meshconfig.MeshConfig, store model.IstioConfigStore, hostname model.Hostname, port *model.Port) bool {
-	authnPolicy := model.GetConsolidateAuthenticationPolicy(mesh, store, hostname, port)
+func (Plugin) RequireTLSMultiplexing(store model.IstioConfigStore, hostname model.Hostname, port *model.Port) bool {
+	authnPolicy := model.GetConsolidateAuthenticationPolicy(store, hostname, port)
 	if authnPolicy == nil || len(authnPolicy.Peers) == 0 {
 		return false
 	}


### PR DESCRIPTION
This PR completely remove references to mesh config auth_policy flag. 

Since Istio 1.0, mTLS enable should be enabled via authentication policy. 

A related clean up on API is in https://github.com/istio/api/pull/596

Issue: https://github.com/istio/istio/issues/5900