### PR TITLE
authz: add TCP support for Istio authorization.

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1169,9 +1169,6 @@ func ValidateServiceRole(name, namespace string, msg proto.Message) error {
 		if len(rule.Services) == 0 {
 			errs = appendErrors(errs, fmt.Errorf("at least 1 service must be specified for rule %d", i))
 		}
-		if len(rule.Methods) == 0 {
-			errs = appendErrors(errs, fmt.Errorf("at least 1 method must be specified for rule %d", i))
-		}
 		for j, constraint := range rule.Constraints {
 			if len(constraint.Key) == 0 {
 				errs = appendErrors(errs, fmt.Errorf("key cannot be empty for constraint %d in rule %d", j, i))

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2750,28 +2750,6 @@ func TestValidateServiceRole(t *testing.T) {
 			expectErrMsg: "at least 1 service must be specified for rule 1",
 		},
 		{
-			name: "no method",
-			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
-				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
-					Constraints: []*rbac.AccessRule_Constraint{
-						{Key: "key", Values: []string{"value"}},
-						{Key: "key", Values: []string{"value"}},
-					},
-				},
-				{
-					Services: []string{"service0"},
-					Methods:  []string{},
-					Constraints: []*rbac.AccessRule_Constraint{
-						{Key: "key", Values: []string{"value"}},
-						{Key: "key", Values: []string{"value"}},
-					},
-				},
-			}},
-			expectErrMsg: "at least 1 method must be specified for rule 1",
-		},
-		{
 			name: "no key in constraint",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -15,11 +15,11 @@
 // Package authz converts Istio RBAC (role-based-access-control) policies (ServiceRole and ServiceRoleBinding)
 // to corresponding filter config that is used by the envoy RBAC filter to enforce access control to
 // the service co-located with envoy.
-// Currently the config is only generated for sidecar node on inbound HTTP listener. The generation
+// Currently the config is only generated for sidecar node on inbound HTTP/TCP listener. The generation
 // is controlled by RbacConfig (a singleton custom resource with cluster scope). User could disable
 // this plugin by either deleting the RbacConfig or set the RbacConfig.mode to OFF.
-// Note: no RbacConfig is created in the deployment of Istio which means this plugin doesn't generate
-// any RBAC config by default.
+// Note: RbacConfig is not created with default istio installation which means this plugin doesn't
+// generate any RBAC config by default.
 package authz
 
 import (
@@ -27,13 +27,11 @@ import (
 	"sort"
 	"strings"
 
-	// Imported so that `dep ensure` do not prune the unused network/rbac/v2 package. Will soon be used
-	// to support the network RBAC filter.
-	_ "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	rbacconfig "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	network_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2"
 	policyproto "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
 	metadata "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 
@@ -50,8 +48,12 @@ var (
 )
 
 const (
-	// rbacFilterName is the name of the RBAC filter in envoy.
-	rbacFilterName = "envoy.filters.http.rbac"
+	// rbacHTTPFilterName is the name of the RBAC http filter in envoy.
+	rbacHTTPFilterName = "envoy.filters.http.rbac"
+
+	// rbacTCPFilterName is the name of the RBAC network filter in envoy.
+	rbacTCPFilterName       = "envoy.filters.network.rbac"
+	rbacTCPFilterStatPrefix = "tcp."
 
 	// attributes that could be used in both ServiceRoleBinding and ServiceRole.
 	attrRequestHeader = "request.headers" // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
@@ -77,6 +79,8 @@ const (
 
 	methodHeader = ":method"
 	pathHeader   = ":path"
+
+	spiffePrefix = "spiffe://"
 )
 
 // serviceMetadata is a collection of different kind of information about a service.
@@ -84,6 +88,12 @@ type serviceMetadata struct {
 	name       string            // full qualified service name, e.g. "productpage.default.svc.cluster.local
 	labels     map[string]string // labels of the service instance
 	attributes map[string]string // additional attributes of the service
+}
+
+type rbacOption struct {
+	roles        []model.Config
+	bindings     []model.Config
+	forTCPFilter bool // The generated config is to be used by the Envoy network filter when true.
 }
 
 func createServiceMetadata(attr *model.ServiceAttributes, in *model.ServiceInstance) *serviceMetadata {
@@ -311,28 +321,36 @@ func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain
 // Can be used to add additional filters (e.g., mixer filter) or add more stuff to the HTTP connection manager
 // on the inbound path
 func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
-	// Only supports sidecar proxy of HTTP listener for now.
-	if in.Node.Type != model.Sidecar || in.ListenerProtocol != plugin.ListenerProtocolHTTP {
+	// Only supports sidecar proxy for now.
+	if in.Node.Type != model.Sidecar {
 		return nil
 	}
 	svc := in.ServiceInstance.Service.Hostname
 	attr := in.ServiceInstance.Service.Attributes
-	//if len(attr) == nil || err != nil {
-	//	rbacLog.Errorf("rbac plugin disabled: invalid service %s: %v", svc, err)
-	//	return nil
-	//}
-
 	if !isRbacEnabled(string(svc), attr.Namespace, in.Env.IstioConfigStore) {
 		return nil
 	}
 
-	service := createServiceMetadata(&attr, in.ServiceInstance)
-	rbacLog.Debugf("building filter config for %v", *service)
-	filter := buildHTTPFilter(service, in.Env.IstioConfigStore)
-	if filter != nil {
-		rbacLog.Infof("built filter config for %s", service.name)
-		for cnum := range mutable.FilterChains {
-			mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, filter)
+	switch in.ListenerProtocol {
+	case plugin.ListenerProtocolTCP:
+		service := createServiceMetadata(&attr, in.ServiceInstance)
+		rbacLog.Debugf("building tcp filter config for %v", *service)
+		filter := buildTCPFilter(service, in.Env.IstioConfigStore)
+		if filter != nil {
+			rbacLog.Infof("built tcp filter config for %s", service.name)
+			for cnum := range mutable.FilterChains {
+				mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, *filter)
+			}
+		}
+	case plugin.ListenerProtocolHTTP:
+		service := createServiceMetadata(&attr, in.ServiceInstance)
+		rbacLog.Debugf("building http filter config for %v", *service)
+		filter := buildHTTPFilter(service, in.Env.IstioConfigStore)
+		if filter != nil {
+			rbacLog.Infof("built http filter config for %s", service.name)
+			for cnum := range mutable.FilterChains {
+				mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, filter)
+			}
 		}
 	}
 
@@ -400,13 +418,12 @@ func isRbacEnabled(svc string, ns string, store model.IstioConfigStore) bool {
 	}
 }
 
-// buildHTTPFilter builds the RBAC http filter that enforces the access control to the specified
-// service which is co-located with the sidecar proxy.
-func buildHTTPFilter(service *serviceMetadata, store model.IstioConfigStore) *http_conn.HttpFilter {
+// rbacPolicyForService returns the (ServiceRole, ServiceRoleBinding, error) for the service.
+func rbacPolicyForService(service *serviceMetadata, store model.IstioConfigStore) (
+	[]model.Config, []model.Config, error) {
 	namespace, present := service.attributes[attrDestNamespace]
 	if !present {
-		rbacLog.Errorf("no namespace for service %v", service)
-		return nil
+		return nil, nil, fmt.Errorf("no namespace for service %v", service)
 	}
 
 	roles := store.ServiceRoles(namespace)
@@ -418,20 +435,11 @@ func buildHTTPFilter(service *serviceMetadata, store model.IstioConfigStore) *ht
 		rbacLog.Infof("no service role binding in namespace %s", namespace)
 	}
 
-	config := convertRbacRulesToFilterConfig(service, roles, bindings)
-	rbacLog.Debugf("generated filter config: %v", *config)
-	return &http_conn.HttpFilter{
-		Name:   rbacFilterName,
-		Config: util.MessageToStruct(config),
-	}
+	return roles, bindings, nil
 }
 
-// convertRbacRulesToFilterConfig converts the current RBAC rules (ServiceRole and ServiceRoleBindings)
-// in service mesh to the corresponding proxy config for the specified service. The generated proxy config
-// will be consumed by envoy RBAC filter to enforce access control on the specified service.
-func convertRbacRulesToFilterConfig(
-	service *serviceMetadata, roles []model.Config, bindings []model.Config) *rbacconfig.RBAC {
-	// roleToBinding maps ServiceRole name to a list of ServiceRoleBindings.
+// roleToBindings returns a map that maps role name to its associated bindings.
+func roleToBindings(bindings []model.Config) map[string][]*rbacproto.ServiceRoleBinding {
 	roleToBinding := map[string][]*rbacproto.ServiceRoleBinding{}
 	for _, binding := range bindings {
 		bindingProto := binding.Spec.(*rbacproto.ServiceRoleBinding)
@@ -443,35 +451,97 @@ func convertRbacRulesToFilterConfig(
 		}
 		roleToBinding[roleName] = append(roleToBinding[roleName], bindingProto)
 	}
+	return roleToBinding
+}
 
+func buildTCPFilter(service *serviceMetadata, store model.IstioConfigStore) *listener.Filter {
+	roles, bindings, err := rbacPolicyForService(service, store)
+	if err != nil {
+		rbacLog.Errorf("failed to get rbac policy: %v", err)
+		return nil
+	}
+
+	// The result of convertRbacRulesToFilterConfig() is wrapped in a config for http filter, here we
+	// need to extract the generated rules and put in a config for network filter.
+	config := convertRbacRulesToFilterConfig(service, rbacOption{roles: roles, bindings: bindings, forTCPFilter: true})
+	tcpConfig := listener.Filter{
+		Name: rbacTCPFilterName,
+		Config: util.MessageToStruct(&network_config.RBAC{
+			Rules:       config.Rules,
+			ShadowRules: config.ShadowRules,
+			StatPrefix:  rbacTCPFilterStatPrefix,
+		}),
+	}
+	rbacLog.Debugf("generated tcp filter config: %v", tcpConfig)
+	return &tcpConfig
+}
+
+// buildHTTPFilter builds the RBAC http filter that enforces the access control to the specified
+// service which is co-located with the sidecar proxy.
+func buildHTTPFilter(service *serviceMetadata, store model.IstioConfigStore) *http_conn.HttpFilter {
+	roles, bindings, err := rbacPolicyForService(service, store)
+	if err != nil {
+		rbacLog.Errorf("failed to get rbac policy: %v", err)
+		return nil
+	}
+
+	config := convertRbacRulesToFilterConfig(service, rbacOption{roles: roles, bindings: bindings, forTCPFilter: false})
+	rbacLog.Debugf("generated http filter config: %v", *config)
+	return &http_conn.HttpFilter{
+		Name:   rbacHTTPFilterName,
+		Config: util.MessageToStruct(config),
+	}
+}
+
+// convertRbacRulesToFilterConfig converts the current RBAC rules (ServiceRole and ServiceRoleBindings)
+// in service mesh to the corresponding proxy config for the specified service. The generated proxy config
+// will be consumed by envoy RBAC filter to enforce access control on the specified service.
+func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption) *http_config.RBAC {
 	rbac := &policyproto.RBAC{
 		Action:   policyproto.RBAC_ALLOW,
 		Policies: map[string]*policyproto.Policy{},
 	}
-
 	permissiveRbac := &policyproto.RBAC{
 		Action:   policyproto.RBAC_ALLOW,
 		Policies: map[string]*policyproto.Policy{},
 	}
 
-	for _, role := range roles {
-		enforcedPrincipals, permissivePrincipals := convertToPrincipals(roleToBinding[role.Name])
-		if len(enforcedPrincipals) == 0 && len(permissivePrincipals) == 0 {
-			rbacLog.Debugf("role skipped for no principals found")
-			continue
-		}
-
+	roleToBindings := roleToBindings(option.bindings)
+	for _, role := range option.roles {
 		rbacLog.Debugf("checking role %v", role.Name)
 		permissions := make([]*policyproto.Permission, 0)
 		for i, rule := range role.Spec.(*rbacproto.ServiceRole).Rules {
 			if service.match(rule) {
-				// Generate the policy if the service is matched to the services specified in ServiceRole.
-				rbacLog.Debugf("matched AccessRule[%d]", i)
-				permissions = append(permissions, convertToPermission(rule))
+				rbacLog.Debugf("rules[%d] matched", i)
+				if option.forTCPFilter {
+					if err := validateRuleForTCPFilter(rule); err != nil {
+						// It's a user misconfiguration if a HTTP rule is specified to a TCP service.
+						// For safety consideration, we ignore the whole rule which means no access is opened to
+						// the TCP service in this case.
+						rbacLog.Errorf("rules[%d] ignored, found HTTP only rule for a TCP service: %v", i, err)
+						continue
+					}
+				}
+				// Generate the policy if the service is matched and validated to the services specified in
+				// ServiceRole.
+				permissions = append(permissions, convertToPermission(rule, option.forTCPFilter))
 			}
 		}
 		if len(permissions) == 0 {
-			rbacLog.Debugf("role skipped for no AccessRule matched")
+			rbacLog.Debugf("role %s skipped for no rule matched", role.Name)
+			continue
+		}
+
+		bindings := roleToBindings[role.Name]
+		if option.forTCPFilter {
+			if err := validateBindingsForTCPFilter(bindings); err != nil {
+				rbacLog.Errorf("role %s skipped, found HTTP only binding for a TCP service: %v", role.Name, err)
+				continue
+			}
+		}
+		enforcedPrincipals, permissivePrincipals := convertToPrincipals(bindings, option.forTCPFilter)
+		if len(enforcedPrincipals) == 0 && len(permissivePrincipals) == 0 {
+			rbacLog.Debugf("role %s skipped for no principals found", role.Name)
 			continue
 		}
 
@@ -490,13 +560,11 @@ func convertRbacRulesToFilterConfig(
 		}
 	}
 
-	return &rbacconfig.RBAC{
-		Rules:       rbac,
-		ShadowRules: permissiveRbac}
+	return &http_config.RBAC{Rules: rbac, ShadowRules: permissiveRbac}
 }
 
 // convertToPermission converts a single AccessRule to a Permission.
-func convertToPermission(rule *rbacproto.AccessRule) *policyproto.Permission {
+func convertToPermission(rule *rbacproto.AccessRule, forTCPFilter bool) *policyproto.Permission {
 	rules := &policyproto.Permission_AndRules{
 		AndRules: &policyproto.Permission_Set{
 			Rules: make([]*policyproto.Permission, 0),
@@ -528,23 +596,29 @@ func convertToPermission(rule *rbacproto.AccessRule) *policyproto.Permission {
 		}
 	}
 
+	if len(rules.AndRules.Rules) == 0 {
+		// None of above rule satisfied means the permission applies to all paths/methods/constraints.
+		rules.AndRules.Rules = append(rules.AndRules.Rules,
+			&policyproto.Permission{Rule: &policyproto.Permission_Any{Any: true}})
+	}
+
 	return &policyproto.Permission{Rule: rules}
 }
 
 // convertToPrincipals converts subjects to two lists of principals, one from enforced mode ServiceBindings,
 // and the other from permissive mode ServiceBindings.
-func convertToPrincipals(bindings []*rbacproto.ServiceRoleBinding) ([]*policyproto.Principal, []*policyproto.Principal) {
+func convertToPrincipals(bindings []*rbacproto.ServiceRoleBinding, forTCPFilter bool) ([]*policyproto.Principal, []*policyproto.Principal) {
 	enforcedPrincipals := make([]*policyproto.Principal, 0)
 	permissivePrincipals := make([]*policyproto.Principal, 0)
 
 	for _, binding := range bindings {
 		if binding.Mode == rbacproto.EnforcementMode_ENFORCED {
 			for _, subject := range binding.Subjects {
-				enforcedPrincipals = append(enforcedPrincipals, convertToPrincipal(subject))
+				enforcedPrincipals = append(enforcedPrincipals, convertToPrincipal(subject, forTCPFilter))
 			}
 		} else {
 			for _, subject := range binding.Subjects {
-				permissivePrincipals = append(permissivePrincipals, convertToPrincipal(subject))
+				permissivePrincipals = append(permissivePrincipals, convertToPrincipal(subject, forTCPFilter))
 			}
 		}
 	}
@@ -553,7 +627,7 @@ func convertToPrincipals(bindings []*rbacproto.ServiceRoleBinding) ([]*policypro
 }
 
 // convertToPrincipal converts a single subject to principal.
-func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
+func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policyproto.Principal {
 	ids := &policyproto.Principal_AndIds{
 		AndIds: &policyproto.Principal_Set{
 			Ids: make([]*policyproto.Principal, 0),
@@ -569,15 +643,32 @@ func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
 				},
 			})
 		} else {
-			// Generate the user field with attrSrcPrincipal in the metadata.
-			id := principalForKeyValue(attrSrcPrincipal, subject.User)
-			if id != nil {
-				ids.AndIds.Ids = append(ids.AndIds.Ids, id)
+			if forTCPFilter {
+				// Generate the user directly in Authenticated principal as metadata is not supported in
+				// TCP filter.
+				// TODO(yangminzhu): Support attrSrcNamespace and attrSrcPrincipal once
+				// https://github.com/envoyproxy/envoy/pull/4250 is merged.
+				ids.AndIds.Ids = append(ids.AndIds.Ids, &policyproto.Principal{
+					Identifier: &policyproto.Principal_Authenticated_{
+						Authenticated: &policyproto.Principal_Authenticated{
+							Name: spiffePrefix + subject.User,
+						},
+					},
+				})
+			} else {
+				// Generate the user field with attrSrcPrincipal in the metadata.
+				id := principalForKeyValue(attrSrcPrincipal, subject.User)
+				if id != nil {
+					ids.AndIds.Ids = append(ids.AndIds.Ids, id)
+				}
 			}
 		}
 	}
 
 	if subject.Group != "" {
+		if subject.Properties == nil {
+			subject.Properties = make(map[string]string)
+		}
 		// Treat subject.Group as the request.auth.claims[groups] property. If
 		// request.auth.claims[groups] has been defined for the subject, subject.Group
 		// overrides request.auth.claims[groups].
@@ -609,6 +700,16 @@ func convertToPrincipal(subject *rbacproto.Subject) *policyproto.Principal {
 				ids.AndIds.Ids = append(ids.AndIds.Ids, id)
 			}
 		}
+	}
+
+	if len(ids.AndIds.Ids) == 0 {
+		// None of above principal satisfied means nobody has the permission.
+		ids.AndIds.Ids = append(ids.AndIds.Ids,
+			&policyproto.Principal{Identifier: &policyproto.Principal_NotId{
+				NotId: &policyproto.Principal{
+					Identifier: &policyproto.Principal_Any{Any: true},
+				},
+			}})
 	}
 
 	return &policyproto.Principal{Identifier: ids}

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -518,7 +518,8 @@ func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption)
 						// It's a user misconfiguration if a HTTP rule is specified to a TCP service.
 						// For safety consideration, we ignore the whole rule which means no access is opened to
 						// the TCP service in this case.
-						rbacLog.Errorf("rules[%d] ignored, found HTTP only rule for a TCP service: %v", i, err)
+						// TODO(yangminzhu): Add metrics for this.
+						rbacLog.Debugf("rules[%d] ignored, found HTTP only rule for a TCP service: %v", i, err)
 						continue
 					}
 				}
@@ -535,7 +536,7 @@ func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption)
 		bindings := roleToBindings[role.Name]
 		if option.forTCPFilter {
 			if err := validateBindingsForTCPFilter(bindings); err != nil {
-				rbacLog.Errorf("role %s skipped, found HTTP only binding for a TCP service: %v", role.Name, err)
+				rbacLog.Debugf("role %s skipped, found HTTP only binding for a TCP service: %v", role.Name, err)
 				continue
 			}
 		}

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -1,0 +1,182 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	policy "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
+	metadata "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+	"github.com/gogo/protobuf/types"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+)
+
+func generateServiceRole(services, methods []string) *rbacproto.ServiceRole {
+	return &rbacproto.ServiceRole{
+		Rules: []*rbacproto.AccessRule{
+			{
+				Services: services,
+				Methods:  methods,
+			},
+		},
+	}
+}
+
+func generateServiceBinding(subject, serviceRoleRef string, mode rbacproto.EnforcementMode) *rbacproto.ServiceRoleBinding {
+	return &rbacproto.ServiceRoleBinding{
+		Mode: mode,
+		Subjects: []*rbacproto.Subject{
+			{
+				User: subject,
+			},
+		},
+		RoleRef: &rbacproto.RoleRef{
+			Kind: "ServiceRole",
+			Name: serviceRoleRef,
+		},
+	}
+}
+
+func generatePermission(headerName, matchSpecifier string) *policy.Permission {
+	return &policy.Permission{
+		Rule: &policy.Permission_AndRules{
+			AndRules: &policy.Permission_Set{
+				Rules: []*policy.Permission{
+					{
+						Rule: &policy.Permission_OrRules{
+							OrRules: &policy.Permission_Set{
+								Rules: []*policy.Permission{
+									{
+										Rule: &policy.Permission_Header{
+											Header: &route.HeaderMatcher{
+												Name: headerName,
+												HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+													ExactMatch: matchSpecifier,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func generateHeaderRule(headers []*route.HeaderMatcher) *policy.Permission_OrRules {
+	rules := &policy.Permission_OrRules{
+		OrRules: &policy.Permission_Set{},
+	}
+	for _, header := range headers {
+		rules.OrRules.Rules = append(rules.OrRules.Rules, &policy.Permission{Rule: &policy.Permission_Header{
+			Header: header,
+		}})
+	}
+	return rules
+}
+
+func generateDestinationPortRule(destinationPort []uint32) *policy.Permission_OrRules {
+	rules := &policy.Permission_OrRules{
+		OrRules: &policy.Permission_Set{},
+	}
+	for _, port := range destinationPort {
+		rules.OrRules.Rules = append(rules.OrRules.Rules, &policy.Permission{
+			Rule: &policy.Permission_DestinationPort{DestinationPort: port}})
+	}
+	return rules
+}
+
+func generateDestinationCidrRule(destinationPrefix []string, PrefixLen []uint32) *policy.Permission_OrRules {
+	rules := &policy.Permission_OrRules{
+		OrRules: &policy.Permission_Set{},
+	}
+	for i := range destinationPrefix {
+		rules.OrRules.Rules = append(rules.OrRules.Rules, &policy.Permission{
+			Rule: &policy.Permission_DestinationIp{
+				DestinationIp: &core.CidrRange{
+					AddressPrefix: destinationPrefix[i],
+					PrefixLen:     &types.UInt32Value{Value: PrefixLen[i]},
+				},
+			}})
+	}
+	return rules
+}
+
+func generatePrincipal(principalName string) *policy.Principal {
+	return &policy.Principal{
+		Identifier: &policy.Principal_AndIds{
+			AndIds: &policy.Principal_Set{
+				Ids: []*policy.Principal{
+					{
+						Identifier: &policy.Principal_Metadata{
+							Metadata: generateMetadataStringMatcher(
+								[]string{"source.principal"}, &metadata.StringMatcher{
+									MatchPattern: &metadata.StringMatcher_Exact{Exact: principalName}}),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *policy.Policy {
+	return &policy.Policy{
+		Permissions: []*policy.Permission{{
+			Rule: &policy.Permission_AndRules{
+				AndRules: &policy.Permission_Set{
+					Rules: []*policy.Permission{
+						{
+							Rule: &policy.Permission_OrRules{
+								OrRules: &policy.Permission_Set{
+									Rules: []*policy.Permission{
+										{
+											Rule: &policy.Permission_Header{
+												Header: &route.HeaderMatcher{
+													Name: ":method",
+													HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{
+														ExactMatch: methodName,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(
+									[]string{attrRequestClaims, "groups"}, claimName),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+}

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -24,6 +24,7 @@ import (
 	rbacproto "istio.io/api/rbac/v1alpha1"
 )
 
+// nolint:deadcode
 func generateServiceRole(services, methods []string) *rbacproto.ServiceRole {
 	return &rbacproto.ServiceRole{
 		Rules: []*rbacproto.AccessRule{
@@ -35,6 +36,7 @@ func generateServiceRole(services, methods []string) *rbacproto.ServiceRole {
 	}
 }
 
+// nolint:deadcode
 func generateServiceBinding(subject, serviceRoleRef string, mode rbacproto.EnforcementMode) *rbacproto.ServiceRoleBinding {
 	return &rbacproto.ServiceRoleBinding{
 		Mode: mode,
@@ -50,6 +52,7 @@ func generateServiceBinding(subject, serviceRoleRef string, mode rbacproto.Enfor
 	}
 }
 
+// nolint:deadcode
 func generatePermission(headerName, matchSpecifier string) *policy.Permission {
 	return &policy.Permission{
 		Rule: &policy.Permission_AndRules{
@@ -79,6 +82,7 @@ func generatePermission(headerName, matchSpecifier string) *policy.Permission {
 	}
 }
 
+// nolint:deadcode
 func generateHeaderRule(headers []*route.HeaderMatcher) *policy.Permission_OrRules {
 	rules := &policy.Permission_OrRules{
 		OrRules: &policy.Permission_Set{},
@@ -91,6 +95,7 @@ func generateHeaderRule(headers []*route.HeaderMatcher) *policy.Permission_OrRul
 	return rules
 }
 
+// nolint:deadcode
 func generateDestinationPortRule(destinationPort []uint32) *policy.Permission_OrRules {
 	rules := &policy.Permission_OrRules{
 		OrRules: &policy.Permission_Set{},
@@ -102,6 +107,7 @@ func generateDestinationPortRule(destinationPort []uint32) *policy.Permission_Or
 	return rules
 }
 
+// nolint:deadcode
 func generateDestinationCidrRule(destinationPrefix []string, PrefixLen []uint32) *policy.Permission_OrRules {
 	rules := &policy.Permission_OrRules{
 		OrRules: &policy.Permission_Set{},
@@ -118,6 +124,7 @@ func generateDestinationCidrRule(destinationPrefix []string, PrefixLen []uint32)
 	return rules
 }
 
+// nolint:deadcode
 func generatePrincipal(principalName string) *policy.Principal {
 	return &policy.Principal{
 		Identifier: &policy.Principal_AndIds{
@@ -136,6 +143,7 @@ func generatePrincipal(principalName string) *policy.Principal {
 	}
 }
 
+// nolint:deadcode
 func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *policy.Policy {
 	return &policy.Policy{
 		Permissions: []*policy.Permission{{

--- a/pilot/pkg/networking/plugin/authz/validate.go
+++ b/pilot/pkg/networking/plugin/authz/validate.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"fmt"
+	"strings"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+)
+
+// validateRuleForTCPFilter checks if the given rule is good for RBAC TCP filter. Returns nil if the
+// rule doesn't include any HTTP specifications.
+func validateRuleForTCPFilter(rule *rbacproto.AccessRule) error {
+	if rule == nil {
+		return nil
+	}
+
+	if len(rule.Paths) != 0 {
+		return fmt.Errorf("paths(%v) not supported", rule.Paths)
+	}
+	if len(rule.Methods) != 0 {
+		return fmt.Errorf("methods(%v) not supported", rule.Methods)
+	}
+	for _, constraint := range rule.Constraints {
+		if strings.HasPrefix(constraint.Key, attrRequestHeader) {
+			return fmt.Errorf("constraint(%v) not supported", constraint)
+		}
+	}
+
+	return nil
+}
+
+// validateBindingsForTCPFilter checks if the give binding is good for RBAC TCP filter. Returns nil
+// if the binding doesn't include any HTTP specifications.
+func validateBindingsForTCPFilter(bindings []*rbacproto.ServiceRoleBinding) error {
+	for _, binding := range bindings {
+		for _, subject := range binding.Subjects {
+			if subject.Group != "" {
+				return fmt.Errorf("group(%v) not supported", subject.Group)
+			}
+			for k := range subject.Properties {
+				switch k {
+				case attrSrcIP:
+					// TODO(yangminzhu): Support attrSrcNamespace and attrSrcPrincipal once
+					// https://github.com/envoyproxy/envoy/pull/4250 is merged.
+					continue
+				default:
+					return fmt.Errorf("property(%v) not supported", k)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pilot/pkg/networking/plugin/authz/validate_test.go
+++ b/pilot/pkg/networking/plugin/authz/validate_test.go
@@ -1,0 +1,132 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"testing"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+)
+
+func TestValidateRule(t *testing.T) {
+	testCases := []struct {
+		name    string
+		rule    *rbacproto.AccessRule
+		success bool
+	}{
+		{
+			name:    "nil rule",
+			success: true,
+		},
+		{
+			name: "rule with path",
+			rule: &rbacproto.AccessRule{
+				Paths: []string{"/"},
+			},
+		},
+		{
+			name: "rule with method",
+			rule: &rbacproto.AccessRule{
+				Methods: []string{"GET"},
+			},
+		},
+		{
+			name: "rule with unsupported constraint",
+			rule: &rbacproto.AccessRule{
+				Constraints: []*rbacproto.AccessRule_Constraint{
+					{
+						Key:    attrDestIP,
+						Values: []string{"1.2.3.4"},
+					},
+					{
+						Key:    attrRequestHeader,
+						Values: []string{"TOKEN"},
+					},
+				},
+			},
+		},
+		{
+			name: "good rule",
+			rule: &rbacproto.AccessRule{
+				Constraints: []*rbacproto.AccessRule_Constraint{
+					{
+						Key:    attrDestIP,
+						Values: []string{"1.2.3.4"},
+					},
+					{
+						Key:    attrDestPort,
+						Values: []string{"80"},
+					},
+				},
+			},
+			success: true,
+		},
+	}
+	for _, tc := range testCases {
+		ret := validateRuleForTCPFilter(tc.rule)
+		if tc.success != (ret == nil) {
+			t.Errorf("%s: expecting %v bot got %v", tc.name, tc.success, ret)
+		}
+	}
+}
+
+func TestValidateBinding(t *testing.T) {
+	testCases := []struct {
+		name     string
+		bindings []*rbacproto.ServiceRoleBinding
+		success  bool
+	}{
+		{
+			name:    "empty bindings",
+			success: true,
+		},
+		{
+			name: "binding with group",
+			bindings: []*rbacproto.ServiceRoleBinding{
+				{
+					Subjects: []*rbacproto.Subject{
+						{Group: "group"},
+					},
+				},
+			},
+		},
+		{
+			name: "binding with unsupported property",
+			bindings: []*rbacproto.ServiceRoleBinding{
+				{
+					Subjects: []*rbacproto.Subject{
+						{Properties: map[string]string{attrSrcNamespace: "ns"}},
+					},
+				},
+			},
+		},
+		{
+			name: "good binding",
+			bindings: []*rbacproto.ServiceRoleBinding{
+				{
+					Subjects: []*rbacproto.Subject{
+						{User: "user", Properties: map[string]string{attrSrcNamespace: "ns"}},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		ret := validateBindingsForTCPFilter(tc.bindings)
+		if tc.success != (ret == nil) {
+			t.Errorf("%s: expecting %v bot got %v", tc.name, tc.success, ret)
+		}
+	}
+}


### PR DESCRIPTION
The core idea is that we'll try to generate both TCP and HTTP filter config for a single ServiceRole\ServiceRoleBinding. We will validate if the ServiceRole\ServiceRoleBinding is valid for TCP and ignore it if it's not.

* Tested manually, will refactor and update the RBAC e2e tests in a following PR
* Will update the docs, tasks and samples in a following PR

/cc @rshriram 