### PR TITLE
Check if package exists before installing minikube-required packages

### DIFF
--- a/tests/e2e/local/common_linux.sh
+++ b/tests/e2e/local/common_linux.sh
@@ -73,3 +73,31 @@ function install_kubectl() {
     sudo mv ./kubectl /usr/local/bin/kubectl
   fi
 }
+
+# check_and_install_packages checks if package is installed before installing it.
+# It is expected to receive 2 parameters,
+# 1st parameter is package management tool - apt|yum, 2nd parameter is package list/array to be checked/installed.
+function check_and_install_packages() {
+  if [ "$#" -ne 2 ]; then
+    echo "Arguments are not equals to 2"
+    echo "Usage: apt|yum package_list"
+    exit 1
+  fi
+  check_cmd="$1"
+  arr="$2"
+  for i in "${arr[@]}";
+  do
+    case $check_cmd in
+      apt)
+        if ! apt list --installed $i | grep installed > /dev/null 2>&1; then
+          sudo apt-get install -y $i > /dev/null 2>&1
+        fi;;
+      yum)
+        if ! yum -q list installed $i > /dev/null 2>&1; then
+           yum install -y $i > /dev/null 2>&1
+        fi;;
+      *)
+        echo "unsupported package management tool";;
+    esac
+  done
+}

--- a/tests/e2e/local/common_linux.sh
+++ b/tests/e2e/local/common_linux.sh
@@ -74,9 +74,10 @@ function install_kubectl() {
   fi
 }
 
-# check_and_install_packages checks if package is installed before installing it.
-# It is expected to receive 2 parameters,
-# 1st parameter is package management tool - apt|yum, 2nd parameter is package list/array to be checked/installed.
+# check_and_install_packages checks if a package is installed before installing it.
+# It expects 2 parameters:
+# $1 - apt|yum  (supported package management tools).
+# $2 - list of packages to be checked or installed.
 function check_and_install_packages() {
   if [ "$#" -ne 2 ]; then
     echo "Arguments are not equals to 2"

--- a/tests/e2e/local/minikube/install_prereqs_debian.sh
+++ b/tests/e2e/local/minikube/install_prereqs_debian.sh
@@ -15,9 +15,9 @@ install_curl
 #Install Kvm2
 echo "Installing KVM2 as required"
 sudo modprobe kvm > /dev/null 2>&1
-sudo apt-get install -y  libvirt-bin > /dev/null 2>&1
-sudo apt-get install -y libvirt-daemon-system libvirt-dev libvirt-clients virt-manager
-sudo apt-get install -y qemu-kvm
+packages_to_install=("libvirt-bin" "libvirt-daemon-system" "libvirt-dev" "libvirt-clients" "virt-manager" "qemu-kvm" )
+check_and_install_packages apt "${packages_to_install[@]}"
+
 sudo systemctl stop libvirtd
 sudo systemctl start libvirtd
 sudo usermod -a -G libvirt "$(whoami)"


### PR DESCRIPTION
Per discussion with @hklai here: https://github.com/istio/istio/pull/8248#discussion_r214234630

This PR checks if packages exist before installing minikube required packages - support both apt and yum(for centos support).


/assign @hklai @JimmyCYJ 