### PR TITLE
make validation reconciliation more resilient when

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     istio: galley
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -38,10 +42,8 @@ spec:
           - --tlsKeyFile=/etc/istio/certs/key.pem
           - --healthCheckInterval=2s
           - --healthCheckFile=/health
-{{- if .Values.global.configValidation }}
           - --webhook-config-file
           - /etc/istio/config/validatingwebhookconfiguration.yaml
-{{- end }}
           volumeMounts:
           - name: certs
             mountPath: /etc/istio/certs

--- a/install/kubernetes/helm/istio/charts/galley/templates/validatingwehookconfiguration.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/validatingwehookconfiguration.yaml.tpl
@@ -10,6 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 webhooks:
+{{- if .Values.global.configValidation }}
   - name: pilot.validation.istio.io
     clientConfig:
       service:
@@ -108,4 +109,5 @@ webhooks:
         - servicecontrolreports
         - tracespans
     failurePolicy: Fail
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Some of the post-install jobs were recently removed. This exposed a
latent race where re-installing istio.yaml resulted in temporary
unavailability of the validation service. Explicitly configure
deployment rollout strategy to minimize "no available endpoints" during rolling updates.