### PR TITLE
Add grafana persist option to istio helm chart (#7553)

### DIFF
--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -96,6 +96,8 @@ Helm charts expose configuration options which are currently in alpha.  The curr
 | `mixer.enabled` | Specifies whether Mixer should be installed | true/false | `true` |
 | `pilot.enabled` | Specifies whether Pilot should be installed | true/false | `true` |
 | `grafana.enabled` | Specifies whether Grafana addon should be installed | true/false | `false` |
+| `grafana.persist` | Specifies whether Grafana addon should persist config data | true/false | `false` |
+| `grafana.storageClassName` | If `grafana.persist` is true, specifies the [`StorageClass`](https://kubernetes.io/docs/concepts/storage/storage-classes/) to use for the `PersistentVolumeClaim` | `StorageClass` | "" |
 | `prometheus.enabled` | Specifies whether Prometheus addon should be installed | true/false | `true` |
 | `servicegraph.enabled` | Specifies whether Servicegraph addon should be installed | true/false | `false` |
 | `tracing.enabled` | Specifies whether Tracing(jaeger) addon should be installed | true/false | `false` |

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -78,4 +78,9 @@ spec:
       {{- include "nodeaffinity" . | indent 6 }}
       volumes:
       - name: data
+{{- if .Values.persist }}
+        persistentVolumeClaim:
+          claimName: istio-grafana-pvc
+{{- else }}
         emptyDir: {}
+{{- end }}

--- a/install/kubernetes/helm/istio/charts/grafana/templates/pvc.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persist }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: istio-grafana-pvc
+  labels:
+    app: {{ template "grafana.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  storageClassName: {{ .Values.storageClassName }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+{{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -408,6 +408,8 @@ grafana:
   enabled: false
   replicaCount: 1
   image: grafana
+  persist: false
+  storageClassName: ""
   security:
     enabled: false
     adminUser: admin


### PR DESCRIPTION
On pod death, the current grafana chart does not persist any
configuration changes made in the UI (like adding alerts).
This adds a boolean option `grafana.persist` to create a
`PersistentVolumeClaim` that mounts to the existing grafana
data volume.

There is an additional option for `storageClassName` to override the
default storage class.

* Moved storageClassName to values.yaml instead of default operator