### PR TITLE
Updated Jaeger to 1.6

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -464,7 +464,7 @@ tracing:
   provider: jaeger
   jaeger:
     hub: docker.io/jaegertracing
-    tag: 1.5
+    tag: 1.6
     memory:
       max_traces: 50000
     ui:


### PR DESCRIPTION
This bumps the jaeger-all-in-one image to the 1.6 version.

I've tested this in our preprod clusters and all seems fine:

<img width="1440" alt="screen shot 2018-08-16 at 09 22 18" src="https://user-images.githubusercontent.com/1486729/44197195-e5783880-a135-11e8-9c9e-de02db3e3f9d.png">
