### PR TITLE
Fix shell globbing in cleanup task

### DIFF
--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -208,7 +208,8 @@ function stopLocalApiserver() {
   if [[ -f $LOG_DIR/etcd.pid ]]; then
     kill -9 "$(cat "$LOG_DIR/etcd.pid")"
     kill -9 "$(cat "$LOG_DIR/apiserver.pid")"
-    rm "$LOG_DIR/{etcd,apiserver}.pid"
+    rm "$LOG_DIR/etcd.pid"
+    rm "$LOG_DIR/apiserver.pid"
   fi
   if [[ -d "${ETCD_DATADIR}" ]]; then
     rm -rf "${ETCD_DATADIR}"
@@ -221,7 +222,8 @@ function stopMultiCluster() {
     if [[ -f $LOG_DIR/etcd$i.pid ]]; then
       kill -9 "$(cat "$LOG_DIR/etcd$i.pid")" || true
       kill -9 "$(cat "$LOG_DIR/apiserver$i.pid")" || true
-      rm "$LOG_DIR/{etcd$i,apiserver$i}.pid" || true
+      rm "$LOG_DIR/etcd$i.pid" || true
+      rm "$LOG_DIR/apiserver$i.pid" || true
       rm "$LOG_DIR/apiserver$i.url" || true
     fi
     if [[ -d "${ETCD_DATADIR}$i" ]]; then


### PR DESCRIPTION
Shell globbings don't work inside quotes:

```
make localTestEnvCleanup
...
rm: cannot remove '/home/jwendell/go/out/log/{etcd,apiserver}.pid': No such file or directory
make: *** [Makefile:440: localTestEnvCleanup] Error 1
```