### PR TITLE
Add  /version as readiness instead of liveness check

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -39,11 +39,11 @@
         volumeMounts:
         - name: uds-socket
           mountPath: /sock
-        livenessProbe:
+        readinessProbe:
           httpGet:
             path: /version
             port: 9093
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
       - name: istio-proxy
         image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"
@@ -134,7 +134,7 @@
         volumeMounts:
         - name: uds-socket
           mountPath: /sock
-        livenessProbe:
+        readinessProbe:
           httpGet:
             path: /version
             port: 9093


### PR DESCRIPTION
Mixer can take some time to load and open ports. This ensures that no traffic is sent to mixer before it is actually ready serve requests.