### PR TITLE
cleanup before running TestTempWorkspace case

### DIFF
--- a/tests/e2e/tests/controller/controller_test.go
+++ b/tests/e2e/tests/controller/controller_test.go
@@ -66,6 +66,14 @@ func makeTempClient(t *testing.T) (*crd.Client, string, func()) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// https://github.com/istio/istio/issues/7593
+	// Ensure validatingwebhookconfiguration is removed.
+	// We DO NOT expect the validator to take effect on the case.
+	if err := util.WaitForValidatingWebhookConfigurationDeletion(client, "istio-galley"); err != nil {
+		t.Fatal(err)
+	}
+
 	ns, err := util.CreateNamespace(client)
 	if err != nil {
 		t.Fatal(err.Error())


### PR DESCRIPTION
a fast fix for #7593

As the test suites run independently, it's difficult to tell which one effect the case here.
It has a great negative impact on the overall performance if we enable the `waitdeletion` logic in framework.
So I'd rather add related check in the case itself for now.

TODO: find a more general way if we meet the scenario in other cases later.