### PR TITLE
Upgrade integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,10 @@ common-test:
 selected-pkg-test:
 	find ${WHAT} -name "*_test.go"|xargs -i dirname {}|uniq|xargs -i go test ${T} {}
 
+.PHONY: upgrade-test
+upgrade-test:
+	tests/upgrade/test_upgrade_from.sh 1.0.1
+
 #-----------------------------------------------------------------------------
 # Target: coverage
 #-----------------------------------------------------------------------------

--- a/tests/upgrade/templates/fortio-cli.yaml
+++ b/tests/upgrade/templates/fortio-cli.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cli-fortio
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cli-fortio
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        imagePullPolicy: Always
+        args:
+          - load
+          - -c
+          - "32"
+          - -t
+          - "300s"
+          - -qps
+          - "10"
+          - http://echosrv.test.svc.cluster.local:8080/echo?size=200

--- a/tests/upgrade/templates/fortio.yaml
+++ b/tests/upgrade/templates/fortio.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echosrv
+spec:
+  ports:
+  - port: 8080
+    name: http
+  selector:
+    app: echosrv
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: echosrv
+spec:
+  host: echosrv.test.svc.cluster.local
+  subsets:
+    - name: v1
+      labels:
+        version: v1
+    - name: v2
+      labels:
+        version: v2
+      trafficPolicy:
+        tls:
+          mode: ISTIO_MUTUAL
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: echosrv-deployment-v1
+spec:
+  replicas: 4
+  minReadySeconds: 60
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: echosrv
+        version: v1
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        ports:
+        - containerPort: 8080
+        args:
+          - server
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: echosrv-deployment-v2
+spec:
+  replicas: 4
+  minReadySeconds: 60
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: echosrv
+        version: v2
+    spec:
+      containers:
+      - name: echosrv
+        image: istio/fortio:latest
+        ports:
+        - containerPort: 8080
+        args:
+          - server
+---

--- a/tests/upgrade/templates/gateway.yaml
+++ b/tests/upgrade/templates/gateway.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: fortio-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - echosrv.test.svc.cluster.local
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: echosrv
+spec:
+  hosts:
+  - echosrv.test.svc.cluster.local
+  gateways:
+  - fortio-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /echo
+    route:
+    - destination:
+        host: echosrv.test.svc.cluster.local
+        port:
+          number: 8080
+    retries:
+      attempts: 5
+      perTryTimeout: 5s
+---
+

