### PR TITLE
Fix local test failures due to a wrong $KUBECONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ export GOPATH
 GO_TOP := $(shell echo ${GOPATH} | cut -d ':' -f1)
 export GO_TOP
 
+# Needed for make test to work out of the box (by default it tries to use ~/.kube/config)
+KUBECONFIG ?= $(GO_TOP)/src/istio.io/istio/.circleci/config
+export KUBECONFIG
+
 # Note that disabling cgo here adversely affects go get.  Instead we'll rely on this
 # to be handled in bin/gobuild.sh
 # export CGO_ENABLED=0


### PR DESCRIPTION
Running `make test` locally fails if we have something in
our ~/.kube/config, as the tests will use that file by default:

```
...
--- FAIL: TestServices (30.00s)
	controller_test.go:59: Post https://192.168.99.100:8443/api/v1/namespaces: dial tcp 192.168.99.100:8443: i/o timeout
FAIL
FAIL	istio.io/istio/pilot/pkg/serviceregistry/kube	30.018s
...
```

Pointing the tests to use the same kubeconfig file as in use by
testEnvLocalK8S.sh fixes this issue, making local tests to pass.