### PR TITLE
optimize `edsClusters` `connectionNumber` to reduce access contention

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -669,7 +669,7 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 		AdsPushAll(s)
 	}
 
-	edsClusterMutex.Lock()
+	edsClusterMutex.RLock()
 	comma := false
 	if len(edsClusters) > 0 {
 		fmt.Fprintln(w, "[")
@@ -689,7 +689,7 @@ func (s *DiscoveryServer) edsz(w http.ResponseWriter, req *http.Request) {
 	} else {
 		w.WriteHeader(404)
 	}
-	edsClusterMutex.Unlock()
+	edsClusterMutex.RUnlock()
 }
 
 // cdsz implements a status and debug interface for CDS.

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -221,8 +221,8 @@ func localityLbEndpointsFromInstances(instances []*model.ServiceInstance) []endp
 }
 
 func connectionID(node string) string {
-	atomic.AddInt64(&connectionNumber, 1)
-	return node + "-" + strconv.FormatInt(atomic.LoadInt64(&connectionNumber), 10)
+	id := atomic.AddInt64(&connectionNumber, 1)
+	return node + "-" + strconv.FormatInt(id, 10)
 }
 
 // StreamEndpoints implements xdsapi.EndpointDiscoveryServiceServer.StreamEndpoints().


### PR DESCRIPTION
1. use `sync.RWMutex` instead of `sync.Mutex`

1. `connectionNumber` read/write with ` sync.atomic`