### PR TITLE
[test-framework] Adding support for component dependencies

### DIFF
--- a/pkg/test/framework/component/component.go
+++ b/pkg/test/framework/component/component.go
@@ -12,25 +12,19 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package errors
+package component
 
 import (
-	"fmt"
+	"istio.io/istio/pkg/test/framework/dependency"
+	"istio.io/istio/pkg/test/framework/environment"
 )
 
-// UnrecognizedEnvironment error
-func UnrecognizedEnvironment(env string) error {
-	return fmt.Errorf("unrecognized environment: %q", env)
-}
-
-// MissingKubeConfigForEnvironment error
-func MissingKubeConfigForEnvironment(env string, envvar string) error {
-	return fmt.Errorf(
-		"environment %q requires kube configuration (can be specified from command-line, or with %s)",
-		env, envvar)
-}
-
-// InvalidTestID error
-func InvalidTestID(maxLength int) error {
-	return fmt.Errorf("testID must be non-empty and cannot be longer than %d characters", maxLength)
+// Component defines the interface for a component of the test framework.
+type Component interface {
+	// ID returns the unique identifier for this component.
+	ID() dependency.Instance
+	// Requires returns all components that are required by this component.
+	Requires() []dependency.Instance
+	// Init creates a new resource that is initialized for the given environment.
+	Init(ctx environment.ComponentContext, deps map[dependency.Instance]interface{}) (interface{}, error)
 }

--- a/pkg/test/framework/components/apiserver/apiserver.go
+++ b/pkg/test/framework/components/apiserver/apiserver.go
@@ -17,16 +17,33 @@ package apiserver
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/kubernetes"
 	"istio.io/istio/pkg/test/kube"
 )
 
