### PR TITLE
Update grafana to its latest version

### DIFF
--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,4 +1,4 @@
-from grafana/grafana:5.0.4
+from grafana/grafana:5.2.2
 
 COPY grafana.ini /etc/grafana/
 RUN chmod 777 -R /etc/grafana/

--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,5 +1,7 @@
 from grafana/grafana:5.2.2
 
+USER root
+
 COPY grafana.ini /etc/grafana/
 RUN chmod 777 -R /etc/grafana/
 
@@ -11,3 +13,5 @@ RUN chmod 777 -R /etc/grafana/provisioning/datasources/
 
 COPY dashboards /var/lib/grafana/dashboards/
 RUN chmod 777 -R /var/lib/grafana/dashboards/
+
+USER grafana


### PR DESCRIPTION
https://github.com/istio/istio/blob/master/addons/grafana/Dockerfile.grafana#L1 shows
that Istio currently uses the version 5.0.4 of grafana, which was released on March 27, 2018.
The latest version of grafana is 5.2.2, released on July 24, 2018. Istio should update its
grafana version to leverage the fixes included in the latest grafana version.