### PR TITLE
fix pilot log formats

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -66,7 +66,7 @@ func (s *Server) Run(ctx context.Context) {
 
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", s.statusPort))
 	if err != nil {
-		log.Warnf("Error listening on status port:", err.Error())
+		log.Warnf("Error listening on status port: %v", err.Error())
 		return
 	}
 	defer l.Close()

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -297,7 +297,7 @@ func (rc *restClient) registerResources() error {
 // DeregisterResources removes third party resources
 func (cl *Client) DeregisterResources() error {
 	for k, rc := range cl.clientset {
-		log.Infof("deregistering for apiVersion ", k)
+		log.Infof("deregistering for apiVersion %s", k)
 		if err := rc.deregisterResources(); err != nil {
 			return err
 		}

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -117,7 +117,7 @@ func (m *Monitor) checkAndUpdate() {
 
 func (m *Monitor) createConfig(c *model.Config) {
 	if _, err := m.store.Create(*c); err != nil {
-		log.Warnf("Failed to create config %s %s/%s: %v (%m)", c.Type, c.Namespace, c.Name, err, *c)
+		log.Warnf("Failed to create config %s %s/%s: %v (%+v)", c.Type, c.Namespace, c.Name, err, *c)
 	}
 }
 
@@ -128,13 +128,13 @@ func (m *Monitor) updateConfig(c *model.Config) {
 	}
 
 	if _, err := m.store.Update(*c); err != nil {
-		log.Warnf("Failed to update config (%m): %v ", *c, err)
+		log.Warnf("Failed to update config (%+v): %v ", *c, err)
 	}
 }
 
 func (m *Monitor) deleteConfig(c *model.Config) {
 	if err := m.store.Delete(c.Type, c.Name, c.Namespace); err != nil {
-		log.Warnf("Failed to delete config (%m): %v ", *c, err)
+		log.Warnf("Failed to delete config (%+v): %v ", *c, err)
 	}
 }
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -132,7 +132,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 			l := util.GetByAddress(listeners, m.Address.String())
 			if l != nil {
 				log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener %s (%s)",
-					m.Name, m.Address, l.Name, l.Address)
+					m.Name, m.Address.String(), l.Name, l.Address.String())
 				continue
 			}
 			listeners = append(listeners, m)

--- a/pilot/pkg/serviceregistry/kube/deregister.go
+++ b/pilot/pkg/serviceregistry/kube/deregister.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/api/core/v1"
@@ -78,7 +79,8 @@ func DeRegisterEndpoint(client kubernetes.Interface, namespace string, svcName s
 			If the service endpoint has not been registered
 			before, report proper error message.
 		*/
-		log.Errora("Could not find ip %s in svc %s endpoints", ip, svcName)
+		err = fmt.Errorf("could not find ip %s in svc %s endpoints", ip, svcName)
+		log.Errora(err)
 		return err
 	}
 	eps, err = client.CoreV1().Endpoints(namespace).Update(eps)

--- a/pilot/test/mock/config.go
+++ b/pilot/test/mock/config.go
@@ -533,7 +533,7 @@ func CheckCacheFreshness(cache model.ConfigStoreCache, namespace string, t *test
 			if len(elts) != 0 {
 				t.Errorf("Got %#v, expected zero elements on Delete event", elts)
 			}
-			log.Infof("Stopping channel for (%#v)", config.Key)
+			log.Infof("Stopping channel for (%#v)", config.Key())
 			close(stop)
 			done <- true
 		}


### PR DESCRIPTION
When running `make`, `go test -p 1  ./pilot/...` fails to build some packages because of invalid log formats, such as

```
go test -p 1  ./pilot/...
?   	istio.io/istio/pilot/cmd	[no test files]
# istio.io/istio/pilot/cmd/pilot-agent/status
pilot/cmd/pilot-agent/status/server.go:69: Warnf call has arguments but no formatting directives
?   	istio.io/istio/pilot/cmd/pilot-agent	[no test files]
# istio.io/istio/pilot/pkg/config/monitor
pilot/pkg/config/monitor/monitor.go:120: Warnf format %m has unknown verb m
pilot/pkg/config/monitor/monitor.go:131: Warnf format %m has unknown verb m
pilot/pkg/config/monitor/monitor.go:137: Warnf format %m has unknown verb m
ok  	istio.io/istio/pilot/pkg/config/aggregate	(cached)
ok  	istio.io/istio/pilot/pkg/config/cloudfoundry	(cached)
```

This PR intends to fix these nits.