### PR TITLE
Adding PodAntiAffinity for HA on control plane

### DIFF
--- a/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
@@ -49,6 +49,15 @@ spec:
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - certmanager 
+              topologyKey: "kubernetes.io/hostname"
 {{ toYaml . | indent 8 }}
     {{- end }}
     {{- with .Values.tolerations }}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -84,4 +84,13 @@ spec:
         configMap:
           name: istio-galley-configuration
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "istio"
+                    operator: In
+                    values:
+                    - galley
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -119,6 +119,15 @@ spec:
           optional: true
       {{- end }}
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - istio-{{ $spec.labels.istio }}
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" $ | indent 6 }}
 ---
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/deployment.yaml
@@ -103,4 +103,13 @@ spec:
           secretName: istio-ingress-certs
           optional: true
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "istio"
+                    operator: In
+                    values:
+                    - {{ template "istio.name" . }} 
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -12,6 +12,15 @@
       - name: uds-socket
         emptyDir: {}
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - policy
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" . | indent 6 }}
       containers:
       - name: mixer
@@ -96,6 +105,16 @@
 
 {{- define "telemetry_container" }}
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - telemetry
+              topologyKey: "kubernetes.io/hostname"
       serviceAccountName: istio-mixer-service-account
       volumes:
       - name: istio-certs

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -153,3 +153,12 @@ spec:
           secretName: istio.istio-pilot-service-account
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                    - pilot
+              topologyKey: "kubernetes.io/hostname"

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -60,4 +60,13 @@ spec:
          optional: true
 {{- end }}
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "istio"
+                    operator: In
+                    values:
+                    - citadel
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -83,4 +83,13 @@ spec:
           - key: config
             path: config
       affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "istio"
+                    operator: In
+                    values:
+                    - sidecar-injector
+              topologyKey: "kubernetes.io/hostname"
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
The PodAntiAffinity annotations will make sure two replicas of the same control pane pods are not scheduled in the same node in a Kubernetes cluster.

Even though Kubernetes will try to schedule pods in different nodes natively, sometimes, due to for instance: a node being low on resources, we will get two replicas of say, Pilot, being scheduled on the same node. If such node goes down, so does all service mesh, which we don't want to.

Having control pane pods distributed across different nodes will ensure that we dont get down time when a single node goes down.

References:
https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/#tolerating-node-failure
https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature