### PR TITLE
pilot: clusterregistry cleanup and fix

### DIFF
--- a/pilot/pkg/config/clusterregistry/conversion.go
+++ b/pilot/pkg/config/clusterregistry/conversion.go
@@ -19,12 +19,11 @@ import (
 	"strings"
 	"sync"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 
 	"istio.io/istio/pilot/pkg/serviceregistry"
@@ -50,7 +49,6 @@ const (
 type RemoteCluster struct {
 	Cluster        *k8s_cr.Cluster
 	FromSecret     string
-	Client         *clientcmdapi.Config
 	ClusterStatus  string
 	Controller     *kube.Controller
 	ControlChannel chan struct{}
@@ -68,15 +66,6 @@ func NewClustersStore() *ClusterStore {
 	return &ClusterStore{
 		rc: rc,
 	}
-}
-
-// GetClusterAccessConfig returns the access config file of a cluster
-func (cs *ClusterStore) GetClusterAccessConfig(cluster *k8s_cr.Cluster) *clientcmdapi.Config {
-	if cluster == nil {
-		return nil
-	}
-	clusterAccessConfig := cs.rc[cluster.ObjectMeta.Name].Client
-	return clusterAccessConfig
 }
 
 // GetClusterID returns a cluster's ID
@@ -141,14 +130,12 @@ func getClustersConfigs(k8s kubernetes.Interface, configMapName, configMapNamesp
 				secretName, secretNamespace, key, err))
 			continue
 		}
-		clientConfig, err := clientcmd.Load(kubeconfig)
-		if err != nil {
+		if _, err = clientcmd.Load(kubeconfig); err != nil {
 			errList = multierror.Append(errList, fmt.Errorf("failed to load client config from secret %s in namespace %s for cluster %s with error: %v",
 				secretName, secretNamespace, key, err))
 			continue
 		}
 		cs.rc[cluster.ObjectMeta.Name] = &RemoteCluster{}
-		cs.rc[cluster.ObjectMeta.Name].Client = clientConfig
 		cs.rc[cluster.ObjectMeta.Name].Cluster = &cluster
 	}
 

--- a/pilot/pkg/config/clusterregistry/conversion_test.go
+++ b/pilot/pkg/config/clusterregistry/conversion_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	k8s_cr "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 )
 
@@ -99,7 +98,6 @@ func TestGetPilotClusters(t *testing.T) {
 								Name: "fakePilot1",
 							},
 						},
-						Client: &clientcmdapi.Config{},
 					},
 					"cluster2": {
 						Cluster: &k8s_cr.Cluster{
@@ -107,7 +105,6 @@ func TestGetPilotClusters(t *testing.T) {
 								Name: "fakePilot2",
 							},
 						},
-						Client: &clientcmdapi.Config{},
 					},
 					"cluster3": {
 						Cluster: &k8s_cr.Cluster{
@@ -115,7 +112,6 @@ func TestGetPilotClusters(t *testing.T) {
 								Name: "fakePilot3",
 							},
 						},
-						Client: &clientcmdapi.Config{},
 					},
 				},
 			},


### PR DESCRIPTION
1. remove RemoteCluster.client

1. handle DeletedFinalStateUnknown type to prevent type cast panic in kubernetes service registry.