### PR TITLE
Multi-Cluster: Make multi-cluster secret controller code common

### DIFF
--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 // BuildClientConfig is a helper function that builds client config from a kubeconfig filepath.
@@ -61,4 +62,20 @@ func CreateClientset(kubeconfig, context string) (*kubernetes.Clientset, error) 
 		return nil, err
 	}
 	return kubernetes.NewForConfig(c)
+}
+
+// CreateInterfaceFromClusterConfig is a helper function to create Kubernetes interface from in memory cluster config struct
+func CreateInterfaceFromClusterConfig(clusterConfig *clientcmdapi.Config) (kubernetes.Interface, error) {
+	return createInterface(clusterConfig)
+}
+
+// createInterface is new function which creates rest config and kubernetes interface
+// from passed cluster's config struct
+func createInterface(clusterConfig *clientcmdapi.Config) (kubernetes.Interface, error) {
+	clientConfig := clientcmd.NewDefaultClientConfig(*clusterConfig, &clientcmd.ConfigOverrides{})
+	rest, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(rest)
 }

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -1,0 +1,257 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretcontroller
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/workqueue"
+
+	//"istio.io/istio/pilot/pkg/serviceregistry/kube"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	mcLabel    = "istio/multiCluster"
+	maxRetries = 5
+)
+
+// Required for unit test override.
+var loadKubeConfig = clientcmd.Load
+
+// addSecretCallback prototype for the add secret callback function.
+type addSecretCallback func(clientset kubernetes.Interface, dataKey string) error
+
+// removeSecretCallback prototype for the remove secret callback function.
+type removeSecretCallback func(dataKey string) error
+
+// Controller is the controller implementation for Secret resources
+type Controller struct {
+	kubeclientset  kubernetes.Interface
+	namespace      string
+	cs             *ClusterStore
+	queue          workqueue.RateLimitingInterface
+	informer       cache.SharedIndexInformer
+	addCallback    addSecretCallback
+	removeCallback removeSecretCallback
+}
+
+// RemoteCluster defines cluster structZZ
+type RemoteCluster struct {
+	secretName string
+}
+
+// ClusterStore is a collection of clusters
+type ClusterStore struct {
+	remoteClusters map[string]*RemoteCluster
+}
+
+// newClustersStore initializes data struct to store clusters information
+func newClustersStore() *ClusterStore {
+	remoteClusters := make(map[string]*RemoteCluster)
+	return &ClusterStore{
+		remoteClusters: remoteClusters,
+	}
+}
+
+// NewController returns a new secret controller
+func NewController(
+	kubeclientset kubernetes.Interface,
+	namespace string,
+	cs *ClusterStore,
+	addCallback addSecretCallback,
+	removeCallback removeSecretCallback) *Controller {
+
+	secretsInformer := cache.NewSharedIndexInformer(
+		&cache.ListWatch{
+			ListFunc: func(opts meta_v1.ListOptions) (runtime.Object, error) {
+				opts.LabelSelector = mcLabel + "=true"
+				return kubeclientset.CoreV1().Secrets(namespace).List(opts)
+			},
+			WatchFunc: func(opts meta_v1.ListOptions) (watch.Interface, error) {
+				opts.LabelSelector = mcLabel + "=true"
+				return kubeclientset.CoreV1().Secrets(namespace).Watch(opts)
+			},
+		},
+		&corev1.Secret{}, 0, cache.Indexers{},
+	)
+
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	controller := &Controller{
+		kubeclientset:  kubeclientset,
+		namespace:      namespace,
+		cs:             cs,
+		informer:       secretsInformer,
+		queue:          queue,
+		addCallback:    addCallback,
+		removeCallback: removeCallback,
+	}
+
+	log.Info("Setting up event handlers")
+	secretsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			key, err := cache.MetaNamespaceKeyFunc(obj)
+			log.Infof("Processing add: %s", key)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			log.Infof("Processing delete: %s", key)
+			if err == nil {
+				queue.Add(key)
+			}
+		},
+	})
+
+	return controller
+}
+
+// Run starts the controller until it receves a message over stopCh
+func (c *Controller) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	log.Info("Starting Secrets controller")
+
+	go c.informer.Run(stopCh)
+
+	// Wait for the caches to be synced before starting workers
+	log.Info("Waiting for informer caches to sync")
+	if !cache.WaitForCacheSync(stopCh, c.informer.HasSynced) {
+		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
+		return
+	}
+	wait.Until(c.runWorker, 5*time.Second, stopCh)
+}
+
+// StartSecretController creates the secret controller.
+func StartSecretController(k8s kubernetes.Interface,
+	addCallback addSecretCallback,
+	removeCallback removeSecretCallback,
+	namespace string) error {
+	stopCh := make(chan struct{})
+	clusterStore := newClustersStore()
+	controller := NewController(k8s, namespace, clusterStore, addCallback, removeCallback)
+
+	go controller.Run(stopCh)
+
+	return nil
+}
+
+func (c *Controller) runWorker() {
+	for c.processNextItem() {
+		// continue looping
+	}
+}
+
+func (c *Controller) processNextItem() bool {
+	secretName, quit := c.queue.Get()
+
+	if quit {
+		return false
+	}
+	defer c.queue.Done(secretName)
+
+	err := c.processItem(secretName.(string))
+	if err == nil {
+		// No error, reset the ratelimit counters
+		c.queue.Forget(secretName)
+	} else if c.queue.NumRequeues(secretName) < maxRetries {
+		log.Errorf("Error processing %s (will retry): %v", secretName, err)
+		c.queue.AddRateLimited(secretName)
+	} else {
+		log.Errorf("Error processing %s (giving up): %v", secretName, err)
+		c.queue.Forget(secretName)
+		utilruntime.HandleError(err)
+	}
+
+	return true
+}
+
+func (c *Controller) processItem(secretName string) error {
+	obj, exists, err := c.informer.GetIndexer().GetByKey(secretName)
+	if err != nil {
+		return fmt.Errorf("error fetching object %s error: %v", secretName, err)
+	}
+
+	if exists {
+		c.addMemberCluster(secretName, obj.(*corev1.Secret))
+	} else {
+		c.deleteMemberCluster(secretName)
+	}
+
+	return nil
+}
+
+func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
+	for clusterID, kubeConfig := range s.Data {
+		// clusterID must be unique even across multiple secrets
+		if _, ok := c.cs.remoteClusters[clusterID]; !ok {
+			if len(kubeConfig) == 0 {
+				log.Infof("Data '%s' in the secret %s in namespace %s is empty, and disregarded ",
+					clusterID, secretName, s.ObjectMeta.Namespace)
+				continue
+			}
+
+			clientConfig, err := loadKubeConfig(kubeConfig)
+			if err != nil {
+				log.Infof("Data '%s' in the secret %s in namespace %s is not a kubeconfig: %v",
+					clusterID, secretName, s.ObjectMeta.Namespace, err)
+				continue
+			}
+
+			log.Infof("Adding new cluster member: %s", clusterID)
+			c.cs.remoteClusters[clusterID] = &RemoteCluster{}
+			c.cs.remoteClusters[clusterID].secretName = secretName
+			client, _ := kube.CreateInterfaceFromClusterConfig(clientConfig)
+			err = c.addCallback(client, clusterID)
+			if err != nil {
+				log.Errorf("error during create of clusterID: %s %v", clusterID, err)
+			}
+		} else {
+			log.Infof("Cluster %s in the secret %s in namespace %s already exists",
+				clusterID, c.cs.remoteClusters[clusterID].secretName, s.ObjectMeta.Namespace)
+		}
+	}
+	log.Infof("Number of clusters in the cluster store: %d", len(c.cs.remoteClusters))
+}
+
+func (c *Controller) deleteMemberCluster(secretName string) {
+	for clusterID, cluster := range c.cs.remoteClusters {
+		if cluster.secretName == secretName {
+			log.Infof("Deleting cluster member: %s", clusterID)
+			err := c.removeCallback(clusterID)
+			if err != nil {
+				log.Errorf("error during cluster delete: %s %v", clusterID, err)
+			}
+			delete(c.cs.remoteClusters, clusterID)
+		}
+	}
+	log.Infof("Number of clusters in the cluster store: %d", len(c.cs.remoteClusters))
+}

