### PR TITLE
remove workaround to parse subjectID as CA put this field optional

### DIFF
--- a/security/pkg/nodeagent/caClient/client.go
+++ b/security/pkg/nodeagent/caClient/client.go
@@ -16,13 +16,8 @@ package ca
 
 import (
 	"context"
-	"crypto/tls"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -69,15 +64,8 @@ func NewCAClient(endpoint, rootPath string) (Client, error) {
 
 func (cl *caClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
 	certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error) {
-	// TODO(quanlin): remove SubjectId field once CA put it as optional.
-	subjectID, err := parseSubjectID(token)
-	if err != nil {
-		return nil, errors.New("failed to construct IstioCertificate request")
-	}
-
 	req := &capb.IstioCertificateRequest{
 		Csr:              string(csrPEM),
-		SubjectId:        subjectID,
 		ValidityDuration: certValidTTLInSec,
 	}
 
@@ -100,51 +88,4 @@ func (cl *caClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
 	}
 
 	return ret, nil
-}
-
-// TODO(quanlin): remove below workaround function once CA put SubjectId field as optional.
-// token format - "Bearer ya29.****"
-type content struct {
-	ID string `json:"azp"`
-}
-
-const tokenPrefix = "Bearer "
-
-// Parse subjectID from token by sending web request and parsing the response content.
-// This function can be removed once CA put SubjectId field as optional.
-func parseSubjectID(token string) (string, error) {
-	if !strings.HasPrefix(token, tokenPrefix) {
-		log.Errorf("invalid token %q, should start with %q", token, tokenPrefix)
-		return "", errors.New("invalid token")
-	}
-
-	strs := strings.Fields(token)
-	url := fmt.Sprintf("https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=%s", strs[1])
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-	resp, err := client.Get(url)
-	if err != nil {
-		log.Errorf("Request against %q failed, %v", url, err)
-		return "", errors.New("failed to parse subject ID")
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Errorf("Failed to read response from %q: %v", url, err)
-		return "", errors.New("failed to parse subject ID")
-	}
-
-	item := content{}
-	if err := json.Unmarshal(body, &item); err != nil {
-		log.Errorf("failed to parse json %v", err)
-		return "", errors.New("failed to parse subject ID")
-	}
-
-	return item.ID, nil
 }


### PR DESCRIPTION
https://github.com/istio/istio/issues/5903

previous nodeagent parses this field from token as workaround, now CA handles this. 