### PR TITLE
Fix the minikube e2e test broken by Error: ImagePullBackOff.

### DIFF
--- a/tests/e2e/local/minikube/README.md
+++ b/tests/e2e/local/minikube/README.md
@@ -38,7 +38,7 @@ You can issue test commands on your host machine.
 E.g.
 ```bash
 cd $ISTIO/istio
-make e2e_simple E2E_ARGS="--use_local_cluster" HUB=localhost:5000 TAG=latest
+make e2e_simple E2E_ARGS="--use_local_cluster" HUB=localhost:5000 TAG=e2e
 ```
 Note the special arguments like **E2E_ARGS**, **HUB**, and **TAG**. They are required to run these tests with the local cluster and a local registry inside the VM. And you can run multiple E2E tests sequentially against the same VM.
 The script has a number of options available [here](../../README.md#options-for-e2e-tests)
@@ -64,7 +64,7 @@ For example, if you want to debug discovery container in pilot, follow steps as 
 1. Run that test in your host/vm.
    ```bash
    # In the VM/Host
-   make e2e_simple E2E_ARGS="--use_local_cluster --skip_cleanup" HUB=10.10.0.2:5000 TAG=latest
+   make e2e_simple E2E_ARGS="--use_local_cluster --skip_cleanup" HUB=10.10.0.2:5000 TAG=e2e
    ```
 1. Run the kubesquash binary
 1. Select the namespace of istio mesh: istio-system

--- a/tests/e2e/local/minikube/setup_test.sh
+++ b/tests/e2e/local/minikube/setup_test.sh
@@ -5,15 +5,15 @@
 . ./setup_minikube_env.sh
 
 # Remove old images.
-read -p "Do you want to delete old docker images tagged localhost:5000/*:latest[default: no]: " -r update
+read -p "Do you want to delete old docker images tagged localhost:5000/*:e2e[default: no]: " -r update
 delete_images=${update:-"no"}
 if [[ $delete_images = *"y"* ]] || [[ $delete_images = *"Y"* ]]; then
-  docker images localhost:5000/*:latest -q | xargs docker rmi -f
+  docker images localhost:5000/*:e2e -q | xargs docker rmi -f
 fi
 
 # Make and Push images to insecure local registry on VM.
 # Set GOOS=linux to make sure linux binaries are built on macOS
 cd "$ISTIO/istio" || exit
-GOOS=linux make docker HUB=localhost:5000 TAG=latest
+GOOS=linux make docker HUB=localhost:5000 TAG=e2e
 
 echo "Setup done."


### PR DESCRIPTION
The minikube e2e test is broken in my local environment due to the test couldn't fetch the necessary images:

```
Events:
  Type     Reason                 Age                From               Message
  ----     ------                 ----               ----               -------
  Normal   SuccessfulMountVolume  49s                kubelet, minikube  MountVolume.SetUp succeeded for volume "istio-envoy"
  Normal   SuccessfulMountVolume  49s                kubelet, minikube  MountVolume.SetUp succeeded for volume "a-token-77n2v"
  Normal   SuccessfulMountVolume  49s                kubelet, minikube  MountVolume.SetUp succeeded for volume "istio-certs"
  Normal   Scheduled              49s                default-scheduler  Successfully assigned a-849db664d9-x55s8 to minikube
  Normal   Started                48s                kubelet, minikube  Started container
  Normal   Pulled                 48s                kubelet, minikube  Container image "localhost:5000/proxy_init:latest" already present on mach
ine
  Normal   Created                48s                kubelet, minikube  Created container
  Normal   Pulled                 46s                kubelet, minikube  Container image "localhost:5000/proxy_init:latest" already present on mach
ine
  Normal   Created                46s                kubelet, minikube  Created container
  Normal   Pulled                 45s                kubelet, minikube  Container image "localhost:5000/proxyv2:latest" already present on machine
  Normal   Started                45s                kubelet, minikube  Started container
  Normal   Created                44s                kubelet, minikube  Created container
  Normal   Started                44s                kubelet, minikube  Started container
  Warning  Failed                 26s (x2 over 45s)  kubelet, minikube  Failed to pull image "localhost:5000/app:latest": rpc error: code = Unknow
n desc = Error response from daemon: Get http://localhost:5000/v2/: dial tcp 127.0.0.1:5000: getsockopt: connection refused
  Warning  Failed                 26s (x2 over 45s)  kubelet, minikube  Error: ErrImagePull
  Normal   BackOff                12s (x3 over 43s)  kubelet, minikube  Back-off pulling image "localhost:5000/app:latest"
  Warning  Failed                 12s (x3 over 43s)  kubelet, minikube  Error: ImagePullBackOff
  Normal   Pulling                0s (x3 over 45s)   kubelet, minikube  pulling image "localhost:5000/app:latest"
```

It seems this is caused by the `TAG=latest` as according to https://kubernetes.io/docs/concepts/containers/images/#updating-images, k8s will always pull the image when TAG is set to `latest`.

After changed the TAG to something different than `latest`, it works again in my local environment.

It seems this becomes broken after #8290 which removed the local registry. /cc @JimmyCYJ 
