### PR TITLE
Add RDS load timestamp to istioctl proxy-status

### DIFF
--- a/istioctl/pkg/util/configdump/route.go
+++ b/istioctl/pkg/util/configdump/route.go
@@ -16,11 +16,37 @@ package configdump
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bradfitz/slice"
 	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
 	proto "github.com/gogo/protobuf/types"
 )
+
+// GetLastUpdatedDynamicRouteTime retrieves the LastUpdated timestamp of the
+// most recently updated DynamicRouteConfig
+func (w *Wrapper) GetLastUpdatedDynamicRouteTime() (*time.Time, error) {
+	routeDump, err := w.GetRouteConfigDump()
+	if err != nil {
+		return nil, err
+	}
+	drc := routeDump.GetDynamicRouteConfigs()
+
+	lastUpdated := time.Unix(0, 0) // get the oldest possible timestamp
+	for i := range drc {
+		if drc[i].LastUpdated != nil {
+			if drLastUpdated, err := proto.TimestampFromProto(drc[i].LastUpdated); err != nil {
+				return nil, err
+			} else if drLastUpdated.After(lastUpdated) {
+				lastUpdated = drLastUpdated
+			}
+		}
+	}
+	if lastUpdated.After(time.Unix(0, 0)) { // if a timestamp was obtained from a drc
+		return &lastUpdated, nil
+	}
+	return nil, nil
+}
 
 // GetDynamicRouteDump retrieves a route dump with just dynamic active routes in it
 func (w *Wrapper) GetDynamicRouteDump(stripVersions bool) (*adminapi.RoutesConfigDump, error) {

--- a/istioctl/pkg/writer/compare/comparator.go
+++ b/istioctl/pkg/writer/compare/comparator.go
@@ -27,6 +27,7 @@ type Comparator struct {
 	envoy, pilot *configdump.Wrapper
 	w            io.Writer
 	context      int
+	location     string
 }
 
 // NewComparator is a comparator constructor
@@ -52,6 +53,7 @@ func NewComparator(w io.Writer, pilotResponses map[string][]byte, envoyResponse 
 	c.envoy = envoyDump
 	c.w = w
 	c.context = 7
+	c.location = "Local" // the time.Location for formatting time.Time instances
 	return c, nil
 }
 

--- a/istioctl/pkg/writer/compare/route_test.go
+++ b/istioctl/pkg/writer/compare/route_test.go
@@ -17,6 +17,7 @@ package compare
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"istio.io/istio/tests/util"
@@ -55,6 +56,7 @@ func TestComparator_RouteDiff(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &bytes.Buffer{}
 			c, err := NewComparator(got, tt.pilot, tt.envoy)
+			c.location = "UTC"
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -68,7 +70,7 @@ func TestComparator_RouteDiff(t *testing.T) {
 				if err := util.Compare(got.Bytes(), want); err != nil {
 					t.Error(err.Error())
 				}
-			} else if got.String() != "Routes Match\n" {
+			} else if !strings.HasPrefix(got.String(), "Routes Match") {
 				t.Errorf("wanted match but got a diff")
 			}
 		})

--- a/istioctl/pkg/writer/compare/testdata/diffenvoyconfigdump.json
+++ b/istioctl/pkg/writer/compare/testdata/diffenvoyconfigdump.json
@@ -458,6 +458,7 @@
             "dynamicRouteConfigs": [
                 {
                     "versionInfo": "2018-06-19 06:21:16.597131985 +0000 UTC m=+38444.053119011",
+                    "lastUpdated": "2018-06-19T06:21:16.597131985+00:00",
                     "routeConfig": {
                         "name": "15004",
                         "virtualHosts": [

--- a/istioctl/pkg/writer/compare/testdata/routediff.txt
+++ b/istioctl/pkg/writer/compare/testdata/routediff.txt
@@ -1,3 +1,4 @@
+Routes Don't Match (RDS last loaded at Tue, 19 Jun 2018 06:21:16 UTC)
 --- Pilot Routes
 +++ Envoy Routes
 @@ -9,16 +9,14 @@


### PR DESCRIPTION
This PR adds the RDS load timestamp to `istioctl proxy-status <pod>` i.e. by obtaining the most recent `LastUpdated` value from all available `DynamicRouteConfig`s.

Signed-off-by: Venil Noronha <veniln@vmware.com>

Fixes #7805 