### PR TITLE
add linux-tools-generic to debug image for perf/flamegraph

### DIFF
--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -19,6 +19,7 @@ RUN apt-get update && \
       elvis-tiny \
       lsof \
       busybox \
+      linux-tools-generic \
       sudo &&  apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add linux-tools-generic to debug image for perf sample collection.