### PR TITLE
fix galley readiness prober

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -149,6 +149,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 
 	if a.ReadinessProbeOptions.IsValid() {
 		s.readinessProbe = probe.NewFileController(a.ReadinessProbeOptions)
+		s.RegisterProbe(s.readinessProbe, "server")
 		s.readinessProbe.Start()
 	}
 


### PR DESCRIPTION
The probe controller for readiness won't work as expect, as we didn't register the probe to it 
/assign @ayj 