### PR TITLE
Properly format values.yaml for docification

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -253,60 +253,60 @@ gateways:
     serviceAnnotations: {}
     type: ClusterIP #change to NodePort or LoadBalancer if need be
     ports:
-      - port: 80
-        name: http2
-      - port: 443
-        name: https
+    - port: 80
+      name: http2
+    - port: 443
+      name: https
     secretVolumes:
-      - name: egressgateway-certs
-        secretName: istio-egressgateway-certs
-        mountPath: /etc/istio/egressgateway-certs
-      - name: egressgateway-ca-certs
-        secretName: istio-egressgateway-ca-certs
-        mountPath: /etc/istio/egressgateway-ca-certs
+    - name: egressgateway-certs
+      secretName: istio-egressgateway-certs
+      mountPath: /etc/istio/egressgateway-certs
+    - name: egressgateway-ca-certs
+      secretName: istio-egressgateway-ca-certs
+      mountPath: /etc/istio/egressgateway-ca-certs
 
   # Mesh ILB gateway creates a gateway of type InternalLoadBalancer,
   # for mesh expansion. It exposes the mtls ports for Pilot,CA as well
   # as non-mtls ports to support upgrades and gradual transition.
   istio-ilbgateway:
-      enabled: false
-      labels:
-        app: istio-ilbgateway
-        istio: ilbgateway
-      replicaCount: 1
-      autoscaleMin: 1
-      autoscaleMax: 5
-      resources:
-        requests:
-          cpu: 800m
-          memory: 512Mi
-        #limits:
-        #  cpu: 1800m
-        #  memory: 256Mi
-      loadBalancerIP: ""
-      serviceAnnotations:
-        cloud.google.com/load-balancer-type: "internal"
-      type: LoadBalancer
-      ports:
-      ## You can add custom gateway ports - google ILB default quota is 5 ports,
-      - port: 15011
-        name: grpc-pilot-mtls
-      # Insecure port - only for migration from 0.8. Will be removed in 1.1
-      - port: 15010
-        name: grpc-pilot
-      - port: 8060
-        targetPort: 8060
-        name: tcp-citadel-grpc-tls
-      # Port 5353 is forwarded to kube-dns
-      - port: 5353
-        name: tcp-dns
-      secretVolumes:
-      - name: ilbgateway-certs
-        secretName: istio-ilbgateway-certs
-        mountPath: /etc/istio/ilbgateway-certs
-      - name: ilbgateway-ca-certs
-        secretName: istio-ilbgateway-ca-certs
-        mountPath: /etc/istio/ilbgateway-ca-certs
+    enabled: false
+    labels:
+      app: istio-ilbgateway
+      istio: ilbgateway
+    replicaCount: 1
+    autoscaleMin: 1
+    autoscaleMax: 5
+    resources:
+      requests:
+        cpu: 800m
+        memory: 512Mi
+      #limits:
+      #  cpu: 1800m
+      #  memory: 256Mi
+    loadBalancerIP: ""
+    serviceAnnotations:
+      cloud.google.com/load-balancer-type: "internal"
+    type: LoadBalancer
+    ports:
+    ## You can add custom gateway ports - google ILB default quota is 5 ports,
+    - port: 15011
+      name: grpc-pilot-mtls
+    # Insecure port - only for migration from 0.8. Will be removed in 1.1
+    - port: 15010
+      name: grpc-pilot
+    - port: 8060
+      targetPort: 8060
+      name: tcp-citadel-grpc-tls
+    # Port 5353 is forwarded to kube-dns
+    - port: 5353
+      name: tcp-dns
+    secretVolumes:
+    - name: ilbgateway-certs
+      secretName: istio-ilbgateway-certs
+      mountPath: /etc/istio/ilbgateway-certs
+    - name: ilbgateway-ca-certs
+      secretName: istio-ilbgateway-ca-certs
+      mountPath: /etc/istio/ilbgateway-ca-certs
 
 
 #


### PR DESCRIPTION
In the istio.github.io repository, we have a tool which processes
values.yaml.  In order for that tool to work correctly, every
level in the YAML must be 2 characters exactly.  In a few cases,
the spacing isn't two, but four, or alternately the lists have a prefix
of two spaces.  I'm not sure why helm processes this incorrect YAML, but
the parser we are using in the docs repo requires strict YAML.