### PR TITLE
BookInfo: Use OpenTracing for productpage headers

### DIFF
--- a/samples/bookinfo/platform/consul/bookinfo.yaml
+++ b/samples/bookinfo/platform/consul/bookinfo.yaml
@@ -16,7 +16,7 @@
 version: '2'
 services:
   details-v1:
-    image: istio/examples-bookinfo-details-v1:1.8.0
+    image: istio/examples-bookinfo-details-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -32,7 +32,7 @@ services:
       - "9080"
 
   ratings-v1:
-    image: istio/examples-bookinfo-ratings-v1:1.8.0
+    image: istio/examples-bookinfo-ratings-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -48,7 +48,7 @@ services:
       - "9080"
 
   reviews-v1:
-    image: istio/examples-bookinfo-reviews-v1:1.8.0
+    image: istio/examples-bookinfo-reviews-v1:1.9.0
     networks:
       istiomesh:
     dns:
@@ -65,7 +65,7 @@ services:
       - "9080"
 
   reviews-v2:
-    image: istio/examples-bookinfo-reviews-v2:1.8.0
+    image: istio/examples-bookinfo-reviews-v2:1.9.0
     networks:
       istiomesh:
     dns:
@@ -82,7 +82,7 @@ services:
       - "9080"
 
   reviews-v3:
-    image: istio/examples-bookinfo-reviews-v3:1.8.0
+    image: istio/examples-bookinfo-reviews-v3:1.9.0
     networks:
       istiomesh:
     dns:
@@ -99,7 +99,7 @@ services:
       - "9080"
 
   productpage-v1:
-    image: istio/examples-bookinfo-productpage-v1:1.8.0
+    image: istio/examples-bookinfo-productpage-v1:1.9.0
     networks:
       istiomesh:
         ipv4_address: 172.28.0.14

--- a/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-productpage
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.8.0
+        image: istio/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: istio/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookinfo-reviews
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        image: istio/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-db.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-db.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
       - name: mongodb 
-        image: istio/examples-bookinfo-mongodb:1.8.0
+        image: istio/examples-bookinfo-mongodb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 27017

--- a/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v2:1.8.0
+        image: istio/examples-bookinfo-details-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-details.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-details.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.8.0
+        image: istio/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-mysql.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
       - name: mysqldb
-        image: istio/examples-bookinfo-mysqldb:1.8.0
+        image: istio/examples-bookinfo-mysqldb:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql-vm.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # This assumes you registered your mysql vm as

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2-mysql.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml
@@ -26,14 +26,14 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.
-          # if you would like to use mysqldb then set DB_TYPE = 'mysql', set 
-          # the rest of the parameters shown here and also create the 
+          # if you would like to use mysqldb then set DB_TYPE = 'mysql', set
+          # the rest of the parameters shown here and also create the
           # mysqldb service using bookinfo-mysql.yaml
-          # - name: DB_TYPE #default to 
+          # - name: DB_TYPE #default to
           #   value: "mysql"
           # - name: MYSQL_DB_HOST
           #   value: mysqldb

--- a/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-ratings.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.8.0
+        image: istio/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo-reviews-v2.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: istio/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/bookinfo.yaml
+++ b/samples/bookinfo/platform/kube/bookinfo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: details
-        image: istio/examples-bookinfo-details-v1:1.8.0
+        image: istio/examples-bookinfo-details-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v1:1.8.0
+        image: istio/examples-bookinfo-ratings-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -112,7 +112,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v1:1.8.0
+        image: istio/examples-bookinfo-reviews-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v2:1.8.0
+        image: istio/examples-bookinfo-reviews-v2:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -150,7 +150,7 @@ spec:
     spec:
       containers:
       - name: reviews
-        image: istio/examples-bookinfo-reviews-v3:1.8.0
+        image: istio/examples-bookinfo-reviews-v3:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080
@@ -185,7 +185,7 @@ spec:
     spec:
       containers:
       - name: productpage
-        image: istio/examples-bookinfo-productpage-v1:1.8.0
+        image: istio/examples-bookinfo-productpage-v1:1.9.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9080

--- a/samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml
+++ b/samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: bookinfo-ratings-v2
       containers:
       - name: ratings
-        image: istio/examples-bookinfo-ratings-v2:1.8.0
+        image: istio/examples-bookinfo-ratings-v2:1.9.0
         imagePullPolicy: IfNotPresent
         env:
           # ratings-v2 will use mongodb as the default db backend.

--- a/samples/bookinfo/src/productpage/Dockerfile
+++ b/samples/bookinfo/src/productpage/Dockerfile
@@ -17,9 +17,15 @@ FROM python:2.7-slim
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
+COPY test-requirements.txt ./
+RUN pip install --no-cache-dir -r test-requirements.txt
+
 COPY productpage.py /opt/microservices/
