### PR TITLE
[Bug Fix] Fix install minikube

### DIFF
--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -63,12 +63,12 @@ fi
 
 # Install minikube.
 function install_minikube() {
-  if ! curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-linux-amd64 \
-      && chmod +x minikube \
-      && sudo mv minikube /usr/local/bin/; then
-    echo "Looks like minikube installation failed."
-    echo "Please install it manually and then run this script again."
-    exit 1
+  if ! (curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.27.0/minikube-linux-amd64 && \ 
+      chmod +x minikube && \
+      sudo mv minikube /usr/local/bin/); then
+      echo "Looks like minikube installation failed."
+      echo "Please install it manually and then run this script again."
+      exit 1
   fi
 }
 


### PR DESCRIPTION
Using minikube to install istio, the output message tells successfully installed but failed to install minikube.

We should use `if !(command1 && command2 && command3)` instead of `if  !command1 && command2 && command3`.

