### PR TITLE
Add mTLS support to Mixer MCP stack

### DIFF
--- a/mixer/adapter/rbac/rbac.go
+++ b/mixer/adapter/rbac/rbac.go
@@ -95,7 +95,7 @@ func (b *builder) SetAuthorizationTypes(types map[string]*authorization.Type) {}
 func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	reg := store.NewRegistry(mixerconfig.StoreInventory()...)
 	groupVersion := &schema.GroupVersion{Group: apiGroup, Version: apiVersion}
-	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion)
+	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion, "")
 	if err != nil {
 		return nil, env.Logger().Errorf("Unable to connect to the configuration server: %v", err)
 	}

--- a/mixer/adapter/rbac/rbac.go
+++ b/mixer/adapter/rbac/rbac.go
@@ -95,7 +95,7 @@ func (b *builder) SetAuthorizationTypes(types map[string]*authorization.Type) {}
 func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	reg := store.NewRegistry(mixerconfig.StoreInventory()...)
 	groupVersion := &schema.GroupVersion{Group: apiGroup, Version: apiVersion}
-	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion, "")
+	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion, nil)
 	if err != nil {
 		return nil, env.Logger().Errorf("Unable to connect to the configuration server: %v", err)
 	}

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -59,8 +59,12 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigStoreURL, "configStoreURL", "", sa.ConfigStoreURL,
 		"URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcp://<address> for MCP/Galley. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 
-	serverCmd.PersistentFlags().StringVarP(&sa.CertFolder, "certFolder", "", sa.CertFolder,
-		"The folder to read the certificates from. This is used for mTLS when connecting to an MCP backend.")
+	serverCmd.PersistentFlags().StringVarP(&sa.CertificateInfo.CertificateFile, "certFile", "", sa.CertificateInfo.CertificateFile,
+		"The location of the certificate file.")
+	serverCmd.PersistentFlags().StringVarP(&sa.CertificateInfo.CertificateFile, "keyFile", "", sa.CertificateInfo.KeyFile,
+		"The location of the key file.")
+	serverCmd.PersistentFlags().StringVarP(&sa.CertificateInfo.CertificateFile, "keyFile", "", sa.CertificateInfo.CACertificateFile,
+		"The location of the CA's cert file.")
 
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigDefaultNamespace, "configDefaultNamespace", "", sa.ConfigDefaultNamespace,
 		"Namespace used to store mesh wide configuration.")

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -57,7 +57,10 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 		"Max number of entries in the check result cache")
 
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigStoreURL, "configStoreURL", "", sa.ConfigStoreURL,
-		"URL of the config store. Use k8s://path_to_kubeconfig or fs:// for file system. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
+		"URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcp://<address> for MCP/Galley. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
+
+	serverCmd.PersistentFlags().StringVarP(&sa.CertFolder, "certFolder", "", sa.CertFolder,
+		"The folder to read the certificates from. This is used for mTLS when connecting to an MCP backend.")
 
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigDefaultNamespace, "configDefaultNamespace", "", sa.ConfigDefaultNamespace,
 		"Namespace used to store mesh wide configuration.")

--- a/mixer/pkg/config/crd/init.go
+++ b/mixer/pkg/config/crd/init.go
@@ -62,7 +62,7 @@ func (b *dynamicListerWatcherBuilder) build(res metav1.APIResource) cache.Lister
 }
 
 // NewStore creates a new Store instance.
