### PR TITLE
RBAC: add the support of subject.group

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -577,8 +577,11 @@ func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
 		// Treat subject.Group as the request.auth.claims[groups] property. If
 		// request.auth.claims[groups] has been defined for the subject, subject.Group
 		// overrides request.auth.claims[groups].
+		if subject.Properties[attrRequestClaimGroups] != "" {
+			rbacLog.Errorf("Both subject.group and request.auth.claims[groups] are defined.\n")
+		}
 		rbacLog.Debugf("Treat subject.Group (%s) as the request.auth.claims[groups]\n", subject.Group)
-		subject.Properties["request.auth.claims[groups]"] = subject.Group
+		subject.Properties[attrRequestClaimGroups] = subject.Group
 	}
 
 	if len(subject.Properties) != 0 {

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -77,7 +77,7 @@ const (
 // serviceMetadata is a collection of different kind of information about a service.
 type serviceMetadata struct {
 	name       string            // full qualified service name, e.g. "productpage.default.svc.cluster.local
-	labels     map[string]string // labels of the service instance
+	labels     map[string]string // labels of the service instance from Pilot, which can be k8s labels for the service
 	attributes map[string]string // additional attributes of the service
 }
 
@@ -463,6 +463,8 @@ func convertRbacRulesToFilterConfig(
 				// Generate the policy if the service is matched to the services specified in ServiceRole.
 				rbacLog.Debugf("matched AccessRule[%d]", i)
 				permissions = append(permissions, convertToPermission(rule))
+			} else {
+				rbacLog.Debugf("Not matched to AccessRule[%d]: %s\n", i, rule.String())
 			}
 		}
 		if len(permissions) == 0 {
@@ -573,7 +575,12 @@ func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
 	}
 
 	if subject.Group != "" {
-		rbacLog.Errorf("ignored Subject.group %s, not implemented", subject.Group)
+		if subject.Properties["request.auth.claims[groups]"] == "" {
+			// Treat subject.Group as the request.auth.claims[groups] property if no existing
+			// request.auth.claims[groups] has been defined for the subject
+			rbacLog.Debugf("Treat subject.Group (%s) as the request.auth.claims[groups]\n", subject.Group)
+			subject.Properties["request.auth.claims[groups]"] = subject.Group
+		}
 	}
 
 	if len(subject.Properties) != 0 {
@@ -671,6 +678,9 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 	return &policyproto.Permission{Rule: orRules}
 }
 
+// Create a Principal based on the key and the value.
+// key: the key of a subject property.
+// value: the value of a subject property.
 func principalForKeyValue(key, value string) *policyproto.Principal {
 	switch {
 	case key == attrSrcIP:

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -573,9 +573,10 @@ func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
 		}
 	}
 
-	if subject.Group != "" && subject.Properties[attrRequestClaimGroups] == "" {
-		// Treat subject.Group as the request.auth.claims[groups] property if no existing
-		// request.auth.claims[groups] has been defined for the subject
+	if subject.Group != "" {
+		// Treat subject.Group as the request.auth.claims[groups] property. If
+		// request.auth.claims[groups] has been defined for the subject, subject.Group
+		// overrides request.auth.claims[groups].
 		rbacLog.Debugf("Treat subject.Group (%s) as the request.auth.claims[groups]\n", subject.Group)
 		subject.Properties["request.auth.claims[groups]"] = subject.Group
 	}

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -572,7 +572,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		}},
 	}
 
-	policy3 := generatePolicyWithHttpMethodAndGroupClaim("GET", "group*")
+	policy3 := generatePolicyWithHTTPMethodAndGroupClaim("GET", "group*")
 
 	expectRbac1 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
@@ -1022,7 +1022,7 @@ func generatePrincipal(principalName string) *policy.Principal {
 	}
 }
 
