### PR TITLE
decouple validation webhook's health checking and reconciliation loop

### DIFF
--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
+
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -41,6 +43,7 @@ import (
 	"istio.io/istio/pilot/pkg/config/kube/crd"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/probe"
 )
 
 var (
@@ -118,6 +121,8 @@ type Webhook struct {
 	// mixer
 	validator store.BackendValidator
 
+	healthProbe          *probe.Probe
+	healthController     probe.Controller
 	healthCheckInterval  time.Duration
 	healthCheckFile      string
 	server               *http.Server
@@ -188,6 +193,17 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 		clientset:           p.Clientset,
 		deploymentName:      p.DeploymentName,
 		deploymentNamespace: p.DeploymentNamespace,
+		healthProbe:         probe.NewProbe(),
+		healthController: probe.NewFileController(&probe.Options{
+			Path:           p.HealthCheckFile,
+			UpdateInterval: p.HealthCheckInterval,
+		}),
+	}
+
+	if wh.healthCheckInterval != 0 && wh.healthCheckFile != "" {
+		wh.healthProbe.RegisterProbe(wh.healthController, "validation")
+		wh.healthProbe.SetAvailable(errors.New("not ready"))
+		wh.healthController.Start()
 	}
 
 	if galleyDeployment, err := wh.clientset.ExtensionsV1beta1().Deployments(wh.deploymentNamespace).Get(wh.deploymentName, v1.GetOptions{}); err != nil { // nolint: lll
@@ -227,13 +243,6 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 	}()
 	defer wh.stop()
 
-	var healthC <-chan time.Time
-	if wh.healthCheckInterval != 0 && wh.healthCheckFile != "" {
-		t := time.NewTicker(wh.healthCheckInterval)
-		healthC = t.C
-		defer t.Stop()
-	}
-
 	// use a timer to debounce file updates
 	var keyCertTimerC <-chan time.Time
 	var configTimerC <-chan time.Time
@@ -247,6 +256,11 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 	var reconcileTickerC <-chan time.Time
 	if wh.webhookConfigFile != "" {
 		reconcileTickerC = time.NewTicker(reconcilePeriod).C
+	}
+
+	if wh.healthCheckInterval != 0 && wh.healthCheckFile != "" {
+		wh.healthProbe.SetAvailable(nil)
+		defer wh.healthController.Close()
 	}
 
 	for {
@@ -279,11 +293,6 @@ func (wh *Webhook) Run(stop <-chan struct{}) {
 			log.Errorf("keyCertWatcher error: %v", err)
 		case err := <-wh.configWatcher.Error:
 			log.Errorf("configWatcher error: %v", err)
-		case <-healthC:
-			content := []byte(`ok`)
-			if err := ioutil.WriteFile(wh.healthCheckFile, content, 0644); err != nil {
-				log.Errorf("Health check update of %q failed: %v", wh.healthCheckFile, err)
-			}
 		case <-stop:
 			return
 		}


### PR DESCRIPTION
The validation webhook's health file updates and configuration
reconciliation were invoked from the same goroutine. Delays in
checking and updating the k8s configuration could result in the health
file not being updated in time to pass the health checks. Use
istio.io/istio/pkg/probe to decouple the two code paths.

fixes https://github.com/istio/istio/issues/7586