### PR TITLE
Implement basic mTLS functionality in Galley

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -54,8 +54,8 @@ func serverCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 		"The location of the key file for mutual TLS")
 	cmd.PersistentFlags().StringVarP(&sa.CACertificateFile, "caCertFile", "", sa.CACertificateFile,
 		"The location of the certificate file for the root certificate authority")
-	cmd.PersistentFlags().StringVarP(&sa.ConfigMapFolder, "configMapFolder", "", sa.ConfigMapFolder,
-		"The config map mount folder for config map based settings")
+	cmd.PersistentFlags().StringVarP(&sa.AccessListFile, "accessListFile", "", sa.AccessListFile,
+		"The access list yaml file that contains the allowd mTLS peer ids.")
 	cmd.PersistentFlags().StringVar(&sa.LivenessProbeOptions.Path, "livenessProbePath", sa.LivenessProbeOptions.Path,
 		"Path to the file for the liveness probe.")
 	cmd.PersistentFlags().DurationVar(&sa.LivenessProbeOptions.UpdateInterval, "livenessProbeInterval", sa.LivenessProbeOptions.UpdateInterval,

--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -46,7 +46,16 @@ func serverCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 		"Maximum size of individual gRPC messages")
 	cmd.PersistentFlags().UintVarP(&sa.MaxConcurrentStreams, "maxConcurrentStreams", "", sa.MaxConcurrentStreams,
 		"Maximum number of outstanding RPCs per connection")
