### PR TITLE
Changed the bug/feature issue template description font to small font

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,25 +5,25 @@ about: Report a bug to help us improve Istio
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<sub><sup>A clear and concise description of what the bug is.</sup></sub>
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<sub><sup>A clear and concise description of what you expected to happen.</sup></sub>
 
 **Steps to reproduce the bug**
-Steps to reproduce the behavior.
+<sub><sup>Steps to reproduce the behavior.</sup></sub>
 
 **Version**
-What version of istio and Kubernetes are you using? Use `istioctl version` and `kubectl version`
+<sub><sup>What version of istio and Kubernetes are you using? Use `istioctl version` and `kubectl version`</sup></sub>
 
 **Is Istio Auth enabled or not?**
-Did you install the stable istio.yaml, istio-auth.yaml.... or if using the Helm chart please provide full command line input.
+<sub><sup>Did you install the stable istio.yaml, istio-auth.yaml.... or if using the Helm chart please provide full command line input.</sup></sub>
 
 **Environment**
-Which environment, cloud vendor, OS, etc are you using?
+<sub><sup>Which environment, cloud vendor, OS, etc are you using?</sup></sub>
 
 **Cluster state**
-If you're running on Kubernetes, consider [following the
+<sub><sup>If you're running on Kubernetes, consider [following the
 instructions](http://istio.io/help/bugs/#generating-a-cluster-state-archive)
 to generate "istio-dump.tar.gz", then attach it here by dragging and dropping
-the file onto this issue.
+the file onto this issue.</sup></sub>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,13 +5,13 @@ about: Suggest an idea to improve Istio
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is
+<sub><sup>A clear and concise description of what the problem is</sup></sub>
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<sub><sup>A clear and concise description of what you want to happen.</sup></sub>
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<sub><sup>A clear and concise description of any alternative solutions or features you've considered.</sup></sub>
 
 **Additional context**
-Add any other context about the feature request here.
+<sub><sup>Add any other context about the feature request here.</sup></sub>


### PR DESCRIPTION
When reading bug/feature reports that were created from the templates I always find it difficult to focus on the user input vs. template description text.
This change will just make the description text smaller to make our life easier.
Other alternatives (such as italic) can be used too.

/assign @geeknoid 