### PR TITLE
Pilot client mcp integration

### DIFF
--- a/mixer/test/client/env/ports.go
+++ b/mixer/test/client/env/ports.go
@@ -57,6 +57,7 @@ const (
 	PilotPluginTest
 	PilotPluginTCPTest
 	PilotPluginTLSTest
+	PilotMCPTest
 
 	// The number of total tests. has to be the last one.
 	maxTestNum

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -105,6 +105,8 @@ func init() {
 		"Select a namespace where the controller resides. If not set, uses ${POD_NAMESPACE} environment variable")
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Plugins, "plugins", bootstrap.DefaultPlugins,
 		"comma separated list of networking plugins to enable")
+	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.MCPServerAddrs, "mcpServerAddrs", []string{},
+		"comma separated list of mesh config protocol server addresses")
 
 	// Config Controller options
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",
@@ -140,8 +142,7 @@ func init() {
 		"Webhook API endpoint (supports http://sockethost, and unix:///absolute/path/to/socket")
 
 	// Deprecated flags.
-	discoveryCmd.PersistentFlags().IntVar(&httpPort, "port", 8080,
-		"Discovery service port")
+	discoveryCmd.PersistentFlags().IntVar(&httpPort, "port", 8080, "Discovery service port")
 	discoveryCmd.PersistentFlags().MarkDeprecated("port", "Use --httpAddr instead")
 	discoveryCmd.PersistentFlags().IntVar(&monitoringPort, "monitoringPort", 9093,
 		"HTTP port to use for the exposing pilot self-monitoring information")

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -41,11 +41,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	mcpapi "istio.io/api/mcp/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/cmd"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"
 	cf "istio.io/istio/pilot/pkg/config/cloudfoundry"
 	"istio.io/istio/pilot/pkg/config/clusterregistry"
+	"istio.io/istio/pilot/pkg/config/coredatamodel"
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/config/kube/ingress"
 	"istio.io/istio/pilot/pkg/config/memory"
