### PR TITLE
add opencensus metrics to mcp/server

### DIFF
--- a/galley/pkg/server/monitoring.go
+++ b/galley/pkg/server/monitoring.go
@@ -19,11 +19,12 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	ocprom "go.opencensus.io/exporter/prometheus"
+	"go.opencensus.io/stats/view"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
-	"github.com/prometheus/client_golang/prometheus"
-	"go.opencensus.io/stats/view"
 )
 
 const (

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -67,7 +67,7 @@ func defaultPatchTable() patchTable {
 		newKubeFromConfigFile: kube.NewKubeFromConfigFile,
 		newSource:             source.New,
 		netListen:             net.Listen,
-		mcpMetricReporter:     func(prefix string) server.Reporter { return server.NewReporter(prefix) },
+		mcpMetricReporter:     func(prefix string) server.Reporter { return server.NewStatsContext(prefix) },
 	}
 }
 

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -58,6 +58,7 @@ type patchTable struct {
 	newKubeFromConfigFile func(string) (kube.Interfaces, error)
 	newSource             func(kube.Interfaces, time.Duration) (runtime.Source, error)
 	netListen             func(network, address string) (net.Listener, error)
+	mcpMetricReporter     func(string) server.Reporter
 }
 
 func defaultPatchTable() patchTable {
@@ -66,6 +67,7 @@ func defaultPatchTable() patchTable {
 		newKubeFromConfigFile: kube.NewKubeFromConfigFile,
 		newSource:             source.New,
 		netListen:             net.Listen,
+		mcpMetricReporter:     func(prefix string) server.Reporter { return server.NewReporter(prefix) },
 	}
 }
 
