### PR TITLE
Add Galley server mode to helm charts

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/accesslist.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/accesslist.yaml.tpl
@@ -1,0 +1,4 @@
+{{ define "accesslist.yaml.tpl" }}
+allowed:
+    - spiffe://cluster.local/ns/{{ .Release.Namespace }}/sa/istio-mixer-service-account
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/clusterrole.yaml
@@ -14,6 +14,12 @@ rules:
 - apiGroups: ["config.istio.io"] # istio mixer CRD watcher
   resources: ["*"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["authentication.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["*"]
   resources: ["deployments"]
   resourceNames: ["istio-galley"]

--- a/install/kubernetes/helm/istio/charts/galley/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/configmap.yaml
@@ -12,4 +12,5 @@ metadata:
 data:
   validatingwebhookconfiguration.yaml: |-
     {{- include "validatingwebhookconfiguration.yaml.tpl" . | indent 4}}
-
+  accesslist.yaml: |-
+    {{- include "accesslist.yaml.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -68,6 +68,25 @@ spec:
                 - --interval=4s
             initialDelaySeconds: 4
             periodSeconds: 4
+        - name: server
+          image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+          - containerPort: 9901
+          command:
+          - /usr/local/bin/galley
+          - server
+          - --insecure=false
+          - --keyFile=/etc/istio/certs/key.pem
+          - --certFile=/etc/istio/certs/cert-chain.pem
+          - --caCertFile=/etc/istio/certs/root-cert.pem
+          volumeMounts:
+          - name: certs
+            mountPath: /etc/istio/certs
+            readOnly: true
+          - name: config
+            mountPath: /etc/istio/config
+            readOnly: true
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -11,5 +11,7 @@ spec:
     name: https-validation
   - port: 9093
     name: http-monitoring
+  - port: 9901
+    name: grpc-mcp
   selector:
     istio: galley


### PR DESCRIPTION
Add Galley server mode to helm charts.

- Add a server entry for MCP server.yaml.
- Add a template/configmap entry for accesslist.yaml, that defines the accesslist from which Galley can read and enforce/deny peers.
- Add Galley in server mode to the pod, as a separate container. (They should be combined into a single mode with https://github.com/istio/istio/issues/7500)
