### PR TITLE
Bug fix: GetPrivateIP timeout does not take effect

### DIFF
--- a/pilot/pkg/proxy/net.go
+++ b/pilot/pkg/proxy/net.go
@@ -30,7 +30,9 @@ const (
 // GetPrivateIP blocks until a private IP address is available, or a timeout is reached.
 func GetPrivateIP(ctx context.Context) (net.IP, bool) {
 	if _, ok := ctx.Deadline(); !ok {
-		context.WithTimeout(ctx, waitTimeout)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, waitTimeout)
+		defer cancel()
 	}
 
 	for {


### PR DESCRIPTION
 GetPrivateIP should use ctx returned from `context.WithTimeout`.