### PR TITLE
ShellCheck: Enable and fix syntax checking rules

### DIFF
--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -67,7 +67,7 @@ fi
 # Install minikube.
 echo "Checking and Installing Minikube version 0.27.0 as required"
 minikube --help > /dev/null
-if [[ $? -ne 0 || (`minikube version` != *"minikube version: v0.27.0"*) ]]; then
+if [[ $? -ne 0 || ($(minikube version) != *"minikube version: v0.27.0"*) ]]; then
   if [ $? -eq 0 ]; then
     echo "Deleting previous minikube cluster and updating minikube to v0.27.0"
     minikube delete

--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -68,7 +68,7 @@ fi
 echo "Checking and Installing Minikube version 0.27.0 as required"
 minikube --help > /dev/null
 if [[ $? -ne 0 || (`minikube version` != *"minikube version: v0.27.0"*) ]]; then
-  if [ $? -eq 0]; then
+  if [ $? -eq 0 ]; then
     echo "Deleting previous minikube cluster and updating minikube to v0.27.0"
     minikube delete
     rm -rf ~/.minikube

--- a/tests/e2e/local/minikube/install_prereqs_macos.sh
+++ b/tests/e2e/local/minikube/install_prereqs_macos.sh
@@ -87,7 +87,7 @@ fi
 
 echo "Checking and Installing Minikube version 0.27.0 as required..."
 minikube --help > /dev/null
-if [[ $? -ne 0 || (`minikube version` != *"minikube version: v0.27.0"*) ]]; then
+if [[ $? -ne 0 || ($(minikube version) != *"minikube version: v0.27.0"*) ]]; then
     if [ $? -eq 0 ]; then
         echo "Deleting previous minikube cluster and updating minikube to v0.27.0"
         minikube delete

--- a/tests/e2e/local/minikube/install_prereqs_macos.sh
+++ b/tests/e2e/local/minikube/install_prereqs_macos.sh
@@ -14,12 +14,10 @@ sudo chown -R $USER:admin /usr/local/bin
 
 echo "Checking curl"
 curl --help > /dev/null
-if [ $? -ne 0 ]; 
-then
+if [ $? -ne 0 ]; then
     echo "curl is not installed. Install it from homebrew."
     brew install curl
-    if [ $? -ne 0 ]; 
-    then
+    if [ $? -ne 0 ]; then
     	echo "Installation of curl from brew fails. Please install it manually."
         exit 1
     else
@@ -31,12 +29,10 @@ fi
 
 echo "Checking docker..."
 docker --help > /dev/null
-if [ $? -ne 0 ]; 
-then
+if [ $? -ne 0 ]; then
     echo "docker is not installed. Install it from homebrew cask."
     brew cask install docker
-    if [ $? -ne 0 ]; 
-    then
+    if [ $? -ne 0 ]; then
     	echo "Installation of docker from brew fails. Please install it manually."
         exit 1
     else
@@ -48,13 +44,11 @@ fi
 
 echo "Checking docker-machine..."
 docker-machine --help > /dev/null
-if [ $? -ne 0 ];
-then
+if [ $? -ne 0 ]; then
     echo "docker-machine is not installed. Downloading and Installing it using curl."
     base=https://github.com/docker/machine/releases/download/v0.14.0 &&
   curl -L $base/docker-machine-$(uname -s)-$(uname -m) >/usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine
-    if [ $? -ne 0 ];
-    then
+    if [ $? -ne 0 ]; then
         echo "Installation of docker-machine failed. Please install it manually."
         exit 1
     else
