### PR TITLE
 ensure kube crd client works on rootScoped resources

### DIFF
--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -349,11 +349,11 @@ func (cl *Client) Get(typ, name, namespace string) (*model.Config, bool) {
 	}
 
 	config := s.object.DeepCopyObject().(IstioObject)
-	err := rc.dynamic.Get().
-		Namespace(namespace).
-		Resource(ResourceName(schema.Plural)).
-		Name(name).
-		Do().Into(config)
+	req := rc.dynamic.Get().Resource(ResourceName(schema.Plural)).Name(name)
+	if namespace != "" {
+		req = req.Namespace(namespace)
+	}
+	err := req.Do().Into(config)
 
 	if err != nil {
 		log.Warna(err)
@@ -455,11 +455,12 @@ func (cl *Client) Delete(typ, name, namespace string) error {
 		return fmt.Errorf("missing type %q", typ)
 	}
 
-	return rc.dynamic.Delete().
-		Namespace(namespace).
-		Resource(ResourceName(schema.Plural)).
-		Name(name).
-		Do().Error()
+	req := rc.dynamic.Delete().Resource(ResourceName(schema.Plural)).Name(name)
+	if namespace != "" {
+		req = req.Namespace(namespace)
+	}
+
+	return req.Do().Error()
 }
 
 // List implements store interface

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -458,6 +458,11 @@ func CheckIstioConfigTypes(store model.ConfigStore, namespace string, t *testing
 		}); err != nil {
 			t.Errorf("Post(%v) => got %v", c.name, err)
 		}
+
+		// Cleanup created config item.
+		if err := store.Delete(configMeta.Type, configMeta.Name, configMeta.Namespace); err != nil {
+			t.Errorf("Error deleting config %s, err: %v", configMeta.Key(), err)
+		}
 	}
 }
 


### PR DESCRIPTION
The PR
1. fix bug in kube crd client to ensure it's delete func can work on rootScoped resources.
(though users can make a  "empty->default namespace" conversion themselves before using the func,
I think we'd better have protection in it, just like we did in Create/Get/Update)

2. Add delete step in CheckIstioConfigTypes to make it idempotent.
Otherwise, we'll get "already existing error" when running test `TestTempWorkspace` multi times:
```
    --- FAIL: TestTempWorkspace/istioConfig (0.03s)
    	config.go:459: Post(RbacConfig) => got rbacconfigs.rbac.istio.io "default" already exists
```