### PR TITLE
Move jaeger specific values under the tracing.jaeger value node

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -23,11 +23,11 @@ spec:
 {{- end }}
       containers:
         - name: jaeger
-          image: "{{ .Values.hub }}/all-in-one:{{ .Values.tag }}"
+          image: "{{ .Values.jaeger.hub }}/all-in-one:{{ .Values.jaeger.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
-            - containerPort: {{ .Values.service.uiPort }}
+            - containerPort: {{ .Values.jaeger.ui.port }}
             - containerPort: 5775
               protocol: UDP
             - containerPort: 6831
@@ -47,11 +47,11 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.uiPort }}
+              port: {{ .Values.jaeger.ui.port }}
           readinessProbe:
             httpGet:
               path: /
-              port: {{ .Values.service.uiPort }}
+              port: {{ .Values.jaeger.ui.port }}
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress-jaeger.yaml
@@ -1,5 +1,5 @@
 {{ if (.Values.jaeger.ingress.enabled) and eq .Values.provider "jaeger" }}
-{{- $servicePort := .Values.service.uiPort -}}
+{{- $servicePort := .Values.jaeger.ui.port -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -21,9 +21,9 @@ items:
   spec:
     ports:
       - name: query-http
-        port: {{ .Values.service.uiPort }}
+        port: {{ .Values.jaeger.ui.port }}
         protocol: TCP
-        targetPort: {{ .Values.service.uiPort }}
+        targetPort: {{ .Values.jaeger.ui.port }}
     selector:
       app: jaeger
 - apiVersion: v1

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -39,6 +39,6 @@ items:
       - name: http-query
         port: 80
         protocol: TCP
-        targetPort: {{ .Values.service.uiPort }}
+        targetPort: {{ .Values.jaeger.ui.port }}
     selector:
       app: jaeger

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -444,8 +444,12 @@ tracing:
   enabled: false
   provider: jaeger
   jaeger:
+    hub: docker.io/jaegertracing
+    tag: 1.5
     memory:
       max_traces: 50000
+    ui:
+      port: 16686
     ingress:
       enabled: false
       # Used to create an Ingress record.
@@ -460,15 +464,12 @@ tracing:
         #   hosts:
         #     - jaeger.local
   replicaCount: 1
-  hub: docker.io/jaegertracing
-  tag: 1.5
   service:
     annotations: {}
     name: http
     type: ClusterIP
     externalPort: 9411
     internalPort: 9411
-    uiPort: 16686
   ingress:
     enabled: false
     # Used to create an Ingress record.


### PR DESCRIPTION
This PR just moves jaeger specific values under the `tracing.jaeger` node in the `values.yaml`. As mentioned by @sdake the `values.yaml` is a public API, and therefore should be stable from 1.0 - the moved properties are jaeger specific, and will make it easier to add other tracing providers in the future.

Resolves #7308