### PR TITLE
Update the secure naming based on the SAN in the actual GCP certificates

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -337,7 +337,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	sa := controller.GetIstioServiceAccounts(hostname, []string{"test-port"})
 	sort.Sort(sort.StringSlice(sa))
 	expected := []string{
-		"spiffe://" + canonicalSaOnVM,
+		"spiffe://accounts.google.com/" + canonicalSaOnVM,
 		"spiffe://company.com/ns/nsA/sa/" + sa2,
 		"spiffe://company.com/ns/nsA/sa/" + k8sSaOnVM,
 	}

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -123,7 +123,7 @@ func serviceHostname(name, namespace, domainSuffix string) model.Hostname {
 
 // canonicalToIstioServiceAccount converts a Canonical service account to an Istio service account
 func canonicalToIstioServiceAccount(saname string) string {
-	return fmt.Sprintf("%v://%v", IstioURIPrefix, saname)
+	return fmt.Sprintf("%v://accounts.google.com/%v", IstioURIPrefix, saname)
 }
 
 // kubeToIstioServiceAccount converts a K8s service account to an Istio service account

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -133,10 +133,10 @@ func TestServiceConversion(t *testing.T) {
 		t.Errorf("number of service accounts is incorrect")
 	}
 	expected := []string{
+		"spiffe://accounts.google.com/" + saC,
+		"spiffe://accounts.google.com/" + saD,
 		"spiffe://company.com/ns/default/sa/" + saA,
 		"spiffe://company.com/ns/default/sa/" + saB,
-		"spiffe://" + saC,
-		"spiffe://" + saD,
 	}
 	if !reflect.DeepEqual(sa, expected) {
 		t.Errorf("Unexpected service accounts %v (expecting %v)", sa, expected)


### PR DESCRIPTION
Update the secure naming based on the SAN in the actual GCP certificates