### PR TITLE
Use the prometheusAddr variable

### DIFF
--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           args:
-          - --prometheusAddr=http://prometheus:9090
+          - --prometheusAddr={{- .Values.prometheusAddr }}
           livenessProbe:
             httpGet:
               path: /graph


### PR DESCRIPTION
Variable hasn't been used by the Servicegraph Chart.

Fixes #7731 