### PR TITLE
nodeagent stops sending SDS resp when receiving confirm request from envoy

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -98,6 +98,21 @@ func (sc *SecretCache) GetSecret(ctx context.Context, proxyID, spiffeID, token s
 	return ns, nil
 }
 
+// SecretExist checks if secret already existed.
+func (sc *SecretCache) SecretExist(proxyID, spiffeID, token, version string) bool {
+	val, exist := sc.secrets.Load(proxyID)
+	if !exist {
+		return false
+	}
+
+	e := val.(sds.SecretItem)
+	if e.SpiffeID == spiffeID && e.Token == token && e.Version == version {
+		return true
+	}
+
+	return false
+}
+
 // Close shuts down the secret cache.
 func (sc *SecretCache) Close() {
 	if sc.rotationTicker != nil {
@@ -190,6 +205,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, spiffeID strin
 		SpiffeID:         spiffeID,
 		Token:            token,
 		CreatedTime:      t,
+		Version:          t.String(),
 	}, nil
 }
 

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -54,6 +54,13 @@ func TestGetSecret(t *testing.T) {
 		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
 	}
 
+	if got, want := sc.SecretExist(proxyID, fakeSpiffeID, "jwtToken1", gotSecret.Version), true; got != want {
+		t.Errorf("SecretExist: got: %v, want: %v", got, want)
+	}
+	if got, want := sc.SecretExist(proxyID, fakeSpiffeID, "nonexisttoken", gotSecret.Version), false; got != want {
+		t.Errorf("SecretExist: got: %v, want: %v", got, want)
+	}
+
 	cachedSecret, found := sc.secrets.Load(proxyID)
 	if !found {
 		t.Errorf("Failed to find secret for proxy %q from secret store: %v", proxyID, err)

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -41,6 +41,13 @@ var (
 	fakeCredentialToken = "faketoken"
 
 	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
+
+	fakeSecret = &SecretItem{
+		CertificateChain: fakeCertificateChain,
+		PrivateKey:       fakePrivateKey,
+		SpiffeID:         fakeSpiffeID,
+		Version:          time.Now().String(),
+	}
 )
 
 func TestStreamSecrets(t *testing.T) {
@@ -262,9 +269,9 @@ func (*mockSecretStore) GetSecret(ctx context.Context, proxyID, spiffeID, token 
 		return nil, fmt.Errorf("unexpected spiffeID %q", spiffeID)
 	}
 
-	return &SecretItem{
-		CertificateChain: fakeCertificateChain,
-		PrivateKey:       fakePrivateKey,
-		SpiffeID:         spiffeID,
-	}, nil
+	return fakeSecret, nil
+}
+
+func (*mockSecretStore) SecretExist(proxyID, spiffeID, token, version string) bool {
+	return spiffeID == fakeSecret.SpiffeID && token == fakeSecret.Token && version == fakeSecret.Version
 }

--- a/security/pkg/nodeagent/sds/secretmanager.go
+++ b/security/pkg/nodeagent/sds/secretmanager.go
@@ -21,7 +21,11 @@ import (
 
 // SecretManager defines secrets management interface which is used by SDS.
 type SecretManager interface {
+	// GetSecret generates new secret and cache the secret.
 	GetSecret(ctx context.Context, proxyID, spiffeID, token string) (*SecretItem, error)
+
+	// SecretExist checks if secret already existed.
+	SecretExist(proxyID, spiffeID, token, version string) bool
 }
 
 // SecretItem is the cached item in in-memory secret store.
@@ -35,6 +39,10 @@ type SecretItem struct {
 	// Credential token passed from envoy, caClient uses this token to send
 	// CSR to CA to sign certificate.
 	Token string
+
+	// Version is used(together with token and SpiffeID) to identify discovery request from
+	// envoy which is used only for confirm purpose.
+	Version string
 
 	CreatedTime time.Time
 }


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

nodeagent stops sending resp to envoy if req.version matches some cached request in server
side, otherwise envoy keep sending same request

verified by running for hours. 