### PR TITLE
Use Kiali v0.6.0 for Istio.

### DIFF
--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -46,5 +46,5 @@ dependencies:
     version: 0.5.1
     condition: kiali.enabled
   - name: certmanager
-    version: 0.1.0
+    version: 0.6.0
     condition: certmanager.enabled

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -43,8 +43,8 @@ dependencies:
     # repository: file://../galley
     condition: galley.enabled
   - name: kiali
-    version: 0.5.1
+    version: 0.6.0
     condition: kiali.enabled
   - name: certmanager
-    version: 0.6.0
+    version: 0.3.1
     condition: certmanager.enabled

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -508,7 +508,7 @@ kiali:
   enabled: false
   replicaCount: 1
   hub: docker.io/kiali
-  tag: istio-release-1.0
+  tag: v0.6.0
   ingress:
     enabled: false
     ## Used to create an Ingress record.


### PR DESCRIPTION
As we are going to release 1.0.1, it is better to update Kiali docker image version to 0.6.0.

Even though Kiali istio-release-1.0 is a retag of v0.6.0, but it is better to use 0.6.0 for Istio 1.0.1 release so that we can trace the version more accurate.

/cc @sdake 