### PR TITLE
cleanup: remove unused field "Client" in listener

### DIFF
--- a/galley/pkg/kube/source/listener.go
+++ b/galley/pkg/kube/source/listener.go
@@ -44,9 +44,6 @@ type listener struct {
 
 	resyncPeriod time.Duration
 
-	// Client for accessing the resources dynamically
-	Client dynamic.Interface
-
 	// The dynamic resource interface for accessing custom resources dynamically.
 	iface dynamic.ResourceInterface
 
@@ -80,7 +77,6 @@ func newListener(
 		spec:         spec,
 		resyncPeriod: resyncPeriod,
 		iface:        iface,
-		Client:       client,
 		processor:    processor,
 	}, nil
 }


### PR DESCRIPTION
AFAIK, listeners will only in need of ResourceInterface (iface)