-func generatePolicyWithHttpMethodAndGroupClaim(methodName, claimName string) *policy.Policy {
+func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *policy.Policy {
 	policy := &policy.Policy{
 		Permissions: []*policy.Permission{{
 			Rule: &policy.Permission_AndRules{

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -18,17 +18,18 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	rbacconfig "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	policy "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
-	"github.com/gogo/protobuf/types"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
 	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/gogo/protobuf/types"
 )
 
 func newIstioStoreWithConfigs(configs []model.Config, t *testing.T) model.IstioConfigStore {
@@ -232,6 +233,17 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-3"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"allow-group"},
+						Methods:  []string{"GET"},
+					},
+				},
+			},
+		},
 	}
 	bindings := []model.Config{
 		{
@@ -270,6 +282,21 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				RoleRef: &rbacproto.RoleRef{
 					Kind: "ServiceRole",
 					Name: "service-role-2",
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-binding-3"},
+			Spec: &rbacproto.ServiceRoleBinding{
+				Subjects: []*rbacproto.Subject{
+					{
+						Group:      "group*",
+						Properties: map[string]string{},
+					},
+				},
+				RoleRef: &rbacproto.RoleRef{
+					Kind: "ServiceRole",
+					Name: "service-role-3",
 				},
 			},
 		},
@@ -545,6 +572,48 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		}},
 	}
 
+	policy3 := &policy.Policy{
+		Permissions: []*policy.Permission{{
+			Rule: &policy.Permission_AndRules{
+				AndRules: &policy.Permission_Set{
+					Rules: []*policy.Permission{
+						{
+							Rule: &policy.Permission_OrRules{
+								OrRules: &policy.Permission_Set{
+									Rules: []*policy.Permission{
+										{
+											Rule: &policy.Permission_Header{
+												Header: &route.HeaderMatcher{
+													Name: ":method",
+													HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+														ExactMatch: "GET",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(
+									[]string{attrRequestClaims, "groups"}, "group*"),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
 	expectRbac1 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
@@ -556,6 +625,12 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
 			"service-role-2": policy2,
+		},
+	}
+	expectRbac3 := &policy.RBAC{
+		Action: policy.RBAC_ALLOW,
+		Policies: map[string]*policy.Policy{
+			"service-role-3": policy3,
 		},
 	}
 	testCases := []struct {
@@ -598,6 +673,13 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				attributes: map[string]string{"destination.name": "attr-name"},
 			},
 			rbac: expectRbac2,
+		},
+		{
+			name: "test group",
+			service: &serviceMetadata{
+				name: "allow-group",
+			},
+			rbac: expectRbac3,
 		},
 	}
 

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -572,48 +572,8 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		}},
 	}
 
-	policy3 := &policy.Policy{
-		Permissions: []*policy.Permission{{
-			Rule: &policy.Permission_AndRules{
-				AndRules: &policy.Permission_Set{
-					Rules: []*policy.Permission{
-						{
-							Rule: &policy.Permission_OrRules{
-								OrRules: &policy.Permission_Set{
-									Rules: []*policy.Permission{
-										{
-											Rule: &policy.Permission_Header{
-												Header: &route.HeaderMatcher{
-													Name: ":method",
-													HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
-														ExactMatch: "GET",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}},
-		Principals: []*policy.Principal{{
-			Identifier: &policy.Principal_AndIds{
-				AndIds: &policy.Principal_Set{
-					Ids: []*policy.Principal{
-						{
-							Identifier: &policy.Principal_Metadata{
-								Metadata: generateMetadataListMatcher(
-									[]string{attrRequestClaims, "groups"}, "group*"),
-							},
-						},
-					},
-				},
-			},
-		}},
-	}
+	policy3 := generatePolicyWithHttpMethodAndGroupClaim("GET", "group*")
+
 	expectRbac1 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
@@ -1060,4 +1020,50 @@ func generatePrincipal(principalName string) *policy.Principal {
 			},
 		},
 	}
+}
+
+func generatePolicyWithHttpMethodAndGroupClaim(methodName, claimName string) *policy.Policy {
+	policy := &policy.Policy{
+		Permissions: []*policy.Permission{{
+			Rule: &policy.Permission_AndRules{
+				AndRules: &policy.Permission_Set{
+					Rules: []*policy.Permission{
+						{
+							Rule: &policy.Permission_OrRules{
+								OrRules: &policy.Permission_Set{
+									Rules: []*policy.Permission{
+										{
+											Rule: &policy.Permission_Header{
+												Header: &route.HeaderMatcher{
+													Name: ":method",
+													HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+														ExactMatch: methodName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(
+									[]string{attrRequestClaims, "groups"}, claimName),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+	return policy
 }


### PR DESCRIPTION
In the RBAC policy, add the support of subject.group to the subjects in a ServiceRoleBinding. A user can use subject.group or "request.auth.claims[groups]" to specify the group-related RBAC policy.
