### PR TITLE
decoupling agent and watcher

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -245,8 +245,10 @@ var (
 
 			envoyProxy := envoy.NewProxy(proxyConfig, role.ServiceNode(), proxyLogLevel, pilotSAN)
 			agent := proxy.NewAgent(envoyProxy, proxy.DefaultRetry)
-			watcher := envoy.NewWatcher(proxyConfig, agent, role, certs, pilotSAN)
+			watcher := envoy.NewWatcher(proxyConfig, role, certs, pilotSAN, agent.ConfigCh())
+
 			ctx, cancel := context.WithCancel(context.Background())
+			go agent.Run(ctx)
 			go watcher.Run(ctx)
 
 			stop := make(chan struct{})

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -1,0 +1,180 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	"istio.io/istio/pilot/pkg/proxy"
+	"istio.io/istio/pkg/bootstrap"
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	// epochFileTemplate is a template for the root config JSON
+	epochFileTemplate = "envoy-rev%d.json"
+)
+
+type envoy struct {
+	config    meshconfig.ProxyConfig
+	node      string
+	extraArgs []string
+	pilotSAN  []string
+	opts      map[string]interface{}
+	errChan   chan error
+}
+
+// NewProxy creates an instance of the proxy control commands
+func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string, pilotSAN []string) proxy.Proxy {
+	// inject tracing flag for higher levels
+	var args []string
+	if logLevel != "" {
+		args = append(args, "-l", logLevel)
+	}
+
+	return &envoy{
+		config:    config,
+		node:      node,
+		extraArgs: args,
+		pilotSAN:  pilotSAN,
+	}
+}
+
+func (e *envoy) args(fname string, epoch int) []string {
+	startupArgs := []string{"-c", fname,
+		"--restart-epoch", fmt.Sprint(epoch),
+		"--drain-time-s", fmt.Sprint(int(convertDuration(e.config.DrainDuration) / time.Second)),
+		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(e.config.ParentShutdownDuration) / time.Second)),
+		"--service-cluster", e.config.ServiceCluster,
+		"--service-node", e.node,
+		"--max-obj-name-len", fmt.Sprint(e.config.StatNameLength),
+		"--allow-unknown-fields",
+	}
+
+	startupArgs = append(startupArgs, e.extraArgs...)
+
+	if e.config.Concurrency > 0 {
+		startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(e.config.Concurrency))
+	}
+
+	if len(e.config.AvailabilityZone) > 0 {
+		startupArgs = append(startupArgs, []string{"--service-zone", e.config.AvailabilityZone}...)
+	}
+
+	return startupArgs
+}
+
+func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
+
+	var fname string
+	// Note: the cert checking still works, the generated file is updated if certs are changed.
+	// We just don't save the generated file, but use a custom one instead. Pilot will keep
+	// monitoring the certs and restart if the content of the certs changes.
+	if len(e.config.CustomConfigFile) > 0 {
+		// there is a custom configuration. Don't write our own config - but keep watching the certs.
+		fname = e.config.CustomConfigFile
+	} else {
+		out, err := bootstrap.WriteBootstrap(&e.config, e.node, epoch, e.pilotSAN, e.opts)
+		if err != nil {
+			log.Errora("Failed to generate bootstrap config", err)
+			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
+			return err
+		}
+		fname = out
+	}
+
+	// spin up a new Envoy process
+	args := e.args(fname, epoch)
+	if len(e.config.CustomConfigFile) == 0 {
+		args = append(args, "--v2-config-only")
+	}
+	log.Infof("Envoy command: %v", args)
+
+	/* #nosec */
+	cmd := exec.Command(e.config.BinaryPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Set if the caller is monitoring envoy, for example in tests or if envoy runs in same
+	// container with the app.
+	if e.errChan != nil {
+		// Caller passed a channel, will wait itself for termination
+		go func() {
+			e.errChan <- cmd.Wait()
+		}()
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-abort:
+		log.Warnf("Aborting epoch %d", epoch)
+		if errKill := cmd.Process.Kill(); errKill != nil {
+			log.Warnf("killing epoch %d caused an error %v", epoch, errKill)
+		}
+		return err
+	case err := <-done:
+		return err
+	}
+}
+
+func (e *envoy) Cleanup(epoch int) {
+	filePath := configFile(e.config.ConfigPath, epoch)
+	if err := os.Remove(filePath); err != nil {
+		log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
+	}
+}
+
+func (e *envoy) Panic(epoch interface{}) {
+	log.Error("cannot start the e with the desired configuration")
+	if epochInt, ok := epoch.(int); ok {
+		// print the failed config file
+		filePath := configFile(e.config.ConfigPath, epochInt)
+		b, _ := ioutil.ReadFile(filePath)
+		log.Errorf(string(b))
+	}
+	os.Exit(-1)
+}
+
+// convertDuration converts to golang duration and logs errors
+func convertDuration(d *types.Duration) time.Duration {
+	if d == nil {
+		return 0
+	}
+	dur, err := types.DurationFromProto(d)
+	if err != nil {
+		log.Warnf("error converting duration %#v, using 0: %v", d, err)
+	}
+	return dur
+}
+
+func configFile(config string, epoch int) string {
+	return path.Join(config, fmt.Sprintf(epochFileTemplate, epoch))
+}

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -28,7 +28,7 @@ func TestEnvoyArgs(t *testing.T) {
 	config.AvailabilityZone = "my-zone"
 	config.Concurrency = 8
 
-	test := envoy{config: config, node: "my-node", extraArgs: []string{"-l", "trace"}}
+	test := &envoy{config: config, node: "my-node", extraArgs: []string{"-l", "trace"}}
 	testProxy := NewProxy(config, "my-node", "trace", nil)
 	if !reflect.DeepEqual(testProxy, test) {
 		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)

--- a/pilot/pkg/proxy/envoy/proxy_test.go
+++ b/pilot/pkg/proxy/envoy/proxy_test.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestEnvoyArgs(t *testing.T) {
+	config := model.DefaultProxyConfig()
+	config.ServiceCluster = "my-cluster"
+	config.AvailabilityZone = "my-zone"
+	config.Concurrency = 8
+
+	test := envoy{config: config, node: "my-node", extraArgs: []string{"-l", "trace"}}
+	testProxy := NewProxy(config, "my-node", "trace", nil)
+	if !reflect.DeepEqual(testProxy, test) {
+		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)
+	}
+
+	got := test.args("test.json", 5)
+	want := []string{
+		"-c", "test.json",
+		"--restart-epoch", "5",
+		"--drain-time-s", "2",
+		"--parent-shutdown-time-s", "3",
+		"--service-cluster", "my-cluster",
+		"--service-node", "my-node",
+		"--max-obj-name-len", fmt.Sprint(config.StatNameLength),
+		"--allow-unknown-fields",
+		"-l", "trace",
+		"--concurrency", "8",
+		"--service-zone", "my-zone",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("envoyArgs() => got %v, want %v", got, want)
+	}
+}
+
+// TestEnvoyRun is no longer used - we are now using v2 bootstrap API.

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -17,43 +17,28 @@ package envoy
 import (
 	"context"
 	"crypto/sha256"
-	"fmt"
 	"hash"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/howeyc/fsnotify"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pilot/pkg/proxy"
-	"istio.io/istio/pkg/bootstrap"
 	"istio.io/istio/pkg/log"
 )
 
