### PR TITLE
Add namespace to mesh expansion resources

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/gateway.yaml
@@ -31,6 +31,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: meshexpansion-gateway
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     istio: ingressgateway
@@ -55,6 +56,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: meshexpansion-ilb-gateway
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     istio: ilbgateway

--- a/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: meshexpansion-pilot
+  namespace: {{ .Release.Namespace }}
 spec:
   hosts:
   - "pilot.istio-system"
@@ -28,6 +29,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: ilb-meshexpansion-pilot
+  namespace: {{ .Release.Namespace }}
 spec:
   hosts:
   - "meshexpansionilb.istio-system"

--- a/install/kubernetes/helm/istio/charts/security/templates/meshexpansion.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/meshexpansion.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: meshexpansion-citadel
+  namespace: {{ .Release.Namespace }}
 spec:
   hosts:
   - "istio-citadel.istio-system"
@@ -28,6 +29,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: meshexpansion-ilb-citadel
+  namespace: {{ .Release.Namespace }}
 spec:
   hosts:
   - "istio-citadel.istio-system"


### PR DESCRIPTION
When deploying the mesh expansion with Istio v1.0.1, I noticed the virtualservices for the mesh expansion were deployed in the `default` namespace, where I would expect them to be in the `istio-system` namespace. This commit tries to fix that.