### PR TITLE
Re-use istio-init container to setup core dump

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -47,25 +47,16 @@ data:
         {{ "[[ else -]]" }}
         - "{{ .Values.global.proxy.excludeInboundPorts }}"
         {{ "[[ end -]]" }}
+        {{- if .Values.global.proxy.enableCoreDump }}
+        - "-c"
+        - "/var/lib/istio/core.proxy"
+        {{- end }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
             add:
             - NET_ADMIN
           privileged: true
-      {{- if .Values.global.proxy.enableCoreDump }}
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
-        command:
-          - /bin/sh
-        image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
-      {{ end }}
       containers:
       - name: istio-proxy
         image: {{ "[[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\") -]]" }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -42,29 +42,16 @@ data:
         - {{ "\"[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) ]]\"" }}
         - "-d"
         - {{ "\"[[ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` " }} {{ .Values.global.proxy.statusPort }} {{ ") (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` " }} "{{ .Values.global.proxy.excludeInboundPorts }}" {{ ") ]]\"" }}
+        {{- if .Values.global.proxy.enableCoreDump }}
+        - "-c"
+        - "/var/lib/istio/core.proxy"
+        {{- end }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
             add:
             - NET_ADMIN
           privileged: true
-      {{- if .Values.global.proxy.enableCoreDump }}
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
-        command:
-          - /bin/sh
-  {{- if contains "/" .Values.global.proxy_init.image }}
-        image: "{{ .Values.global.proxy_init.image }}"
-  {{- else }}
-        image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
-  {{- end }}
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
-      {{ end }}
       containers:
       - name: istio-proxy
         image: {{ "[[ annotation .ObjectMeta `sidecar.istio.io/proxyImage` " }} "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}" {{ " ]]" }}

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -55,6 +55,10 @@ initContainers:
   - "[[ annotation .ObjectMeta $includeInboundPortsKey (includeInboundPorts .Spec.Containers) ]]"
   - "-d"
   - "[[ excludeInboundPort $statusPortValue (annotation .ObjectMeta $excludeInboundPortsKey "{{ .ExcludeInboundPorts }}") ]]"
+  {{ if eq .EnableCoreDump true -}}
+  - "-c"
+  - "/var/lib/istio/core.proxy"
+  {{ end -}}
   {{ if eq .ImagePullPolicy "" -}}
   imagePullPolicy: IfNotPresent
   {{ else -}}
@@ -64,22 +68,9 @@ initContainers:
     capabilities:
       add:
       - NET_ADMIN
-    {{ if eq .DebugMode true -}}
+    {{- if eq .DebugMode true }}
     privileged: true
-    {{ end -}}
-{{- if eq .EnableCoreDump true }}
-- args:
-  - -c
-  - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
-  command:
-  - /bin/sh
-  image: {{ .InitImage }}
-  imagePullPolicy: IfNotPresent
-  name: enable-core-dump
-  resources: {}
-  securityContext:
-    privileged: true
-{{- end }}
+    {{- end }}
 containers:
 - name: istio-proxy
   image: [[ annotation .ObjectMeta $proxyImageKey "{{ .ProxyImage }}" ]] 

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init","enable-core-dump"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -112,6 +112,8 @@ spec:
         - "80"
         - -d
         - "15020"
+        - -c
+        - /var/lib/istio/core.proxy
         image: docker.io/istio/proxy_init:unittest
         imagePullPolicy: IfNotPresent
         name: istio-init
@@ -120,17 +122,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-      - args:
-        - -c
-        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
-        command:
-        - /bin/sh
-        image: docker.io/istio/proxy_init:unittest
-        imagePullPolicy: IfNotPresent
-        name: enable-core-dump
-        resources: {}
-        securityContext:
-          privileged: true
       volumes:
       - emptyDir:
           medium: Memory


### PR DESCRIPTION
We don't need a special init container just for that task.

Closes: #8111.