-
+	cmd.PersistentFlags().BoolVarP(&sa.Insecure, "insecure", "", sa.Insecure,
+		"Use insecure gRPC communication")
+	cmd.PersistentFlags().StringVarP(&sa.CertificateFile, "certFile", "", sa.CertificateFile,
+		"The location of the certificate file for mutual TLS")
+	cmd.PersistentFlags().StringVarP(&sa.KeyFile, "keyFile", "", sa.KeyFile,
+		"The location of the key file for mutual TLS")
+	cmd.PersistentFlags().StringVarP(&sa.CACertificateFile, "caCertFile", "", sa.CACertificateFile,
+		"The location of the certificate file for the root certificate authority")
+	cmd.PersistentFlags().StringVarP(&sa.ConfigMapFolder, "configMapFolder", "", sa.ConfigMapFolder,
+		"The config map mount folder for config map based settings")
 	cmd.PersistentFlags().StringVar(&sa.LivenessProbeOptions.Path, "livenessProbePath", sa.LivenessProbeOptions.Path,
 		"Path to the file for the liveness probe.")
 	cmd.PersistentFlags().DurationVar(&sa.LivenessProbeOptions.UpdateInterval, "livenessProbeInterval", sa.LivenessProbeOptions.UpdateInterval,

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -25,12 +25,13 @@ import (
 )
 
 const (
-	defaultCertDir         = "/etc/istio/certs/"
-	defaultConfigMapFolder = "/etc/istio/config"
-
+	defaultCertDir    = "/etc/istio/certs/"
 	defaultCertFile   = defaultCertDir + "cert-chain.pem"
 	defaultCACertFile = defaultCertDir + "root-cert.pem"
 	defaultCertKey    = defaultCertDir + "key.pem"
+
+	defaultConfigMapFolder = "/etc/istio/config/"
+	defaultAccessListFile  = defaultConfigMapFolder + "accesslist.yaml"
 )
 
 // Args contains the startup arguments to instantiate Galley.
@@ -65,8 +66,8 @@ type Args struct {
 	// CACertificateFile is the trusted root certificate authority's cert file.
 	CACertificateFile string
 
-	// ConfigMapFolder is the folder where Galley will look for Kubernetes Config Map based configuration.
-	ConfigMapFolder string
+	// AccessListFile is the YAML file that specifies ids of the allowed mTLS peers.
+	AccessListFile string
 
 	// The logging options to use
 	LoggingOptions *log.Options
@@ -92,7 +93,7 @@ func DefaultArgs() *Args {
 		CertificateFile:        defaultCertFile,
 		KeyFile:                defaultCertKey,
 		CACertificateFile:      defaultCACertFile,
-		ConfigMapFolder:        defaultConfigMapFolder,
+		AccessListFile:         defaultAccessListFile,
 		LoggingOptions:         log.DefaultOptions(),
 		LivenessProbeOptions:   &probe.Options{},
 		ReadinessProbeOptions:  &probe.Options{},
@@ -114,7 +115,7 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "KeyFile: %s\n", a.KeyFile)
 	fmt.Fprintf(buf, "CertificateFile: %s\n", a.CertificateFile)
 	fmt.Fprintf(buf, "CACertificateFile: %s\n", a.CACertificateFile)
-	fmt.Fprintf(buf, "ConfigMapFolder: %s\n", a.ConfigMapFolder)
+	fmt.Fprintf(buf, "AccessListFile: %s\n", a.AccessListFile)
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "LivenessProbeOptions: %#v\n", *a.LivenessProbeOptions)
 	fmt.Fprintf(buf, "ReadinessProbeOptions: %#v\n", *a.ReadinessProbeOptions)

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -24,6 +24,15 @@ import (
 	"istio.io/istio/pkg/probe"
 )
 
+const (
+	defaultCertDir         = "/etc/istio/certs/"
+	defaultConfigMapFolder = "/etc/istio/config"
+
+	defaultCertFile   = defaultCertDir + "cert-chain.pem"
+	defaultCACertFile = defaultCertDir + "root-cert.pem"
+	defaultCertKey    = defaultCertDir + "key.pem"
+)
+
 // Args contains the startup arguments to instantiate Galley.
 type Args struct {
 	// The path to kube configuration file.
@@ -44,6 +53,21 @@ type Args struct {
 	// Maximum number of outstanding RPCs per connection
 	MaxConcurrentStreams uint
 
+	// Insecure gRPC service is used for the MCP server. CertificateFile and KeyFile is ignored.
+	Insecure bool
+
+	// CertificateFile to use for mTLS gRPC.
+	CertificateFile string
+
+	// KeyFile to use for mTLS gRPC.
+	KeyFile string
+
+	// CACertificateFile is the trusted root certificate authority's cert file.
+	CACertificateFile string
+
+	// ConfigMapFolder is the folder where Galley will look for Kubernetes Config Map based configuration.
+	ConfigMapFolder string
+
 	// The logging options to use
 	LoggingOptions *log.Options
 
@@ -61,9 +85,14 @@ type Args struct {
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
 func DefaultArgs() *Args {
 	return &Args{
-		APIAddress:             "tcp://127.0.0.1:9901",
+		APIAddress:             "tcp://0.0.0.0:9901",
 		MaxReceivedMessageSize: 1024 * 1024,
 		MaxConcurrentStreams:   1024,
+		Insecure:               false,
+		CertificateFile:        defaultCertFile,
+		KeyFile:                defaultCertKey,
+		CACertificateFile:      defaultCACertFile,
+		ConfigMapFolder:        defaultConfigMapFolder,
 		LoggingOptions:         log.DefaultOptions(),
 		LivenessProbeOptions:   &probe.Options{},
 		ReadinessProbeOptions:  &probe.Options{},
@@ -81,6 +110,11 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "EnableGrpcTracing: %v\n", a.APIAddress)
 	fmt.Fprintf(buf, "MaxReceivedMessageSize: %d\n", a.MaxReceivedMessageSize)
 	fmt.Fprintf(buf, "MaxConcurrentStreams: %d\n", a.MaxConcurrentStreams)
+	fmt.Fprintf(buf, "Insecure: %v\n", a.Insecure)
+	fmt.Fprintf(buf, "KeyFile: %s\n", a.KeyFile)
+	fmt.Fprintf(buf, "CertificateFile: %s\n", a.CertificateFile)
+	fmt.Fprintf(buf, "CACertificateFile: %s\n", a.CACertificateFile)
+	fmt.Fprintf(buf, "ConfigMapFolder: %s\n", a.ConfigMapFolder)
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "LivenessProbeOptions: %#v\n", *a.LivenessProbeOptions)
 	fmt.Fprintf(buf, "ReadinessProbeOptions: %#v\n", *a.ReadinessProbeOptions)

--- a/galley/pkg/server/args_test.go
+++ b/galley/pkg/server/args_test.go
@@ -20,7 +20,7 @@ func TestDefaultArgs(t *testing.T) {
 	a := DefaultArgs()
 
 	// Spot check a few things
-	if a.APIAddress != "tcp://127.0.0.1:9901" {
+	if a.APIAddress != "tcp://0.0.0.0:9901" {
 		t.Fatalf("unexpected APIAddress: %v", a.APIAddress)
 	}
 

--- a/galley/pkg/server/configmap.go
+++ b/galley/pkg/server/configmap.go
@@ -1,0 +1,123 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"sync"
+
+	"github.com/howeyc/fsnotify"
+	"gopkg.in/yaml.v2"
+
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/server"
+)
+
+const (
+	accesslistfilename = "accesslist.yaml"
+)
+
+type accessList struct {
+	Allowed []string
+}
+
+func watchAccessList(stopCh <-chan struct{}, folder string) (*server.ListAuthChecker, error) {
+
+	accesslistfile := path.Join(folder, accesslistfilename)
+
+	// Do the initial read.
+	list, err := readAccessList(accesslistfile)
+	if err != nil {
+		return nil, err
+	}
+
+	checker := server.NewListAuthChecker()
+	checker.Set(list.Allowed...)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = watcher.Watch(accesslistfile); err != nil {
+		return nil, fmt.Errorf("unable to watch accesslist file %q: %v", accesslistfile, err)
+	}
+
+	// Coordinate the goroutines for orderly shutdown
+	var exitSignal sync.WaitGroup
+	exitSignal.Add(1)
+	exitSignal.Add(1)
+
+	go func() {
+		defer exitSignal.Done()
+
+		for {
+			select {
+			case e := <-watcher.Event:
+				if e.IsCreate() || e.IsModify() {
+					if list, err = readAccessList(accesslistfile); err != nil {
+						log.Errorf("Error reading access list %q: %v", accesslistfile, err)
+					} else {
+						checker.Set(list.Allowed...)
+					}
+				}
+				break
+
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	// Watch error events in a separate go routine See:
+	// https://github.com/fsnotify/fsnotify#faq
+	go func() {
+		defer exitSignal.Done()
+
+		for {
+			select {
+			case e := <-watcher.Error:
+				log.Errorf("error event while watching access list file: %v", e)
+				break
+
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+
+	go func() {
+		exitSignal.Wait()
+		_ = watcher.Close()
+	}()
+
+	return checker, nil
+}
+
+func readAccessList(accesslistfile string) (accessList, error) {
+	b, err := ioutil.ReadFile(accesslistfile)
+	if err != nil {
+		return accessList{}, fmt.Errorf("unable to read access list file %q: %v", accesslistfile, err)
+	}
+
+	var list accessList
+	if err = yaml.Unmarshal(b, &list); err != nil {
+		return accessList{}, fmt.Errorf("unable to parse access list file %q: %v", accesslistfile, err)
+	}
+
+	return list, nil
+}

--- a/galley/pkg/server/configmap.go
+++ b/galley/pkg/server/configmap.go
@@ -53,6 +53,8 @@ func watchAccessList(stopCh <-chan struct{}, folder string) (*server.ListAuthChe
 		return nil, err
 	}
 
+	// TODO: https://github.com/istio/istio/issues/7877
+	// It looks like fsnotify watchers have problems due to following symlinks. This needs to be handled.
 	if err = watcher.Watch(accesslistfile); err != nil {
 		return nil, fmt.Errorf("unable to watch accesslist file %q: %v", accesslistfile, err)
 	}

--- a/galley/pkg/server/configmap_test.go
+++ b/galley/pkg/server/configmap_test.go
@@ -1,0 +1,141 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package server
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/mcp/server"
+)
+
+func TestWatchAccessList_Basic(t *testing.T) {
+	initial := `
+allowed:
+    - spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account
+`
+
+	_, stopCh, checker, err := setupWatchAccessList(t, initial)
+	defer close(stopCh)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	actual := checker.String()
+	expected := `
+Allowed ids:
+spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account
+`
+
+	actual = strings.TrimSpace(actual)
+	expected = strings.TrimSpace(expected)
+
+	if actual != expected {
+		t.Fatalf("Mismatch:\ngot:\n%v\nwanted:\n%v\n", actual, expected)
+	}
+}
+
+func TestWatchAccessList_Initial_Unparseable(t *testing.T) {
+	initial := `
+332332
+	rfjeritojoi
+`
+
+	_, stopCh, _, err := setupWatchAccessList(t, initial)
+	defer close(stopCh)
+	if err == nil {
+		t.Fatal("Expected error not found")
+	}
+}
+
+func TestWatchAccessList_Initial_NotExists(t *testing.T) {
+	folder, err := ioutil.TempDir(os.TempDir(), "testWatchAccessList")
+	if err != nil {
+		t.Fatalf("error creating tmp folder: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	if _, err = watchAccessList(stopCh, folder); err == nil {
+		t.Fatalf("expected error not found")
+	}
+}
+
+func TestWatchAccessList_Update(t *testing.T) {
+	initial := `
+allowed:
+    - spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account
+`
+
+	file, stopCh, checker, err := setupWatchAccessList(t, initial)
+	defer close(stopCh)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	updated := `
+allowed:
+    - spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account
+`
+
+	writeFile(t, file, updated)
+
+	expected := `
+Allowed ids:
+spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account
+`
+	expected = strings.TrimSpace(expected)
+
+	var actual string
+	for i := 0; i < 100; i++ {
+		actual = checker.String()
+		actual = strings.TrimSpace(actual)
+
+		if actual == expected {
+			return
+		}
+
+		time.Sleep(time.Millisecond * 10)
+	}
+
+	t.Fatalf("Mismatch:\ngot:\n%v\nwanted:\n%v\n", actual, expected)
+}
+
+func setupWatchAccessList(t *testing.T, initialdata string) (string, chan struct{}, *server.ListAuthChecker, error) {
+	folder, err := ioutil.TempDir(os.TempDir(), "testWatchAccessList")
+	if err != nil {
+		t.Fatalf("error creating tmp folder: %v", err)
+	}
+
+	file := path.Join(folder, accesslistfilename)
+
+	writeFile(t, file, initialdata)
+
+	stopCh := make(chan struct{})
+	checker, err := watchAccessList(stopCh, folder)
+	return file, stopCh, checker, err
+}
+
+func writeFile(t *testing.T, file, contents string) {
+	if err := ioutil.WriteFile(file, []byte(contents), os.ModePerm); err != nil {
+		t.Fatalf("error writing access file contents: %v", err)
+	}
+}

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -103,7 +103,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	var checker *server.ListAuthChecker
 	if !a.Insecure {
 
-		checker, err = watchAccessList(s.stopCh, a.ConfigMapFolder)
+		checker, err = watchAccessList(s.stopCh, a.AccessListFile)
 		if err != nil {
 			return nil, err
 		}

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -112,10 +112,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
-		credentials, err := creds.CreateForServer(watcher)
-		if err != nil {
-			return nil, err
-		}
+		credentials := creds.CreateForServer(watcher)
 
 		grpcOptions = append(grpcOptions, grpc.Creds(credentials))
 	}

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -22,6 +22,8 @@ import (
 
 	"google.golang.org/grpc"
 
+	"istio.io/istio/pkg/mcp/creds"
+
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/galley/pkg/kube/source"
 	"istio.io/istio/galley/pkg/metadata"
@@ -44,6 +46,7 @@ type Server struct {
 	mcp        *server.Server
 	listener   net.Listener
 	controlZ   *ctrlz.Server
+	stopCh     chan struct{}
 
 	// probes
 	livenessProbe  probe.Controller
@@ -92,14 +95,34 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	distributor := snapshot.New()
 	s.processor = runtime.NewProcessor(src, distributor)
 
-	s.mcp = server.New(distributor, metadata.Types.TypeURLs(), nil)
-
 	var grpcOptions []grpc.ServerOption
 	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(uint32(a.MaxConcurrentStreams)))
 	grpcOptions = append(grpcOptions, grpc.MaxRecvMsgSize(int(a.MaxReceivedMessageSize)))
 
+	s.stopCh = make(chan struct{})
+	var checker *server.ListAuthChecker
+	if !a.Insecure {
+
+		checker, err = watchAccessList(s.stopCh, a.ConfigMapFolder)
+		if err != nil {
+			return nil, err
+		}
+
+		watcher, err := creds.WatchFiles(s.stopCh, a.CertificateFile, a.KeyFile, a.CACertificateFile)
+		if err != nil {
+			return nil, err
+		}
+		credentials, err := creds.CreateForServer(watcher)
+		if err != nil {
+			return nil, err
+		}
+
+		grpcOptions = append(grpcOptions, grpc.Creds(credentials))
+	}
 	grpc.EnableTracing = a.EnableGRPCTracing
 	s.grpcServer = grpc.NewServer(grpcOptions...)
+
+	s.mcp = server.New(distributor, metadata.Types.TypeURLs(), checker)
 
 	// get the network stuff setup
 	network := "tcp"
@@ -168,6 +191,11 @@ func (s *Server) Wait() error {
 
 // Close cleans up resources used by the server.
 func (s *Server) Close() error {
+	if s.stopCh != nil {
+		close(s.stopCh)
+		s.stopCh = nil
+	}
+
 	if s.shutdown != nil {
 		s.grpcServer.GracefulStop()
 		_ = s.Wait()

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -54,7 +54,9 @@ loop:
 			break loop
 		}
 
-		_, err := newServer(DefaultArgs(), p)
+		args := DefaultArgs()
+		args.Insecure = true
+		_, err := newServer(args, p)
 		if err == nil {
 			t.Fatalf("Expected error not found for i=%d", i)
 		}
@@ -69,7 +71,9 @@ func TestNewServer(t *testing.T) {
 		return runtime.NewInMemorySource(), nil
 	}
 
-	s, err := newServer(DefaultArgs(), p)
+	args := DefaultArgs()
+	args.Insecure = true
+	s, err := newServer(args, p)
 	if err != nil {
 		t.Fatalf("Unexpected error creating service: %v", err)
 	}
@@ -87,6 +91,7 @@ func TestNewServer_ValidProbeOptions(t *testing.T) {
 	}
 
 	a := DefaultArgs()
+	a.Insecure = true
 	a.LivenessProbeOptions = &probe.Options{Path: os.TempDir() + "/liveness", UpdateInterval: time.Second}
 	a.ReadinessProbeOptions = &probe.Options{Path: os.TempDir() + "/readiness", UpdateInterval: time.Second}
 
@@ -107,7 +112,9 @@ func TestServer_Basic(t *testing.T) {
 		return runtime.NewInMemorySource(), nil
 	}
 
-	s, err := newServer(DefaultArgs(), p)
+	args := DefaultArgs()
+	args.Insecure = true
+	s, err := newServer(args, p)
 	if err != nil {
 		t.Fatalf("Unexpected error creating service: %v", err)
 	}

--- a/pkg/mcp/server/listchecker.go
+++ b/pkg/mcp/server/listchecker.go
@@ -17,6 +17,8 @@ package server
 import (
 	"crypto/x509/pkix"
 	"errors"
+	"sort"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc/credentials"
@@ -70,6 +72,22 @@ func (l *ListAuthChecker) Set(ids ...string) {
 	l.idsMutex.Lock()
 	defer l.idsMutex.Unlock()
 	l.ids = newIds
+}
+
+// String is an implementation of Stringer.String.
+func (l *ListAuthChecker) String() string {
+	var ids []string
+	for id := range l.ids {
+		ids = append(ids, id)
+	}
+
+	sort.Strings(ids)
+
+	result := `Allowed ids:
+`
+	result += strings.Join(ids, "\n")
+
+	return result
 }
 
 // Check is an implementation of AuthChecker.Check.

--- a/pkg/mcp/server/listchecker.go
+++ b/pkg/mcp/server/listchecker.go
@@ -74,6 +74,15 @@ func (l *ListAuthChecker) Set(ids ...string) {
 	l.ids = newIds
 }
 
+// Allowed checks whether the given id is allowed.
+func (l *ListAuthChecker) Allowed(id string) bool {
+	l.idsMutex.Lock()
+	defer l.idsMutex.Unlock()
+
+	_, found := l.ids[id]
+	return found
+}
+
 // String is an implementation of Stringer.String.
 func (l *ListAuthChecker) String() string {
 	var ids []string


### PR DESCRIPTION
Implement basic mTLS functionality in Galley.

- Introduce new command-line flags to Galley server, to specify the location of the cert files and whether the server should start in insecure mode.
- Add support for an accesslist configmap file that can be used to dynamically specify the list of ids to be checked for access control.
