### PR TITLE
Update istio-cluster.jinja

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -75,7 +75,7 @@ resources:
       autoDelete: true
       initializeParams:
         diskName: {{ CLUSTER_NAME }}-vm-disk
-        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-8
+        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9
     metadata:
       items:
       - key: startup-script


### PR DESCRIPTION
The [GKE quickstart](https://istio.io/docs/setup/kubernetes/quick-start-gke-dm/) deployment-manager instructions fail citing a missing source image.

Just had to s/debian-8/debian-9/ to get it working again.