### PR TITLE
Add kubeadm support for test/e2e/local

### DIFF
--- a/tests/e2e/local/kubeadm/README.md
+++ b/tests/e2e/local/kubeadm/README.md
@@ -1,0 +1,77 @@
+# Benefits:
+1. Set up a local kubeadm environment once and run E2E tests on local machine, so you can test and debug locally.
+1. No need to worry about kubernetes cluster setup.
+
+# Prereqs:
+1. Set up Istio Dev environment using https://github.com/istio/istio/wiki/Dev-Guide.
+
+1. Install
+  * [docker](https://docs.docker.com/)
+  * [kubeadm](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
+  * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - Verify `kubectl version` returns both server and client versions
+  * [curl](https://curl.haxx.se/) - Verify `curl --help` prints the help information.
+  * [crictl](https://github.com/kubernetes-incubator/cri-tools) - Verify `crictl version` returns version >= 1.11
+  * [kubectl](https://kubernetes.io/docs/setup/independent/install-kubeadm/)
+
+You can run the following script to check/install of all pre-requisites, or use it as a reference to install them manually.
+(This requires installation of [Homebrew](https://brew.sh) on MacOS or debian based Linux distributions)
+
+```bash
+. ./install_prereqs.sh
+```
+
+# Steps
+## 1. Set up kubeadm Environment
+```bash
+. ./setup_host.sh
+```
+
+## 2. Build Istio images
+Build images on your host machine:
+```bash
+. ./setup_test.sh
+```
+
+## 2. Run tests!
+You can issue test commands on your host machine.
+E.g.
+```bash
+cd $ISTIO/istio
+make e2e_simple E2E_ARGS="--use_local_cluster" HUB=localhost:5000 TAG=latest
+```
+Note the special arguments like **E2E_ARGS**, **HUB**, and **TAG**. They are required to run these tests with the local cluster and a local registry inside the VM. And you can run multiple E2E tests sequentially against the same VM.
+The script has a number of options available [here](../../README.md#options-for-e2e-tests)
+
+# Cleanup
+To destroy the kubeadm:
+```bash
+kubeadm reset
+``` 
+
+To cleanup host settings only (remove docker daemon setup and port forwarding)
+```bash
+. ./cleanup_host.sh
+```
+### Debug with KubeSquash
+You can try debugging Istio with debugger tool [KubeSquash](https://github.com/solo-io/kubesquash). 
+For example, if you want to debug discovery container in pilot, follow steps as follows:
+1. Run that test in your host/vm.
+   ```bash
+   # In the VM/Host
+   make e2e_simple E2E_ARGS="--use_local_cluster --skip_cleanup" HUB=10.10.0.2:5000 TAG=latest
+   ```
+1. Run the kubesquash binary
+1. Select the namespace of istio mesh: istio-system
+1. Select Pilot Pod from the pods list
+1. Select discovery container after that
+1. You will get a prompt like `Going to attach dlv to pod istio-pilot-67db57c96d-c86ff. continue? `. Say Yes
+
+After this delve would be attached to discovery container for you to debug.
+
+For more information on debugging with delve, please check [Debug an Istio container with Delve](https://github.com/istio/istio/wiki/Dev-Guide#debug-an-istio-container-with-delve)
+
+# Troubleshooting
+Please refer [Troubleshooting](Troubleshooting.md) doc for information on this.
+
+# Tips
+Please refer [Tips](../Tips.md) doc for some suggestions that we have found useful for debugging with e2e tests.

--- a/tests/e2e/local/kubeadm/cleanup_host.sh
+++ b/tests/e2e/local/kubeadm/cleanup_host.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Delete namespace istio-system if exists
+kubectl delete namespace istio-system > /dev/null 2>&1
+

--- a/tests/e2e/local/kubeadm/install_prereqs.sh
+++ b/tests/e2e/local/kubeadm/install_prereqs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+case "${OSTYPE}" in
+  linux*)
+    DISTRO="$(lsb_release -i -s)"
+    case "${DISTRO}" in
+      Debian|Ubuntu)
+        ./install_prereqs_debian.sh;;
+      *) echo "unsupported distro: ${DISTRO}" ;;
+    esac;;
+  *) echo "unsupported: ${OSTYPE}" ;;
+esac

--- a/tests/e2e/local/kubeadm/install_prereqs_debian.sh
+++ b/tests/e2e/local/kubeadm/install_prereqs_debian.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+SCRIPTPATH="$(cd "$(dirname "$0")" || exit; pwd -P)"
+ROOTDIR="$(dirname "${SCRIPTPATH}")"
+# shellcheck source=tests/e2e/local/common_linux.sh
+source "${ROOTDIR}/common_linux.sh"
+
+check_apt_get
+
+install_curl
+
+install_docker
+
+# install crictl
+CRICTL_VERSION="v1.11.1"
+curl -LO https://github.com/kubernetes-incubator/cri-tools/releases/download/$CRICTL_VERSION/crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+sudo tar zxvf crictl-$CRICTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+rm -f crictl-$CRICTL_VERSION-linux-amd64.tar.gz
+
+# install kubelet kubeadm kubectl via apt-get way
+sudo apt-get install -y apt-transport-https
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+sudo apt-get --quiet -y update
+sudo apt-get install -y kubelet kubeadm kubectl
+sudo apt-mark hold kubelet kubeadm kubectl
+
+echo "Everything installed for you and you are ready to go!"

--- a/tests/e2e/local/kubeadm/setup_host.sh
+++ b/tests/e2e/local/kubeadm/setup_host.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+echo "Starting kubeadm."
+# In order for Network Policy to work correctly, you need to pass --pod-network-cidr=192.168.0.0/16 to kubeadm init.
+kubeadm init --pod-network-cidr=192.168.0.0/16  --node-name=e2e-test-local
+
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+# By default, cluster created by kubeadm will not schedule pods on the master.  If we want to be able to
+# schedule pods on the master, e.g. for a single-machine Kubernetes cluster for development, run:
+kubectl taint nodes --all node-role.kubernetes.io/master-
+
+# Install Calico. Note that Calico works on amd64 only.
+kubectl apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+kubectl apply -f https://docs.projectcalico.org/v3.1/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml
+
+while ! kubectl get pods -n kube-system | grep coredns |  grep Running > /dev/null; do
+  echo "coredns not ready, will check again in 5 sec"
+  sleep 5
+done
+
+# Set up env ISTIO if not done yet
+if [[ -z "${ISTIO// }" ]]; then
+  if [[ -z "${GOPATH// }" ]]; then
+    echo GOPATH is not set. Please set and run script again.
+    exit
+  fi
+  export ISTIO=$GOPATH/src/istio.io
+  echo 'Set ISTIO to' "$ISTIO"
+fi
+
+echo "Host Setup Completed"

--- a/tests/e2e/local/kubeadm/setup_test.sh
+++ b/tests/e2e/local/kubeadm/setup_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Remove old imges.
+docker images 10.10.0.2:5000/*:latest -q | xargs docker rmi
+
+# Make and Push images to insecure local registry on VM.
+# Set GOOS=linux to make sure linux binaries are built on MacOS
+cd "$ISTIO/istio" || exit
+GOOS=linux make docker HUB=10.10.0.2:5000 TAG=latest
+GOOS=linux make push HUB=10.10.0.2:5000 TAG=latest
+
+# Verify images are pushed in repository.
+echo "Check images present in repositories"
+curl 10.10.0.2:5000/v2/_catalog
+echo "Setup done."


### PR DESCRIPTION
Add kubeadm support for test/e2e/local. Currently, this PR only covers debian/ubuntu platform.

Fixes: #8167

**NOTE:** This PR only works for debian platform and will support MacOS and CentOS in follow-ups.