### PR TITLE
Forward client cert in header

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -321,6 +321,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 				rds:              rdsName,
 				useRemoteAddress: true,
 				direction:        http_conn.EGRESS, // viewed as from gateway to internal
+				connectionManager: &http_conn.HttpConnectionManager{
+					// Forward client cert if connection is mTLS
+					ForwardClientCertDetails: http_conn.SANITIZE_SET,
+				},
 			},
 		}
 		httpListeners = append(httpListeners, o)
@@ -339,6 +343,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 					rds:              model.GatewayRDSRouteName(server),
 					useRemoteAddress: true,
 					direction:        http_conn.EGRESS, // viewed as from gateway to internal
+					connectionManager: &http_conn.HttpConnectionManager{
+						// Forward client cert if connection is mTLS
+						ForwardClientCertDetails: http_conn.SANITIZE_SET,
+					},
 				},
 			}
 			httpListeners = append(httpListeners, o)

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -259,6 +259,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				rds:              "", // no RDS for inbound traffic
 				useRemoteAddress: false,
 				direction:        http_conn.INGRESS,
+				connectionManager: &http_conn.HttpConnectionManager{
+					// Append and forward client cert to backend.
+					ForwardClientCertDetails: http_conn.APPEND_FORWARD,
+				},
 			}
 		case plugin.ListenerProtocolTCP:
 			tcpNetworkFilters = buildInboundNetworkFilters(instance)


### PR DESCRIPTION
In some cases, the application needs to use client certificates (from mTLS, including custom ingress mTLS). While Envoy supports [`x-forwarded-client-cert`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-client-cert), current Istio implementation does not use it (i.e uses the default `SANITIZE` mode)

This PR configures Envoy to forward (and not forward) following this rules:
- `forward_only` for ingress Envoy: allow certificate will be forwarded to the next hop.
- `append_forward` for sidecar inbound: allows both certificate from previous hop (i.e ingress) and certificate between previous hop and current hop be presented to application.
- `sanitize` for sidecar outbound: prevent application put anything to the `x-forwarded-client-cert` header.