### PR TITLE
[Bug Fix] Fix newgrp in libvirt install

### DIFF
--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -18,7 +18,6 @@ sudo apt-get install -y qemu-kvm
 sudo systemctl stop libvirtd
 sudo systemctl start libvirtd
 sudo usermod -a -G libvirt "$(whoami)"
-newgrp libvirt
 curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && chmod +x docker-machine-driver-kvm2 && sudo mv docker-machine-driver-kvm2 /usr/local/bin/
 # We run following commands only for making scripts resilient to failures. Hence
 # ignoring any errors from them too.


### PR DESCRIPTION
Because `newgrp` will never return - it create a new shell and do exec, we usually don't use it in scripts. `newgrp` will make `install_prereqs_debian.sh` skip the rest commands.

This PR removes the `newgrp` in `install_prereqs_debian.sh`.

@gargnupur @nmittler 