### PR TITLE
Move some common util functions to an individual file

### DIFF
--- a/tests/e2e/local/common_linux.sh
+++ b/tests/e2e/local/common_linux.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common utilities for Istio local installation on linux platform.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install Curl on Ubuntu platform
+function install_curl() {
+  echo "Checking and Installing Curl as required"
+  if ! curl --help > /dev/null; then
+    sudo sed -i -e 's/us.archive.ubuntu.com/archive.ubuntu.com/g' /etc/apt/sources.list
+    sudo apt-get --quiet -y install curl
+    if ! curl --help > /dev/null; then
+      echo "curl could not be installed. Please install it and run this script again."
+      exit 1
+    fi
+  fi
+}
+
+# Check if dpkg is installed
+function check_dpkg() {
+  if ! dpkg --help > /dev/null; then
+    echo "dpkg not installed. Please install it and run this script again."
+    exit 1
+  fi
+}
+
+# Check if apt-get is installed
+function check_apt_get() {
+  if ! apt-get --help > /dev/null; then
+    echo "apt-get not installed. Please install it and run this script again."
+    exit 1
+fi
+
+# Install Docker
+function install_docker() {
+  echo "Checking and Installing Docker as required"
+  if ! docker --help > /dev/null; then
+    # docker-ce depends on libltdl7
+    apt-get install -y libltdl7
+    curl -L https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.03.0~ce-0~debian_amd64.deb -o docker-ce.deb
+    if ! sudo dpkg -i docker-ce.deb; then
+      echo "Looks like docker installation failed."
+      echo "Please install it manually and then run this script again."
+      exit 1
+    fi
+  fi
+}
+
+# Install Kubectl on Linux platform
+function install_kubectl() {
+  echo "Checking and Installing Kubectl as required"
+  if ! kubectl --help > /dev/null; then
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+  fi
+}

--- a/tests/e2e/local/common_macos.sh
+++ b/tests/e2e/local/common_macos.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common utilities for Istio local installation on MacOS platform.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install Curl on MacOS platform
+function install_curl() {
+  echo "Checking curl"
+  if ! curl --help > /dev/null; then
+    echo "curl is not installed. Install it from homebrew."
+    if ! brew install curl; then
+      echo "Installation of curl from brew fails. Please install it manually."
+      exit 1
+    else
+      echo "Done."
+    fi
+  else
+    echo "curl exists."
+  fi
+}
+
+# Install Docker
+function install_docker() {
+  echo "Checking docker..."
+  if ! docker --help > /dev/null; then
+    echo "docker is not installed. Install it from homebrew cask."
+    if ! brew cask install docker; then
+      echo "Installation of docker from brew fails. Please install it manually."
+      exit 1
+    else
+      echo "Done."
+    fi
+  else
+    echo "docker exists. Please make sure to update it to latest version."
+  fi
+}
+
+function install_docker_machine() {
+  echo "Checking docker-machine..."
+  if ! docker-machine --help > /dev/null; then
+    echo "docker-machine is not installed. Downloading and Installing it using curl."
+    base=https://github.com/docker/machine/releases/download/v0.14.0 &&
+    if ! curl -L "$base/docker-machine-$(uname -s)-$(uname -m)" >/usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine; then
+        echo "Installation of docker-machine failed. Please install it manually."
+        exit 1
+    else
+        echo "Done."
+    fi
+  else
+    echo "docker-machine exists. Please make sure to update it to latest version."
+    docker-machine version
+  fi
+}
+
+# Install Kubectl on MacOS platform
+function install_kubectl() {
+  echo "Checking kubectl..."
+  if ! kubectl --help > /dev/null; then
+    echo "kubectl is not installed. Installing the lastest stable release..."
+    if ! brew install kubectl; then
+    	echo "Installation of kubectl from brew fails. Please install it manually."
+        exit 1
+    else
+    	echo "Done."
+    fi
+  else
+    echo "kubectl exists. Please make sure to update it to latest version."
+  fi
+}
+
+# Check if homebrew is installed
+function check_homebrew() {
+  if ! brew --help > /dev/null; then
+    echo "Homebrew is not installed. Please go to https://docs.brew.sh/Installation to install Homebrew."
+    exit 1
+  fi
+}

--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -1,28 +1,13 @@
 #!/bin/bash
 
-# Check if apt-get is installed
-if ! apt-get --help > /dev/null; then
-    echo "apt-get not installed. Please install it and run this script again."
-    exit 1
-fi
+source "../common_linux.sh"
+
+check_apt_get
 sudo apt-get --quiet -y update
 
-# Check if dpkg is installed
-if ! dpkg --help > /dev/null; then
-    echo "dpkg not installed. Please install it and run this script again."
-    exit 1
-fi
+check_dpkg
 
-#Install Curl
-echo "Checking and Installing Curl as required"
-if ! curl --help > /dev/null; then
-    sudo sed -i -e 's/us.archive.ubuntu.com/archive.ubuntu.com/g' /etc/apt/sources.list
-    sudo apt-get --quiet -y install curl
-    if ! curl --help > /dev/null; then
-      echo "curl could not be installed. Please install it and run this script again."
-      exit 1
-    fi
-fi
+install_curl
 
 #Install Kvm2
 echo "Installing KVM2 as required"
@@ -40,26 +25,9 @@ curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-
 sudo virsh net-autostart default > /dev/null 2>&1
 sudo virsh net-start default > /dev/null 2>&1
 
-# Install kubectl
-echo "Checking and Installing Kubectl as required"
-if ! kubectl --help > /dev/null; then
-  curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
-  chmod +x ./kubectl
-  sudo mv ./kubectl /usr/local/bin/kubectl
-fi
+install_kubectl
 
-#Install Docker
-echo "Checking and Installing Docker as required"
-if ! docker --help > /dev/null; then
-  # docker-ce depends on libltdl7
-  apt-get install -y libltdl7
-  curl -L https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.03.0~ce-0~debian_amd64.deb -o docker-ce.deb
-  if ! sudo dpkg -i docker-ce.deb; then
-      echo "Looks like docker installation failed."
-      echo "Please install it manually and then run this script again."
-      exit 1
-  fi
-fi
+install_docker
 
 # Install minikube.
 function install_minikube() {

--- a/tests/e2e/local/minikube/install_prereqs_macos.sh
+++ b/tests/e2e/local/minikube/install_prereqs_macos.sh
@@ -1,56 +1,19 @@
 #!/bin/bash
 
-# Check if homebrew is installed
-if ! brew --help > /dev/null; then
-    echo "Homebrew is not installed. Please go to https://docs.brew.sh/Installation to install Homebrew."
-    exit 1
-fi
+source ../common_macos.sh
+
+check_homebrew
 
 echo "Update homebrew..."
 brew update > /dev/null
 # Give write permissions for /usr/local/bin, so that brew can create symlinks.
 sudo chown -R "$USER:admin" /usr/local/bin
 
-echo "Checking curl"
-if ! curl --help > /dev/null; then
-    echo "curl is not installed. Install it from homebrew."
-    if ! brew install curl; then
-    	echo "Installation of curl from brew fails. Please install it manually."
-        exit 1
-    else
-    	echo "Done."
-    fi
-else
-    echo "curl exists."
-fi
+install_curl
 
-echo "Checking docker..."
-if ! docker --help > /dev/null; then
-    echo "docker is not installed. Install it from homebrew cask."
-    if ! brew cask install docker; then
-    	echo "Installation of docker from brew fails. Please install it manually."
-        exit 1
-    else
-    	echo "Done."
-    fi
-else
-    echo "docker exists. Please make sure to update it to latest version."
-fi
+install_docker
 
-echo "Checking docker-machine..."
-if ! docker-machine --help > /dev/null; then
-    echo "docker-machine is not installed. Downloading and Installing it using curl."
-    base=https://github.com/docker/machine/releases/download/v0.14.0 &&
-    if ! curl -L "$base/docker-machine-$(uname -s)-$(uname -m)" >/usr/local/bin/docker-machine && chmod +x /usr/local/bin/docker-machine; then
-        echo "Installation of docker-machine failed. Please install it manually."
-        exit 1
-    else
-        echo "Done."
-    fi
-else
-    echo "docker-machine exists. Please make sure to update it to latest version."
-    docker-machine version
-fi
+install_docker_machine
 
 function fail_hyperkit_installation() {
     # shellcheck disable=SC2181
@@ -107,17 +70,6 @@ else
     install_minikube
 fi
 
-echo "Checking kubectl..."
-if ! kubectl --help > /dev/null; then
-    echo "kubectl is not installed. Installing the lastest stable release..."
-    if ! brew install kubectl; then
-    	echo "Installation of kubectl from brew fails. Please install it manually."
-        exit 1
-    else
-    	echo "Done."
-    fi
-else
-    echo "kubectl exists. Please make sure to update it to latest version."
-fi
+install_kubectl
 
 echo "Prerequisite check and installation process finishes."

--- a/tests/e2e/local/vagrant/install_prereqs_debian.sh
+++ b/tests/e2e/local/vagrant/install_prereqs_debian.sh
@@ -1,28 +1,12 @@
 #!/bin/bash
 
-# Check if apt-get is installed
-if ! apt-get --help > /dev/null; then
-    echo "apt-get not installed. Please install it and run this script again."
-    exit 1
-fi
+source ../common_linux.sh
+
+check_apt_get
 sudo apt-get --quiet -y update
 
-# Check if dpkg is installed
-if ! dpkg --help > /dev/null; then
-    echo "dpkg not installed. Please install it and run this script again."
-    exit 1
-fi
-
-#Install Curl
-echo "Checking and Installing Curl as required"
-if ! curl --help > /dev/null; then
-    sudo sed -i -e 's/us.archive.ubuntu.com/archive.ubuntu.com/g' /etc/apt/sources.list
-    sudo apt-get --quiet -y install curl
-    if ! curl --help > /dev/null; then
-      echo "curl could not be installed. Please install it and run this script again."
-      exit 1
-    fi
-fi
+check_dpkg
+install_curl
 
 # Install virtualbox.
 echo "Checking and Installing Virtualbox as required"
@@ -51,17 +35,7 @@ else
     fi
 fi
 
-
-#Install Docker
-echo "Checking and Installing Docker as required"
-if ! docker --help > /dev/null; then
-  curl -L https://download.docker.com/linux/debian/dists/stretch/pool/stable/amd64/docker-ce_18.03.0~ce-0~debian_amd64.deb docker-ce.deb
-  if ! sudo dpkg -i docker-ce.deb; then
-      echo "Looks like docker installation failed."
-      echo "Please install it manually and then run this script again."
-      exit 1
-  fi
-fi
+install_docker
 
 # Install vagrant.
 echo "Checking and Installing Vagrant as required"
@@ -74,13 +48,7 @@ if ! vagrant --help > /dev/null; then
   fi
 fi
 
-# Install kubectl
-echo "Checking and Installing Kubectl as required"
-if ! kubectl --help > /dev/null; then
-  curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
-  chmod +x ./kubectl
-  sudo mv ./kubectl /usr/local/bin/kubectl
-fi
+install_kubectl
 
 echo "Everything installed for you and you are ready to go!"
 

--- a/tests/e2e/local/vagrant/install_prereqs_macos.sh
+++ b/tests/e2e/local/vagrant/install_prereqs_macos.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# Check if homebrew is installed
-if ! brew --help > /dev/null; then
-    echo "Homebrew is not installed. Please go to https://docs.brew.sh/Installation to install Homebrew."
-    exit 1
-fi
+source ../common_macos.sh
+
+check_homebrew
 
 echo "Update homebrew..."
 brew update
@@ -22,18 +20,7 @@ else
     echo "curl exists."
 fi
 
-echo "Checking docker..."
-if ! docker --help > /dev/null; then
-    echo "docker is not installed. Install it from homebrew cask."
-    if ! brew cask install docker; then
-    	echo "Installation from brew fails. Please install it manually."
-        exit 1
-    else
-    	echo "Done."
-    fi
-else
-    echo "docker exists. Please make sure to update it to latest version."
-fi
+install_docker
 
 echo "Checking vitualbox..."
 if ! virtualbox --help > /dev/null; then
@@ -68,17 +55,6 @@ else
     vagrant version
 fi
 
-echo "Checking kubectl..."
-if ! kubectl --help > /dev/null; then
-    echo "kubectl is not installed. Installing the lastest stable release..."
-    if ! brew install kubectl; then
-    	echo "Installation from brew fails. Please install it manually."
-        exit 1
-    else
-    	echo "Done."
-    fi
-else
-    echo "kubectl exists. Please make sure to update it to latest version."
-fi
+install_kubectl
 
 echo "Prerequisite check and installation process finishes."


### PR DESCRIPTION
There are some duplicated installation scripts among minikube and vagrant. This PR refactor some common scripts into functions and move them to an individual file - common.sh