### PR TITLE
Support Timestamp type for valueTypeEncoder

### DIFF
--- a/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder.go
@@ -16,11 +16,9 @@ package dynamic
 
 import (
 	"fmt"
-
-	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-
 	"time"
 
+	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/api/policy/v1beta1"
@@ -102,8 +100,11 @@ func valueTypeEncoderBuilder(_ *descriptor.DescriptorProto, fd *descriptor.Field
 					if er != nil {
 						return er
 					}
-					ts := ev.(time.Time)
-					vVal.Value = &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{&types.Timestamp{ts.Unix(), int32(ts.Nanosecond())}}}
+					ts, er := types.TimestampProto(ev.(time.Time))
+					if er != nil {
+						return er
+					}
+					vVal.Value = &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{ts}}
 					return nil
 				}
 			default:

--- a/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder.go
@@ -19,6 +19,10 @@ import (
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
 	"istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/lang/compiled"
@@ -90,6 +94,16 @@ func valueTypeEncoderBuilder(_ *descriptor.DescriptorProto, fd *descriptor.Field
 						return er
 					}
 					vVal.Value = &v1beta1.Value_DoubleValue{ev}
+					return nil
+				}
+			case v1beta1.TIMESTAMP:
+				enc = func(bag attribute.Bag, vVal *v1beta1.Value) error {
+					ev, er := expr.Evaluate(bag)
+					if er != nil {
+						return er
+					}
+					ts := ev.(time.Time)
+					vVal.Value = &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{&types.Timestamp{ts.Unix(), int32(ts.Nanosecond())}}}
 					return nil
 				}
 			default:

--- a/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/api/policy/v1beta1"
@@ -118,6 +117,10 @@ func TestValueTypeEncoder_Errors(t *testing.T) {
 func TestValueTypeEncoder(t *testing.T) {
 	compiler := compiled.NewBuilder(StatdardVocabulary())
 	now := time.Now()
+	ts, err := types.TimestampProto(now)
+	if err != nil {
+		t.Fatalf("invalid time: %v", err)
+	}
 	for _, tst := range []struct {
 		input    interface{}
 		output   v1beta1.Value
@@ -170,7 +173,7 @@ func TestValueTypeEncoder(t *testing.T) {
 		},
 		{
 			input:  "response.time",
-			output: v1beta1.Value{Value: &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{&types.Timestamp{now.Unix(), int32(now.Nanosecond())}}}},
+			output: v1beta1.Value{Value: &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{ts}}},
 			bag: map[string]interface{}{
 				"response.time": now,
 			},

--- a/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/valueTypeEncoder_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 
+	"github.com/gogo/protobuf/types"
+
 	"istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/lang/compiled"
@@ -62,10 +64,6 @@ func TestValueTypeEncoder_Errors(t *testing.T) {
 		{
 			input:        "badAttribute",
 			builderError: errors.New("unknown attribute"),
-		},
-		{
-			input:        "response.time",
-			builderError: errors.New("unsupported type"),
 		},
 		{
 			input:        "incorrectMessage",
@@ -119,6 +117,7 @@ func TestValueTypeEncoder_Errors(t *testing.T) {
 
 func TestValueTypeEncoder(t *testing.T) {
 	compiler := compiled.NewBuilder(StatdardVocabulary())
+	now := time.Now()
 	for _, tst := range []struct {
 		input    interface{}
 		output   v1beta1.Value
@@ -167,6 +166,13 @@ func TestValueTypeEncoder(t *testing.T) {
 			output: v1beta1.Value{Value: &v1beta1.Value_BoolValue{false}},
 			bag: map[string]interface{}{
 				"test.bool": false,
+			},
+		},
+		{
+			input:  "response.time",
+			output: v1beta1.Value{Value: &v1beta1.Value_TimestampValue{&v1beta1.TimeStamp{&types.Timestamp{now.Unix(), int32(now.Nanosecond())}}}},
+			bag: map[string]interface{}{
+				"response.time": now,
 			},
 		},
 	} {


### PR DESCRIPTION
I'm working on the integration between Apache Skywalking and istio, following [Mixer-Out-Of-Process-Adapter-Walkthrough](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Walkthrough).

But the mixer currently can't encode TIMESTAMP type which is be used by `request.time`, `response.time` etc. So I add a new switch-case branch in `valueTypeEncoder.go` to support it.