### PR TITLE
Remove GKE version spec from DM quickstart

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -8,7 +8,6 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ properties['gkeClusterName'] }}
-      initialClusterVersion: 1.10.5
       legacyAbac:
         enabled: false
       initialNodeCount: {{ properties['initialNodeCount'] }}


### PR DESCRIPTION
Remove GKE version spec.

Currently the instaler will fail because the `1.10.5` is not a valid GKE version.   Not  setting  it will use the defaults at the moment:  `defaultClusterVersion: 1.9.7-gke.6`


ref:
- https://github.com/istio/istio/issues/8611
- https://github.com/istio/istio.github.io/issues/2571


https://cloud.google.com/kubernetes-engine/docs/tutorials/installing-istio#create_a_cluster