### PR TITLE
Update Proxy SHA to latest with reverted TCP proxy changes (release-1.0).

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "2656f34080413d3aec444aa659cc78057508c57b"
+		"lastStableSHA": "99cfc3f74c414dd4fa4aa784a0f8b13e22b81893"
 	}
 ]


### PR DESCRIPTION
Pulling the following changes from github.com/istio/proxy:

99cfc3f Update Envoy SHA to latest with reverted TCP proxy changes (release-1.0). (#1956)

Pulling the following changes from github.com/istio/envoy:

2d8386532 Disable broken thrift_proxy tests for TCP connection pool.
828847db1 Revert "tcp_proxy: convert TCP proxy to use TCP connection pool (#4067)"

Fixes istio/istio#8310.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>