### PR TITLE
helm: delete post-install hook when it fails

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/create-custom-resources-job.yaml
@@ -48,7 +48,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
   labels:
     app: istio-grafana
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
If for some reason the hook fails, I should be able to run `helm delete --purge` and it'll clean itself up for another run.

Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>