### PR TITLE
remove CRDs in post delete hook.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -645,6 +645,7 @@ isti%.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--set global.crdsPostDeleteHookEnabled=false \
 		--set istio_cni.enabled=${ENABLE_ISTIO_CNI} \
 		${EXTRA_HELM_SETTINGS} \
 		--values install/kubernetes/helm/istio/values-$@ \
@@ -659,6 +660,7 @@ generate_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--set global.crdsPostDeleteHookEnabled=false \
 		--set istio_cni.enabled=${ENABLE_ISTIO_CNI} \
 		${EXTRA_HELM_SETTINGS} \
 		--values install/kubernetes/helm/istio/values.yaml \
@@ -672,6 +674,7 @@ generate_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--set global.mtls.enabled=true \
 		--set global.controlPlaneSecurityEnabled=true \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--set global.crdsPostDeleteHookEnabled=false \
 		--set istio_cni.enabled=${ENABLE_ISTIO_CNI} \
 		${EXTRA_HELM_SETTINGS} \
 		--values install/kubernetes/helm/istio/values.yaml \

--- a/install/kubernetes/helm/istio/charts/certmanager/templates/cleanup-crds.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/cleanup-crds.yaml
@@ -1,0 +1,110 @@
+# The reason for creating a ServiceAccount and ClusterRole specifically for this
+# post-delete hooked job is because the certmanager ServiceAccount is being deleted
+# before this hook is launched.
+#
+# It's also important that the ServiceAccount, ClusterRole and ClusterRoleBinding
+# will be ready before running the hooked Job therefore the hook weights.
+
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: certmanager-cleanup-crds-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "certmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: certmanager-cleanup-crds-{{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "certmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: certmanager-cleanup-crds-{{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "2"
+  labels:
+    app: {{ template "certmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: certmanager-cleanup-crds-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: certmanager-cleanup-crds-service-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: certmanager-cleanup-crds
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
+  labels:
+    app: {{ template "certmanager.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      name: certmanager-cleanup-crds
+      labels:
+        app: {{ template "certmanager.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: certmanager-cleanup-crds-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          command:
+          - /bin/bash
+          - -c
+          - >
+              kubectl delete crd clusterissuers.certmanager.k8s.io;
+              kubectl delete crd issuers.certmanager.k8s.io;
+              kubectl delete crd certificates.certmanager.k8s.io;
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/charts/certmanager/templates/cleanup-crds.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/cleanup-crds.yaml
@@ -5,6 +5,7 @@
 # It's also important that the ServiceAccount, ClusterRole and ClusterRoleBinding
 # will be ready before running the hooked Job therefore the hook weights.
 
+{{- if .Values.global.crdsPostDeleteHookEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -108,3 +109,4 @@ spec:
               kubectl delete crd issuers.certmanager.k8s.io;
               kubectl delete crd certificates.certmanager.k8s.io;
       restartPolicy: OnFailure
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/cleanup-crds.yaml
+++ b/install/kubernetes/helm/istio/templates/cleanup-crds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.crdsPostDeleteHookEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -102,3 +103,4 @@ spec:
                 kubectl delete crd $name;
               done
       restartPolicy: OnFailure
+{{- end }}

--- a/install/kubernetes/helm/istio/templates/cleanup-crds.yaml
+++ b/install/kubernetes/helm/istio/templates/cleanup-crds.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: istio-cleanup-crds-service-account
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "istio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-cleanup-crds-{{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app: {{ template "istio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-cleanup-crds-{{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "2"
+  labels:
+    app: {{ template "istio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-cleanup-crds-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-cleanup-crds-service-account
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-cleanup-crds
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
+  labels:
+    app: {{ template "istio.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      name: istio-cleanup-crds
+      labels:
+        app: {{ template "istio.name" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-cleanup-crds-service-account
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
+      containers:
+        - name: hyperkube
+          image: "{{ .Values.global.hyperkube.hub }}/hyperkube:{{ .Values.global.hyperkube.tag }}"
+          command:
+          - /bin/bash
+          - -c
+          - >
+              kubectl get crd | grep "istio.io" |  while read -r entry; do
+                name=$(echo $entry | awk '{print $1}');
+                kubectl delete crd $name;
+              done
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -333,3 +333,8 @@ global:
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
   useMCP: false
+  
+  # Specifies whether the CRDs cleanup post-delete hook should be enabled or not. 
+  # If set to false, the CRDs cleanup post-delete hook will be disabled, and the 
+  # CRDs need to be manually deleted before the second installation.
+  crdsPostDeleteHookEnabled: true


### PR DESCRIPTION
Currently there is a filed issue about `crd-install` hook: `helm` doesn't remove `CRD` that created with `crd-install` hook after deleting the chart
See: https://github.com/helm/helm/issues/4440

The helm community suggest that we need to handle CRDs remove in `post-delete` hook.

If the helm version < 2.10, we also need to cleaup the CRDs created manually.

So let's put CRDs remove in `post-delete` hook.