### PR TITLE
Fix shellcheck errors in go generate sh files

### DIFF
--- a/bin/counterfeiter.sh
+++ b/bin/counterfeiter.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
 WD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$(dirname $WD)
+ROOT="$(dirname "$WD")"
 
 # Ensure expected GOPATH setup
-if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
+if [ "$ROOT" != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
   die "Istio not found in GOPATH/src/istio.io/"
 fi
 
 gen_img=gcr.io/istio-testing/go_generate_dependency:2018-07-26
 
-docker run  -i -e GOPATH=/go:$GOPATH --rm --entrypoint counterfeiter -v $ROOT:$ROOT -w $(pwd) $gen_img $*
+docker run  -i -e GOPATH=/go:$GOPATH --rm --entrypoint counterfeiter -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*
+
+

--- a/bin/counterfeiter.sh
+++ b/bin/counterfeiter.sh
@@ -10,6 +10,7 @@ fi
 
 gen_img=gcr.io/istio-testing/go_generate_dependency:2018-07-26
 
+# shellcheck disable=SC2048
 docker run  -i -e GOPATH=/go:$GOPATH --rm --entrypoint counterfeiter -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*
 
 

--- a/bin/go-bindata.sh
+++ b/bin/go-bindata.sh
@@ -10,4 +10,5 @@ fi
 
 gen_img=gcr.io/istio-testing/go_generate_dependency:2018-07-26
 
+# shellcheck disable=SC2048
 docker run  -i  --rm --entrypoint go-bindata -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*

--- a/bin/go-bindata.sh
+++ b/bin/go-bindata.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 
 WD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT=$(dirname $WD)
+ROOT="$(dirname "$WD")"
 
 # Ensure expected GOPATH setup
-if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
+if [ "$ROOT" != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
   die "Istio not found in GOPATH/src/istio.io/"
 fi
 
 gen_img=gcr.io/istio-testing/go_generate_dependency:2018-07-26
 
-docker run  -i  --rm --entrypoint go-bindata -v $ROOT:$ROOT -w $(pwd) $gen_img $*
+docker run  -i  --rm --entrypoint go-bindata -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*
+
+
+
+

--- a/bin/go-bindata.sh
+++ b/bin/go-bindata.sh
@@ -11,7 +11,3 @@ fi
 gen_img=gcr.io/istio-testing/go_generate_dependency:2018-07-26
 
 docker run  -i  --rm --entrypoint go-bindata -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*
-
-
-
-

--- a/bin/mixer_codegen.sh
+++ b/bin/mixer_codegen.sh
@@ -6,7 +6,7 @@ die () {
 }
 
 WD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT="$(dirname $WD)"
+ROOT="$(dirname "$WD")"
 
 if [ ! -e "$ROOT/Gopkg.lock" ]; then
   echo "Please run 'dep ensure' first"

--- a/bin/protoc.sh
+++ b/bin/protoc.sh
@@ -5,15 +5,14 @@ if [[ $# -le 0 ]]; then
     exit 1
 fi
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$(dirname "$WD")"
 
 # Ensure expected GOPATH setup
-if [ $ROOT != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
+if [ "$ROOT" != "${GOPATH-$HOME/go}/src/istio.io/istio" ]; then
   die "Istio not found in GOPATH/src/istio.io/"
 fi
 
 gen_img=gcr.io/istio-testing/protoc:2018-06-12
 
-docker run  -i  --rm --entrypoint /usr/bin/protoc -v $ROOT:$ROOT -w $(pwd) $gen_img $*
+docker run  -i  --rm --entrypoint /usr/bin/protoc -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*

--- a/bin/protoc.sh
+++ b/bin/protoc.sh
@@ -15,4 +15,5 @@ fi
 
 gen_img=gcr.io/istio-testing/protoc:2018-06-12
 
+# shellcheck disable=SC2048
 docker run  -i  --rm --entrypoint /usr/bin/protoc -v "$ROOT":"$ROOT" -w "$(pwd)" "$gen_img" $*

--- a/docker/build_and_push_go_generate_dependency.sh
+++ b/docker/build_and_push_go_generate_dependency.sh
@@ -8,8 +8,8 @@
 HUB=gcr.io/istio-testing
 VERSION=$(date +%Y-%m-%d)
 
-docker build --no-cache -t $HUB/go_generate_dependency:$VERSION -f Dockerfile.go_generate_dependency .
+docker build --no-cache -t $HUB/go_generate_dependency:"$VERSION" -f Dockerfile.go_generate_dependency .
 
 gcloud auth configure-docker
 
-docker push $HUB/go_generate_dependency:$VERSION
+docker push $HUB/go_generate_dependency:"$VERSION"


### PR DESCRIPTION
@Tahler : is it possible to get an exception for rule SC2048?

We need $* instead of "$@" for commands to work properly using docker files

Fixing bug https://github.com/istio/istio/issues/7861 for go generate files