### PR TITLE
Enable testlinter and fix violations of skip by issue rule.

### DIFF
--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -41,6 +41,14 @@ popd
 $gometalinter --config=./mixer/tools/adapterlinter/gometalinter.json ./mixer/adapter/...
 echo 'gometalinter on adapters OK'
 
+echo 'Running testlinter ...'
+pushd tests/util/checker/testlinter
+go install .
+popd
+
+$gometalinter --config=./tests/util/checker/testlinter/testlinter.json ./...
+echo 'testlinter OK'
+
 echo 'Running helm lint on istio & istio-remote ....'
 helm lint ./install/kubernetes/helm/{istio,istio-remote}
 echo 'helm lint on istio & istio-remote OK'

--- a/mixer/pkg/runtime/config/validator/validator_test.go
+++ b/mixer/pkg/runtime/config/validator/validator_test.go
@@ -290,7 +290,7 @@ func TestValidator(t *testing.T) {
 }
 
 func TestValidatorToRememberValidation(t *testing.T) {
-	t.SkipNow()
+	t.Skip("https://github.com/istio/istio/issues/7696")
 	for _, c := range []struct {
 		title string
 		ev1   *store.Event

--- a/pilot/pkg/serviceregistry/consul/monitor_test.go
+++ b/pilot/pkg/serviceregistry/consul/monitor_test.go
@@ -30,9 +30,6 @@ const (
 )
 
 func TestController(t *testing.T) {
-	// https://github.com/istio/istio/issues/2318
-	t.SkipNow()
-
 	ts := newServer()
 	defer ts.Server.Close()
 	conf := api.DefaultConfig()

--- a/tests/e2e/tests/pilot/a_zipkin_test.go
+++ b/tests/e2e/tests/pilot/a_zipkin_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 func TestZipkin(t *testing.T) {
-	t.Skipf("Skipping %s", t.Name())
+	t.Skip("https://github.com/istio/istio/issues/7695")
 	for i := 0; i < numTraces; i++ {
 		testName := fmt.Sprintf("index_%d", i)
 		traceSent := false

--- a/tests/e2e/tests/simple/a_simple_1_test.go
+++ b/tests/e2e/tests/simple/a_simple_1_test.go
@@ -246,6 +246,7 @@ func TestAuthWithHeaders(t *testing.T) {
 }
 
 func Test503sDuringChanges(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/1038")
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	rulePath1 := util.GetResourcePath(yamlPath(routingR1Yaml))
 	rulePath2 := util.GetResourcePath(yamlPath(routingR2Yaml))
@@ -290,6 +291,7 @@ func Test503sDuringChanges(t *testing.T) {
 // This one may need to be fixed through some retries or health check
 // config/setup/policy in envoy (through pilot)
 func Test503sWithBadClusters(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/1038")
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	rulePath := util.GetResourcePath(yamlPath(routingRNPYaml))
 	go func() {

--- a/tests/e2e/tests/simple/a_simple_1_test.go
+++ b/tests/e2e/tests/simple/a_simple_1_test.go
@@ -246,7 +246,6 @@ func TestAuthWithHeaders(t *testing.T) {
 }
 
 func Test503sDuringChanges(t *testing.T) {
-	t.Skip("Skipping Test503sDuringChanges until bug #1038 is fixed") // TODO fix me!
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	rulePath1 := util.GetResourcePath(yamlPath(routingR1Yaml))
 	rulePath2 := util.GetResourcePath(yamlPath(routingR2Yaml))
@@ -291,7 +290,6 @@ func Test503sDuringChanges(t *testing.T) {
 // This one may need to be fixed through some retries or health check
 // config/setup/policy in envoy (through pilot)
 func Test503sWithBadClusters(t *testing.T) {
-	t.Skip("Skipping Test503sWithBadClusters until bug #1038 is fixed") // TODO fix me!
 	url := tc.Kube.IngressOrFail(t) + "/fortio/debug"
 	rulePath := util.GetResourcePath(yamlPath(routingRNPYaml))
 	go func() {

--- a/tests/util/checker/testlinter/lint_rules_list.go
+++ b/tests/util/checker/testlinter/lint_rules_list.go
@@ -24,16 +24,11 @@ import (
 var LintRulesList = map[TestType][]checker.Rule{
 	UnitTest: { // list of rules which should apply to unit test file
 		rules.NewSkipByIssue(),
-		rules.NewNoGoroutine(),
-		rules.NewNoSleep(),
-		rules.NewNoShort(),
 	},
 	IntegTest: { // list of rules which should apply to integration test file
 		rules.NewSkipByIssue(),
-		rules.NewSkipByShort(),
 	},
 	E2eTest: { // list of rules which should apply to e2e test file
 		rules.NewSkipByIssue(),
-		rules.NewSkipByShort(),
 	},
 }

--- a/tests/util/checker/testlinter/testdata/e2e/e2e_test.go
+++ b/tests/util/checker/testlinter/testdata/e2e/e2e_test.go
@@ -7,6 +7,7 @@ import (
 func SetCount()       {}
 func Count(n int) int { return n }
 
+// nolint: testlinter
 func TestE2eInvalidSkip(t *testing.T) {
 	t.Skip("invalid t.Skip without url to GitHub issue.")
 	SetCount()
@@ -22,6 +23,7 @@ func TestE2eInvalidSkip(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/6041")
 }
 
+// nolint: testlinter
 func TestE2eNoShort(t *testing.T) {
 	SetCount()
 	if Count(1) != 1 {
@@ -36,6 +38,7 @@ func TestE2eNoShort(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestE2eSkipAtTop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode.")
@@ -53,6 +56,7 @@ func TestE2eSkipAtTop(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestE2eSkipAtTop2(t *testing.T) {
 	if !testing.Short() {
 		SetCount()

--- a/tests/util/checker/testlinter/testdata/integration/integtest_test.go
+++ b/tests/util/checker/testlinter/testdata/integration/integtest_test.go
@@ -7,6 +7,7 @@ import (
 func SetCount()       {}
 func Count(n int) int { return n }
 
+// nolint: testlinter
 func TestIntegInvalidSkip(t *testing.T) {
 	t.Skip("invalid t.Skip without url to GitHub issue.")
 	SetCount()
@@ -22,6 +23,7 @@ func TestIntegInvalidSkip(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/6041")
 }
 
+// nolint: testlinter
 func TestIntegNoShort(t *testing.T) {
 	SetCount()
 	if Count(1) != 1 {
@@ -36,6 +38,7 @@ func TestIntegNoShort(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestIntegSkipAtTop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode.")
@@ -53,6 +56,7 @@ func TestIntegSkipAtTop(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestIntegSkipAtTop2(t *testing.T) {
 	if !testing.Short() {
 		SetCount()

--- a/tests/util/checker/testlinter/testdata/integtest_integ_test.go
+++ b/tests/util/checker/testlinter/testdata/integtest_integ_test.go
@@ -7,6 +7,7 @@ import (
 func SetCount()       {}
 func Count(n int) int { return n }
 
+// nolint: testlinter
 func TestIntegInvalidSkip(t *testing.T) {
 	t.Skip("invalid t.Skip without url to GitHub issue.")
 	SetCount()
@@ -22,6 +23,7 @@ func TestIntegInvalidSkip(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/6041")
 }
 
+// nolint: testlinter
 func TestIntegNoShort(t *testing.T) {
 	SetCount()
 	if Count(1) != 1 {
@@ -36,6 +38,7 @@ func TestIntegNoShort(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestIntegSkipAtTop(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode.")
@@ -53,6 +56,7 @@ func TestIntegSkipAtTop(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestIntegSkipAtTop2(t *testing.T) {
 	if !testing.Short() {
 		SetCount()

--- a/tests/util/checker/testlinter/testdata/unit_test.go
+++ b/tests/util/checker/testlinter/testdata/unit_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// nolint: testlinter
 func TestInvalidSkip(t *testing.T) {
 	t.Skip("invalid skip without url to GitHub issue.")
 	SetCount()
@@ -20,6 +21,7 @@ func TestInvalidSkip(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/6041")
 }
 
+// nolint: testlinter
 func TestInvalidShort(t *testing.T) {
 	SetCount()
 	if Count(1) != 1 {
@@ -38,6 +40,7 @@ func TestInvalidShort(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestInvalidSleep(t *testing.T) {
 	SetCount()
 	if Count(1) != 1 {
@@ -53,6 +56,7 @@ func TestInvalidSleep(t *testing.T) {
 	}
 }
 
+// nolint: testlinter
 func TestInvalidGoroutine(t *testing.T) {
 	go SetCount()
 	if Count(5) != 5 {

--- a/tests/util/checker/testlinter/testlinter.json
+++ b/tests/util/checker/testlinter/testlinter.json
@@ -1,0 +1,13 @@
+{
+  "Deadline": "90s",
+  "Linters": {
+    "testlinter": {
+      "Command": "testlinter",
+      "Pattern": "PATH:LINE:COL:MESSAGE",
+      "PartitionStrategy": "directories"
+    }
+  },
+  "Enable": [
+    "testlinter"
+  ]
+}


### PR DESCRIPTION
Enable testlinter with skip by issue rule turned on. So that make lint will check invalid use of t.Skip(). 
Also fix tests that violate skip by issue rule.