### PR TITLE
Add tests/e2e/local OWNERS file

### DIFF
--- a/tests/e2e/local/OWNERS
+++ b/tests/e2e/local/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - gargnupur
+  - kimikowang 
+  - hklai
+  - JimmyCYJ

--- a/tests/e2e/local/minikube/OWNERS
+++ b/tests/e2e/local/minikube/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-  - gargnupur
-  - kimikowang 
-  - hklai
-  - JimmyCYJ

--- a/tests/e2e/local/vagrant/OWNERS
+++ b/tests/e2e/local/vagrant/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-  - gargnupur
-  - kimikowang 
-  - hklai
-  - JimmyCYJ


### PR DESCRIPTION
As we have put some common util functions into the file `tests/e2e/local/common_*.sh`, Approvers in the original `minikube` and `vagrant` sub-directories should still have the privilege to approve the codes in these files.

I am just copying the OWNERS file from `tests/e2e/local/minikube` and `tests/e2e/local/vagrant` to the parent directory - without adding or deleting anyone :)

/cc @costinm @sdake @hklai @gargnupur @kimikowang @JimmyCYJ Please take a look when you have chance :) THANKS!