### PR TITLE
Correct authn tls-check for permissive mode.

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -463,11 +463,10 @@ func getServerAuthProtocol(mtls *authn.MutualTls) int {
 	if mtls == nil {
 		return authnHTTP
 	}
-	if mtls.Mode == authn.MutualTls_STRICT {
-		return authnMTls
-	} else {
+	if mtls.Mode == authn.MutualTls_PERMISSIVE {
 		return authnPermissive
 	}
+	return authnMTls
 }
 
 // AuthenticationDebug holds debug information for service authentication policy.


### PR DESCRIPTION
- Show "HTTP/mTLS" for server protocol if authentication policy is permissive mTLS.
- Status should also be `OK` in that case, regardless whether client is in HTTP or mTLS.