### PR TITLE
fix jaeger UI issue in kiali.

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/service.yaml
@@ -12,3 +12,20 @@ spec:
     port: 20001
   selector:
     app: kiali
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali-jaeger
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kiali
+spec:
+  type: NodePort
+  ports:
+  - name: jaeger
+    protocol: TCP
+    nodePort: 32439
+    port: 20002
+  selector:
+    app: kiali


### PR DESCRIPTION
Kiali community has released kiali v0.6.0 on Aug 16th, to fix some UI issues and also tagged it as `istio-release-1.0`.
We need to merge the patch https://github.com/kiali/kiali/commit/8446cc1e8c6bcd4240dc6baaf35e30ad75b5b832 to fix the jaeger service can't be accessed from Kiali UI issue.