### PR TITLE
Improve config validation health checks

### DIFF
--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -51,6 +51,7 @@ var (
 
 const (
 	watchDebounceDelay = 100 * time.Millisecond
+	reconcilePeriod    = 5 * time.Second
 )
 
 // WebhookParameters contains the configuration for the Istio Pilot validation
@@ -247,7 +248,7 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 
 	var reconcileTickerC <-chan time.Time
 	if wh.webhookConfigFile != "" {
-		reconcileTickerC = time.NewTicker(time.Second).C
+		reconcileTickerC = time.NewTicker(reconcilePeriod).C
 	}
 
 	for {

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           - --caCertFile=/etc/istio/certs/root-cert.pem
           - --tlsCertFile=/etc/istio/certs/cert-chain.pem
           - --tlsKeyFile=/etc/istio/certs/key.pem
-          - --healthCheckInterval=2s
+          - --healthCheckInterval=1s
           - --healthCheckFile=/health
           - --webhook-config-file
           - /etc/istio/config/validatingwebhookconfiguration.yaml
@@ -58,18 +58,18 @@ spec:
                 - /usr/local/bin/galley
                 - probe
                 - --probe-path=/health
-                - --interval=4s
-            initialDelaySeconds: 4
-            periodSeconds: 4
+                - --interval=10s
+            initialDelaySeconds: 5
+            periodSeconds: 5
           readinessProbe:
             exec:
               command:
                 - /usr/local/bin/galley
                 - probe
                 - --probe-path=/health
-                - --interval=4s
-            initialDelaySeconds: 4
-            periodSeconds: 4
+                - --interval=10s
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Readiness and liveliness probes were failing on some providers because
GET requests were blocking for multiple seconds. Mitigate the issue
by decreasing the frequency of GET (to avoid possible throttling) and
increase the acceptable health check interval from 4s to 10s.

Shorm term fix for https://github.com/istio/istio/issues/7586. Longer
term fix requires switching to proper controller-style
reconciliation. That work should be aligned with the sidecar injector.