### PR TITLE
[cherrypick]Restructure the pkg/nodeagent. (#5888)

### DIFF
--- a/security/cmd/node_agent/main.go
+++ b/security/cmd/node_agent/main.go
@@ -24,12 +24,12 @@ import (
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
-	"istio.io/istio/security/cmd/node_agent/na"
 	"istio.io/istio/security/pkg/cmd"
+	nvm "istio.io/istio/security/pkg/nodeagent/vm"
 )
 
 var (
-	naConfig = na.NewConfig()
+	naConfig = nvm.NewConfig()
 
 	rootCmd = &cobra.Command{
 		Use:   "node_agent",
@@ -97,7 +97,7 @@ func runNodeAgent() {
 		log.Errora(err)
 		os.Exit(-1)
 	}
-	nodeAgent, err := na.NewNodeAgent(naConfig)
+	nodeAgent, err := nvm.NewNodeAgent(naConfig)
 	if err != nil {
 		log.Errora(err)
 		os.Exit(-1)

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -18,6 +18,19 @@ import (
 	"log"
 
 	"github.com/spf13/cobra"
+
+	nvm "istio.io/istio/security/pkg/nodeagent/vm"
+)
+
+const (
+	// MgmtAPIPath is the path to call mgmt.
+	MgmtAPIPath string = "/tmp/udsuspver/mgmt.sock"
+
+	// WorkloadAPIUdsHome is the uds file directory for workload api.
+	WorkloadAPIUdsHome string = "/tmp/nodeagent"
+
+	// WorkloadAPIUdsFile is the uds file name for workload api.
+	WorkloadAPIUdsFile string = "/server.sock"
 )
 
 var (
@@ -26,6 +39,8 @@ var (
 		Use:   "nodeagent",
 		Short: "Node agent",
 	}
+
+	naConfig nvm.Config
 )
 
 // Placeholder.

--- a/security/pkg/nodeagent/gcp/gcp.go
+++ b/security/pkg/nodeagent/gcp/gcp.go
@@ -1,0 +1,16 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcp provides the functionality to use GCP identity.
+package gcp

--- a/security/pkg/nodeagent/registry/server.go
+++ b/security/pkg/nodeagent/registry/server.go
@@ -1,0 +1,201 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+
+	"github.com/gogo/googleapis/google/rpc"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
+	"istio.io/istio/security/pkg/nodeagent/secrets"
+	nvm "istio.io/istio/security/pkg/nodeagent/vm"
+	pkiutil "istio.io/istio/security/pkg/pki/util"
+	pb "istio.io/istio/security/proto"
+)
+
+// Server specifies the node agent server.
+// TODO(incfly): adds sync.Mutex to protects the fields, such as `handlerMap`.
+type Server struct {
+	// map from uid to workload handler instance.
+	handlerMap map[string]handler.WorkloadHandler
+	// makes mgmt-api server to stop
+	done      chan bool
+	config    *nvm.Config
+	retriever Retriever
+	// the workload identity running together with the NodeAgent, only used for vm mode.
+	// TODO(incfly): uses this once Server supports vm mode.
+	identity string // nolint
+	// secretServer manages the secrets associated for different workload.
+	secretServer secrets.SecretServer
+}
+
+// Retriever is the interface responsible for retrieving key/cert from upstream CA.
+type Retriever interface {
+	Retrieve(opt *pkiutil.CertOptions) (newCert, certChain, privateKey []byte, err error)
+}
+
+// New creates an NodeAgent server.
+func New(cfg *nvm.Config, retriever Retriever) (*Server, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("unablet to create when config is nil")
+	}
+	ss, err := secrets.NewSecretServer(&secrets.Config{
+		Mode:            secrets.SecretFile,
+		SecretDirectory: cfg.SecretDirectory,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to init nodeagent due to secret server %v", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to create caclient err %v", err)
+	}
+	return &Server{
+		done:         make(chan bool, 1),
+		handlerMap:   make(map[string]handler.WorkloadHandler),
+		retriever:    retriever,
+		config:       cfg,
+		secretServer: ss,
+	}, nil
+}
+
+// startLoop loops for the VM mode, i.e not running on k8s.
+// TODO(inclfy): copy paste from nodeagent.go
+func (s *Server) startLoop() { //nolint
+}
+
+// Stop terminates the UDS.
+func (s *Server) Stop() {
+	s.done <- true
+}
+
+// WaitDone waits for a response back from Workloadhandler
+func (s *Server) WaitDone() {
+	<-s.done
+}
+
+// Serve opens the UDS channel and starts to serve NodeAgentService on that uds channel.
+func (s *Server) Serve(path string) {
+	grpcServer := grpc.NewServer()
+	pb.RegisterNodeAgentServiceServer(grpcServer, s)
+
+	var lis net.Listener
+	var err error
+	_, e := os.Stat(path)
+	if e == nil {
+		e := os.RemoveAll(path)
+		if e != nil {
+			log.Errorf("failed to %s with error %v", path, err)
+		}
+	}
+	lis, err = net.Listen("unix", path)
+	if err != nil {
+		log.Errorf("failed to listen at unix domain socket %v", err)
+	}
+
+	go func(ln net.Listener, s *Server) {
+		<-s.done
+		_ = ln.Close()
+		s.CloseAllWlds()
+	}(lis, s)
+
+	_ = grpcServer.Serve(lis)
+}
+
+// WorkloadAdded defines the server side action when a workload is added.
+func (s *Server) WorkloadAdded(ctx context.Context, request *pb.WorkloadInfo) (*pb.NodeAgentMgmtResponse, error) {
+	uid := request.Attrs.Uid
+	sa := request.Attrs.Serviceaccount
+	ns := request.Attrs.Namespace
+	wlstr := fmt.Sprintf("ns = %v, service account = %v, uid = %v", ns, sa, uid)
+	log.Infof("workload %v added", wlstr)
+	if _, ok := s.handlerMap[uid]; ok {
+		status := &rpc.Status{Code: int32(rpc.ALREADY_EXISTS), Message: "Already exists"}
+		log.Infof("workload %v already exists", request)
+		return &pb.NodeAgentMgmtResponse{Status: status}, nil
+	}
+
+	logReturn := func(tmpl string, err error) error {
+		msg := fmt.Sprintf("%v for %v error %v", tmpl, wlstr, err)
+		log.Errorf(msg)
+		return fmt.Errorf(msg)
+	}
+
+	// Send CSR request to CA.
+	host, err := pkiutil.GenSanURI(ns, sa)
+	if err != nil {
+		return nil, logReturn("failed to generate san uri", err)
+	}
+	cert, chain, priv, err := s.retriever.Retrieve(&pkiutil.CertOptions{
+		Host:       host,
+		Org:        s.config.CAClientConfig.Org,
+		RSAKeySize: s.config.CAClientConfig.RSAKeySize,
+		TTL:        s.config.CAClientConfig.RequestedCertTTL,
+	})
+	if err != nil {
+		return nil, logReturn("csr request failed", err)
+	}
+	rootCert, err := ioutil.ReadFile(s.config.CAClientConfig.RootCertFile)
+	if err != nil {
+		return nil, logReturn("failed to load root cert err", err)
+	}
+	kb, err := pkiutil.NewVerifiedKeyCertBundleFromPem(cert, priv, chain, rootCert)
+	if err != nil {
+		return nil, logReturn("failed to build key cert bundle", err)
+	}
+
+	if err := s.secretServer.Put(sa, kb); err != nil {
+		return nil, logReturn("failed to save key cert", err)
+	}
+
+	s.handlerMap[uid] = handler.NewHandler(request, s.config.WorkloadOpts)
+	go s.handlerMap[uid].Serve()
+
+	status := &rpc.Status{Code: int32(rpc.OK), Message: "OK"}
+	return &pb.NodeAgentMgmtResponse{Status: status}, nil
+}
+
+// WorkloadDeleted defines the server side action when a workload is deleted.
+func (s *Server) WorkloadDeleted(ctx context.Context, request *pb.WorkloadInfo) (*pb.NodeAgentMgmtResponse, error) {
+	uid := request.Attrs.Uid
+	if _, ok := s.handlerMap[uid]; !ok {
+		status := &rpc.Status{Code: int32(rpc.NOT_FOUND), Message: "Not found"}
+		return &pb.NodeAgentMgmtResponse{Status: status}, nil
+	}
+
+	log.Infof("Uid %s: Stop.", uid)
+	s.handlerMap[uid].Stop()
+	s.handlerMap[uid].WaitDone()
+	delete(s.handlerMap, uid)
+
+	status := &rpc.Status{Code: int32(rpc.OK), Message: "OK"}
+	return &pb.NodeAgentMgmtResponse{Status: status}, nil
+}
+
+// CloseAllWlds closes the paths.
+func (s *Server) CloseAllWlds() {
+	for _, wld := range s.handlerMap {
+		wld.Stop()
+	}
+	for _, wld := range s.handlerMap {
+		wld.WaitDone()
+	}
+}

--- a/security/pkg/nodeagent/registry/server_test.go
+++ b/security/pkg/nodeagent/registry/server_test.go
@@ -1,0 +1,216 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gogo/googleapis/google/rpc"
+	"golang.org/x/net/context"
+
+	"istio.io/istio/security/cmd/node_agent_k8s/workload/handler"
+	wapi "istio.io/istio/security/cmd/node_agent_k8s/workloadapi"
+	"istio.io/istio/security/pkg/caclient"
+	"istio.io/istio/security/pkg/nodeagent/secrets"
+	nvm "istio.io/istio/security/pkg/nodeagent/vm"
+	pkiutil "istio.io/istio/security/pkg/pki/util"
+	pb "istio.io/istio/security/proto"
+)
+
+type certFiles struct {
+	dir           string
+	rootFile      string
+	keyFile       string
+	certChainFile string
+	bundle        pkiutil.KeyCertBundle
+}
+
+func setupCertFiles(t *testing.T) (*certFiles, func()) {
+	t.Helper()
+	dir, err := ioutil.TempDir("./", "management_server")
+	if err != nil {
+		t.Errorf("failed to setup temp dir")
+	}
+	rootCAOpts := pkiutil.CertOptions{
+		IsCA:         true,
+		IsSelfSigned: true,
+		TTL:          time.Hour,
+		Org:          "Root CA",
+		RSAKeySize:   2048,
+	}
+	rootCertBytes, rootKeyBytes, err := pkiutil.GenCertKeyFromOptions(rootCAOpts)
+	if err != nil {
+		t.Error(err)
+	}
+	kb, err := pkiutil.NewVerifiedKeyCertBundleFromPem(rootCertBytes, rootKeyBytes, rootCertBytes, rootCertBytes)
+	if err != nil {
+		t.Errorf("failed to create testing keycert bundle %v", err)
+	}
+	cf := &certFiles{
+		dir:           dir,
+		rootFile:      filepath.Join(dir, "root-cert.pem"),
+		keyFile:       filepath.Join(dir, "priv.pem"),
+		certChainFile: filepath.Join(dir, "cert-chain.pem"),
+		bundle:        kb,
+	}
+	if err := ioutil.WriteFile(cf.rootFile, rootCertBytes, secrets.CertFilePermission); err != nil {
+		t.Errorf("failed to write testing root-cert into file %v err %v", cf.rootFile, err)
+	}
+	if err := ioutil.WriteFile(cf.keyFile, rootKeyBytes, secrets.KeyFilePermission); err != nil {
+		t.Errorf("failed to write private key file %v error %v", cf.keyFile, err)
+	}
+	if err := ioutil.WriteFile(cf.certChainFile, rootCertBytes, secrets.CertFilePermission); err != nil {
+		t.Errorf("failed to write cert chain file %v error %v", cf.certChainFile, err)
+	}
+	return cf, func() {
+		_ = os.RemoveAll(dir)
+	}
+}
+
+type fakeRetriever struct {
+	signer    pkiutil.KeyCertBundle
+	bundleMap map[string]pkiutil.KeyCertBundle
+	errMsg    string
+}
+
+func (f *fakeRetriever) setupWorkload(host string) error {
+	rootCert, rootKey, certChain, rootCertBytes := f.signer.GetAll()
+	csrPEM, priv, err := pkiutil.GenCSR(pkiutil.CertOptions{
+		Host:       host,
+		RSAKeySize: 1024,
+		IsCA:       false,
+	})
+	if err != nil {
+		return err
+	}
+	csr, err := pkiutil.ParsePemEncodedCSR(csrPEM)
+	if err != nil {
+		return err
+	}
+	certBytes, err := pkiutil.GenCertFromCSR(csr, rootCert, csr.PublicKey, *rootKey, time.Hour, false)
+	if err != nil {
+		return err
+	}
+	cert := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	kb, err := pkiutil.NewVerifiedKeyCertBundleFromPem(cert, priv, certChain, rootCertBytes)
+	if err != nil {
+		return err
+	}
+	f.bundleMap[host] = kb
+	return nil
+}
+
+func (f *fakeRetriever) Retrieve(opt *pkiutil.CertOptions) (newCert, certChain, privateKey []byte, err error) {
+	if f.errMsg != "" {
+		return nil, nil, nil, fmt.Errorf(f.errMsg)
+	}
+	kb, ok := f.bundleMap[opt.Host]
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("not found in the fake retriever %v", opt.Host)
+	}
+	cert, priv, chain, _ := kb.GetAllPem()
+	return cert, chain, priv, nil
+}
+
+func TestWorkloadAddedService(t *testing.T) {
+	cf, cleanup := setupCertFiles(t)
+	defer cleanup()
+	fake := &fakeRetriever{
+		signer:    cf.bundle,
+		bundleMap: make(map[string]pkiutil.KeyCertBundle),
+	}
+	if err := fake.setupWorkload("spiffe://cluster.local/ns/ns1/sa/sa1"); err != nil {
+		t.Error(err)
+	}
+	server, err := New(&nvm.Config{
+		WorkloadOpts: handler.Options{
+			SockFile: "path",
+			RegAPI:   wapi.RegisterGrpc,
+		},
+		CAClientConfig: caclient.Config{
+			RootCertFile:  cf.rootFile,
+			CertChainFile: cf.certChainFile,
+			KeyFile:       cf.keyFile,
+			RSAKeySize:    1024,
+			Env:           "onprem",
+		},
+		SecretDirectory: cf.dir,
+	}, fake)
+	testCases := []struct {
+		id     string
+		attr   *pb.WorkloadInfo_WorkloadAttributes
+		status rpc.Status
+	}{
+		{
+			id:     "WorkloadAdded Success",
+			attr:   &pb.WorkloadInfo_WorkloadAttributes{Uid: "uid-foo", Serviceaccount: "sa1", Namespace: "ns1"},
+			status: rpc.Status{Code: int32(rpc.OK), Message: "OK"},
+		},
+		{
+			id:     "WorkloadAdded already exists",
+			attr:   &pb.WorkloadInfo_WorkloadAttributes{Uid: "uid-foo", Serviceaccount: "sa1", Namespace: "ns1"},
+			status: rpc.Status{Code: int32(rpc.ALREADY_EXISTS), Message: "Already exists"},
+		},
+	}
+	for _, tc := range testCases {
+		if err != nil {
+			t.Errorf("[%v]: failed to create NodeAgent server %v", tc.id, err)
+		}
+		resp, err := server.WorkloadAdded(context.Background(), &pb.WorkloadInfo{Attrs: tc.attr})
+		if err != nil {
+			t.Errorf("[%v] failed to add workload %v", tc.id, err)
+		}
+		fmt.Println("respon ", resp, " ", tc.id)
+		if !reflect.DeepEqual(*resp.Status, tc.status) {
+			t.Errorf("[%v] expect status (%v) got (%v)", tc.id, tc.status, *resp.Status)
+		}
+	}
+}
+
+func TestWorkloadDeletedService(t *testing.T) {
+	server := &Server{
+		handlerMap: map[string]handler.WorkloadHandler{},
+		done:       make(chan bool),
+		config: &nvm.Config{
+			WorkloadOpts: handler.Options{
+				SockFile: "path",
+				RegAPI:   wapi.RegisterGrpc,
+			},
+			CAClientConfig: caclient.Config{},
+		},
+	}
+	server.handlerMap["testid"] = nil
+
+	attrs := pb.WorkloadInfo_WorkloadAttributes{Uid: "testid2"}
+	naInp := &pb.WorkloadInfo{Attrs: &attrs}
+
+	resp, err := server.WorkloadDeleted(context.Background(), naInp)
+	if err != nil {
+		t.Errorf("Failed to WorkloadDeleted.")
+	}
+	if resp.Status.Code != int32(rpc.NOT_FOUND) {
+		t.Errorf("Failed to WorkloadDeleted with resp %v.", resp)
+	}
+}

--- a/security/pkg/nodeagent/vm/config.go
+++ b/security/pkg/nodeagent/vm/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"time"

--- a/security/pkg/nodeagent/vm/config_test.go
+++ b/security/pkg/nodeagent/vm/config_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"testing"

--- a/security/pkg/nodeagent/vm/nafactory.go
+++ b/security/pkg/nodeagent/vm/nafactory.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"fmt"

--- a/security/pkg/nodeagent/vm/nafactory_test.go
+++ b/security/pkg/nodeagent/vm/nafactory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"testing"

--- a/security/pkg/nodeagent/vm/nodeagent.go
+++ b/security/pkg/nodeagent/vm/nodeagent.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"fmt"

--- a/security/pkg/nodeagent/vm/nodeagent_test.go
+++ b/security/pkg/nodeagent/vm/nodeagent_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package na
+package vm
 
 import (
 	"fmt"


### PR DESCRIPTION
* Move the mesh expansion node agent into the pkg/nodeagent.
* Add a gcp subpackage for nodeagent.
* Lint formatting.

cherrypick https://github.com/istio/istio/pull/5888 to master 