### PR TITLE
Add Makefile and CircleCI support for the tests using the new test framework.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,30 @@ jobs:
       - store_artifacts:
           path: /tmp
 
+  test-integration-local:
+      <<: *defaults
+      environment:
+        KUBECONFIG: /go/src/istio.io/istio/.circleci/config
+      resource_class: xlarge
+      steps:
+        - checkout
+        - <<: *markJobStartsOnGCS
+        - run: make sync
+        - run:
+            command: |
+              mkdir -p /go/out/tests
+              export PATH=$GOPATH/bin:$PATH
+              make localTestEnv
+              set -o pipefail
+              make test.integration T=-v | tee -a /go/out/tests/build-log.txt
+        - <<: *recordZeroExitCodeIfTestPassed
+        - <<: *recordNonzeroExitCodeIfTestFailed
+        - <<: *markJobFinishesOnGCS
+        - store_test_results:
+            path: /go/out/tests
+        - store_artifacts:
+            path: /tmp
+
   # Run nightly, to verify 'dep ensure --update' works
   depupdate:
     <<: *defaults
@@ -602,3 +626,7 @@ workflows:
       - e2e-pilot-cloudfoundry-v1alpha3-v2:
           requires:
             - build
+      - test-integration-local:
+          requires:
+            - build
+

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ ${ISTIO_OUT}/envoy: init
 ${ISTIO_ENVOY_DEBUG_PATH}: init
 ${ISTIO_ENVOY_RELEASE_PATH}: init
 
-# Pull depdendencies, based on the checked in Gopkg.lock file.
+# Pull dependencies, based on the checked in Gopkg.lock file.
 # Developers must manually run `dep ensure` if adding new deps
 depend: init | $(ISTIO_OUT)
 
@@ -708,6 +708,11 @@ include tools/deb/istio.mk
 # Target: e2e tests
 #-----------------------------------------------------------------------------
 include tests/istio.mk
+
+#-----------------------------------------------------------------------------
+# Target: integration tests
+#-----------------------------------------------------------------------------
+include tests/integration2/tests.mk
 
 #-----------------------------------------------------------------------------
 # Target: bench check

