### PR TITLE
Rename updater update to apply

### DIFF
--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -42,7 +42,7 @@ type updater struct {
 }
 
 // Update interface method implementation.
-func (u *updater) Update(ch *client.Change) error {
+func (u *updater) Apply(ch *client.Change) error {
 	fmt.Printf("Incoming change: %v\n", ch.MessageName)
 
 	for i, o := range ch.Objects {

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -189,8 +189,8 @@ func (b *backend) List() map[store.Key]*store.BackEndResource {
 	return result
 }
 
-// Update implements client.Updater.Update.
-func (b *backend) Update(change *client.Change) error {
+// Apply implements client.Updater.Apply
+func (b *backend) Apply(change *client.Change) error {
 	b.state.Lock()
 	defer b.state.Unlock()
 	defer b.callUpdateHook()

--- a/mixer/pkg/config/mcp/backend_test.go
+++ b/mixer/pkg/config/mcp/backend_test.go
@@ -61,8 +61,8 @@ type testState struct {
 	server  *mcptest.Server
 	backend store.Backend
 
-	// updateWg is used to synchronize between w.r.t. to the Updater.Update call.
-	// updateWg.Done() will be called each time Updater.Update call completes successfully.
+	// updateWg is used to synchronize between w.r.t. to the Updater.Apply call.
+	// updateWg.Done() will be called each time Updater.Apply call completes successfully.
 	// Test authors need to call add on this, before sending updates through the server.
 	updateWg sync.WaitGroup
 }

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -56,7 +56,7 @@ type Change struct {
 
 // Updater provides configuration changes in batches of the same protobuf message type.
 type Updater interface {
-	// Update is invoked when the client receives new configuration updates
+	// Apply is invoked when the client receives new configuration updates
 	// from the server. The caller should return an error if any of the provided
 	// configuration resources are invalid or cannot be applied. The client will
 	// propagate errors back to the server accordingly.

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -60,7 +60,7 @@ type Updater interface {
 	// from the server. The caller should return an error if any of the provided
 	// configuration resources are invalid or cannot be applied. The client will
 	// propagate errors back to the server accordingly.
-	Update(*Change) error
+	Apply(*Change) error
 }
 
 type perTypeState struct {
@@ -235,7 +235,7 @@ func (c *Client) handleResponse(response *mcp.MeshConfigResponse) error {
 		change.Objects = append(change.Objects, object)
 	}
 
-	if err := c.updater.Update(change); err != nil {
+	if err := c.updater.Apply(change); err != nil {
 		errDetails := status.Error(codes.InvalidArgument, err.Error())
 		return c.sendNACKRequest(response, state.version(), errDetails)
 	}

--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -97,7 +97,7 @@ func (ts *testStream) Recv() (*mcp.MeshConfigResponse, error) {
 	return response, nil
 }
 
-func (ts *testStream) Update(change *Change) error {
+func (ts *testStream) Apply(change *Change) error {
 	if ts.updateError {
 		return errors.New("update error")
 	}

--- a/pkg/mcp/configz/configz_test.go
+++ b/pkg/mcp/configz/configz_test.go
@@ -38,7 +38,7 @@ import (
 type updater struct {
 }
 
-func (u *updater) Update(c *client.Change) error {
+func (u *updater) Apply(c *client.Change) error {
 	return nil
 }
 


### PR DESCRIPTION
This rename allows us to combine both updater and ConfigStoreCache and removes any chance of name collisions in the future.