### PR TITLE
Helm chart: Respect custom proxy_init image value for enable-core-dump container

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -49,7 +49,11 @@ data:
         - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
           - /bin/sh
-        image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
+  {{- if contains "/" .Values.global.proxy_init.image }}
+        image: "{{ .Values.global.proxy_init.image }}"
+  {{- else }}
+        image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
+  {{- end }}
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/7857.
Used the same logic as for the `istio-init` container.