### PR TITLE
fix ut "TestErrors/unix_socket_removal"

### DIFF
--- a/mixer/pkg/server/server_test.go
+++ b/mixer/pkg/server/server_test.go
@@ -268,7 +268,7 @@ func TestErrors(t *testing.T) {
 		},
 		{"unix socket removal",
 			func(a *Args, pt *patchTable) {
-				a.APIAddress = "unix:///dev/null"
+				a.APIAddress = "unix:///dev"
 			},
 		},
 	}


### PR DESCRIPTION
After running ut case go test ./mixer/pkg/server/ --run=TestErrors -v, leave the host system some err, like:
```shell
# go test ./mixer/pkg/server/ --run=TestErrors -v
go tool compile: open /dev/null: no such device or address
go tool compile: open /dev/null: no such device or address
# git st
fatal: open /dev/null or dup failed: No such device or address
```
Which is because `/dev/null` mod changed, before is `crw-rw-rw-`, and after test `srwxr-xr-x`.

This pr fixed the problem. 