### PR TITLE
Fix broken if-checks in shell scripts

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -15,7 +15,7 @@
 #   limitations under the License.
 
 if BUILD_GIT_REVISION=$(git rev-parse HEAD 2> /dev/null); then
-    if git diff-index --quiet HEAD; then
+    if ! git diff-index --quiet HEAD; then
         BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
     fi
 else

--- a/install/tools/setupIstioVM.sh
+++ b/install/tools/setupIstioVM.sh
@@ -44,7 +44,7 @@ function istioNetworkInit() {
   systemctl restart dnsmasq
 
   # Update DHCP - if needed
-  if grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null; then
+  if ! grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null; then
     echo 'prepend domain-name-servers 127.0.0.1;' >> /etc/dhcp/dhclient.conf
     # TODO: find a better way to re-trigger dhclient
     dhclient -v -1


### PR DESCRIPTION
As discovered by @jwendell in #7702, I broke two if-checks in [this commit](https://github.com/istio/istio/commit/51e762b0c55b203e3c5855a34518522edfd6a2db#diff-71308222e525f5ff137b91be32b49db6). Notice that both instances which previously used the `!=` operator (i.e. `if [[ $? != 0 ]]; then`) were improperly changed. This PR corrects them.

/cc @jwendell 
/cc @mandarjog 
/assign @mandarjog 