### PR TITLE
Revert "remove requestedServerName attribute (#7278)"

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -75,6 +75,8 @@ spec:
       valueType: DURATION
     connection.mtls:
       valueType: BOOL
+    connection.requested_server_name:
+      valueType: STRING
     context.protocol:
       valueType: STRING
     context.timestamp:
@@ -222,6 +224,7 @@ spec:
     clientTraceId: request.headers["x-client-trace-id"] | ""
     latency: response.duration | "0ms"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    requestedServerName: connection.requested_server_name | ""
     userAgent: request.useragent | ""
     responseTimestamp: response.time
     receivedBytes: request.total_size | 0
@@ -260,6 +263,7 @@ spec:
     protocol: context.protocol | "tcp"
     connectionDuration: connection.duration | "0ms"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
+    requestedServerName: connection.requested_server_name | ""
     receivedBytes: connection.received.bytes | 0
     sentBytes: connection.sent.bytes | 0
     totalReceivedBytes: connection.received.bytes_total | 0

--- a/mixer/testdata/config/accesslog.yaml
+++ b/mixer/testdata/config/accesslog.yaml
@@ -45,6 +45,7 @@ spec:
     clientTraceId: request.headers["x-client-trace-id"] | ""
     latency: response.duration | "0ms"
     connectionMtls: connection.mtls | false
+    requestedServerName: connection.requested_server_name | ""
     userAgent: request.useragent | ""
     responseTimestamp: response.time | timestamp("2017-01-01T00:00:00Z")
     receivedBytes: request.total_size | 0

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -73,6 +73,8 @@ spec:
         valueType: DURATION
       connection.mtls:
         valueType: BOOL
+      connection.requested_server_name:
+        valueType: STRING
       context.protocol:
         valueType: STRING
       context.timestamp:

--- a/mixer/testdata/config/tcp_accesslog.yaml
+++ b/mixer/testdata/config/tcp_accesslog.yaml
@@ -34,6 +34,7 @@ spec:
     protocol: context.protocol | "tcp"
     connectionDuration: connection.duration | "0ms"
     connectionMtls: connection.mtls | false
+    requestedServerName: connection.requested_server_name | ""
     receivedBytes: connection.received.bytes | 0
     sentBytes: connection.sent.bytes | 0
     totalReceivedBytes: connection.received.bytes_total | 0


### PR DESCRIPTION
This reverts commit 31398b36c17733af015dbcfe55f999e2c51a096e.

The requestedServerName field wasn't populated because the Global Dictionary of Mixer wasn't up-to-date.

PR #7788 updates Mixer's Global Dictionary. Hence, requestedServerName should work now.