### PR TITLE
Pick most specific matching virtual service in mesh for TCP/TLS

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -412,6 +412,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 
 	meshGateway := map[string]bool{model.IstioMeshGateway: true}
 	configs := env.VirtualServices(meshGateway)
+	virtualServiceForHost := makeVirtualServiceForHost(configs)
 
 	var tcpListeners, httpListeners []*xdsapi.Listener
 	// For conflicit resolution
@@ -530,8 +531,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 					// The conflict resolution is done later in this code
 				}
 
-				listenerOpts.filterChainOpts = buildSidecarOutboundTCPTLSFilterChainOpts(node, env, configs,
-					destinationIPAddress, service, servicePort, proxyLabels, meshGateway)
+				listenerOpts.filterChainOpts = buildSidecarOutboundTCPTLSFilterChainOpts(node, env,
+					destinationIPAddress, service, servicePort, proxyLabels, meshGateway, virtualServiceForHost)
 			default:
 				// UDP or other protocols: no need to log, it's too noisy
 				continue

--- a/pilot/pkg/networking/core/v1alpha3/tls_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls_test.go
@@ -1,0 +1,50 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestVirtualServiceForHost(t *testing.T) {
+	wildcard := &v1alpha3.VirtualService{Hosts: []string{"*"}}
+	cnn := &v1alpha3.VirtualService{Hosts: []string{"www.cnn.com", "*.cnn.com", "*.com"}}
+	cnnEdition := &v1alpha3.VirtualService{Hosts: []string{"edition.cnn.com"}}
+	uk := &v1alpha3.VirtualService{Hosts: []string{"*.co.uk"}}
+	configs := []model.Config{{Spec: wildcard}, {Spec: cnn}, {Spec: cnnEdition}, {Spec: uk}}
+
+	tests := []struct {
+		in   string
+		want *v1alpha3.VirtualService
+	}{
+		{in: "www.cnn.com", want: cnn},
+		{in: "money.cnn.com", want: cnn},
+		{in: "edition.cnn.com", want: cnnEdition},
+		{in: "bbc.co.uk", want: uk},
+		{in: "www.wikipedia.org", want: wildcard},
+	}
+
+	f := makeVirtualServiceForHost(configs)
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if vs := f(model.Hostname(tt.in)); vs != tt.want {
+				t.Fatalf("incorrect virtual service match")
+			}
+		})
+	}
+}

--- a/pilot/pkg/networking/core/v1alpha3/tls_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls_test.go
@@ -22,11 +22,10 @@ import (
 )
 
 func TestVirtualServiceForHost(t *testing.T) {
-	wildcard := &v1alpha3.VirtualService{Hosts: []string{"*"}}
 	cnn := &v1alpha3.VirtualService{Hosts: []string{"www.cnn.com", "*.cnn.com", "*.com"}}
 	cnnEdition := &v1alpha3.VirtualService{Hosts: []string{"edition.cnn.com"}}
 	uk := &v1alpha3.VirtualService{Hosts: []string{"*.co.uk"}}
-	configs := []model.Config{{Spec: wildcard}, {Spec: cnn}, {Spec: cnnEdition}, {Spec: uk}}
+	configs := []model.Config{{Spec: cnn}, {Spec: cnnEdition}, {Spec: uk}}
 
 	tests := []struct {
 		in   string
@@ -36,7 +35,7 @@ func TestVirtualServiceForHost(t *testing.T) {
 		{in: "money.cnn.com", want: cnn},
 		{in: "edition.cnn.com", want: cnnEdition},
 		{in: "bbc.co.uk", want: uk},
-		{in: "www.wikipedia.org", want: wildcard},
+		{in: "www.wikipedia.org", want: nil},
 	}
 
 	f := makeVirtualServiceForHost(configs)


### PR DESCRIPTION
Right now the code picks the first matching virtual service. Since virtual services are sorted by creation time, it uses the oldest matching virtual service. This PR fixes the logic to use the virtual service that matches most specifically.