### PR TITLE
Prints server info on istioctl version

### DIFF
--- a/istioctl/cmd/istioctl/istioctl_test.go
+++ b/istioctl/cmd/istioctl/istioctl_test.go
@@ -409,32 +409,3 @@ func TestKubeInject(t *testing.T) {
 		})
 	}
 }
-
-func TestVersion(t *testing.T) {
-	cases := []testCase{
-		{ // case 0
-			configs: []model.Config{},
-			args:    strings.Split("version", " "),
-			expectedRegexp: regexp.MustCompile("Version: unknown\nGitRevision: unknown\n" +
-				"User: unknown@unknown\nHub: unknown\nGolangVersion: go1.([0-9\\.]+)\n" +
-				"BuildStatus: unknown\n"),
-		},
-		{ // case 1 short output
-			configs:        []model.Config{},
-			args:           strings.Split("version -s", " "),
-			expectedOutput: "unknown@unknown-unknown-unknown-unknown-unknown\n",
-		},
-		{ // case 2 bogus arg
-			configs:        []model.Config{},
-			args:           strings.Split("version --typo", " "),
-			expectedOutput: "Error: unknown flag: --typo\n",
-			wantException:  true,
-		},
-	}
-
-	for i, c := range cases {
-		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
-			verifyOutput(t, c)
-		})
-	}
-}

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -632,7 +632,7 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(contextCmd)
-	rootCmd.AddCommand(version.CobraCommand())
+	rootCmd.AddCommand(version.CobraCommandWithOptions(version.CobraOptions{GetRemoteVersion: getRemoteInfo}))
 	rootCmd.AddCommand(gendeployment.Command(&istioNamespace))
 	rootCmd.AddCommand(experimentalCmd)
 
@@ -641,6 +641,15 @@ func init() {
 		Section: "istioctl CLI",
 		Manual:  "Istio Control",
 	}))
