### PR TITLE
Change istio-auth enabled or not to installation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,8 +16,8 @@ about: Report a bug to help us improve Istio
 **Version**
 {{ What version of Istio and Kubernetes are you using? Use `istioctl version` and `kubectl version` }}
 
-**Is Istio Auth enabled or not?**
-{{ Did you install the stable istio.yaml, istio-auth.yaml.... or if using the Helm chart please provide full command line input }}
+**Installation**
+{{ Please describe how Istio was installed }}
 
 **Environment**
 {{ Which environment, cloud vendor, OS, etc are you using? }}


### PR DESCRIPTION
Currently many bug reports start out with a question from the triager
"how did you install Istio"?  Cover the auth case with this question,
as well as gather required information up front to better triage
incoming bug reports.