### PR TITLE
ShellCheck: Enable and fix SC1090 and SC1091

### DIFF
--- a/bin/envsetup.sh
+++ b/bin/envsetup.sh
@@ -27,6 +27,7 @@ if [ -f .istiorc ] ; then
 fi
 
 if [ -f "$HOME/.istiorc" ] ; then
+  # shellcheck disable=SC1090
   source "$HOME/.istiorc"
 fi
 
@@ -67,6 +68,7 @@ function lunch() {
     local env=$1
 
     if [[ -f $HOME/.istio/${env} ]]; then
+        # shellcheck disable=SC1090
         source "$HOME/.istio/${env}"
     fi
 

--- a/bin/envsetup.sh
+++ b/bin/envsetup.sh
@@ -22,6 +22,7 @@ export TAG=${ISTIO_TAG:-$USER}
 export OUT=${GOPATH}/out
 
 if [ -f .istiorc ] ; then
+  # shellcheck disable=SC1091
   source .istiorc
 fi
 

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -25,6 +25,7 @@ ISTIO_STAGING=${ISTIO_STAGING:-.}
 function istioVersionSource() {
   echo "Sourced ${ISTIO_STAGING}/istio.VERSION"
   cat "${ISTIO_STAGING}/istio.VERSION"
+  # shellcheck disable=SC1090
   source "${ISTIO_STAGING}/istio.VERSION"
 }
 

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -51,8 +51,11 @@ USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
 CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 
 
+# shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
+# shellcheck source=prow/mason_lib.sh
 source "${ROOT}/prow/mason_lib.sh"
+# shellcheck source=prow/cluster_lib.sh
 source "${ROOT}/prow/cluster_lib.sh"
 
 function cleanup() {

--- a/prow/istio-postsubmit.sh
+++ b/prow/istio-postsubmit.sh
@@ -29,6 +29,7 @@ set -u
 # Print commands
 set -x
 
+# shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 

--- a/prow/istio-presubmit.sh
+++ b/prow/istio-presubmit.sh
@@ -29,6 +29,7 @@ set -u
 set -x
 set -e
 
+# shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 

--- a/prow/istio-unit-tests.sh
+++ b/prow/istio-unit-tests.sh
@@ -24,6 +24,7 @@ set -u
 set -x
 set -e
 
+# shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 setup_and_export_git_sha
 

--- a/release/create_github_release.sh
+++ b/release/create_github_release.sh
@@ -44,6 +44,7 @@ REQUEST_FILE="$(mktemp /tmp/github.request.XXXX)"
 RESPONSE_FILE="$(mktemp /tmp/github.response.XXXX)"
 UPLOAD_DIR=""
 
+# shellcheck source=release/json_parse_shared.sh
 source "${SCRIPTPATH}/json_parse_shared.sh"
 
 function usage() {

--- a/release/create_tag_reference.sh
+++ b/release/create_tag_reference.sh
@@ -41,6 +41,7 @@ USER_NAME=""
 BUILD_FILE=""
 ORG="istio"
 
+# shellcheck source=release/json_parse_shared.sh
 source "${SCRIPTPATH}/json_parse_shared.sh"
 
 function usage() {

--- a/release/gcb_build_lib.sh
+++ b/release/gcb_build_lib.sh
@@ -21,6 +21,7 @@ set -o pipefail
 set -x
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+# shellcheck source=release/json_parse_shared.sh
 source "${SCRIPTPATH}/json_parse_shared.sh"
 
 # parse_result_file(): parses the result from a build query.

--- a/release/start_gcb_build.sh
+++ b/release/start_gcb_build.sh
@@ -25,6 +25,7 @@ set -o pipefail
 set -x
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+# shellcheck source=release/gcb_build_lib.sh
 source "${SCRIPTPATH}/gcb_build_lib.sh"
 
 PROJECT_ID=""

--- a/release/start_gcb_publish.sh
+++ b/release/start_gcb_publish.sh
@@ -31,6 +31,7 @@ set -o pipefail
 set -x
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+# shellcheck source=release/gcb_build_lib.sh
 source "${SCRIPTPATH}/gcb_build_lib.sh"
 
 PROJECT_ID=""
@@ -61,7 +62,7 @@ function usage() {
     -m <file> name of manifest file in repo specified by -u     (optional, defaults to $REPO_FILE )
     -t <tag>  commit tag or branch for manifest repo in -u      (optional, defaults to $REPO_FILE_VER )
     -w        specify that script should wait until build done  (optional)
-  
+
     -d <hub>  docker hub                                        (optional, defaults to $DOCKER_DST )
     -r <name> GCR bucket to store build artifacts               (required)
     -s <name> GCS bucket to read build artifacts                (required)

--- a/release/start_gcb_tag.sh
+++ b/release/start_gcb_tag.sh
@@ -32,6 +32,7 @@ set -o pipefail
 set -x
 
 SCRIPTPATH=$( cd "$(dirname "$0")" ; pwd -P )
+# shellcheck source=release/gcb_build_lib.sh
 source "${SCRIPTPATH}/gcb_build_lib.sh"
 
 PROJECT_ID=""
@@ -59,7 +60,7 @@ function usage() {
     -u <url>  URL to git repo with manifest file                (required)
     -m <file> name of manifest file in repo specified by -u     (optional, defaults to $REPO_FILE )
     -t <tag>  commit tag or branch for manifest repo in -u      (optional, defaults to $REPO_FILE_VER )
-    -w        specify that script should wait until build done  (optional)  
+    -w        specify that script should wait until build done  (optional)
 
     -s <name> GCS bucket to read build artifacts                (required)
     -g <path> GCS bucket&path to file with github secret        (optional, detaults to $GCS_GITHUB_SECRET )

--- a/samples/rawvm/demo.sh
+++ b/samples/rawvm/demo.sh
@@ -4,6 +4,7 @@ set -x
 set -e
 
 # Source istio.VERSION
+# shellcheck disable=SC1091
 source ../../istio.VERSION
 # This assume you installed the control plane already
 # kubectl apply -f install/kube/istio-auth.yaml

--- a/tests/e2e/local/minikube/setup_test.sh
+++ b/tests/e2e/local/minikube/setup_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Check and setup Minikube environment
+# shellcheck source=tests/e2e/local/minikube/setup_minikube_env.sh
 . ./setup_minikube_env.sh
 
 # Remove old imges.

--- a/tools/deb/istio-ca.sh
+++ b/tools/deb/istio-ca.sh
@@ -23,6 +23,7 @@ set -e
 # Load optional config variables
 ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
 if [[ -r ${ISTIO_SIDECAR_CONFIG} ]]; then
+  # shellcheck disable=SC1090
   . "$ISTIO_SIDECAR_CONFIG"
 fi
 

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -65,11 +65,13 @@ IFS=,
 # settings (CIDR range)
 ISTIO_CLUSTER_CONFIG=${ISTIO_CLUSTER_CONFIG:-/var/lib/istio/envoy/cluster.env}
 if [ -r "${ISTIO_CLUSTER_CONFIG}" ]; then
+  # shellcheck disable=SC1090
   . "${ISTIO_CLUSTER_CONFIG}"
 fi
 
 ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
 if [ -r "${ISTIO_SIDECAR_CONFIG}" ]; then
+  # shellcheck disable=SC1090
   . "${ISTIO_SIDECAR_CONFIG}"
 fi
 

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -23,12 +23,14 @@ set -e
 # Load optional config variables
 ISTIO_SIDECAR_CONFIG=${ISTIO_SIDECAR_CONFIG:-/var/lib/istio/envoy/sidecar.env}
 if [[ -r ${ISTIO_SIDECAR_CONFIG} ]]; then
+  # shellcheck disable=SC1090
   . "$ISTIO_SIDECAR_CONFIG"
 fi
 
 # Load config variables ISTIO_SYSTEM_NAMESPACE, CONTROL_PLANE_AUTH_POLICY
 ISTIO_CLUSTER_CONFIG=${ISTIO_CLUSTER_CONFIG:-/var/lib/istio/envoy/cluster.env}
 if [[ -r ${ISTIO_CLUSTER_CONFIG} ]]; then
+  # shellcheck disable=SC1090
   . "$ISTIO_CLUSTER_CONFIG"
 fi
 

--- a/tools/run_canonical_perf_tests.sh
+++ b/tools/run_canonical_perf_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# shellcheck source=tools/setup_perf_cluster.sh
 source "${DIR}/setup_perf_cluster.sh"
 
 LABEL="${1}"

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -5,6 +5,7 @@
 TOOLS_DIR="$(cd "$(dirname "${0}")" && pwd -P)"
 ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 
+# Set global rule exclusions here, separated by comma (e.g. SC1090,SC1091).
 # See https://github.com/koalaman/shellcheck/wiki for details on each code's
 # corresponding rule.
 EXCLUDES=""

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -7,7 +7,7 @@ ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 
 # See https://github.com/koalaman/shellcheck/wiki for details on each code's
 # corresponding rule.
-EXCLUDES="1090"
+EXCLUDES=""
 
 # All files ending in .sh.
 SH_FILES=$( \

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -7,8 +7,7 @@ ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 
 # See https://github.com/koalaman/shellcheck/wiki for details on each code's
 # corresponding rule.
-EXCLUDES="1090,"
-EXCLUDES="${EXCLUDES}1091"
+EXCLUDES="1090"
 
 # All files ending in .sh.
 SH_FILES=$( \


### PR DESCRIPTION
Enable and fix [SC1090](https://github.com/koalaman/shellcheck/wiki/SC1090) and [SC1091](https://github.com/koalaman/shellcheck/wiki/SC1091). Both are related to verifying how scripts are used as dependencies (through `source` or `.`).

Many scripts, such as `$HOME/.istiorc` do not exist in the repository so those instances are disabled.

These are the final two violated rules for ShellCheck 5.0!

/cc @mandarjog
/assign @mandarjog