### PR TITLE
make use of sync.Cond to reduce pilot cpu usage

### DIFF
--- a/pilot/pkg/serviceregistry/kube/queue.go
+++ b/pilot/pkg/serviceregistry/kube/queue.go
@@ -60,7 +60,7 @@ func NewTask(handler Handler, obj interface{}, event model.Event) Task {
 type queueImpl struct {
 	delay   time.Duration
 	queue   []Task
-	lock    sync.Mutex
+	cond    *sync.Cond
 	closing bool
 }
 
@@ -70,24 +70,25 @@ func NewQueue(errorDelay time.Duration) Queue {
 		delay:   errorDelay,
 		queue:   make([]Task, 0),
 		closing: false,
-		lock:    sync.Mutex{},
+		cond:    sync.NewCond(&sync.Mutex{}),
 	}
 }
 
 func (q *queueImpl) Push(item Task) {
-	q.lock.Lock()
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
 	if !q.closing {
 		q.queue = append(q.queue, item)
 	}
-	q.lock.Unlock()
+	q.cond.Signal()
 }
 
 func (q *queueImpl) Run(stop <-chan struct{}) {
 	go func() {
 		<-stop
-		q.lock.Lock()
+		q.cond.L.Lock()
 		q.closing = true
-		q.lock.Unlock()
+		q.cond.L.Unlock()
 	}()
 
 	rate := os.Getenv(enableQueueThrottleEnv)
@@ -110,24 +111,27 @@ func (q *queueImpl) Run(stop <-chan struct{}) {
 			rateLimiter.Accept()
 		}
 
-		q.lock.Lock()
-		if q.closing {
-			q.lock.Unlock()
-			return
-		} else if len(q.queue) == 0 {
-			q.lock.Unlock()
-		} else {
-			item, q.queue = q.queue[0], q.queue[1:]
-			q.lock.Unlock()
+		q.cond.L.Lock()
+		for !q.closing && len(q.queue) == 0 {
+			q.cond.Wait()
+		}
 
-			for {
-				err := item.handler(item.obj, item.event)
-				if err != nil {
-					log.Infof("Work item failed (%v), repeating after delay %v", err, q.delay)
-					time.Sleep(q.delay)
-				} else {
-					break
-				}
+		if len(q.queue) == 0 {
+			q.cond.L.Unlock()
+			// We must be shutting down.
+			return
+		}
+
+		item, q.queue = q.queue[0], q.queue[1:]
+		q.cond.L.Unlock()
+
+		for {
+			err := item.handler(item.obj, item.event)
+			if err != nil {
+				log.Infof("Work item failed (%v), repeating after delay %v", err, q.delay)
+				time.Sleep(q.delay)
+			} else {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Bug fix: #6962

reduce pilot cpu usage from about 20% down to below 1%

```

top 

Master branch:
102332 root      20   0   60232  44672  27148 S  19.9  0.3   3:56.67 /usr/local/bin/pilot-discovery discovery

After this fix:
50347 root      20   0   61292  47652  26896 S   0.7  0.3   0:00.98 /usr/local/bin/pilot-discovery discovery 
```