### PR TITLE
Delete redundant parameter copy

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -141,7 +141,7 @@ func (s *DiscoveryServer) periodicRefresh() {
 	defer ticker.Stop()
 	for range ticker.C {
 		adsLog.Infof("ADS: periodic push of envoy configs %s", versionInfo())
-		s.AdsPushAll(versionInfo(), s.env.PushContext)
+		s.AdsPushAll(versionInfo())
 	}
 }
 
@@ -214,7 +214,7 @@ func (s *DiscoveryServer) ClearCacheFunc() func() {
 		version = versionLocal
 		versionMutex.Unlock()
 
-		go s.AdsPushAll(versionLocal, push)
+		go s.AdsPushAll(versionLocal)
 	}
 }
 


### PR DESCRIPTION
No need to pass the  s.env.PushContext parameter here.