-// convertDuration converts to golang duration and logs errors
-func convertDuration(d *types.Duration) time.Duration {
-	if d == nil {
-		return 0
-	}
-	dur, err := types.DurationFromProto(d)
-	if err != nil {
-		log.Warnf("error converting duration %#v, using 0: %v", d, err)
-	}
-	return dur
-}
+const (
+	// defaultMinDelay is the minimum amount of time between delivery of two successive events via updateFunc.
+	defaultMinDelay = 10 * time.Second
+)
 
 // Watcher triggers reloads on changes to the proxy config
 type Watcher interface {
 	// Run the watcher loop (blocking call)
 	Run(context.Context)
-
-	// Reload the agent with the latest configuration
-	Reload()
 }
 
 // CertSource is file source for certificates
@@ -65,37 +50,33 @@ type CertSource struct {
 }
 
 type watcher struct {
-	agent    proxy.Agent
 	role     model.Proxy
 	config   meshconfig.ProxyConfig
 	certs    []CertSource
 	pilotSAN []string
+	updates  chan<- interface{}
 }
 
 // NewWatcher creates a new watcher instance from a proxy agent and a set of monitored certificate paths
 // (directories with files in them)
-func NewWatcher(config meshconfig.ProxyConfig, agent proxy.Agent, role model.Proxy,
-	certs []CertSource, pilotSAN []string) Watcher {
+func NewWatcher(
+	config meshconfig.ProxyConfig,
+	role model.Proxy,
+	certs []CertSource,
+	pilotSAN []string,
+	updates chan<- interface{}) Watcher {
 	return &watcher{
-		agent:    agent,
 		role:     role,
 		config:   config,
 		certs:    certs,
 		pilotSAN: pilotSAN,
+		updates:  updates,
 	}
 }
 
-const (
-	// defaultMinDelay is the minimum amount of time between delivery of two successive events via updateFunc.
-	defaultMinDelay = 10 * time.Second
-)
-
 func (w *watcher) Run(ctx context.Context) {
-	// agent consumes notifications from the controller
-	go w.agent.Run(ctx)
-
-	// kickstart the proxy with partial state (in case there are no notifications coming)
-	w.Reload()
+	// kick start the proxy with partial state (in case there are no notifications coming)
+	w.SendConfig()
 
 	// monitor certificates
 	certDirs := make([]string, 0, len(w.certs))
@@ -103,18 +84,18 @@ func (w *watcher) Run(ctx context.Context) {
 		certDirs = append(certDirs, cert.Directory)
 	}
 
-	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.Reload)
+	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.SendConfig)
 
 	<-ctx.Done()
 }
 
