### PR TITLE
Fix cache invalidation for remote clusters (#8344)

### DIFF
--- a/pilot/pkg/config/clusterregistry/secretcontroller.go
+++ b/pilot/pkg/config/clusterregistry/secretcontroller.go
@@ -242,8 +242,8 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 				})
 			stopCh := make(chan struct{})
 			c.cs.rc[clusterID].ControlChannel = stopCh
-			_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { c.discoveryServer.ClearCacheFunc() })
-			_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { c.discoveryServer.ClearCacheFunc() })
+			_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { c.discoveryServer.ClearCacheFunc()() })
+			_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { c.discoveryServer.ClearCacheFunc()() })
 			go kubectl.Run(stopCh)
 		} else {
 			log.Infof("Cluster %s in the secret %s in namespace %s already exists",


### PR DESCRIPTION
Fix issue #8343
The returned function from ClearCacheFunc() was not called and the
cache was not invalidated when changes took place. Made the fix to
call the returned function.

(cherry picked from commit d3a9dd27e1b5cfa182f6c171370fee94071be791)