--- a/tests/integration2/README.md
+++ b/tests/integration2/README.md
@@ -1,0 +1,83 @@
+# Istio Integration Tests
+
+This folder contains Istio integration tests that use the test framework checked in at 
+[istio.io/istio/pkg/test/framework](https://github.com/istio/istio/tree/master/pkg/test/framework).
+
+### Basics
+
+The goal of the framework is to make it as easy to author and run tests as possible. In it is most simplest
+case, just typing ```go test ./...``` should be sufficient to run tests.
+
+The test framework is designed to work with standard go tooling and allows developers
+to write environment-agnostics tests in a high-level fashion. The quickest way to get started with authoring
+new tests is to checkout the code in 
+[examples](https://github.com/istio/istio/tree/master/tests/integration2/example) folder.
+
+The test framework has various flags that can be set to change its behavior.
+
+ 
+### Environments
+
+The test framework currently support two environments:
+ 
+  * **Local**: The test binaries run either in-memory, or locally as processes.
+  * **Kubernetes**: The test binaries run in a Kubernetes cluster, but the test logic runs in the test binary.
+  
+When running tests, only one environment can be specified:
+
+```shell
+go test ./... -istio.test.env local
+go test ./... -istio.test.env kubernetes
+```
+
+By default, the tests will be executed in the
+specified environment. However, test authors can specifically indicate a particular environment as
+a requirement for their tests. If the indicated environment does not match the environment that is required
+by the test, then the test will be skipped.
+
+```go
+
+// Will be skipped in kubernetes environment.
+func TestLocalOnly(t *testing.T) {
+	framework.Requires(t, dependency.Local)
+	// ...
+}
+```
+
+When an environment is not specified, the tests will run against the local environment by default.
+
+#### Kubernetes Environment
+
+When running the tests against the Kubernetes environment, you will need to explicitly specify a kube config
+file for the cluster you need to use. **Be aware that the target cluster will be changed destructively**.
+
+```shell
+go test ./...  -istio.test.env kubernetes -istio.test.kube.config ~/.kube/config
+```
+
+### Adding New Tests
+
+Please follow the general guidance for adding new tests:
+
+ * Create a new top-level folder for top-level components (i.e. mixer, pilot galley).
+
+```shell 
+cd ${ISTIO}/tets/integration2
+mkdir mycomponent
+```
+
+ * In that folder, create a new Go test with a TestMain specified:
+ 
+ ```Go
+func TestMain(m *testing.M) {
+	framework.Run("mycomponent_test", m)
+}
+ ```
+ 
+  * Add your folder name to the top-level 
+  [tests.mk](https://github.com/istio/istio/tree/master/tests/integration2/tests.mk) to file get it included 
+  in make targets and check-in gates:
+  
+```make
+INTEGRATION_TEST_NAMES = galley mixer mycomponent
+``` 

--- a/tests/integration2/README.md
+++ b/tests/integration2/README.md
@@ -5,7 +5,7 @@ This folder contains Istio integration tests that use the test framework checked
 
 ### Basics
 
-The goal of the framework is to make it as easy as possible to author and run tests. In it is most simplest
+The goal of the framework is to make it as easy as possible to author and run tests. In its simplest
 case, just typing ```go test ./...``` should be sufficient to run tests.
 
 The test framework is designed to work with standard go tooling and allows developers

--- a/tests/integration2/README.md
+++ b/tests/integration2/README.md
@@ -5,12 +5,12 @@ This folder contains Istio integration tests that use the test framework checked
 
 ### Basics
 
-The goal of the framework is to make it as easy to author and run tests as possible. In it is most simplest
+The goal of the framework is to make it as easy as possible to author and run tests. In it is most simplest
 case, just typing ```go test ./...``` should be sufficient to run tests.
 
 The test framework is designed to work with standard go tooling and allows developers
 to write environment-agnostics tests in a high-level fashion. The quickest way to get started with authoring
-new tests is to checkout the code in 
+new tests is to checkout the code in the
 [examples](https://github.com/istio/istio/tree/master/tests/integration2/examples) folder.
 
 The test framework has various flags that can be set to change its behavior.
@@ -18,7 +18,7 @@ The test framework has various flags that can be set to change its behavior.
  
 ### Environments
 
-The test framework currently support two environments:
+The test framework currently supports two environments:
  
   * **Local**: The test binaries run either in-memory, or locally as processes.
   * **Kubernetes**: The test binaries run in a Kubernetes cluster, but the test logic runs in the test binary.
@@ -48,7 +48,8 @@ When an environment is not specified, the tests will run against the local envir
 #### Kubernetes Environment
 
 When running the tests against the Kubernetes environment, you will need to explicitly specify a kube config
-file for the cluster you need to use. **Be aware that the target cluster will be changed destructively**.
+file for the cluster you need to use. **Be aware that any existing Istio deployment will be altered and/or
+removed**.
 
 ```console
 $ go test ./...  -istio.test.env kubernetes -istio.test.kube.config ~/.kube/config

--- a/tests/integration2/README.md
+++ b/tests/integration2/README.md
@@ -11,7 +11,7 @@ case, just typing ```go test ./...``` should be sufficient to run tests.
 The test framework is designed to work with standard go tooling and allows developers
 to write environment-agnostics tests in a high-level fashion. The quickest way to get started with authoring
 new tests is to checkout the code in 
-[examples](https://github.com/istio/istio/tree/master/tests/integration2/example) folder.
+[examples](https://github.com/istio/istio/tree/master/tests/integration2/examples) folder.
 
 The test framework has various flags that can be set to change its behavior.
 
@@ -25,9 +25,9 @@ The test framework currently support two environments:
   
 When running tests, only one environment can be specified:
 
-```shell
-go test ./... -istio.test.env local
-go test ./... -istio.test.env kubernetes
+```console
+$ go test ./... -istio.test.env local
+$ go test ./... -istio.test.env kubernetes
 ```
 
 By default, the tests will be executed in the
@@ -36,7 +36,6 @@ a requirement for their tests. If the indicated environment does not match the e
 by the test, then the test will be skipped.
 
 ```go
-
 // Will be skipped in kubernetes environment.
 func TestLocalOnly(t *testing.T) {
 	framework.Requires(t, dependency.Local)
@@ -51,8 +50,8 @@ When an environment is not specified, the tests will run against the local envir
 When running the tests against the Kubernetes environment, you will need to explicitly specify a kube config
 file for the cluster you need to use. **Be aware that the target cluster will be changed destructively**.
 
-```shell
-go test ./...  -istio.test.env kubernetes -istio.test.kube.config ~/.kube/config
+```console
+$ go test ./...  -istio.test.env kubernetes -istio.test.kube.config ~/.kube/config
 ```
 
 ### Adding New Tests
@@ -61,14 +60,14 @@ Please follow the general guidance for adding new tests:
 
  * Create a new top-level folder for top-level components (i.e. mixer, pilot galley).
 
-```shell 
-cd ${ISTIO}/tets/integration2
-mkdir mycomponent
+```console 
+$ cd ${ISTIO}/tests/integration2
+$ mkdir mycomponent
 ```
 
  * In that folder, create a new Go test with a TestMain specified:
  
- ```Go
+ ```go
 func TestMain(m *testing.M) {
 	framework.Run("mycomponent_test", m)
 }

--- a/tests/integration2/tests.mk
+++ b/tests/integration2/tests.mk
@@ -1,0 +1,40 @@
+#-----------------------------------------------------------------------------
+# Target: test.integration.*
+#-----------------------------------------------------------------------------
+
+# The names of the integration test folders at ROOT/tests/integration2/*.
+INTEGRATION_TEST_NAMES = galley mixer
+
+# Generate the names of the integration test targets that use local environment (i.e. test.integration.galley)
+INTEGRATION_TESTS_LOCAL = $(addprefix test.integration., $(INTEGRATION_TEST_NAMES))
+
+# Generate the names of the integration test targets that use kubernetes environment (i.e. test.integration.galley.kube)
+INTEGRATION_TESTS_KUBE  = $(addsuffix .kube, $(addprefix test.integration., $(INTEGRATION_TEST_NAMES)))
+
+# Calculate the Kubernetes config file to use. Default to the one in user's home.
+# TODO: This probably needs to be more intelligent and take environment variables into account.
+INTEGRATION_TEST_KUBECONFIG = ~/.kube/config
+ifneq ($(KUBECONFIG),)
+    INTEGRATION_TEST_KUBECONFIG = $(KUBECONFIG)
+endif
+
+# This is a useful debugging target for testing everything.
+.PHONY: test.integration.all
+test.integration.all: test.integration test.integration.kube
+
+# All integration tests targeting local environment.
+.PHONY: test.integration
+test.integration: $(INTEGRATION_TESTS_LOCAL)
+
+# All integration tests targeting Kubernetes environment.
+.PHONY: test.integration.kube
+test.integration.kube: $(INTEGRATION_TESTS_KUBE)
+
+# Generate integration test targets for local environment.
+$(INTEGRATION_TESTS_LOCAL): test.integration.%:
+	$(GO) test -p 1 ${T} ./tests/integration2/$*/... --istio.test.env local
+
+# Generate integration test targets for kubernetes environment.
+$(INTEGRATION_TESTS_KUBE): test.integration.%.kube:
+	$(GO) test -p 1 ${T} ./tests/integration2/$*/... --istio.test.env kubernetes --istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG}
+


### PR DESCRIPTION
Adds Makefile and Circle config entries for ported tests using the new test framework.

- Adds a new makefile include (similar to the e2e one) that generates a set of targets for running new integration tests through command-line. The names of these are derived from the folder names (but still needs to be explicitly specified in the Makefile).
- Adds a job for running the integration tests against the local environment in CircleCI. This is a straight up copy from the original test job.
- Add a README.md file giving a brief introduction to writing tests and using the framework.
