### PR TITLE
fix vulnerability in istio grafana image.

### DIFF
--- a/addons/grafana/Dockerfile.grafana
+++ b/addons/grafana/Dockerfile.grafana
@@ -2,6 +2,8 @@ from grafana/grafana:5.2.2
 
 USER root
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 COPY grafana.ini /etc/grafana/
 RUN chmod 777 -R /etc/grafana/
 


### PR DESCRIPTION
fix vulnerability issue in istio grafana image due outdated versions of some core tools, like openssl, curl ...

We can keep the tools updated by simply adding `apt-get upgrade ...` step to its dockerfile. 

![image](https://user-images.githubusercontent.com/5468682/45084949-14c90680-b132-11e8-9663-d905fe3dfa66.png)
