### PR TITLE
Allow fractional percentages in fault injections

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "1fc6253f572fbef1ba1fd304fd81c79539824eb1"
+		"lastStableSHA": "4ee7e8ecd3dbec46dfefa33ee42110ed7182056a"
 	}
 ]

--- a/mixer/test/client/fault_inject/fault_inject_test.go
+++ b/mixer/test/client/fault_inject/fault_inject_test.go
@@ -72,7 +72,9 @@ const allAbortFaultFilter = `
 - name: envoy.fault
   config:
     abort:
-      percent: 100
+      percentage:
+        numerator: 100
+        denominator: HUNDRED
       http_status: 503
 `
 

--- a/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
@@ -92,8 +92,8 @@ var checkAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 
@@ -153,8 +153,8 @@ var reportAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 

--- a/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
@@ -90,8 +90,8 @@ var checkAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 
@@ -150,8 +150,8 @@ var reportAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 

--- a/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
@@ -94,8 +94,8 @@ var checkAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 
@@ -156,8 +156,8 @@ var reportAttributesOkGet = `
      "aud": "aud1",
      "some-other-string-claims": "some-claims-kept"
   },
-	"request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) +
-	`
+  "request.auth.raw_claims": ` + fmt.Sprintf("%q", secIstioAuthUserinfoHeaderValue) + `,
+  "request.url_path": "/echo"
 }
 `
 

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -332,7 +332,7 @@ var (
 			ID:   "pod1.ns2",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
@@ -345,7 +345,7 @@ var (
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		Service: &svc,

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -134,7 +134,6 @@ static_resources:
 }
 `
 	// See issue https://github.com/istio/proxy/issues/1910
-	// "source.principal": "cluster.local/ns/default/sa/client",
 	// "source.user": "cluster.local/ns/default/sa/client",
 	checkAttributesOkInbound = `
 {
@@ -153,6 +152,7 @@ static_resources:
   "destination.service.name": "svc",
   "destination.service.namespace": "ns3",
   "destination.service.uid": "istio://ns3/services/svc",
+  "source.principal": "cluster.local/ns/default/sa/client",
   "source.uid": "kubernetes://pod2.ns2",
   "request.headers": {
      ":method": "GET",
@@ -219,7 +219,6 @@ static_resources:
 }`
 
 	// See issue https://github.com/istio/proxy/issues/1910
-	// "source.principal": "cluster.local/ns/default/sa/client",
 	// "source.user": "cluster.local/ns/default/sa/client",
 	reportAttributesOkInbound = `
 {
@@ -269,7 +268,8 @@ static_resources:
      "server": "envoy"
   },
   "response.total_size": "*",
-  "request.url_path": "/echo"
+  "request.url_path": "/echo",
+  "source.principal": "cluster.local/ns/default/sa/client"
 }`
 )
 

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -356,7 +356,7 @@ var (
 			ID:   "pod1.ns2",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
@@ -369,7 +369,7 @@ var (
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		Service: &svc,

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -209,7 +209,7 @@ var (
 			ID:   "pod1.ns1",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
@@ -222,7 +222,7 @@ var (
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
 			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.0",
+				"ISTIO_PROXY_VERSION": "1.1",
 			},
 		},
 		Service: &svc,

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -3,7 +3,7 @@ ARG proxy_version
 ARG istio_version
 
 # Environment variables indicating this proxy's version/capabilities as opaque string
-ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.0"
+ENV ISTIO_META_ISTIO_PROXY_VERSION "1.1.0"
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -6,7 +6,7 @@ ARG istio_version
 ADD envoy /usr/local/bin/envoy
 
 # Environment variables indicating this proxy's version/capabilities as opaque string
-ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.0"
+ENV ISTIO_META_ISTIO_PROXY_VERSION "1.1.0"
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -1405,6 +1405,22 @@ func TestValidateHTTPFaultInjectionAbort(t *testing.T) {
 				HttpStatus: 9000,
 			},
 		}, valid: false},
