### PR TITLE
fix vulnerability in istio grafana image.

### DIFF
--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -1,5 +1,7 @@
 from grafana/grafana:5.2.3
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 USER root
 
 COPY grafana.ini /etc/grafana/


### PR DESCRIPTION
fix vulnerability issue in istio grafana image due outdated versions of some core tools, like openssl, curl ...

We can keep the tools updated by simply adding `apt-get upgrade ...` step to its dockerfile. 

![image](https://user-images.githubusercontent.com/5468682/45084949-14c90680-b132-11e8-9663-d905fe3dfa66.png)
