### PR TITLE
Fix flakiness with redisquota tests

### DIFF
--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -292,7 +292,7 @@ func (h *handler) getKeyAndQuotaAmount(instance *quota.Instance, quota *config.P
 
 	for idx := range quota.Overrides {
 		if matchDimensions(&quota.Overrides[idx].Dimensions, &instance.Dimensions) {
-			h.logger.Infof("quota override: %v selected for %v", quota.Overrides[idx], *instance)
+			h.logger.Debugf("quota override: %v selected for %v", quota.Overrides[idx], *instance)
 
 			if hash, ok := h.dimensionHash[&quota.Overrides[idx].Dimensions]; ok {
 				// override key and max amount
@@ -323,7 +323,7 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 				return adapter.QuotaResult{}, nil
 			}
 
-			h.logger.Infof("key: %v maxAmount: %v", key, maxAmount)
+			h.logger.Debugf("key: %v maxAmount: %v", key, maxAmount)
 
 			// execute lua algorithm script
 			result, err := script.Run(
@@ -355,8 +355,6 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 			if allocated <= 0 {
 				ret = status.WithResourceExhausted("redisquota: Resource exhausted")
 			}
-
-			h.logger.Infof("allocated: %d expiration: %v status: %v", allocated, expiration* time.Nanosecond, ret)
 
 			return adapter.QuotaResult{
 				Status:        ret,

--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -292,7 +292,7 @@ func (h *handler) getKeyAndQuotaAmount(instance *quota.Instance, quota *config.P
 
 	for idx := range quota.Overrides {
 		if matchDimensions(&quota.Overrides[idx].Dimensions, &instance.Dimensions) {
-			h.logger.Debugf("quota override: %v selected for %v", quota.Overrides[idx], *instance)
+			h.logger.Infof("quota override: %v selected for %v", quota.Overrides[idx], *instance)
 
 			if hash, ok := h.dimensionHash[&quota.Overrides[idx].Dimensions]; ok {
 				// override key and max amount
@@ -323,7 +323,7 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 				return adapter.QuotaResult{}, nil
 			}
 
-			h.logger.Debugf("key: %v maxAmount: %v", key, maxAmount)
+			h.logger.Infof("key: %v maxAmount: %v", key, maxAmount)
 
 			// execute lua algorithm script
 			result, err := script.Run(
@@ -355,6 +355,8 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 			if allocated <= 0 {
 				ret = status.WithResourceExhausted("redisquota: Resource exhausted")
 			}
+
+			h.logger.Infof("allocated: %d expiration: %v status: %v", allocated, expiration* time.Nanosecond, ret)
 
 			return adapter.QuotaResult{
 				Status:        ret,

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -1110,8 +1110,8 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 	// consider only successful requests (as recorded at productpage service)
 	callsToRatings := succReqs
 
-	// the rate-limit is 1 rps
-	want200s := 1. * actualDuration
+	// the rate-limit is 0.1 rps from ratings to reviews.
+	want200s := 0.1 * actualDuration
 
 	// everything in excess of 200s should be 429s (ideally)
 	want429s := callsToRatings - want200s

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -103,7 +103,7 @@ e2e_simple_noauth_run: out_dir
 	--rbac_enable=false --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 e2e_mixer_run: out_dir
-	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/mixer \
+	set -o pipefail; go test -v -timeout 35m ./tests/e2e/tests/mixer \
 	--auth_enable=false --egress=false --ingress=false --rbac_enable=false \
 	--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
@@ -168,7 +168,7 @@ test/local/noauth/e2e_simple: out_dir generate_yaml
 	--rbac_enable=false --use_local_cluster --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 test/local/e2e_mixer: out_dir generate_yaml
-	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/mixer \
+	set -o pipefail; go test -v -timeout 35m ./tests/e2e/tests/mixer \
 	--auth_enable=false --egress=false --ingress=false --rbac_enable=false \
 	--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
@@ -207,7 +207,7 @@ test/local/auth/e2e_bookinfo_envoyv2: out_dir generate_yaml
 		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 test/local/noauth/e2e_mixer_envoyv2: out_dir generate_yaml
-	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/mixer \
+	set -o pipefail; go test -v -timeout 35m ./tests/e2e/tests/mixer \
 	--auth_enable=false --egress=false --ingress=false --rbac_enable=false \
 	--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 


### PR DESCRIPTION
When tests run in GKE, looks like they take more time to init and thus initial numbers we get for metrics are not accurate.
Sending a warmup traffic before calculating prior429 and prior400 in redisquota test