### PR TITLE
Refactor grpc dial with dialcontext

### DIFF
--- a/pilot/test/client/client.go
+++ b/pilot/test/client/client.go
@@ -228,11 +228,13 @@ func setupDefaultTest() job {
 		}
 
 		var err error
-		grpcConn, err = grpc.Dial(address,
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		grpcConn, err = grpc.DialContext(ctx, address,
 			security,
 			grpc.WithAuthority(authority),
-			grpc.WithBlock(),
-			grpc.WithTimeout(timeout))
+			grpc.WithBlock())
 		if err != nil {
 			log.Fatalf("did not connect: %v", err)
 			return nil

--- a/tests/util/echo.go
+++ b/tests/util/echo.go
@@ -447,11 +447,13 @@ func (ec *EchoClient) setupDefaultTest() (job, error) {
 		}
 
 		var err error
-		ec.grpcConn, err = grpc.Dial(address,
+		ctx, cancel := context.WithTimeout(context.Background(), ec.timeout)
+		defer cancel()
+
+		ec.grpcConn, err = grpc.DialContext(ctx, address,
 			security,
 			grpc.WithAuthority(authority),
-			grpc.WithBlock(),
-			grpc.WithTimeout(ec.timeout))
+			grpc.WithBlock())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Now the grpc.WithTimeout has deprecated, so use DialContext and context.WithTimeout like golang introduced.