### PR TITLE
[Bug Fix] Fix sh function not found error in minikube

### DIFF
--- a/tests/e2e/local/minikube/install_prereqs.sh
+++ b/tests/e2e/local/minikube/install_prereqs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 case "${OSTYPE}" in
-  darwin*) sh install_prereqs_macos.sh;;
+  darwin*) ./install_prereqs_macos.sh;;
   linux*)
     DISTRO="$(lsb_release -i -s)"
     # If lsb_release is not installed on CentOS, DISTRO will be empty.
@@ -10,9 +10,9 @@ case "${OSTYPE}" in
     fi
     case "${DISTRO}" in
       Debian|Ubuntu)
-        sh install_prereqs_debian.sh;;
+        ./install_prereqs_debian.sh;;
       CentOS)
-        sh install_prereqs_centos.sh;;
+        ./install_prereqs_centos.sh;;
       *) echo "unsupported distro: ${DISTRO}" ;;
     esac;;
   *) echo "unsupported: ${OSTYPE}" ;;


### PR DESCRIPTION
We may not be able to call `sh install_prereqs_xxx.sh` directly, we should call `./install_prereqs_xxx.sh` instead. Because there are some functions in the install_prereqs_xxx.sh and we need bash instead of sh to call them, otherwise there would be some errors e.g. function not found, syntax error `(` ...

This PR is intended to fix the bug.

PS: My test environment is Ubuntu 18.04:

```
# cat /etc/os-release 
NAME="Ubuntu"
VERSION="18.04.1 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.1 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

/assign @hklai @gargnupur @JimmyCYJ 


