### PR TITLE
Use debian-9 GCE image family.

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -75,7 +75,7 @@ resources:
       autoDelete: true
       initializeParams:
         diskName: {{ CLUSTER_NAME }}-vm-disk
-        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-8
+        sourceImage: https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/family/debian-9
     metadata:
       items:
       - key: startup-script


### PR DESCRIPTION
The debian-8 GCE image is deprecated so is not usable by default in the
deployment manager script.  So we'll bump up to debian-9 and that should
keep for a couple of years.

With this change, it fixed https://github.com/istio/istio/issues/7049 for me and I was able to create my cluster using deployment manager on GKE