### PR TITLE
Add config volumes and containers to gateways

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -106,6 +106,9 @@ spec:
             mountPath: {{ .mountPath | quote }}
             readOnly: true
           {{- end }}
+{{- if $spec.additionalContainers }}
+{{ toYaml $spec.additionalContainers | indent 8 }}
+{{- end }}
       volumes:
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -117,6 +117,12 @@ spec:
           secretName: {{ .secretName | quote }}
           optional: true
       {{- end }}
+      {{- range $spec.configVolumes }}
+      - name: {{ .name }}
+        configMap:
+          name: {{ .configMapName | quote }}
+          optional: true
+      {{- end }}
       affinity:
       {{- include "nodeaffinity" $ | indent 6 }}
 ---


### PR DESCRIPTION
This PR enables adding additional containers to a gateway and also config map volumes. This is required for the a-la carte gateway deployment. Istio admin could easily deploy a gateway with additional containers for additional proxies and other containers for gateway functionality etc.

Usage example: https://github.com/istio/istio.github.io/pull/1984/files#diff-f575cfe44a3c5c856818f557636cba53R243