### PR TITLE
add sds uds volume mount for gateway

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -108,6 +108,10 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           volumeMounts:
+          {{- if $.Values.global.mtls.enabled }}
+          - name: sdsudspath
+            mountPath: /var/run/sds
+          {{- end }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
@@ -120,6 +124,11 @@ spec:
 {{ toYaml $spec.additionalContainers | indent 8 }}
 {{- end }}
       volumes:
+      {{- if $.Values.global.mtls.enabled }}
+      - name: sdsudspath
+        hostPath:
+          path: /var/run/sds
+      {{- end }}
       - name: istio-certs
         secret:
           secretName: istio.{{ $key }}-service-account

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -108,10 +108,8 @@ spec:
               fieldRef:
                 fieldPath: metadata.name
           volumeMounts:
-          {{- if $.Values.global.mtls.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
-          {{- end }}
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
@@ -124,11 +122,9 @@ spec:
 {{ toYaml $spec.additionalContainers | indent 8 }}
 {{- end }}
       volumes:
-      {{- if $.Values.global.mtls.enabled }}
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
-      {{- end }}
       - name: istio-certs
         secret:
           secretName: istio.{{ $key }}-service-account


### PR DESCRIPTION
https://github.com/istio/istio/issues/5891, https://github.com/istio/istio/issues/6411
ingress-gateway is an envoy instance and it needs to add sds volume mount when global auth is enabled, for mTLS with sidecars inside mesh, (sidecar inject was made in https://github.com/istio/istio/pull/7678)