--- a/tests/upgrade/test_upgrade_from.sh
+++ b/tests/upgrade/test_upgrade_from.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+# This test checks for control and data plane upgrade from the passed in version to $HUB/$TAG.
+# It runs the following steps:
+# 1. Installs istio with multiple gateway replicas at source version. Version is defined by tag e.g. 1.0.0
+# 2. Installs fortio echosrv with a couple of different subsets/destination rules with multiple replicas.
+# 3. Sends external traffic to echosrv through ingress gateway.
+# 4. Sends internal traffic to echosrv from fortio load pod.
+# 5. Upgrades control plane to current head version.
+# 6. Does a rolling restart of one of the echosrv subsets.
+# 7. Parses the output from the load pod to check for any errors during upgrade and returns 1 is any are found.
+#
+# Note: in order to generate the correct manifest, the script must git checkout the source and target release tags.
+#       This will fail if the workspace is not clean.
+# Note: assumes clean cluster with nothing installed. Try kubectl delete namespace --now istio-system test
+
+usage() {
+    echo "Usage:"
+    echo "  ./test_upgrade_from.sh <from tag>" 
+    echo
+    echo '  e.g. ./test_upgrade_from.sh 1.0.0 (target is $HUB/$TAG)'
+    echo
+    exit 1
+}
+
+if [[ -z "${1}" ]]; then
+    usage
+fi
+
+FROM_TAG=${1}
+FROM_HUB=gcr.io/istio-release
+
+ISTIO_ROOT=${GOPATH}/src/istio.io/istio
+LOCAL_FORTIO_LOG=/tmp/fortio_local.log
+POD_FORTIO_LOG=/tmp/fortio_pod.log
+
+# Make sure to change templates/*.yaml with the correct address if this changes.
+TEST_NAMESPACE=test
+
+original_branch=`git rev-parse --abbrev-ref HEAD`
+cur_branch=${original_branch}
+cur_sha=`git rev-parse HEAD`
+
+installIstioSystemAtVersionHelmTemplate() {
+   helm template ${ISTIO_ROOT}/install/kubernetes/helm/istio \
+    --name istio --namespace istio-system \
+    --set gateways.istio-ingressgateway.replicaCount=4 \
+    --set gateways.istio-ingressgateway.autoscaleMin=4 \
+    --set global.hub=${1} \
+    --set global.tag=${2} > ${ISTIO_ROOT}/istio.yaml
+
+   kubectl apply -n istio-system -f ${ISTIO_ROOT}/istio.yaml
+}
+
+gitChangeToTag() {
+   original_branch=`git rev-parse --abbrev-ref HEAD`
+   git checkout tags/${1} || die "Cannot git checkout, ensure your workspace is clean."
+   cur_branch=`git rev-parse --abbrev-ref HEAD`
+   cur_sha=`git rev-parse HEAD`
+   writeMsg "Switching branch from ${original_branch} to tags/${1}"
+}
+
+gitRestorePrevBranch() {
+   git checkout ${original_branch}
+   cur_branch=`git rev-parse --abbrev-ref HEAD`
+   cur_sha=`git rev-parse HEAD`
+   writeMsg "Switching branch to ${original_branch}"
+}
+
+installIstioSystemAtTag() {
+   gitChangeToTag ${2}
+   installIstioSystemAtVersionHelmTemplate ${1} ${2}
+   gitRestorePrevBranch
+}
+
+installTest() {
+    writeMsg "Installing test deployments"
+   kubectl apply -n ${TEST_NAMESPACE} -f ${ISTIO_ROOT}/tests/upgrade/templates/gateway.yaml
+   # We don't want to auto-inject into istio-system, so echosrv and load client must be in different namespace.
+   kubectl apply -n ${TEST_NAMESPACE} -f ${ISTIO_ROOT}/tests/upgrade/templates/fortio.yaml
+   sleep 10
+}
+
+sendInternalRequestTraffic() {
+   writeMsg "Sending internal traffic"
+   kubectl apply -n ${TEST_NAMESPACE} -f ${ISTIO_ROOT}/tests/upgrade/templates/fortio-cli.yaml
+}
+
+sendExternalRequestTraffic() {
+    writeMsg "Sending external traffic"
+    fortio load -c 32 -t 300s -qps 10 -H "Host:echosrv.test.svc.cluster.local" http://${1}/echo?size=200 &> ${LOCAL_FORTIO_LOG}
+}
+
+restartDataPlane() {
+    # Apply label within deployment spec.
+    # This is a hack to force a rolling restart without making any material changes to spec.
+    cur_time=$(date +%s)
+    writeMsg "Restarting deployment ${1}"
+    kubectl patch deployment ${1} -n ${TEST_NAMESPACE} -p'{"spec":{"template":{"spec":{"containers":[{"name":"echosrv","env":[{"name":"RESTART_","value":"1"}]}]}}}}'
+}
+
+writeMsg() {
+    printf "\n\n****************\n\n${1}\n\n****************\n\n"
+
+}
+
+waitForIngress() {
+    sleep_time_sec=10
+    INGRESS_HOST=""
+    while [ -z ${INGRESS_HOST} ]; do
+        echo "Waiting for ingress-gateway addr..."
+        INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+        INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
+        INGRESS_ADDR=${INGRESS_HOST}:${INGRESS_PORT}
+        sleep ${sleep_time_sec}
+        (( sleep_time_sofar += $sleep_time_sec ))
+        if (( sleep_time_sofar > 300 )); then
+            echo "Timed out waiting for ingress-gateway address"
+            exit 1
+        fi
+    done
+    echo "Got ingress-gateway addr: ${INGRESS_ADDR}"
+}
+
+
+waitForPodsReady() {
+    sleep_time_sec=10
+    while :; do
+        echo "Waiting for pods to be ready in ${1}..."
+        pods_str=$(kubectl -n ${1} get pods | tail -n +2 )
+        arr=()
+        while read -r line; do
+           arr+=("$line")
+        done <<< "$pods_str"
+
+        ready="true"
+        for line in "${arr[@]}"; do
+            if [[ ${line} != *"Running"* ]]; then
+                ready="false"
+            fi
+        done
+        if [  "${ready}" = "true" ]; then
+            echo "All pods ready."
+            return
+        fi
+
+        sleep ${sleep_time_sec}
+        (( sleep_time_sofar += $sleep_time_sec ))
+        if (( sleep_time_sofar > 300 )); then
+            echo "Timed out waiting for pods to be ready."
+            echo ${pods_str}
+            exit 1
+        fi
+    done
+}
+
+checkEchosrv() {
+    sleep_time_sec=10
+    while :; do
+        resp=$( curl -o /dev/null -s -w "%{http_code}\n" -HHost:echosrv.${TEST_NAMESPACE}.svc.cluster.local http://${INGRESS_ADDR}/echo )
+        if [[ "${resp}" = *"200"* ]]; then
+            echo "Got correct response from echosrv."
+            return
+        else
+            echo "Got bad echosrv response: ${resp}"
+        fi
+
+        sleep ${sleep_time_sec}
+        (( sleep_time_sofar += $sleep_time_sec ))
+        if (( sleep_time_sofar > 300 )); then
+            echo "Timed out waiting for 200 from echosrv."
+            exit 1
+        fi
+    done
+}
+
+git fetch upstream --tags --prune
+git fetch origin --tags --prune
+
+kubectl create namespace istio-system
+kubectl create namespace ${TEST_NAMESPACE}
+kubectl label namespace ${TEST_NAMESPACE} istio-injection=enabled
+
+pushd ${ISTIO_ROOT}
+
+installIstioSystemAtTag ${FROM_HUB} ${FROM_TAG}
+waitForIngress
+waitForPodsReady istio-system
+
+installTest
+waitForPodsReady ${TEST_NAMESPACE}
+sleep 20
+checkEchosrv
+
+sendInternalRequestTraffic
+sendExternalRequestTraffic ${INGRESS_ADDR}
+sleep 20
+installIstioSystemAtVersionHelmTemplate ${HUB} ${TAG}
+waitForPodsReady istio-system
+sleep 60
+restartDataPlane echosrv-deployment-v1
+sleep 100
+
+cli_pod_name=$(kubectl -n ${TEST_NAMESPACE} get pods -lapp=cli-fortio -o jsonpath='{.items[0].metadata.name}')
+echo "Traffic client pod is ${cli_pod_name}, waiting for traffic to complete..."
+kubectl logs -f -n ${TEST_NAMESPACE} -c echosrv ${cli_pod_name} &> ${POD_FORTIO_LOG}
+
+local_log_str=$(grep "Code 200" ${LOCAL_FORTIO_LOG})
+pod_log_str=$(grep "Code 200"  ${POD_FORTIO_LOG})
+
+if [[ ${local_log_str} == "" ]]; then
+    echo "No Code 200 found in external traffic log"
+elif [[ ${local_log_str} != *"(100.0"* ]]; then
+    printf "\n\nErrors found in external traffic log:\n\n"
+    cat ${LOCAL_FORTIO_LOG}
+fi
+
+if [[ ${pod_log_str} == "" ]]; then
+    echo "No Code 200 found in internal traffic log"
+elif [[ ${pod_log_str} != *"(100.0"* ]]; then
+    printf "\n\nErrors found in internal traffic log:\n\n"
+    cat ${POD_FORTIO_LOG}
+    exit 1
+fi
+
+popd
+
+echo "SUCCESS"

--- a/tests/upgrade/test_upgrade_from.sh
+++ b/tests/upgrade/test_upgrade_from.sh
@@ -6,13 +6,13 @@
 # 2. Installs fortio echosrv with a couple of different subsets/destination rules with multiple replicas.
 # 3. Sends external traffic to echosrv through ingress gateway.
 # 4. Sends internal traffic to echosrv from fortio load pod.
-# 5. Upgrades control plane to current head version.
+# 5. Upgrades control plane to $HUB/$TAG. *** Ensure these are available or upgrade will fail! ***
 # 6. Does a rolling restart of one of the echosrv subsets.
 # 7. Parses the output from the load pod to check for any errors during upgrade and returns 1 is any are found.
 #
-# Note: in order to generate the correct manifest, the script must git checkout the source and target release tags.
-#       This will fail if the workspace is not clean.
-# Note: assumes clean cluster with nothing installed. Try kubectl delete namespace --now istio-system test
+# Note 1: in order to generate the correct manifest, the script must git checkout the source and target release tags.
+#         This will fail if the workspace is not clean.
+# Note 2: assumes clean cluster with nothing installed. Try kubectl delete namespace --now istio-system test.
 
 usage() {
     echo "Usage:"


### PR DESCRIPTION
This test tests control and data plane upgrade from a source tag to the helm template generated at $HUB/$TAG in the current branch. The make upgrade-test target is currently hard-coded to 1.0.1 but this can be used for any combination of upgrades/downgrades.

It runs the following:
1. Installs istio with multiple gateway replicas at source version. Version is defined by tag e.g. 1.0.0
2. Installs echosrv with a couple of different subsets/destination rules with multiple replicas.
3. Sends external traffic to echosrv through ingress gateway.
4. Sends internal traffic to echosrv from fortio load pod.
5. Upgrades control plane to $HUB/$TAG using helm from the current branch.
6. Does a rolling restart of one of the echosrv subsets.
7. Parses the output from the load pod to check for any errors during upgrade and returns 1 is any are found.

