### PR TITLE
Prep install 101 (#8091)

### DIFF
--- a/install/kubernetes/helm/istio-remote/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio-remote
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart needed for remote Kubernetes clusters to join the main Istio control plane
 keywords:

--- a/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: security
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio authentication
 keywords:

--- a/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sidecarInjectorWebhook
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for sidecar injector webhook deployment
 keywords:

--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -1,8 +1,6 @@
 dependencies:
   - name: sidecarInjectorWebhook
-    version: 1.0.0
-    # repository: file://../sidecarInjectorWebhook
+    version: 1.0.1
     condition: sidecarInjectorWebhook.enabled
   - name: security
-    version: 1.0.0
-    # repository: file://../security
+    version: 1.0.1

--- a/install/kubernetes/helm/istio/Chart.yaml
+++ b/install/kubernetes/helm/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:

--- a/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: certmanager
-version: 0.1.0
-appVersion: latest
+version: 1.0.1
+appVersion: 0.3.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/galley/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: galley
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for galley deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/gateways/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gateways
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio gateways
 keywords:

--- a/install/kubernetes/helm/istio/charts/grafana/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: grafana
-version: 0.1.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/ingress/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: ingress
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for ingress deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for detail.
 name: kiali
-version: 0.5.1
-appVersion: 0.5.1
+version: 1.0.1
+appVersion: 0.6.0
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/mixer/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mixer
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for mixer deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/pilot/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pilot
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for pilot deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/prometheus/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: prometheus
-version: 0.1.0
-appVersion: latest
+version: 1.0.1
+appVersion: 2.3.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/security/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/security/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: security
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio authentication
 keywords:

--- a/install/kubernetes/helm/istio/charts/servicegraph/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: servicegraph
-version: 0.1.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sidecarInjectorWebhook
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for sidecar injector webhook deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/telemetry-gateway/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/telemetry-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telemetry-gateway
-version: 1.0.0
-appVersion: 1.0.0
+version: 1.0.1
+appVersion: 1.0.1
 tillerVersion: ">=2.7.2"
 description: Helm chart for configuring a gateway for Istio telemetry addons
 icon: https://istio.io/favicons/android-192x192.png

--- a/install/kubernetes/helm/istio/charts/tracing/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: tracing
-version: 0.1.0
-appVersion: 1.5
+version: 1.0.1
+appVersion: 1.5.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -1,50 +1,40 @@
 dependencies:
   - name: sidecarInjectorWebhook
-    version: 1.0.0
-    # repository: file://../sidecarInjectorWebhook
+    version: 1.0.1
     condition: sidecarInjectorWebhook.enabled
   - name: security
-    version: 1.0.0
-    # repository: file://../security
+    version: 1.0.1
     condition: security.enabled
   - name: ingress
-    version: 1.0.0
-    # repository: file://../ingress
+    version: 1.0.1
     condition: ingress.enabled
   - name: gateways
-    version: 1.0.0
-    # repository: file://../gateways
+    version: 1.0.1
     condition: gateways.enabled
   - name: mixer
-    version: 1.0.0
-    # repository: file://../mixer
+    version: 1.0.1
     condition: mixer.enabled
   - name: pilot
-    version: 1.0.0
-    # repository: file://../pilot
+    version: 1.0.1
     condition: pilot.enabled
   - name: grafana
-    version: 0.1.0
-    # repository: file://../addons/grafana
+    version: 1.0.1
     condition: grafana.enabled
   - name: prometheus
-    version: 0.1.0
-    # repository: file://../addons/prometheus
+    version: 1.0.1
     condition: prometheus.enabled
   - name: servicegraph
-    version: 0.1.0
-    # repository: file://../addons/servicegraph
+    version: 1.0.1
     condition: servicegraph.enabled
   - name: tracing
-    version: 0.1.0
+    version: 1.0.1
     condition: tracing.enabled
   - name: galley
-    version: 1.0.0
-    # repository: file://../galley
+    version: 1.0.1
     condition: galley.enabled
   - name: kiali
-    version: 0.5.1
+    version: 1.0.1
     condition: kiali.enabled
   - name: certmanager
-    version: 0.1.0
+    version: 1.0.1
     condition: certmanager.enabled


### PR DESCRIPTION
* Prepare Helm charts for 1.0.1 release

An umbrella chart, of which Istio is, should not contain
a requirements.yaml.  Unfortunately because of how conditions
work in Helm, a requirements.yaml is required.  This patch
removes the comment noise relating to repos to reduce
cargo cult programming.

* Clean istio-remote of incorrect cargo cult

* Change all versions to 1.0.1

This includes appVersion, which may not be technically correct.

The version field should definately be 1.0.1 for all chart/subcharts
shipped with Istio as Istio is the umbrella chart.

* Prepare Istio 1.0.1 for release

* Address various appVersion problems

* Address review comments

(cherry picked from commit 32cef7bbc075c622c913bb3f21a780ec53376629)