### PR TITLE
Add the namespace to the grafana secret

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: grafana
+  namespace: {{ .Release.Namespace }}
   labels:
     app: grafana
 type: Opaque


### PR DESCRIPTION
Secret has been created in the default namespace instead of Istio's.

This has been indirectly fixed in master with #7719 but issue still exists in this branch.
Fixes #8429