### PR TITLE
dep ensure --update fortio.org/fortio

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -39,7 +39,7 @@
   version = "v0.5.0"
 
 [[projects]]
-  digest = "1:c1cdf31e8b0454e518f59226b222b48aec62a884015304e5b82a704bef056cd3"
+  digest = "1:ca58755cd68a0c97d7d2791b0123c10a119f6384fa222b439c74a2aed49b470a"
   name = "fortio.org/fortio"
   packages = [
     ".",
@@ -54,8 +54,8 @@
     "version",
   ]
   pruneopts = "T"
-  revision = "36bffaa50c7cc47038fc7572c83221640a603425"
-  version = "v1.2.0"
+  revision = "4a5012fb92ee87ecbdd80ed2cb031f5cf9c50cbc"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:add5f01e863553e80ded66e1cba646ad947932e66f90813741d51c97a1ee7a59"

--- a/vendor/fortio.org/fortio/.circleci/config.yml
+++ b/vendor/fortio.org/fortio/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2
 defaultEnv: &defaultEnv
     docker:
       # specify the version
-      - image: docker.io/fortio/fortio.build:v10
+      - image: docker.io/fortio/fortio.build:v11
     working_directory: /go/src/fortio.org/fortio
 
 jobs:

--- a/vendor/fortio.org/fortio/CONTRIBUTING.md
+++ b/vendor/fortio.org/fortio/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing to Fortio
+
+Contributions whether through issues, documentation, bug fixes, or new features
+are most welcome !
+
+Please also see [Contributing to Istio](https://github.com/istio/community/blob/master/CONTRIBUTING.md#contributing-to-istio)
+and [Getting started contributing to Fortio](https://github.com/fortio/fortio/wiki/FAQ#how-do-i-get-started-contributing-to-fortio) in the FAQ.
+

--- a/vendor/fortio.org/fortio/Dockerfile
+++ b/vendor/fortio.org/fortio/Dockerfile
@@ -1,12 +1,12 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v10 as build
+FROM docker.io/fortio/fortio.build:v11 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # Submodule handling
 RUN make -C fortio submodule
 # We moved a lot of the logic into the Makefile so it can be reused in brew
 # but that also couples the 2, this expects to find binaries in the right place etc
-RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_BIN=../fortio_go1.10.bin
+RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_BIN=../fortio_go_latest.bin
 # Check we still build with go 1.8 (and macos does not break)
 RUN make -C fortio official-build BUILD_DIR=/build OFFICIAL_BIN=../fortio_go1.8.mac GOOS=darwin GO_BIN=/usr/local/go/bin/go
 # Optionally (comment out) Build with 1.8 for perf comparison
@@ -21,9 +21,9 @@ FROM scratch as release
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /go/src/fortio.org/fortio/ui/static /usr/local/lib/fortio/static
 COPY --from=build /go/src/fortio.org/fortio/ui/templates /usr/local/lib/fortio/templates
-#COPY --from=build /go/src/fortio.org/fortio_go1.10.bin /usr/local/bin/fortio_go1.10
+#COPY --from=build /go/src/fortio.org/fortio_go_latest.bin /usr/local/bin/fortio_go_latest
 #COPY --from=build /go/src/fortio.org/fortio_go1.8.bin /usr/local/bin/fortio_go1.8
-COPY --from=build /go/src/fortio.org/fortio_go1.10.bin /usr/local/bin/fortio
+COPY --from=build /go/src/fortio.org/fortio_go_latest.bin /usr/local/bin/fortio
 EXPOSE 8079
 EXPOSE 8080
 EXPOSE 8081

--- a/vendor/fortio.org/fortio/Dockerfile.build
+++ b/vendor/fortio.org/fortio/Dockerfile.build
@@ -5,16 +5,18 @@ RUN apt-get -y update && \
   apt-get --no-install-recommends -y upgrade && \
   apt-get --no-install-recommends -y install ca-certificates curl make git gcc \
   libc6-dev apt-transport-https ssh
-# Install both go1.10.3 and go1.8.7 so we don't become incompatible with 1.8
+# Install both go1.11, go1.10.3 and go1.8.7 so we don't become incompatible with 1.8
 RUN curl -f https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz | tar xfz - -C /usr/local
 # Newer go have no problem with being installed in random directories without requiring GOROOT so we
-# leave the old go in /usr/local and put the new one, despite being preferred, in a different root:
+# leave the old go in /usr/local and put the new ones, despite being preferred, in a different root:
 RUN mkdir /go1.10
 RUN curl -f https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz | tar xfz - -C /go1.10
+RUN mkdir /go1.11
+RUN curl -f https://dl.google.com/go/go1.11.linux-amd64.tar.gz | tar xfz - -C /go1.11
 ENV GOPATH /go
 RUN mkdir -p $GOPATH/bin
 # We do pick the latest go first in the path
-ENV PATH /go1.10/go/bin:/usr/local/go/bin:$PATH:$GOPATH/bin
+ENV PATH /go1.11/go/bin:/usr/local/go/bin:$PATH:$GOPATH/bin
 RUN go version # check it's indeed the version we expect
 # This is now handled through dep and vendor submodule
 # RUN go get -u google.golang.org/grpc

--- a/vendor/fortio.org/fortio/Dockerfile.echosrv
+++ b/vendor/fortio.org/fortio/Dockerfile.echosrv
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v10 as build
+FROM docker.io/fortio/fortio.build:v11 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio official-build-version BUILD_DIR=/build OFFICIAL_TARGET=fortio.org/fortio/echosrv OFFICIAL_BIN=../echosrv.bin

--- a/vendor/fortio.org/fortio/Dockerfile.fcurl
+++ b/vendor/fortio.org/fortio/Dockerfile.fcurl
@@ -1,5 +1,5 @@
 # Build the binaries in larger image
-FROM docker.io/fortio/fortio.build:v10 as build
+FROM docker.io/fortio/fortio.build:v11 as build
 WORKDIR /go/src/fortio.org
 COPY . fortio
 # fcurl should not need vendor/no dependencies

--- a/vendor/fortio.org/fortio/Dockerfile.test
+++ b/vendor/fortio.org/fortio/Dockerfile.test
@@ -1,5 +1,5 @@
 # Getting the source tree ready for running tests (sut)
-FROM docker.io/fortio/fortio.build:v10
+FROM docker.io/fortio/fortio.build:v11
 WORKDIR /go/src/fortio.org
 COPY . fortio
 RUN make -C fortio dependencies

--- a/vendor/fortio.org/fortio/Makefile
+++ b/vendor/fortio.org/fortio/Makefile
@@ -7,7 +7,7 @@
 IMAGES=echosrv fcurl # plus the combo image / Dockerfile without ext.
 
 DOCKER_PREFIX := docker.io/fortio/fortio
-BUILD_IMAGE_TAG := v10
+BUILD_IMAGE_TAG := v11
 BUILD_IMAGE := $(DOCKER_PREFIX).build:$(BUILD_IMAGE_TAG)
 
 TAG:=$(USER)$(shell date +%y%m%d_%H%M%S)
@@ -52,13 +52,14 @@ test: dependencies
 
 local-lint: dependencies vendor.check
 	gometalinter $(DEBUG_LINTERS) \
-	--deadline=180s --enable-all --aggregate \
-	--exclude=.pb.go --disable=gocyclo --disable=gas --line-length=132 \
-	$(LINT_PACKAGES)
+	--deadline=180s --enable-all --aggregate --exclude=.pb.go \
+	--disable=gocyclo --disable=gas --disable=gosec \
+	--disable=gochecknoglobals --disable=gochecknoinits \
+	--line-length=132 $(LINT_PACKAGES)
 
 # Lint everything by default but ok to "make lint LINT_PACKAGES=./fhttp"
 LINT_PACKAGES:=$(PACKAGES)
-# TODO: do something about cyclomatic complexity; maybe reenable gas
+# TODO: do something about cyclomatic complexity; maybe reenable gas and gosec
 # Note CGO_ENABLED=0 is needed to avoid errors as gcc isn't part of the
 # build image
 lint: dependencies
@@ -164,7 +165,7 @@ release: dependencies
 BUILD_DIR := /tmp/fortio_build
 LIB_DIR := /usr/local/lib/fortio
 DATA_DIR := /var/lib/fortio
-OFFICIAL_BIN := ../fortio_go1.10.bin
+OFFICIAL_BIN := ../fortio.bin
 GOOS := 
 GO_BIN := go
 GIT_STATUS := $(strip $(shell git status --porcelain | wc -l))

--- a/vendor/fortio.org/fortio/README.md
+++ b/vendor/fortio.org/fortio/README.md
@@ -7,7 +7,8 @@
 [![CircleCI](https://circleci.com/gh/fortio/fortio.svg?style=shield)](https://circleci.com/gh/fortio/fortio)
 <img src="https://fortio.org/fortio-logo-color.png" height=141 width=141 align=right>
 
-Fortio (Φορτίο) started as [Istio](https://istio.io/)'s load testing tool and now graduated to be its own project.
+Fortio (Φορτίο) started as, and is, [Istio](https://istio.io/)'s load testing tool and now graduated to be its own project.
+
 Fortio runs at a specified query per second (qps) and records an histogram of execution time
 and calculates percentiles (e.g. p99 ie the response time such as 99% of the requests take less than that number (in seconds, SI unit)).
 It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).
@@ -279,7 +280,7 @@ Content-Type: text/plain; charset=UTF-8
 Date: Wed, 08 Aug 2018 22:00:48 GMT
 Content-Length: 231
 
-Φορτίο version 1.2.0 unknown go1.10.3 echo debug server up for 2m3.4s on ldemailly-macbookpro.roam.corp.google.com - request from
+Φορτίο version 1.2.0 unknown go1.10.3 echo debug server up for 2m3.4s on ldemailly-macbookpro - request from
 
 GET /debug HTTP/1.1
 
@@ -347,7 +348,7 @@ Using server key /path/to/fortio/server.key to construct TLS credentials
 ```
 
 * Next, use `grpcping` with the `-cacert` flag:
-  
+
 `/path/to/fortio/ca.crt` is the path to the CA certificate
 that issued the server certificate for `localhost`. In our example, the server certificate is
 `/path/to/fortio/server.crt`:
@@ -673,7 +674,7 @@ Code 429 : 56 (1.9 %)
 Code 503 : 15 (0.5 %)
 ```
 
-There are newer/live examples on [istio.io/docs/performance-and-scalability/synthetic-benchmarks/](https://istio.io/docs/performance-and-scalability/synthetic-benchmarks/)
+There are newer/live examples on [istio.io/docs/concepts/performance-and-scalability/#synthetic-end-to-end-benchmarks](https://istio.io/docs/concepts/performance-and-scalability/#synthetic-end-to-end-benchmarks)
 
 ## Contributing
 
@@ -702,3 +703,7 @@ standard --fix ui/static/js/fortio_chart.js
 ## See also
 
 Our wiki and the [Fortio FAQ](https://github.com/fortio/fortio/wiki/FAQ) (including for instance differences between `fortio` and `wrk` or `httpbin`)
+
+## Disclaimer
+
+This is not an officially supported Google product.

--- a/vendor/fortio.org/fortio/Webtest.sh
+++ b/vendor/fortio.org/fortio/Webtest.sh
@@ -1,4 +1,17 @@
 #! /bin/bash
+# Copyright 2017 Istio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 set -x
 # Check we can build the image
 make docker-internal TAG=webtest || exit 1
@@ -78,7 +91,7 @@ docker exec $DOCKERNAME /usr/local/bin/fortio grpcping localhost
 PPROF_URL="$BASE_URL/debug/pprof/heap?debug=1"
 $CURL $PPROF_URL | grep -i TotalAlloc # should find this in memory profile
 # creating dummy container to hold a volume for test certs due to remote docker bind mount limitation.
-DOCKERVOLID=$(docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v10 /bin/true)
+DOCKERVOLID=$(docker create -v $TEST_CERT_VOL --name $DOCKERSECVOLNAME docker.io/fortio/fortio.build:v11 /bin/true)
 # copying cert files into the certs volume of the dummy container
 for f in ca.crt server.crt server.key; do docker cp $PWD/cert-tmp/$f $DOCKERSECVOLNAME:$TEST_CERT_VOL/$f; done
 # start server in secure grpc mode. uses non-default ports to avoid conflicts with fortio_server container.

--- a/vendor/fortio.org/fortio/bincommon/commonflags.go
+++ b/vendor/fortio.org/fortio/bincommon/commonflags.go
@@ -49,11 +49,11 @@ func (f *headersFlagList) Set(value string) error {
 // FlagsUsage prints end of the usage() (flags part + error message).
 func FlagsUsage(w io.Writer, msgs ...interface{}) {
 	// nolint: gas
-	fmt.Fprintf(w, "flags are:\n")
+	_, _ = fmt.Fprintf(w, "flags are:\n")
 	flag.CommandLine.SetOutput(w)
 	flag.PrintDefaults()
 	if len(msgs) > 0 {
-		fmt.Fprintln(w, msgs...) // nolint: gas
+		_, _ = fmt.Fprintln(w, msgs...)
 	}
 }
 

--- a/vendor/fortio.org/fortio/fcurl/fcurl.go
+++ b/vendor/fortio.org/fortio/fcurl/fcurl.go
@@ -30,7 +30,7 @@ import (
 // Prints usage
 func usage(w io.Writer, msgs ...interface{}) {
 	// nolint: gas
-	fmt.Fprintf(w, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
+	_, _ = fmt.Fprintf(w, "Φορτίο fortio-curl %s usage:\n\t%s [flags] url\n",
 		version.Short(),
 		os.Args[0])
 	bincommon.FlagsUsage(w, msgs...)

--- a/vendor/fortio.org/fortio/fgrpc/grpcrunner.go
+++ b/vendor/fortio.org/fortio/fgrpc/grpcrunner.go
@@ -246,7 +246,7 @@ func RunGRPCTest(o *GRPCRunnerOptions) (*GRPCRunnerResults, error) {
 		which = "Ping"
 	}
 	for _, k := range keys {
-		fmt.Fprintf(out, "%s %s : %d\n", which, k, total.RetCodes[k])
+		_, _ = fmt.Fprintf(out, "%s %s : %d\n", which, k, total.RetCodes[k])
 	}
 	return &total, nil
 }

--- a/vendor/fortio.org/fortio/fhttp/http_client.go
+++ b/vendor/fortio.org/fortio/fhttp/http_client.go
@@ -71,7 +71,11 @@ func (h *HTTPOptions) Init(url string) *HTTPOptions {
 	h.initDone = true
 	h.URL = url
 	h.NumConnections = 1
-	if h.HTTPReqTimeOut <= 0 {
+	if h.HTTPReqTimeOut == 0 {
+		log.Debugf("Request timeout not set, using default %v", HTTPReqTimeOutDefaultValue)
+		h.HTTPReqTimeOut = HTTPReqTimeOutDefaultValue
+	}
+	if h.HTTPReqTimeOut < 0 {
 		log.Warnf("Invalid timeout %v, setting to %v", h.HTTPReqTimeOut, HTTPReqTimeOutDefaultValue)
 		h.HTTPReqTimeOut = HTTPReqTimeOutDefaultValue
 	}

--- a/vendor/fortio.org/fortio/fhttp/httprunner.go
+++ b/vendor/fortio.org/fortio/fhttp/httprunner.go
@@ -137,7 +137,7 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 		runtime.GC()               // get up-to-date statistics
 		pprof.WriteHeapProfile(fm) // nolint:gas,errcheck
 		fm.Close()                 // nolint:gas,errcheck
-		fmt.Fprintf(out, "Wrote profile data to %s.{cpu|mem}\n", o.Profiler)
+		_, _ = fmt.Fprintf(out, "Wrote profile data to %s.{cpu|mem}\n", o.Profiler)
 	}
 	// Numthreads may have reduced but it should be ok to accumulate 0s from
 	// unused ones. We also must cleanup all the created clients.
@@ -158,9 +158,9 @@ func RunHTTPTest(o *HTTPRunnerOptions) (*HTTPRunnerResults, error) {
 	r.Options().ReleaseRunners()
 	sort.Ints(keys)
 	totalCount := float64(total.DurationHistogram.Count)
-	fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
+	_, _ = fmt.Fprintf(out, "Sockets used: %d (for perfect keepalive, would be %d)\n", total.SocketCount, r.Options().NumThreads)
 	for _, k := range keys {
-		fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
+		_, _ = fmt.Fprintf(out, "Code %3d : %d (%.1f %%)\n", k, total.RetCodes[k], 100.*float64(total.RetCodes[k])/totalCount)
 	}
 	total.HeaderSizes = total.headerSizes.Export()
 	total.Sizes = total.sizes.Export()

--- a/vendor/fortio.org/fortio/fortio_main.go
+++ b/vendor/fortio.org/fortio/fortio_main.go
@@ -55,7 +55,7 @@ func (f *proxiesFlagList) Set(value string) error {
 
 // Usage to a writer
 func usage(w io.Writer, msgs ...interface{}) {
-	fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
+	_, _ = fmt.Fprintf(w, "Φορτίο %s usage:\n\t%s command [flags] target\n%s\n%s\n%s\n%s\n",
 		version.Short(),
 		os.Args[0],
 		"where command is one of: load (load testing), server (starts grpc ping and",
@@ -241,17 +241,17 @@ func fortioLoad(justCurl bool, percList []float64) {
 	prevGoMaxProcs := runtime.GOMAXPROCS(*goMaxProcsFlag)
 	out := os.Stderr
 	qps := *qpsFlag // TODO possibly use translated <=0 to "max" from results/options normalization in periodic/
-	fmt.Fprintf(out, "Fortio %s running at %g queries per second, %d->%d procs",
+	_, _ = fmt.Fprintf(out, "Fortio %s running at %g queries per second, %d->%d procs",
 		version.Short(), qps, prevGoMaxProcs, runtime.GOMAXPROCS(0))
 	if *exactlyFlag > 0 {
-		fmt.Fprintf(out, ", for %d calls: %s\n", *exactlyFlag, url)
+		_, _ = fmt.Fprintf(out, ", for %d calls: %s\n", *exactlyFlag, url)
 	} else {
 		if *durationFlag <= 0 {
 			// Infinite mode is determined by having a negative duration value
 			*durationFlag = -1
-			fmt.Fprintf(out, ", until interrupted: %s\n", url)
+			_, _ = fmt.Fprintf(out, ", until interrupted: %s\n", url)
 		} else {
-			fmt.Fprintf(out, ", for %v: %s\n", *durationFlag, url)
+			_, _ = fmt.Fprintf(out, ", for %v: %s\n", *durationFlag, url)
 		}
 	}
 	if qps <= 0 {
@@ -307,7 +307,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 		res, err = fhttp.RunHTTPTest(&o)
 	}
 	if err != nil {
-		fmt.Fprintf(out, "Aborting because %v\n", err)
+		_, _ = fmt.Fprintf(out, "Aborting because %v\n", err)
 		os.Exit(1)
 	}
 	rr := res.Result()
@@ -315,7 +315,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 	if ro.Exactly > 0 {
 		warmup = 0
 	}
-	fmt.Fprintf(out, "All done %d calls (plus %d warmup) %.3f ms avg, %.1f qps\n",
+	_, _ = fmt.Fprintf(out, "All done %d calls (plus %d warmup) %.3f ms avg, %.1f qps\n",
 		rr.DurationHistogram.Count,
 		warmup,
 		1000.*rr.DurationHistogram.Avg,
@@ -350,7 +350,7 @@ func fortioLoad(justCurl bool, percList []float64) {
 				log.Fatalf("Close error for %s: %v", jsonFileName, err)
 			}
 		}
-		fmt.Fprintf(out, "Successfully wrote %d bytes of Json data to %s\n", n, jsonFileName)
+		_, _ = fmt.Fprintf(out, "Successfully wrote %d bytes of Json data to %s\n", n, jsonFileName)
 	}
 }
 

--- a/vendor/fortio.org/fortio/periodic/periodic.go
+++ b/vendor/fortio.org/fortio/periodic/periodic.go
@@ -327,20 +327,20 @@ func (r *periodicRunner) Run() RunnerResults {
 				leftOver = r.Exactly - totalCalls
 				if log.Log(log.Warning) {
 					// nolint: gas
-					fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] : exactly %d, %d calls each (total %d + %d)\n",
+					_, _ = fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] : exactly %d, %d calls each (total %d + %d)\n",
 						r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Exactly, numCalls, totalCalls, leftOver)
 				}
 			} else {
 				if log.Log(log.Warning) {
 					// nolint: gas
-					fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
+					_, _ = fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] for %v : %d calls each (total %d)\n",
 						r.QPS, r.NumThreads, runtime.GOMAXPROCS(0), r.Duration, numCalls, totalCalls)
 				}
 			}
 		} else {
 			// Always print that as we need ^C to interrupt, in that case the user need to notice
 			// nolint: gas
-			fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] until interrupted\n",
+			_, _ = fmt.Fprintf(r.Out, "Starting at %g qps with %d thread(s) [gomax %d] until interrupted\n",
 				r.QPS, r.NumThreads, runtime.GOMAXPROCS(0))
 			numCalls = 0
 		}
@@ -348,12 +348,12 @@ func (r *periodicRunner) Run() RunnerResults {
 		if !useExactly && !hasDuration {
 			// Always log something when waiting for ^C
 			// nolint: gas
-			fmt.Fprintf(r.Out, "Starting at max qps with %d thread(s) [gomax %d] until interrupted\n",
+			_, _ = fmt.Fprintf(r.Out, "Starting at max qps with %d thread(s) [gomax %d] until interrupted\n",
 				r.NumThreads, runtime.GOMAXPROCS(0))
 		} else {
 			if log.Log(log.Warning) {
 				// nolint: gas
-				fmt.Fprintf(r.Out, "Starting at max qps with %d thread(s) [gomax %d] ",
+				_, _ = fmt.Fprintf(r.Out, "Starting at max qps with %d thread(s) [gomax %d] ",
 					r.NumThreads, runtime.GOMAXPROCS(0))
 			}
 			if useExactly {
@@ -362,13 +362,13 @@ func (r *periodicRunner) Run() RunnerResults {
 				leftOver = r.Exactly % int64(r.NumThreads)
 				if log.Log(log.Warning) {
 					// nolint: gas
-					fmt.Fprintf(r.Out, "for %s (%d per thread + %d)\n", requestedDuration, numCalls, leftOver)
+					_, _ = fmt.Fprintf(r.Out, "for %s (%d per thread + %d)\n", requestedDuration, numCalls, leftOver)
 				}
 			} else {
 				requestedDuration = fmt.Sprint(r.Duration)
 				if log.Log(log.Warning) {
 					// nolint: gas
-					fmt.Fprintf(r.Out, "for %s\n", requestedDuration)
+					_, _ = fmt.Fprintf(r.Out, "for %s\n", requestedDuration)
 				}
 			}
 		}
@@ -419,7 +419,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	actualQPS := float64(functionDuration.Count) / elapsed.Seconds()
 	if log.Log(log.Warning) {
 		// nolint: gas
-		fmt.Fprintf(r.Out, "Ended after %v : %d calls. qps=%.5g\n", elapsed, functionDuration.Count, actualQPS)
+		_, _ = fmt.Fprintf(r.Out, "Ended after %v : %d calls. qps=%.5g\n", elapsed, functionDuration.Count, actualQPS)
 	}
 	if useQPS {
 		percentNegative := 100. * float64(sleepTime.Hdata[0]) / float64(sleepTime.Count)
@@ -428,7 +428,7 @@ func (r *periodicRunner) Run() RunnerResults {
 		// user.
 		if percentNegative > 5 {
 			sleepTime.Print(r.Out, "Aggregated Sleep Time", []float64{50})
-			fmt.Fprintf(r.Out, "WARNING %.2f%% of sleep were falling behind\n", percentNegative) // nolint: gas
+			_, _ = fmt.Fprintf(r.Out, "WARNING %.2f%% of sleep were falling behind\n", percentNegative) // nolint: gas
 		} else {
 			if log.Log(log.Verbose) {
 				sleepTime.Print(r.Out, "Aggregated Sleep Time", []float64{50})
@@ -448,7 +448,7 @@ func (r *periodicRunner) Run() RunnerResults {
 	} else {
 		functionDuration.Counter.Print(r.Out, "Aggregated Function Time")
 		for _, p := range result.DurationHistogram.Percentiles {
-			fmt.Fprintf(r.Out, "# target %g%% %.6g\n", p.Percentile, p.Value) // nolint: gas
+			_, _ = fmt.Fprintf(r.Out, "# target %g%% %.6g\n", p.Percentile, p.Value) // nolint: gas
 		}
 	}
 	select {

--- a/vendor/fortio.org/fortio/release/Dockerfile.in
+++ b/vendor/fortio.org/fortio/release/Dockerfile.in
@@ -1,5 +1,5 @@
 # Concatenated after ../Dockerfile to create the tgz
-FROM docker.io/fortio/fortio.build:v10 as stage
+FROM docker.io/fortio/fortio.build:v11 as stage
 WORKDIR /stage
 COPY --from=release /usr/local usr/local
 RUN mkdir -p var/lib/fortio

--- a/vendor/fortio.org/fortio/release/release.sh
+++ b/vendor/fortio.org/fortio/release/release.sh
@@ -1,4 +1,18 @@
 #! /bin/bash
+# Copyright 2017 Istio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # To be run by ../Makefile as release/release.sh
 set -x
 set -e

--- a/vendor/fortio.org/fortio/release/updateFlags.sh
+++ b/vendor/fortio.org/fortio/release/updateFlags.sh
@@ -1,4 +1,18 @@
 #! /bin/bash
+# Copyright 2017 Istio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Extract fortio's help and rewrap it to 80 cols
 # TODO: do like fmt does to keep leading identation
 fortio help | expand | fold -s | sed -e "s/ $//"

--- a/vendor/fortio.org/fortio/stats/stats.go
+++ b/vendor/fortio.org/fortio/stats/stats.go
@@ -78,7 +78,7 @@ func (c *Counter) StdDev() float64 {
 
 // Print prints stats.
 func (c *Counter) Print(out io.Writer, msg string) {
-	fmt.Fprintf(out, "%s : count %d avg %.8g +/- %.4g min %g max %g sum %.9g\n", // nolint(errorcheck)
+	_, _ = fmt.Fprintf(out, "%s : count %d avg %.8g +/- %.4g min %g max %g sum %.9g\n", // nolint(errorcheck)
 		msg, c.Count, c.Avg(), c.StdDev(), c.Min, c.Max, c.Sum)
 }
 
@@ -387,25 +387,24 @@ func (e *HistogramData) CalcPercentiles(percentiles []float64) *HistogramData {
 // Also calculates the percentile.
 func (e *HistogramData) Print(out io.Writer, msg string) {
 	if len(e.Data) == 0 {
-		fmt.Fprintf(out, "%s : no data\n", msg) // nolint: gas
+		_, _ = fmt.Fprintf(out, "%s : no data\n", msg) // nolint: gas
 		return
 	}
 	// the base counter part:
-	fmt.Fprintf(out, "%s : count %d avg %.8g +/- %.4g min %g max %g sum %.9g\n", // nolint(errorcheck)
+	_, _ = fmt.Fprintf(out, "%s : count %d avg %.8g +/- %.4g min %g max %g sum %.9g\n",
 		msg, e.Count, e.Avg, e.StdDev, e.Min, e.Max, e.Sum)
-	fmt.Fprintln(out, "# range, mid point, percentile, count") // nolint: gas
+	_, _ = fmt.Fprintln(out, "# range, mid point, percentile, count")
 	sep := ">="
 	for i, b := range e.Data {
 		if i > 0 {
 			sep = ">" // last interval is inclusive (of max value)
 		}
-		// nolint: gas
-		fmt.Fprintf(out, "%s %.6g <= %.6g , %.6g , %.2f, %d\n", sep, b.Start, b.End, (b.Start+b.End)/2., b.Percent, b.Count)
+		_, _ = fmt.Fprintf(out, "%s %.6g <= %.6g , %.6g , %.2f, %d\n", sep, b.Start, b.End, (b.Start+b.End)/2., b.Percent, b.Count)
 	}
 
 	// print the information of target percentiles
 	for _, p := range e.Percentiles {
-		fmt.Fprintf(out, "# target %g%% %.6g\n", p.Percentile, p.Value) // nolint: gas
+		_, _ = fmt.Fprintf(out, "# target %g%% %.6g\n", p.Percentile, p.Value) // nolint: gas
 	}
 }
 

--- a/vendor/fortio.org/fortio/version/version.go
+++ b/vendor/fortio.org/fortio/version/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	major = 1
 	minor = 2
-	patch = 0
+	patch = 1
 
 	debug = false // turn on to debug init()
 )


### PR DESCRIPTION
to get 1.2.1 (small bug fix over 1.2.0) also to confirm it's easy/working to upgrade fortio

ps: somehow the first invocation of `dep ensure --update fortio.org/fortio` failed with
```
$ dep ensure --update fortio.org/fortio
Solving failure: Could not introduce go.opencensus.io@v0.14.0, as it has a dependency on github.com/prometheus/client_golang with constraint >=0.8.0, which does not allow the currently selected version of v0.9.0-pre1
```
2nd exact same invocation just worked...

this was with
```
$ dep version
dep:
 version     : v0.5.0
 build date  : 2018-07-26
 git hash    : 224a564
 go version  : go1.10.3
 go compiler : gc
 platform    : darwin/amd64
 features    : ImportDuringSolve=false
```
(ie the latest release from the dep install script)