### PR TITLE
[Helm] Apply imagePullSecrets to components that don't use serviceaccounts

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
+{{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
+{{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
       containers:
         - name: servicegraph
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment.yaml
@@ -21,6 +21,12 @@ spec:
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}
+{{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+{{- end }}
+{{- end }}
       containers:
         - name: jaeger
           image: "{{ .Values.jaeger.hub }}/all-in-one:{{ .Values.jaeger.tag }}"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -95,6 +95,8 @@ global:
 
   # ImagePullSecrets for all ServiceAccount, list of secrets in the same namespace
   # to use for pulling any images in pods that reference this ServiceAccount.
+  # For components that don't use ServiceAccounts (i.e. grafana, servicegraph, tracing)
+  # ImagePullSecrets will be added to the corresponding Deployment(StatefulSet) objects.
   # Must be set for any clustser configured with privte docker registry.
   imagePullSecrets:
     # - private-registry-key


### PR DESCRIPTION
Helm chart is currently designed to apply imagePullSecrets to serviceaccounts.
Problem is imagePullSecrets isn't applied to components that don't use serviceaccounts (i.e. grafana, servicegraph, tracing) 

Added ImagePullSecrets to deployment object for components that don't use serviceaccounts.
