### PR TITLE
call the gateway container of a gateway pod "istio-proxy"

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       priorityClassName: "{{ $.Values.global.priorityClassName }}"
 {{- end }}
       containers:
-        - name: {{ $spec.labels.istio }}
+        - name: istio-proxy
           image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           ports:


### PR DESCRIPTION
it is required for `istioctl proxy-config` tool to work correctly. `proxy-config`
looks for "istio-proxy" container, or for a single container in a pod.

When the gateway pod contains a single gateway container, `proxy-config` works.
Once an additional container is added, for any purpose, `proxy-config` will
stop working since it will not know from which container to
dump the config information.

Calling the contaner by the same name as the deployment, as it is today,
does not add much information. Calling the container `istio-proxy` makes it
clear that we have the same proxy in the gateway pod, as the sidecar proxy in
the application pods.