### PR TITLE
(release-1.0) Use service name instead of cluster name for SNI w/ istio mtls

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -102,7 +102,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 				destinationRule := config.Spec.(*networking.DestinationRule)
 				// NOTE : this thing is modifying destination rules in place. Not a good idea
 				// when we start caching stuff.
-				convertIstioMutual(destinationRule, upstreamServiceAccounts)
+				convertIstioMutual(destinationRule, service, upstreamServiceAccounts)
 				applyTrafficPolicy(defaultCluster, destinationRule.TrafficPolicy, port)
 
 				for _, subset := range destinationRule.Subsets {
@@ -226,13 +226,19 @@ func convertResolution(resolution model.Resolution) v2.Cluster_DiscoveryType {
 }
 
 // convertIstioMutual fills key cert fields for all TLSSettings when the mode is `ISTIO_MUTUAL`.
-func convertIstioMutual(destinationRule *networking.DestinationRule, upstreamServiceAccount []string) {
+func convertIstioMutual(destinationRule *networking.DestinationRule, service *model.Service, upstreamServiceAccount []string) {
 	converter := func(tls *networking.TLSSettings) {
 		if tls == nil {
 			return
 		}
 		if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
-			*tls = *buildIstioMutualTLS(upstreamServiceAccount, tls.Sni)
+			// Allow user specified SNIs in the istio mtls settings - which is useful
+			// for routing via gateways. If there is no SNI, set the SNI as the service Hostname
+			sni := tls.Sni
+			if len(sni) == 0 {
+				sni = string(service.Hostname)
+			}
+			*tls = *buildIstioMutualTLS(upstreamServiceAccount, sni)
 		}
 	}
 
@@ -260,9 +266,7 @@ func buildIstioMutualTLS(upstreamServiceAccount []string, sni string) *networkin
 		ClientCertificate: path.Join(model.AuthCertsPath, model.CertChainFilename),
 		PrivateKey:        path.Join(model.AuthCertsPath, model.KeyFilename),
 		SubjectAltNames:   upstreamServiceAccount,
-		// Allow user specified SNIs in the istio mtls settings - which is useful
-		// for routing via gateways
-		Sni: sni,
+		Sni:               sni,
 	}
 }
 
@@ -484,10 +488,6 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings) 
 			Sni: tls.Sni,
 		}
 
-		// Set default SNI of cluster name for istio_mutual if sni is not set.
-		if len(tls.Sni) == 0 && tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
-			cluster.TlsContext.Sni = cluster.Name
-		}
 		if cluster.Http2ProtocolOptions != nil {
 			// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
 			if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -156,7 +156,7 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(gomega.Equal("outbound|8080|foobar|foo.example.org"))
-	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal(cluster.Name))
+	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal("foo.example.org"))
 }
 
 func buildEnvForClustersWithIstioMutualWithSNI(sniValue string) *model.Environment {


### PR DESCRIPTION
Per spec TLS SNI field can only be FQDNs, though boring SSL
accepts any arbitrary string. We are currently sending the cluster name as the SNI string
for ISTIO_MUTUAL tls mode. But this prevents an ingress gateway in remote cluster from accepting
traffic as the user cannot use the cluster name as a hostname in the gateway spec.

cc @PiotrSikora

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>