### PR TITLE
Let "pilot_grpc_address" take over param DiscoveryAddress in WriteBootstrap

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -94,9 +94,9 @@ data:
       #
       # Address where istio Pilot service is running
       {{- if .Values.global.remotePilotCreateSvcEndpoint }}
-      discoveryAddress: {{ $defPilotHostname }}:15005
+      discoveryAddress: {{ $defPilotHostname }}:15011
       {{- else }}
-      discoveryAddress: {{ $pilotAddress }}:15005
+      discoveryAddress: {{ $pilotAddress }}:15011
       {{- end }}
     {{- else }}
       #
@@ -105,8 +105,8 @@ data:
       #
       # Address where istio Pilot service is running
       {{- if .Values.global.remotePilotCreateSvcEndpoint }}
-      discoveryAddress: {{ $defPilotHostname }}:15007
+      discoveryAddress: {{ $defPilotHostname }}:15010
       {{- else }}
-      discoveryAddress: {{ $pilotAddress }}:15007
+      discoveryAddress: {{ $pilotAddress }}:15010
       {{- end }}
     {{- end }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -67,18 +67,18 @@ spec:
           - MUTUAL_TLS
           - --discoveryAddress
           {{- if $.Values.global.istioNamespace }}
-          - istio-pilot.{{ $.Values.global.istioNamespace }}:15005
+          - istio-pilot.{{ $.Values.global.istioNamespace }}:15011
           {{- else }}
-          - istio-pilot:15005
+          - istio-pilot:15011
           {{- end }}
         {{- else }}
           - --controlPlaneAuthPolicy
           - NONE
           - --discoveryAddress
           {{- if $.Values.global.istioNamespace }}
-          - istio-pilot.{{ $.Values.global.istioNamespace }}:8080
+          - istio-pilot.{{ $.Values.global.istioNamespace }}:15010
           {{- else }}
-          - istio-pilot:8080
+          - istio-pilot:15010
           {{- end }}
         {{- end }}
           resources:

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -55,12 +55,12 @@ spec:
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
           - --discoveryAddress
-          - istio-pilot:15005
+          - istio-pilot:15011
         {{- else }}
           - --controlPlaneAuthPolicy
           - NONE
           - --discoveryAddress
-          - istio-pilot:8080
+          - istio-pilot:15010
         {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -97,13 +97,13 @@ data:
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15005
+      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15011
     {{- else }}
       #
       # Mutual TLS authentication between sidecars and istio control plane.
       controlPlaneAuthPolicy: NONE
       #
       # Address where istio Pilot service is running
-      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15007
+      discoveryAddress: istio-pilot.{{ .Release.Namespace }}:15010
     {{- end }}
 {{- end }}

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -204,25 +204,7 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	if err != nil {
 		return "", err
 	}
-	StoreHostPort(h, p, "pilot_address", opts)
-
-	// Default values for the grpc address.
-	// TODO: take over the DiscoveryAddress or add a separate mesh config option
-	// Default value
-	grpcPort := "15010"
-	if config.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-		grpcPort = "15011"
-	}
-	grpcHost := h // Use pilot host
-
-	grpcAddress := opts["pilot_grpc"]
-	if grpcAddress != nil {
-		grpcHost, grpcPort, err = GetHostPort("gRPC", grpcAddress.(string))
-		if err != nil {
-			return "", err
-		}
-	}
-	StoreHostPort(grpcHost, grpcPort, "pilot_grpc_address", opts)
+	StoreHostPort(h, p, "pilot_grpc_address", opts)
 
 	if config.ZipkinAddress != "" {
 		h, p, err = GetHostPort("Zipkin", config.ZipkinAddress)

--- a/pkg/bootstrap/testdata/all.proto
+++ b/pkg/bootstrap/testdata/all.proto
@@ -3,7 +3,7 @@ binary_path:             "/usr/local/bin/envoy"
 service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 5}
 parent_shutdown_duration: {seconds: 6}
-discovery_address:       "mypilot:1001"
+discovery_address:       "mypilot:15011"
 discovery_refresh_delay:  {seconds: 3}
 zipkin_address:           "localhost:6000"
 connect_timeout:          {seconds: 7}

--- a/pkg/bootstrap/testdata/auth.proto
+++ b/pkg/bootstrap/testdata/auth.proto
@@ -3,7 +3,7 @@ binary_path:             "/usr/local/bin/envoy"
 service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 2}
 parent_shutdown_duration: {seconds: 3}
-discovery_address:       "istio-pilot:15005"
+discovery_address:       "istio-pilot:15011"
 discovery_refresh_delay:  {seconds: 1}
 zipkin_address:           ""
 connect_timeout:          {seconds: 1}

--- a/pkg/bootstrap/testdata/default.proto
+++ b/pkg/bootstrap/testdata/default.proto
@@ -3,7 +3,7 @@ binary_path:             "/usr/local/bin/envoy"
 service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 2}
 parent_shutdown_duration: {seconds: 3}
-discovery_address:       "istio-pilot:15007"
+discovery_address:       "istio-pilot:15010"
 discovery_refresh_delay:  {seconds: 1}
 zipkin_address:           ""
 connect_timeout:          {seconds: 1}


### PR DESCRIPTION
It is kind of ugly to hard code the pilot ports here,
and since the generated opts "pilot_address" is not used any more, I think it reasonable to Let "pilot_grpc_address" reuse the DiscoveryAddress param.