### PR TITLE
pilot mcp integration fixes

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -28,7 +28,7 @@
           - --address
           - unix:///sock/mixer.socket
 {{- if $.Values.global.useMixerMCP }}
-          - --configStoreURL=mcp://istio-galley.{{ $.Release.Namespace }}.svc:9901
+          - --configStoreURL=mcps://istio-galley.{{ $.Release.Namespace }}.svc:9901
           - --certFile=/etc/certs/cert-chain.pem
           - --keyFile=/etc/certs/key.pem
           - --caCertFile=/etc/certs/root-cert.pem
@@ -135,7 +135,7 @@
           - --address
           - unix:///sock/mixer.socket
 {{- if $.Values.global.useMixerMCP }}
-          - --configStoreURL=mcp://istio-galley.{{ $.Release.Namespace }}.svc:9901
+          - --configStoreURL=mcps://istio-galley.{{ $.Release.Namespace }}.svc:9901
           - --certFile=/etc/certs/cert-chain.pem
           - --keyFile=/etc/certs/key.pem
           - --caCertFile=/etc/certs/root-cert.pem

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -58,7 +58,7 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 		"Max number of entries in the check result cache")
 
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigStoreURL, "configStoreURL", "", sa.ConfigStoreURL,
-		"URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcp://<address> for MCP/Galley. "+
+		"URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcps://<address> for MCP/Galley. "+
 			"If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 
 	serverCmd.PersistentFlags().StringVarP(&sa.ConfigDefaultNamespace, "configDefaultNamespace", "", sa.ConfigDefaultNamespace,

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -56,13 +56,13 @@ func Register(builders map[string]store.Builder) {
 	}
 
 	builders["mcp"] = builder
-	builders["mcpi"] = builder
+	builders["mcps"] = builder
 }
 
 // NewStore creates a new Store instance.
 func newStore(u *url.URL, credOptions *creds.Options, fn updateHookFn) (store.Backend, error) {
 	insecure := true
-	if u.Scheme == "mcp" {
+	if u.Scheme == "mcps" {
 		insecure = false
 		if credOptions == nil {
 			return nil, errors.New("no credentials specified with secure MCP scheme")

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -49,7 +49,7 @@ type Args struct {
 	// Maximum number of goroutines in the adapter worker pool
 	AdapterWorkerPoolSize int
 
-	// URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcp://<host> to
+	// URL of the config store. Use k8s://path_to_kubeconfig, fs:// for file system, or mcps://<host> to
 	// connect to Galley. If path_to_kubeconfig is empty, in-cluster kubeconfig is used.")
 	// If this is empty (and ConfigStore isn't specified), "k8s://" will be used.
 	ConfigStoreURL string

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -29,17 +29,19 @@ import (
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/version"
 )
 
 var (
 	httpPort       int
 	monitoringPort int
-	serverArgs     bootstrap.PilotArgs
+	serverArgs     = bootstrap.PilotArgs{
+		CtrlZOptions:         ctrlz.DefaultOptions(),
+		MCPCredentialOptions: creds.DefaultOptions(),
+	}
 
 	loggingOptions = log.DefaultOptions()
-
-	ctrlzOptions = ctrlz.DefaultOptions()
 
 	rootCmd = &cobra.Command{
 		Use:          "pilot-discovery",
@@ -106,8 +108,11 @@ func init() {
 		"Select a namespace where the controller resides. If not set, uses ${POD_NAMESPACE} environment variable")
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Plugins, "plugins", bootstrap.DefaultPlugins,
 		"comma separated list of networking plugins to enable")
+
+	// MCP client flags
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.MCPServerAddrs, "mcpServerAddrs", []string{},
 		"comma separated list of mesh config protocol server addresses")
+	serverArgs.MCPCredentialOptions.AttachCobraFlags(discoveryCmd)
 
 	// Config Controller options
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",
@@ -153,8 +158,7 @@ func init() {
 	loggingOptions.AttachCobraFlags(rootCmd)
 
 	// Attach the Istio Ctrlz options to the command.
-	ctrlzOptions.AttachCobraFlags(rootCmd)
-	serverArgs.CtrlZOptions = ctrlzOptions
+	serverArgs.CtrlZOptions.AttachCobraFlags(rootCmd)
 
 	cmd.AddFlags(rootCmd)
 

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -111,7 +111,8 @@ func init() {
 
 	// MCP client flags
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.MCPServerAddrs, "mcpServerAddrs", []string{},
-		"comma separated list of mesh config protocol server addresses")
+		"comma separated list of MCP server addresses with "+
+			"mcp:// (secure) or mcpi:// (insecure) schema, e.g. mcp://istio-galley.istio-system.svc:9901")
 	serverArgs.MCPCredentialOptions.AttachCobraFlags(discoveryCmd)
 
 	// Config Controller options

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -112,7 +112,7 @@ func init() {
 	// MCP client flags
 	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.MCPServerAddrs, "mcpServerAddrs", []string{},
 		"comma separated list of MCP server addresses with "+
-			"mcp:// (secure) or mcpi:// (insecure) schema, e.g. mcp://istio-galley.istio-system.svc:9901")
+			"mcp:// (insecure) or mcps:// (secure) schema, e.g. mcps://istio-galley.istio-system.svc:9901")
 	serverArgs.MCPCredentialOptions.AttachCobraFlags(discoveryCmd)
 
 	// Config Controller options

--- a/pkg/mcp/testing/server.go
+++ b/pkg/mcp/testing/server.go
@@ -63,7 +63,7 @@ func NewServer(port int, typeUrls []string) (*Server, error) {
 
 	p := l.Addr().(*net.TCPAddr).Port
 
-	u, err := url.Parse(fmt.Sprintf("mcpi://localhost:%d", p))
+	u, err := url.Parse(fmt.Sprintf("mcp://localhost:%d", p))
 	if err != nil {
 		_ = l.Close()
 		return nil, err

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -122,7 +122,7 @@ func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int
 
 func addMcpAddrs(mcpServerAddr string) func(*bootstrap.PilotArgs) {
 	return func(arg *bootstrap.PilotArgs) {
-		arg.MCPServerAddrs = []string{mcpServerAddr}
+		arg.MCPServerAddrs = []string{"mcpi://" + mcpServerAddr}
 	}
 }
 

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -122,7 +122,7 @@ func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int
 
 func addMcpAddrs(mcpServerAddr string) func(*bootstrap.PilotArgs) {
 	return func(arg *bootstrap.PilotArgs) {
-		arg.MCPServerAddrs = []string{"mcpi://" + mcpServerAddr}
+		arg.MCPServerAddrs = []string{"mcp://" + mcpServerAddr}
 	}
 }
 


### PR DESCRIPTION
- fix parsing order of name and namespace from MCP resource
- set the network domain suffix in the mcp core data model resources
- force cached config to be rebuilt on MCP updates
- hook-up client certs to mcp client
- fix handling of namespace vs. cluster-scoped auth policy
 