### PR TITLE
Helm chart: allow annotations on mixer pods

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -212,6 +212,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- with $.Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- if eq $mname "policy"}}
 {{- template "policy_container" $ }}
 {{- else }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -353,6 +353,8 @@ mixer:
     cpu:
       targetAverageUtilization: 80
 
+  podAnnotations: {}
+
   prometheusStatsdExporter:
     hub: docker.io/prom
     tag: v0.6.0


### PR DESCRIPTION
Allows additional annotations to be added to the mixer pods.