### PR TITLE
Bug fix and perf improvements.

### DIFF
--- a/mixer/pkg/protobuf/yaml/encoder.go
+++ b/mixer/pkg/protobuf/yaml/encoder.go
@@ -45,9 +45,34 @@ func (e *Encoder) EncodeBytes(data map[string]interface{}, msgName string, skipU
 	buf := GetBuffer()
 	defer func() { PutBuffer(buf) }()
 
+	if err := e.coreEncodeBytes(buf, data, msgName, skipUnknown); err != nil {
+		return nil, err
+	}
+
+	original := buf.Bytes()
+	result := make([]byte, len(original), len(original))
+	copy(result, original)
+	return result, nil
+}
+
+// encodeBytes updates a proto.Buffer from a yaml representation of a proto.
+func (e *Encoder) encodeBytes(data map[string]interface{}, msgName string, skipUnknown bool, dest *proto.Buffer) error {
+	buf := GetBuffer()
+	defer func() { PutBuffer(buf) }()
+
+	if err := e.coreEncodeBytes(buf, data, msgName, skipUnknown); err != nil {
+		return err
+	}
+
+	_ = dest.EncodeRawBytes(buf.Bytes())
+	return nil
+}
+
+// coreEncodeBytes updates a proto.Buffer from a yaml representation of a proto.
+func (e *Encoder) coreEncodeBytes(buf *proto.Buffer, data map[string]interface{}, msgName string, skipUnknown bool) error {
 	message := e.resolver.ResolveMessage(msgName)
 	if message == nil {
-		return nil, fmt.Errorf("cannot resolve message '%s'", msgName)
+		return fmt.Errorf("cannot resolve message '%s'", msgName)
 	}
 	for k, v := range data {
 		fd := FindFieldByName(message, k)
@@ -55,14 +80,15 @@ func (e *Encoder) EncodeBytes(data map[string]interface{}, msgName string, skipU
 			if skipUnknown {
 				continue
 			}
-			return nil, fmt.Errorf("field '%s' not found in message '%s'", k, message.GetName())
+			return fmt.Errorf("field '%s' not found in message '%s'", k, message.GetName())
 		}
 
 		if err := e.visit(k, v, fd, skipUnknown, buf); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return buf.Bytes(), nil
+
+	return nil
 }
 
 func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDescriptorProto, skipUnknown bool, buffer *proto.Buffer) error {
@@ -795,13 +821,12 @@ func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDe
 				tmpMapEntry := make(map[string]interface{}, 2)
 				tmpMapEntry["key"] = key
 				tmpMapEntry["value"] = val
-				bytes, err := e.EncodeBytes(tmpMapEntry, field.GetTypeName(), skipUnknown)
-				if err != nil {
-					return fmt.Errorf("/%s: '%v'", fmt.Sprintf("%s[%v]", name, key), err)
-				}
 
 				_ = buffer.EncodeVarint(encodeIndexAndType(fieldNumber, wireType))
-				_ = buffer.EncodeRawBytes(bytes)
+
+				if err := e.encodeBytes(tmpMapEntry, field.GetTypeName(), skipUnknown, buffer); err != nil {
+					return fmt.Errorf("/%s: '%v'", fmt.Sprintf("%s[%v]", name, key), err)
+				}
 			}
 		} else if repeated {
 			// 	generated proto code for repeated message fields
@@ -829,13 +854,11 @@ func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDe
 				if !ok {
 					return badTypeError(fmt.Sprintf("%s[%d]", name, i), tName, iface)
 				}
-				bytes, err := e.EncodeBytes(c, field.GetTypeName(), skipUnknown)
-				if err != nil {
-					return fmt.Errorf("/%s: '%v'", fmt.Sprintf("%s[%d]", name, i), err)
-				}
 
 				_ = buffer.EncodeVarint(encodeIndexAndType(fieldNumber, wireType))
-				_ = buffer.EncodeRawBytes(bytes)
+				if err := e.encodeBytes(c, field.GetTypeName(), skipUnknown, buffer); err != nil {
+					return fmt.Errorf("/%s: '%v'", fmt.Sprintf("%s[%d]", name, i), err)
+				}
 			}
 		} else {
 			// 	generated proto code for field of message type
@@ -848,26 +871,25 @@ func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDe
 			//		return 0, err
 			//	}
 			//	i += n1
-			var bytes []byte
-			var err error
+			_ = buffer.EncodeVarint(encodeIndexAndType(fieldNumber, wireType))
+
 			ne := e.namedEncoder[field.GetTypeName()]
 			if ne != nil {
-				bytes, err = ne(data)
+				bytes, err := ne(data)
+				if err != nil {
+					return fmt.Errorf("/%s: '%v'", name, err)
+				}
+				buffer.EncodeRawBytes(bytes)
 			} else {
 				v, ok := data.(map[string]interface{})
 				if !ok {
 					return badTypeError(name, strings.TrimPrefix(field.GetTypeName(), "."), data)
 				}
 
-				bytes, err = e.EncodeBytes(v, field.GetTypeName(), skipUnknown)
+				if err := e.encodeBytes(v, field.GetTypeName(), skipUnknown, buffer); err != nil {
+					return fmt.Errorf("/%s: '%v'", name, err)
+				}
 			}
-
-			if err != nil {
-				return fmt.Errorf("/%s: '%v'", name, err)
-			}
-
-			_ = buffer.EncodeVarint(encodeIndexAndType(fieldNumber, wireType))
-			_ = buffer.EncodeRawBytes(bytes)
 
 			return nil
 		}

--- a/mixer/pkg/runtime/handler/signature.go
+++ b/mixer/pkg/runtime/handler/signature.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 
+	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/pkg/log"
 )
 
@@ -57,7 +58,7 @@ func calculateSignature(handler hndlr, insts interface{}) signature {
 	}
 	sort.Strings(instanceNames)
 
-	buf := new(bytes.Buffer)
+	buf := pool.GetBuffer()
 	encoded := true
 
 	encoded = encoded && encode(buf, handler.AdapterName())
@@ -73,10 +74,11 @@ func calculateSignature(handler hndlr, insts interface{}) signature {
 
 	if encoded {
 		sha := sha1.Sum(buf.Bytes())
-		buf.Reset()
+		pool.PutBuffer(buf)
 		return sha
 	}
 
+	pool.PutBuffer(buf)
 	return zeroSignature
 }
 


### PR DESCRIPTION
- Use a buffer pool when computing signatures in runtime/handler

- Fix a bug in protobuf yaml code where it was using a byte[] from a pooled buffer
even after having put the buffer back into a pool, leading to racy behavior.