### PR TITLE
Initial support to get coverage from e2e tests on minikube

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -1,0 +1,61 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coverage
+
+import (
+	"os"
+	"os/signal"
+	"fmt"
+	"syscall"
+)
+
+type Coverage struct {
+	FatalLog  chan string
+	Terminate chan os.Signal
+	Exit      chan error
+}
+
+func Enabled() bool {
+	return os.Getenv("COVERAGE") == "true"
+}
+
+func NewCoverage() *Coverage {
+	cov := Coverage{
+		FatalLog:  make(chan string),
+		Terminate: make(chan os.Signal),
+		Exit:      make(chan error),
+	}
+	signal.Notify(cov.Terminate, syscall.SIGINT, syscall.SIGTERM)
+	return &cov
+}
+
+func (c *Coverage) LogFatal(format string, args ...interface{}) {
+	message := fmt.Sprintf(format, args...)
+	_, _ = fmt.Fprintf(os.Stderr, message+"\n") // #nosec
+	c.FatalLog <- message
+}
+
+func (c *Coverage) Wait() error {
+
+	select {
+	case log := <-c.FatalLog:
+		return fmt.Errorf(log)
+	case err := <-c.Exit:
+		return err
+	case <-c.Terminate:
+		return nil
+	}
+
+}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -5,6 +5,12 @@
       priorityClassName: "{{ $.Values.global.priorityClassName }}"
 {{- end }}
       volumes:
+    {{- if .Values.global.istiotesting.coverageMode }}
+      - name: coverage
+        hostPath:
+          path: /coverage
+          type: DirectoryOrCreate
+    {{- end }}
       - name: istio-certs
         secret:
           secretName: istio.istio-mixer-service-account
