### PR TITLE
`version` should be well protected

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -212,7 +212,7 @@ func (s *DiscoveryServer) ClearCacheFunc() func() {
 		s.env.PushContext = push
 		versionLocal := time.Now().Format(time.RFC3339)
 		initContextTime := time.Since(t0)
-		adsLog.Infof("InitContext %v for push takes %s", versionLocal, initContextTime)
+		adsLog.Debugf("InitContext %v for push takes %s", versionLocal, initContextTime)
 
 		// TODO: propagate K8S version and use it instead
 		versionMutex.Lock()

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -34,7 +34,7 @@ var (
 	// Disabled by default.
 	periodicRefreshDuration = 0 * time.Second
 
-	versionMutex sync.Mutex
+	versionMutex sync.RWMutex
 
 	// version is the timestamp of the last registry event.
 	version = "0"
@@ -209,17 +209,17 @@ func (s *DiscoveryServer) ClearCacheFunc() func() {
 			// TODO: metric !!
 			return
 		}
+		s.env.PushContext = push
+		versionLocal := time.Now().Format(time.RFC3339)
 		initContextTime := time.Since(t0)
+		adsLog.Infof("InitContext %v for push takes %s", version, initContextTime)
 
 		// TODO: propagate K8S version and use it instead
 		versionMutex.Lock()
-		s.env.PushContext = push
-		version = time.Now().Format(time.RFC3339)
+		version = versionLocal
 		versionMutex.Unlock()
 
-		adsLog.Infof("Context init for push %v %s", initContextTime, version)
-
-		go s.AdsPushAll(versionInfo(), push)
+		go s.AdsPushAll(versionLocal, push)
 	}
 }
 
@@ -228,7 +228,7 @@ func nonce() string {
 }
 
 func versionInfo() string {
-	versionMutex.Lock()
-	defer versionMutex.Unlock()
+	versionMutex.RLock()
+	defer versionMutex.RUnlock()
 	return version
 }

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -212,7 +212,7 @@ func (s *DiscoveryServer) ClearCacheFunc() func() {
 		s.env.PushContext = push
 		versionLocal := time.Now().Format(time.RFC3339)
 		initContextTime := time.Since(t0)
-		adsLog.Infof("InitContext %v for push takes %s", version, initContextTime)
+		adsLog.Infof("InitContext %v for push takes %s", versionLocal, initContextTime)
 
 		// TODO: propagate K8S version and use it instead
 		versionMutex.Lock()


### PR DESCRIPTION
cherry-pick #7840 to release-1.0

1. optimize:make use of sync.RWMutex 

1. make use of local var instead of  `version` which should be lock protected

1. `AdsPushAll` should use the `version` set in this push trigger.