### PR TITLE
Fix data race between LDS and CDS

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -320,11 +320,20 @@ func (ps *PushContext) initServiceRegistry(env *Environment) error {
 	if err != nil {
 		return err
 	}
-	ps.Services = services
+	// Sort the services in order of creation.
+	ps.Services = sortServicesByCreationTime(services)
 	for _, s := range services {
 		ps.ServiceByHostname[s.Hostname] = s
 	}
 	return nil
+}
+
+// sortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
+func sortServicesByCreationTime(services []*Service) []*Service {
+	sort.SliceStable(services, func(i, j int) bool {
+		return services[i].CreationTime.Before(services[j].CreationTime)
+	})
+	return services
 }
 
 // Caches list of virtual services

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -335,14 +335,6 @@ type listenerEntry struct {
 	listener    *xdsapi.Listener
 }
 
-// sortServicesByCreationTime sorts the list of services in ascending order by their creation time (if available).
-func sortServicesByCreationTime(services []*model.Service) []*model.Service {
-	sort.SliceStable(services, func(i, j int) bool {
-		return services[i].CreationTime.Before(services[j].CreationTime)
-	})
-	return services
-}
-
 func protocolName(p model.Protocol) string {
 	switch plugin.ModelProtocolToListenerProtocol(p) {
 	case plugin.ListenerProtocolHTTP:
@@ -400,9 +392,6 @@ func (c outboundListenerConflict) addMetric(push *model.PushContext) {
 // IPs and ports, but requires that ports of non-load balanced service be unique.
 func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.Environment, node *model.Proxy, push *model.PushContext,
 	proxyInstances []*model.ServiceInstance, services []*model.Service) []*xdsapi.Listener {
-
-	// Sort the services in order of creation.
-	services = sortServicesByCreationTime(services)
 
 	var proxyLabels model.LabelsCollection
 	for _, w := range proxyInstances {

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -155,7 +155,11 @@ func getOldestService(services ...*model.Service) *model.Service {
 func buildOutboundListeners(p plugin.Plugin, services ...*model.Service) []*xdsapi.Listener {
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
 
-	env := buildListenerEnv()
+	env := buildListenerEnv(services)
+
+	if err := env.PushContext.InitContext(&env); err != nil {
+		return nil
+	}
 
 	instances := make([]*model.ServiceInstance, len(services))
 	for i, s := range services {
@@ -217,8 +221,9 @@ func buildService(hostname string, ip string, protocol model.Protocol, creationT
 	}
 }
 
-func buildListenerEnv() model.Environment {
-	serviceDiscovery := &fakes.ServiceDiscovery{}
+func buildListenerEnv(services []*model.Service) model.Environment {
+	serviceDiscovery := new(fakes.ServiceDiscovery)
+	serviceDiscovery.ServicesReturns(services, nil)
 
 	configStore := &fakes.IstioConfigStore{}
 


### PR DESCRIPTION
BuildListeners does an in inplace sort operation on a services array that happens to be shared across multiple concurrent push operations. This leads to potential data races, where one thread is iterating over the array in buildClusters for CDS, while another is sorting the array in buildListeners for LDS, leading to situations where the CDS output misses clusters that should otherwise have been there.

This is probably the cause of missing clusters issue that @mandarjog found while debugging issues reported by @markns . This could also potentially contribute to reducing proxy startup times.

Moved the sort operation to push context initialization as a solution.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>