### PR TITLE
Support customize --vm-driver for minikube

### DIFF
--- a/tests/e2e/local/minikube/README.md
+++ b/tests/e2e/local/minikube/README.md
@@ -26,6 +26,10 @@ You can run the following script to check/install of all pre-requisites, or use 
 . ./setup_host.sh
 ```
 
+We support customize minikube `--vm-driver`, the default is kvm2 you can set any vm-driver you like via exporting `VM_DRIVER`for you environment.
+
+For VM that doesn't support nested virtualization, you may pass `--vm-driver=none` via `export VM_DRIVER=none`.
+
 ## 2. Build istio images
 Build images on your host machine:
 ```bash

--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -14,6 +14,10 @@ case "${OSTYPE}" in
   *) echo "unsupported: ${OSTYPE}" ;;
 esac
 
+if [ ! -z "$VM_DRIVER" ]; then
+  vm_driver=$VM_DRIVER
+fi
+
 echo "Using $vm_driver as VM for Minikube."
 
 # Delete any previous minikube cluster
@@ -22,7 +26,8 @@ minikube delete
 echo "Starting Minikube."
 
 # Start minikube
-minikube start \
+# When minikube runs in `--vm-driver=none` mode, it requires root permission.
+sudo -E minikube start \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota" \


### PR DESCRIPTION
Support customize --vm-driver for minikube - it is also required for task #8598 as VM launched by circle ci may do not support nested virtualization.

/assign @hklai @JimmyCYJ 