--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -1,0 +1,121 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretcontroller
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const secretName string = "testSecretName"
+const secretNameSpace string = "istio-system"
+
+var testCreateControllerCalled bool
+var testDeleteControllerCalled bool
+
+func testCreateController(k8sInterface kubernetes.Interface, clusterID string) error {
+	testCreateControllerCalled = true
+	return nil
+}
+
+func testDeleteController(clusterID string) error {
+	testDeleteControllerCalled = true
+	return nil
+}
+
+func createMultiClusterSecret(k8s *fake.Clientset) error {
+	data := map[string][]byte{}
+	secret := v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: secretNameSpace,
+			Labels: map[string]string{
+				"istio/multiCluster": "true",
+			},
+		},
+		Data: map[string][]byte{},
+	}
+
+	data["testRemoteCluster"] = []byte("Test")
+	secret.Data = data
+	_, err := k8s.CoreV1().Secrets(secretNameSpace).Create(&secret)
+	return err
+}
+
+func deleteMultiClusterSecret(k8s *fake.Clientset) error {
+	var immediate int64
+
+	return k8s.CoreV1().Secrets(secretNameSpace).Delete(
+		secretName, &metav1.DeleteOptions{GracePeriodSeconds: &immediate})
+}
+
+func mockLoadKubeConfig(kubeconfig []byte) (*clientcmdapi.Config, error) {
+	return &clientcmdapi.Config{}, nil
+}
+
+func Test_SecretController(t *testing.T) {
+	loadKubeConfig = mockLoadKubeConfig
+
+	clientset := fake.NewSimpleClientset()
+
+	// Start the secret controller and sleep to allow secret process to start.
+	err := StartSecretController(
+		clientset, testCreateController, testDeleteController, secretNameSpace)
+	if err != nil {
+		t.Fatalf("Could not start secret controller: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Create the multicluster secret.
+	err = createMultiClusterSecret(clientset)
+	if err != nil {
+		t.Fatalf("Unexpected error on secret create: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// Test
+	if testCreateControllerCalled != true {
+		t.Fatalf("Test failed on create secret, create callback function not called")
+	}
+
+	if testDeleteControllerCalled != false {
+		t.Fatalf("Test failed on create secret, delete callback function called")
+	}
+
+	// Reset test variables and delete the multicluster secret.
+	testCreateControllerCalled = false
+	testDeleteControllerCalled = false
+
+	err = deleteMultiClusterSecret(clientset)
+	if err != nil {
+		t.Fatalf("Unexpected error on secret delete: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	// Test
+	if testCreateControllerCalled != false {
+		t.Fatalf("Test failed on delete secret, create callback function called")
+	}
+
+	if testDeleteControllerCalled != true {
+		t.Fatalf("Test failed on delete secret, delete callback function not called")
+	}
+}


### PR DESCRIPTION
Create a common package for the multi-cluster secret controller code. Code for this PR was copied/updated from the current pilot implementation. This PR does not contain a consumer of this library.
Future PRs will be:
- mixer support for multi-cluster (includes accessing the multi-cluster secret controller common library.)
- changing the pilot code to use this new common library. This PR will also include removing the existing pilot code that supports the multi-cluster secret controller code, ./pilot/pkg/config/clusterregistry/.