### PR TITLE
e2e guide docs typo fix

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -51,7 +51,7 @@ kubectl exec -it <test pod> -n <test namespace> -c app -- client -h
 
 
 # Adding New E2E Tests
-[demo_test.go](tests/bookinfo/demo_test.go) is a sample test that covers four cases: default routing, versiong routing, failt delay, and version migration.
+[demo_test.go](tests/bookinfo/demo_test.go) is a sample test that covers four cases: default routing, version routing, fault delay, and version migration.
 Each case applies traffic rules and then clean up after the test. It can serve as a reference for building new test cases.
 
 See below for guidelines for creating a new E2E testsr.

--- a/tests/e2e/UsingGKE.md
+++ b/tests/e2e/UsingGKE.md
@@ -1,4 +1,4 @@
-# Running E2E tests on your own kubernets cluster
+# Running E2E tests on your own kubernetes cluster
 
 * [Step 1: Create a kubernetes cluster](#step-1-create-and-setup-a-kubernetes-cluster)
 * [Step 2: Get cluster credentials](#step-2-get-cluster-credentials)


### PR DESCRIPTION
nit: found some typo when walking through the e2e guide.