-func (w *watcher) Reload() {
+func (w *watcher) SendConfig() {
 	h := sha256.New()
 	for _, cert := range w.certs {
 		generateCertHash(h, cert.Directory, cert.Files)
 	}
 
-	w.agent.ScheduleConfigUpdate(h.Sum(nil))
+	w.updates <- h.Sum(nil)
 }
 
 type watchFileEventsFn func(ctx context.Context, wch <-chan *fsnotify.FileEvent,
@@ -197,141 +178,4 @@ func generateCertHash(h hash.Hash, certsDir string, files []string) {
 			log.Warna(err)
 		}
 	}
-}
-
-const (
-	// EpochFileTemplate is a template for the root config JSON
-	EpochFileTemplate = "envoy-rev%d.json"
-)
-
-func configFile(config string, epoch int) string {
-	return path.Join(config, fmt.Sprintf(EpochFileTemplate, epoch))
-}
-
-type envoy struct {
-	config    meshconfig.ProxyConfig
-	node      string
-	extraArgs []string
-	pilotSAN  []string
-	opts      map[string]interface{}
-	errChan   chan error
-}
-
-// NewProxy creates an instance of the proxy control commands
-func NewProxy(config meshconfig.ProxyConfig, node string, logLevel string, pilotSAN []string) proxy.Proxy {
-	// inject tracing flag for higher levels
-	var args []string
-	if logLevel != "" {
-		args = append(args, "-l", logLevel)
-	}
-
-	return envoy{
-		config:    config,
-		node:      node,
-		extraArgs: args,
-		pilotSAN:  pilotSAN,
-	}
-}
-
-func (proxy envoy) args(fname string, epoch int) []string {
-	startupArgs := []string{"-c", fname,
-		"--restart-epoch", fmt.Sprint(epoch),
-		"--drain-time-s", fmt.Sprint(int(convertDuration(proxy.config.DrainDuration) / time.Second)),
-		"--parent-shutdown-time-s", fmt.Sprint(int(convertDuration(proxy.config.ParentShutdownDuration) / time.Second)),
-		"--service-cluster", proxy.config.ServiceCluster,
-		"--service-node", proxy.node,
-		"--max-obj-name-len", fmt.Sprint(proxy.config.StatNameLength),
-		"--allow-unknown-fields",
-	}
-
-	startupArgs = append(startupArgs, proxy.extraArgs...)
-
-	if proxy.config.Concurrency > 0 {
-		startupArgs = append(startupArgs, "--concurrency", fmt.Sprint(proxy.config.Concurrency))
-	}
-
-	if len(proxy.config.AvailabilityZone) > 0 {
-		startupArgs = append(startupArgs, []string{"--service-zone", proxy.config.AvailabilityZone}...)
-	}
-
-	return startupArgs
-}
-
-func (proxy envoy) Run(config interface{}, epoch int, abort <-chan error) error {
-
-	var fname string
-	// Note: the cert checking still works, the generated file is updated if certs are changed.
-	// We just don't save the generated file, but use a custom one instead. Pilot will keep
-	// monitoring the certs and restart if the content of the certs changes.
-	if len(proxy.config.CustomConfigFile) > 0 {
-		// there is a custom configuration. Don't write our own config - but keep watching the certs.
-		fname = proxy.config.CustomConfigFile
-	} else {
-		out, err := bootstrap.WriteBootstrap(&proxy.config, proxy.node, epoch, proxy.pilotSAN, proxy.opts)
-		if err != nil {
-			log.Errora("Failed to generate bootstrap config", err)
-			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
-			return err
-		}
-		fname = out
-	}
-
-	// spin up a new Envoy process
-	args := proxy.args(fname, epoch)
-	if len(proxy.config.CustomConfigFile) == 0 {
-		args = append(args, "--v2-config-only")
-	}
-	log.Infof("Envoy command: %v", args)
-
-	/* #nosec */
-	cmd := exec.Command(proxy.config.BinaryPath, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	// Set if the caller is monitoring envoy, for example in tests or if envoy runs in same
-	// container with the app.
-	if proxy.errChan != nil {
-		// Caller passed a channel, will wait itself for termination
-		go func() {
-			proxy.errChan <- cmd.Wait()
-		}()
-		return nil
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- cmd.Wait()
-	}()
-
-	select {
-	case err := <-abort:
-		log.Warnf("Aborting epoch %d", epoch)
-		if errKill := cmd.Process.Kill(); errKill != nil {
-			log.Warnf("killing epoch %d caused an error %v", epoch, errKill)
-		}
-		return err
-	case err := <-done:
-		return err
-	}
-}
-
-func (proxy envoy) Cleanup(epoch int) {
-	filePath := configFile(proxy.config.ConfigPath, epoch)
-	if err := os.Remove(filePath); err != nil {
-		log.Warnf("Failed to delete config file %s for %d, %v", filePath, epoch, err)
-	}
-}
-
-func (proxy envoy) Panic(epoch interface{}) {
-	log.Error("cannot start the proxy with the desired configuration")
-	if epochInt, ok := epoch.(int); ok {
-		// print the failed config file
-		filePath := configFile(proxy.config.ConfigPath, epochInt)
-		b, _ := ioutil.ReadFile(filePath)
-		log.Errorf(string(b))
-	}
-	os.Exit(-1)
 }

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -42,8 +42,7 @@ func (ta *TestAgent) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func TestRunReload(t *testing.T) {
-	called := make(chan bool)
+func TestRunSendConfig(t *testing.T) {
 	agent := &TestAgent{
 		configCh: make(chan interface{}),
 	}
@@ -59,7 +58,7 @@ func TestRunReload(t *testing.T) {
 	go watcher.Run(ctx)
 
 	select {
-	case <-called:
+	case <-agent.configCh:
 		// expected
 		cancel()
 	case <-time.After(time.Second):

--- a/pilot/pkg/proxy/envoy/watcher_test.go
+++ b/pilot/pkg/proxy/envoy/watcher_test.go
@@ -18,12 +18,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -34,30 +31,28 @@ import (
 )
 
 type TestAgent struct {
-	schedule func(interface{})
+	configCh chan interface{}
 }
 
-func (ta TestAgent) ScheduleConfigUpdate(config interface{}) {
-	ta.schedule(config)
+func (ta *TestAgent) ConfigCh() chan<- interface{} {
+	return ta.configCh
 }
 
-func (ta TestAgent) Run(ctx context.Context) {
+func (ta *TestAgent) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
 func TestRunReload(t *testing.T) {
 	called := make(chan bool)
-	agent := TestAgent{
-		schedule: func(_ interface{}) {
-			called <- true
-		},
+	agent := &TestAgent{
+		configCh: make(chan interface{}),
 	}
 	config := model.DefaultProxyConfig()
 	node := model.Proxy{
 		Type: model.Ingress,
 		ID:   "random",
 	}
-	watcher := NewWatcher(config, agent, node, []CertSource{{Directory: "random"}}, nil)
+	watcher := NewWatcher(config, node, []CertSource{{Directory: "random"}}, nil, agent.ConfigCh())
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// watcher starts agent and schedules a config update
@@ -71,24 +66,6 @@ func TestRunReload(t *testing.T) {
 		t.Errorf("The callback is not called within time limit " + time.Now().String())
 		cancel()
 	}
-}
-
-type pilotStubHandler struct {
-	sync.Mutex
-	States []pilotStubState
-}
-
-type pilotStubState struct {
-	StatusCode int
-	Response   string
-}
-
-func (p *pilotStubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	p.Lock()
-	w.WriteHeader(p.States[0].StatusCode)
-	_, _ = w.Write([]byte(p.States[0].Response))
-	p.States = p.States[1:]
-	p.Unlock()
 }
 
 func TestWatchCerts_Multiple(t *testing.T) {
@@ -215,36 +192,3 @@ func TestGenerateCertHash(t *testing.T) {
 		t.Error("hash should not be affected by empty directory")
 	}
 }
-
-func TestEnvoyArgs(t *testing.T) {
-	config := model.DefaultProxyConfig()
-	config.ServiceCluster = "my-cluster"
-	config.AvailabilityZone = "my-zone"
-	config.Concurrency = 8
-
-	test := envoy{config: config, node: "my-node", extraArgs: []string{"-l", "trace"}}
-	testProxy := NewProxy(config, "my-node", "trace", nil)
-	if !reflect.DeepEqual(testProxy, test) {
-		t.Errorf("unexpected struct got\n%v\nwant\n%v", testProxy, test)
-	}
-
-	got := test.args("test.json", 5)
-	want := []string{
-		"-c", "test.json",
-		"--restart-epoch", "5",
-		"--drain-time-s", "2",
-		"--parent-shutdown-time-s", "3",
-		"--service-cluster", "my-cluster",
-		"--service-node", "my-node",
-		"--max-obj-name-len", fmt.Sprint(config.StatNameLength),
-		"--allow-unknown-fields",
-		"-l", "trace",
-		"--concurrency", "8",
-		"--service-zone", "my-zone",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("envoyArgs() => got %v, want %v", got, want)
-	}
-}
-
-// TestEnvoyRun is no longer used - we are now using v2 bootstrap API.


### PR DESCRIPTION
1. decoupling agent and watcher, watcher send config update to agent by a channel.

1. split watcher and proxy. They are orthogonal.