### PR TITLE
Add example for istioctl deregister and fix wrong comments

### DIFF
--- a/istioctl/cmd/istioctl/deregister.go
+++ b/istioctl/cmd/istioctl/deregister.go
@@ -25,7 +25,9 @@ var (
 	deregisterCmd = &cobra.Command{
 		Use:   "deregister <svcname> <ip>",
 		Short: "De-registers a service instance",
-		Args:  cobra.MinimumNArgs(2),
+		Example: `# de-register an endpoint 172.17.0.2 from service my-svc:
+istioctl deregister my-svc 172.17.0.2`,
+		Args: cobra.MinimumNArgs(2),
 		RunE: func(c *cobra.Command, args []string) error {
 			svcName := args[0]
 			ip := args[1]

--- a/pilot/pkg/serviceregistry/kube/deregister.go
+++ b/pilot/pkg/serviceregistry/kube/deregister.go
@@ -61,8 +61,8 @@ func removeIPFromEndpoint(eps *v1.Endpoints, ip string) bool {
 	return match
 }
 
-// DeRegisterEndpoint registers the endpoint (and the service if it
-// already exists). It creates or updates as needed.
+// DeRegisterEndpoint removes the endpoint (and the service if it
+// already exists) from Kubernetes. It creates or updates as needed.
 func DeRegisterEndpoint(client kubernetes.Interface, namespace string, svcName string,
 	ip string) error {
 	getOpt := meta_v1.GetOptions{IncludeUninitialized: true}


### PR DESCRIPTION
This PR:

* Add example for istioctl deregister command 

* fix wrong comments

NOTE: should we update the document [here](https://istio.io/docs/reference/commands/istioctl/)?