### PR TITLE
Always rebuild ./security/toole/generate_cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ go.generate.diff: $(ISTIO_OUT)
 	git diff HEAD > $(ISTIO_OUT)/after_go_generate.diff
 	diff $(ISTIO_OUT)/before_go_generate.diff $(ISTIO_OUT)/after_go_generate.diff
 
+.PHONY: ${GEN_CERT}
 ${GEN_CERT}:
 	GOOS=$(GOOS_LOCAL) && GOARCH=$(GOARCH_LOCAL) && CGO_ENABLED=1 bin/gobuild.sh $@ ./security/tools/generate_cert
 


### PR DESCRIPTION
#7716 added a new command option `--mode` but the `generate_cert` binary is not automatically rebuilt as it doesn't depend on the source code `security/tools/generate_cert/main.go`. 
This breaks the `make docker` if developer have ran it before.