### PR TITLE
Fix in cluster registry to work on multiple nodes cluster

### DIFF
--- a/tests/util/localregistry/README.md
+++ b/tests/util/localregistry/README.md
@@ -7,6 +7,7 @@ Istio by allowing a developer to push docker images locally rather than to some 
 To run the local registry in your kubernetes cluster:
 
 ```shell
+$ kubectl create ns docker-registry
 $ kubectl apply -f ./tests/util/localregistry/localregistry.yaml
 ```
 
@@ -15,19 +16,21 @@ $ kubectl apply -f ./tests/util/localregistry/localregistry.yaml
 After the registry server is running, expose it locally by executing:
 
 ```shell
-$ kubectl port-forward --namespace kube-system $POD 5000:5000
+$ kubectl port-forward --namespace docker-registry $POD 5000:5000
 ```
 
 If you're testing locally with minikube, `$POD` can be set with:
 
 ```shell
-$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+$ POD=$(kubectl get pods --namespace docker-registry -l k8s-app=kube-registry \
   -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
   | grep Running | head -1 | cut -f1 -d' ')
 ```
 
 ### Push Local Images
 
+Note that on GKE nodes, localhost does not seem to resolve to 127.0.0.1, so you
+should use 127.0.0.1 instead of localhost in all the following shell calls.
 Build and push the Istio docker images to the local registry, by running:
 
 ```shell

--- a/tests/util/localregistry/localregistry.yaml
+++ b/tests/util/localregistry/localregistry.yaml
@@ -1,27 +1,24 @@
 # after creating the local registry, to push images to it you need to open up a port to the pod's registry:
-# $ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+# $ POD=$(kubectl get pods --namespace docker-registry -l k8s-app=kube-registry \
 #               -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
 #               | grep Running | head -1 | cut -f1 -d' ')
-# $ kubectl port-forward --namespace kube-system $POD 5000:5000
+# $ kubectl port-forward --namespace docker-registry $POD 5000:5000
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
-  name: kube-registry-v0
-  namespace: kube-system
-  labels:
-    k8s-app: kube-registry
-    version: v0
+  name: kube-registry
+  namespace: docker-registry
 spec:
-  replicas: 1
   selector:
-    k8s-app: kube-registry
-    version: v0
+    matchLabels:
+      k8s-app: kube-registry
+  replicas: 1
+  serviceName: kube-registry
   template:
     metadata:
       labels:
         k8s-app: kube-registry
-        version: v0
     spec:
       containers:
       - name: registry
@@ -50,10 +47,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kube-registry
-  namespace: kube-system
+  namespace: docker-registry
   labels:
     k8s-app: kube-registry
-    kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
     k8s-app: kube-registry
@@ -62,27 +58,32 @@ spec:
     port: 5000
     protocol: TCP
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: DaemonSet
 metadata:
   name: kube-registry-proxy
-  namespace: kube-system
+  namespace: docker-registry
+  labels:
+    k8s-app: kube-registry
 spec:
-  containers:
-  - name: kube-registry-proxy
-    image: gcr.io/google_containers/kube-registry-proxy:0.3
-    resources:
-      limits:
-        cpu: 100m
-        memory: 50Mi
-    env:
-    - name: REGISTRY_HOST
-      value: kube-registry
-    - name: REGISTRY_PORT
-      value: "5000"
-    - name: FORWARD_PORT
-      value: "5000"
-    ports:
-    - name: registry
-      containerPort: 5000
-      hostPort: 5000
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-registry-proxy
+    spec:
+      containers:
+      - name: kube-registry-proxy
+        image: gcr.io/google_containers/kube-registry-proxy:0.4
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+        env:
+        - name: REGISTRY_HOST
+          value: kube-registry.docker-registry.svc.cluster.local
+        - name: REGISTRY_PORT
+          value: "5000"
+        ports:
+        - name: registry
+          containerPort: 80
+          hostPort: 5000

--- a/tests/util/localregistry/localregistry.yaml
+++ b/tests/util/localregistry/localregistry.yaml
@@ -5,7 +5,7 @@
 # $ kubectl port-forward --namespace docker-registry $POD 5000:5000
 
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: kube-registry
   namespace: docker-registry
@@ -14,7 +14,6 @@ spec:
     matchLabels:
       k8s-app: kube-registry
   replicas: 1
-  serviceName: kube-registry
   template:
     metadata:
       labels:


### PR DESCRIPTION
1. Update the registry to be on its own namespace as pods were being deleted in the kube-system namespace.

1. Use a statefulset as we can only have one Pod running the registry since we use an emptyDir volume.

1. Use a daemon set to proxy the registry service on every node, such that its considered local, and therefore no need to update docker configuration on every node to allow for insecure registry.