### PR TITLE
coverage improvement for istio.io/istio/pilot/pkg/model

### DIFF
--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -1,0 +1,259 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+)
+
+func TestAddConfig(t *testing.T) {
+
+	roleCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRole.Type, Name: "test-role-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRole{},
+	}
+	bindingCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRoleBinding.Type, Name: "test-binding-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRoleBinding{
+			Subjects: []*rbacproto.Subject{{User: "test-user-1"}},
+			RoleRef:  &rbacproto.RoleRef{Kind: "ServiceRole", Name: "test-role-1"},
+		},
+	}
+
+	invalidateBindingCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRoleBinding.Type, Name: "test-binding-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRoleBinding{
+			Subjects: []*rbacproto.Subject{{User: "test-user-1"}},
+			RoleRef:  &rbacproto.RoleRef{Kind: "ServiceRole", Name: ""},
+		},
+	}
+
+	cases := []struct {
+		name                     string
+		config                   []Config
+		authzPolicies            *AuthorizationPolicies
+		expectedRolesAndBindings *RolesAndBindings
+	}{
+		{
+			name:                     "test add config for ServiceRole",
+			config:                   []Config{roleCfg},
+			authzPolicies:            &AuthorizationPolicies{},
+			expectedRolesAndBindings: &RolesAndBindings{[]Config{roleCfg}, map[string][]*rbacproto.ServiceRoleBinding{}},
+		},
+		{
+			name:                     "test add invalidate config for ServiceRoleBinding",
+			config:                   []Config{invalidateBindingCfg},
+			authzPolicies:            &AuthorizationPolicies{},
+			expectedRolesAndBindings: nil,
+		},
+		{
+			name:          "test add config for ServiceRoleBinding",
+			config:        []Config{bindingCfg},
+			authzPolicies: &AuthorizationPolicies{},
+			expectedRolesAndBindings: &RolesAndBindings{
+				[]Config{},
+				map[string][]*rbacproto.ServiceRoleBinding{
+					bindingCfg.Spec.(*rbacproto.ServiceRoleBinding).RoleRef.Name: {bindingCfg.Spec.(*rbacproto.ServiceRoleBinding)},
+				},
+			},
+		},
+		{
+			name:          "test add config for both ServiceRoleBinding and ServiceRole",
+			config:        []Config{roleCfg, bindingCfg},
+			authzPolicies: &AuthorizationPolicies{},
+			expectedRolesAndBindings: &RolesAndBindings{
+				[]Config{roleCfg},
+				map[string][]*rbacproto.ServiceRoleBinding{
+					bindingCfg.Spec.(*rbacproto.ServiceRoleBinding).RoleRef.Name: {bindingCfg.Spec.(*rbacproto.ServiceRoleBinding)},
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for _, role := range c.config {
+				c.authzPolicies.AddConfig(&role)
+			}
+			if !reflect.DeepEqual(c.expectedRolesAndBindings, c.authzPolicies.NamespaceToPolicies[NamespaceAll]) {
+				t.Errorf("[%s]Excepted:\n%v\n, Got: \n%v\n", c.name, c.expectedRolesAndBindings, c.authzPolicies.NamespaceToPolicies[NamespaceAll])
+			}
+		})
+	}
+}
+
+func TestRolesForNamespace(t *testing.T) {
+	roleCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRole.Type, Name: "test-role-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRole{},
+	}
+	bindingCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRoleBinding.Type, Name: "test-binding-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRoleBinding{
+			Subjects: []*rbacproto.Subject{{User: "test-user-1"}},
+			RoleRef:  &rbacproto.RoleRef{Kind: "ServiceRole", Name: "test-role-1"},
+		},
+	}
+
+	cases := []struct {
+		name                            string
+		authzPolicies                   *AuthorizationPolicies
+		ns                              string
+		expectedRolesServiceRoleBinding []Config
+	}{
+		{
+			name:          "authzPolicies is nil",
+			authzPolicies: nil,
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: []Config{},
+		},
+		{
+			name:          "the NamespaceToPolicies of authzPolicies is nil",
+			authzPolicies: &AuthorizationPolicies{},
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: []Config{},
+		},
+		{
+			name:          "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
+			authzPolicies: &AuthorizationPolicies{map[string]*RolesAndBindings{}, nil},
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: []Config{},
+		},
+		{
+			name: "the roles of authzPolicies in NamespaceToPolicies is nil",
+			authzPolicies: &AuthorizationPolicies{
+				map[string]*RolesAndBindings{
+					"default": {
+						Roles:              []Config{},
+						RoleNameToBindings: map[string][]*rbacproto.ServiceRoleBinding{},
+					},
+				},
+				nil,
+			},
+			ns: NamespaceAll,
+			expectedRolesServiceRoleBinding: []Config{},
+		},
+		{
+			name: "all seems ok",
+			authzPolicies: &AuthorizationPolicies{
+				map[string]*RolesAndBindings{
+					NamespaceAll: {
+						Roles:              []Config{roleCfg, bindingCfg},
+						RoleNameToBindings: map[string][]*rbacproto.ServiceRoleBinding{},
+					},
+				},
+				nil,
+			},
+			ns: NamespaceAll,
+			expectedRolesServiceRoleBinding: []Config{roleCfg, bindingCfg},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.authzPolicies.RolesForNamespace(c.ns)
+			if !reflect.DeepEqual(c.expectedRolesServiceRoleBinding, actual) {
+				t.Errorf("Got different Config, Excepted:\n%v\n, Got: \n%v\n", c.expectedRolesServiceRoleBinding, actual)
+			}
+		})
+	}
+}
+
+func TestRoleToBindingsForNamespace(t *testing.T) {
+
+	bindingCfg := Config{
+		ConfigMeta: ConfigMeta{
+			Type: ServiceRoleBinding.Type, Name: "test-binding-1", Namespace: NamespaceAll},
+		Spec: &rbacproto.ServiceRoleBinding{
+			Subjects: []*rbacproto.Subject{{User: "test-user-1"}},
+			RoleRef:  &rbacproto.RoleRef{Kind: "ServiceRole", Name: "test-role-1"},
+		},
+	}
+
+	cases := []struct {
+		name                            string
+		authzPolicies                   *AuthorizationPolicies
+		ns                              string
+		expectedRolesServiceRoleBinding map[string][]*rbacproto.ServiceRoleBinding
+	}{
+		{
+			name:          "authzPolicies is nil",
+			authzPolicies: nil,
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
+		},
+		{
+			name:          "the NamespaceToPolicies of authzPolicies is nil",
+			authzPolicies: &AuthorizationPolicies{},
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
+		},
+		{
+			name:          "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
+			authzPolicies: &AuthorizationPolicies{map[string]*RolesAndBindings{}, nil},
+			ns:            NamespaceAll,
+			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
+		},
+		{
+			name: "the roles of authzPolicies in NamespaceToPolicies is nil",
+			authzPolicies: &AuthorizationPolicies{
+				map[string]*RolesAndBindings{
+					"default": {
+						Roles:              []Config{},
+						RoleNameToBindings: map[string][]*rbacproto.ServiceRoleBinding{},
+					},
+				},
+				nil,
+			},
+			ns: NamespaceAll,
+			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
+		},
+		{
+			name: "all seems ok",
+			authzPolicies: &AuthorizationPolicies{
+				map[string]*RolesAndBindings{
+					NamespaceAll: {
+						Roles: []Config{},
+						RoleNameToBindings: map[string][]*rbacproto.ServiceRoleBinding{
+							bindingCfg.Spec.(*rbacproto.ServiceRoleBinding).RoleRef.Name: {bindingCfg.Spec.(*rbacproto.ServiceRoleBinding)},
+						},
+					},
+				},
+				nil,
+			},
+			ns: NamespaceAll,
+			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{
+				bindingCfg.Spec.(*rbacproto.ServiceRoleBinding).RoleRef.Name: {bindingCfg.Spec.(*rbacproto.ServiceRoleBinding)},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := c.authzPolicies.RoleToBindingsForNamespace(c.ns)
+			if !reflect.DeepEqual(c.expectedRolesServiceRoleBinding, actual) {
+				t.Errorf("Got different ServiceRoleBinding, Excepted:\n%v\n, Got: \n%v\n", c.expectedRolesServiceRoleBinding, actual)
+			}
+		})
+	}
+}

