### PR TITLE
Change issue template to use brackets instead of italics for readability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,25 +5,25 @@ about: Report a bug to help us improve Istio
 ---
 
 **Describe the bug**
-_A clear and concise description of what the bug is._
+{{ A clear and concise description of what the bug is. }}
 
 **Expected behavior**
-_A clear and concise description of what you expected to happen._
+{{ A clear and concise description of what you expected to happen. }}
 
 **Steps to reproduce the bug**
-_Steps to reproduce the behavior._
+{{ Steps to reproduce the behavior. }}
 
 **Version**
-_What version of istio and Kubernetes are you using? Use `istioctl version` and `kubectl version`_
+{{ What version of istio and Kubernetes are you using? Use `istioctl version` and `kubectl version`. }}
 
 **Is Istio Auth enabled or not?**
-_Did you install the stable istio.yaml, istio-auth.yaml.... or if using the Helm chart please provide full command line input._
+{{ Did you install the stable istio.yaml, istio-auth.yaml.... or if using the Helm chart please provide full command line input. }}
 
 **Environment**
-_Which environment, cloud vendor, OS, etc are you using?_
+{{ Which environment, cloud vendor, OS, etc are you using? }}
 
 **Cluster state**
-_If you're running on Kubernetes, consider [following the
+{{ If you're running on Kubernetes, consider [following the
 instructions](http://istio.io/help/bugs/#generating-a-cluster-state-archive)
 to generate "istio-dump.tar.gz", then attach it here by dragging and dropping
-the file onto this issue._
+the file onto this issue. }}

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,13 +5,13 @@ about: Suggest an idea to improve Istio
 ---
 
 **Is your feature request related to a problem? Please describe.**
-_A clear and concise description of what the problem is._
+{{ A clear and concise description of what the problem is. }}
 
 **Describe the solution you'd like**
-_A clear and concise description of what you want to happen._
+{{ A clear and concise description of what you want to happen. }}
 
 **Describe alternatives you've considered**
-_A clear and concise description of any alternative solutions or features you've considered._
+{{ A clear and concise description of any alternative solutions or features you've considered. }}
 
 **Additional context**
-_Add any other context about the feature request here._
+{{ Add any other context about the feature request here. }}


### PR DESCRIPTION
Thanks for getting rid of the `<sup>`, that was very hard to read, but I still have a hard time reading the italics. This just updates the template to surround the info text with brackets {{ like this }} to denote that the user should fill them in, rather than _like this_. I think it still gets the point across but makes issues more readable by using a normal font. Brackets are arbitrary, but harken to the golang template syntax.

Compare the rendered markdown :

------
**Is your feature request related to a problem? Please describe.**
{{ A clear and concise description of what the problem is. }}

**Describe the solution you'd like**
{{ A clear and concise description of what you want to happen. }}

**Describe alternatives you've considered**
{{ A clear and concise description of any alternative solutions or features you've considered. }}

**Additional context**
{{ Add any other context about the feature request here. }}

------
**Is your feature request related to a problem? Please describe.**
_A clear and concise description of what the problem is._

**Describe the solution you'd like**
_A clear and concise description of what you want to happen._

**Describe alternatives you've considered**
_A clear and concise description of any alternative solutions or features you've considered._

**Additional context**
_Add any other context about the feature request here._

------
