### PR TITLE
Update proxy sha to fix TestAgent

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "c9d2230782e5b8c0c3dc29d7470a6c79863c9cbe"
+		"lastStableSHA": "a35b8f44b78439c3beeb2d3e805ab6b991d14f24"
 	}
 ]

--- a/mixer/test/client/failed_request/failed_request_test.go
+++ b/mixer/test/client/failed_request/failed_request_test.go
@@ -66,7 +66,7 @@ const reportAttributesMixerFail = `
   "check.error_code": 16,
   "check.error_message": "UNAUTHENTICATED:Unauthenticated by mixer.",
   "context.protocol": "http",
-  "context.proxy_error_code": "-",
+  "context.proxy_error_code": "UAEX",
   "mesh1.ip": "[1 1 1 1]",
   "mesh2.ip": "[0 0 0 0 0 0 0 0 0 0 255 255 204 152 189 116]",
   "mesh3.ip": "[0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 8]",


### PR DESCRIPTION
Fix TestAgent fail caused by #8149, we need to update Envoy as well to match the updated api.