### PR TITLE
Cleanup: replace MessageName with TypeURL in MCP

### DIFF
--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	serverAddr = flag.String("server", "127.0.0.1:9901", "The server address")
-	types      = flag.String("types", "", "The types of resources to deploy")
+	types      = flag.String("types", "", "The fully qualified type URLs of resources to deploy")
 	id         = flag.String("id", "", "The node id for the client")
 )
 
@@ -43,10 +43,10 @@ type updater struct {
 
 // Update interface method implementation.
 func (u *updater) Apply(ch *client.Change) error {
-	fmt.Printf("Incoming change: %v\n", ch.MessageName)
+	fmt.Printf("Incoming change: %v\n", ch.TypeURL)
 
 	for i, o := range ch.Objects {
-		fmt.Printf("%s[%d]\n", ch.MessageName, i)
+		fmt.Printf("%s[%d]\n", ch.TypeURL, i)
 
 		b, err := json.MarshalIndent(o, "  ", "  ")
 		if err != nil {

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -134,10 +134,10 @@ func (b *backend) Init(kinds []string) error {
 	}
 	b.mapping = m
 
-	messageNames := b.mapping.messageNames()
-	scope.Infof("Requesting following messages:")
-	for i, name := range messageNames {
-		scope.Infof("  [%d] %s", i, name)
+	typeURLs := b.mapping.typeURLs()
+	scope.Infof("Requesting following types:")
+	for i, url := range typeURLs {
+		scope.Infof("  [%d] %s", i, url)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -183,7 +183,7 @@ func (b *backend) Init(kinds []string) error {
 	}
 
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
-	c := client.New(cl, messageNames, b, mixerNodeID, map[string]string{})
+	c := client.New(cl, typeURLs, b, mixerNodeID, map[string]string{})
 	configz.Register(c)
 
 	b.state = &state{
@@ -264,9 +264,9 @@ func (b *backend) Apply(change *client.Change) error {
 	defer b.callUpdateHook()
 
 	newTypeStates := make(map[string]map[store.Key]*store.BackEndResource)
-	typeURL := fmt.Sprintf("type.googleapis.com/%s", change.MessageName)
+	typeURL := change.TypeURL
 
-	scope.Debugf("Received update for: type:%s, count:%d", change.MessageName, len(change.Objects))
+	scope.Debugf("Received update for: type:%s, count:%d", typeURL, len(change.Objects))
 
 	for _, o := range change.Objects {
 		var kind string
@@ -274,7 +274,7 @@ func (b *backend) Apply(change *client.Change) error {
 		var contents proto.Message
 
 		if scope.DebugEnabled() {
-			scope.Debugf("Processing incoming resource: %q @%s [%s]", o.Metadata.Name, o.Version, o.MessageName)
+			scope.Debugf("Processing incoming resource: %q @%s [%s]", o.Metadata.Name, o.Version, o.TypeURL)
 		}
 
 		// Demultiplex the resource, if it is a legacy type, and figure out its kind.

--- a/mixer/pkg/config/mcp/conversion.go
+++ b/mixer/pkg/config/mcp/conversion.go
@@ -99,18 +99,13 @@ func constructMapping(allKinds []string, schema *kube.Schema) (*mapping, error) 
 	}, nil
 }
 
-// messageNames returns all MessageNames that should be requested from the MCP server.
-func (m *mapping) messageNames() []string {
-	messageName := func(s string) string {
-		idx := strings.LastIndex(s, "/")
-		return s[idx+1:]
-	}
-
+// typeURLs returns all TypeURLs that should be requested from the MCP server.
+func (m *mapping) typeURLs() []string {
 	result := make([]string, 0, len(m.typeURLsToKinds)+1)
 	for u := range m.typeURLsToKinds {
-		result = append(result, messageName(u))
+		result = append(result, u)
 	}
-	result = append(result, legacyMixerResourceMessageName)
+	result = append(result, legacyMixerResourceTypeURL)
 
 	return result
 }

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"io"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -34,22 +33,18 @@ import (
 // try to re-establish the bi-directional grpc stream after this delay.
 var reestablishStreamDelay = time.Second
 
-const (
-	typeURLBase = "type.googleapis.com/"
-)
-
 // Object contains a decoded versioned object with metadata received from the server.
 type Object struct {
-	MessageName string
-	Metadata    *mcp.Metadata
-	Resource    proto.Message
-	Version     string
+	TypeURL  string
+	Metadata *mcp.Metadata
+	Resource proto.Message
+	Version  string
 }
 
-// Change is a collection of configuration objects of the same protobuf message type.
+// Change is a collection of configuration objects of the same protobuf type.
 type Change struct {
-	MessageName string
-	Objects     []*Object
+	TypeURL string
+	Objects []*Object
 
 	// TODO(ayj) add incremental add/remove enum when the mcp protocol supports it.
 }
@@ -145,7 +140,7 @@ func (r *recentRequestsJournal) snapshot() []RecentRequestInfo {
 }
 
 // New creates a new instance of the MCP client for the specified message types.
-func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedMessageNames []string, updater Updater, id string, metadata map[string]string) *Client { // nolint: lll
+func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedTypeURLs []string, updater Updater, id string, metadata map[string]string) *Client { // nolint: lll
 	clientInfo := &mcp.Client{
 		Id: id,
 		Metadata: &types.Struct{
@@ -159,8 +154,7 @@ func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedMessageNames 
 	}
 
 	state := make(map[string]*perTypeState)
-	for _, messageName := range supportedMessageNames {
-		typeURL := typeURLBase + messageName
+	for _, typeURL := range supportedTypeURLs {
 		state[typeURL] = &perTypeState{}
 	}
 
@@ -201,15 +195,9 @@ func (c *Client) handleResponse(response *mcp.MeshConfigResponse) *mcp.MeshConfi
 		return c.sendNACKRequest(response, "", errDetails)
 	}
 
-	responseMessageName := response.TypeUrl
-	// extract the message name from the fully qualified type_url.
-	if slash := strings.LastIndex(response.TypeUrl, "/"); slash >= 0 {
-		responseMessageName = response.TypeUrl[slash+1:]
-	}
-
 	change := &Change{
-		MessageName: responseMessageName,
-		Objects:     make([]*Object, 0, len(response.Envelopes)),
+		TypeURL: response.TypeUrl,
+		Objects: make([]*Object, 0, len(response.Envelopes)),
 	}
 	for _, envelope := range response.Envelopes {
 		var dynamicAny types.DynamicAny
@@ -225,10 +213,10 @@ func (c *Client) handleResponse(response *mcp.MeshConfigResponse) *mcp.MeshConfi
 		}
 
 		object := &Object{
-			MessageName: responseMessageName,
-			Metadata:    envelope.Metadata,
-			Resource:    dynamicAny.Message,
-			Version:     response.VersionInfo,
+			TypeURL:  response.TypeUrl,
+			Metadata: envelope.Metadata,
+			Resource: dynamicAny.Message,
+			Version:  response.VersionInfo,
 		}
 		change.Objects = append(change.Objects, object)
 	}

--- a/pkg/mcp/configz/configz_test.go
+++ b/pkg/mcp/configz/configz_test.go
@@ -56,7 +56,7 @@ func TestConfigZ(t *testing.T) {
 
 	u := &updater{}
 	clnt := mcp.NewAggregatedMeshConfigServiceClient(cc)
-	cl := client.New(clnt, []string{"google.protobuf.Empty"}, u, "zoo", map[string]string{"foo": "bar"})
+	cl := client.New(clnt, []string{"type.googleapis.com/google.protobuf.Empty"}, u, "zoo", map[string]string{"foo": "bar"})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cl.Run(ctx)

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"sync/atomic"
 
 	"google.golang.org/grpc/codes"
@@ -158,17 +157,13 @@ func (s *Server) newConnection(stream mcp.AggregatedMeshConfigService_StreamAggr
 		id:        atomic.AddInt64(&s.nextStreamID, 1),
 	}
 
-	var messageNames []string
+	var types []string
 	for _, typeURL := range s.supportedTypes {
 		con.watches[typeURL] = &watch{}
-
-		// extract the message name from the fully qualified type_url.
-		if slash := strings.LastIndex(typeURL, "/"); slash >= 0 {
-			messageNames = append(messageNames, typeURL[slash+1:])
-		}
+		types = append(types, typeURL)
 	}
 
-	scope.Infof("MCP: connection %v: NEW, supported types: %#v", con, messageNames)
+	scope.Infof("MCP: connection %v: NEW, supported types: %#v", con, types)
 	return con, nil
 }
 


### PR DESCRIPTION
Replace MessageName with TypeURL in MCP
Partially address #6437 

/assign @ayj 