@@ -66,8 +60,7 @@ else
 fi
 
 function fail_hyperkit_installation() {
-  if [ $? -ne 0 ];
-    then
+    if [ $? -ne 0 ]; then
         echo "Installation of hyperkit driver failed. Please install it manually."
         exit 1
     fi
@@ -75,8 +68,7 @@ function fail_hyperkit_installation() {
 
 echo "Checking hyperkit..."
 hyperkit -h > /dev/null
-if [ $? -ne 0 ];
-then
+if [ $? -ne 0 ]; then
     echo "hyperkit is not installed. Downloading and installing using curl."
     curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit
     fail_hyperkit_installation
@@ -95,16 +87,14 @@ fi
 
 echo "Checking and Installing Minikube version 0.27.0 as required..."
 minikube --help > /dev/null
-if [[ $? -ne 0 || (`minikube version` != *"minikube version: v0.27.0"*) ]];
-then
-    if [ $? -eq 0]; then
+if [[ $? -ne 0 || (`minikube version` != *"minikube version: v0.27.0"*) ]]; then
+    if [ $? -eq 0 ]; then
         echo "Deleting previous minikube cluster and updating minikube to v0.27.0"
         minikube delete
     fi
     echo "Minikube version 0.27.0 is not installed. Installing it using curl."
     curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-darwin-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-    if [ $? -ne 0 ]; 
-    then
+    if [ $? -ne 0 ]; then
     	echo "Installation of Minikube version 0.27.0 failed. Please install it manually."
         exit 1
     else
@@ -114,12 +104,10 @@ fi
 
 echo "Checking kubectl..."
 kubectl --help > /dev/null
-if [ $? -ne 0 ]; 
-then
+if [ $? -ne 0 ]; then
     echo "kubectl is not installed. Installing the lastest stable release..."
     brew install kubectl
-    if [ $? -ne 0 ]; 
-    then
+    if [ $? -ne 0 ]; then
     	echo "Installation of kubectl from brew fails. Please install it manually."
         exit 1
     else

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -7,12 +7,8 @@ ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 
 # See https://github.com/koalaman/shellcheck/wiki for details on each code's
 # corresponding rule.
-EXCLUDES="1009,"
-EXCLUDES="${EXCLUDES}1020,"
-EXCLUDES="${EXCLUDES}1054,"
+EXCLUDES="1054,"
 EXCLUDES="${EXCLUDES}1056,"
-EXCLUDES="${EXCLUDES}1072,"
-EXCLUDES="${EXCLUDES}1073,"
 EXCLUDES="${EXCLUDES}1083,"
 EXCLUDES="${EXCLUDES}1090,"
 EXCLUDES="${EXCLUDES}1091,"

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -68,13 +68,15 @@ SH_FILES=$( \
         -name '*.sh' -type f \
         -not -path '*/vendor/*' \
         -not -path '*/.git/*')
-# All files not ending in .sh but containing a shebang.
+# All files not ending in .sh but starting with a shebang.
 SHEBANG_FILES=$( \
     find "${ISTIO_ROOT}" \
         -not -name '*.sh' -type f \
         -not -path '*/vendor/*' \
-        -not -path '*/.git/*' -print0 \
-        | xargs -0 grep -l '^#!.*sh')
+        -not -path '*/.git/*' | \
+        while read f; do
+            head -n 1 "$f" | grep -q '^#!.*sh' && echo "$f";
+        done)
 
 echo "${SH_FILES}" "${SHEBANG_FILES}" \
     | xargs shellcheck --exclude="${EXCLUDES}"


### PR DESCRIPTION
- Reduces files checked
  - "run_shellcheck.sh" was checking template files such as [install-custom-resources.sh.tpl](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/templates/install-custom-resources.sh.tpl), which ShellCheck is not capable of parsing
- Enables and fixes various syntax checking rules
  - [SC1020](https://github.com/koalaman/shellcheck/wiki/SC1020) and related [SC1009](https://github.com/koalaman/shellcheck/wiki/SC1009)
  - [SC1073](https://github.com/koalaman/shellcheck/wiki/SC1073) and related [SC1072](https://github.com/koalaman/shellcheck/wiki/SC1072)

/cc @mandarjog 
/assign @mandarjog 