+COPY tests/unit/* /opt/microservices/
 COPY templates /opt/microservices/templates
 COPY requirements.txt /opt/microservices/
+
 EXPOSE 9080
 WORKDIR /opt/microservices
+RUN python -m unittest discover
 CMD python productpage.py 9080

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -103,7 +103,6 @@ service_dict = {
 # x-b3-parentspanid
 # x-b3-sampled
 # x-b3-flags
-# x-ot-span-context
 #
 # This example code uses OpenTracing (http://opentracing.io/) to propagate
 # the 'b3' (zipkin) headers. Using OpenTracing for this is not a requirement.
@@ -176,9 +175,7 @@ def getForwardHeaders(request):
     if 'user' in session:
         headers['end-user'] = session['user']
 
-    incoming_headers = [ 'x-request-id',
-                         'x-ot-span-context'
-    ]
+    incoming_headers = ['x-request-id']
 
     for ihdr in incoming_headers:
         val = request.headers.get(ihdr)

--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -16,6 +16,13 @@
 
 
 from flask import Flask, request, session, render_template, redirect, url_for
+from flask import _request_ctx_stack as stack
+from jaeger_client import Tracer, ConstSampler
+from jaeger_client.reporter import NullReporter
+from jaeger_client.codecs import B3Codec
+from opentracing.ext import tags
+from opentracing.propagation import Format
+from opentracing_instrumentation.request_context import get_current_span, span_in_context
 import simplejson as json
 import requests
 import sys
@@ -80,18 +87,96 @@ service_dict = {
     "reviews" : reviews,
 }
 
+# A note on distributed tracing:
+#
+# Although Istio proxies are able to automatically send spans, they need some
+# hints to tie together the entire trace. Applications need to propagate the
+# appropriate HTTP headers so that when the proxies send span information, the
+# spans can be correlated correctly into a single trace.
+#
+# To do this, an application needs to collect and propagate the following
+# headers from the incoming request to any outgoing requests:
+#
+# x-request-id
+# x-b3-traceid
+# x-b3-spanid
+# x-b3-parentspanid
+# x-b3-sampled
+# x-b3-flags
+# x-ot-span-context
+#
+# This example code uses OpenTracing (http://opentracing.io/) to propagate
+# the 'b3' (zipkin) headers. Using OpenTracing for this is not a requirement.
+# Using OpenTracing allows you to add application-specific tracing later on,
+# but you can just manually forward the headers if you prefer.
+#
+# The OpenTracing example here is very basic. It only forwards headers. It is
+# intended as a reference to help people get started, eg how to create spans,
+# extract/inject context, etc.
+
+# A very basic OpenTracing tracer (with null reporter)
+tracer = Tracer(
+    one_span_per_rpc=True,
+    service_name='productpage',
+    reporter=NullReporter(),
+    sampler=ConstSampler(decision=True),
+    extra_codecs={Format.HTTP_HEADERS: B3Codec()}
+)
+
+
+def trace():
+    '''
+    Function decorator that creates opentracing span from incoming b3 headers
+    '''
+    def decorator(f):
+        def wrapper(*args, **kwargs):
+            request = stack.top.request
+            try:
+                # Create a new span context, reading in values (traceid,
+                # spanid, etc) from the incoming x-b3-*** headers.
+                span_ctx = tracer.extract(
+                    Format.HTTP_HEADERS,
+                    dict(request.headers)
+                )
+                # Note: this tag means that the span will *not* be
+                # a child span. It will use the incoming traceid and
+                # spanid. We do this to propagate the headers verbatim.
+                rpc_tag = {tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER}
+                span = tracer.start_span(
+                    operation_name='op', child_of=span_ctx, tags=rpc_tag
+                )
+            except Exception as e:
+                # We failed to create a context, possibly due to no
+                # incoming x-b3-*** headers. Start a fresh span.
+                # Note: This is a fallback only, and will create fresh headers,
+                # not propagate headers.
+                span = tracer.start_span('op')
+            with span_in_context(span):
+                r = f(*args, **kwargs)
+                return r
+        wrapper.__name__ = f.__name__
+        return wrapper
+    return decorator
+
+
 def getForwardHeaders(request):
     headers = {}
 
+    # x-b3-*** headers can be populated using the opentracing span
+    span = get_current_span()
+    carrier = {}
+    tracer.inject(
+        span_context=span.context,
+        format=Format.HTTP_HEADERS,
+        carrier=carrier)
+
+    headers.update(carrier)
+
+    # We handle other (non x-b3-***) headers manually
     if 'user' in session:
         headers['end-user'] = session['user']
 
     incoming_headers = [ 'x-request-id',
-                         'x-b3-traceid',
-                         'x-b3-spanid',
-                         'x-b3-parentspanid',
-                         'x-b3-sampled',
-                         'x-b3-flags',
                          'x-ot-span-context'
     ]
 
@@ -138,6 +223,7 @@ def logout():
 
 
 @app.route('/productpage')
+@trace()
 def front():
     product_id = 0 # TODO: replace default value
     headers = getForwardHeaders(request)
@@ -162,6 +248,7 @@ def productsRoute():
 
 
 @app.route('/api/v1/products/<product_id>')
+@trace()
 def productRoute(product_id):
     headers = getForwardHeaders(request)
     status, details = getProductDetails(product_id, headers)
@@ -169,6 +256,7 @@ def productRoute(product_id):
 
 
 @app.route('/api/v1/products/<product_id>/reviews')
+@trace()
 def reviewsRoute(product_id):
     headers = getForwardHeaders(request)
     status, reviews = getProductReviews(product_id, headers)
@@ -176,6 +264,7 @@ def reviewsRoute(product_id):
 
 
 @app.route('/api/v1/products/<product_id>/ratings')
+@trace()
 def ratingsRoute(product_id):
     headers = getForwardHeaders(request)
     status, ratings = getProductRatings(product_id, headers)

--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -9,9 +9,12 @@ gevent==1.2.2
 greenlet==0.4.12
 idna==2.6
 itsdangerous==0.24
+jaeger-client==3.11.0
 Jinja2==2.10
 json2html==1.2.1
 MarkupSafe==1.0
+opentracing==1.2.2
+opentracing-instrumentation==2.4.3
 requests==2.18.4
 simplejson==3.13.2
 urllib3==1.22

--- a/samples/bookinfo/src/productpage/test-requirements.txt
+++ b/samples/bookinfo/src/productpage/test-requirements.txt
@@ -1,0 +1,1 @@
+requests-mock==1.5.2

--- a/samples/bookinfo/src/productpage/tests/unit/test_productpage.py
+++ b/samples/bookinfo/src/productpage/tests/unit/test_productpage.py
@@ -1,0 +1,83 @@
+#
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Run from the top level productpage directory with:
+#
+# pip install -r test-requirements.txt
+# python -m unittest discover tests/unit
+
+import unittest
+
+import requests_mock
+
+import productpage
+
+
+class ApplianceTest(unittest.TestCase):
+
+    def setUp(self):
+        self.app = productpage.app.test_client()
+
+    @requests_mock.Mocker()
+    def test_header_propagation_reviews(self, m):
+        """ Check that tracing headers are forwarded correctly """
+        product_id = 0
+        # Register expected headers with the mock. If the headers
+        # don't match, the mock won't fire, an E500 will be triggered
+        # and the test will fail.
+        expected_headers = {
+            'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b72',
+            'x-b3-traceid': '40c7fdf104e3de67',
+            'x-b3-spanid': '40c7fdf104e3de67',
+            'x-b3-sampled': '1'
+        }
+        m.get("http://reviews:9080/reviews/%d" % product_id, text='{}',
+              request_headers=expected_headers)
+
+        uri = "/api/v1/products/%d/reviews" % product_id
+        headers = {
+            'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b72',
+            'x-b3-traceid': '40c7fdf104e3de67',
+            'x-b3-spanid': '40c7fdf104e3de67',
+            'x-b3-sampled': '1'
+        }
+        actual = self.app.get(uri, headers=headers)
+        self.assertEqual(200, actual.status_code)
+
+    @requests_mock.Mocker()
+    def test_header_propagation_ratings(self, m):
+        """ Check that tracing headers are forwarded correctly """
+        product_id = 0
+        # Register expected headers with the mock. If the headers
+        # don't match, the mock won't fire, an E500 will be triggered
+        # and the test will fail.
+        expected_headers = {
+            'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b73',
+            'x-b3-traceid': '30c7fdf104e3de66',
+            'x-b3-spanid': '30c7fdf104e3de66',
+            'x-b3-sampled': '1'
+        }
+        m.get("http://ratings:9080/ratings/%d" % product_id, text='{}',
+              request_headers=expected_headers)
+
+        uri = "/api/v1/products/%d/ratings" % product_id
+        headers = {
+            'x-request-id': '34eeb41d-d267-9e49-8b84-dde403fc5b73',
+            'x-b3-traceid': '30c7fdf104e3de66',
+            'x-b3-spanid': '30c7fdf104e3de66',
+            'x-b3-sampled': '1'
+        }
+        actual = self.app.get(uri, headers=headers)
+        self.assertEqual(200, actual.status_code)


### PR DESCRIPTION
Update the productpage service to use OpenTracing for forwarding b3
(zipkin) headers.

This patch gives a basic example of using OpenTracing with Istio, which
may be a useful reference. Using OpenTracing gives application developers
the potential to create spans representing work.

This patch leaves the existing header propagation behaviour unchanged.
Eg we continue to propagate "x-b3-spanid" unchanged, and it will continue
to be overwritten automatically by the sidecar.

Reference: https://github.com/istio/proxy/issues/168