### PR TITLE
Add time duration to stale EDS

### DIFF
--- a/istioctl/pkg/writer/pilot/status_test.go
+++ b/istioctl/pkg/writer/pilot/status_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -38,6 +39,7 @@ func TestStatusWriter_PrintAll(t *testing.T) {
 			input: map[string][]v2.SyncStatus{
 				"pilot1": statusInput1(),
 				"pilot2": statusInput2(),
+				"pilot3": statusInput3(),
 			},
 			want: "testdata/multiStatusMultiPilot.txt",
 		},
@@ -172,6 +174,22 @@ func statusInput2() []v2.SyncStatus {
 			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			EndpointAcked: "2009-11-10 22:00:00 +0000 UTC m=+0.000000001",
+			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+		},
+	}
+}
+
+func statusInput3() []v2.SyncStatus {
+	return []v2.SyncStatus{
+		{
+			ProxyID:       "proxy3",
+			ProxyVersion:  "1.0",
+			ClusterSent:   "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			ClusterAcked:  time.Time{}.String(),
+			ListenerAcked: "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			EndpointSent:  "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
+			EndpointAcked: time.Time{}.String(),
 			RouteSent:     "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 			RouteAcked:    "2009-11-10 23:00:00 +0000 UTC m=+0.000000001",
 		},

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,3 +1,4 @@
-NAME       CDS       LDS        EDS               RDS          PILOT      VERSION
-proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
-proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot2     1.0
+PROXY      CDS                            LDS          EDS                                 RDS          PILOT      VERSION
+proxy1     STALE (1h0m0s)                 SYNCED       SYNCED (100%)                       NOT SENT     pilot1     1.0
+proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s) (0%)                 SYNCED       pilot2     1.0
+proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged) (0%)     SYNCED       pilot3     1.0

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,4 +1,4 @@
-PROXY      CDS                            LDS          EDS                                 RDS          PILOT      VERSION
+NAME       CDS                            LDS          EDS                                 RDS          PILOT      VERSION
 proxy1     STALE (1h0m0s)                 SYNCED       SYNCED (100%)                       NOT SENT     pilot1     1.0
 proxy2     STALE (1h0m0s)                 SYNCED       STALE (1h0m0s) (0%)                 SYNCED       pilot2     1.0
 proxy3     STALE (Never Acknowledged)     NOT SENT     STALE (Never Acknowledged) (0%)     SYNCED       pilot3     1.0

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-PROXY      CDS                LDS        EDS                     RDS          PILOT      VERSION
+NAME       CDS                LDS        EDS                     RDS          PILOT      VERSION
 proxy1     STALE (1h0m0s)     SYNCED     SYNCED (100%)           NOT SENT     pilot1     1.0
 proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED       pilot1     1.0

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-NAME       CDS       LDS        EDS               RDS          PILOT      VERSION
-proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
-proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot1     1.0
+PROXY      CDS                LDS        EDS                     RDS          PILOT      VERSION
+proxy1     STALE (1h0m0s)     SYNCED     SYNCED (100%)           NOT SENT     pilot1     1.0
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED       pilot1     1.0

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-NAME       CDS       LDS        EDS            RDS        PILOT      VERSION
-proxy2     STALE     SYNCED     STALE (0%)     SYNCED     pilot2     1.0
+PROXY      CDS                LDS        EDS                     RDS        PILOT      VERSION
+proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.0

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-PROXY      CDS                LDS        EDS                     RDS        PILOT      VERSION
+NAME       CDS                LDS        EDS                     RDS        PILOT      VERSION
 proxy2     STALE (1h0m0s)     SYNCED     STALE (1h0m0s) (0%)     SYNCED     pilot2     1.0


### PR DESCRIPTION
Addresses issue #6518. Adds a time duration to a `STALE` xds status. Allows for better debugging of issues affecting the `proxy-status`. 

**Note:** This PR is a work in progress and I still need to add test coverage. Please review, suggestions welcome!