### PR TITLE
Fix path of manifest file for bookinfo sample application

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/bookinfo_cmd.j2
+++ b/install/kubernetes/ansible/istio/tasks/bookinfo_cmd.j2
@@ -1,5 +1,5 @@
 {% if cluster_flavour == 'ocp' %}
 {{ cmd_path }} adm policy add-scc-to-user privileged -z default -n {{ sample_namespace }}
 {% endif %}
-{{ cmd_path }} apply -n {{ sample_namespace }} -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/kube/bookinfo.yaml)
+{{ cmd_path }} apply -n {{ sample_namespace }} -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/platform/kube/bookinfo.yaml)
 {{ cmd_path }} expose svc productpage -n {{ sample_namespace }}


### PR DESCRIPTION
The installation of the bookinfo sample application fails because of a mispelled path of the manifest file.
This  commit fixes the path in the jinja2 template **bookinfo_cmd.j2**