### PR TITLE
[Ansible Installer] Including Missing SCC on change_scc file

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/change_scc.yml
+++ b/install/kubernetes/ansible/istio/tasks/change_scc.yml
@@ -10,5 +10,8 @@
     - istio-ca-service-account
     - istio-sidecar-injector-service-account
     - istio-citadel-service-account
+    - istio-ingress-service-account
+    - istio-galley-service-account
+    - istio-cleanup-old-ca-service-account
     - prometheus
     - default


### PR DESCRIPTION
This PR fixes #7709 

Deploying without the missing the scc files, I have hit a problem when it tried to mount volumes inside the pods.

![pods](https://user-images.githubusercontent.com/2313749/43803636-c8a8d8d0-9a6f-11e8-8921-05b9841033dd.png)

Following the istio guide (https://istio.io/docs/setup/kubernetes/platform-setup/openshift/), I have noticed the missing scc.

Adding those on the file lead to istio 1.0 sucessfull deployment.

Best Regards,
Guilherme Baufaker Rêgo

cc @ymesika @gyliu513 @sdake 