### PR TITLE
Several fixes for Kiali integration

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -50,6 +50,22 @@ spec:
             secretKeyRef:
               name: kiali
               key: passphrase
+        - name: PROMETHEUS_SERVICE_URL
+          value: http://prometheus:9090
+{{- if .Values.dashboard.grafanaURL }}
+        - name: GRAFANA_URL
+          value: {{ .Values.dashboard.grafanaURL }}
+{{- end }}
+        - name: GRAFANA_DASHBOARD
+          value: istio-service-dashboard
+        - name: GRAFANA_VAR_SERVICE_SOURCE
+          value: var-service
+        - name: GRAFANA_VAR_SERVICE_DEST
+          value: var-service
+{{- if .Values.dashboard.jaegerURL }}
+        - name: JAEGER_URL
+          value: {{ .Values.dashboard.jaegerURL }}
+{{- end }}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -507,6 +507,12 @@ kiali:
     # changed by overriding the secret
     passphrase: admin
 
+    # Override the automatically detected Grafana URL, usefull when Grafana service has no ExternalIPs
+    # grafanaURL:
+
+    # Override the automatically detected Jaeger URL, usefull when Jaeger service has no ExternalIPs
+    # jaegerURL:
+
 # Certmanager uses ACME to sign certificates. Since Istio gateways are
 # mounting the TLS secrets the Certificate CRDs must be created in the
 # istio-system namespace. Once the certificate has been created, the


### PR DESCRIPTION
- Use a non-namespaced PROMETHEUS_SERVICE_URL (Kiali hardcodes istio-system kiali/kiali#350)
- Enable URL configuration for Grafana and Jaeger (Kiali tries to autodetect a service with an ExternalIP)
- Use a GRAFANA_DASHBOARD that really exists