@@ -64,7 +66,11 @@ import (
 	srmemory "istio.io/istio/pilot/pkg/serviceregistry/memory"
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
+	mcpclient "istio.io/istio/pkg/mcp/client"
 	"istio.io/istio/pkg/version"
+
+	// Import the resource package to pull in all proto types.
+	_ "istio.io/istio/galley/pkg/metadata"
 )
 
 const (
@@ -137,6 +143,7 @@ type PilotArgs struct {
 	MeshConfig       *meshconfig.MeshConfig
 	CtrlZOptions     *ctrlz.Options
 	Plugins          []string
+	MCPServerAddrs   []string
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -432,7 +439,42 @@ func (c *mockController) Run(<-chan struct{}) {}
 
 // initConfigController creates the config controller in the pilotConfig.
 func (s *Server) initConfigController(args *PilotArgs) error {
-	if args.Config.Controller != nil {
+	mcpServerAddrs := args.MCPServerAddrs
+
+	if len(mcpServerAddrs) > 0 {
+		clientNodeID := args.Namespace
+		supportedTypes := make([]string, len(model.IstioConfigTypes))
+		for i, model := range model.IstioConfigTypes {
+			supportedTypes[i] = fmt.Sprintf("type.googleapis.com/%s", model.MessageName)
+		}
+
+		mcpController := coredatamodel.NewController()
+
+		s.addStartFunc(func(stop <-chan struct{}) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				<-stop
+				cancel()
+			}()
+
+			for _, addr := range mcpServerAddrs {
+				// TODO: make this a secure connection before shipping
+				conn, err := grpc.Dial(addr, grpc.WithInsecure())
+				if err != nil {
+					log.Errorf("Unable connecting to MCP Server: %v\n", err)
+					return err
+				}
+
+				cl := mcpapi.NewAggregatedMeshConfigServiceClient(conn)
+				mcpClient := mcpclient.New(cl, supportedTypes, mcpController, clientNodeID, map[string]string{})
+				go mcpClient.Run(ctx)
+			}
+			return nil
+		})
+
+		s.configController = mcpController
+
+	} else if args.Config.Controller != nil {
 		s.configController = args.Config.Controller
 	} else if args.Config.FileDir != "" {
 		store := memory.Make(model.IstioConfigTypes)

--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -1,0 +1,224 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coredatamodel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/log"
+	mcpclient "istio.io/istio/pkg/mcp/client"
+)
+
+var errUnsupported = errors.New("this operation is not supported by mcp controller")
+
+// CoreDataModel is a combined interface for ConfigStoreCache
+// MCP Updater and ServiceDiscovery
+type CoreDataModel interface {
+	model.ConfigStoreCache
+	mcpclient.Updater
+}
+
+// Controller is a temporary storage for the changes received
+// via MCP server
+type Controller struct {
+	configStoreMu sync.RWMutex
+	// keys [type][namespace][name]
+	configStore              map[string]map[string]map[string]model.Config
+	descriptorsByMessageName map[string]model.ProtoSchema
+}
+
+// NewController provides a new CoreDataModel controller
+func NewController() CoreDataModel {
+	descriptorsByMessageName := make(map[string]model.ProtoSchema, len(model.IstioConfigTypes))
+	for _, descriptor := range model.IstioConfigTypes {
+		descriptorsByMessageName[descriptor.MessageName] = descriptor
+	}
+
+	// Remove this when https://github.com/istio/istio/issues/7947 is done
+	configStore := make(map[string]map[string]map[string]model.Config)
+	for _, typ := range model.IstioConfigTypes.Types() {
+		configStore[typ] = make(map[string]map[string]model.Config)
+	}
+	return &Controller{
+		configStore:              configStore,
+		descriptorsByMessageName: descriptorsByMessageName,
+	}
+}
+
+// ConfigDescriptor returns all the ConfigDescriptors that this
+// controller is responsible for
+func (c *Controller) ConfigDescriptor() model.ConfigDescriptor {
+	return model.IstioConfigTypes
+}
+
+// List returns all the config that is stored by type and namespace
+// if namespace is empty string it returns config for all the namespaces
+func (c *Controller) List(typ, namespace string) (out []model.Config, err error) {
+	_, ok := c.ConfigDescriptor().GetByType(typ)
+	if !ok {
+		return nil, fmt.Errorf("list unknown type %s", typ)
+	}
+	c.configStoreMu.Lock()
+	byType, ok := c.configStore[typ]
+	c.configStoreMu.Unlock()
+	if !ok {
+		return nil, nil
+	}
+
+	if namespace == "" {
+		// ByType does not need locking since
+		// we replace the entire sub-map
+		if ok {
+			for _, byNamespace := range byType {
+				for _, config := range byNamespace {
+					out = append(out, config)
+				}
+			}
+			return out, nil
+		}
+	}
+
+	if byNamespace, ok := byType[namespace]; ok {
+		for _, config := range byNamespace {
+			out = append(out, config)
+		}
+	}
+	return out, nil
+}
+
+// Apply receives changes from MCP server and creates the
+// corresponding config
+func (c *Controller) Apply(change *mcpclient.Change) error {
+	messagename := extractMessagename(change.TypeURL)
+	descriptor, ok := c.descriptorsByMessageName[messagename]
+	if !ok {
+		return fmt.Errorf("apply type not supported %s", messagename)
+	}
+
+	schema, valid := c.ConfigDescriptor().GetByType(descriptor.Type)
+	if !valid {
+		return fmt.Errorf("descriptor type not supported %s", messagename)
+	}
+
+	// innerStore is [namespace][name]
+	innerStore := make(map[string]map[string]model.Config)
+	for _, obj := range change.Objects {
+		name, nameSpace := extractNameNamespace(obj.Metadata.Name)
+
+		now := time.Now()
+		conf := model.Config{
+			ConfigMeta: model.ConfigMeta{
+				Type:              descriptor.Type,
+				Group:             descriptor.Group,
+				Version:           descriptor.Version,
+				Name:              name,
+				Namespace:         nameSpace,
+				ResourceVersion:   now.String(),
+				CreationTimestamp: meta_v1.Time{Time: now},
+			},
+			Spec: obj.Resource,
+		}
+
+		if err := schema.Validate(conf.Name, conf.Namespace, conf.Spec); err != nil {
+			return err
+		}
+
+		namedConfig, ok := innerStore[conf.Namespace]
+		if ok {
+			namedConfig[conf.Name] = conf
+		} else {
+			innerStore[conf.Namespace] = map[string]model.Config{
+				conf.Name: conf,
+			}
+		}
+	}
+
+	c.configStoreMu.Lock()
+	c.configStore[descriptor.Type] = innerStore
+	c.configStoreMu.Unlock()
+
+	return nil
+}
+
+// HasSynced is not implemented, waiting for the following issue
+// pending https://github.com/istio/istio/issues/7947
+func (c *Controller) HasSynced() bool {
+	// TODO:The configStore already populated with all the keys to avoid nil map issue
+	if len(c.configStore) == 0 {
+		return false
+	}
+	for _, descriptor := range c.ConfigDescriptor() {
+		if _, ok := c.configStore[descriptor.Type]; !ok {
+			return false
+		}
+
+	}
+	return true
+}
+
+// Run is not implemented
+func (c *Controller) Run(stop <-chan struct{}) {
+	log.Warnf("Run: %s", errUnsupported)
+}
+
+// RegisterEventHandler is not implemented
+func (c *Controller) RegisterEventHandler(typ string, handler func(model.Config, model.Event)) {
+	log.Warnf("registerEventHandler %s", errUnsupported)
+}
+
+// Get is not implemented
+func (c *Controller) Get(typ, name, namespace string) (*model.Config, bool) {
+	log.Warnf("get %s", errUnsupported)
+	return nil, false
+}
+
+// Update is not implemented
+func (c *Controller) Update(config model.Config) (newRevision string, err error) {
+	log.Warnf("update %s", errUnsupported)
+	return "", errUnsupported
+}
+
+// Create is not implemented
+func (c *Controller) Create(config model.Config) (revision string, err error) {
+	log.Warnf("create %s", errUnsupported)
+	return "", errUnsupported
+}
+
+// Delete is not implemented
+func (c *Controller) Delete(typ, name, namespace string) error {
+	return errUnsupported
+}
+
+func extractNameNamespace(metadataName string) (string, string) {
+	segments := strings.Split(metadataName, "/")
+	if len(segments) == 2 {
+		return segments[0], segments[1]
+	}
+	return segments[0], ""
+}
+
+func extractMessagename(typeURL string) string {
+	if slash := strings.LastIndex(typeURL, "/"); slash >= 0 {
+		return typeURL[slash+1:]
+	}
+	return typeURL
+}

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -1,0 +1,327 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coredatamodel_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	google_protobuf "github.com/gogo/protobuf/types"
+	"github.com/onsi/gomega"
+
+	mcpapi "istio.io/api/mcp/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/config/coredatamodel"
+	"istio.io/istio/pilot/pkg/model"
+	mcpclient "istio.io/istio/pkg/mcp/client"
+)
+
+var (
+	baseURL = "type.googleapis.com/"
+
+	gateway = &networking.Gateway{
+		Servers: []*networking.Server{
+			{
+				Port: &networking.Port{
+					Number:   443,
+					Name:     "https",
+					Protocol: "HTTP",
+				},
+				Hosts: []string{"*.secure.example.com"},
+			},
+		},
+	}
+
+	gateway2 = &networking.Gateway{
+		Servers: []*networking.Server{
+			{
+				Port: &networking.Port{
+					Number:   80,
+					Name:     "http",
+					Protocol: "HTTP",
+				},
+				Hosts: []string{"*.example.com"},
+			},
+		},
+	}
+
+	gateway3 = &networking.Gateway{
+		Servers: []*networking.Server{
+			{
+				Port: &networking.Port{
+					Number:   8080,
+					Name:     "http",
+					Protocol: "HTTP",
+				},
+				Hosts: []string{"foo.example.com"},
+			},
+		},
+	}
+)
+
+func TestHasSynced(t *testing.T) {
+	t.Skip("Pending: https://github.com/istio/istio/issues/7947")
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	g.Expect(controller.HasSynced()).To(gomega.BeFalse())
+}
+
+func TestConfigDescriptor(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	descriptors := controller.ConfigDescriptor()
+	g.Expect(descriptors).To(gomega.Equal(model.IstioConfigTypes))
+}
+
+func TestListInvalidType(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	c, err := controller.List("bad-type", "some-phony-name-space.com")
+	g.Expect(c).To(gomega.BeNil())
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("list unknown type"))
+}
+
+func TestListCorrectTypeNoData(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	c, err := controller.List("virtual-service", "some-phony-name-space.com")
+	g.Expect(c).To(gomega.BeNil())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
+func TestListAllNameSpace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	messages := convertToEnvelope(g, []*networking.Gateway{gateway, gateway2, gateway3})
+	message, message2, message3 := messages[0], messages[1], messages[2]
+	change := convert(
+		[]proto.Message{message, message2, message3},
+		[]string{"some-gateway1/namespace1", "some-other-gateway/default", "some-other-gateway3"},
+		model.Gateway.MessageName)
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	c, err := controller.List("gateway", "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(3))
+
+	for _, conf := range c {
+		g.Expect(conf.Type).To(gomega.Equal(model.Gateway.Type))
+		if conf.Name == "some-gateway1" {
+			g.Expect(conf.Spec).To(gomega.Equal(message))
+			g.Expect(conf.Namespace).To(gomega.Equal("namespace1"))
+		} else if conf.Name == "some-other-gateway" {
+			g.Expect(conf.Namespace).To(gomega.Equal("default"))
+			g.Expect(conf.Spec).To(gomega.Equal(message2))
+		} else {
+			g.Expect(conf.Name).To(gomega.Equal("some-other-gateway3"))
+			g.Expect(conf.Namespace).To(gomega.Equal(""))
+			g.Expect(conf.Spec).To(gomega.Equal(message3))
+		}
+	}
+}
+
+func TestListSpecificNameSpace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	messages := convertToEnvelope(g, []*networking.Gateway{gateway, gateway2, gateway3})
+	message, message2, message3 := messages[0], messages[1], messages[2]
+
+	change := convert(
+		[]proto.Message{message, message2, message3},
+		[]string{"some-gateway1/namespace1", "some-other-gateway/default", "some-other-gateway3/namespace1"},
+		model.Gateway.MessageName)
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	c, err := controller.List("gateway", "namespace1")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(2))
+
+	for _, conf := range c {
+		g.Expect(conf.Type).To(gomega.Equal(model.Gateway.Type))
+		g.Expect(conf.Namespace).To(gomega.Equal("namespace1"))
+		if conf.Name == "some-gateway1" {
+			g.Expect(conf.Spec).To(gomega.Equal(message))
+		} else {
+			g.Expect(conf.Name).To(gomega.Equal("some-other-gateway3"))
+			g.Expect(conf.Spec).To(gomega.Equal(message3))
+		}
+	}
+}
+
+func TestApplyInvalidType(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	message := convertToEnvelope(g, []*networking.Gateway{gateway})
+	change := convert([]proto.Message{message[0]}, []string{"some-gateway"}, "bad-type")
+
+	err := controller.Apply(change)
+	g.Expect(err).To(gomega.HaveOccurred())
+}
+
+func TestApplyValidTypeWithNoBaseURL(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	var createAndCheckGateway = func(g *gomega.GomegaWithT, controller coredatamodel.CoreDataModel, port uint32) {
+		gateway := &networking.Gateway{
+			Servers: []*networking.Server{
+				{
+					Port: &networking.Port{
+						Number:   port,
+						Name:     "http",
+						Protocol: "HTTP",
+					},
+					Hosts: []string{"*.example.com"},
+				},
+			},
+		}
+		marshaledGateway, err := proto.Marshal(gateway)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		message, err := makeMessage(marshaledGateway, model.Gateway.MessageName)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		change := convert([]proto.Message{message}, []string{"some-gateway"}, model.Gateway.MessageName)
+		err = controller.Apply(change)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+
+		c, err := controller.List("gateway", "")
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(len(c)).To(gomega.Equal(1))
+		g.Expect(c[0].Name).To(gomega.Equal("some-gateway"))
+		g.Expect(c[0].Type).To(gomega.Equal(model.Gateway.Type))
+		g.Expect(c[0].Spec).To(gomega.Equal(message))
+		g.Expect(c[0].Spec).To(gomega.ContainSubstring(fmt.Sprintf("number:%d", port)))
+	}
+	createAndCheckGateway(g, controller, 80)
+	createAndCheckGateway(g, controller, 9999)
+}
+
+func TestApplyMetadataNameIncludesNamespace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	message := convertToEnvelope(g, []*networking.Gateway{gateway})
+
+	change := convert([]proto.Message{message[0]}, []string{"some-gateway/istio-namespace"}, model.Gateway.MessageName)
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	c, err := controller.List("gateway", "istio-namespace")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(1))
+	g.Expect(c[0].Name).To(gomega.Equal("some-gateway"))
+	g.Expect(c[0].Type).To(gomega.Equal(model.Gateway.Type))
+	g.Expect(c[0].Spec).To(gomega.Equal(message[0]))
+}
+
+func TestApplyMetadataNameWithoutNamespace(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	message := convertToEnvelope(g, []*networking.Gateway{gateway})
+
+	change := convert([]proto.Message{message[0]}, []string{"some-gateway"}, model.Gateway.MessageName)
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	c, err := controller.List("gateway", "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(1))
+	g.Expect(c[0].Name).To(gomega.Equal("some-gateway"))
+	g.Expect(c[0].Type).To(gomega.Equal(model.Gateway.Type))
+	g.Expect(c[0].Spec).To(gomega.Equal(message[0]))
+}
+
+func TestApplyChangeNoObjects(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController()
+
+	message := convertToEnvelope(g, []*networking.Gateway{gateway})
+	change := convert([]proto.Message{message[0]}, []string{"some-gateway"}, model.Gateway.MessageName)
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	c, err := controller.List("gateway", "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(1))
+	g.Expect(c[0].Name).To(gomega.Equal("some-gateway"))
+	g.Expect(c[0].Type).To(gomega.Equal(model.Gateway.Type))
+	g.Expect(c[0].Spec).To(gomega.Equal(message[0]))
+
+	change = convert([]proto.Message{}, []string{"some-gateway"}, model.Gateway.MessageName)
+
+	err = controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	c, err = controller.List("gateway", "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(len(c)).To(gomega.Equal(0))
+}
+
+func convert(resources []proto.Message, names []string, responseMessageName string) *mcpclient.Change {
+	out := new(mcpclient.Change)
+	out.TypeURL = responseMessageName
+	for i, res := range resources {
+		out.Objects = append(out.Objects,
+			&mcpclient.Object{
+				TypeURL: responseMessageName,
+				Metadata: &mcpapi.Metadata{
+					Name: names[i],
+				},
+				Resource: res,
+			},
+		)
+	}
+	return out
+}
+
+func convertToEnvelope(g *gomega.GomegaWithT, gateways []*networking.Gateway) (messages []proto.Message) {
+	for _, gateway := range gateways {
+		marshaledGateway, err := proto.Marshal(gateway)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		message, err := makeMessage(marshaledGateway, model.Gateway.MessageName)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		messages = append(messages, message)
+	}
+	return messages
+}
+
+func makeMessage(value []byte, responseMessageName string) (proto.Message, error) {
+	resource := &google_protobuf.Any{
+		TypeUrl: fmt.Sprintf("type.googleapis.com/%s", responseMessageName),
+		Value:   value,
+	}
+
+	var dynamicAny google_protobuf.DynamicAny
+	err := google_protobuf.UnmarshalAny(resource, &dynamicAny)
+	if err == nil {
+		return dynamicAny.Message, nil
+	}
+
+	return nil, err
+}

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -1,0 +1,151 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/onsi/gomega"
+
+	"istio.io/istio/mixer/test/client/env"
+	testenv "istio.io/istio/mixer/test/client/env"
+	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pilot/pkg/model"
+	mockmcp "istio.io/istio/tests/e2e/tests/pilot/mock/mcp"
+	"istio.io/istio/tests/util"
+
+	// Import the resource package to pull in all proto types.
+	_ "istio.io/istio/galley/pkg/metadata"
+)
+
+const (
+	pilotDebugPort = 5555
+	pilotGrpcPort  = 15010
+	mcpServerAddr  = "127.0.0.1:15014"
+)
+
+func TestPilotMCPClient(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	t.Log("building & starting mock mcp server...")
+	mcpServer, err := runMcpServer(g, t)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	initLocalPilotTestEnv(t, mcpServerAddr, pilotGrpcPort, pilotDebugPort)
+
+	g.Eventually(func() (string, error) {
+		return curlPilot(fmt.Sprintf("http://127.0.0.1:%d/debug/configz", pilotDebugPort))
+	}, "30s", "1s").Should(gomega.ContainSubstring("gateway"))
+
+	t.Log("run edge router envoy...")
+	gateway := runEnvoy(t, pilotGrpcPort, pilotDebugPort)
+
+	defer func() {
+		mcpServer.Close()
+		gateway.TearDown()
+	}()
+
+	t.Log("check that envoy is listening on the configured gateway...")
+	gatewayResource := fmt.Sprintf("127.0.0.1:%s", "8099")
+	g.Eventually(func() error {
+		_, err := net.Dial("tcp", gatewayResource)
+		return err
+	}, "180s", "1s").Should(gomega.Succeed())
+}
+
+func runMcpServer(g *gomega.GomegaWithT, t *testing.T) (*mockmcp.Server, error) {
+	supportedTypes := make([]string, len(model.IstioConfigTypes))
+	for i, model := range model.IstioConfigTypes {
+		supportedTypes[i] = fmt.Sprintf("type.googleapis.com/%s", model.MessageName)
+	}
+
+	server, err := mockmcp.NewServer(mcpServerAddr, supportedTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	return server, nil
+}
+
+func runEnvoy(t *testing.T, grpcPort, debugPort uint16) *env.TestSetup {
+	t.Log("create a new envoy test environment")
+	tmpl, err := ioutil.ReadFile(util.IstioSrc + "/tests/testdata/cf_bootstrap_tmpl.json")
+	if err != nil {
+		t.Fatal("Can't read bootstrap template", err)
+	}
+	nodeIDGateway := "router~x~x~x"
+
+	gateway := env.NewTestSetup(25, t)
+	gateway.SetNoMixer(true)
+	gateway.SetNoProxy(true)
+	gateway.SetNoBackend(true)
+	gateway.IstioSrc = util.IstioSrc
+	gateway.IstioOut = util.IstioOut
+	gateway.Ports().PilotGrpcPort = grpcPort
+	gateway.Ports().PilotHTTPPort = debugPort
+	gateway.EnvoyConfigOpt = map[string]interface{}{
+		"NodeID": nodeIDGateway,
+	}
+	gateway.EnvoyTemplate = string(tmpl)
+	gateway.EnvoyParams = []string{
+		"--service-node", nodeIDGateway,
+		"--service-cluster", "x",
+	}
+	if err := gateway.SetUp(); err != nil {
+		t.Fatalf("Failed to setup test: %v", err)
+	}
+	return gateway
+}
+
+func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int) {
+	testenv.NewTestSetup(testenv.PilotMCPTest, t)
+	debugAddr := fmt.Sprintf("127.0.0.1:%d", debugPort)
+	grpcAddr := fmt.Sprintf("127.0.0.1:%d", grpcPort)
+	util.EnsureTestServer(addMcpAddrs(mcpAddr), setupPilotDiscoveryHTTPAddr(debugAddr), setupPilotDiscoveryGrpcAddr(grpcAddr))
+}
+
+func addMcpAddrs(mcpServerAddr string) func(*bootstrap.PilotArgs) {
+	return func(arg *bootstrap.PilotArgs) {
+		arg.MCPServerAddrs = []string{mcpServerAddr}
+	}
+}
+
+func setupPilotDiscoveryHTTPAddr(http string) func(*bootstrap.PilotArgs) {
+	return func(arg *bootstrap.PilotArgs) {
+		arg.DiscoveryOptions.HTTPAddr = http
+	}
+}
+
+func setupPilotDiscoveryGrpcAddr(grpc string) func(*bootstrap.PilotArgs) {
+	return func(arg *bootstrap.PilotArgs) {
+		arg.DiscoveryOptions.GrpcAddr = grpc
+	}
+}
+
+func curlPilot(apiEndpoint string) (string, error) {
+	resp, err := http.DefaultClient.Get(apiEndpoint)
+	if err != nil {
+		return "", err
+	}
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(respBytes), nil
+}

--- a/tests/e2e/tests/pilot/mock/mcp/server.go
+++ b/tests/e2e/tests/pilot/mock/mcp/server.go
@@ -1,0 +1,177 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mcp
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+
+	"github.com/gogo/protobuf/proto"
+	google_protobuf "github.com/gogo/protobuf/types"
+	"google.golang.org/grpc"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+	mcpserver "istio.io/istio/pkg/mcp/server"
+)
+
+type mockWatcher struct{}
+
+func (m mockWatcher) Watch(req *mcp.MeshConfigRequest,
+	resp chan<- *mcpserver.WatchResponse) (*mcpserver.WatchResponse, mcpserver.CancelWatchFunc) {
+
+	var cancelFunc mcpserver.CancelWatchFunc
+	cancelFunc = func() {
+		log.Printf("watch canceled for %s\n", req.GetTypeUrl())
+	}
+
+	if req.GetTypeUrl() == fmt.Sprintf("type.googleapis.com/%s", model.Gateway.MessageName) {
+		marshaledFirstGateway, err := proto.Marshal(firstGateway)
+		if err != nil {
+			log.Fatalf("marshaling gateway %s\n", err)
+		}
+		marshaledSecondGateway, err := proto.Marshal(secondGateway)
+		if err != nil {
+			log.Fatalf("marshaling gateway %s\n", err)
+		}
+
+		return &mcpserver.WatchResponse{
+			Version: req.GetVersionInfo(),
+			TypeURL: req.GetTypeUrl(),
+			Envelopes: []*mcp.Envelope{
+				{
+					Metadata: &mcp.Metadata{
+						Name: "some-name",
+					},
+					Resource: &google_protobuf.Any{
+						TypeUrl: req.GetTypeUrl(),
+						Value:   marshaledFirstGateway,
+					},
+				},
+				{
+					Metadata: &mcp.Metadata{
+						Name: "some-other-name",
+					},
+					Resource: &google_protobuf.Any{
+						TypeUrl: req.GetTypeUrl(),
+						Value:   marshaledSecondGateway,
+					},
+				},
+			},
+		}, cancelFunc
+	}
+
+	return &mcpserver.WatchResponse{
+		Version:   req.GetVersionInfo(),
+		TypeURL:   req.GetTypeUrl(),
+		Envelopes: []*mcp.Envelope{},
+	}, cancelFunc
+}
+
+type Server struct {
+	// The internal snapshot.Cache that the server is using.
+	Watcher *mockWatcher
+
+	// TypeURLs that were originally passed in.
+	TypeURLs []string
+
+	// Port that the service is listening on.
+	Port int
+
+	// The gRPC compatible address of the service.
+	URL *url.URL
+
+	gs *grpc.Server
+	l  net.Listener
+}
+
+func NewServer(addr string, typeUrls []string) (*Server, error) {
+	watcher := mockWatcher{}
+	s := mcpserver.New(watcher, typeUrls, nil)
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	p := l.Addr().(*net.TCPAddr).Port
+
+	u, err := url.Parse(fmt.Sprintf("tcp://localhost:%d", p))
+	if err != nil {
+		_ = l.Close()
+		return nil, err
+	}
+
+	gs := grpc.NewServer()
+
+	mcp.RegisterAggregatedMeshConfigServiceServer(gs, s)
+	go func() { _ = gs.Serve(l) }()
+	log.Printf("MCP mock server listening on %s", addr)
+
+	return &Server{
+		Watcher:  &watcher,
+		TypeURLs: typeUrls,
+		Port:     p,
+		URL:      u,
+		gs:       gs,
+		l:        l,
+	}, nil
+}
+
+func (t *Server) Close() (err error) {
+	if t.gs != nil {
+		t.gs.Stop()
+		t.gs = nil
+	}
+
+	t.l = nil // gRPC stack will close this
+	t.Watcher = nil
+	t.TypeURLs = nil
+	t.Port = 0
+
+	return
+}
+
+var firstGateway = &networking.Gateway{
+	Servers: []*networking.Server{
+		&networking.Server{
+			Port: &networking.Port{
+				Name:     "http-8099",
+				Number:   8099,
+				Protocol: "http",
+			},
+			Hosts: []string{
+				"bar.example.com",
+			},
+		},
+	},
+}
+
+var secondGateway = &networking.Gateway{
+	Servers: []*networking.Server{
+		&networking.Server{
+			Port: &networking.Port{
+				Name:     "tcp-880",
+				Number:   880,
+				Protocol: "tcp",
+			},
+			Hosts: []string{
+				"foo.example.org",
+			},
+		},
+	},
+}

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -97,9 +97,9 @@ func init() {
 
 // EnsureTestServer will ensure a pilot server is running in process and initializes
 // the MockPilotUrl and MockPilotGrpcAddr to allow connections to the test pilot.
-func EnsureTestServer() *bootstrap.Server {
+func EnsureTestServer(args ...func(*bootstrap.PilotArgs)) *bootstrap.Server {
 	if MockTestServer == nil {
-		err := setup()
+		err := setup(args...)
 		if err != nil {
 			log.Fatal("Failed to start in-process server", err)
 		}
@@ -107,7 +107,7 @@ func EnsureTestServer() *bootstrap.Server {
 	return MockTestServer
 }
 
-func setup() error {
+func setup(additionalArgs ...func(*bootstrap.PilotArgs)) error {
 	// TODO: point to test data directory
 	// Setting FileDir (--configDir) disables k8s client initialization, including for registries,
 	// and uses a 100ms scan. Must be used with the mock registry (or one of the others)
@@ -151,6 +151,10 @@ func setup() error {
 	args.Config.FileDir = IstioSrc + "/tests/testdata/config"
 
 	bootstrap.PilotCertDir = IstioSrc + "/tests/testdata/certs/pilot"
+
+	for _, apply := range additionalArgs {
+		apply(&args)
+	}
 
 	// Create and setup the controller.
 	s, err := bootstrap.NewServer(args)


### PR DESCRIPTION
This PR is the phase one (IstioConfigStore only and no ServiceDiscovery) of the MCP client integration work, also added an end to end test which verifies that provided gateway via mcp is enabled by envoy. 