### PR TITLE
always create istio-sidecar-injector configmap with default install

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -168,4 +169,4 @@ data:
           {{ "[[ else -]]" }}
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
-
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.omitSidecarInjectorConfigMap }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -170,3 +171,4 @@ data:
           {{ "[[ else -]]" }}
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sidecarInjectorWebhook.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -171,4 +170,3 @@ data:
           {{ "[[ else -]]" }}
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
-{{- end }}

--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -7,6 +7,12 @@ global:
   # and this options must be set off.
   crds: false
 
+  # Omit the istio-sidecar-injector configmap when generate a
+  # standalone gateway. Gateways may be created in namespaces other
+  # than `istio-system` and we don't want to re-create the injector
+  # configmap in those.
+  omitSidecarInjectorConfigMap: true
+
   # istio control plane namespace
   istioNamespace: istio-system
 


### PR DESCRIPTION
Manual injection with kube-inject uses the sidecar template from the
in-cluster istio-sidecar-injector configmap. These configmap was not
created when automatic injection was disabled.

fixes https://github.com/istio/istio/issues/7567