### PR TITLE
[helm chart] quotes for service annotation values

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
   annotations:
     {{- range $key, $val := $spec.serviceAnnotations }}
-    {{ $key }}: {{ $val }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $val := .Values.service.annotations }}
-    {{ $key }}: {{ $val }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
     app: {{ template "grafana.name" . }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     istio: ingress
   annotations:
     {{- range $key, $val := .Values.service.annotations }}
-    {{ $key }}: {{ $val }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
 spec:
 {{- if .Values.service.loadBalancerIP }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     prometheus.io/scrape: 'true'
     {{- range $key, $val := .Values.service.annotations }}
-    {{ $key }}: {{ $val }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
     name: prometheus

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $val := .Values.service.annotations }}
-    {{ $key }}: {{ $val }}
+    {{ $key }}: {{ $val | quote }}
     {{- end }}
   labels:
     app: servicegraph

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service-jaeger.yaml
@@ -10,7 +10,7 @@ items:
     namespace: {{ .Release.Namespace }}
     annotations:
       {{- range $key, $val := .Values.service.annotations }}
-      {{ $key }}: {{ $val }}
+      {{ $key }}: {{ $val | quote }}
       {{- end }}
     labels:
       app: jaeger

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -27,7 +27,7 @@ items:
     namespace: {{ .Release.Namespace }}
     annotations:
       {{- range $key, $val := .Values.service.annotations }}
-      {{ $key }}: {{ $val }}
+      {{ $key }}: {{ $val | quote }}
       {{- end }}
     labels:
       app: jaeger


### PR DESCRIPTION
Issue: annotation values' quotes are removed. 
```yaml
service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: 'true'
service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '300'
```
becomes 
```yaml
service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: true
service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: 300
```

Solution: add quote option