### PR TITLE
[Ansible Installer] Updating Kiali to v0.6

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: v0.6.0
+      kiali_version: v0.6
 
   - name: Install Kiali on Openshift
     shell: |

--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: istio-release-1.0
+      kiali_version: v0.6.0
 
   - name: Install Kiali on Openshift
     shell: |

--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: istio-1.0
+      kiali_version: istio-release-1.0
 
   - name: Install Kiali on Openshift
     shell: |


### PR DESCRIPTION
Hello Everyone,

Kiali has released `istio-release-1.0` which does include support for Istio 1.0 so in order to match the correct tag and branch for Kiali (https://hub.docker.com/r/kiali/kiali/tags/ and https://github.com/kiali/kiali/tree/istio-release-1.0).

I am sending this PR for Ansible and I will send another PR for Helm Installer.

Best Regards,
Guilherme Baufaker Rêgo