### PR TITLE
rbac: fix the rbacconfig scope to Cluster.

### DIFF
--- a/install/kubernetes/helm/istio/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/templates/crds.yaml
@@ -105,6 +105,27 @@ spec:
   scope: Namespaced
   version: v1alpha3
 ---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: rbacconfigs.rbac.istio.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: istio-pilot
+    istio: rbac
+spec:
+  group: rbac.istio.io
+  names:
+    kind: RbacConfig
+    plural: rbacconfigs
+    singular: rbacconfig
+    categories:
+    - istio-io
+    - rbac-istio-io
+  scope: Cluster
+  version: v1alpha1
+---
 # {{- end }}
 
 # these CRDs only make sense when security is enabled
@@ -954,29 +975,6 @@ spec:
     - policy-istio-io
   scope: Namespaced
   version: v1alpha2
----
-
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: rbacconfigs.rbac.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: mixer
-    package: istio.io.mixer
-    istio: rbac
-spec:
-  group: rbac.istio.io
-  names:
-    kind: RbacConfig
-    plural: rbacconfigs
-    singular: rbacconfig
-    categories:
-    - istio-io
-    - rbac-istio-io
-  scope: Namespaced
-  version: v1alpha1
 ---
 
 kind: CustomResourceDefinition


### PR DESCRIPTION
It is changed to cluster scope in [pilot](https://github.com/istio/istio/blob/2048b25f2dfb1ed949399de1cdd1fb71d26abeee/pilot/pkg/model/config.go#L461) and also only used in pilot.

/cc @liminw 