### PR TITLE
Remove privilege=true

### DIFF
--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -23,7 +23,6 @@ services:
           - apiserver
     ports:
       - "8080:8080"
-    privileged: true
     environment:
       - SERVICE_IGNORE=1
     command: ["kube-apiserver", "--etcd-servers", "http://etcd:2379", "--service-cluster-ip-range", "10.99.0.0/16", "--insecure-port", "8080", "-v", "2", "--insecure-bind-address", "0.0.0.0"]

--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -23,6 +23,7 @@ services:
           - apiserver
     ports:
       - "8080:8080"
+    privileged: true
     environment:
       - SERVICE_IGNORE=1
     command: ["kube-apiserver", "--etcd-servers", "http://etcd:2379", "--service-cluster-ip-range", "10.99.0.0/16", "--insecure-port", "8080", "-v", "2", "--insecure-bind-address", "0.0.0.0"]

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -52,9 +52,9 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          {{ if .Values.global.proxy.priviledged }}
-          priviledge: true
-          {{end }}
+          {{ if .Values.global.proxy.privileged }}
+          privileged: true
+          {{ end }}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - name: enable-core-dump

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -52,6 +52,9 @@ data:
           capabilities:
             add:
             - NET_ADMIN
+          {{ if .Values.global.proxy.priviledged }}
+          priviledge: true
+          {{end }}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - args:
@@ -63,6 +66,10 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
+        {{ if .Values.global.proxy.priviledged }}
+        securityContext:
+          privileged: true
+        {{end }}
       {{ end }}
       containers:
       - name: istio-proxy

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -57,19 +57,17 @@ data:
           {{end }}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
-      - args:
+      - name: enable-core-dump
+        args:
         - -c
         - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         command:
           - /bin/sh
         image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
         imagePullPolicy: IfNotPresent
-        name: enable-core-dump
         resources: {}
-        {{ if .Values.global.proxy.priviledged }}
         securityContext:
           privileged: true
-        {{end }}
       {{ end }}
       containers:
       - name: istio-proxy
@@ -134,7 +132,6 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
           capabilities:

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -52,7 +52,6 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - args:
@@ -64,8 +63,6 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-        securityContext:
-          privileged: true
       {{ end }}
       containers:
       - name: istio-proxy

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -56,7 +56,9 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
+          {{ if .Values.sidecarInjectorWebhook.priviledged }}
+          priviledge: true
+          {{end }}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - args:
@@ -68,8 +70,8 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-        securityContext:
-          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
+          securityContext:
+            privileged: true
       {{ end }}
       containers:
       - name: istio-proxy
