### PR TITLE
Inject: Fix potential empty pod name and namespace

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -403,7 +403,7 @@ func injectRequired(ignored []string, namespacePolicy InjectionPolicy, podSpec *
 
 		log.Debugf("Sidecar injection policy for %v/%v: namespacePolicy:%v useDefault:%v inject:%v required:%v %s",
 			metadata.Namespace,
-			metadata.Name,
+			potentialPodName(metadata),
 			namespacePolicy,
 			useDefault,
 			inject,
@@ -741,4 +741,14 @@ type SidecarInjectionStatus struct {
 func sidecarTemplateVersionHash(in string) string {
 	hash := sha256.Sum256([]byte(in))
 	return hex.EncodeToString(hash[:])
+}
+
+func potentialPodName(metadata *metav1.ObjectMeta) string {
+	if metadata.Name != "" {
+		return metadata.Name
+	}
+	if metadata.GenerateName != "" {
+		return metadata.GenerateName + "***** (actual name not yet known)"
+	}
+	return ""
 }


### PR DESCRIPTION
Looking at the sidecar-injector logs, one can see:

```
... Sidecar injection policy for /: namespacePolicy:enabled ...
```

The pod namespace and name are both empty, because when the
pod creation comes from a deployment, those fields reach
the webhook *not* populated.

This patch improves the logs by trying to use metadata.GenerateName
for the pod name. Now the logs look like:

```
... Sidecar injection policy for t2/httpbin-77647f7b59-*****: namespacePolicy:enabled ...
```