### PR TITLE
Use externalTrafficPolicy: Local for ingress and gateways.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/service.yaml
@@ -22,6 +22,9 @@ spec:
   loadBalancerIP: "{{ $spec.loadBalancerIP }}"
 {{- end }}
   type: {{ .type }}
+{{- if $spec.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $spec.externalTrafficPolicy }}
+{{- end }}
   selector:
     {{- range $key, $val := $spec.labels }}
     {{ $key }}: {{ $val }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
   type: {{ .Values.service.type }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   selector:
     istio: ingress
   ports:

--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -55,6 +55,7 @@ gateways:
     loadBalancerIP: ""
     serviceAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+    externalTrafficPolicy: Local
 
     ports:
       ## You can add custom gateway ports

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -167,6 +167,7 @@ ingress:
     annotations: {}
     loadBalancerIP: ""
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+    externalTrafficPolicy: Local
     ports:
     - port: 80
       name: http
@@ -206,6 +207,7 @@ gateways:
     loadBalancerIP: ""
     serviceAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+    externalTrafficPolicy: Local
 
     ports:
       ## You can add custom gateway ports
@@ -293,6 +295,7 @@ gateways:
     serviceAnnotations:
       cloud.google.com/load-balancer-type: "internal"
     type: LoadBalancer
+    externalTrafficPolicy: Local
     ports:
     ## You can add custom gateway ports - google ILB default quota is 5 ports,
     - port: 15011


### PR DESCRIPTION
Fixes #7328.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>