+}
+
+func getRemoteInfo() (*version.MeshInfo, error) {
+	kubeClient, err := clientExecFactory(kubeconfig, configContext)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeClient.GetIstioVersions(istioNamespace)
 }
 
 func main() {

--- a/istioctl/cmd/istioctl/proxyconfig_test.go
+++ b/istioctl/cmd/istioctl/proxyconfig_test.go
@@ -23,6 +23,7 @@ import (
 
 	"istio.io/istio/istioctl/pkg/kubernetes"
 	"istio.io/istio/pilot/test/util"
+	"istio.io/istio/pkg/version"
 )
 
 type execTestCase struct {
@@ -202,4 +203,8 @@ func (client mockExecConfig) PilotDiscoveryDo(pilotNamespace, method, path strin
 		return results, nil
 	}
 	return nil, fmt.Errorf("unable to find any Pilot instances")
+}
+
+func (client mockExecConfig) GetIstioVersions(namespace string) (*version.MeshInfo, error) {
+	return nil, nil
 }

--- a/istioctl/cmd/istioctl/version_test.go
+++ b/istioctl/cmd/istioctl/version_test.go
@@ -1,0 +1,195 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	"istio.io/istio/istioctl/pkg/kubernetes"
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/version"
+)
+
+var meshInfo = version.MeshInfo{
+	{"Pilot", version.BuildInfo{"1.0.0", "gitSHA123", "user1", "host1", "go1.10", "hub.docker.com", "Clean"}},
+	{"Injector", version.BuildInfo{"1.0.1", "gitSHAabc", "user2", "host2", "go1.10.1", "hub.docker.com", "Modified"}},
+	{"Citadel", version.BuildInfo{"1.2", "gitSHA321", "user3", "host3", "go1.11.0", "hub.docker.com", "Clean"}},
+}
+
+type outputKind int
+
+const (
+	rawOutputMock outputKind = iota
+	shortOutputMock
+	jsonOutputMock
+	yamlOutputMock
+)
+
+func printMeshVersion(kind outputKind) string {
+	switch kind {
+	case yamlOutputMock:
+		ver := &version.Version{MeshVersion: &meshInfo}
+		res, _ := yaml.Marshal(ver)
+		return string(res)
+	case jsonOutputMock:
+		res, _ := json.MarshalIndent(&meshInfo, "", "  ")
+		return string(res)
+	}
+
+	res := ""
+	for _, info := range meshInfo {
+		switch kind {
+		case rawOutputMock:
+			res += fmt.Sprintf("%s version: %#v\n", info.Component, info.Info)
+		case shortOutputMock:
+			res += fmt.Sprintf("%s version: %s\n", info.Component, info.Info.Version)
+		}
+	}
+	return res
+}
+
+func TestVersion(t *testing.T) {
+	clientExecFactory = mockExecClientVersionTest
+
+	cases := []testCase{
+		{ // case 0 client-side only, normal output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=false", " "),
+			expectedRegexp: regexp.MustCompile("version.BuildInfo{Version:\"unknown\", GitRevision:\"unknown\", " +
+				"User:\"unknown\", Host:\"unknown\", GolangVersion:\"go1.([0-9\\.]+)\", DockerHub:\"unknown\", BuildStatus:\"unknown\"}"),
+		},
+		{ // case 1 client-side only, short output
+			configs:        []model.Config{},
+			args:           strings.Split("version -s --remote=false", " "),
+			expectedOutput: "unknown\n",
+		},
+		{ // case 2 client-side only, yaml output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=false -o yaml", " "),
+			expectedRegexp: regexp.MustCompile("clientVersion:\n" +
+				"  golang_version: go1.([0-9\\.]+)\n" +
+				"  host: unknown\n" +
+				"  hub: unknown\n" +
+				"  revision: unknown\n" +
+				"  status: unknown\n" +
+				"  user: unknown\n" +
+				"  version: unknown\n\n"),
+		},
+		{ // case 3 client-side only, json output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=false -o json", " "),
+			expectedRegexp: regexp.MustCompile("{\n" +
+				"  \"clientVersion\": {\n" +
+				"    \"version\": \"unknown\",\n" +
+				"    \"revision\": \"unknown\",\n" +
+				"    \"user\": \"unknown\",\n" +
+				"    \"host\": \"unknown\",\n" +
+				"    \"golang_version\": \"go1.([0-9\\.]+)\",\n" +
+				"    \"hub\": \"unknown\",\n" +
+				"    \"status\": \"unknown\"\n" +
+				"  }\n" +
+				"}\n"),
+		},
+
+		{ // case 4 remote, normal output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=true --short=false --output=", " "),
+			expectedRegexp: regexp.MustCompile("client version: version.BuildInfo{Version:\"unknown\", GitRevision:\"unknown\", " +
+				"User:\"unknown\", Host:\"unknown\", GolangVersion:\"go1.([0-9\\.]+)\", DockerHub:\"unknown\", BuildStatus:\"unknown\"}\n" +
+				printMeshVersion(rawOutputMock)),
+		},
+		{ // case 5 remote, short output
+			configs:        []model.Config{},
+			args:           strings.Split("version --short=true --remote=true --output=", " "),
+			expectedOutput: "client version: unknown\n" + printMeshVersion(shortOutputMock),
+		},
+		{ // case 6 remote, yaml output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=true -o yaml", " "),
+			expectedRegexp: regexp.MustCompile("clientVersion:\n" +
+				"  golang_version: go1.([0-9\\.]+)\n" +
+				"  host: unknown\n" +
+				"  hub: unknown\n" +
+				"  revision: unknown\n" +
+				"  status: unknown\n" +
+				"  user: unknown\n" +
+				"  version: unknown\n" + printMeshVersion(yamlOutputMock)),
+		},
+		{ // case 7 remote, json output
+			configs: []model.Config{},
+			args:    strings.Split("version --remote=true -o json", " "),
+			expectedRegexp: regexp.MustCompile("{\n" +
+				"  \"clientVersion\": {\n" +
+				"    \"version\": \"unknown\",\n" +
+				"    \"revision\": \"unknown\",\n" +
+				"    \"user\": \"unknown\",\n" +
+				"    \"host\": \"unknown\",\n" +
+				"    \"golang_version\": \"go1.([0-9\\.]+)\",\n" +
+				"    \"hub\": \"unknown\",\n" +
+				"    \"status\": \"unknown\"\n" +
+				"  },\n" +
+				printMeshVersion(jsonOutputMock)),
+		},
+
+		{ // case 8 bogus arg
+			configs:        []model.Config{},
+			args:           strings.Split("version --typo", " "),
+			expectedOutput: "Error: unknown flag: --typo\n",
+			wantException:  true,
+		},
+
+		{ // case 9 bogus output arg
+			configs:        []model.Config{},
+			args:           strings.Split("version --output xyz", " "),
+			expectedOutput: "Error: --output must be 'yaml' or 'json'\n",
+			wantException:  true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d %s", i, strings.Join(c.args, " ")), func(t *testing.T) {
+			verifyOutput(t, c)
+		})
+	}
+}
+
+type mockExecVersionConfig struct {
+}
+
+func (client mockExecVersionConfig) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
+	return nil, nil
+}
+
+func (client mockExecVersionConfig) EnvoyDo(podName, podNamespace, method, path string, body []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (client mockExecVersionConfig) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (client mockExecVersionConfig) GetIstioVersions(namespace string) (*version.MeshInfo, error) {
+	return &meshInfo, nil
+}
+
+func mockExecClientVersionTest(kubeconfig, configContext string) (kubernetes.ExecClient, error) {
+	return &mockExecVersionConfig{}, nil
+}

--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -16,8 +16,10 @@ package kubernetes
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -26,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/version"
 )
 
 var (
@@ -45,6 +48,7 @@ type Client struct {
 type ExecClient interface {
 	EnvoyDo(podName, podNamespace, method, path string, body []byte) ([]byte, error)
 	AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error)
+	GetIstioVersions(namespace string) (*version.MeshInfo, error)
 }
 
 // NewClient is the constructor for the client wrapper
@@ -119,7 +123,7 @@ func (client *Client) PodExec(podName, podNamespace, container string, command [
 
 // AllPilotsDiscoveryDo makes an http request to each Pilot discovery instance
 func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
-	pilots, err := client.GetPilotPods(pilotNamespace)
+	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{"labelSelector": "istio=pilot"})
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +146,7 @@ func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, 
 
 // PilotDiscoveryDo makes an http request to a single Pilot discovery instance
 func (client *Client) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
-	pilots, err := client.GetPilotPods(pilotNamespace)
+	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{"labelSelector": "istio=pilot"})
 	if err != nil {
 		return nil, err
 	}
@@ -174,12 +178,14 @@ func (client *Client) ExtractExecResult(podName, podNamespace, container string,
 	return stdout.Bytes(), nil
 }
 
-// GetPilotPods retrieves the pod objects for all known pilots
-func (client *Client) GetPilotPods(namespace string) ([]v1.Pod, error) {
+// GetIstioPods retrieves the pod objects for Istio deployments
+func (client *Client) GetIstioPods(namespace string, params map[string]string) ([]v1.Pod, error) {
 	req := client.Get().
 		Resource("pods").
-		Namespace(namespace).
-		Param("labelSelector", "istio=pilot")
+		Namespace(namespace)
+	for k, v := range params {
+		req.Param(k, v)
+	}
 
 	res := req.Do()
 	if res.Error() != nil {
@@ -214,4 +220,81 @@ func (client *Client) GetPilotAgentContainer(podName, podNamespace string) (stri
 		}
 	}
 	return proxyContainer, nil
+}
+
+type podDetail struct {
+	binary    string
+	container string
+}
+
+// GetIstioVersions gets the version for each Istio component
+func (client *Client) GetIstioVersions(namespace string) (*version.MeshInfo, error) {
+	pods, err := client.GetIstioPods(namespace, map[string]string{"labelSelector": "istio"})
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 {
+		return nil, errors.New("unable to find any Istio pod in namespace " + namespace)
+	}
+
+	labelToPodDetail := map[string]podDetail{
+		"pilot":            {"/usr/local/bin/pilot-discovery", "discovery"},
+		"citadel":          {"/usr/local/bin/istio_ca", "citadel"},
+		"egressgateway":    {"/usr/local/bin/pilot-agent", "egressgateway"},
+		"galley":           {"/usr/local/bin/galley", "validator"},
+		"ingressgateway":   {"/usr/local/bin/pilot-agent", "ingressgateway"},
+		"telemetry":        {"/usr/local/bin/mixs", "mixer"},
+		"policy":           {"/usr/local/bin/mixs", "mixer"},
+		"sidecar-injector": {"/usr/local/bin/sidecar-injector", "sidecar-injector-webhook"},
+	}
+
+	res := version.MeshInfo{}
+	for _, pod := range pods {
+		component := pod.Labels["istio"]
+
+		// Special cases
+		switch component {
+		case "statsd-prom-bridge":
+			continue
+		case "mixer":
+			component = pod.Labels["istio-mixer-type"]
+		}
+
+		server := version.ServerInfo{Component: component}
+
+		if detail, ok := labelToPodDetail[component]; ok {
+			cmd := []string{detail.binary, "version"}
+			cmdJSON := append(cmd, "-o", "json")
+
+			var info version.BuildInfo
+
+			stdout, stderr, err := client.PodExec(pod.Name, pod.Namespace, detail.container, cmdJSON)
+			if err == nil && stderr.String() == "" {
+				err = json.Unmarshal(stdout.Bytes(), &info)
+				if err != nil {
+					return nil, fmt.Errorf("error converting server info from JSON: %v", err)
+				}
+			} else if strings.HasPrefix(stderr.String(), "Error: unknown shorthand flag") {
+				// Try the old behavior
+				stdout, err := client.ExtractExecResult(pod.Name, pod.Namespace, detail.container, cmd)
+				if err == nil {
+					info, err = version.NewBuildInfoFromOldString(string(stdout))
+					if err != nil {
+						return nil, fmt.Errorf("error converting server info from JSON: %v", err)
+					}
+				} else {
+					return nil, fmt.Errorf("error execing into %v %v container: %v", pod.Name, detail.container, err)
+				}
+			} else {
+				if err != nil {
+					return nil, fmt.Errorf("error execing into %v %v container: %v", pod.Name, detail.container, err)
+				}
+				return nil, fmt.Errorf("error execing into %v %v container: %v", pod.Name, detail.container, stderr.String())
+			}
+
+			server.Info = info
+		}
+		res = append(res, server)
+	}
+	return &res, nil
 }

--- a/pkg/version/cobra.go
+++ b/pkg/version/cobra.go
@@ -15,28 +15,103 @@
 package version
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 
+	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
 )
 
+// Version holds info for client and control plane versions
+type Version struct {
+	ClientVersion *BuildInfo `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	MeshVersion   *MeshInfo  `json:"meshVersion,omitempty" yaml:"meshVersion,omitempty"`
+}
+
+// GetRemoteVersionFunc is the function protoype to be passed to CobraOptions so that it is
+// called when invoking `cmd version`
+type GetRemoteVersionFunc func() (*MeshInfo, error)
+
+// CobraOptions holds options to be passed to `CobraCommandWithOptions`
+type CobraOptions struct {
+	// GetRemoteVersion is the function to be invoked to retrieve remote versions for
+	// Istio components. Optional. If not set, the 'version' subcommand will not attempt
+	// to connect to a remote side, and CLI flags such as '--remote' will be hidden.
+	GetRemoteVersion GetRemoteVersionFunc
+}
+
 // CobraCommand returns a command used to print version information.
 func CobraCommand() *cobra.Command {
-	var short bool
+	return CobraCommandWithOptions(CobraOptions{})
+}
+
+// CobraCommandWithOptions returns a command used to print version information.
+// It accepts an CobraOptions argument that might modify its behavior
+func CobraCommandWithOptions(options CobraOptions) *cobra.Command {
+	var (
+		short         bool
+		output        string
+		remote        bool
+		version       Version
+		remoteVersion *MeshInfo
+		serverErr     error
+	)
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Prints out build version information",
-		Run: func(cmd *cobra.Command, args []string) {
-			if short {
-				fmt.Fprintln(cmd.OutOrStdout(), Info)
-			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), Info.LongForm())
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if output != "" && output != "yaml" && output != "json" {
+				return errors.New(`--output must be 'yaml' or 'json'`)
 			}
+
+			version.ClientVersion = &Info
+
+			if options.GetRemoteVersion != nil && remote {
+				remoteVersion, serverErr = options.GetRemoteVersion()
+				version.MeshVersion = remoteVersion
+			}
+
+			switch output {
+			case "":
+				if short {
+					if remoteVersion != nil {
+						fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.Version)
+						for _, remote := range *remoteVersion {
+							fmt.Fprintf(cmd.OutOrStdout(), "%s version: %s\n", remote.Component, remote.Info.Version)
+						}
+
+					} else {
+						fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.Version)
+					}
+				} else {
+					if remoteVersion != nil {
+						fmt.Fprintf(cmd.OutOrStdout(), "client version: %s\n", version.ClientVersion.LongForm())
+						for _, remote := range *remoteVersion {
+							fmt.Fprintf(cmd.OutOrStdout(), "%s version: %s\n", remote.Component, remote.Info.LongForm())
+						}
+					} else {
+						fmt.Fprintf(cmd.OutOrStdout(), "%s\n", version.ClientVersion.LongForm())
+					}
+				}
+			case "yaml":
+				marshalled, _ := yaml.Marshal(&version)
+				fmt.Fprintln(cmd.OutOrStdout(), string(marshalled))
+			case "json":
+				marshalled, _ := json.MarshalIndent(&version, "", "  ")
+				fmt.Fprintln(cmd.OutOrStdout(), string(marshalled))
+			}
+
+			return serverErr
 		},
 	}
 
-	cmd.PersistentFlags().BoolVarP(&short, "short", "s", short, "Displays a short form of the version information")
+	cmd.Flags().BoolVarP(&short, "short", "s", false, "Displays a short form of the version information")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "One of 'yaml' or 'json'.")
+	if options.GetRemoteVersion != nil {
+		cmd.Flags().BoolVar(&remote, "remote", false, "Prints remote version information, from the control plane")
+	}
 
 	return cmd
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,6 +18,7 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strings"
 )
 
 // The following fields are populated at build time using -ldflags -X.
@@ -42,6 +43,53 @@ type BuildInfo struct {
 	BuildStatus   string `json:"status"`
 }
 
+// ServerInfo contains the version for a single control plane component
+type ServerInfo struct {
+	Component string
+	Info      BuildInfo
+}
+
+// MeshInfo contains the versions for all Istio control plane components
+type MeshInfo []ServerInfo
+
+// NewBuildInfoFromOldString creates a BuildInfo struct based on the output
+// of previous Istio components '-- version' output
+func NewBuildInfoFromOldString(oldOutput string) (BuildInfo, error) {
+	res := BuildInfo{}
+
+	lines := strings.Split(oldOutput, "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.SplitN(line, ":", 2)
+		if fields != nil {
+			if len(fields) != 2 {
+				return BuildInfo{}, fmt.Errorf("invalid BuildInfo input, field '%s' is not valid", fields[0])
+			}
+			value := strings.TrimSpace(fields[1])
+			switch fields[0] {
+			case "Version":
+				res.Version = value
+			case "GitRevision":
+				res.GitRevision = value
+			case "User":
+				res.User = value
+			case "Hub":
+				res.DockerHub = value
+			case "GolangVersion":
+				res.GolangVersion = value
+			case "BuildStatus":
+				res.BuildStatus = value
+			default:
+				return BuildInfo{}, fmt.Errorf("invalid BuildInfo input, field '%s' is not valid", fields[0])
+			}
+		}
+	}
+
+	return res, nil
+}
+
 var (
 	// Info exports the build version information.
 	Info BuildInfo
@@ -64,33 +112,11 @@ func (b BuildInfo) String() string {
 		b.BuildStatus)
 }
 
-// LongForm returns a multi-line version information
-//
+// LongForm returns a dump of the Info struct
 // This looks like:
 //
-// ```
-// Version: <version>
-// GitRevision: <git revision>
-// User: user@host
-// Hub: <docker hub>
-// GolangVersion: go1.9.2
-// BuildStatus: <build status>
-// ```
 func (b BuildInfo) LongForm() string {
-	return fmt.Sprintf(`Version: %v
-GitRevision: %v
-User: %v@%v
-Hub: %v
-GolangVersion: %v
-BuildStatus: %v
-`,
-		b.Version,
-		b.GitRevision,
-		b.User,
-		b.Host,
-		b.DockerHub,
-		b.GolangVersion,
-		b.BuildStatus)
+	return fmt.Sprintf("%#v", b)
 }
 
 func init() {


### PR DESCRIPTION
Similar to what `kubectl version` does, this patch adds the ability
to show server's info on the output.

The default behavior is to just show client info. The flag `--remote`
was added to show server information. Fetching server info might take
some time, so, it's an opt-in feature rather than a default behavior.

This patch also modifies the output to match the `kubectl` behavior, i.e.:
 - Dumps the version structure
 - Adds JSON and YAML output formats

This is useful for debugging purposes, where one can easily find
the version of each Istio component in the control plane that's
actually deployed.

Examples of usage:
 - mixs version -o yaml
 - galley version -o json
 - istioctl version --remote
 - istioctl version --remote --short
 - istioctl version --remote -o yaml

Closes #2491.