### PR TITLE
prepare for the new kiali that will support istio 1.0

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: v0.5.0
+      kiali_version: istio-release-1.0
 
   - name: Install Kiali on Openshift
     shell: |

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for detail.
 name: kiali
-version: 0.5.0
-appVersion: 0.5.0
+version: 0.5.1
+appVersion: 0.5.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -43,7 +43,7 @@ dependencies:
     # repository: file://../galley
     condition: galley.enabled
   - name: kiali
-    version: 0.5.0
+    version: 0.5.1
     condition: kiali.enabled
   - name: certmanager
     version: 0.1.0

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -487,7 +487,7 @@ kiali:
   enabled: false
   replicaCount: 1
   hub: docker.io/kiali
-  tag: v0.5.0
+  tag: istio-release-1.0
   ingress:
     enabled: false
     ## Used to create an Ingress record.


### PR DESCRIPTION
Kiali and Istio are currently not on the same release schedule. This causes some pains. To help alleviate some of this, this  PR has been introduced. I would like to hear from the Istio team if this is OK.

This PR changes the helm and ansible scripts so it no longer pulls down Kiali v0.5.0. That version of Kiali only supports Istio 0.8.0 - to be more specific, it is broken for Istio 1.0.

Kiali is going to release soon, but is not ready yet. However, to avoid people pulling down a broken Kiali into their Istio 1.0 system, this PR will pull down an not-yet-existing Kiali image label "istio-release-1.0". In a few weeks time, Kiali will officially release its Istio 1.0-supported version, at which time its image will be labeled with "istio-release-1.0" (and thus these helm/ansible installers will pull down the proper binary).

This does 2 things:

1) avoids a bad user experience by prohibiting Istio 1.0 users from installing Kiali v0.5.0 which won't work with Istio 1.0

and

2) allows users to immediately pick up the new Kiali once it is released (thus allowing Istio 1.0 installations to still get Kiali even though they were not on the same release schedule and thus we don't have to wait for an Istio 1.1 to be released before Kiali can be pulled down via these Helm/Ansible installers).

How does this proposal sound?

@gbaufake please look at the changes in this PR and make sure I didn't miss anything.