### PR TITLE
Fixes: #8244

### DIFF
--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -3,7 +3,7 @@ ARG proxy_version
 ARG istio_version
 
 # Environment variables indicating this proxy's version/capabilities as opaque string
-ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.0"
+ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.2"
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -6,7 +6,7 @@ ARG istio_version
 ADD envoy /usr/local/bin/envoy
 
 # Environment variables indicating this proxy's version/capabilities as opaque string
-ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.0"
+ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.2"
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging


### PR DESCRIPTION
Dockerfiles have hardcoded proxy versions.  This small PR
changes the hardcoded version to 1.0.2 for the next release of Istio.