@@ -123,7 +125,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	grpc.EnableTracing = a.EnableGRPCTracing
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 
-	s.mcp = server.New(distributor, metadata.Types.TypeURLs(), checker)
+	s.mcp = server.New(distributor, metadata.Types.TypeURLs(), checker, p.mcpMetricReporter("galley/"))
 
 	// get the network stuff setup
 	network := "tcp"

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -24,6 +24,8 @@ import (
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/testing/mock"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/server"
+	"istio.io/istio/pkg/mcp/testing"
 )
 
 func TestNewServer_Errors(t *testing.T) {
@@ -69,6 +71,9 @@ func TestNewServer(t *testing.T) {
 	p.newSource = func(kube.Interfaces, time.Duration) (runtime.Source, error) {
 		return runtime.NewInMemorySource(), nil
 	}
+	p.mcpMetricReporter = func(s string) server.Reporter {
+		return mcptest.NewInMemoryReporter()
+	}
 
 	args := DefaultArgs()
 	args.APIAddress = "tcp://0.0.0.0:0"
@@ -88,6 +93,9 @@ func TestServer_Basic(t *testing.T) {
 	p.newKubeFromConfigFile = func(string) (kube.Interfaces, error) { return mk, nil }
 	p.newSource = func(kube.Interfaces, time.Duration) (runtime.Source, error) {
 		return runtime.NewInMemorySource(), nil
+	}
+	p.mcpMetricReporter = func(s string) server.Reporter {
+		return mcptest.NewInMemoryReporter()
 	}
 
 	args := DefaultArgs()

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -25,7 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/testing/mock"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/mcp/server"
-	"istio.io/istio/pkg/mcp/testing"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 func TestNewServer_Errors(t *testing.T) {
@@ -72,7 +72,7 @@ func TestNewServer(t *testing.T) {
 		return runtime.NewInMemorySource(), nil
 	}
 	p.mcpMetricReporter = func(s string) server.Reporter {
-		return mcptest.NewInMemoryServerStatsContext()
+		return mcptestmon.NewInMemoryServerStatsContext()
 	}
 
 	args := DefaultArgs()
@@ -95,7 +95,7 @@ func TestServer_Basic(t *testing.T) {
 		return runtime.NewInMemorySource(), nil
 	}
 	p.mcpMetricReporter = func(s string) server.Reporter {
-		return mcptest.NewInMemoryReporter()
+		return mcptestmon.NewInMemoryServerStatsContext()
 	}
 
 	args := DefaultArgs()

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -72,7 +72,7 @@ func TestNewServer(t *testing.T) {
 		return runtime.NewInMemorySource(), nil
 	}
 	p.mcpMetricReporter = func(s string) server.Reporter {
-		return mcptest.NewInMemoryReporter()
+		return mcptest.NewInMemoryServerStatsContext()
 	}
 
 	args := DefaultArgs()

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -1,0 +1,107 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/stats/view"
+)
+
+const (
+	typeURL   = "typeURL"
+	errorCode = "code"
+	errorStr  = "error"
+	connectionID = "connectionID"
+)
+
+var (
+	TypeURLTag      tag.Key
+	ErrorCodeTag    tag.Key
+	ErrorTag        tag.Key
+	ConnectionIDTag tag.Key
+
+	// buckets are powers of 4
+	byteBuckets = []float64{1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824}
+
+	ClientCount = stats.Int64(
+		"mcp/server/client_count",
+		"The number of clients currently connected.",
+		stats.UnitDimensionless)
+
+	RequestSizesBytes = stats.Int64(
+		"mcp/server/message_sizes_bytes",
+		"Size of messages received from clients.",
+		stats.UnitBytes)
+
+	RequestAcks = stats.Int64(
+		"mcp/server/request_acks",
+		"The number of request acks received by the server.",
+		stats.UnitDimensionless)
+
+	RequestNacks = stats.Int64(
+		"mcp/server/request_nacks",
+		"The number of request nacks received by the server.",
+		stats.UnitDimensionless)
+
+	SendFailures = stats.Int64(
+		"mcp/server/send_failures",
+		"The number of send failures in the server.",
+		stats.UnitDimensionless)
+
+	RecvFailures = stats.Int64(
+		"mcp/server/recv_failures",
+		"The number of recv failures in the server.",
+		stats.UnitDimensionless)
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+func init() {
+	var err error
+	if TypeURLTag, err = tag.NewKey(typeURL); err != nil {
+		panic(err)
+	}
+	if ErrorCodeTag, err = tag.NewKey(errorCode); err != nil {
+		panic(err)
+	}
+	if ErrorTag, err = tag.NewKey(errorStr); err != nil {
+		panic(err)
+	}
+	if ConnectionIDTag, err = tag.NewKey(connectionID); err != nil {
+		panic(err)
+	}
+
+	err = view.Register(
+		newView(ClientCount, []tag.Key{}, view.LastValue()),
+		newView(RequestSizesBytes, []tag.Key{ConnectionIDTag}, view.Distribution(byteBuckets...)),
+		newView(RequestAcks, []tag.Key{TypeURLTag}, view.Count()),
+		newView(RequestNacks, []tag.Key{ErrorCodeTag, TypeURLTag}, view.Count()),
+		newView(SendFailures, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+		newView(RecvFailures, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -40,7 +40,7 @@ var (
 	byteBuckets = []float64{1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824}
 
 	ClientCount = stats.Int64(
-		"mcp/server/client_count",
+		"mcp/server/clients_total",
 		"The number of clients currently connected.",
 		stats.UnitDimensionless)
 
@@ -50,22 +50,22 @@ var (
 		stats.UnitBytes)
 
 	RequestAcks = stats.Int64(
-		"mcp/server/request_acks",
+		"mcp/server/request_acks_total",
 		"The number of request acks received by the server.",
 		stats.UnitDimensionless)
 
 	RequestNacks = stats.Int64(
-		"mcp/server/request_nacks",
+		"mcp/server/request_nacks_total",
 		"The number of request nacks received by the server.",
 		stats.UnitDimensionless)
 
 	SendFailures = stats.Int64(
-		"mcp/server/send_failures",
+		"mcp/server/send_failures_total",
 		"The number of send failures in the server.",
 		stats.UnitDimensionless)
 
 	RecvFailures = stats.Int64(
-		"mcp/server/recv_failures",
+		"mcp/server/recv_failures_total",
 		"The number of recv failures in the server.",
 		stats.UnitDimensionless)
 )

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -31,6 +31,136 @@ const (
 	connectionID = "connectionID"
 )
 
+type Reporter interface {
+	SetClientsTotal(clients int64)
+	RecordSendError(err error, code codes.Code)
+	RecordRecvError(err error, code codes.Code)
+	RecordRequestSize(typeURL string, connectionID int64, size int)
+	RecordRequestAck(typeURL string, connectionID int64)
+	RecordRequestNack(typeURL string, connectionID int64)
+}
+
+type StatsContext struct {
+	clientsTotal      *stats.Int64Measure
+	requestSizesBytes *stats.Int64Measure
+	requestAcksTotal  *stats.Int64Measure
+	requestNacksTotal *stats.Int64Measure
+	sendFailuresTotal *stats.Int64Measure
+	recvFailuresTotal *stats.Int64Measure
+}
+
+func (s *StatsContext) SetClientsTotal(clients int64) {
+	stats.Record(context.Background(), s.clientsTotal.M(clients))
+}
+
+func (s *StatsContext) recordError(err error, code codes.Code, stat *stats.Int64Measure) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(ErrorTag, err.Error()),
+		tag.Insert(ErrorCodeTag, strconv.FormatUint(uint64(code), 10)))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %", ctxErr)
+		return
+	}
+	stats.Record(ctx, stat.M(1))
+}
+
+func (s *StatsContext) RecordSendError(err error, code codes.Code) {
+	s.recordError(err, code, s.sendFailuresTotal)
+}
+
+func (s *StatsContext) RecordRecvError(err error, code codes.Code) {
+	s.recordError(err, code, s.recvFailuresTotal)
+}
+
+func (s *StatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(TypeURLTag, typeURL),
+		tag.Insert(ConnectionIDTag, strconv.FormatInt(connectionID, 10)))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %", ctxErr)
+		return
+	}
+	stats.Record(ctx, s.requestSizesBytes.M(int64(size)))
+}
+
+func (s *StatsContext) RecordRequestAck(typeURL string, connectionID int64) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(TypeURLTag, typeURL),
+		tag.Insert(ConnectionIDTag, strconv.FormatInt(connectionID, 10)))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %", ctxErr)
+		return
+	}
+	stats.Record(ctx, s.requestAcksTotal.M(1))
+}
+
+func (s *StatsContext) RecordRequestNack(typeURL string, connectionID int64) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(TypeURLTag, typeURL),
+		tag.Insert(ConnectionIDTag, strconv.FormatInt(connectionID, 10)))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %", ctxErr)
+		return
+	}
+	stats.Record(ctx, s.requestNacksTotal.M(1))
+}
+
+func NewReporter(prefix string) *StatsContext {
+	ctx := &StatsContext{
+		// ClientsTotal is a measure of the number of connected clients.
+		clientsTotal: stats.Int64(
+			prefix+"mcp/server/clients_total",
+			"The number of clients currently connected.",
+			stats.UnitDimensionless),
+
+		// RequestSizesBytes is a distribution of incoming message sizes.
+		requestSizesBytes: stats.Int64(
+			prefix+"mcp/server/message_sizes_bytes",
+			"Size of messages received from clients.",
+			stats.UnitBytes),
+
+		// RequestAcksTotal is a measure of the number of received ACK requests.
+		requestAcksTotal: stats.Int64(
+			prefix+"mcp/server/request_acks_total",
+			"The number of request acks received by the server.",
+			stats.UnitDimensionless),
+
+		// RequestNacksTotal is a measure of the number of received NACK requests.
+		requestNacksTotal: stats.Int64(
+			prefix+"mcp/server/request_nacks_total",
+			"The number of request nacks received by the server.",
+			stats.UnitDimensionless),
+
+		// SendFailuresTotal is a measure of the number of network send failures.
+		sendFailuresTotal: stats.Int64(
+			prefix+"mcp/server/send_failures_total",
+			"The number of send failures in the server.",
+			stats.UnitDimensionless),
+
+		// RecvFailuresTotal is a measure of the number of network recv failures.
+		recvFailuresTotal: stats.Int64(
+			prefix+"mcp/server/recv_failures_total",
+			"The number of recv failures in the server.",
+			stats.UnitDimensionless),
+	}
+
+	err := view.Register(
+		newView(ctx.clientsTotal, []tag.Key{}, view.LastValue()),
+		newView(ctx.requestSizesBytes, []tag.Key{ConnectionIDTag}, view.Distribution(byteBuckets...)),
+		newView(ctx.requestAcksTotal, []tag.Key{TypeURLTag}, view.Count()),
+		newView(ctx.requestNacksTotal, []tag.Key{ErrorCodeTag, TypeURLTag}, view.Count()),
+		newView(ctx.sendFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+		newView(ctx.recvFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return ctx
+}
+
+
 var (
 	// TypeURLTag holds the type URL for the context.
 	TypeURLTag tag.Key
@@ -43,42 +173,6 @@ var (
 
 	// buckets are powers of 4
 	byteBuckets = []float64{1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824}
-
-	// ClientsTotal is a measure of the number of connected clients.
-	ClientsTotal = stats.Int64(
-		"mcp/server/clients_total",
-		"The number of clients currently connected.",
-		stats.UnitDimensionless)
-
-	// RequestSizesBytes is a distribution of incoming message sizes.
-	RequestSizesBytes = stats.Int64(
-		"mcp/server/message_sizes_bytes",
-		"Size of messages received from clients.",
-		stats.UnitBytes)
-
-	// RequestAcksTotal is a measure of the number of received ACK requests.
-	RequestAcksTotal = stats.Int64(
-		"mcp/server/request_acks_total",
-		"The number of request acks received by the server.",
-		stats.UnitDimensionless)
-
-	// RequestNacksTotal is a measure of the number of received NACK requests.
-	RequestNacksTotal = stats.Int64(
-		"mcp/server/request_nacks_total",
-		"The number of request nacks received by the server.",
-		stats.UnitDimensionless)
-
-	// SendFailuresTotal is a measure of the number of network send failures.
-	SendFailuresTotal = stats.Int64(
-		"mcp/server/send_failures_total",
-		"The number of send failures in the server.",
-		stats.UnitDimensionless)
-
-	// RecvFailuresTotal is a measure of the number of network recv failures.
-	RecvFailuresTotal = stats.Int64(
-		"mcp/server/recv_failures_total",
-		"The number of recv failures in the server.",
-		stats.UnitDimensionless)
 )
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
@@ -89,13 +183,6 @@ func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregatio
 		TagKeys:     keys,
 		Aggregation: aggregation,
 	}
-}
-
-func recordError(err error, code codes.Code, stat *stats.Int64Measure) {
-	ctx, err := tag.New(context.Background(),
-		tag.Insert(ErrorTag, err.Error()),
-		tag.Insert(ErrorCodeTag, strconv.FormatUint(uint64(code), 10)))
-	stats.Record(ctx, stat.M(1))
 }
 
 func init() {
@@ -110,19 +197,6 @@ func init() {
 		panic(err)
 	}
 	if ConnectionIDTag, err = tag.NewKey(connectionID); err != nil {
-		panic(err)
-	}
-
-	err = view.Register(
-		newView(ClientsTotal, []tag.Key{}, view.LastValue()),
-		newView(RequestSizesBytes, []tag.Key{ConnectionIDTag}, view.Distribution(byteBuckets...)),
-		newView(RequestAcksTotal, []tag.Key{TypeURLTag}, view.Count()),
-		newView(RequestNacksTotal, []tag.Key{ErrorCodeTag, TypeURLTag}, view.Count()),
-		newView(SendFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
-		newView(RecvFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
-	)
-
-	if err != nil {
 		panic(err)
 	}
 }

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -98,7 +98,9 @@ func (s *StatsContext) RecordRequestNack(typeURL string, connectionID int64) {
 }
 
 func NewStatsContext(prefix string) *StatsContext {
-	if !strings.HasSuffix(prefix, "/") {
+	if len(prefix) == 0 {
+		panic("must specify prefix for MCP server monitoring.")
+	} else if !strings.HasSuffix(prefix, "/") {
 		prefix += "/"
 	}
 	ctx := &StatsContext{

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -15,15 +15,18 @@
 package server
 
 import (
+	"context"
+	"strconv"
+
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 const (
-	typeURL   = "typeURL"
-	errorCode = "code"
-	errorStr  = "error"
+	typeURL      = "typeURL"
+	errorCode    = "code"
+	errorStr     = "error"
 	connectionID = "connectionID"
 )
 
@@ -75,6 +78,13 @@ func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregatio
 		TagKeys:     keys,
 		Aggregation: aggregation,
 	}
+}
+
+func recordError(err error, code int64, stat *stats.Int64Measure) {
+	ctx, err := tag.New(context.Background(),
+		tag.Insert(ErrorTag, err.Error()),
+		tag.Insert(ErrorCodeTag, strconv.FormatUint(uint64(code), 10)))
+	stats.Record(ctx, stat.M(1))
 }
 
 func init() {

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -189,7 +189,7 @@ func (s *Server) newConnection(stream mcp.AggregatedMeshConfigService_StreamAggr
 	}
 
 	atomic.AddInt32(&s.connections, 1)
-	stats.Record(context.Background(), ClientCount.M(int64(s.connections)))
+	stats.Record(context.Background(), ClientCount.M(int64(atomic.LoadInt32(&s.connections))))
 
 	scope.Infof("MCP: connection %v: NEW, supported types: %#v", con, types)
 	return con, nil

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -290,10 +290,7 @@ func (con *connection) receive() {
 				scope.Infof("MCP: connection %v: TERMINATED %q", con, err)
 				return
 			}
-			ctx, err := tag.New(context.Background(),
-				tag.Insert(ErrorTag, err.Error()),
-				tag.Insert(ErrorCodeTag, strconv.FormatUint(uint64(code), 10)))
-			stats.Record(ctx, RecvFailures.M(1))
+			recordError(err, code, RecvFailures)
 			scope.Errorf("MCP: connection %v: TERMINATED with errors: %v", con, err)
 			// Save the stream error prior to closing the stream. The caller
 			// should access the error after the channel closure.

--- a/pkg/mcp/server/server_test.go
+++ b/pkg/mcp/server/server_test.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	mcp "istio.io/api/mcp/v1alpha1"
-	"istio.io/istio/pkg/mcp/testing"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 type mockConfigWatcher struct {
@@ -240,7 +240,7 @@ func TestMultipleRequests(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -293,7 +293,7 @@ func TestAuthCheck_Failure(t *testing.T) {
 	}
 
 	checker := NewListAuthChecker()
-	s := New(config, WatchResponseTypes, checker, mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, checker, mcptestmon.NewInMemoryServerStatsContext())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -327,7 +327,7 @@ func TestAuthCheck_Success(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, &fakeAuthChecker{}, mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, &fakeAuthChecker{}, mcptestmon.NewInMemoryServerStatsContext())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -375,7 +375,7 @@ func TestWatchBeforeResponsesAvailable(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -413,7 +413,7 @@ func TestWatchClosed(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want watch failed")
 	}
@@ -436,7 +436,7 @@ func TestSendError(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	// check that response fails since watch gets closed
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
@@ -462,7 +462,7 @@ func TestReceiveError(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
 	}
@@ -486,7 +486,7 @@ func TestUnsupportedTypeError(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
 	}
@@ -508,7 +508,7 @@ func TestStaleNonce(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 	stop := make(chan struct{})
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
@@ -573,7 +573,7 @@ func TestAggregatedHandlers(t *testing.T) {
 		TypeUrl: fakeType2TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
@@ -611,7 +611,7 @@ func TestAggregateRequestType(t *testing.T) {
 	stream := makeMockStream(t)
 	stream.recv <- &mcp.MeshConfigRequest{Client: client}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("StreamAggregatedResources() => got nil, want an error")
 	}

--- a/pkg/mcp/server/server_test.go
+++ b/pkg/mcp/server/server_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/pkg/mcp/testing"
 )
 
 type mockConfigWatcher struct {
@@ -239,7 +240,7 @@ func TestMultipleRequests(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -292,7 +293,7 @@ func TestAuthCheck_Failure(t *testing.T) {
 	}
 
 	checker := NewListAuthChecker()
-	s := New(config, WatchResponseTypes, checker)
+	s := New(config, WatchResponseTypes, checker, mcptest.NewInMemoryReporter())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -326,7 +327,7 @@ func TestAuthCheck_Success(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, &fakeAuthChecker{})
+	s := New(config, WatchResponseTypes, &fakeAuthChecker{}, mcptest.NewInMemoryReporter())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -374,7 +375,7 @@ func TestWatchBeforeResponsesAvailable(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
@@ -412,7 +413,7 @@ func TestWatchClosed(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want watch failed")
 	}
@@ -435,7 +436,7 @@ func TestSendError(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	// check that response fails since watch gets closed
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
@@ -461,7 +462,7 @@ func TestReceiveError(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
 	}
@@ -485,7 +486,7 @@ func TestUnsupportedTypeError(t *testing.T) {
 	}
 
 	// check that response fails since watch gets closed
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("Stream() => got no error, want send error")
 	}
@@ -507,7 +508,7 @@ func TestStaleNonce(t *testing.T) {
 		TypeUrl: fakeType0TypeURL,
 	}
 	stop := make(chan struct{})
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
@@ -572,7 +573,7 @@ func TestAggregatedHandlers(t *testing.T) {
 		TypeUrl: fakeType2TypeURL,
 	}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	go func() {
 		if err := s.StreamAggregatedResources(stream); err != nil {
 			t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
@@ -610,7 +611,7 @@ func TestAggregateRequestType(t *testing.T) {
 	stream := makeMockStream(t)
 	stream.recv <- &mcp.MeshConfigRequest{Client: client}
 
-	s := New(config, WatchResponseTypes, NewAllowAllChecker())
+	s := New(config, WatchResponseTypes, NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 	if err := s.StreamAggregatedResources(stream); err == nil {
 		t.Error("StreamAggregatedResources() => got nil, want an error")
 	}

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -28,6 +28,8 @@ type requestKey struct {
 	connectionID int64
 }
 
+// InMemoryServerStatsContext enables MCP server metric collection which is
+// stored in memory for testing purposes.
 type InMemoryServerStatsContext struct {
 	ClientsTotal      int64
 	RequestSizesBytes map[requestKey][]int64
@@ -37,31 +39,41 @@ type InMemoryServerStatsContext struct {
 	RecvFailuresTotal map[errorCodeKey]int64
 }
 
+// SetClientsTotal updates the current client count to the given argument.
 func (s *InMemoryServerStatsContext) SetClientsTotal(clients int64) {
 	s.ClientsTotal = clients
 }
 
+// RecordSendError records an error during a network send with its error
+// string and code.
 func (s *InMemoryServerStatsContext) RecordSendError(err error, code codes.Code) {
 	s.SendFailuresTotal[errorCodeKey{err.Error(), code}]++
 }
 
+// RecordRecvError records an error during a network recv with its error
+// string and code.
 func (s *InMemoryServerStatsContext) RecordRecvError(err error, code codes.Code) {
 	s.RecvFailuresTotal[errorCodeKey{err.Error(), code}]++
 }
 
+// RecordRequestSize records the size of a request from a connection for a specific type URL.
 func (s *InMemoryServerStatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
 	key := requestKey{typeURL, connectionID}
 	s.RequestSizesBytes[key] = append(s.RequestSizesBytes[key], int64(size))
 }
 
+// RecordRequestAck records an ACK message for a type URL on a connection.
 func (s *InMemoryServerStatsContext) RecordRequestAck(typeURL string, connectionID int64) {
 	s.RequestAcksTotal[requestKey{typeURL, connectionID}]++
 }
 
+// RecordRequestNack records a NACK message for a type URL on a connection.
 func (s *InMemoryServerStatsContext) RecordRequestNack(typeURL string, connectionID int64) {
 	s.RequestNacksTotal[requestKey{typeURL, connectionID}]++
 }
 
+// NewInMemoryServerStatsContext creates a new context for tracking metrics
+// in memory.
 func NewInMemoryServerStatsContext() *InMemoryServerStatsContext {
 	return &InMemoryServerStatsContext{
 		RequestSizesBytes: make(map[requestKey][]int64),

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mcptest
+package mcptestmon
 
 import (
 	"google.golang.org/grpc/codes"
@@ -28,7 +28,7 @@ type requestKey struct {
 	connectionID int64
 }
 
-type InMemoryStatsContext struct {
+type InMemoryServerStatsContext struct {
 	ClientsTotal      int64
 	RequestSizesBytes map[requestKey][]int64
 	RequestAcksTotal  map[requestKey]int64
@@ -37,33 +37,33 @@ type InMemoryStatsContext struct {
 	RecvFailuresTotal map[errorCodeKey]int64
 }
 
-func (s *InMemoryStatsContext) SetClientsTotal(clients int64) {
+func (s *InMemoryServerStatsContext) SetClientsTotal(clients int64) {
 	s.ClientsTotal = clients
 }
 
-func (s *InMemoryStatsContext) RecordSendError(err error, code codes.Code) {
+func (s *InMemoryServerStatsContext) RecordSendError(err error, code codes.Code) {
 	s.SendFailuresTotal[errorCodeKey{err.Error(), code}]++
 }
 
-func (s *InMemoryStatsContext) RecordRecvError(err error, code codes.Code) {
+func (s *InMemoryServerStatsContext) RecordRecvError(err error, code codes.Code) {
 	s.RecvFailuresTotal[errorCodeKey{err.Error(), code}]++
 }
 
-func (s *InMemoryStatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
+func (s *InMemoryServerStatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
 	key := requestKey{typeURL, connectionID}
 	s.RequestSizesBytes[key] = append(s.RequestSizesBytes[key], int64(size))
 }
 
-func (s *InMemoryStatsContext) RecordRequestAck(typeURL string, connectionID int64) {
+func (s *InMemoryServerStatsContext) RecordRequestAck(typeURL string, connectionID int64) {
 	s.RequestAcksTotal[requestKey{typeURL, connectionID}]++
 }
 
-func (s *InMemoryStatsContext) RecordRequestNack(typeURL string, connectionID int64) {
+func (s *InMemoryServerStatsContext) RecordRequestNack(typeURL string, connectionID int64) {
 	s.RequestNacksTotal[requestKey{typeURL, connectionID}]++
 }
 
-func NewInMemoryReporter() *InMemoryStatsContext {
-	return &InMemoryStatsContext{
+func NewInMemoryServerStatsContext() *InMemoryServerStatsContext {
+	return &InMemoryServerStatsContext{
 		RequestSizesBytes: make(map[requestKey][]int64),
 		RequestAcksTotal:  make(map[requestKey]int64),
 		RequestNacksTotal: make(map[requestKey]int64),

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -16,7 +16,7 @@ package mcptestmon
 
 import (
 	"sync"
-	
+
 	"google.golang.org/grpc/codes"
 )
 

--- a/pkg/mcp/testing/reporter.go
+++ b/pkg/mcp/testing/reporter.go
@@ -1,0 +1,59 @@
+package mcptest
+
+import (
+	"google.golang.org/grpc/codes"
+)
+
+type errorCodeKey struct {
+	error string
+	code  codes.Code
+}
+
+type requestKey struct {
+	typeURL      string
+	connectionID int64
+}
+
+type InMemoryStatsContext struct {
+	ClientsTotal      int64
+	RequestSizesBytes map[requestKey][]int64
+	RequestAcksTotal  map[requestKey]int64
+	RequestNacksTotal map[requestKey]int64
+	SendFailuresTotal map[errorCodeKey]int64
+	RecvFailuresTotal map[errorCodeKey]int64
+}
+
+func (s *InMemoryStatsContext) SetClientsTotal(clients int64) {
+	s.ClientsTotal = clients
+}
+
+func (s *InMemoryStatsContext) RecordSendError(err error, code codes.Code) {
+	s.SendFailuresTotal[errorCodeKey{err.Error(), code}]++
+}
+
+func (s *InMemoryStatsContext) RecordRecvError(err error, code codes.Code) {
+	s.RecvFailuresTotal[errorCodeKey{err.Error(), code}]++
+}
+
+func (s *InMemoryStatsContext) RecordRequestSize(typeURL string, connectionID int64, size int) {
+	key := requestKey{typeURL, connectionID}
+	s.RequestSizesBytes[key] = append(s.RequestSizesBytes[key], int64(size))
+}
+
+func (s *InMemoryStatsContext) RecordRequestAck(typeURL string, connectionID int64) {
+	s.RequestAcksTotal[requestKey{typeURL, connectionID}]++
+}
+
+func (s *InMemoryStatsContext) RecordRequestNack(typeURL string, connectionID int64) {
+	s.RequestNacksTotal[requestKey{typeURL, connectionID}]++
+}
+
+func NewInMemoryReporter() *InMemoryStatsContext {
+	return &InMemoryStatsContext{
+		RequestSizesBytes: make(map[requestKey][]int64),
+		RequestAcksTotal:  make(map[requestKey]int64),
+		RequestNacksTotal: make(map[requestKey]int64),
+		SendFailuresTotal: make(map[errorCodeKey]int64),
+		RecvFailuresTotal: make(map[errorCodeKey]int64),
+	}
+}

--- a/pkg/mcp/testing/reporter.go
+++ b/pkg/mcp/testing/reporter.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mcptest
 
 import (

--- a/pkg/mcp/testing/server.go
+++ b/pkg/mcp/testing/server.go
@@ -53,7 +53,7 @@ var _ io.Closer = &Server{}
 // from the Port field of the returned server struct.
 func NewServer(port int, typeUrls []string) (*Server, error) {
 	cache := snapshot.New()
-	s := server.New(cache, typeUrls, server.NewAllowAllChecker())
+	s := server.New(cache, typeUrls, server.NewAllowAllChecker(), NewInMemoryReporter())
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	l, err := net.Listen("tcp", addr)

--- a/pkg/mcp/testing/server.go
+++ b/pkg/mcp/testing/server.go
@@ -26,6 +26,7 @@ import (
 
 	"istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/snapshot"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 // Server is a simple MCP server, used for testing purposes.
@@ -53,7 +54,7 @@ var _ io.Closer = &Server{}
 // from the Port field of the returned server struct.
 func NewServer(port int, typeUrls []string) (*Server, error) {
 	cache := snapshot.New()
-	s := server.New(cache, typeUrls, server.NewAllowAllChecker(), NewInMemoryReporter())
+	s := server.New(cache, typeUrls, server.NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	l, err := net.Listen("tcp", addr)

--- a/tests/e2e/tests/pilot/mock/mcp/server.go
+++ b/tests/e2e/tests/pilot/mock/mcp/server.go
@@ -23,6 +23,7 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	mcpserver "istio.io/istio/pkg/mcp/server"
+	"istio.io/istio/pkg/mcp/testing"
 )
 
 type WatchResponse func(req *mcp.MeshConfigRequest) (*mcpserver.WatchResponse, mcpserver.CancelWatchFunc)
@@ -58,7 +59,7 @@ func NewServer(addr string, typeUrls []string, watchResponseFunc WatchResponse) 
 	watcher := mockWatcher{
 		response: watchResponseFunc,
 	}
-	s := mcpserver.New(watcher, typeUrls, mcpserver.NewAllowAllChecker())
+	s := mcpserver.New(watcher, typeUrls, mcpserver.NewAllowAllChecker(), mcptest.NewInMemoryReporter())
 
 	l, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/tests/e2e/tests/pilot/mock/mcp/server.go
+++ b/tests/e2e/tests/pilot/mock/mcp/server.go
@@ -23,7 +23,7 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	mcpserver "istio.io/istio/pkg/mcp/server"
-	"istio.io/istio/pkg/mcp/testing"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 type WatchResponse func(req *mcp.MeshConfigRequest) (*mcpserver.WatchResponse, mcpserver.CancelWatchFunc)
@@ -59,7 +59,7 @@ func NewServer(addr string, typeUrls []string, watchResponseFunc WatchResponse) 
 	watcher := mockWatcher{
 		response: watchResponseFunc,
 	}
-	s := mcpserver.New(watcher, typeUrls, mcpserver.NewAllowAllChecker(), mcptest.NewInMemoryReporter())
+	s := mcpserver.New(watcher, typeUrls, mcpserver.NewAllowAllChecker(), mcptestmon.NewInMemoryServerStatsContext())
 
 	l, err := net.Listen("tcp", addr)
 	if err != nil {


### PR DESCRIPTION
This is the first CL for adding metrics to Galley. I just want feedback here to make sure the code is correctly structured. I'll probably batch other modules together once this is reviewed. I am by no means a Go expert, so go nuts. @douglas-reid I included you since you did the opencensus refactor.
Part of #3311.