### PR TITLE
make the auth checker in Gally configurable

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -48,6 +48,8 @@ func serverCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 		"Maximum number of outstanding RPCs per connection")
 	cmd.PersistentFlags().BoolVarP(&sa.Insecure, "insecure", "", sa.Insecure,
 		"Use insecure gRPC communication")
+	cmd.PersistentFlags().StringVarP(&sa.AuthChecker, "authChecker", "", sa.AuthChecker,
+		"The type of auth checker to invoke, currently only list(ListAuthChecker) is supported.")
 	cmd.PersistentFlags().StringVarP(&sa.CertificateFile, "certFile", "", sa.CertificateFile,
 		"The location of the certificate file for mutual TLS")
 	cmd.PersistentFlags().StringVarP(&sa.KeyFile, "keyFile", "", sa.KeyFile,

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -32,6 +32,8 @@ const (
 
 	defaultConfigMapFolder = "/etc/istio/config/"
 	defaultAccessListFile  = defaultConfigMapFolder + "accesslist.yaml"
+
+	defaultAuthChecker = "list"
 )
 
 // Args contains the startup arguments to instantiate Galley.
@@ -56,6 +58,9 @@ type Args struct {
 
 	// Insecure gRPC service is used for the MCP server. CertificateFile and KeyFile is ignored.
 	Insecure bool
+
+	// Type of auth checker to invoke.
+	AuthChecker string
 
 	// CertificateFile to use for mTLS gRPC.
 	CertificateFile string
@@ -90,6 +95,7 @@ func DefaultArgs() *Args {
 		MaxReceivedMessageSize: 1024 * 1024,
 		MaxConcurrentStreams:   1024,
 		Insecure:               false,
+		AuthChecker:            defaultAuthChecker,
 		CertificateFile:        defaultCertFile,
 		KeyFile:                defaultCertKey,
 		CACertificateFile:      defaultCACertFile,
@@ -112,6 +118,7 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "MaxReceivedMessageSize: %d\n", a.MaxReceivedMessageSize)
 	fmt.Fprintf(buf, "MaxConcurrentStreams: %d\n", a.MaxConcurrentStreams)
 	fmt.Fprintf(buf, "Insecure: %v\n", a.Insecure)
+	fmt.Fprintf(buf, "AuthChecker: %s\n", a.AuthChecker)
 	fmt.Fprintf(buf, "KeyFile: %s\n", a.KeyFile)
 	fmt.Fprintf(buf, "CertificateFile: %s\n", a.CertificateFile)
 	fmt.Fprintf(buf, "CACertificateFile: %s\n", a.CACertificateFile)


### PR DESCRIPTION
We could have other kinds of checker to support in the future,
so I think it would be better to make it configurable.

We may even introduce registration mechanism for custom authorizers in the future.