### PR TITLE
Revert "remove unused post install hook for remote chart. (#7718)"

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/security/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-security-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: security
+data:
+  custom-resources.yaml: |-
+    {{- if .Values.global.mtls.enabled }}
+      {{- include "security-default.yaml.tpl" . | indent 4}}
+    {{- end }}
+  run.sh: |-
+    {{- include "install-custom-resources.sh.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/create-custom-resources-job.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.global.mtls.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-security-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-security-post-install-{{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.istio.io"] # needed to create security destination rules
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-security-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-security-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-security-post-install-account
+    namespace: {{ .Release.Namespace }}
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-security-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-security-post-install
+      labels:
+        app: istio-security
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-security-post-install-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]
+          volumeMounts:
+            - mountPath: "/tmp/security"
+              name: tmp-configmap-security
+      volumes:
+        - name: tmp-configmap-security
+          configMap:
+            name: istio-security-custom-resources
+      restartPolicy: OnFailure
+{{- end }}

--- a/install/kubernetes/helm/istio-remote/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/templates/enable-mesh-mtls.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.mtls.enabled }}
+{{ define "security-default.yaml.tpl" }}
 # These policy and destination rules effectively enable mTLS for all services in the mesh. For now,
 # they are added to Istio installation yaml for backward compatible. In future, they should be in
 # a separated yaml file so that customer can enable mTLS independent from installation.

--- a/install/kubernetes/helm/istio-remote/templates/install-custom-resources.sh.tpl
+++ b/install/kubernetes/helm/istio-remote/templates/install-custom-resources.sh.tpl
@@ -1,0 +1,27 @@
+{{ define "install-custom-resources.sh.tpl" }}
+#!/bin/sh
+set -e
+
+if [ "$#" -ne "1" ]; then
+    echo "first argument should be path to custom resource yaml"
+    exit 1
+fi
+
+pathToResourceYAML=${1}
+
+/kubectl get validatingwebhookconfiguration istio-galley 2>/dev/null
+if [ "$?" -eq 0 ]; then
+    echo "istio-galley validatingwebhookconfiguration found - waiting for istio-galley deployment to be ready"
+    while true; do
+        kubectl -n {{ .Release.Namespace }} get deployment istio-galley 2>/dev/null
+        if [ "$?" -eq 0 ]; then
+            break
+        fi
+        sleep 1
+    done
+    /kubectl -n {{ .Release.Namespace }} rollout status deployment istio-galley
+    echo "istio-galley deployment ready for configuration validation"
+fi
+sleep 5
+/kubectl apply -f ${pathToResourceYAML}
+{{ end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-grafana-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: grafana
+data:
+  custom-resources.yaml: |-
+    {{- include "grafana-default.yaml.tpl" . | indent 4}}
+  run.sh: |-
+    {{- include "install-custom-resources.sh.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-grafana-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-grafana-post-install-{{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-grafana-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-grafana-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-grafana-post-install-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-grafana-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: istio-grafana
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-grafana-post-install
+      labels:
+        app: istio-grafana
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-grafana-post-install-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          command: [ "/bin/bash", "/tmp/grafana/run.sh", "/tmp/grafana/custom-resources.yaml" ]
+          volumeMounts:
+            - mountPath: "/tmp/grafana"
+              name: tmp-configmap-grafana
+      volumes:
+        - name: tmp-configmap-grafana
+          configMap:
+            name: istio-grafana-custom-resources
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/charts/grafana/templates/grafana-ports-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/grafana-ports-mtls.yaml
@@ -1,3 +1,4 @@
+{{ define "grafana-default.yaml.tpl" }}
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
@@ -8,3 +9,4 @@ spec:
   - name: grafana
     ports:
     - number: {{ .Values.service.externalPort }}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-security-custom-resources
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    istio: security
+data:
+  custom-resources.yaml: |-
+    {{- if .Values.global.mtls.enabled }}
+      {{- include "security-default.yaml.tpl" . | indent 4}}
+    {{- end }}
+  run.sh: |-
+    {{- include "install-custom-resources.sh.tpl" . | indent 4}}

--- a/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/create-custom-resources-job.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.global.mtls.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-security-post-install-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-security-post-install-{{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["authentication.istio.io"] # needed to create default authn policy
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.istio.io"] # needed to create security destination rules
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get"]
+- apiGroups: ["extensions"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-security-post-install-role-binding-{{ .Release.Namespace }}
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-security-post-install-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-security-post-install-account
+    namespace: {{ .Release.Namespace }}
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-security-post-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+  labels:
+    app: istio-security
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      name: istio-security-post-install
+      labels:
+        app: istio-security
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: istio-security-post-install-account
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          command: [ "/bin/bash", "/tmp/security/run.sh", "/tmp/security/custom-resources.yaml" ]
+          volumeMounts:
+            - mountPath: "/tmp/security"
+              name: tmp-configmap-security
+      volumes:
+        - name: tmp-configmap-security
+          configMap:
+            name: istio-security-custom-resources
+      restartPolicy: OnFailure
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.mtls.enabled }}
+{{ define "security-default.yaml.tpl" }}
 # These policy and destination rules effectively enable mTLS for all services in the mesh. For now,
 # they are added to Istio installation yaml for backward compatible. In future, they should be in
 # a separated yaml file so that customer can enable mTLS independent from installation.

--- a/install/kubernetes/helm/istio/templates/install-custom-resources.sh.tpl
+++ b/install/kubernetes/helm/istio/templates/install-custom-resources.sh.tpl
@@ -1,0 +1,32 @@
+{{ define "install-custom-resources.sh.tpl" }}
+#!/bin/sh
+
+set -x
+
+if [ "$#" -ne "1" ]; then
+    echo "first argument should be path to custom resource yaml"
+    exit 1
+fi
+
+pathToResourceYAML=${1}
+
+/kubectl get validatingwebhookconfiguration istio-galley 2>/dev/null
+if [ "$?" -eq 0 ]; then
+    echo "istio-galley validatingwebhookconfiguration found - waiting for istio-galley deployment to be ready"
+    while true; do
+        /kubectl -n {{ .Release.Namespace }} get deployment istio-galley 2>/dev/null
+        if [ "$?" -eq 0 ]; then
+            break
+        fi
+        sleep 1
+    done
+    /kubectl -n {{ .Release.Namespace }} rollout status deployment istio-galley
+    if [ "$?" -ne 0 ]; then
+        echo "istio-galley deployment rollout status check failed"
+        exit 1
+    fi
+    echo "istio-galley deployment ready for configuration validation"
+fi
+sleep 5
+/kubectl apply -f ${pathToResourceYAML}
+{{ end }}


### PR DESCRIPTION
This reverts commit 4a78161824da9c7712a07f245487316c689b0245.

This seems to be the potential culprit in some of the postsubmit jobs and checkin gates.

- Reverting 1d62f44a1a7a2e0cfe2c9381f9e1ad53a7eb9fdb as well.

http://k8s-testgrid.appspot.com/istio-postsubmits#circleci-e2e-simple