### PR TITLE
Add endpoint subcommand for istioctl proxy-config

### DIFF
--- a/istioctl/cmd/istioctl/proxyconfig_test.go
+++ b/istioctl/cmd/istioctl/proxyconfig_test.go
@@ -47,6 +47,9 @@ func TestProxyConfig(t *testing.T) {
 	cannedConfig := map[string][]byte{
 		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile("../../pkg/writer/compare/testdata/envoyconfigdump.json", t),
 	}
+	endpointConfig := map[string][]byte{
+		"details-v1-5b7f94f9bc-wp5tb": util.ReadFile("../../pkg/writer/envoy/clusters/testdata/clusters.json", t),
+	}
 	cases := []execTestCase{
 		{ // case 0
 			args:           strings.Split("proxy-config", " "),
@@ -99,6 +102,18 @@ xds-grpc                                        -         -          -          
 NAME                                                    VIRTUAL HOSTS
 15004                                                   2
 inbound|9080||productpage.default.svc.cluster.local     1
+`,
+		},
+		{ // case 9 endpoint invalid
+			args:           strings.Split("proxy-config endpoint invalid", " "),
+			expectedRegexp: regexp.MustCompile("^Error: unable to retrieve Pod: pods \"invalid\" not found.*"),
+			wantException:  true, // "istioctl get invalid" should fail
+		},
+		{ // case 10 endpoint valid
+			execClientConfig: endpointConfig,
+			args:             strings.Split("proxy-config endpoint details-v1-5b7f94f9bc-wp5tb --port=9093", " "),
+			expectedOutput: `ENDPOINT             CLUSTER
+172.17.0.14:9093     outbound|9093||istio-policy.istio-system.svc.cluster.local
 `,
 		},
 	}

--- a/istioctl/pkg/util/clusters/wrapper.go
+++ b/istioctl/pkg/util/clusters/wrapper.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"bytes"
+
+	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+	"github.com/gogo/protobuf/jsonpb"
+)
+
+// Wrapper is a wrapper around the Envoy Clusters
+// It has extra helper functions for handling any/struct/marshal protobuf pain
+type Wrapper struct {
+	*adminapi.Clusters
+}
+
+// MarshalJSON is a custom marshaller to handle protobuf pain
+func (w *Wrapper) MarshalJSON() ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	jsonm := &jsonpb.Marshaler{}
+	err := jsonm.Marshal(buffer, w)
+	if err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON is a custom unmarshaller to handle protobuf pain
+func (w *Wrapper) UnmarshalJSON(b []byte) error {
+	buf := bytes.NewBuffer(b)
+	jsonum := &jsonpb.Unmarshaler{}
+	cd := &adminapi.Clusters{}
+	err := jsonum.Unmarshal(buf, cd)
+	*w = Wrapper{cd}
+	return err
+
+}

--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -1,0 +1,152 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	adminapi "github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha"
+
+	"istio.io/istio/istioctl/pkg/util/clusters"
+	protio "istio.io/istio/istioctl/pkg/util/proto"
+)
+
+// EndpointFilter is used to pass filter information into route based config writer print functions
+type EndpointFilter struct {
+	Address string
+	Port    uint32
+	Cluster string
+}
+
+// ConfigWriter is a writer for processing responses from the Envoy Admin config_dump endpoint
+type ConfigWriter struct {
+	Stdout   io.Writer
+	clusters *clusters.Wrapper
+}
+
+// EndpointCluster is used to store the endpoint and cluster
+type EndpointCluster struct {
+	address string
+	port    int
+	cluster string
+}
+
+// Prime loads the clusters output into the writer ready for printing
+func (c *ConfigWriter) Prime(b []byte) error {
+	cd := clusters.Wrapper{}
+	err := json.Unmarshal(b, &cd)
+	if err != nil {
+		return fmt.Errorf("error unmarshalling config dump response from Envoy: %v", err)
+	}
+	c.clusters = &cd
+	return nil
+}
+
+func retrieveEndpointAddress(host *adminapi.HostStatus) string {
+	return host.Address.GetSocketAddress().Address
+}
+
+func retrieveEndpointPort(l *adminapi.HostStatus) uint32 {
+	return l.Address.GetSocketAddress().GetPortValue()
+}
+
+// Verify returns true if the passed host matches the filter fields
+func (e *EndpointFilter) Verify(host *adminapi.HostStatus, cluster string) bool {
+	if e.Address == "" && e.Port == 0 && e.Cluster == "" {
+		return true
+	}
+	if e.Address != "" && strings.ToLower(retrieveEndpointAddress(host)) != strings.ToLower(e.Address) {
+		return false
+	}
+	if e.Port != 0 && retrieveEndpointPort(host) != e.Port {
+		return false
+	}
+	if e.Cluster != "" && strings.ToLower(cluster) != strings.ToLower(e.Cluster) {
+		return false
+	}
+	return true
+}
+
+// PrintEndpointsSummary prints just the endpoints config summary to the ConfigWriter stdout
+func (c *ConfigWriter) PrintEndpointsSummary(filter EndpointFilter) error {
+	if c.clusters == nil {
+		return fmt.Errorf("config writer has not been primed")
+	}
+
+	w := new(tabwriter.Writer).Init(c.Stdout, 0, 8, 5, ' ', 0)
+
+	clusterEndpoint := make([]EndpointCluster, 0)
+	for _, cluster := range c.clusters.ClusterStatuses {
+		for _, host := range cluster.HostStatuses {
+			if filter.Verify(host, cluster.Name) {
+				addr := retrieveEndpointAddress(host)
+				port := retrieveEndpointPort(host)
+
+				clusterEndpoint = append(clusterEndpoint, EndpointCluster{addr, int(port), cluster.Name})
+			}
+		}
+	}
+
+	clusterEndpoint = retrieveSortedEndpointClusterSlice(clusterEndpoint)
+	fmt.Fprintln(w, "ENDPOINT\tCLUSTER")
+	for _, ce := range clusterEndpoint {
+		endpoint := ce.address + ":" + strconv.Itoa(int(ce.port))
+		fmt.Fprintf(w, "%v\t%v\n", endpoint, ce.cluster)
+	}
+
+	return w.Flush()
+}
+
+// PrintEndpoints prints the endpoints config to the ConfigWriter stdout
+func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter) error {
+	if c.clusters == nil {
+		return fmt.Errorf("config writer has not been primed")
+	}
+
+	filteredClusters := protio.MessageSlice{}
+	for _, cluster := range c.clusters.ClusterStatuses {
+		for _, host := range cluster.HostStatuses {
+			if filter.Verify(host, cluster.Name) {
+				filteredClusters = append(filteredClusters, cluster)
+			}
+		}
+
+	}
+	out, err := json.MarshalIndent(filteredClusters, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(c.Stdout, string(out))
+	return nil
+}
+
+func retrieveSortedEndpointClusterSlice(ec []EndpointCluster) []EndpointCluster {
+	sort.Slice(ec, func(i, j int) bool {
+		if ec[i].address == ec[j].address {
+			if ec[i].port == ec[j].port {
+				return ec[i].cluster < ec[j].cluster
+			}
+			return ec[i].port < ec[j].port
+		}
+		return ec[i].address < ec[j].address
+	})
+	return ec
+}

--- a/istioctl/pkg/writer/envoy/clusters/clusters_test.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters_test.go
@@ -1,0 +1,141 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"istio.io/istio/pilot/test/util"
+)
+
+func TestConfigWriter_PrintEndpointSummary(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         EndpointFilter
+		wantOutputFile string
+		callPrime      bool
+		wantErr        bool
+	}{
+		{
+			name:           "display all endpoints when no filter is passed",
+			filter:         EndpointFilter{},
+			wantOutputFile: "testdata/clustersummary.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "filter endpoints in the summary",
+			filter:         EndpointFilter{Cluster: "outbound|9093||istio-policy.istio-system.svc.cluster.local"},
+			wantOutputFile: "testdata/clustersummaryfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "handles address filtering",
+			filter:         EndpointFilter{Address: "172.17.0.14"},
+			wantOutputFile: "testdata/clustersummaryfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "handles port filtering",
+			filter:         EndpointFilter{Port: 9093},
+			wantOutputFile: "testdata/clustersummaryfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:      "errors if config writer is not primed",
+			callPrime: false,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOut := &bytes.Buffer{}
+			cw := &ConfigWriter{Stdout: gotOut}
+			cd, _ := ioutil.ReadFile("testdata/clusters.json")
+			if tt.callPrime {
+				cw.Prime(cd)
+			}
+			err := cw.PrintEndpointsSummary(tt.filter)
+			if tt.wantOutputFile != "" {
+				util.CompareContent(gotOut.Bytes(), tt.wantOutputFile, t)
+			}
+			if err == nil && tt.wantErr {
+				t.Errorf("PrintEndpointSummary (%v) did not produce expected err", tt.name)
+			} else if err != nil && !tt.wantErr {
+				t.Errorf("PrintEndpointSummary (%v) produced unexpected err: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestConfigWriter_PrintClusterDump(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         EndpointFilter
+		wantOutputFile string
+		callPrime      bool
+		wantErr        bool
+	}{
+		{
+			name:           "display all endpoints when no filter is passed",
+			filter:         EndpointFilter{},
+			wantOutputFile: "testdata/clustersnofiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "filter endpoints",
+			filter:         EndpointFilter{Cluster: "outbound|9093||istio-policy.istio-system.svc.cluster.local"},
+			wantOutputFile: "testdata/clusterfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "handles Address filtering",
+			filter:         EndpointFilter{Address: "172.17.0.14"},
+			wantOutputFile: "testdata/clusterfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:           "handles port filtering",
+			filter:         EndpointFilter{Port: 9093},
+			wantOutputFile: "testdata/clusterfiltered.txt",
+			callPrime:      true,
+		},
+		{
+			name:      "errors if config writer is not primed",
+			callPrime: false,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOut := &bytes.Buffer{}
+			cw := &ConfigWriter{Stdout: gotOut}
+			cd, _ := ioutil.ReadFile("testdata/clusters.json")
+			if tt.callPrime {
+				cw.Prime(cd)
+			}
+			err := cw.PrintEndpoints(tt.filter)
+			if tt.wantOutputFile != "" {
+				util.CompareContent(gotOut.Bytes(), tt.wantOutputFile, t)
+			}
+			if err == nil && tt.wantErr {
+				t.Errorf("PrintEndpoint (%v) did not produce expected err", tt.name)
+			} else if err != nil && !tt.wantErr {
+				t.Errorf("PrintEndpoint (%v) produced unexpected err: %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clusterfiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clusterfiltered.txt
@@ -1,0 +1,33 @@
+[
+    {
+        "name": "outbound|9093||istio-policy.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.14",
+                        "portValue": 9093
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    }
+]

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
@@ -1,0 +1,159 @@
+{
+  "cluster_statuses": [
+    {
+    "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+    "addedViaApi": true,
+    "hostStatuses": [
+      {
+        "address": {
+          "socketAddress": {
+            "address": "172.17.0.4",
+            "portValue": 443
+          }
+        },
+        "stats": {
+          "cx_active": {
+            "type": "GAUGE"
+          },
+          "cx_connect_fail": {},
+          "cx_total": {},
+          "rq_active": {
+            "type": "GAUGE"
+          },
+          "rq_error": {},
+          "rq_success": {},
+          "rq_timeout": {},
+          "rq_total": {}
+        },
+        "healthStatus": {
+          "edsHealthStatus": "HEALTHY"
+        }
+      }
+    ]
+  },
+  {
+    "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+    "addedViaApi": true,
+    "hostStatuses": [
+      {
+        "address": {
+          "socketAddress": {
+            "address": "172.17.0.13",
+            "portValue": 443
+          }
+        },
+        "stats": {
+          "cx_active": {
+            "type": "GAUGE"
+          },
+          "cx_connect_fail": {},
+          "cx_total": {},
+          "rq_active": {
+            "type": "GAUGE"
+          },
+          "rq_error": {},
+          "rq_success": {},
+          "rq_timeout": {},
+          "rq_total": {}
+        },
+        "healthStatus": {
+          "edsHealthStatus": "HEALTHY"
+        }
+      }
+    ]
+  },
+  {
+    "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+    "addedViaApi": true,
+    "hostStatuses": [
+      {
+        "address": {
+          "socketAddress": {
+            "address": "172.17.0.19",
+            "portValue": 443
+          }
+        },
+        "stats": {
+          "cx_active": {
+            "type": "GAUGE"
+          },
+          "cx_connect_fail": {},
+          "cx_total": {},
+          "rq_active": {
+            "type": "GAUGE"
+          },
+          "rq_error": {},
+          "rq_success": {},
+          "rq_timeout": {},
+          "rq_total": {}
+        },
+        "healthStatus": {
+          "edsHealthStatus": "HEALTHY"
+        }
+      }
+    ]
+  },
+  {
+    "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+    "addedViaApi": true,
+    "hostStatuses": [
+      {
+        "address": {
+          "socketAddress": {
+            "address": "172.17.0.6",
+            "portValue": 443
+          }
+        },
+        "stats": {
+          "cx_active": {
+            "type": "GAUGE"
+          },
+          "cx_connect_fail": {},
+          "cx_total": {},
+          "rq_active": {
+            "type": "GAUGE"
+          },
+          "rq_error": {},
+          "rq_success": {},
+          "rq_timeout": {},
+          "rq_total": {}
+        },
+        "healthStatus": {
+          "edsHealthStatus": "HEALTHY"
+        }
+      }
+    ]
+  },
+    {
+      "name": "outbound|9093||istio-policy.istio-system.svc.cluster.local",
+      "addedViaApi": true,
+      "hostStatuses": [
+        {
+          "address": {
+            "socketAddress": {
+              "address": "172.17.0.14",
+              "portValue": 9093
+            }
+          },
+          "stats": {
+            "cx_active": {
+              "type": "GAUGE"
+            },
+            "cx_connect_fail": {},
+            "cx_total": {},
+            "rq_active": {
+              "type": "GAUGE"
+            },
+            "rq_error": {},
+            "rq_success": {},
+            "rq_timeout": {},
+            "rq_total": {}
+          },
+          "healthStatus": {
+            "edsHealthStatus": "HEALTHY"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
@@ -1,0 +1,157 @@
+[
+    {
+        "name": "outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.4",
+                        "portValue": 443
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    },
+    {
+        "name": "outbound|443||istio-ingressgateway.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.13",
+                        "portValue": 443
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    },
+    {
+        "name": "outbound|443||istio-galley.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.19",
+                        "portValue": 443
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    },
+    {
+        "name": "outbound|443||istio-egressgateway.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.6",
+                        "portValue": 443
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    },
+    {
+        "name": "outbound|9093||istio-policy.istio-system.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.14",
+                        "portValue": 9093
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    }
+]

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
@@ -1,0 +1,6 @@
+ENDPOINT             CLUSTER
+172.17.0.13:443      outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
+172.17.0.14:9093     outbound|9093||istio-policy.istio-system.svc.cluster.local
+172.17.0.19:443      outbound|443||istio-galley.istio-system.svc.cluster.local
+172.17.0.4:443       outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local
+172.17.0.6:443       outbound|443||istio-egressgateway.istio-system.svc.cluster.local

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersummaryfiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersummaryfiltered.txt
@@ -1,0 +1,2 @@
+ENDPOINT             CLUSTER
+172.17.0.14:9093     outbound|9093||istio-policy.istio-system.svc.cluster.local


### PR DESCRIPTION
Now we can't get endpoint list, so add endpoint subcommand for istioctl proxy-config to get endpoints, support for json, summary, filter(Endpoint address/port, Cluster name).

**List summary:**
```
istioctl proxy-config endpoint details-v1-7495976ddf-9s2kr
ENDPOINT               CLUSTER
127.0.0.1:9080         inbound|9080||details.default.svc.cluster.local
172.17.0.10:9411       outbound|9411||zipkin.istio-system.svc.cluster.local
172.17.0.10:14267      outbound|14267||jaeger-collector.istio-system.svc.cluster.local
172.17.0.10:14268      outbound|14268||jaeger-collector.istio-system.svc.cluster.local
172.17.0.10:16686      outbound|16686||jaeger-query.istio-system.svc.cluster.local
172.17.0.10:16686      outbound|80||tracing.istio-system.svc.cluster.local
172.17.0.11:9090       outbound|9090||prometheus.istio-system.svc.cluster.local
172.17.0.12:8088       outbound|8088||servicegraph.istio-system.svc.cluster.local
172.17.0.13:80         outbound|80||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.13:443        outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.13:8060       outbound|8060||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.13:15011      outbound|15011||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.13:15030      outbound|15030||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.13:15031      outbound|15031||istio-ingressgateway.istio-system.svc.cluster.local
```

**List summary with filter:**
```
istioctl proxy-config endpoint details-v1-7495976ddf-9s2kr --port=443
ENDPOINT            CLUSTER
172.17.0.13:443     outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
172.17.0.19:443     outbound|443||istio-galley.istio-system.svc.cluster.local
172.17.0.4:443      outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local
172.17.0.6:443      outbound|443||istio-egressgateway.istio-system.svc.cluster.local
```

**List with json format:**
```
istioctl proxy-config endpoint details-v1-7495976ddf-9s2kr --address=127.0.0.1 -ojson
[
    {
        "name": "inbound|9080||details.default.svc.cluster.local",
        "addedViaApi": true,
        "hostStatuses": [
            {
                "address": {
                    "socketAddress": {
                        "address": "127.0.0.1",
                        "portValue": 9080
                    }
                },
                "stats": {
                    "cx_active": {
                        "type": "GAUGE"
                    },
                    "cx_connect_fail": {},
                    "cx_total": {
                        "value": "8"
                    },
                    "rq_active": {
                        "type": "GAUGE"
                    },
                    "rq_error": {},
                    "rq_success": {
                        "value": "9"
                    },
                    "rq_timeout": {},
                    "rq_total": {
                        "value": "9"
                    }
                },
                "healthStatus": {
                    "edsHealthStatus": "HEALTHY"
                }
            }
        ]
    }
]
```
