### PR TITLE
Fix data races in pkg/cache

### DIFF
--- a/pkg/cache/ttlCache.go
+++ b/pkg/cache/ttlCache.go
@@ -212,5 +212,11 @@ func (c *ttlCache) RemoveAll() {
 }
 
 func (c *ttlCache) Stats() Stats {
-	return c.stats
+	return Stats{
+		Evictions: atomic.LoadUint64(&c.stats.Evictions),
+		Hits:      atomic.LoadUint64(&c.stats.Hits),
+		Misses:    atomic.LoadUint64(&c.stats.Misses),
+		Writes:    atomic.LoadUint64(&c.stats.Writes),
+		Removals:  atomic.LoadUint64(&c.stats.Removals),
+	}
 }


### PR DESCRIPTION
Addresses reported failures of `go test -race`:

```
$ go test -race istio.io/istio/mixer/adapter/prometheus
ok      istio.io/istio/mixer/adapter/prometheus 4.862s

$ go test -race istio.io/istio/pkg/cache
ok      istio.io/istio/pkg/cache        22.384s
```