### PR TITLE
Replace "MaxMsgSize" with "MaxRecvMsgSize" in grpc server

### DIFF
--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -65,7 +65,7 @@ func (ts *testState) createGRPCServer() (string, error) {
 
 	var grpcOptions []grpc.ServerOption
 	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(32))
-	grpcOptions = append(grpcOptions, grpc.MaxMsgSize(1024*1024))
+	grpcOptions = append(grpcOptions, grpc.MaxRecvMsgSize(1024*1024))
 
 	// get everything wired up
 	ts.gs = grpc.NewServer(grpcOptions...)

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -48,7 +48,7 @@ func (bs *benchState) createGRPCServer() (string, error) {
 	}
 
 	// get everything wired up
-	bs.gs = grpc.NewServer(grpc.MaxConcurrentStreams(256), grpc.MaxMsgSize(1024*1024))
+	bs.gs = grpc.NewServer(grpc.MaxConcurrentStreams(256), grpc.MaxRecvMsgSize(1024*1024))
 
 	bs.gp = pool.NewGoroutinePool(32, false)
 	bs.gp.AddWorkers(32)

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -126,7 +126,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 
 	var grpcOptions []grpc.ServerOption
 	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(uint32(a.MaxConcurrentStreams)))
-	grpcOptions = append(grpcOptions, grpc.MaxMsgSize(int(a.MaxMessageSize)))
+	grpcOptions = append(grpcOptions, grpc.MaxRecvMsgSize(int(a.MaxMessageSize)))
 
 	var interceptors []grpc.UnaryServerInterceptor
 	var err error


### PR DESCRIPTION
As "MaxMsgSize" is now deprecated, use MaxRecvMsgSize instead in grpc server,