### PR TITLE
Remove duplicated service for jaeger.

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -1,44 +1,19 @@
 apiVersion: v1
-kind: List
-items:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: zipkin
-    namespace: {{ .Release.Namespace }}
-    labels:
-      app: jaeger
-      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
-  spec:
-    type: {{ .Values.service.type }}
-    ports:
-      - port: {{ .Values.service.externalPort }}
-        targetPort: {{ .Values.service.internalPort }}
-        protocol: TCP
-        name: {{ .Values.service.name }}
-    selector:
-      app: jaeger
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: tracing
-    namespace: {{ .Release.Namespace }}
-    annotations:
-      {{- range $key, $val := .Values.service.annotations }}
-      {{ $key }}: {{ $val }}
-      {{- end }}
-    labels:
-      app: jaeger
-      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      release: {{ .Release.Name }}
-      heritage: {{ .Release.Service }}
-  spec:
-    ports:
-      - name: http-query
-        port: 80
-        protocol: TCP
-        targetPort: {{ .Values.service.uiPort }}
-    selector:
-      app: jaeger
+kind: Service
+metadata:
+  name: zipkin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: jaeger
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: jaeger


### PR DESCRIPTION
As we have `jaeger query` service at:https://github.com/istio/istio/blob/release-1.0/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml#L6-L28
We should remove the duplicated service in: https://github.com/istio/istio/blob/release-1.0/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml

Following the jaeger tracing template from: https://github.com/jaegertracing/jaeger-kubernetes/blob/master/all-in-one/jaeger-all-in-one-template.yml

