### PR TITLE
update sds uds file permission mode

### DIFF
--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -101,6 +101,14 @@ func (s *Server) initDiscoveryService(options *Options, st SecretManager) error 
 		return err
 	}
 
+	if _, err := os.Stat(options.UDSPath); err == nil {
+		log.Debugf("%q exists", options.UDSPath)
+
+		if err := os.Chmod(options.UDSPath, 0777); err != nil {
+			log.Errorf("failed to update %q permission", options.UDSPath)
+		}
+	}
+
 	go func() {
 		if err = s.grpcServer.Serve(s.grpcListener); err != nil {
 			log.Errorf("SDS grpc server failed to start: %v", err)

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -104,7 +104,7 @@ func (s *Server) initDiscoveryService(options *Options, st SecretManager) error 
 	if _, err := os.Stat(options.UDSPath); err == nil {
 		log.Debugf("%q exists", options.UDSPath)
 
-		if err := os.Chmod(options.UDSPath, 0777); err != nil {
+		if err := os.Chmod(options.UDSPath, 0666); err != nil {
 			log.Errorf("failed to update %q permission", options.UDSPath)
 		}
 	}


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

to unblock integration, update sds uds file permission mode so that istio-proxy user has permission to access socket file after volume mount. 

ideally should only grant permission to istio-proxy user, however nodeagent couldn't get that user in its owner container; another option is changing permission during istio-proxy container init. 