### PR TITLE
stalebot: add no stalebot label for wip issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -43,3 +43,4 @@ issues:
     - help wanted
     - kind/customer issue
     - Epic
+    - no stalebot


### PR DESCRIPTION
I imagine this label will primarily be used for identified owners that may callify the
issue as second priority. These issues may fall into a future
release and should be ignored by the stalebot.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>