### PR TITLE
Remove blank excludes flag

### DIFF
--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -5,11 +5,6 @@
 TOOLS_DIR="$(cd "$(dirname "${0}")" && pwd -P)"
 ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 
-# Set global rule exclusions here, separated by comma (e.g. SC1090,SC1091).
-# See https://github.com/koalaman/shellcheck/wiki for details on each code's
-# corresponding rule.
-EXCLUDES=""
-
 # All files ending in .sh.
 SH_FILES=$( \
     find "${ISTIO_ROOT}" \
@@ -26,5 +21,9 @@ SHEBANG_FILES=$( \
             head -n 1 "$f" | grep -q '^#!.*sh' && echo "$f";
         done)
 
+# Set global rule exclusions with the "excludes" flag, separated by comma (e.g.
+# "--excludes=SC1090,SC1091"). See https://github.com/koalaman/shellcheck/wiki
+# for details on each code's corresponding rule.
+
 echo "${SH_FILES}" "${SHEBANG_FILES}" \
-    | xargs shellcheck --exclude="${EXCLUDES}"
+    | xargs shellcheck


### PR DESCRIPTION
When ShellCheck finds errors, it is currently unable to display them, and instead shows "Prelude.read: no parse" because of the empty "--excludes=" flag. See [this CircleCI job](https://circleci.com/gh/istio/istio/153959?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link), which failed in #7788 for an example.

This PR removes the empty flag.

It's an elusive bug since it only causes problems if there are violations, probably due to some lazy loading in the Haskell implementation.

/cc @kyessenov @mandarjog @gargnupur 
/assign @kyessenov 
