### PR TITLE
optimize pilot-discovery server

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -52,6 +52,7 @@ var (
 		Use:   "discovery",
 		Short: "Start Istio proxy discovery service",
 		RunE: func(c *cobra.Command, args []string) error {
+			cmd.PrintFlags(c.Flags())
 			if err := log.Configure(loggingOptions); err != nil {
 				return err
 			}

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -75,8 +75,7 @@ var (
 			}
 
 			// Start the server
-			_, err = discoveryServer.Start(stop)
-			if err != nil {
+			if err := discoveryServer.Start(stop); err != nil {
 				return fmt.Errorf("failed to start discovery service: %v", err)
 			}
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -800,7 +800,8 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			<-stop
 			model.JwtKeyResolver.Close()
 
-			err = s.httpServer.Shutdown(context.TODO())
+			ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+			err = s.httpServer.Shutdown(ctx)
 			if err != nil {
 				log.Warna(err)
 			}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -15,6 +15,7 @@
 package bootstrap
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,8 +70,6 @@ import (
 const (
 	// ConfigMapKey should match the expected MeshConfig file name
 	ConfigMapKey = "mesh"
-	// CopilotTimeout when to cancel remote gRPC call to copilot
-	CopilotTimeout = 5 * time.Second
 )
 
 var (
@@ -165,15 +165,6 @@ type Server struct {
 	kubeRegistry     *kube.Controller
 }
 
-func createInterface(kubeconfig string) (kubernetes.Interface, error) {
-	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-
-	if err != nil {
-		return nil, err
-	}
-	return kubernetes.NewForConfig(restConfig)
-}
-
 // NewServer creates a new Server instance based on the provided arguments.
 func NewServer(args PilotArgs) (*Server, error) {
 	// If the namespace isn't set, try looking it up from the environment.
@@ -227,18 +218,17 @@ func NewServer(args PilotArgs) (*Server, error) {
 }
 
 // Start starts all components of the Pilot discovery service on the port specified in DiscoveryServiceOptions.
-// If Port == 0, a port number is automatically chosen. This method returns the address on which the server is
-// listening for incoming connections. Content serving is started by this method, but is executed asynchronously.
-// Serving can be cancelled at any time by closing the provided stop channel.
-func (s *Server) Start(stop <-chan struct{}) (net.Addr, error) {
+// If Port == 0, a port number is automatically chosen. Content serving is started by this method,
+// but is executed asynchronously. Serving can be cancelled at any time by closing the provided stop channel.
+func (s *Server) Start(stop <-chan struct{}) error {
 	// Now start all of the components.
 	for _, fn := range s.startFuncs {
 		if err := fn(stop); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return s.HTTPListeningAddr, nil
+	return nil
 }
 
 // startFunc defines a function that will be used to start one or more components of the Pilot discovery service.
@@ -322,7 +312,7 @@ func GetMeshConfig(kube kubernetes.Interface, namespace, name string) (*v1.Confi
 
 	config, err := kube.CoreV1().ConfigMaps(namespace).Get(name, meta_v1.GetOptions{})
 	if err != nil {
-		if strings.Contains(err.Error(), fmt.Sprintf("\"%s\" not found", name)) {
+		if errors.IsNotFound(err) {
 			defaultMesh := model.DefaultMeshConfig()
 			return nil, &defaultMesh, nil
 		}
@@ -397,11 +387,8 @@ func (s *Server) initMixerSan(args *PilotArgs) error {
 	return nil
 }
 
-func (s *Server) getKubeCfgFile(args *PilotArgs) (kubeCfgFile string) {
-	if kubeCfgFile == "" {
-		kubeCfgFile = args.Config.KubeConfig
-	}
-	return
+func (s *Server) getKubeCfgFile(args *PilotArgs) string {
+	return args.Config.KubeConfig
 }
 
 // initKubeClient creates the k8s client if running in an k8s environment.
@@ -415,18 +402,23 @@ func (s *Server) initKubeClient(args *PilotArgs) error {
 	}
 
 	if needToCreateClient && args.Config.FileDir == "" {
-		var client kubernetes.Interface
-		var kuberr error
-
 		kubeCfgFile := s.getKubeCfgFile(args)
-		client, kuberr = createInterface(kubeCfgFile)
-
+		client, kuberr := createInterface(kubeCfgFile)
 		if kuberr != nil {
 			return multierror.Prefix(kuberr, "failed to connect to Kubernetes API.")
 		}
 		s.kubeClient = client
 	}
 	return nil
+}
+
+func createInterface(kubeconfig string) (kubernetes.Interface, error) {
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(restConfig)
 }
 
 type mockController struct{}
@@ -808,13 +800,13 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			<-stop
 			model.JwtKeyResolver.Close()
 
-			err = s.httpServer.Close()
+			err = s.httpServer.Shutdown(context.TODO())
 			if err != nil {
 				log.Warna(err)
 			}
-			s.grpcServer.Stop()
+			s.grpcServer.GracefulStop()
 			if s.secureGRPCServer != nil {
-				s.secureGRPCServer.Stop()
+				s.secureGRPCServer.GracefulStop()
 			}
 		}()
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"istio.io/istio/pkg/log"
 )
@@ -38,5 +39,12 @@ func WaitSignal(stop chan struct{}) {
 func AddFlags(rootCmd *cobra.Command) {
 	flag.CommandLine.VisitAll(func(gf *flag.Flag) {
 		rootCmd.PersistentFlags().AddGoFlag(gf)
+	})
+}
+
+// PrintFlags logs the flags in the flagset
+func PrintFlags(flags *pflag.FlagSet) {
+	flags.VisitAll(func(flag *pflag.Flag) {
+		log.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
 }

--- a/pkg/test/framework/components/apps/local/envoy/agent/pilot/agent_test.go
+++ b/pkg/test/framework/components/apps/local/envoy/agent/pilot/agent_test.go
@@ -239,8 +239,7 @@ func newPilot(namespace string, t *testing.T) (*bootstrap.Server, model.ConfigSt
 
 	// Start the server
 	stop := make(chan struct{})
-	_, err = server.Start(stop)
-	if err != nil {
+	if err := server.Start(stop); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -159,8 +159,7 @@ func NewLocalPilot(namespace string) (LocalPilot, error) {
 
 	// Start the server
 	stopChan := make(chan struct{})
-	_, err = server.Start(stopChan)
-	if err != nil {
+	if err := server.Start(stopChan); err != nil {
 		return nil, err
 	}
 

--- a/tests/local/cluster_registry_test.go
+++ b/tests/local/cluster_registry_test.go
@@ -227,7 +227,7 @@ func initMulticlusterPilot(IstioSrc string) (*bootstrap.Server, error) {
 
 func startMulticlusterPilot(s *bootstrap.Server, stop chan struct{}) {
 	// Start the server
-	_, _ = s.Start(stop)
+	s.Start(stop)
 }
 
 func prepareEnv(t *testing.T) error {

--- a/tests/local/xds_local_test.go
+++ b/tests/local/xds_local_test.go
@@ -190,7 +190,7 @@ func initLocalPilot(IstioSrc string) (*bootstrap.Server, error) {
 
 func startLocalPilot(s *bootstrap.Server, stop chan struct{}) {
 	// Start the server
-	_, _ = s.Start(stop)
+	s.Start(stop)
 }
 
 // Test availability of local API Server

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -168,8 +168,7 @@ func setup() error {
 	MockTestServer = s
 
 	// Start the server.
-	_, err = s.Start(stop)
-	if err != nil {
+	if err := s.Start(stop); err != nil {
 		return err
 	}
 

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -185,8 +185,7 @@ func startPilot() error {
 	}
 
 	// Start the server.
-	_, err = s.Start(stop)
-	if err != nil {
+	if err := s.Start(stop); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
1. print all flags

1. remove useless `HTTPListeningAddr` return param

1. check is not found error by kubernetes standard lib instead of string match