-func NewStore(u *url.URL, gv *schema.GroupVersion) (store.Backend, error) {
+func NewStore(u *url.URL, gv *schema.GroupVersion, _ string) (store.Backend, error) {
 	kubeconfig := u.Path
 	namespaces := u.Query().Get("ns")
 	retryTimeout := crdRetryTimeout

--- a/mixer/pkg/config/crd/init.go
+++ b/mixer/pkg/config/crd/init.go
@@ -62,7 +62,7 @@ func (b *dynamicListerWatcherBuilder) build(res metav1.APIResource) cache.Lister
 }
 
 // NewStore creates a new Store instance.
-func NewStore(u *url.URL, gv *schema.GroupVersion, _ string) (store.Backend, error) {
+func NewStore(u *url.URL, gv *schema.GroupVersion, _ *store.CertificateInfo) (store.Backend, error) {
 	kubeconfig := u.Path
 	namespaces := u.Query().Get("ns")
 	retryTimeout := crdRetryTimeout

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -48,8 +48,8 @@ const (
 // Do not use 'init()' for automatic registration; linker will drop
 // the whole module because it looks unused.
 func Register(builders map[string]store.Builder) {
-	builder := func(u *url.URL, gv *schema.GroupVersion, certFolder string) (store.Backend, error) {
-		return newStore(u, certFolder, nil)
+	builder := func(u *url.URL, gv *schema.GroupVersion, certInfo *store.CertificateInfo) (store.Backend, error) {
+		return newStore(u, certInfo, nil)
 	}
 
 	builders["mcp"] = builder
@@ -57,13 +57,13 @@ func Register(builders map[string]store.Builder) {
 }
 
 // NewStore creates a new Store instance.
-func newStore(u *url.URL, certFolder string, fn updateHookFn) (store.Backend, error) {
+func newStore(u *url.URL, certInfo *store.CertificateInfo, fn updateHookFn) (store.Backend, error) {
 	insecure := u.Scheme == "mcpi"
 
 	return &backend{
 		serverAddress: u.Host,
 		insecure:      insecure,
-		certFolder:    certFolder,
+		certInfo:      certInfo,
 		Probe:         probe.NewProbe(),
 		updateHook:    fn,
 	}, nil
@@ -83,8 +83,8 @@ type backend struct {
 	// address of the MCP server.
 	serverAddress string
 
-	// The folder from which to load certificates.
-	certFolder string
+	// The location of the certificate files.
+	certInfo *store.CertificateInfo
 
 	// The cancellation function that is used to cancel gRPC/MCP operations.
 	cancel context.CancelFunc
@@ -140,15 +140,11 @@ func (b *backend) Init(kinds []string) error {
 			address = strings.Split(address, ":")[0]
 		}
 
-		watcher, err := creds.WatchFolder(ctx.Done(), b.certFolder)
+		watcher, err := creds.WatchFiles(ctx.Done(), b.certInfo.CertificateFile, b.certInfo.KeyFile, b.certInfo.CACertificateFile)
 		if err != nil {
 			return err
 		}
-		credentials, err := creds.CreateForClient(address, watcher)
-		if err != nil {
-			return err
-		}
-
+		credentials := creds.CreateForClient(address, watcher)
 		securityOption = grpc.WithTransportCredentials(credentials)
 	}
 

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"istio.io/istio/pkg/mcp/creds"
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/galley/pkg/kube/converter/legacy"
@@ -45,13 +48,22 @@ const (
 // Do not use 'init()' for automatic registration; linker will drop
 // the whole module because it looks unused.
 func Register(builders map[string]store.Builder) {
-	builders["mcp"] = func(u *url.URL, gv *schema.GroupVersion) (store.Backend, error) { return newStore(u, nil) }
+	builder := func(u *url.URL, gv *schema.GroupVersion, certFolder string) (store.Backend, error) {
+		return newStore(u, certFolder, nil)
+	}
+
+	builders["mcp"] = builder
+	builders["mcpi"] = builder
 }
 
 // NewStore creates a new Store instance.
-func newStore(u *url.URL, fn updateHookFn) (store.Backend, error) {
+func newStore(u *url.URL, certFolder string, fn updateHookFn) (store.Backend, error) {
+	insecure := u.Scheme == "mcpi"
+
 	return &backend{
 		serverAddress: u.Host,
+		insecure:      insecure,
+		certFolder:    certFolder,
 		Probe:         probe.NewProbe(),
 		updateHook:    fn,
 	}, nil
@@ -65,8 +77,14 @@ type backend struct {
 	// mapping of CRD <> typeURLs.
 	mapping *mapping
 
+	// Use insecure communication for gRPC.
+	insecure bool
+
 	// address of the MCP server.
 	serverAddress string
+
+	// The folder from which to load certificates.
+	certFolder string
 
 	// The cancellation function that is used to cancel gRPC/MCP operations.
 	cancel context.CancelFunc
@@ -114,12 +132,33 @@ func (b *backend) Init(kinds []string) error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	conn, err := grpc.DialContext(ctx, b.serverAddress, grpc.WithInsecure())
+
+	securityOption := grpc.WithInsecure()
+	if !b.insecure {
+		address := b.serverAddress
+		if strings.Contains(address, ":") {
+			address = strings.Split(address, ":")[0]
+		}
+
+		watcher, err := creds.WatchFolder(ctx.Done(), b.certFolder)
+		if err != nil {
+			return err
+		}
+		credentials, err := creds.CreateForClient(address, watcher)
+		if err != nil {
+			return err
+		}
+
+		securityOption = grpc.WithTransportCredentials(credentials)
+	}
+
+	conn, err := grpc.DialContext(ctx, b.serverAddress, securityOption)
 	if err != nil {
 		cancel()
 		scope.Errorf("Error connecting to server: %v\n", err)
 		return err
 	}
+
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
 	c := client.New(cl, messageNames, b, mixerNodeID, map[string]string{})
 	configz.Register(c)

--- a/mixer/pkg/config/mcp/backend_test.go
+++ b/mixer/pkg/config/mcp/backend_test.go
@@ -91,7 +91,7 @@ func createState(t *testing.T) *testState {
 		st.updateWg.Done()
 	}
 
-	if st.backend, err = newStore(st.server.URL, "", hookFn); err != nil {
+	if st.backend, err = newStore(st.server.URL, nil, hookFn); err != nil {
 		t.Fatal(err)
 	}
 

--- a/mixer/pkg/config/mcp/backend_test.go
+++ b/mixer/pkg/config/mcp/backend_test.go
@@ -91,7 +91,7 @@ func createState(t *testing.T) *testState {
 		st.updateWg.Done()
 	}
 
-	if st.backend, err = newStore(st.server.URL, hookFn); err != nil {
+	if st.backend, err = newStore(st.server.URL, "", hookFn); err != nil {
 		t.Fatal(err)
 	}
 

--- a/mixer/pkg/config/store/store.go
+++ b/mixer/pkg/config/store/store.go
@@ -247,8 +247,16 @@ func WithBackend(b Backend) Store {
 	return &store{backend: b}
 }
 
+// CertificateInfo is used to pass certificate file information to the config backend. This is mainly used
+// by the MCP backend.
+type CertificateInfo struct {
+	CertificateFile   string
+	KeyFile           string
+	CACertificateFile string
+}
+
 // Builder is the type of function to build a Backend.
-type Builder func(u *url.URL, gv *schema.GroupVersion, certFolder string) (Backend, error)
+type Builder func(u *url.URL, gv *schema.GroupVersion, certInfo *CertificateInfo) (Backend, error)
 
 // RegisterFunc is the type to register a builder for URL scheme.
 type RegisterFunc func(map[string]Builder)
@@ -275,7 +283,7 @@ const (
 )
 
 // NewStore creates a new Store instance with the specified backend.
-func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion, certFolder string) (Store, error) {
+func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion, certInfo *CertificateInfo) (Store, error) {
 	u, err := url.Parse(configURL)
 
 	if err != nil {
@@ -288,7 +296,7 @@ func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion,
 		b = newFsStore(u.Path)
 	default:
 		if builder, ok := r.builders[u.Scheme]; ok {
-			b, err = builder(u, groupVersion, certFolder)
+			b, err = builder(u, groupVersion, certInfo)
 			if err != nil {
 				return nil, err
 			}

--- a/mixer/pkg/config/store/store.go
+++ b/mixer/pkg/config/store/store.go
@@ -248,7 +248,7 @@ func WithBackend(b Backend) Store {
 }
 
 // Builder is the type of function to build a Backend.
-type Builder func(u *url.URL, gv *schema.GroupVersion) (Backend, error)
+type Builder func(u *url.URL, gv *schema.GroupVersion, certFolder string) (Backend, error)
 
 // RegisterFunc is the type to register a builder for URL scheme.
 type RegisterFunc func(map[string]Builder)
@@ -275,7 +275,7 @@ const (
 )
 
 // NewStore creates a new Store instance with the specified backend.
-func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion) (Store, error) {
+func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion, certFolder string) (Store, error) {
 	u, err := url.Parse(configURL)
 
 	if err != nil {
@@ -288,7 +288,7 @@ func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion)
 		b = newFsStore(u.Path)
 	default:
 		if builder, ok := r.builders[u.Scheme]; ok {
-			b, err = builder(u, groupVersion)
+			b, err = builder(u, groupVersion, certFolder)
 			if err != nil {
 				return nil, err
 			}

--- a/mixer/pkg/config/store/store_test.go
+++ b/mixer/pkg/config/store/store_test.go
@@ -74,7 +74,7 @@ func newTestBackend() *testStore {
 }
 
 func registerTestStore(builders map[string]Builder) {
-	builders["test"] = func(u *url.URL, gv *schema.GroupVersion) (Backend, error) {
+	builders["test"] = func(u *url.URL, gv *schema.GroupVersion, credFolder string) (Backend, error) {
 		return newTestBackend(), nil
 	}
 }
@@ -221,7 +221,7 @@ func TestRegistry(t *testing.T) {
 		{"://", false},
 		{"test://", true},
 	} {
-		_, err := r.NewStore(c.u, groupVersion)
+		_, err := r.NewStore(c.u, groupVersion, "/etc")
 		ok := err == nil
 		if ok != c.ok {
 			t.Errorf("Want %v, Got %v, Err %v", c.ok, ok, err)

--- a/mixer/pkg/config/store/store_test.go
+++ b/mixer/pkg/config/store/store_test.go
@@ -74,7 +74,7 @@ func newTestBackend() *testStore {
 }
 
 func registerTestStore(builders map[string]Builder) {
-	builders["test"] = func(u *url.URL, gv *schema.GroupVersion, credFolder string) (Backend, error) {
+	builders["test"] = func(u *url.URL, gv *schema.GroupVersion, _ *CertificateInfo) (Backend, error) {
 		return newTestBackend(), nil
 	}
 }
@@ -221,7 +221,7 @@ func TestRegistry(t *testing.T) {
 		{"://", false},
 		{"test://", true},
 	} {
-		_, err := r.NewStore(c.u, groupVersion, "/etc")
+		_, err := r.NewStore(c.u, groupVersion, nil)
 		ok := err == nil
 		if ok != c.ok {
 			t.Errorf("Want %v, Got %v, Err %v", c.ok, ok, err)

--- a/mixer/pkg/runtime/config/validator/validator_test.go
+++ b/mixer/pkg/runtime/config/validator/validator_test.go
@@ -84,7 +84,7 @@ func getValidatorForTest() (*Validator, error) {
 		return nil, err
 	}
 	groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion)
+	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion, "")
 	if err != nil {
 		return nil, err
 	}

--- a/mixer/pkg/runtime/config/validator/validator_test.go
+++ b/mixer/pkg/runtime/config/validator/validator_test.go
@@ -84,7 +84,7 @@ func getValidatorForTest() (*Validator, error) {
 		return nil, err
 	}
 	groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion, "")
+	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -48,9 +48,13 @@ type Args struct {
 	// Maximum number of goroutines in the adapter worker pool
 	AdapterWorkerPoolSize int
 
-	// URL of the config store. Use k8s://path_to_kubeconfig or fs:// for file system. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
+	// URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcp://<host> to
+	// connect to Galley. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 	// If this is empty (and ConfigStore isn't specified), "k8s://" will be used.
 	ConfigStoreURL string
+
+	// The folder to read service account certificates from. This is used for connecting to the MCP backend.
+	CertFolder string
 
 	// For testing; this one is used for the backend store if ConfigStoreURL is empty. Specifying both is invalid.
 	ConfigStore store.Store
@@ -108,6 +112,7 @@ func DefaultArgs() *Args {
 		MaxConcurrentStreams:   1024,
 		APIWorkerPoolSize:      1024,
 		AdapterWorkerPoolSize:  1024,
+		CertFolder:             "/etc/certs",
 		ConfigDefaultNamespace: constant.DefaultConfigNamespace,
 		LoggingOptions:         log.DefaultOptions(),
 		TracingOptions:         tracing.DefaultOptions(),
@@ -150,6 +155,7 @@ func (a *Args) String() string {
 	fmt.Fprint(buf, "SingleThreaded: ", a.SingleThreaded, "\n")
 	fmt.Fprint(buf, "NumCheckCacheEntries: ", a.NumCheckCacheEntries, "\n")
 	fmt.Fprint(buf, "ConfigStoreURL: ", a.ConfigStoreURL, "\n")
+	fmt.Fprint(buf, "CertFolder: ", a.CertFolder, "\n")
 	fmt.Fprint(buf, "ConfigDefaultNamespace: ", a.ConfigDefaultNamespace, "\n")
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "TracingOptions: %#v\n", *a.TracingOptions)

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/probe"
 	"istio.io/istio/pkg/tracing"
 )
@@ -53,8 +54,8 @@ type Args struct {
 	// If this is empty (and ConfigStore isn't specified), "k8s://" will be used.
 	ConfigStoreURL string
 
-	// The folder to read service account certificates from. This is used for connecting to the MCP backend.
-	CertFolder string
+	// The certificate file locations for the MCP config backend.
+	CertificateInfo store.CertificateInfo
 
 	// For testing; this one is used for the backend store if ConfigStoreURL is empty. Specifying both is invalid.
 	ConfigStore store.Store
@@ -106,13 +107,17 @@ type Args struct {
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
 func DefaultArgs() *Args {
 	return &Args{
-		APIPort:                9091,
-		MonitoringPort:         9093,
-		MaxMessageSize:         1024 * 1024,
-		MaxConcurrentStreams:   1024,
-		APIWorkerPoolSize:      1024,
-		AdapterWorkerPoolSize:  1024,
-		CertFolder:             "/etc/certs",
+		APIPort:               9091,
+		MonitoringPort:        9093,
+		MaxMessageSize:        1024 * 1024,
+		MaxConcurrentStreams:  1024,
+		APIWorkerPoolSize:     1024,
+		AdapterWorkerPoolSize: 1024,
+		CertificateInfo: store.CertificateInfo{
+			CertificateFile:   "/etc/certs/" + creds.DefaultCertificateFile,
+			KeyFile:           "/etc/certs/" + creds.DefaultKeyFile,
+			CACertificateFile: "/etc/certs/" + creds.DefaultCACertificateFile,
+		},
 		ConfigDefaultNamespace: constant.DefaultConfigNamespace,
 		LoggingOptions:         log.DefaultOptions(),
 		TracingOptions:         tracing.DefaultOptions(),
@@ -155,7 +160,9 @@ func (a *Args) String() string {
 	fmt.Fprint(buf, "SingleThreaded: ", a.SingleThreaded, "\n")
 	fmt.Fprint(buf, "NumCheckCacheEntries: ", a.NumCheckCacheEntries, "\n")
 	fmt.Fprint(buf, "ConfigStoreURL: ", a.ConfigStoreURL, "\n")
-	fmt.Fprint(buf, "CertFolder: ", a.CertFolder, "\n")
+	fmt.Fprint(buf, "CertificateFile: ", a.CertificateInfo.CertificateFile, "\n")
+	fmt.Fprint(buf, "KeyFile: ", a.CertificateInfo.KeyFile, "\n")
+	fmt.Fprint(buf, "CACertificateFile: ", a.CertificateInfo.CACertificateFile, "\n")
 	fmt.Fprint(buf, "ConfigDefaultNamespace: ", a.ConfigDefaultNamespace, "\n")
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "TracingOptions: %#v\n", *a.TracingOptions)

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -190,7 +190,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 
 		reg := store.NewRegistry(config.StoreInventory()...)
 		groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-		if st, err = reg.NewStore(configStoreURL, groupVersion, a.CertFolder); err != nil {
+		if st, err = reg.NewStore(configStoreURL, groupVersion, &a.CertificateInfo); err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("unable to connect to the configuration server: %v", err)
 		}

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -190,7 +190,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 
 		reg := store.NewRegistry(config.StoreInventory()...)
 		groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-		if st, err = reg.NewStore(configStoreURL, groupVersion); err != nil {
+		if st, err = reg.NewStore(configStoreURL, groupVersion, a.CertFolder); err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("unable to connect to the configuration server: %v", err)
 		}

--- a/pkg/mcp/creds/watcher.go
+++ b/pkg/mcp/creds/watcher.go
@@ -30,6 +30,15 @@ import (
 
 var scope = log.RegisterScope("mcp-creds", "MCP Credential utilities", 0)
 
+const (
+	// DefaultCertificateFile is the default name to use for the certificate file.
+	DefaultCertificateFile = "cert-chain.pem"
+	// DefaultKeyFile is the default name to use for the key file.
+	DefaultKeyFile = "key.pem"
+	// DefaultCACertificateFile is the default name to use for the Certificate Authority's certificate file.
+	DefaultCACertificateFile = "root-cert.pem"
+)
+
 // CertificateWatcher watches a x509 cert/key file and loads it up in memory as needed.
 type CertificateWatcher struct {
 	caCertFile string
@@ -53,9 +62,9 @@ type CertificateWatcher struct {
 //
 // Internally WatchFolder will call WatchFiles.
 func WatchFolder(stop <-chan struct{}, folder string) (*CertificateWatcher, error) {
-	certFile := path.Join(folder, "cert-chain.pem")
-	keyFile := path.Join(folder, "key.pem")
-	caCertFile := path.Join(folder, "root-cert.pem")
+	certFile := path.Join(folder, DefaultCertificateFile)
+	keyFile := path.Join(folder, DefaultKeyFile)
+	caCertFile := path.Join(folder, DefaultCACertificateFile)
 
 	return WatchFiles(stop, certFile, keyFile, caCertFile)
 }


### PR DESCRIPTION
Add mTLS support to Mixer MCP stack.

- Add a command-line flag to specify the location of the certificate files.
- Jam the parameter through the config initialization stack to the MCP backend (sorry, I am not proud of this).
- Optionally enable using secure mode (based on the URL)
