### PR TITLE
istio-pilot shoud be in istio-system namespace

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
     name: istio-pilot
+    namespace: {{ $.Release.Namespace }}
 spec:
     maxReplicas: {{ .Values.autoscaleMax }}
     minReplicas: {{ .Values.autoscaleMin }}


### PR DESCRIPTION
istio-pilot HorizontalPodAutoscaler located in `default` namespace. 

I think it should be in istio-system.

/assign @costinm 