### PR TITLE
Intruduce portforward lib into test-framework

### DIFF
--- a/pkg/test/framework/components/mixer/mixer.go
+++ b/pkg/test/framework/components/mixer/mixer.go
@@ -17,16 +17,16 @@ package mixer
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
-
-	"io"
 
 	istio_mixer_v1 "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/adapter"
@@ -142,9 +142,12 @@ func (c *kubeComponent) Init(ctx environment.ComponentContext, deps map[dependen
 	// TODO: Right now, simply connect to the telemetry backend at port 9092. We can expand this to connect
 	// to policy backend and dynamically figure out ports later.
 	// See https://github.com/istio/istio/issues/6175
-	forwarder := kube.NewPortForwarder(e.KubeSettings().KubeConfig, pod.Namespace, pod.Name, 9092)
-
-	if err = forwarder.Start(); err != nil {
+	options := &kube.PodSelectOptions{
+		PodNamespace: pod.Namespace,
+		PodName:      pod.Name,
+	}
+	forwarder, err := kube.PortForward(e.KubeSettings().KubeConfig, options, "", strconv.Itoa(9092))
+	if err != nil {
 		return nil, err
 	}
 
@@ -175,7 +178,7 @@ type deployedMixer struct {
 	server  *server.Server
 	workdir string
 
-	forwarder *kube.PortForwarder
+	forwarder kube.PortForwarder
 }
 
 // Report implements DeployedMixer.Report.

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -16,13 +16,13 @@ package pilot
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"strconv"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	adsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"google.golang.org/grpc"
-
-	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 
@@ -118,7 +118,7 @@ type localPilot struct {
 
 type kubePilot struct {
 	*pilotClient
-	forwarder *kube.PortForwarder
+	forwarder kube.PortForwarder
 }
 
 // NewLocalPilot creates a new pilot for the local environment.
@@ -177,8 +177,12 @@ func NewLocalPilot(namespace string) (LocalPilot, error) {
 func NewKubePilot(kubeConfig, namespace, pod string) (environment.DeployedPilot, error) {
 	// Start port-forwarding for pilot.
 	// TODO(nmittler): Don't use a hard-coded port.
-	forwarder := kube.NewPortForwarder(kubeConfig, namespace, pod, pilotAdsPort)
-	if err := forwarder.Start(); err != nil {
+	options := &kube.PodSelectOptions{
+		PodNamespace: namespace,
+		PodName:      pod,
+	}
+	forwarder, err := kube.PortForward(kubeConfig, options, "", strconv.Itoa(pilotAdsPort))
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/test/kube/forwarder.go
+++ b/pkg/test/kube/forwarder.go
@@ -1,107 +1,206 @@
-//  Copyright 2018 Istio Authors
+// Copyright 2018 Istio Authors
 //
-//  Licensed under the Apache License, Version 2.0 (the "License");
-//  you may not use this file except in compliance with the License.
-//  You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Unless required by applicable law or agreed to in writing, software
-//  distributed under the License is distributed on an "AS IS" BASIS,
-//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//  See the License for the specific language governing permissions and
-//  limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package kube
 
 import (
-	"context"
+	"bytes"
+	"errors"
 	"fmt"
-	"os/exec"
+	"net/http"
+	"os"
 	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+
+	kubelib "istio.io/istio/pkg/kube"
 )
 
-// TODO: Consider replacing this code with a direct call to the underlying client library, or wrapping
-// the executable call in a shell function, so that the process doesn't end up running indefinitely in case
-// of abrupt end to the test run.
-// See https://github.com/istio/istio/issues/6173
-
-// PortForwarder represents a locally started kubectl process that forwards a local port to one within the
-// cluster.
-type PortForwarder struct {
-	ctx     context.Context
-	cancel  context.CancelFunc
-	cmd     *exec.Cmd
-	address string
-	target  string
+// PortForwarder is a wrapper for port forward.
+type PortForwarder interface {
+	ForwardPorts() error
+	Address() string
+	Close()
 }
 
-// NewPortForwarder returns a new PortForwarder the specified port in the given namespace/pod.
-func NewPortForwarder(kubeconfig string, ns string, pod string, port int) *PortForwarder {
-	command := fmt.Sprintf("kubectl port-forward --kubeconfig=%s -n %s %s :%d", kubeconfig, ns, pod, port)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
-
-	return &PortForwarder{
-		ctx:    ctx,
-		cancel: cancel,
-		cmd:    cmd,
-		target: fmt.Sprintf("%s/%s (%d)", ns, pod, port),
-	}
+type defaultPortForwarder struct {
+	forwarder *portforward.PortForwarder
+	readyCh   <-chan struct{}
+	address   string
+	output    *bytes.Buffer
 }
 
-// Address is the local address for the port forwarder.
-func (p *PortForwarder) Address() string {
-	return p.address
+// PodSelectOptions contains options for pod selection.
+// Must specify PodNamespace and one of PodName/LabelSelector.
+type PodSelectOptions struct {
+	PodNamespace  string
+	PodName       string
+	LabelSelector string
 }
 
-// Start the port forwarder.
-func (p *PortForwarder) Start() error {
-	pipe, err := p.cmd.StdoutPipe()
-	if err != nil {
-		panic("")
-	}
-	if err != nil {
-		return err
-	}
+func (f *defaultPortForwarder) ForwardPorts() error {
+	errCh := make(chan error)
+	go func() {
+		errCh <- f.forwarder.ForwardPorts()
+	}()
 
-	err = p.cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	// Parse the first line from kubectl to scrape the local address.
-	buffer := make([]byte, 4096)
-	pos := 0
-	_, err = retry(defaultTimeout, defaultRetryWait, func() (interface{}, bool, error) {
-
-		ptr := buffer[pos:]
-		n, err2 := pipe.Read(ptr)
-		if err2 != nil {
-			_ = p.cmd.Process.Kill()
-			return nil, true, err2
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("failure running port forward process: %v", err)
+	case <-f.readyCh:
+		address, err := extractAddress(f.output.String())
+		if err != nil {
+			return err
 		}
-		pos += n
-		s := string(buffer[0:pos])
-		if strings.Contains(s, "\n") {
-			s = s[len("Forwarding from "):]
-			parts := strings.Split(s, "->")
-			p.address = strings.TrimSpace(parts[0])
-			scope.Debugf("Starting port forward: %s => %s", p.address, p.target)
-			return nil, true, nil
-		}
-
-		return nil, false, nil
-	})
-
-	return err
+		f.address = address
+		return nil
+	}
 }
 
-// Close the port forwarder.
-func (p *PortForwarder) Close() {
-	p.cancel()
-	if p.cmd != nil {
-		_ = p.cmd.Wait()
+func (f *defaultPortForwarder) Address() string {
+	return f.address
+}
+
+func (f *defaultPortForwarder) Close() {
+	f.forwarder.Close()
+}
+
+// NewPortForwarder return a new PortForwarder instance.
+func NewPortForwarder(client *rest.RESTClient, config *rest.Config, options *PodSelectOptions, ports string) (PortForwarder, error) {
+	if err := validatePodSelectOptions(options); err != nil {
+		return nil, err
 	}
+	podName := options.PodName
+	if podName == "" {
+		// Retrieve pod according to labelSelector if pod name not specified.
+		pod, err := getSelectedPod(client, options)
+		if err != nil {
+			return nil, err
+		}
+		podName = pod.Name
+	}
+
+	req := client.Post().Resource("pods").Namespace(options.PodNamespace).Name(podName).SubResource("portforward")
+
+	transport, upgrader, err := spdy.RoundTripperFor(config)
+	if err != nil {
+		return nil, fmt.Errorf("failure creating roundtripper: %v", err)
+	}
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	stopCh := make(chan struct{})
+	readyCh := make(chan struct{})
+	output := bytes.NewBuffer(make([]byte, 4096))
+	fw, err := portforward.New(dialer, []string{ports}, stopCh, readyCh, output, os.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("failed establishing port-forward: %v", err)
+	}
+
+	return &defaultPortForwarder{
+		forwarder: fw,
+		readyCh:   readyCh,
+		output:    output,
+	}, nil
+}
+
+// getSelectedPod retrieves pods according to given options.
+func getSelectedPod(client *rest.RESTClient, options *PodSelectOptions) (*v1.Pod, error) {
+	podGet := client.Get().Resource("pods").Namespace(options.PodNamespace).Param("labelSelector", options.LabelSelector)
+	obj, err := podGet.Do().Get()
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving pod: %v", err)
+	}
+
+	podList := obj.(*v1.PodList)
+	if len(podList.Items) < 1 {
+		return nil, errors.New("no corresponding pods found")
+	}
+
+	return &podList.Items[0], nil
+}
+
+// validatePodSelectOptions test if given PodSelectOptions is valid.
+func validatePodSelectOptions(options *PodSelectOptions) error {
+	if options.PodNamespace == "" {
+		return fmt.Errorf("no pod namespace specified")
+	}
+	if options.PodName == "" && options.LabelSelector == "" {
+		return fmt.Errorf("neither pod name nor label selector specified")
+	}
+
+	return nil
+}
+
+func extractAddress(output string) (string, error) {
+	// TODO: improve this when we have multi port inputs.
+	if strings.Contains(output, "\n") {
+		output = output[len("Forwarding from "):]
+		parts := strings.Split(output, "->")
+		return strings.TrimSpace(parts[0]), nil
+	}
+
+	return "", fmt.Errorf("failed to get address from output: %s", output)
+}
+
+// NewRestClient return rest client with default config.
+// TODO: remove this when we have common rest client library in test-framework.
+func NewRestClient(kubeconfig, configContext string) (*rest.RESTClient, *rest.Config, error) {
+	config, err := defaultRestConfig(kubeconfig, configContext)
+	if err != nil {
+		return nil, nil, err
+	}
+	restClient, err := rest.RESTClientFor(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return restClient, config, nil
+}
+
+func defaultRestConfig(kubeconfig, configContext string) (*rest.Config, error) {
+	config, err := kubelib.BuildClientConfig(kubeconfig, configContext)
+	if err != nil {
+		return nil, err
+	}
+	config.APIPath = "/api"
+	config.GroupVersion = &v1.SchemeGroupVersion
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: scheme.Codecs}
+	return config, nil
+}
+
+// PortForward is an utility function to help construct port forwarder.
+// TODO(lichuqiang): find a better place for it.
+func PortForward(kubeconfig string, options *PodSelectOptions, localPort, remotePort string) (PortForwarder, error) {
+	rc, config, err := NewRestClient(kubeconfig, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kube client: %v", err)
+	}
+
+	ports := localPort + ":" + remotePort
+	forwarder, err := NewPortForwarder(rc, config, options, ports)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create port forwarder: %v", err)
+	}
+
+	if err := forwarder.ForwardPorts(); err != nil {
+		return nil, fmt.Errorf("error in port forward: %v", err)
+	}
+
+	return forwarder, nil
 }

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -41,6 +41,7 @@ import (
 	"fortio.org/fortio/periodic"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/e2e/framework"
 	"istio.io/istio/tests/util"
 )
@@ -294,7 +295,7 @@ func deleteAllRoutingConfig() error {
 
 type promProxy struct {
 	namespace        string
-	portFwdProcesses []*os.Process
+	portFwdProcesses []kube.PortForwarder
 }
 
 func newPromProxy(namespace string) *promProxy {
@@ -354,25 +355,17 @@ func podLogs(labelSelector string, container string) {
 
 // portForward sets up local port forward to the pod specified by the "app" label
 func (p *promProxy) portForward(labelSelector string, localPort string, remotePort string) error {
-	var pod string
-	var err error
-	var proc *os.Process
-
-	getName := fmt.Sprintf("kubectl -n %s get pod -l %s -o jsonpath='{.items[0].metadata.name}'", p.namespace, labelSelector)
-	pod, err = util.Shell(getName)
-	if err != nil {
-		return err
-	}
-	log.Infof("%s pod name: %s", labelSelector, pod)
-
 	log.Infof("Setting up %s proxy", labelSelector)
-	portFwdCmd := fmt.Sprintf("kubectl port-forward %s %s:%s -n %s", strings.Trim(pod, "'"), localPort, remotePort, p.namespace)
-	log.Info(portFwdCmd)
-	if proc, err = util.RunBackground(portFwdCmd); err != nil {
-		log.Errorf("Failed to port forward: %s", err)
+	options := &kube.PodSelectOptions{
+		PodNamespace:  p.namespace,
+		LabelSelector: labelSelector,
+	}
+	forwarder, err := kube.PortForward(tc.Kube.KubeConfig, options, localPort, remotePort)
+	if err != nil {
+		log.Errorf("Error in port forward: %v", err)
 		return err
 	}
-	p.portFwdProcesses = append(p.portFwdProcesses, proc)
+	p.portFwdProcesses = append(p.portFwdProcesses, forwarder)
 
 	// Give it some time since process is launched in the background
 	time.Sleep(3 * time.Second)
@@ -381,7 +374,7 @@ func (p *promProxy) portForward(labelSelector string, localPort string, remotePo
 		return err
 	}
 
-	log.Infof("running %s port-forward in background, pid = %d", labelSelector, proc.Pid)
+	log.Infof("running %s port-forward in background", labelSelector)
 	return nil
 }
 
@@ -405,11 +398,8 @@ func (p *promProxy) Setup() error {
 
 func (p *promProxy) Teardown() (err error) {
 	log.Info("Cleaning up mixer proxy")
-	for _, proc := range p.portFwdProcesses {
-		err := proc.Kill()
-		if err != nil {
-			log.Errorf("Failed to kill port-forward process, pid: %d", proc.Pid)
-		}
+	for _, pf := range p.portFwdProcesses {
+		pf.Close()
 	}
 	return
 }


### PR DESCRIPTION
Fix #6173 
Replace "kubectl port-forward" with that in client-go,
to make sure  the port-forwarder lifecycle is limited