### PR TITLE
remove deprecated LoadBalancingDisabled and ExternalName

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -74,10 +74,6 @@ type Service struct {
 	// These services are defined using Istio's ServiceEntry spec.
 	MeshExternal bool
 
-	// LoadBalancingDisabled indicates that no load balancing should be done for this service.
-	// Deprecated : made obsolete by the MeshExternal and Resolution flags.
-	LoadBalancingDisabled bool `json:"-"`
-
 	// Resolution indicates how the service instances need to be resolved before routing
 	// traffic. Most services in the service registry will use static load balancing wherein
 	// the proxy will decide the service instance that will receive the traffic. Service entries

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -61,12 +61,6 @@ type Service struct {
 	// connections
 	Ports PortList `json:"ports,omitempty"`
 
-	// ExternalName is only set for external services and holds the external
-	// service DNS name.  External services are name-based solution to represent
-	// external service instances as a service inside the cluster.
-	// Deprecated : made obsolete by the MeshExternal and Resolution flags.
-	ExternalName Hostname `json:"external"`
-
 	// ServiceAccounts specifies the service accounts that run the service.
 	ServiceAccounts []string `json:"serviceaccounts,omitempty"`
 

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -69,17 +69,14 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 
 	resolution := model.ClientSideLB
 	meshExternal := false
-	loadBalancingDisabled := false
 
 	if svc.Spec.Type == v1.ServiceTypeExternalName && svc.Spec.ExternalName != "" {
 		external = svc.Spec.ExternalName
 		resolution = model.Passthrough
 		meshExternal = true
-		loadBalancingDisabled = true
 	}
 
 	if addr == model.UnspecifiedIP && external == "" { // headless services should not be load balanced
-		loadBalancingDisabled = true
 		resolution = model.Passthrough
 	}
 
@@ -104,14 +101,13 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 	sort.Sort(sort.StringSlice(serviceaccounts))
 
 	return &model.Service{
-		Hostname:              serviceHostname(svc.Name, svc.Namespace, domainSuffix),
-		Ports:                 ports,
-		Address:               addr,
-		ServiceAccounts:       serviceaccounts,
-		LoadBalancingDisabled: loadBalancingDisabled,
-		MeshExternal:          meshExternal,
-		Resolution:            resolution,
-		CreationTime:          svc.CreationTimestamp.Time,
+		Hostname:        serviceHostname(svc.Name, svc.Namespace, domainSuffix),
+		Ports:           ports,
+		Address:         addr,
+		ServiceAccounts: serviceaccounts,
+		MeshExternal:    meshExternal,
+		Resolution:      resolution,
+		CreationTime:    svc.CreationTimestamp.Time,
 		Attributes: model.ServiceAttributes{
 			Name:      svc.Name,
 			Namespace: svc.Namespace,


### PR DESCRIPTION
`LoadBalancingDisabled` and `ExternalName` were marked as _deprecated_  in 2018/3/27.

#8262 removes the use of `ExternalName` and https://github.com/istio/istio/pull/8303/commits/f6585631b53b9fc5ddaf1bc28e3e399f840e385f removes the filed in struct.

/assign @ayj 