### PR TITLE
Update Envoy SHA to latest.

### DIFF
--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -198,6 +198,7 @@ function startEnvoy() {
     "${ISTIO_OUT}/envoy" -c tests/testdata/multicluster/envoy_local_v2.yaml \
         --base-id 4 --service-cluster xds_cluster \
         --service-node local.test \
+        --allow-unknown-fields \
         --log-level debug \
         --log-path "${LOG_DIR}/envoy.log"&
     echo $! > "$LOG_DIR/envoy4.pid"

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "7fde77a6ae6b976aae801ac036fbddd00e39ad4f"
+		"lastStableSHA": "1fc6253f572fbef1ba1fd304fd81c79539824eb1"
 	}
 ]

--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -49,6 +49,7 @@ func (s *TestSetup) NewEnvoy() (*Envoy, error) {
 	args := []string{"-c", confPath,
 		"--v2-config-only",
 		"--drain-time-s", "1",
+		"--allow-unknown-fields",
 		// base id is shared between restarted envoys
 		"--base-id", strconv.Itoa(int(s.testName))}
 	if s.stress {

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -241,6 +241,7 @@ func (proxy envoy) args(fname string, epoch int) []string {
 		"--service-cluster", proxy.config.ServiceCluster,
 		"--service-node", proxy.node,
 		"--max-obj-name-len", fmt.Sprint(proxy.config.StatNameLength),
+		"--allow-unknown-fields",
 	}
 
 	startupArgs = append(startupArgs, proxy.extraArgs...)

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -237,6 +237,7 @@ func TestEnvoyArgs(t *testing.T) {
 		"--service-cluster", "my-cluster",
 		"--service-node", "my-node",
 		"--max-obj-name-len", fmt.Sprint(config.StatNameLength),
+		"--allow-unknown-fields",
 		"-l", "trace",
 		"--concurrency", "8",
 		"--service-zone", "my-zone",

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -64,6 +64,7 @@ func args(config *meshconfig.ProxyConfig, node, fname string, epoch int, cliarg 
 		"--service-cluster", config.ServiceCluster,
 		"--service-node", node,
 		"--max-obj-name-len", fmt.Sprint(config.StatNameLength),
+		"--allow-unknown-fields",
 	}
 
 	for _, v := range cliarg {

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -97,7 +97,7 @@ if [ ${EXEC_USER} == "${USER:-}" ] ; then
     "${CONTROL_PLANE_AUTH_POLICY[@]}"
 else
 
-# Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
+# Will run: ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' --allow-unknown-fields $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
 exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy ${ISTIO_AGENT_FLAGS_ARRAY[*]} \
     --serviceCluster $SVC \
     --discoveryAddress ${PILOT_ADDRESS} \


### PR DESCRIPTION
Pulling the following changes from github.com/istio/proxy:

1fc6253 add debug logs for collecting rbac attributes (#1922)
c5282b6 Update Envoy SHA to latest with LcTrie optimizations. (#1918)
4ced9e7 Update clang to 6.0 and use it for release binaries. (#1914)
585abec fixed broken links to dev guide and contribution guide (#1913)
c63d841 Provide source version information in the binary. (#1915)
b49589a Install clang-format in the build image used by CircleCI. (#1917)
5d42471 Fix macOS build on CircleCI. (#1916)
b1f4e7e add rbac filter to istio http integration test. (#1907)

Pulling the following changes from github.com/envoyproxy/envoy:

73bd3d95c http_filter: add addEncodedTrailers and addDecodedTrailers (#3980)
c3652aad5 rbac/fuzz: fix build (#4150)
07bc27c05 fix flaky RBAC integration test. (#4147)
b150d61a9 header_map: copy constructor for HeaderMapImpl. (#4129)
f345c8b23 test: moving websocket tests to using HTTP codec. (#4143)
da500d20f upstream: init host hc value based on hc value from other priorities (#3959)
da6194b94 test: add tests for corner-cases around sending requests before run() starts or after run() ends. (#4114)
3527f7799 perf: reduce the memory usage of LC Trie construction (#4117)
b538e46d8 test: moving redundant code in websocket_integration_test to utilities (#4127)
a3c55bf7b test: make YamlLoadFromStringFail less picky about error msg. (#4141)
c283439b6 rbac: add rbac network filter. (#4083)
5a7152d21 fuzz: route lookup and header finalization fuzzer. (#4116)
589467360 Set content-type and content-length (#4113)
714ae130a fault: use FractionalPercent for percent (#3978)
fde378705 test: Fix inverted exact match logic in IntegrationTcpClient::waitForData() (#4134)
794a00126 Added cluster_name to load assignment config for static cluster (#4123)
19f51e5e1 ssl: refactor ContextConfig to use TlsCertificateConfig (#4115)
0a4bffc5a syscall: refactor OsSysCalls for deeper errno latching (#4111)
ec0d98e5e thrift_proxy: fix oneway bugs (#4025)
1381673ad Do not crash when converting YAML to JSON fails (#4110)
2662bf1f2 config: allow unknown fields flag (take 2) (#4096)
1ab839c1f Use a jittered backoff strategy for handling HdsDelegate stream/connection failures (#4108)
7309c14cf bazel: use GCS remote cache (#4050)
5fe4e14f0 Add thread local cache of overload action states (#4090)
3bb7fbc5f Added TCP healthcheck capabilities to the HdsDelegate (#4079)
98037ed37 secret: add secret provider interface and use it for TlsCertificates (#4086)
3e15c9490 upstream: allow custom extension protocol options (#4098)
9b33c49d1 Rename message types in hds.proto to improve readability (#4109)
bb70b42bb fuzz: router header formatter/parser fuzz test. (#4105)
fe57f6b33 fuzz: http parsing utility fuzzer. (#4107)
73dfedc95 ci: link ninja-buid to ninja for centos (#4106)
1cd509ef1 docs: add curl to Ubuntu deps (#4104)
45b900829 Handling updates from the management server on HDS (#4077)
510994c6a Don't use SIGTERM for admin /quitquitquit, just shut down directly. (#4099)
29b60291e fuzz: access log formatter fuzz test. (#4102)
765cac42f Destroy pending updates when updating a cluster (#4084)
aafdf6037 authz_client_fix: fixed ext_authz http client when request contains content-length greater than 0 (#3888)
22ae0ab93 HttpConnectionManager and upstream counters for total completed requests (#3995)
04616d676  tcp_proxy: convert TCP proxy to use TCP connection pool (#4067)
e759eab17 buffer: add prepend functions to Buffer::Instance (#4064)

Fixes #7710, fixes #7817, and hopefully fixes #7759.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>