### PR TITLE
Remove local registry setup from minikube VM environment.

### DIFF
--- a/tests/e2e/local/minikube/README.md
+++ b/tests/e2e/local/minikube/README.md
@@ -27,11 +27,11 @@ You can run the following script to check/install of all pre-requisites, or use 
 ```
 
 ## 2. Build istio images
-Push images from your local dev environment to the local registry on host:
+Build images on your host machine:
 ```bash
 . ./setup_test.sh
 ```
-You should push new images whenever you modify istio source code.
+Minikube reuses the Docker daemon on your host machine to access images.
 
 ## 2. Run tests!
 You can issue test commands on your host machine.

--- a/tests/e2e/local/minikube/cleanup_host.sh
+++ b/tests/e2e/local/minikube/cleanup_host.sh
@@ -3,9 +3,6 @@
 # Getting docker back to it's previous setup.
 eval "$(docker-machine env -u)"
 
-# Removing port forwarding that was setup.
-kill "$(pgrep "kubectl port-forward")" > /dev/null 2>&1
-
 # Delete namespace istio-system if exists
 kubectl delete namespace istio-system > /dev/null 2>&1
 

--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -50,24 +50,4 @@ if [[ -z "${ISTIO// }" ]]; then
   echo 'Set ISTIO to' "$ISTIO"
 fi
 
-#Setup LocalRegistry
-if [ ! -f "$ISTIO/istio/tests/util/localregistry/localregistry.yaml" ]; then
-    echo File "$ISTIO/istio/tests/util/localregistry/localregistry.yaml" not found!.
-    echo Please make sure "$ISTIO" points to your Istio codebase.
-    echo See https://github.com/istio/istio/wiki/Dev-Guide#setting-up-environment-variables
-    exit
-fi
-kubectl apply -f "$ISTIO/istio/tests/util/localregistry/localregistry.yaml"
-echo "local registry started"
-
-while ! kubectl get pods -n kube-system | grep kube-registry-v0 | grep Running > /dev/null; do
-  echo "kube-registry-v0 not ready, will check again in 5 sec"
-  sleep 5
-done
-
-#Setup port forwarding
-echo "Setting up port forwarding"
-POD=$(kubectl get po -n kube-system | grep kube-registry-v0 | awk '{print $1;}')
-kubectl port-forward --namespace kube-system "$POD" 5000:5000 &
-
 echo "Host Setup Completed"

--- a/tests/e2e/local/minikube/setup_minikube_env.sh
+++ b/tests/e2e/local/minikube/setup_minikube_env.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-# Check if port forwarding is setup
-# TODO: This ps | grep | grep is pretty hacky. Rewrite it.
-# shellcheck disable=SC2009
-if ! ps -eaf | grep "kubectl port-forward" | grep "kube-registry" | grep "5000:5000" > /dev/null; then
-    echo "Port Forwarding not setup.Trying to set it up."
-    POD=$(kubectl get po -n kube-system | grep kube-registry-v0 | awk '{print $1;}')
-    # if ... &; then ... fi is a syntax error. Dropping the ';' is correct.
-    if ! kubectl port-forward --namespace kube-system "$POD" 5000:5000 & then
-        echo "Could not set up Port Forwarding. Something wrong with Minikube setup. Please check your setup and try again."
-        exit 1
-    fi
-fi
-echo "Port Forwarding is Setup"
-
 # Check if minikube docker environment is setup.
 if ! docker info | grep "localhost:5000" > /dev/null; then
     echo "Minikube docker environment not setup. Trying to set it up."
@@ -23,3 +9,4 @@ if ! docker info | grep "localhost:5000" > /dev/null; then
     fi
 fi
 echo "Minikube docker environment is setup for this shell"
+echo "To verify that localhost:5000 is added as insecure registry, please run docker info"

--- a/tests/e2e/local/minikube/setup_minikube_env.sh
+++ b/tests/e2e/local/minikube/setup_minikube_env.sh
@@ -9,4 +9,3 @@ if ! docker info | grep "localhost:5000" > /dev/null; then
     fi
 fi
 echo "Minikube docker environment is setup for this shell"
-echo "To verify that localhost:5000 is added as insecure registry, please run docker info"

--- a/tests/e2e/local/minikube/setup_test.sh
+++ b/tests/e2e/local/minikube/setup_test.sh
@@ -15,9 +15,5 @@ fi
 # Set GOOS=linux to make sure linux binaries are built on macOS
 cd "$ISTIO/istio" || exit
 GOOS=linux make docker HUB=localhost:5000 TAG=latest
-GOOS=linux make push HUB=localhost:5000 TAG=latest
 
-# Verify images are pushed in repository.
-echo "Check images present in repositories"
-curl localhost:5000/v2/_catalog
 echo "Setup done."


### PR DESCRIPTION
We don't need local registry when running e2e tests on local minikube VM environment. This [page](https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md) explains how minikube accesses images built on host machine. Remove the setup for local registry and update instructions.