--- a/pilot/pkg/model/config.go
+++ b/pilot/pkg/model/config.go
@@ -623,6 +623,7 @@ func (store *istioConfigStore) EnvoyFilter(workloadLabels LabelsCollection) *Con
 				continue
 			}
 		}
+		mergedFilterConfig.WorkloadLabels = make(map[string]string)
 		mergedFilterConfig.Filters = append(mergedFilterConfig.Filters, filter.Filters...)
 	}
 

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -347,3 +347,34 @@ func BenchmarkSort(b *testing.B) {
 		sort.Sort(given)
 	}
 }
+
+func TestIsValidSubsetKey(t *testing.T) {
+	cases := []struct {
+		subsetkey string
+		expectErr bool
+	}{
+		{
+			subsetkey: "outbound|80|subset|hostname",
+			expectErr: false,
+		},
+		{
+			subsetkey: "outbound|80||hostname",
+			expectErr: false,
+		},
+		{
+			subsetkey: "outbound|80|subset||hostname",
+			expectErr: true,
+		},
+		{
+			subsetkey: "",
+			expectErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		err := IsValidSubsetKey(c.subsetkey)
+		if !err != c.expectErr {
+			t.Errorf("got %v but want %v\n", err, c.expectErr)
+		}
+	}
+}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3119,3 +3119,53 @@ func TestValidateRbacConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateMixerService(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    *mccpb.IstioService
+		valid bool
+	}{
+		{
+			name: "no name and service",
+			in:   &mccpb.IstioService{},
+		},
+		{
+			name: "specify both name and service",
+			in:   &mccpb.IstioService{Service: "test-service-service", Name: "test-service-name"},
+		},
+		{
+			name: "specify both namespace and service",
+			in:   &mccpb.IstioService{Service: "test-service-service", Namespace: "test-service-namespace"},
+		},
+		{
+			name: "specify both domain and service",
+			in:   &mccpb.IstioService{Service: "test-service-service", Domain: "test-service-domain"},
+		},
+		{
+			name: "invalid name label",
+			in:   &mccpb.IstioService{Name: strings.Repeat("x", 64)},
+		},
+		{
+			name: "invalid namespace label",
+			in:   &mccpb.IstioService{Name: "test-service-name", Namespace: strings.Repeat("x", 64)},
+		},
+		{
+			name: "invalid domian or labels",
+			in:   &mccpb.IstioService{Name: "test-service-name", Domain: strings.Repeat("x", 256)},
+		},
+		{
+			name:  "valid",
+			in:    validService,
+			valid: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ValidateMixerService(c.in); (got == nil) != c.valid {
+				t.Errorf("ValidateMixerService(%v): got(%v) != want(%v): %v", c.name, got == nil, c.valid, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
xref #8568
before change:
```
istio.io/istio/pilot/pkg/model/authorization.go:51:	addServiceRole				0.0%
istio.io/istio/pilot/pkg/model/authorization.go:68:	addServiceRoleBinding			0.0%
istio.io/istio/pilot/pkg/model/authorization.go:96:	AddConfig				0.0%
istio.io/istio/pilot/pkg/model/authorization.go:112:	RolesForNamespace			0.0%
istio.io/istio/pilot/pkg/model/authorization.go:126:	RoleToBindingsForNamespace		0.0%
istio.io/istio/pilot/pkg/model/authorization.go:140:	newAuthzPolicies			0.0%
...
istio.io/istio/pilot/pkg/model/config.go:565:		ServiceEntries				0.0%
istio.io/istio/pilot/pkg/model/config.go:574:		sortConfigByCreationTime		0.0%
istio.io/istio/pilot/pkg/model/config.go:604:		EnvoyFilter				0.0%
istio.io/istio/pilot/pkg/model/config.go:635:		HTTPAPISpecByDestination		0.0%
```
and coverage of this package is 
```
coverage: 66.70% of statements
```
But after change
```
istio.io/istio/pilot/pkg/model/authorization.go:51:	addServiceRole				87.5%
istio.io/istio/pilot/pkg/model/authorization.go:68:	addServiceRoleBinding			92.9%
istio.io/istio/pilot/pkg/model/authorization.go:96:	AddConfig				83.3%
istio.io/istio/pilot/pkg/model/authorization.go:112:	RolesForNamespace			100.0%
istio.io/istio/pilot/pkg/model/authorization.go:126:	RoleToBindingsForNamespace		100.0%
....
istio.io/istio/pilot/pkg/model/config.go:565:		ServiceEntries				75.0%
istio.io/istio/pilot/pkg/model/config.go:574:		sortConfigByCreationTime		66.7%
istio.io/istio/pilot/pkg/model/config.go:604:		EnvoyFilter				71.4%
istio.io/istio/pilot/pkg/model/config.go:635:		HTTPAPISpecByDestination		91.7%
```
and coverage of this package is 
```
coverage: 71.3% of statements
```
greater than `70%` defined in [https://github.com/istio/istio/blob/master/codecov.requirement](https://github.com/istio/istio/blob/master/codecov.requirement)