### PR TITLE
improve kube service registry queue performance

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2197,7 +2197,6 @@
     "k8s.io/client-go/tools/portforward",
     "k8s.io/client-go/tools/remotecommand",
     "k8s.io/client-go/transport/spdy",
-    "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1",
     "k8s.io/helm/pkg/chartutil",


### PR DESCRIPTION
Address comments: https://github.com/istio/istio/pull/8123#pullrequestreview-148614187
 >we can remove the rate limiter from the queue ( which slows down loading of events ).