### PR TITLE
Bad default for Kaili - Updated install_addons.yml

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: istio-release-1.0
+      kiali_version: istio-1.0
 
   - name: Install Kiali on Openshift
     shell: |


### PR DESCRIPTION
The default path to pull the Kaili addon is pointing to an invalid branch: `istio-release-1.0`

So installing with `"addon": ["kiali"]` is giving 404 errors from the curl command.

This change sets the default `kiali_version` to the branch here:
https://github.com/kiali/kiali/tree/istio-1.0
