### PR TITLE
add sleep ServiceAccount to sleep sample

### DIFF
--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -16,6 +16,11 @@
 # Sleep service
 ##################################################################################################
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sleep
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: sleep
@@ -39,6 +44,7 @@ spec:
       labels:
         app: sleep
     spec:
+      serviceAccountName: sleep
       containers:
       - name: sleep
         image: tutum/curl


### PR DESCRIPTION
Adding a SeviceAccount should not cause any harm, it should help in demonstrating the policies by source workload, monitoring `source.principle`.