### PR TITLE
Fix spelling error in file tests/util/checker/testlinter/README.md

### DIFF
--- a/tests/util/checker/testlinter/README.md
+++ b/tests/util/checker/testlinter/README.md
@@ -78,8 +78,8 @@ If you want to disable all rules for a file path, you can specify `*` as the ID.
 Example:
 ```base
 var Whitelist = map[string][]string{
-    "/istoi/mixer/pkg/*": {"skip_issue", "short_skip"},
-    "/istoi/piloy/pkg/simply_test.go": {"*"},
+    "/istio/mixer/pkg/*": {"skip_issue", "short_skip"},
+    "/istio/pilot/pkg/simply_test.go": {"*"},
 }
 ```
 


### PR DESCRIPTION
Fix spelling error in file tests/util/checker/testlinter/README.md