### PR TITLE
Add local minikube test job in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,43 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
+  test-local-minikube:
+    <<: *integrationDefaults
+    environment:
+            - VM_DRIVER: none
+            - GOPATH: /go
+    steps:
+      - <<: *initWorkingDir
+      - checkout
+      - attach_workspace:
+          at:  /go
+      - <<: *markJobStartsOnGCS
+      - run: make sync
+      - run: |
+          tests/e2e/local/minikube/install_prereqs.sh
+          tests/e2e/local/minikube/setup_host.sh
+          tests/e2e/local/minikube/setup_test.sh
+      - run:
+          command: |
+            if [ ! -f /go/out/linux_amd64/release/pilot-discovery ]; then
+              # Should only happen when re-running a job, and the workspace is gone
+              time make build test-bins
+            fi
+            make docker.all
+      - run: docker images
+      - run: make e2e_simple E2E_ARGS="--use_local_cluster" HUB=localhost:5000 TAG=e2e
+      - <<: *recordZeroExitCodeIfTestPassed
+      - <<: *recordNonzeroExitCodeIfTestFailed
+      - <<: *markJobFinishesOnGCS
+      - store_artifacts:
+          path: /home/circleci/logs
+      - store_artifacts:
+          path: /tmp
+      - store_artifacts:
+          path: /var/lib/localkube/
+      - store_test_results:
+          path: /go/out/tests
+
   e2e-dashboard:
     <<: *integrationDefaults
     environment:

--- a/tests/e2e/local/minikube/README.md
+++ b/tests/e2e/local/minikube/README.md
@@ -26,6 +26,10 @@ You can run the following script to check/install of all pre-requisites, or use 
 . ./setup_host.sh
 ```
 
+We support customize minikube `--vm-driver`, the default is kvm2 you can set any vm-driver you like via exporting `VM_DRIVER`for you environment.
+
+For VM that doesn't support nested virtualization, you may pass `--vm-driver=none` via `export VM_DRIVER=none`.
+
 ## 2. Build istio images
 Build images on your host machine:
 ```bash

--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -14,6 +14,10 @@ case "${OSTYPE}" in
   *) echo "unsupported: ${OSTYPE}" ;;
 esac
 
+if [ ! -z "$VM_DRIVER" ]; then
+  vm_driver=$VM_DRIVER
+fi
+
 echo "Using $vm_driver as VM for Minikube."
 
 # Delete any previous minikube cluster
@@ -22,7 +26,8 @@ minikube delete
 echo "Starting Minikube."
 
 # Start minikube
-minikube start \
+# When minikube runs in `--vm-driver=none` mode, it requires root permission.
+sudo -E minikube start \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota" \


### PR DESCRIPTION
Per #8598 

This PR add tests for scripts in `test/e2e/local` so that they would be easily broken.

PS. How to make the test job non-required for now?

/assign @hklai @rshriram 