### PR TITLE
Experimental dual-use mode for citadel

### DIFF
--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -70,6 +70,9 @@ func init() {
 	flags.StringVar(&cAClientConfig.RootCertFile, "root-cert",
 		"/etc/certs/root-cert.pem", "Root Certificate file")
 
+	flags.BoolVar(&naConfig.DualUse, "experimental-dual-use",
+		false, "Enable dual-use mode. Generates certificates with a CommonName identical to the SAN.")
+
 	naConfig.LoggingOptions.AttachCobraFlags(rootCmd)
 	cmd.InitializeFlags(rootCmd)
 }

--- a/security/cmd/node_agent/na/config.go
+++ b/security/cmd/node_agent/na/config.go
@@ -40,6 +40,9 @@ type Config struct {
 
 	// SecretDirectory is the directory to to save keys/certs when using file mode SecretServer.
 	SecretDirectory string
+
+	// DualUse defines whether the generated CSRs are for dual-use mode (SAN+CN).
+	DualUse bool
 }
 
 // NewConfig creates a new Config instance with default values.

--- a/security/cmd/node_agent/na/nodeagent.go
+++ b/security/cmd/node_agent/na/nodeagent.go
@@ -118,6 +118,7 @@ func (na *nodeAgentInternal) createRequest() ([]byte, *pb.CsrRequest, error) {
 		Host:       na.identity,
 		Org:        na.config.CAClientConfig.Org,
 		RSAKeySize: na.config.CAClientConfig.RSAKeySize,
+		IsDualUse:  na.config.DualUse,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -86,7 +86,7 @@ type IstioCA struct {
 }
 
 // NewSelfSignedIstioCAOptions returns a new IstioCAOptions instance using self-signed certificate.
-func NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL time.Duration, org string,
+func NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL time.Duration, org string, dualUse bool,
 	namespace string, core corev1.SecretsGetter) (caOpts *IstioCAOptions, err error) {
 	// For the first time the CA is up, it generates a self-signed key/cert pair and write it to
 	// cASecret. For subsequent restart, CA will reads key/cert from cASecret.
@@ -105,6 +105,7 @@ func NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL time.Duration, o
 			IsCA:         true,
 			IsSelfSigned: true,
 			RSAKeySize:   caKeySize,
+			IsDualUse:    dualUse,
 		}
 		pemCert, pemKey, ckErr := util.GenCertKeyFromOptions(options)
 		if ckErr != nil {

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -87,11 +87,12 @@ func TestCreateSelfSignedIstioCAWithoutSecret(t *testing.T) {
 	defaultCertTTL := 30 * time.Minute
 	maxCertTTL := time.Hour
 	org := "test.ca.org"
+	dualUse := false
 	caNamespace := "default"
 	client := fake.NewSimpleClientset()
 
-	caopts, err := NewSelfSignedIstioCAOptions(caCertTTL, defaultCertTTL, maxCertTTL, org, caNamespace,
-		client.CoreV1())
+	caopts, err := NewSelfSignedIstioCAOptions(caCertTTL, defaultCertTTL, maxCertTTL,
+		org, dualUse, caNamespace, client.CoreV1())
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}
@@ -160,9 +161,10 @@ func TestCreateSelfSignedIstioCAWithSecret(t *testing.T) {
 	maxCertTTL := time.Hour
 	org := "test.ca.org"
 	caNamespace := "default"
+	dualUse := false
 
-	caopts, err := NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL, org, caNamespace,
-		client.CoreV1())
+	caopts, err := NewSelfSignedIstioCAOptions(caCertTTL, certTTL, maxCertTTL,
+		org, dualUse, caNamespace, client.CoreV1())
 	if err != nil {
 		t.Fatalf("Failed to create a self-signed CA Options: %v", err)
 	}

--- a/security/pkg/pki/ca/controller/secret.go
+++ b/security/pkg/pki/ca/controller/secret.go
@@ -87,6 +87,9 @@ type SecretController struct {
 	// Length of the grace period for the certificate rotation.
 	gracePeriodRatio float32
 
+	// Whether the certificates are for dual-use clients (SAN+CN).
+	dualUse bool
+
 	// Whether the certificates are for CAs.
 	forCA bool
 
@@ -105,7 +108,7 @@ type SecretController struct {
 }
 
 // NewSecretController returns a pointer to a newly constructed SecretController instance.
-func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, gracePeriodRatio float32, minGracePeriod time.Duration,
+func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, gracePeriodRatio float32, minGracePeriod time.Duration, dualUse bool,
 	core corev1.CoreV1Interface, forCA bool, namespace string, dnsNames map[string]DNSNameEntry) (*SecretController, error) {
 
 	if gracePeriodRatio < 0 || gracePeriodRatio > 1 {
@@ -121,6 +124,7 @@ func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, grac
 		certTTL:          certTTL,
 		gracePeriodRatio: gracePeriodRatio,
 		minGracePeriod:   minGracePeriod,
+		dualUse:          dualUse,
 		core:             core,
 		forCA:            forCA,
 		dnsNames:         dnsNames,
@@ -314,6 +318,7 @@ func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string
 	options := util.CertOptions{
 		Host:       id,
 		RSAKeySize: keySize,
+		IsDualUse:  sc.dualUse,
 	}
 
 	csrPEM, keyPEM, err := util.GenCSR(options)

--- a/security/pkg/pki/ca/controller/secret_test.go
+++ b/security/pkg/pki/ca/controller/secret_test.go
@@ -159,7 +159,7 @@ func TestSecretController(t *testing.T) {
 			},
 		}
 		controller, err := NewSecretController(createFakeCA(), defaultTTL,
-			tc.gracePeriodRatio, defaultMinGracePeriod, client.CoreV1(), false,
+			tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
 			metav1.NamespaceAll, webhooks)
 		if tc.shouldFail {
 			if err == nil {
@@ -200,7 +200,7 @@ func TestSecretContent(t *testing.T) {
 	saNamespace := "test-namespace"
 	client := fake.NewSimpleClientset()
 	controller, err := NewSecretController(createFakeCA(), defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod,
-		client.CoreV1(), false, metav1.NamespaceAll, map[string]DNSNameEntry{})
+		false, client.CoreV1(), false, metav1.NamespaceAll, map[string]DNSNameEntry{})
 	if err != nil {
 		t.Errorf("Failed to create secret controller: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestSecretContent(t *testing.T) {
 func TestDeletedIstioSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	controller, err := NewSecretController(createFakeCA(), defaultTTL, defaultGracePeriodRatio, defaultMinGracePeriod,
-		client.CoreV1(), false, metav1.NamespaceAll, nil)
+		false, client.CoreV1(), false, metav1.NamespaceAll, nil)
 	if err != nil {
 		t.Errorf("failed to create secret controller: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestUpdateSecret(t *testing.T) {
 	for k, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		controller, err := NewSecretController(createFakeCA(), time.Hour, tc.gracePeriodRatio, tc.minGracePeriod,
-			client.CoreV1(), false, metav1.NamespaceAll, nil)
+			false, client.CoreV1(), false, metav1.NamespaceAll, nil)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}

--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -218,6 +218,32 @@ func TestGenCertKeyFromOptions(t *testing.T) {
 				KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 			},
 		},
+		{
+			name: "Generate dual-use cert",
+			certOptions: CertOptions{
+				Host:         "spiffe://domain/ns/bar/sa/foo",
+				NotBefore:    notBefore,
+				TTL:          ttl,
+				SignerCert:   caCert,
+				SignerPriv:   caPriv,
+				Org:          "",
+				IsCA:         false,
+				IsSelfSigned: false,
+				IsClient:     true,
+				IsServer:     true,
+				RSAKeySize:   512,
+				IsDualUse:    true,
+			},
+			verifyFields: &VerifyFields{
+				ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+				IsCA:        false,
+				KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+				NotBefore:   notBefore,
+				TTL:         ttl,
+				Org:         "MyOrg",
+				CommonName:  "spiffe://domain/ns/bar/sa/foo",
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/security/pkg/pki/util/generate_csr.go
+++ b/security/pkg/pki/util/generate_csr.go
@@ -61,6 +61,9 @@ func GenCSRTemplate(options CertOptions) (*x509.CertificateRequest, error) {
 		if err != nil {
 			return nil, err
 		}
+		if options.IsDualUse {
+			template.Subject.CommonName = h
+		}
 		template.ExtraExtensions = []pkix.Extension{*s}
 	}
 

--- a/security/pkg/pki/util/generate_csr_test.go
+++ b/security/pkg/pki/util/generate_csr_test.go
@@ -68,3 +68,21 @@ func TestGenCSRWithInvalidOption(t *testing.T) {
 		t.Errorf("Should have failed")
 	}
 }
+
+func TestGenCSRTemplateForDualUse(t *testing.T) {
+	opts := CertOptions{
+		Host:       "test_ca.com",
+		Org:        "MyOrg",
+		RSAKeySize: 512,
+		IsDualUse:  true,
+	}
+
+	csr, err := GenCSRTemplate(opts)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if csr.Subject.CommonName != opts.Host {
+		t.Errorf("unexpected value for 'CommonName' field: want %v but got %v", opts.Host, csr.Subject.CommonName)
+	}
+}

--- a/security/pkg/pki/util/keycertbundle.go
+++ b/security/pkg/pki/util/keycertbundle.go
@@ -196,6 +196,7 @@ func (b *KeyCertBundleImpl) CertOptions() (*CertOptions, error) {
 		IsCA:       b.cert.IsCA,
 		TTL:        b.cert.NotAfter.Sub(b.cert.NotBefore),
 		RSAKeySize: size,
+		IsDualUse:  ids[0] == b.cert.Subject.CommonName,
 	}, nil
 }
 

--- a/security/pkg/pki/util/verify_cert.go
+++ b/security/pkg/pki/util/verify_cert.go
@@ -32,6 +32,7 @@ type VerifyFields struct {
 	KeyUsage    x509.KeyUsage
 	IsCA        bool
 	Org         string
+	CommonName  string
 }
 
 // VerifyCertificate verifies a given PEM encoded certificate by
@@ -124,6 +125,11 @@ func VerifyCertificate(privPem []byte, certChainPem []byte, rootCertPem []byte,
 	if org := expectedFields.Org; org != "" && !reflect.DeepEqual([]string{org}, cert.Issuer.Organization) {
 		return fmt.Errorf("unexpected value for 'Organization' field: want %v but got %v",
 			[]string{org}, cert.Issuer.Organization)
+	}
+
+	if cn := expectedFields.CommonName; cn != cert.Subject.CommonName {
+		return fmt.Errorf("unexpected value for 'CommonName' field: want %v but got %v",
+			cn, cert.Subject.CommonName)
 	}
 
 	return nil


### PR DESCRIPTION
Context: #7153 

This implements dual-use mode for both Citadel and NodeAgent with `--experimental-dual-use`.   NodeAgent wasn't mentioned in the issue discussion, but I assume it should be part of the whole deal.

A couple points:

- Wasn't sure about `security/pkg/pki/util/keycertbundle.go` - the `CertOptions` for rotation come from inspecting the cert itself.  We can detect probable dual use with`ids[0] == b.cert.Subject.CommonName` but it seems a bit strange.  
In general the rotation flow is disconnected from the flag configuration.

- When in CA-server mode, should it generate a dual-use cert for itself? (in `applyServerCertificate` - it doesn't right now)

@justinburke @myidpt 