### PR TITLE
Fix configmap update test.

### DIFF
--- a/galley/pkg/server/configmap_test.go
+++ b/galley/pkg/server/configmap_test.go
@@ -90,8 +90,8 @@ allowed:
 
 	writeFile(t, file, updated)
 
-	for i := 0; i < 100; i++ {
-		if checker.Allowed("spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account") {
+	for i := 0; i < 3000; i++ {
+		if checker.Allowed("spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account") {
 			return
 		}
 


### PR DESCRIPTION
There was a copy paste error in the test that @elevran  fixed. But he is also seeing the error in Prow. This is most likely a resource issue on the Prow side (after the fix).

This PR both includes and increases the timeout range.