+		{name: "valid percentage", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: 0.001,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
+				HttpStatus: 200,
+			},
+		}, valid: true},
+		{name: "invalid fractional percent", in: &networking.HTTPFaultInjection_Abort{
+			Percentage: &networking.Percent{
+				Value: -10.0,
+			},
+			ErrorType: &networking.HTTPFaultInjection_Abort_HttpStatus{
+				HttpStatus: 200,
+			},
+		}, valid: false},
 	}
 
 	for _, tc := range testCases {
@@ -1445,6 +1461,22 @@ func TestValidateHTTPFaultInjectionDelay(t *testing.T) {
 			Percent: 20,
 			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
 				FixedDelay: &types.Duration{Seconds: 3, Nanos: 42},
+			},
+		}, valid: false},
+		{name: "valid fractional percentage", in: &networking.HTTPFaultInjection_Delay{
+			Percentage: &networking.Percent{
+				Value: 0.001,
+			},
+			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
+				FixedDelay: &types.Duration{Seconds: 3},
+			},
+		}, valid: true},
+		{name: "invalid fractional percentage", in: &networking.HTTPFaultInjection_Delay{
+			Percentage: &networking.Percent{
+				Value: -10.0,
+			},
+			HttpDelayType: &networking.HTTPFaultInjection_Delay_FixedDelay{
+				FixedDelay: &types.Duration{Seconds: 3},
 			},
 		}, valid: false},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -59,7 +59,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundHTTPRouteConfig(env *mo
 	traceOperation := fmt.Sprintf("%s:%d/*", instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
 	defaultRoute := istio_route.BuildDefaultHTTPRoute(node, clusterName, traceOperation)
 
-	if _, is10Proxy := node.GetProxyVersion(); !is10Proxy {
+	if !util.Is1xProxy(node) {
 		// Enable websocket on default route
 		actionRoute, ok := defaultRoute.Action.(*route.Route_Route)
 		if ok {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -475,7 +475,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 
 				var svcListenAddress string
 				// This is to maintain backward compatibility with 0.8 envoy
-				if _, is10Proxy := node.GetProxyVersion(); !is10Proxy {
+				if !util.Is1xProxy(node) {
 					if service.Resolution != model.Passthrough {
 						svcListenAddress = service.GetServiceAddressForProxy(node)
 					}
@@ -788,7 +788,7 @@ func buildHTTPConnectionManager(env *model.Environment, node *model.Proxy, httpO
 	connectionManager.StatPrefix = httpOpts.statPrefix
 	connectionManager.UseRemoteAddress = &google_protobuf.BoolValue{Value: httpOpts.useRemoteAddress}
 
-	if _, is10Proxy := node.GetProxyVersion(); is10Proxy {
+	if util.Is1xProxy(node) {
 		// Allow websocket upgrades
 		websocketUpgrade := &http_conn.HttpConnectionManager_UpgradeConfig{UpgradeType: "websocket"}
 		connectionManager.UpgradeConfigs = []*http_conn.HttpConnectionManager_UpgradeConfig{websocketUpgrade}

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -107,9 +107,8 @@ func buildOutboundNetworkFilters(node *model.Proxy, clusterName string, deprecat
 
 	var tcpFilter *listener.Filter
 	var err error
-	_, is10Proxy := node.GetProxyVersion()
 
-	if len(deprecatedTCPFilterMatchAddress) > 0 && !is10Proxy {
+	if len(deprecatedTCPFilterMatchAddress) > 0 && !util.Is1xProxy(node) {
 		if tcpFilter, err = buildDeprecatedTCPProxyFilter(clusterName, deprecatedTCPFilterMatchAddress); err != nil {
 			return nil
 		}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -632,7 +632,11 @@ func translateFault(node *model.Proxy, in *networking.HTTPFaultInjection) *xdsht
 				out.Delay.Percentage = translateIntegerToFractionalPercent(in.Delay.Percent)
 			}
 		} else {
-			out.Delay.Percent = uint32(in.Delay.Percent)
+			if in.Delay.Percentage != nil {
+				out.Delay.Percent = uint32(in.Delay.Percentage.Value)
+			} else {
+				out.Delay.Percent = uint32(in.Delay.Percent)
+			}
 		}
 		switch d := in.Delay.HttpDelayType.(type) {
 		case *networking.HTTPFaultInjection_Delay_FixedDelay:
@@ -655,7 +659,11 @@ func translateFault(node *model.Proxy, in *networking.HTTPFaultInjection) *xdsht
 				out.Abort.Percentage = translateIntegerToFractionalPercent(in.Abort.Percent)
 			}
 		} else {
-			out.Abort.Percent = uint32(in.Abort.Percent)
+			if in.Abort.Percentage != nil {
+				out.Abort.Percent = uint32(in.Abort.Percentage.Value)
+			} else {
+				out.Abort.Percent = uint32(in.Abort.Percent)
+			}
 		}
 		switch a := in.Abort.ErrorType.(type) {
 		case *networking.HTTPFaultInjection_Abort_HttpStatus:

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -48,7 +48,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		IPAddress: "1.1.1.1",
 		ID:        "someID",
 		Domain:    "foo.com",
-		Metadata:  map[string]string{"ISTIO_PROXY_VERSION": "1.0"},
+		Metadata:  map[string]string{"ISTIO_PROXY_VERSION": "1.1"},
 	}
 	gatewayNames := map[string]bool{"some-gateway": true}
 

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -145,18 +145,18 @@ func SortVirtualHosts(hosts []route.VirtualHost) {
 	})
 }
 
+// isProxyVersion checks whether the given Proxy version matches the supplied prefix.
+func isProxyVersion(node *model.Proxy, prefix string) bool {
+	ver, found := node.GetProxyVersion()
+	return found && strings.HasPrefix(ver, prefix)
+}
+
 // Is1xProxy checks whether the given Proxy version is 1.x.
 func Is1xProxy(node *model.Proxy) bool {
-	if ver, found := node.GetProxyVersion(); found && strings.HasPrefix(ver, "1.") {
-		return true
-	}
-	return false
+	return isProxyVersion(node, "1.")
 }
 
 // Is11Proxy checks whether the given Proxy version is 1.1.
 func Is11Proxy(node *model.Proxy) bool {
-	if ver, found := node.GetProxyVersion(); found && strings.HasPrefix(ver, "1.1") {
-		return true
-	}
-	return false
+	return isProxyVersion(node, "1.1")
 }

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -145,6 +145,14 @@ func SortVirtualHosts(hosts []route.VirtualHost) {
 	})
 }
 
+// Is1xProxy checks whether the given Proxy version is 1.x.
+func Is1xProxy(node *model.Proxy) bool {
+	if ver, found := node.GetProxyVersion(); found && strings.HasPrefix(ver, "1.") {
+		return true
+	}
+	return false
+}
+
 // Is11Proxy checks whether the given Proxy version is 1.1.
 func Is11Proxy(node *model.Proxy) bool {
 	if ver, found := node.GetProxyVersion(); found && strings.HasPrefix(ver, "1.1") {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -144,3 +144,11 @@ func SortVirtualHosts(hosts []route.VirtualHost) {
 		return hosts[i].Name < hosts[j].Name
 	})
 }
+
+// Is11Proxy checks whether the given Proxy version is 1.1.
+func Is11Proxy(node *model.Proxy) bool {
+	if ver, found := node.GetProxyVersion(); found && strings.HasPrefix(ver, "1.1") {
+		return true
+	}
+	return false
+}

--- a/pilot/pkg/proxy/envoy/v2/init_test.go
+++ b/pilot/pkg/proxy/envoy/v2/init_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 var nodeMetadata = &proto.Struct{Fields: map[string]*proto.Value{
-	"ISTIO_PROXY_VERSION": &proto.Value{Kind: &proto.Value_StringValue{StringValue: "1.0"}}, // actual value doesn't matter
+	"ISTIO_PROXY_VERSION": &proto.Value{Kind: &proto.Value_StringValue{StringValue: "1.1"}}, // actual value doesn't matter
 }}
 
 // Extract cluster load assignment from a discovery response.

--- a/samples/CONFIG-MIGRATION.md
+++ b/samples/CONFIG-MIGRATION.md
@@ -201,7 +201,8 @@ spec:
       version: v1
   httpFault:
     delay:
-      percent: 100
+      percentage:
+        value: 100.0
       fixedDelay: 7s
 ```
 
@@ -225,7 +226,8 @@ spec:
       version: v1
   httpFault:
     delay:
-      percent: 100
+      percentage:
+        value: 100.0
       fixedDelay: 7s
 ```
 

--- a/samples/bookinfo/networking/virtual-service-ratings-test-abort.yaml
+++ b/samples/bookinfo/networking/virtual-service-ratings-test-abort.yaml
@@ -12,7 +12,8 @@ spec:
           exact: jason
     fault:
       abort:
-        percent: 100
+        percentage:
+          value: 100.0
         httpStatus: 500
     route:
     - destination:

--- a/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
+++ b/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
@@ -12,7 +12,8 @@ spec:
           exact: jason
     fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100.0
         fixedDelay: 7s
     route:
     - destination:

--- a/samples/bookinfo/platform/consul/virtual-service-ratings-test-abort.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-ratings-test-abort.yaml
@@ -12,7 +12,8 @@ spec:
           exact: jason
     fault:
       abort:
-        percent: 100
+        percentage:
+          value: 100.0
         httpStatus: 500
     route:
     - destination:

--- a/samples/bookinfo/platform/consul/virtual-service-ratings-test-delay.yaml
+++ b/samples/bookinfo/platform/consul/virtual-service-ratings-test-delay.yaml
@@ -12,7 +12,8 @@ spec:
           exact: jason
     fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100.0
         fixedDelay: 7s
     route:
     - destination:

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/envoyfilter-c.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/envoyfilter-c.yaml
@@ -15,7 +15,8 @@ spec:
     filterName: envoy.fault
     filterConfig:
       abort:
-        percent: 100
+        percentage:
+          value: 100.0
         httpStatus: 444
       headers:
         name: envoyfilter-test

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/envoyfilter-c.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/envoyfilter-c.yaml
@@ -16,7 +16,8 @@ spec:
     filterConfig:
       abort:
         percentage:
-          value: 100.0
+          numerator: 100
+          denominator: HUNDRED
         httpStatus: 444
       headers:
         name: envoyfilter-test

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-fault-injection.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-fault-injection.yaml
@@ -19,8 +19,10 @@ spec:
         weight: 100
       fault:
         delay:
-          percent: 100
+          percentage:
+            value: 100.0
           fixedDelay: 5s
         abort:
-          percent: 100
+          percentage:
+            value: 100.0
           httpStatus: 503

--- a/tests/testdata/config/rule-fault-injection.yaml
+++ b/tests/testdata/config/rule-fault-injection.yaml
@@ -58,8 +58,10 @@ spec:
         weight: 100
       fault:
         delay:
-          percent: 100
+          percentage:
+            value: 100.0
           fixedDelay: 5s
         abort:
-          percent: 100
+          percentage:
+            value: 100.0
           httpStatus: 503


### PR DESCRIPTION
This PR enables the translation of (integer/double) percentages to `envoy.type.FractionalPercent` which allows sub-percent fault injections. Fixes #7903.

* Update implementation to support fractional percentage as in Envoy
* Update `PROXY_REPO_SHA` to [1fc6253](https://github.com/istio/proxy/tree/1fc6253f572fbef1ba1fd304fd81c79539824eb1)

Signed-off-by: Venil Noronha <veniln@vmware.com>

/cc @rshriram 