### PR TITLE
Data race fix for recent changes in pilot

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -243,6 +243,9 @@ func (ps *PushContext) UpdateMetrics() {
 // VirtualServices lists all virtual services bound to the specified gateways
 // This replaces store.VirtualServices
 func (ps *PushContext) VirtualServices(gateways map[string]bool) []Config {
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
+
 	configs := ps.VirtualServiceConfigs
 	out := make([]Config, 0)
 	for _, config := range configs {


### PR DESCRIPTION
Fixing a data race introduced by #7635 (release-1.0) and #7779 (master).
Causes `racetest` to constantly fail.

Please consider cherry picking it into `release-1.0`.

cc @rshriram @costinm 
