### PR TITLE
Print hint message before invoking installation scripts and fix a bunch of shell check errors

### DIFF
--- a/tests/e2e/local/common.sh
+++ b/tests/e2e/local/common.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common utilities for Istio local installation on any platform.
+
+# read_input_y reads user's input.
+# If receives a y|Y, it will return 0, otherwise will return 1.
+function read_input_y() {
+  read -p "If you are OK with that, press Y|y to continue [default: no]: " -r continue
+  ok=${continue:-"no"}
+  if [[ $ok = *"y"* ]] || [[ $ok = *"Y"* ]]; then
+    return 0
+  else
+    return 1
+  fi
+}

--- a/tests/e2e/local/minikube/install_prereqs.sh
+++ b/tests/e2e/local/minikube/install_prereqs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
+SCRIPTPATH="$(cd "$(dirname "$0")" || exit ; pwd -P)"
 ROOTDIR="$(dirname "${SCRIPTPATH}")"
 # shellcheck source=tests/e2e/local/common.sh
 source "${ROOTDIR}/common.sh"
@@ -8,7 +8,7 @@ source "${ROOTDIR}/common.sh"
 case "${OSTYPE}" in
   darwin*)
     echo "We are going to install/update curl, homebrew, docker, kubectl, hyperkit, minikube in your system."
-    echo "And will do `homebrew update` to fetch the latest packages."
+    echo "And will do homebrew update to fetch the latest packages."
     if read_input_y; then
       ./install_prereqs_macos.sh
     fi;;
@@ -21,13 +21,13 @@ case "${OSTYPE}" in
     case "${DISTRO}" in
       Debian|Ubuntu)
         echo "We are going to install/update curl, apt-get, dpkg, docker, kubectl, kvm2, minikube in your system."
-        echo "And will do `apt-get update` to fetch the latest packages."
+        echo "And will do apt-get update to fetch the latest packages."
         if read_input_y; then
           ./install_prereqs_debian.sh
         fi;;
       CentOS)
         echo "We are going to install/update curl, yum, rpm, docker, kubectl, kvm2, minikube in your system."
-        echo "And will do `yum update` to fetch the latest packages."
+        echo "And will do yum update to fetch the latest packages."
         if read_input_y; then
           ./install_prereqs_centos.sh
         fi;;

--- a/tests/e2e/local/minikube/install_prereqs.sh
+++ b/tests/e2e/local/minikube/install_prereqs.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 
+SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
+ROOTDIR="$(dirname "${SCRIPTPATH}")"
+# shellcheck source=tests/e2e/local/common.sh
+source "${ROOTDIR}/common.sh"
+
 case "${OSTYPE}" in
-  darwin*) sh install_prereqs_macos.sh;;
+  darwin*)
+    echo "We are going to install/update curl, homebrew, docker, kubectl, hyperkit, minikube in your system."
+    echo "And will do `homebrew update` to fetch the latest packages."
+    if read_input_y; then
+      ./install_prereqs_macos.sh
+    fi;;
   linux*)
     DISTRO="$(lsb_release -i -s)"
     # If lsb_release is not installed on CentOS, DISTRO will be empty.
@@ -10,9 +20,17 @@ case "${OSTYPE}" in
     fi
     case "${DISTRO}" in
       Debian|Ubuntu)
-        sh install_prereqs_debian.sh;;
+        echo "We are going to install/update curl, apt-get, dpkg, docker, kubectl, kvm2, minikube in your system."
+        echo "And will do `apt-get update` to fetch the latest packages."
+        if read_input_y; then
+          ./install_prereqs_debian.sh
+        fi;;
       CentOS)
-        sh install_prereqs_centos.sh;;
+        echo "We are going to install/update curl, yum, rpm, docker, kubectl, kvm2, minikube in your system."
+        echo "And will do `yum update` to fetch the latest packages."
+        if read_input_y; then
+          ./install_prereqs_centos.sh
+        fi;;
       *) echo "unsupported distro: ${DISTRO}" ;;
     esac;;
   *) echo "unsupported: ${OSTYPE}" ;;


### PR DESCRIPTION
Per @sdake 

> a command line option could be passed to install_prereqs.sh that disables the "are you sure you want to continue?" feature of each script and default to "ask for permission".

In tests/e2e/local scripts, we usually install/update packages with the option `--quiet`, probably we need to print hint message before invoking installation scripts.

@sdake you want this?