### PR TITLE
Increase default gateway cpu requests in helm chart

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -196,13 +196,13 @@ gateways:
     replicaCount: 1
     autoscaleMin: 1
     autoscaleMax: 5
-    resources: {}
+    resources:
+      requests:
+        cpu: 500m
+      #  memory: 256Mi
       # limits:
       #  cpu: 100m
       #  memory: 128Mi
-      #requests:
-      #  cpu: 1800m
-      #  memory: 256Mi
 
     loadBalancerIP: ""
     loadBalancerSourceRanges: {}
@@ -254,6 +254,9 @@ gateways:
     replicaCount: 1
     autoscaleMin: 1
     autoscaleMax: 5
+    resources:
+      requests:
+        cpu: 500m
     serviceAnnotations: {}
     type: ClusterIP #change to NodePort or LoadBalancer if need be
     ports:


### PR DESCRIPTION
The default request of 10m causes the autoscaler to always scale the
gateway pods to their maximum as they always use more than 6m even when
idle.

Not sure what a good value for the request is, arbitrarily choose 500m.