### PR TITLE
Avoid data races in Discovery

### DIFF
--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -418,14 +418,15 @@ func (ds *DiscoveryService) ClearCache() {
 func debouncePush(startDebounce time.Time) {
 	clearCacheMutex.Lock()
 	since := time.Since(lastClearCacheEvent)
+	events := clearCacheEvents
 	clearCacheMutex.Unlock()
 
 	if since > 2*DebounceAfter ||
 		time.Since(startDebounce) > DebounceMax {
 
 		log.Infof("Push debounce stable %d: %v since last change, %v since last push",
-			clearCacheEvents,
-			time.Since(lastClearCacheEvent), time.Since(lastClearCache))
+			events,
+			since, time.Since(lastClearCache))
 		clearCacheMutex.Lock()
 		clearCacheTimerSet = false
 		lastClearCache = time.Now()
@@ -433,8 +434,8 @@ func debouncePush(startDebounce time.Time) {
 		V2ClearCache()
 	} else {
 		log.Infof("Push debounce %d: %v since last change, %v since last push",
-			clearCacheEvents,
-			time.Since(lastClearCacheEvent), time.Since(lastClearCache))
+			events,
+			since, time.Since(lastClearCache))
 		time.AfterFunc(DebounceAfter, func() {
 			debouncePush(startDebounce)
 		})


### PR DESCRIPTION
Raised when running racetest locally.