### PR TITLE
Atomically create and start a test mock server

### DIFF
--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -26,13 +26,10 @@ import (
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	defer ms.Stop()
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
@@ -75,13 +72,10 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	defer ms.Stop()
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
@@ -156,13 +150,10 @@ func TestGetPublicKey(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 	defer r.Close()
 
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	defer ms.Stop()
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"
@@ -200,13 +191,10 @@ func TestJwtPubKeyRefresh(t *testing.T) {
 	r := newJwksResolver(time.Millisecond /*ExpireDuration*/, 100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
 	defer r.Close()
 
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	defer ms.Stop()
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	mockCertURL := ms.URL + "/oauth2/v3/certs"

--- a/pilot/pkg/model/jwks_resolver_test.go
+++ b/pilot/pkg/model/jwks_resolver_test.go
@@ -26,7 +26,7 @@ import (
 func TestResolveJwksURIUsingOpenID(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	defer ms.Stop()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
@@ -72,7 +72,7 @@ func TestResolveJwksURIUsingOpenID(t *testing.T) {
 func TestSetAuthenticationPolicyJwksURIs(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	defer ms.Stop()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
@@ -150,7 +150,7 @@ func TestGetPublicKey(t *testing.T) {
 	r := newJwksResolver(JwtPubKeyExpireDuration, JwtPubKeyEvictionDuration, JwtPubKeyRefreshInterval)
 	defer r.Close()
 
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	defer ms.Stop()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
@@ -191,7 +191,7 @@ func TestJwtPubKeyRefresh(t *testing.T) {
 	r := newJwksResolver(time.Millisecond /*ExpireDuration*/, 100*time.Millisecond /*EvictionDuration*/, 2*time.Millisecond /*RefreshInterval*/)
 	defer r.Close()
 
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	defer ms.Stop()
 	if err != nil {
 		t.Fatal("failed to start a mock server")

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -56,8 +56,8 @@ type MockOpenIDDiscoveryServer struct {
 	PubKeyHitNum uint64
 }
 
-// NewServer creates a mock openID discovery server.
-func NewServer(start bool) (*MockOpenIDDiscoveryServer, error) {
+// StartNewServer creates a mock openID discovery server and starts it
+func StartNewServer() (*MockOpenIDDiscoveryServer, error) {
 	serverMutex.Lock()
 	defer serverMutex.Unlock()
 
@@ -77,10 +77,7 @@ func NewServer(start bool) (*MockOpenIDDiscoveryServer, error) {
 		return nil, err
 	}
 
-	if start {
-		return server, server.Start()
-	}
-	return server, nil
+	return server, server.Start()
 }
 
 // Start starts the mock server.

--- a/pilot/pkg/model/test/mockopenidserver.go
+++ b/pilot/pkg/model/test/mockopenidserver.go
@@ -67,14 +67,9 @@ func StartNewServer() (*MockOpenIDDiscoveryServer, error) {
 		return nil, err
 	}
 
-	server, err := &MockOpenIDDiscoveryServer{
+	server := &MockOpenIDDiscoveryServer{
 		Port: port,
 		URL:  fmt.Sprintf("http://localhost:%d", port),
-	}, nil
-
-	if err != nil {
-		log.Errorf("Failed to create a new mock server", err)
-		return nil, err
 	}
 
 	return server, server.Start()

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -451,12 +451,9 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 }
 
 func TestConvertPolicyToJwtConfigWithInlineKey(t *testing.T) {
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	jwksURI := ms.URL + "/oauth2/v3/certs"
@@ -503,12 +500,9 @@ func TestConvertPolicyToJwtConfigWithInlineKey(t *testing.T) {
 }
 
 func TestBuildJwtFilter(t *testing.T) {
-	ms, err := test.NewServer()
+	ms, err := test.NewServer(true)
 	if err != nil {
-		t.Fatal("failed to create mock server")
-	}
-	if err := ms.Start(); err != nil {
-		t.Fatal("failed to start mock server")
+		t.Fatal("failed to start a mock server")
 	}
 
 	jwksURI := ms.URL + "/oauth2/v3/certs"

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -451,7 +451,7 @@ func TestConvertPolicyToJwtConfig(t *testing.T) {
 }
 
 func TestConvertPolicyToJwtConfigWithInlineKey(t *testing.T) {
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
 	}
@@ -500,7 +500,7 @@ func TestConvertPolicyToJwtConfigWithInlineKey(t *testing.T) {
 }
 
 func TestBuildJwtFilter(t *testing.T) {
-	ms, err := test.NewServer(true)
+	ms, err := test.StartNewServer()
 	if err != nil {
 		t.Fatal("failed to start a mock server")
 	}


### PR DESCRIPTION
`racetest` is occasionally failing due to failure to start a test mock server.
I suspect this is due to two-phases creation of the server and starting it where port is being catched in  between those two calls.

Example of a failed `racetest` due to this [can be found here](https://circleci.com/gh/istio/istio/145519) with this error:
```
Server failed to listen 37252 listen tcp :37252: bind: address already in use
```

The PR is atomically creating a mock instance and starting it to avoid this.

Adds to #6730