### PR TITLE
Render the sidecar injector configmap always

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.sidecarInjectorWebhook.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -156,4 +155,3 @@ data:
           {{ "[[ else -]]" }}
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
-{{- end }}


### PR DESCRIPTION
Commit eeb9d77ff8 changed a bunch of stuff, and doesn't mention this change in the commit message, so it may even have been accidental?

Either way, with the sidecar injector webhook turned off, manual injection using `istioctl kube-inject` still needs this configmap, and it isn't present any more. This PR re-enables it.
Even when the sidecar injector is disabled, as `istioctl kube-inject`
needs it.

I checked the istio-remote chart but this change wasn't made to it.