### PR TITLE
statsd-exporter introduced knative regression

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -258,7 +258,7 @@ mixer:
 
   prometheusStatsdExporter:
     repository: prom/statsd-exporter
-    tag: latest
+    tag: v0.6.0
     resources: {}
 
 #


### PR DESCRIPTION
stats-exporter:latest introduced a breaking change documented here
https://github.com/knative/serving/issues/1921

The correct solution is to use statsd-exporter that shipped with
Istio 0.8.0 - which was v0.6.0.