### PR TITLE
Avoid copy lock by using reference

### DIFF
--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -245,7 +245,7 @@ func init() {
 		Metadata: &types.Struct{Fields: map[string]*types.Value{}},
 	}
 	for k, v := range metadata {
-		client.Metadata.Fields[k] = &types.Value{Kind: &types.Value_StringValue{v}}
+		client.Metadata.Fields[k] = &types.Value{Kind: &types.Value_StringValue{StringValue: v}}
 	}
 }
 

--- a/pkg/mcp/creds/watcher.go
+++ b/pkg/mcp/creds/watcher.go
@@ -195,7 +195,7 @@ func (c *CertificateWatcher) start() error {
 		c.options.CertificateFile, c.options.KeyFile)
 
 	// Coordinate the goroutines for orderly shutdown
-	var exitSignal sync.WaitGroup
+	exitSignal := &sync.WaitGroup{}
 	exitSignal.Add(1)
 	exitSignal.Add(1)
 
@@ -211,7 +211,7 @@ func (c *CertificateWatcher) start() error {
 	return nil
 }
 
-func (c *CertificateWatcher) watch(exitSignal sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) {
+func (c *CertificateWatcher) watch(exitSignal *sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) {
 
 	defer exitSignal.Done()
 
@@ -248,7 +248,7 @@ func (c *CertificateWatcher) watch(exitSignal sync.WaitGroup, certFileWatcher, k
 	}
 }
 
-func (c *CertificateWatcher) watchErrors(exitSignal sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) {
+func (c *CertificateWatcher) watchErrors(exitSignal *sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) {
 
 	defer exitSignal.Done()
 
@@ -265,7 +265,7 @@ func (c *CertificateWatcher) watchErrors(exitSignal sync.WaitGroup, certFileWatc
 	}
 }
 
-func closeWatchers(exitSignal sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) { // nolint: interfacer
+func closeWatchers(exitSignal *sync.WaitGroup, certFileWatcher, keyFileWatcher fileWatcher) { // nolint: interfacer
 	exitSignal.Wait()
 	_ = certFileWatcher.Close()
 	_ = keyFileWatcher.Close()

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -274,7 +274,7 @@ func (con *connection) processClientRequest(req *mcp.MeshConfigRequest) error {
 			scope.Debugf("MCP: connection %v: WATCH for %v", con, req.TypeUrl)
 		} else {
 			scope.Debugf("MCP: connection %v ACK version=%q with nonce=%q",
-				con, req.TypeUrl, req.VersionInfo, req.ResponseNonce)
+				con, req.VersionInfo, req.ResponseNonce)
 		}
 
 		if watch.cancel != nil {


### PR DESCRIPTION
WaitGroup value shouldn't be copied (like any other `sync` structs) therefore passing its pointer as an argument.
\+ Two minor fixes.