@@ -132,7 +134,9 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
+          {{ if .Values.sidecarInjectorWebhook.priviledged }}
+          privileged: true
+          {{end }}
           readOnlyRootFilesystem: true
           {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
           capabilities:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -56,6 +56,7 @@ data:
           capabilities:
             add:
             - NET_ADMIN
+          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - args:
@@ -67,6 +68,8 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
+        securityContext:
+          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
       {{ end }}
       containers:
       - name: istio-proxy
@@ -129,7 +132,7 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-          privileged: false
+          privileged:  {{ .Values.sidecarInjectorWebhook.priviledged }}
           readOnlyRootFilesystem: true
           {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
           capabilities:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -56,7 +56,7 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          {{ if .Values.sidecarInjectorWebhook.priviledged }}
+          {{ if .Values.global.proxy.priviledged }}
           priviledge: true
           {{end }}
         restartPolicy: Always
@@ -70,8 +70,8 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-          securityContext:
-            privileged: true
+        securityContext:
+          privileged: true
       {{ end }}
       containers:
       - name: istio-proxy
@@ -134,7 +134,7 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-          {{ if .Values.sidecarInjectorWebhook.priviledged }}
+          {{ if .Values.global.proxy.priviledged }}
           privileged: true
           {{end }}
           readOnlyRootFilesystem: true

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -56,7 +56,6 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - args:
@@ -68,8 +67,6 @@ data:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-        securityContext:
-          privileged: true
       {{ end }}
       containers:
       - name: istio-proxy

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -56,8 +56,8 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          {{ if .Values.global.proxy.priviledged }}
-          priviledge: true
+          {{ if .Values.global.proxy.privileged }}
+          privileged: true
           {{ end -}}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
@@ -134,7 +134,7 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
-          {{ if .Values.global.proxy.priviledged }}
+          {{ if .Values.global.proxy.privileged }}
           privileged: true
           {{ end -}}
           readOnlyRootFilesystem: true

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -58,17 +58,17 @@ data:
             - NET_ADMIN
           {{ if .Values.global.proxy.priviledged }}
           priviledge: true
-          {{end }}
+          {{ end -}}
         restartPolicy: Always
       {{ if eq .Values.global.proxy.enableCoreDump true }}
-      - args:
+      - name: enable-core-dump
+        args:
         - -c
         - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
         command:
           - /bin/sh
         image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
         imagePullPolicy: IfNotPresent
-        name: enable-core-dump
         resources: {}
         securityContext:
           privileged: true
@@ -136,7 +136,7 @@ data:
         securityContext:
           {{ if .Values.global.proxy.priviledged }}
           privileged: true
-          {{end }}
+          {{ end -}}
           readOnlyRootFilesystem: true
           {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
           capabilities:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -38,9 +38,9 @@ global:
     accessLogFile: "/dev/stdout"
 
     #If set to true, istio-proxy container will have privileged securityContext
-    priviledged: false
+    privileged: false
 
-    # If set, newly injected sidecars will have core dumps enabled and priviledged securityContext
+    # If set, newly injected sidecars will have core dumps enabled and privileged securityContext
     enableCoreDump: false
 
     # istio egress capture whitelist

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -37,7 +37,10 @@ global:
     # disable access log for sidecar.
     accessLogFile: "/dev/stdout"
 
-    # If set, newly injected sidecars will have core dumps enabled.
+    #If set to true, istio-proxy container will have privileged securityContext
+    priviledged: false
+
+    # If set, newly injected sidecars will have core dumps enabled and priviledged securityContext
     enableCoreDump: false
 
     # istio egress capture whitelist
@@ -322,7 +325,6 @@ sidecarInjectorWebhook:
   replicaCount: 1
   image: sidecar_injector
   enableNamespacesByDefault: false
-  priviledged: false
 
 #
 # galley configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -322,6 +322,7 @@ sidecarInjectorWebhook:
   replicaCount: 1
   image: sidecar_injector
   enableNamespacesByDefault: false
+  priviledged: false
 
 #
 # galley configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -40,7 +40,7 @@ global:
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false
 
-    # If set, newly injected sidecars will have core dumps enabled and privileged securityContext
+    # If set, newly injected sidecars will have core dumps enabled.
     enableCoreDump: false
 
     # istio egress capture whitelist

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -134,6 +134,7 @@ type Params struct {
 	Version         string                 `json:"version"`
 	EnableCoreDump  bool                   `json:"enableCoreDump"`
 	DebugMode       bool                   `json:"debugMode"`
+	Privileged      bool                   `json:"privileged"`
 	Mesh            *meshconfig.MeshConfig `json:"-"`
 	ImagePullPolicy string                 `json:"imagePullPolicy"`
 	// Comma separated list of IP ranges in CIDR form. If set, only redirect outbound traffic to Envoy for these IP

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -62,6 +62,7 @@ func TestIntoResourceFile(t *testing.T) {
 		imagePullPolicy     string
 		enableCoreDump      bool
 		debugMode           bool
+		privileged          bool
 		duration            time.Duration
 		includeIPRanges     string
 		excludeIPRanges     string
@@ -324,6 +325,7 @@ func TestIntoResourceFile(t *testing.T) {
 				SidecarProxyUID:     DefaultSidecarProxyUID,
 				Version:             "12345678",
 				EnableCoreDump:      c.enableCoreDump,
+				Privileged:          c.privileged,
 				Mesh:                &mesh,
 				DebugMode:           c.debugMode,
 				IncludeIPRanges:     c.includeIPRanges,

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -150,7 +150,9 @@ containers:
     privileged: true
     readOnlyRootFilesystem: false
     {{ else -}}
-    privileged: false
+	{{ if eq .Privileged true -}}
+    privileged: true
+    {{ end -}}
     readOnlyRootFilesystem: true
     [[ if eq (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
     capabilities:

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -151,7 +151,11 @@ containers:
     {{ if (or (eq .DebugMode true) (eq .Privileged true)) -}}
     privileged: true
     {{ end -}}
+    {{ if eq .DebugMode true -}}
+    readOnlyRootFilesystem: false
+    {{ else }}
     readOnlyRootFilesystem: true
+    {{ end }}
     [[ if eq (or (index .ObjectMeta.Annotations "sidecar.istio.io/interceptionMode") .ProxyConfig.InterceptionMode.String) "TPROXY" -]]
     capabilities:
       add:

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -79,8 +79,6 @@ initContainers:
   imagePullPolicy: IfNotPresent
   name: enable-core-dump
   resources: {}
-  securityContext:
-    privileged: true
 {{ end -}}
 containers:
 - name: istio-proxy

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -150,7 +150,7 @@ containers:
     privileged: true
     readOnlyRootFilesystem: false
     {{ else -}}
-	{{ if eq .Privileged true -}}
+    {{ if eq .Privileged true -}}
     privileged: true
     {{ end -}}
     readOnlyRootFilesystem: true

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -79,7 +79,7 @@ initContainers:
   image: {{ .InitImage }}
   imagePullPolicy: IfNotPresent
   resources: {}
-  security:
+  securityContext:
     privileged: true
 {{ end -}}
 containers:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -75,7 +75,6 @@ spec:
               requests:
                 cpu: 10m
             securityContext:
-              privileged: false
               readOnlyRootFilesystem: true
               runAsUser: 1337
             volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
     spec:
       template:

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -7,7 +7,7 @@ spec:
   jobTemplate:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
     spec:
       template:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -74,7 +74,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -94,7 +94,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -79,7 +79,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"cf8e923d548717ca9b4dc9ef7ebc89c6f3ee8829760562897475b1ce777b488e","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"9377cbf8169b07aad9a5e8b1c7133a247562ca8506f1221e9e762f8960327e17","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -118,6 +118,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
+        securityContext:
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"9377cbf8169b07aad9a5e8b1c7133a247562ca8506f1221e9e762f8960327e17","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"c0d8ec3607e856a7b3dcc031241d625d38eabf3bf8397c25b5c7bdfec6fbf8ea","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -118,6 +118,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
+        securityContext:
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"85d30eed4dc57749b5734f2ddee1ba14f602161e3d211c405a0925e53093646c","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"cf8e923d548717ca9b4dc9ef7ebc89c6f3ee8829760562897475b1ce777b488e","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -118,8 +118,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-        securityContext:
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -119,8 +119,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: enable-core-dump
         resources: {}
-        securityContext:
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c6d101f68fb63e03418bccd952180d428ba3f9db7479dcc76eb852e5a34d5067","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"85d30eed4dc57749b5734f2ddee1ba14f602161e3d211c405a0925e53093646c","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -94,7 +94,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"df7b6b6a1af192ed6369ee0618a7725c253dbe562036ed92c30bcc4a45cbec99","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"da7ac5d80a00d68fad4cfa51e7e57c7fe964f41332565fb14533c5bed0220b39","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"b3158df353029b439db914633f3e416dd520be3d86515c367b60a7f14e4d5f71","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"df7b6b6a1af192ed6369ee0618a7725c253dbe562036ed92c30bcc4a45cbec99","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -77,7 +77,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -77,7 +77,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:
@@ -199,7 +198,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,7 +130,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,7 +130,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"97da22e31664d92bedf1b0432a9034c3a96298c01a5800f7e3a30035cf7b82d9","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"038cdd84eee3ac54cdb01d3270026bc9da577c89f4e26d03e85f5c2c48daa975","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"038cdd84eee3ac54cdb01d3270026bc9da577c89f4e26d03e85f5c2c48daa975","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"8436c505c184a74ccd26472a2c841892f0c617ea534ac1c8e61b025eb17eadc4","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -96,7 +96,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -77,7 +77,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: true
           readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
@@ -110,7 +109,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -77,6 +77,7 @@ spec:
           requests:
             cpu: 10m
         securityContext:
+          privileged: true
           readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
@@ -109,6 +110,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"version":"d396445130be29fbad356be3fdaadb671eefa9b6fe45193025294c1e57b2b8ba","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"1b9baaf463c6430e8e4b8c315bbe74cfd42a64616e56b11726bc362e8e21acd5","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -78,7 +78,7 @@ spec:
             cpu: 10m
         securityContext:
           privileged: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -10,7 +10,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/proxyImage: docker.io/istio/proxy2_debug:unittest
-        sidecar.istio.io/status: '{"version":"1b9baaf463c6430e8e4b8c315bbe74cfd42a64616e56b11726bc362e8e21acd5","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"579648425637fe78a979d1cecabcdd133ac2ffa6ca485776f1bdded1513c5f6a","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -78,7 +78,7 @@ spec:
             cpu: 10m
         securityContext:
           privileged: true
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"5ce82bab9a96fab202c04401bb79ab6b6aced343bab2a9527ce9c1f6ccad5ca2","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"74769ec1aa74631be4b7ae6c01a0e2d7dffeec59095644f8341f35673c632769","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -80,7 +80,7 @@ spec:
             add:
             - NET_ADMIN
           privileged: true
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
         volumeMounts:
         - mountPath: /etc/istio/proxy
           name: istio-envoy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c891bf210f116d776f91e93758be9bc03f300196c8b8694fb8ad47bd0aa71e01","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"5ce82bab9a96fab202c04401bb79ab6b6aced343bab2a9527ce9c1f6ccad5ca2","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -76,8 +76,11 @@ spec:
           requests:
             cpu: 10m
         securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
           privileged: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /etc/istio/proxy
           name: istio-envoy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -79,7 +79,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: false
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"f0ea5c6ac1d8b66b8372ce0279fab8d01942049e7d60e711b7f5ad3071a280db","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"0518e30f2aac879cafd358418b366e4275e868fc87ae038ceabf53741f6452e8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"8307ffaffcb48bd6e31774e5753cba19e436a6badfc3b219be668129f0ae20ab","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"f0ea5c6ac1d8b66b8372ce0279fab8d01942049e7d60e711b7f5ad3071a280db","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"d396445130be29fbad356be3fdaadb671eefa9b6fe45193025294c1e57b2b8ba","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"1b9baaf463c6430e8e4b8c315bbe74cfd42a64616e56b11726bc362e8e21acd5","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -77,7 +77,7 @@ spec:
             cpu: 10m
         securityContext:
           privileged: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -76,6 +76,7 @@ spec:
           requests:
             cpu: 10m
         securityContext:
+          privileged: true
           readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
@@ -108,6 +109,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"1b9baaf463c6430e8e4b8c315bbe74cfd42a64616e56b11726bc362e8e21acd5","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"579648425637fe78a979d1cecabcdd133ac2ffa6ca485776f1bdded1513c5f6a","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -77,7 +77,7 @@ spec:
             cpu: 10m
         securityContext:
           privileged: true
-          readOnlyRootFilesystem: true
+          readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
         - mountPath: /etc/istio/proxy

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: true
           readOnlyRootFilesystem: false
           runAsUser: 1337
         volumeMounts:
@@ -109,7 +108,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -73,7 +73,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -95,7 +95,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -131,7 +131,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -131,7 +131,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -79,7 +79,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:
@@ -200,7 +199,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+    sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
   creationTimestamp: null
   name: hello
 spec:

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+    sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
   creationTimestamp: null
   name: hello
 spec:

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -66,7 +66,6 @@ spec:
       requests:
         cpu: 10m
     securityContext:
-      privileged: false
       readOnlyRootFilesystem: true
       runAsUser: 1337
     volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -73,7 +73,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -75,7 +75,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -79,7 +79,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"4ca19663f2e12e18f8c18276fe31111f92735b13affff33dd404bb8edb3e85ff","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -74,7 +74,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"f0ea5c6ac1d8b66b8372ce0279fab8d01942049e7d60e711b7f5ad3071a280db","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"0518e30f2aac879cafd358418b366e4275e868fc87ae038ceabf53741f6452e8","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"8307ffaffcb48bd6e31774e5753cba19e436a6badfc3b219be668129f0ae20ab","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"f0ea5c6ac1d8b66b8372ce0279fab8d01942049e7d60e711b7f5ad3071a280db","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -74,7 +74,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"0ea03c59badf300d9a81c3a4e72c071350eb1dd910e7d739bd8ddd9fef9eb71d","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"657b8c55610a9a533dfa6b05049c84f6798b68fbea91837225e3aeb8c9c370b6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"ba9173bb3e2a1218051bc9b347224bf20dc925b5c88564ac4b79114e3437e574","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"0ea03c59badf300d9a81c3a4e72c071350eb1dd910e7d739bd8ddd9fef9eb71d","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: traffic

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -74,7 +74,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -27,7 +27,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -94,7 +94,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -79,7 +79,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -94,7 +94,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -77,7 +77,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:
@@ -199,7 +198,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -130,7 +130,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -96,7 +96,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -73,7 +73,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -24,7 +24,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -95,7 +95,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -11,7 +11,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello
@@ -131,7 +131,7 @@ items:
     template:
       metadata:
         annotations:
-          sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+          sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
           app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -79,7 +79,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:
@@ -200,7 +199,6 @@ items:
             requests:
               cpu: 10m
           securityContext:
-            privileged: false
             readOnlyRootFilesystem: true
             runAsUser: 1337
           volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -76,7 +76,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -73,7 +73,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -75,7 +75,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -79,7 +79,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"c62757c15b560ddbb9ac3e8c1cbbcbce6bbc40ee79d1a4c9970fe27dc02434a6","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"53742a1a36ff6cd539668836e95b15543d22ca54a75cb83b6f58397d9f882f8f","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -78,7 +78,6 @@ spec:
           requests:
             cpu: 10m
         securityContext:
-          privileged: false
           readOnlyRootFilesystem: true
           runAsUser: 1337
         volumeMounts:

--- a/tests/e2e/local/vagrant/setup_vm.sh
+++ b/tests/e2e/local/vagrant/setup_vm.sh
@@ -28,7 +28,7 @@ vagrant ssh -c "sudo systemctl daemon-reload"
 vagrant ssh -c "sudo systemctl restart docker"
 
 # Setting up kubernetest Cluster on VM for Istio Tests.
-echo "Adding priviledges to kubernetes cluster..."
+echo "Adding privileges to kubernetes cluster..."
 vagrant ssh -c "sudo sed -i 's/ExecStart=\/usr\/bin\/hyperkube kubelet/ExecStart=\/usr\/bin\/hyperkube kubelet --allow-privileged=true/' /etc/systemd/system/kubelet.service"
 vagrant ssh -c "sudo systemctl daemon-reload"
 vagrant ssh -c "sudo systemctl stop kubelet"


### PR DESCRIPTION
Added a helm option to control if privileged=true is set in istio-proxy container and istio-init container.

Setting debug to true also enables privileged mode.

For the enable-core-dump-container, privileged mode is always set to true.