### PR TITLE
lint tools complain about redundant newline in Println

### DIFF
--- a/tools/license/get_dep_licenses.go
+++ b/tools/license/get_dep_licenses.go
@@ -214,7 +214,7 @@ func main() {
 	}
 
 	if matchDetail {
-		fmt.Println("\n\n")
+		fmt.Printf("\n\n")
 		fmt.Println("===========================================================")
 		fmt.Println("The following packages had inexact licenses:")
 		fmt.Println("===========================================================")
@@ -226,7 +226,7 @@ func main() {
 			fmt.Println("-----------------------------------------------------------")
 		}
 
-		fmt.Println("\n\n")
+		fmt.Printf("\n\n")
 		fmt.Println("===========================================================")
 		fmt.Println("The following packages had exact licenses:")
 		fmt.Println("===========================================================")
@@ -238,7 +238,7 @@ func main() {
 			}
 		}
 	} else {
-		fmt.Println("\n\n")
+		fmt.Printf("\n\n")
 		fmt.Println("===========================================================")
 		fmt.Println("Package licenses")
 		fmt.Println("===========================================================")


### PR DESCRIPTION
e.g.:
```
# istio.io/istio/tools/license
tools/license/get_dep_licenses.go:217: Println arg list ends with redundant newline
tools/license/get_dep_licenses.go:229: Println arg list ends with redundant newline
tools/license/get_dep_licenses.go:241: Println arg list ends with redundant newline
```