### PR TITLE
Revert "mixer: add sidecar health probe (#7102)"

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -92,12 +92,6 @@
           readOnly: true
         - name: uds-socket
           mountPath: /sock
-        livenessProbe:
-          httpGet:
-            path: /version
-            port: 15093
-          initialDelaySeconds: 5
-          periodSeconds: 5
 {{- end }}
 
 {{- define "telemetry_container" }}
@@ -193,12 +187,6 @@
           readOnly: true
         - name: uds-socket
           mountPath: /sock
-        livenessProbe:
-          httpGet:
-            path: /version
-            port: 15093
-          initialDelaySeconds: 5
-          periodSeconds: 5
 {{- end }}
 
 

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -21,13 +21,6 @@ static_resources:
   - connect_timeout: 1.000s
     hosts:
     - socket_address:
-        address: 127.0.0.1
-        port_value: 9093
-    name: in.9093
-    type: STATIC
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
         address: zipkin
         port_value: 9411
     name: zipkin
@@ -61,32 +54,6 @@ static_resources:
 {{- end }}
     type: STRICT_DNS
   listeners:
-  - address:
-      socket_address:
-        address: 0.0.0.0
-        port_value: 15093
-    filter_chains:
-    - filters:
-      - config:
-          codec_type: AUTO
-          generate_request_id: false
-          http_filters:
-          - name: envoy.router
-          route_config:
-            name: health
-            virtual_hosts:
-            - domains:
-              - '*'
-              name: health
-              routes:
-              - match:
-                  prefix: /
-                route:
-                  cluster: in.9093
-                  timeout: 0.000s
-          stat_prefix: health
-        name: envoy.http_connection_manager
-    name: health
   - address:
       socket_address:
         address: 0.0.0.0

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -21,44 +21,11 @@ static_resources:
   - connect_timeout: 1.000s
     hosts:
     - socket_address:
-        address: 127.0.0.1
-        port_value: 9093
-    name: in.9093
-    type: STATIC
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
         address: zipkin
         port_value: 9411
     name: zipkin
     type: STRICT_DNS
   listeners:
-  - address:
-      socket_address:
-        address: 0.0.0.0
-        port_value: 15093
-    filter_chains:
-    - filters:
-      - config:
-          codec_type: AUTO
-          generate_request_id: false
-          http_filters:
-          - name: envoy.router
-          route_config:
-            name: health
-            virtual_hosts:
-            - domains:
-              - '*'
-              name: health
-              routes:
-              - match:
-                  prefix: /
-                route:
-                  cluster: in.9093
-                  timeout: 0.000s
-          stat_prefix: health
-        name: envoy.http_connection_manager
-    name: health
   - address:
       socket_address:
         address: 0.0.0.0


### PR DESCRIPTION
This reverts commit 86dc1496ef02591ce2f6b2490b161841733e1ffc.

We are seeing Mixer-Telemetry pod unhealthy due to proxy hc failure.

Probe was initially added to address mixer restart issue due to UDS bind failures.
That is addressed in other ways.