### PR TITLE
Add option to deployableConfig to remove existing resources

### DIFF
--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -164,8 +164,9 @@ type deployableConfig struct {
 	Namespace string
 	YamlFiles []string
 	// List of resources must be removed during deployableConfig setup, and restored
-	// during teardown. Typically, these are resources added by default installation and need to
-	// be modified for test. These resources are in the same namespace defined above.
+	// during teardown. These resources must exist before deployableConfig setup runs, and should be
+	// in the same namespace defined above. Typically, they are added by the default Istio installation
+	// (e.g the default global authentication policy) and need to be modified for tests.
 	Removes    []resource
 	applied    []string
 	removed    []string
@@ -176,7 +177,7 @@ type deployableConfig struct {
 func (c *deployableConfig) Setup() error {
 	c.removed = []string{}
 	for _, r := range c.Removes {
-		content, err := util.KubeExport(c.Namespace, r.Kind, r.Name, c.kubeconfig)
+		content, err := util.KubeGetYaml(c.Namespace, r.Kind, r.Name, c.kubeconfig)
 		if err != nil {
 			// Run the teardown function now and return
 			_ = c.Teardown()

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -150,6 +150,17 @@ func KubeApply(namespace, yamlFileName string, kubeconfig string) error {
 	return err
 }
 
+// KubeExport kubectl get yaml content for given resource.
+func KubeExport(namespace, resource, name string, kubeconfig string) (string, error) {
+	var cmd string
+	if namespace == "" {
+		cmd = fmt.Sprintf("kubectl get %s %s -o yaml --kubeconfig=%s --export", resource, name, kubeconfig)
+	}
+	cmd = fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
+
+	return Shell(cmd)
+}
+
 // KubeApplyContentSilent kubectl apply from contents silently
 func KubeApplyContentSilent(namespace, yamlContents string, kubeconfig string) error {
 	tmpfile, err := WriteTempfile(os.TempDir(), "kubeapply", ".yaml", yamlContents)

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -155,8 +155,9 @@ func KubeExport(namespace, resource, name string, kubeconfig string) (string, er
 	var cmd string
 	if namespace == "" {
 		cmd = fmt.Sprintf("kubectl get %s %s -o yaml --kubeconfig=%s --export", resource, name, kubeconfig)
+	} else {
+		cmd = fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
 	}
-	cmd = fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
 
 	return Shell(cmd)
 }

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -150,14 +150,12 @@ func KubeApply(namespace, yamlFileName string, kubeconfig string) error {
 	return err
 }
 
-// KubeExport kubectl get yaml content for given resource.
-func KubeExport(namespace, resource, name string, kubeconfig string) (string, error) {
-	var cmd string
+// KubeGetYaml kubectl get yaml content for given resource.
+func KubeGetYaml(namespace, resource, name string, kubeconfig string) (string, error) {
 	if namespace == "" {
-		cmd = fmt.Sprintf("kubectl get %s %s -o yaml --kubeconfig=%s --export", resource, name, kubeconfig)
-	} else {
-		cmd = fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
+		namespace = "default"
 	}
+	cmd := fmt.Sprintf("kubectl get %s %s -n %s -o yaml --kubeconfig=%s --export", resource, name, namespace, kubeconfig)
 
 	return Shell(cmd)
 }


### PR DESCRIPTION
This change allows to write e2e test that needs to modify existing resources. One of example is for [PR 7750](https://github.com/istio/istio/pull/7750), which need to change the default authentication policy and destination rules.

