### PR TITLE
Defer self-registering validation webhook until endpoint is ready 

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -42,7 +42,7 @@ func (wh *Webhook) endpointReady() error {
 	}
 
 	if len(endpoints.Subsets) == 0 {
-		return fmt.Errorf("%s/%v endpoint not ready: not subsets", wh.deploymentNamespace, wh.deploymentName)
+		return fmt.Errorf("%s/%v endpoint not ready: no subsets", wh.deploymentNamespace, wh.deploymentName)
 	}
 
 	for _, subset := range endpoints.Subsets {
@@ -67,7 +67,7 @@ func (wh *Webhook) createOrUpdateWebhookConfig() {
 	// the rest of the system. Minimize this problem by waiting the
 	// galley endpoint is available at least once before
 	// self-registering. Subsequent Istio upgrades rely on deployment
-	// rolling updates to set maxUnavailable to at least one.
+	// rolling updates to set maxUnavailable to zero.
 	if !wh.endpointReadyOnce {
 		if err := wh.endpointReady(); err != nil {
 			log.Warnf("%v validatingwebhookconfiguration update deferred: %v",

--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -70,8 +70,8 @@ func (wh *Webhook) createOrUpdateWebhookConfig() {
 	// rolling updates to set maxUnavailable to at least one.
 	if !wh.endpointReadyOnce {
 		if err := wh.endpointReady(); err != nil {
-			log.Warnf("%v validatingwebhookconfiguration update deferred: %v/%v endpoint not ready: %v",
-				wh.deploymentNamespace, wh.deploymentName, err)
+			log.Warnf("%v validatingwebhookconfiguration update deferred: %v",
+				wh.webhookConfiguration.Name, err)
 			reportValidationConfigUpdateError(errors.New("endpoint not ready"))
 			return
 		}

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -259,7 +259,11 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 				wh.createOrUpdateWebhookConfig()
 			}
 		case <-reconcileTickerC:
-			if wh.webhookConfiguration != nil {
+			if wh.webhookConfiguration == nil {
+				if err := wh.rebuildWebhookConfig(); err == nil {
+					wh.createOrUpdateWebhookConfig()
+				}
+			} else {
 				wh.createOrUpdateWebhookConfig()
 			}
 		case event, more := <-wh.keyCertWatcher.Event:

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -50,7 +50,6 @@ var (
 )
 
 const (
-	watchDebounceDelay     = 100 * time.Millisecond
 	waitEndpointReadyDelay = 100 * time.Millisecond
 )
 

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -50,7 +50,7 @@ var (
 )
 
 const (
-	waitEndpointReadyDelay = 100 * time.Millisecond
+	watchDebounceDelay = 100 * time.Millisecond
 )
 
 // WebhookParameters contains the configuration for the Istio Pilot validation

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -18,3 +18,7 @@ rules:
   resources: ["deployments"]
   resourceNames: ["istio-galley"]
   verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["endpoints"]
+  resourceNames: ["istio-galley"]
+  verbs: ["get"]

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -703,7 +703,7 @@ func (k *KubeInfo) deployIstio() error {
 			}
 		}
 		if !validationReady {
-			return errors.New("Timed out waiting for validatingwebhookconfiguration istio-galley to be created")
+			return errors.New("timeout waiting for validatingwebhookconfiguration istio-galley to be created")
 		}
 	}
 	return nil

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -57,6 +57,7 @@ const (
 	defaultSidecarInjectorFile     = "istio-sidecar-injector.yaml"
 	ingressCertsName               = "istio-ingress-certs"
 	maxDeploymentRolloutTime       = 480 * time.Second
+	maxValidationReadyCheckTime    = 30 * time.Second
 	helmServiceAccountFile         = "helm-service-account.yaml"
 	istioHelmInstallDir            = istioInstallDir + "/helm/istio"
 	caCertFileName                 = "samples/certs/ca-cert.pem"
@@ -688,7 +689,24 @@ func (k *KubeInfo) deployIstio() error {
 		}
 	}
 
-	return util.CheckDeployments(k.Namespace, maxDeploymentRolloutTime, k.KubeConfig)
+	if err := util.CheckDeployments(k.Namespace, maxDeploymentRolloutTime, k.KubeConfig); err != nil {
+		return err
+	}
+
+	if *useGalleyConfigValidator {
+		timeout := time.Now().Add(maxValidationReadyCheckTime)
+		var validationReady bool
+		for time.Now().Before(timeout) {
+			if _, err := util.ShellSilent("kubectl get validatingwebhookconfiguration istio-galley --kubeconfig=%s", k.KubeConfig); err == nil {
+				validationReady = true
+				break
+			}
+		}
+		if !validationReady {
+			return errors.New("Timed out waiting for validatingwebhookconfiguration istio-galley to be created")
+		}
+	}
+	return nil
 }
 
 // DeployTiller deploys tiller in Istio mesh or returns error

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -109,7 +109,7 @@ e2e_galley_run: out_dir
 	go test -v -timeout 25m ./tests/e2e/tests/galley -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} -use_galley_config_validator -cluster_wide
 
 e2e_dashboard_run: out_dir
-	go test -v -timeout 25m ./tests/e2e/tests/dashboard -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
+	go test -v -timeout 25m ./tests/e2e/tests/dashboard -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} -use_galley_config_validator -cluster_wide
 
 e2e_bookinfo_run: out_dir
 	go test -v -timeout 60m ./tests/e2e/tests/bookinfo -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}


### PR DESCRIPTION
Wait for the istio-galley endpoint to show one ready address before creating the validatingwebhookconfiguration. 

fixes https://github.com/istio/istio/issues/7746