### PR TITLE
[Helm Installer] Include Kiali Jaeger Service

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/kiali-jaeger-service.yml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/kiali-jaeger-service.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali-jaeger
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kiali
+spec:
+  type: NodePort
+  ports:
+  - name: jaeger
+    protocol: TCP
+    nodePort: 32439
+    port: 20002
+  selector:
+    app: kiali


### PR DESCRIPTION
Hello Everyone, 

Kiali was released `istio-release-1.0` with support with Istio 1.0

The only addition for helm existing template is the Kiali Jaeger Service.


Best Regards,
Guilherme Baufaker Rêgo