### PR TITLE
Log error for bad values of autoInject

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -280,6 +280,8 @@ func injectRequired(ignored []string, namespacePolicy InjectionPolicy, podSpec *
 	var required bool
 	switch namespacePolicy {
 	default: // InjectionPolicyOff
+		log.Errorf("Illegal value for autoInject:%s, must be one of [%s,%s]. Auto injection disabled!",
+			namespacePolicy, InjectionPolicyDisabled, InjectionPolicyEnabled)
 		required = false
 	case InjectionPolicyDisabled:
 		if useDefault {


### PR DESCRIPTION
https://github.com/istio/istio/issues/7535
In a nutshell, autoInject policy should be either enabled or disabled. Any other value should really result in a validation error, but we don't have a good place to do that due to CR sequencing. 
Rather than hackily accepting other likely values like true/false, this is keeping the current behavior but logging an error message that should make it fairly easy to track down the bad value.