### PR TITLE
Exec cancel() when stop server timeout

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -797,7 +797,8 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			<-stop
 			model.JwtKeyResolver.Close()
 
-			ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
 			err = s.httpServer.Shutdown(ctx)
 			if err != nil {
 				log.Warna(err)


### PR DESCRIPTION
When use context.WithTimeout and timeout occured, we should exec the func cancel(), so the ctx.Done() will done and return the Error.