### PR TITLE
refactor func createSecret() to BuildSecret()

### DIFF
--- a/security/pkg/pki/ca/controller/secret.go
+++ b/security/pkg/pki/ca/controller/secret.go
@@ -226,14 +226,7 @@ func (sc *SecretController) saUpdated(oldObj, curObj interface{}) {
 }
 
 func (sc *SecretController) upsertSecret(saName, saNamespace string) {
-	secret := &v1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{ServiceAccountNameAnnotationKey: saName},
-			Name:        GetSecretName(saName),
-			Namespace:   saNamespace,
-		},
-		Type: IstioSecretType,
-	}
+	secret := ca.BuildSecret(saName, GetSecretName(saName), saNamespace, nil, nil, nil, nil, nil, IstioSecretType)
 
 	_, exists, err := sc.scrtStore.Get(secret)
 	if err != nil {


### PR DESCRIPTION
- fix
`// TODO(wattli): move the two functions below as a util function to share with secret_test.go`
- fix the name of some var (as @incfly pointed out, naming of `cACertID`, `cAPrivateKeyID`, etc. are out of convention)

/assign @wattli @myidpt 
