### PR TITLE
pilot_cli: use CoreV1 interface as Core() is deprecated

### DIFF
--- a/pilot/tools/debug/pilot_cli.go
+++ b/pilot/tools/debug/pilot_cli.go
@@ -98,7 +98,7 @@ func getAllPods(kubeconfig string) (*v1.PodList, error) {
 	if err != nil {
 		return nil, err
 	}
-	return clientset.Core().Pods("").List(meta_v1.ListOptions{})
+	return clientset.CoreV1().Pods(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
 }
 
 func NewPodInfo(nameOrAppLabel string, kubeconfig string, proxyType string) *PodInfo {


### PR DESCRIPTION
pilot_cli: use CoreV1 interface as Core() is deprecated