### PR TITLE
Fix Grafana secret namespace

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: grafana
+  namespace: {{ .Release.Namespace }}
   labels:
     app: grafana
 type: Opaque


### PR DESCRIPTION
The Grafana secret is created in the default namespace when using the Helm chart to install Istio.
The Grafana pod is failing to start if you use the flag 'grafana.security.enabled'.