### PR TITLE
remove deprecated flags

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -38,8 +38,8 @@ spec:
           args:
           - proxy
           - router
-          - -v
-          - "2"
+          - --log_output_level
+          - 'info'
           - --discoveryRefreshDelay
           - '1s' #discoveryRefreshDelay
           - --drainDuration

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
           args:
           - proxy
           - ingress
-          - -v
-          - "2"
+          - --log_output_level
+          - 'info'
           - --discoveryRefreshDelay
           - '1s' #discoveryRefreshDelay
           - --drainDuration

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -380,18 +380,4 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 
 	// NOTE: we don't currently expose a command-line option to control ErrorOutputPaths since it
 	// seems too esoteric.
-
-	// TODO: Remove all this stuff by the 1.0 release
-	var dummy string
-	var dummy2 bool
-	cmd.PersistentFlags().StringVarP(&dummy, "v", "v", "", "deprecated")
-	cmd.PersistentFlags().StringVarP(&dummy, "stderrthreshold", "", "", "deprecated")
-	cmd.PersistentFlags().BoolVarP(&dummy2, "alsologtostderr", "", false, "deprecated")
-	cmd.PersistentFlags().BoolVarP(&dummy2, "logtostderr", "", false, "deprecated")
-
-	_ = cmd.PersistentFlags().MarkDeprecated("v", "please use --log_output_level instead")
-	_ = cmd.PersistentFlags().MarkShorthandDeprecated("v", "please use --log_output_level instead")
-	_ = cmd.PersistentFlags().MarkDeprecated("stderrthreshold", "please use --log_output_level instead")
-	_ = cmd.PersistentFlags().MarkDeprecated("logtostderr", "please use --log_target instead")
-	_ = cmd.PersistentFlags().MarkDeprecated("alsologtostderr", "please use --log_target instead")
 }

--- a/pkg/log/options_test.go
+++ b/pkg/log/options_test.go
@@ -272,66 +272,6 @@ func TestOpts(t *testing.T) {
 			RotationMaxBackups: 1234,
 			LogGrpc:            true,
 		}},
-
-		// legacy, has no effect
-		{"--v 2", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
-			LogGrpc:            true,
-		}},
-
-		// legacy, has no effect
-		{"-v 2", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
-			LogGrpc:            true,
-		}},
-
-		// legacy, has no effect
-		{"--stderrthreshold 2", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
-			LogGrpc:            true,
-		}},
-
-		// legacy, has no effect
-		{"--logtostderr", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
-			LogGrpc:            true,
-		}},
-
-		// legacy, has no effect
-		{"--alsologtostderr", Options{
-			OutputPaths:        []string{defaultOutputPath},
-			ErrorOutputPaths:   []string{defaultErrorOutputPath},
-			outputLevels:       DefaultScopeName + ":" + levelToString[defaultOutputLevel],
-			stackTraceLevels:   DefaultScopeName + ":" + levelToString[defaultStackTraceLevel],
-			RotationMaxAge:     defaultRotationMaxAge,
-			RotationMaxSize:    defaultRotationMaxSize,
-			RotationMaxBackups: defaultRotationMaxBackups,
-			LogGrpc:            true,
-		}},
 	}
 
 	for j := 0; j < 2; j++ {


### PR DESCRIPTION
"v",  "stderrthreshold", "alsologtostderr",  "logtostderr" flags were marked deprecated and be removed by release-1.0 in this commit : https://github.com/istio/istio/commit/c6166bfc6aa14632f92ded01a2b16bbcd827e913#diff-e9b196e59598f68845ef24588c26dcb5R199