### PR TITLE
Re-enable "Check Scripts" as optional part of make lint

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,7 +1,6 @@
 # Builder version
-CI_HUB ?= istio
 CI_VERSION ?= go1.10-k8s1.10.4-helm2.7.2-minikube0.25
-LINT_VERSION ?= $(addsuffix -shellcheck5.0,${CI_VERSION})
+CI_HUB ?= istio
 
 ci.image:
 	docker build -t "${CI_HUB}/ci:$(CI_VERSION)" -f Dockerfile .
@@ -17,18 +16,4 @@ ci.run:
 		--entrypoint /bin/bash \
 		"${CI_HUB}/ci:$(CI_VERSION)"
 
-lint.image:
-	docker build -t "${CI_HUB}/lint:$(LINT_VERSION)" -f lint.dockerfile .
-
-lint.push:
-	docker push "${CI_HUB}/lint:$(LINT_VERSION)" 
-
-lint.run:
-	docker run --rm -u $(shell id -u) -it \
-		-v ${GOPATH}:${GOPATH} \
-		-w ${PWD} \
-		-e USER=${USER} \
-		--entrypoint /bin/bash \
-		"${CI_HUB}/lint:$(LINT_VERSION)"
-
-.PHONY: ci.image ci.push ci.run lint.image lint.push lint.run
+.PHONY: ci.image ci.push ci.run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,10 +425,17 @@ jobs:
       - store_artifacts:
           path: /go/out/istio-sidecar.deb
 
-  lint:
-    working_directory: /go/src/istio.io/istio
+  shellcheck:
     docker:
-      - image: istio/lint:go1.10-k8s1.10.4-helm2.7.2-minikube0.25-shellcheck5.0
+      - image: koalaman/shellcheck-alpine:v0.5.0
+    steps:
+      - checkout
+      - run:
+          name: Check Scripts
+          command: /root/project/tools/run_shellcheck.sh
+
+  lint:
+    <<: *defaults
     environment:
       KUBECONFIG: /go/src/istio.io/istio/.circleci/config
     resource_class: xlarge
@@ -566,6 +573,7 @@ workflows:
 
   all:
     jobs:
+      - shellcheck
       - lint
       - build
       - test

--- a/.circleci/lint.dockerfile
+++ b/.circleci/lint.dockerfile
@@ -1,5 +1,0 @@
-FROM koalaman/shellcheck:v0.5.0 AS shellcheck
-
-FROM istio/ci:go1.10-k8s1.10.4-helm2.7.2-minikube0.25
-
-COPY --from=shellcheck /bin/shellcheck /bin/shellcheck

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -27,8 +27,8 @@ SHEBANG_FILES=$( \
             head -n 1 "$f" | grep -q '^#!.*sh' && echo "$f";
         done)
 
-# Set global rule exclusions with the "excludes" flag, separated by comma (e.g.
-# "--excludes=SC1090,SC1091"). See https://github.com/koalaman/shellcheck/wiki
+# Set global rule exclusions with the "exclude" flag, separated by comma (e.g.
+# "--exclude=SC1090,SC1091"). See https://github.com/koalaman/shellcheck/wiki
 # for details on each code's corresponding rule.
 
 echo "${SH_FILES}" "${SHEBANG_FILES}" \

--- a/tools/run_shellcheck.sh
+++ b/tools/run_shellcheck.sh
@@ -2,6 +2,12 @@
 #
 # Runs shellcheck on all shell scripts in the istio repository.
 
+if ! command -v shellcheck > /dev/null; then
+    echo 'error: ShellCheck is not installed'
+    echo 'Visit https://github.com/koalaman/shellcheck#installing'
+    exit 1
+fi
+
 TOOLS_DIR="$(cd "$(dirname "${0}")" && pwd -P)"
 ISTIO_ROOT="$(cd "$(dirname "${TOOLS_DIR}")" && pwd -P)"
 


### PR DESCRIPTION
Resolves #7861.

This PR fixes the force-merged ShellCheck violations and re-enables the "Check Scripts" task as disabled by #7862.

It also addresses the array-building issues discovered in #7880.

/cc @gargnupur @ozevren @rkpagadala @mandarjog @kyessenov 

Edit: No longer fixes the new violations.