@@ -25,11 +31,25 @@
         - containerPort: 9093
         - containerPort: 42422
         args:
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - --test.run=TestCoverageMain
+          - --test.coverprofile=/coverage/$(POD_NAME)-istio-policy.cov
+        {{- end }}
           - --address
           - unix:///sock/mixer.socket
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+        env:
+      {{- if .Values.global.istiotesting.coverageMode }}
+        - name: COVERAGE
+          value: "true"
+      {{- end }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
@@ -37,6 +57,10 @@
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
+      {{- if .Values.global.istiotesting.coverageMode }}
+        - name: coverage
+          mountPath: /coverage
+      {{- end }}
         - name: uds-socket
           mountPath: /sock
         livenessProbe:
@@ -98,6 +122,12 @@
     spec:
       serviceAccountName: istio-mixer-service-account
       volumes:
+    {{- if .Values.global.istiotesting.coverageMode }}
+      - name: coverage
+        hostPath:
+          path: /coverage
+          type: DirectoryOrCreate
+    {{- end }}
       - name: istio-certs
         secret:
           secretName: istio.istio-mixer-service-account
@@ -120,11 +150,25 @@
         - containerPort: 9093
         - containerPort: 42422
         args:
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - --test.run=TestCoverageMain
+          - --test.coverprofile=/coverage/$(POD_NAME)-istio-telemetry.cov
+        {{- end }}
           - --address
           - unix:///sock/mixer.socket
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+        env:
+      {{- if .Values.global.istiotesting.coverageMode }}
+        - name: COVERAGE
+          value: "true"
+      {{- end }}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
@@ -132,6 +176,10 @@
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
         volumeMounts:
+      {{- if .Values.global.istiotesting.coverageMode }}
+        - name: coverage
+          mountPath: /coverage
+      {{- end }}
         - name: uds-socket
           mountPath: /sock
         livenessProbe:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
 {{- end }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
+{{- if .Values.global.istiotesting.coverageMode }}
+          - --test.run=TestCoverageMain
+          - --test.coverprofile=/coverage/$(POD_NAME)-dicovery.cov
+          - '-'
+{{- end }}
           - "discovery"
 {{- if .Values.global.oneNamespace }}
           - "-a"
@@ -59,6 +64,10 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           env:
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - name: COVERAGE
+            value: "true"
+        {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -90,6 +99,10 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           volumeMounts:
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - name: coverage
+            mountPath: /coverage
+        {{- end }}
           - name: config-volume
             mountPath: /etc/istio/config
           - name: istio-certs
@@ -145,6 +158,12 @@ spec:
             readOnly: true
 {{- end }}
       volumes:
+    {{- if .Values.global.istiotesting.coverageMode }}
+      - name: coverage
+        hostPath:
+          path: /coverage
+          type: DirectoryOrCreate
+    {{- end }}
       - name: config-volume
         configMap:
           name: istio

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -26,9 +26,24 @@ spec:
 {{- end }}
       containers:
         - name: citadel
+          env:
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - name: COVERAGE
+            value: "true"
+        {{- end }}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
+          {{- if .Values.global.istiotesting.coverageMode }}
+            - --test.run=TestCoverageMain
+            - --test.coverprofile=/coverage/$(POD_NAME)-citadel.cov
+            - '-'
+          {{- end }}
             - --append-dns-names=true
             - --grpc-port=8060
             - --grpc-hostname=citadel
@@ -48,16 +63,28 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
-{{- if not .Values.selfSigned }}
           volumeMounts:
+        {{- if not .Values.selfSigned }}
           - name: cacerts
             mountPath: /etc/cacerts
             readOnly: true
+        {{- end }}
+        {{- if .Values.global.istiotesting.coverageMode }}
+          - name: coverage
+            mountPath: /coverage
+        {{- end }}
       volumes:
+    {{- if not .Values.selfSigned }}
       - name: cacerts
         secret:
          secretName: cacerts
          optional: true
-{{- end }}
+    {{- end }}
+    {{- if .Values.global.istiotesting.coverageMode }}
+      - name: coverage
+        hostPath:
+          path: /coverage
+          type: DirectoryOrCreate
+    {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
           image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
+          {{- if .Values.global.istiotesting.coverageMode }}
+            - --test.run=TestCoverageMain
+            - --test.coverprofile=/coverage/$(POD_NAME)-sidecar-injector-webhook.cov
+            - '-'
+          {{- end }}
             - --caCertFile=/etc/istio/certs/root-cert.pem
             - --tlsCertFile=/etc/istio/certs/cert-chain.pem
             - --tlsKeyFile=/etc/istio/certs/key.pem
@@ -35,6 +40,16 @@ spec:
             - --meshConfig=/etc/istio/config/mesh
             - --healthCheckInterval=2s
             - --healthCheckFile=/health
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          {{- if .Values.global.istiotesting.coverageMode }}
+          - name: COVERAGE
+            value: "true"
+          {{- end }}
           volumeMounts:
           - name: config-volume
             mountPath: /etc/istio/config
@@ -45,6 +60,10 @@ spec:
           - name: inject-config
             mountPath: /etc/istio/inject
             readOnly: true
+          {{- if .Values.global.istiotesting.coverageMode }}
+          - name: coverage
+            mountPath: /coverage
+          {{- end }}
           livenessProbe:
             exec:
               command:
@@ -82,5 +101,12 @@ spec:
           items:
           - key: config
             path: config
+      {{- if .Values.global.istiotesting.coverageMode }}
+      - name: coverage
+        hostPath:
+          path: /coverage
+          type: DirectoryOrCreate
+      {{- end }}
+
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -155,6 +155,12 @@ global:
   # and this options must be set off.
   crds: true
 
+  # Any customization for istio testing should be here
+  istiotesting:
+    # Enable code coverage mode
+    coverageMode: false
+
+
 #
 # ingress configuration
 #

--- a/istioctl/cmd/istioctl/coverage_test.go
+++ b/istioctl/cmd/istioctl/coverage_test.go
@@ -16,14 +16,15 @@ package main
 
 import (
 	"testing"
+
 	"istio.io/istio/coverage"
 )
 
 func TestCoverageMain(t *testing.T) {
 	if coverage.Enabled() {
-		cov := coverage.NewCoverage()
+		cov := coverage.NewHelper()
 		go func() {
-			cov.Exit <-rootCmd.Execute()
+			cov.Exit <- rootCmd.Execute()
 		}()
 		cov.Wait()
 	}

--- a/istioctl/cmd/istioctl/coverage_test.go
+++ b/istioctl/cmd/istioctl/coverage_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"istio.io/istio/coverage"
+)
+
+func TestCoverageMain(t *testing.T) {
+	if coverage.Enabled() {
+		cov := coverage.NewCoverage()
+		go func() {
+			cov.Exit <-rootCmd.Execute()
+		}()
+		cov.Wait()
+	}
+}

--- a/mixer/cmd/mixs/coverage_test.go
+++ b/mixer/cmd/mixs/coverage_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestCoverageMain(t *testing.T) {
 	if coverage.Enabled() {
-		cov := coverage.NewCoverage()
+		cov := coverage.NewHelper()
 		rootCmd := cmd.GetRootCmd(os.Args[1:], supportedTemplates(), supportedAdapters(), shared.Printf, cov.LogFatal)
 		go func() {
 			cov.Exit <- rootCmd.Execute()

--- a/mixer/cmd/mixs/coverage_test.go
+++ b/mixer/cmd/mixs/coverage_test.go
@@ -1,0 +1,37 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	"istio.io/istio/coverage"
+	"istio.io/istio/mixer/cmd/mixs/cmd"
+	"istio.io/istio/mixer/cmd/shared"
+)
+
+func TestCoverageMain(t *testing.T) {
+	if coverage.Enabled() {
+		cov := coverage.NewCoverage()
+		rootCmd := cmd.GetRootCmd(os.Args[1:], supportedTemplates(), supportedAdapters(), shared.Printf, cov.LogFatal)
+		go func() {
+			cov.Exit <- rootCmd.Execute()
+		}()
+		if err := cov.Wait(); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/pilot/cmd/pilot-discovery/coverage_test.go
+++ b/pilot/cmd/pilot-discovery/coverage_test.go
@@ -16,14 +16,15 @@ package main
 
 import (
 	"testing"
+
 	"istio.io/istio/coverage"
 )
 
 func TestCoverageMain(t *testing.T) {
 	if coverage.Enabled() {
-		cov := coverage.NewCoverage()
+		cov := coverage.NewHelper()
 		go func() {
-			cov.Exit <-rootCmd.Execute()
+			cov.Exit <- rootCmd.Execute()
 		}()
 		cov.Wait()
 	}

--- a/pilot/cmd/pilot-discovery/coverage_test.go
+++ b/pilot/cmd/pilot-discovery/coverage_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"istio.io/istio/coverage"
+)
+
+func TestCoverageMain(t *testing.T) {
+	if coverage.Enabled() {
+		cov := coverage.NewCoverage()
+		go func() {
+			cov.Exit <-rootCmd.Execute()
+		}()
+		cov.Wait()
+	}
+}

--- a/pilot/cmd/sidecar-injector/coverage_test.go
+++ b/pilot/cmd/sidecar-injector/coverage_test.go
@@ -16,14 +16,15 @@ package main
 
 import (
 	"testing"
+
 	"istio.io/istio/coverage"
 )
 
 func TestCoverageMain(t *testing.T) {
 	if coverage.Enabled() {
-		cov := coverage.NewCoverage()
+		cov := coverage.NewHelper()
 		go func() {
-			cov.Exit <-rootCmd.Execute()
+			cov.Exit <- rootCmd.Execute()
 		}()
 		cov.Wait()
 	}

--- a/pilot/cmd/sidecar-injector/coverage_test.go
+++ b/pilot/cmd/sidecar-injector/coverage_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"istio.io/istio/coverage"
+)
+
+func TestCoverageMain(t *testing.T) {
+	if coverage.Enabled() {
+		cov := coverage.NewCoverage()
+		go func() {
+			cov.Exit <-rootCmd.Execute()
+		}()
+		cov.Wait()
+	}
+}

--- a/security/cmd/istio_ca/coverage_test.go
+++ b/security/cmd/istio_ca/coverage_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"istio.io/istio/coverage"
+)
+
+
+func TestCoverageMain(t *testing.T) {
+	if coverage.Enabled() {
+		cov := coverage.NewCoverage()
+		go func() {
+			cov.Exit <-rootCmd.Execute()
+		}()
+		cov.Wait()
+	}
+}

--- a/security/cmd/istio_ca/coverage_test.go
+++ b/security/cmd/istio_ca/coverage_test.go
@@ -16,15 +16,15 @@ package main
 
 import (
 	"testing"
+
 	"istio.io/istio/coverage"
 )
 
-
 func TestCoverageMain(t *testing.T) {
 	if coverage.Enabled() {
-		cov := coverage.NewCoverage()
+		cov := coverage.NewHelper()
 		go func() {
-			cov.Exit <-rootCmd.Execute()
+			cov.Exit <- rootCmd.Execute()
 		}()
 		cov.Wait()
 	}

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -6,4 +6,5 @@ ADD ca-certificates.tgz /
 WORKDIR /tmp/
 ADD istio_ca /usr/local/bin/istio_ca
 
-ENTRYPOINT [ "/usr/local/bin/istio_ca", "--self-signed-ca" ]
+ENTRYPOINT [ "/usr/local/bin/istio_ca" ]
+CMD [ "--self-signed-ca" ]

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -90,7 +90,7 @@ func NewCommonConfigWithVersion(testID, version string) (*CommonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := newKubeInfo(t.TempDir, t.RunID, version)
+	k, err := newKubeInfo(t, version)
 	if err != nil {
 		return nil, err
 	}
@@ -195,10 +195,6 @@ func (c *CommonConfig) saveLogs(r int) error {
 		return nil
 	}
 	log.Info("Saving logs")
-	if err := c.Info.Update(r); err != nil {
-		log.Errorf("Could not create status file. Error %s", err)
-		return err
-	}
 	return c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.KubeConfig)
 }
 

--- a/tests/e2e/framework/framework_test.go
+++ b/tests/e2e/framework/framework_test.go
@@ -53,7 +53,7 @@ func newCommonConfig(testID string) (*CommonConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	k, err := newKubeInfo(t.TempDir, t.RunID, "")
+	k, err := newKubeInfo(t, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Trying to make code coverage less intrusive as possible. All coverage enable binary are created in go/linux_amd64/coverage, such that they don't impact normal workflows. One needs to set the env variable ```COVERAGE=true``` to produce coverage enable binaries. However the docker images created will use the same name.

Updated the helm template for code coverage. The data will be saved on the minikube vm on /coverage.

Right now only a few binaries are enabled (mixs, istioctl, pilot-discovery, sidecar-injector and istio_ca), simply because more intrusive work is required to get the other to work. I was able to run the e2e-simple e2e on minikube with success, and got some failures on the e2e_all suite, but still able to some coverage information.

I am working with another team to be able to merge the code coverage to test grid, but part of the tool they use is not open source yet. Once that's done I'll update a circle CI codecov target to get more data. 