-// InitKube initializes a new API Server component for the kubernetes environment.
-func InitKube(ctx environment.ComponentContext) (interface{}, error) {
+// KubeComponent is a framework component for the Kubernetes API server.
+var KubeComponent = &kubeComponent{}
+
+type kubeComponent struct {
+}
+
+// ID implements the component.Component interface.
+func (c *kubeComponent) ID() dependency.Instance {
+	return dependency.APIServer
+}
+
+// Requires implements the component.Component interface.
+func (c *kubeComponent) Requires() []dependency.Instance {
+	return make([]dependency.Instance, 0)
+}
+
+// Init implements the component.Component interface.
+func (c *kubeComponent) Init(ctx environment.ComponentContext, deps map[dependency.Instance]interface{}) (interface{}, error) {
 	kubeEnv, ok := ctx.Environment().(*kubernetes.Implementation)
 	if !ok {
-		return nil, fmt.Errorf("unsupported environment: %q", ctx.Environment().EnvironmentName())
+		return nil, fmt.Errorf("unsupported environment: %q", ctx.Environment().EnvironmentID())
 	}
 
 	return &deployedAPIServer{

--- a/pkg/test/framework/components/registry/registry.go
+++ b/pkg/test/framework/components/registry/registry.go
@@ -1,0 +1,56 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+
+	"istio.io/istio/pkg/test/framework/component"
+	"istio.io/istio/pkg/test/framework/dependency"
+	"istio.io/istio/pkg/test/framework/environment"
+)
+
+// Registry of test components.
+type Registry struct {
+	componentMap map[dependency.Instance]component.Component
+}
+
+// New creates a new registry instance.
+func New() *Registry {
+	return &Registry{
+		componentMap: make(map[dependency.Instance]component.Component),
+	}
+}
+
+// Register a component.
+func (r *Registry) Register(c component.Component) {
+	r.componentMap[c.ID()] = c
+}
+
+// Get returns the component with the given ID.
+func (r *Registry) Get(id dependency.Instance) (component.Component, bool) {
+	c, ok := r.componentMap[id]
+	return c, ok
+}
+
+// Init initializes the component with the given name, and returns its instance.
+func (r *Registry) Init(id dependency.Instance, depMap map[dependency.Instance]interface{}, ctx environment.ComponentContext) (interface{}, error) {
+	c, found := r.Get(id)
+	if !found {
+		return nil, fmt.Errorf("component not found: name:%q, environment:%q", id.String(), ctx.Environment().EnvironmentID())
+	}
+
+	return c.Init(ctx, depMap)
+}

--- a/pkg/test/framework/environment.go
+++ b/pkg/test/framework/environment.go
@@ -166,7 +166,7 @@ func (e *environment) GetPolicyBackendOrFail(t testing.TB) env.DeployedPolicyBac
 }
 
 func (e *environment) get(dep dependency.Instance) (interface{}, error) {
-	s, ok := e.ctx.Tracker[dep]
+	s, ok := e.ctx.Tracker.Get(dep)
 	if !ok {
 		return nil, fmt.Errorf("dependency not initialized: %v", dep)
 	}
@@ -198,7 +198,7 @@ func (e *environment) GetAPIServerOrFail(t testing.TB) env.DeployedAPIServer {
 }
 
 func (e *environment) getOrFail(t testing.TB, dep dependency.Instance) interface{} {
-	s, ok := e.ctx.Tracker[dep]
+	s, ok := e.ctx.Tracker.Get(dep)
 	if !ok {
 		t.Fatalf("Dependency not initialized: %v", dep)
 	}

--- a/pkg/test/framework/environment/environment.go
+++ b/pkg/test/framework/environment/environment.go
@@ -98,8 +98,8 @@ type (
 	// Implementation is a tagging interface for the underlying environment specific implementation (i.e.
 	// kubernetes or local environment specific implementation).
 	Implementation interface {
-		// EnvironmentName is the name of the implemented environment.
-		EnvironmentName() string
+		// EnvironmentID is the unique ID of the implemented environment.
+		EnvironmentID() settings.EnvironmentID
 	}
 
 	// Deployed represents a deployed component

--- a/pkg/test/framework/environments/kubernetes/app.go
+++ b/pkg/test/framework/environments/kubernetes/app.go
@@ -104,7 +104,8 @@ type app struct {
 
 var _ environment.DeployedApp = &app{}
 
-func getApp(serviceName, namespace string) (environment.DeployedApp, error) {
+// NewApp creates a new DeployedApp for the given app name/namespace.
+func NewApp(serviceName, namespace string) (environment.DeployedApp, error) {
 	// Get the yaml config for the service
 	yamlBytes, err := util.ShellSilent("kubectl get svc %s -n %s -o yaml", serviceName, namespace)
 	if err != nil {

--- a/pkg/test/framework/environments/kubernetes/app_test.go
+++ b/pkg/test/framework/environments/kubernetes/app_test.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package kubernetes
+package kubernetes_test
 
 import (
 	"testing"
@@ -20,18 +20,24 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/framework/environments/kubernetes"
 )
 
 // TODO(nmittler): Remove from final code. This is just helpful for initial debugging.
 
-// These methods will only work if you already have an environment deployed with apps.
-func TestHttp(t *testing.T) {
-	e := Environment{
-		TestNamespace: "istio-system",
-	}
+const namespace = "istio-system"
 
-	a := e.GetAppOrFail("a", t)
-	b := e.GetAppOrFail("b", t)
+func TestHttp(t *testing.T) {
+	t.Skip("Skipping this test. Must be enabled manually.")
+
+	a, err := kubernetes.NewApp("a", namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := kubernetes.NewApp("b", namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	endpoint := b.EndpointsForProtocol(model.ProtocolHTTP)[0]
 	u := endpoint.MakeURL()

--- a/pkg/test/framework/environments/kubernetes/implementation.go
+++ b/pkg/test/framework/environments/kubernetes/implementation.go
@@ -26,6 +26,7 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/internal"
+	"istio.io/istio/pkg/test/framework/settings"
 	"istio.io/istio/pkg/test/framework/tmpl"
 	"istio.io/istio/pkg/test/kube"
 )
@@ -66,9 +67,9 @@ func New() *Implementation {
 	return &Implementation{}
 }
 
-// EnvironmentName is the name of this environment implementation.
-func (e *Implementation) EnvironmentName() string {
-	return "kubernetes"
+// EnvironmentID is the name of this environment implementation.
+func (e *Implementation) EnvironmentID() settings.EnvironmentID {
+	return settings.Kubernetes
 }
 
 // Initialize the environment. This is called once during the lifetime of the suite.

--- a/pkg/test/framework/environments/local/implementation.go
+++ b/pkg/test/framework/environments/local/implementation.go
@@ -17,6 +17,7 @@ package local
 import (
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/internal"
+	"istio.io/istio/pkg/test/framework/settings"
 	"istio.io/istio/pkg/test/framework/tmpl"
 )
 
@@ -43,9 +44,9 @@ func New() *Implementation {
 	}
 }
 
-// EnvironmentName is the name of this environment implementation.
-func (e *Implementation) EnvironmentName() string {
-	return "local"
+// EnvironmentID is the name of this environment implementation.
+func (e *Implementation) EnvironmentID() settings.EnvironmentID {
+	return settings.Local
 }
 
 // Initialize the environment. This is called once during the lifetime of the suite.

--- a/pkg/test/framework/internal/context.go
+++ b/pkg/test/framework/internal/context.go
@@ -15,7 +15,7 @@
 package internal
 
 import (
-	"istio.io/istio/pkg/test/framework/dependency"
+	"istio.io/istio/pkg/test/framework/components/registry"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/settings"
 )
@@ -24,17 +24,21 @@ import (
 type TestContext struct {
 	settings settings.Settings
 	impl     environment.Implementation
-	Tracker  Tracker
+	// Tracker is visible for use from the driver.
+	Tracker *Tracker
+	// Registry is visible for use from the driver.
+	Registry *registry.Registry
 }
 
 var _ environment.ComponentContext = &TestContext{}
 
 // NewTestContext initializes and returns a new instance of TestContext.
-func NewTestContext(s settings.Settings, impl environment.Implementation) *TestContext {
+func NewTestContext(s settings.Settings, impl environment.Implementation, registry *registry.Registry) *TestContext {
 	return &TestContext{
 		settings: s,
 		impl:     impl,
-		Tracker:  make(map[dependency.Instance]interface{}),
+		Registry: registry,
+		Tracker:  newTracker(registry),
 	}
 }
 

--- a/pkg/test/framework/settings/flags.go
+++ b/pkg/test/framework/settings/flags.go
@@ -26,7 +26,7 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-var arguments = defaultArgs()
+var settings = defaultSettings()
 var showHelp = false
 var logOptions = log.DefaultOptions()
 
@@ -54,7 +54,7 @@ func init() {
 
 func processFlags() error {
 	// First, apply the environment variables.
-	applyEnvironmentVariables(arguments)
+	applyEnvironmentVariables(settings)
 
 	flag.Parse()
 	if err := cmdForLog.PersistentFlags().Parse(os.Args[1:]); err != nil {
@@ -80,27 +80,27 @@ func processFlags() error {
 	// Capture environment variables
 	hub := os.Getenv("HUB")
 	tag := os.Getenv("TAG")
-	arguments.Hub = hub
-	arguments.Tag = tag
+	settings.Hub = hub
+	settings.Tag = tag
 
 	return nil
 }
 
 func attachFlags(stringVar func(*string, string, string, string), boolVar func(*bool, string, bool, string)) {
-	stringVar(&arguments.WorkDir, "work_dir", os.TempDir(),
+	stringVar(&settings.WorkDir, "work_dir", os.TempDir(),
 		"Local working directory for creating logs/temp files. If left empty, os.TempDir() is used.")
 
-	stringVar(&arguments.Environment, "environment", arguments.Environment,
+	stringVar((*string)(&settings.Environment), "environment", string(settings.Environment),
 		fmt.Sprintf("Specify the environment to run the tests against. Allowed values are: [%s, %s]",
 			Local, Kubernetes))
 
-	stringVar(&arguments.KubeConfig, "config", arguments.KubeConfig,
+	stringVar(&settings.KubeConfig, "config", settings.KubeConfig,
 		"The path to the kube config file for cluster environments")
 
 	boolVar(&showHelp, "hh", showHelp,
 		"Show the help page for the test framework")
 
-	boolVar(&arguments.NoCleanup, "no-cleanup", arguments.NoCleanup, "Do not cleanup resources after test completion")
+	boolVar(&settings.NoCleanup, "no-cleanup", settings.NoCleanup, "Do not cleanup resources after test completion")
 }
 
 func doShowHelp() {
@@ -124,6 +124,6 @@ func applyEnvironmentVariables(a *Settings) {
 	}
 
 	if ISTIO_TEST_ENVIRONMENT.Value() != "" {
-		a.Environment = ISTIO_TEST_ENVIRONMENT.Value()
+		a.Environment = EnvironmentID(ISTIO_TEST_ENVIRONMENT.Value())
 	}
 }

--- a/pkg/test/framework/settings/settings.go
+++ b/pkg/test/framework/settings/settings.go
@@ -23,21 +23,24 @@ import (
 	"istio.io/istio/pkg/test/framework/errors"
 )
 
+// EnvironmentID is a unique identifier for a testing environment.
+type EnvironmentID string
+
 const (
 	// MaxTestIDLength is the maximum length allowed for testID.
 	MaxTestIDLength = 30
 
-	// Local environment name
-	Local = "local"
+	// Local environment identifier
+	Local = EnvironmentID("local")
 
-	// Kubernetes environment name
-	Kubernetes = "kubernetes"
+	// Kubernetes environment identifier
+	Kubernetes = EnvironmentID("kubernetes")
 )
 
 // Settings is the set of arguments to the test driver.
 type Settings struct {
 	// Environment to run the tests in. By default, a local environment will be used.
-	Environment string
+	Environment EnvironmentID
 
 	// Path to kube config file. Required if the environment is kubernetes.
 	KubeConfig string
@@ -69,7 +72,7 @@ func New(testID string) (*Settings, error) {
 	}
 
 	// Make a local copy.
-	s := *arguments
+	s := *settings
 	s.TestID = testID
 	s.RunID = generateRunID(testID)
 
@@ -80,8 +83,8 @@ func New(testID string) (*Settings, error) {
 	return &s, nil
 }
 
-// defaultArgs returns the default set of arguments.
-func defaultArgs() *Settings {
+// defaultSettings returns the default set of arguments.
+func defaultSettings() *Settings {
 	return &Settings{
 		Environment: Local,
 	}
@@ -93,11 +96,11 @@ func (a *Settings) Validate() error {
 	case Local, Kubernetes:
 
 	default:
-		return errors.UnrecognizedEnvironment(a.Environment)
+		return errors.UnrecognizedEnvironment(string(a.Environment))
 	}
 
 	if a.Environment == Kubernetes && a.KubeConfig == "" {
-		return errors.MissingKubeConfigForEnvironment(Kubernetes, ISTIO_TEST_KUBE_CONFIG.Name())
+		return errors.MissingKubeConfigForEnvironment(string(Kubernetes), ISTIO_TEST_KUBE_CONFIG.Name())
 	}
 
 	if a.TestID == "" || len(a.TestID) > MaxTestIDLength {


### PR DESCRIPTION
- Added Component interface, which is now implemented by all components

- Separate component registries for local and kubernetes

- Updated the dependency Tracker to initialize all dependencies of
a component before initializing the component, itself.