### PR TITLE
kube-inject failed while unset Values.global.proxy.resources

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -149,12 +149,13 @@ data:
           {{ "[[ else -]]" }}
           runAsUser: 1337
           {{ "[[- end ]]" }}
+        {{ "[[ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -]]" }}
         resources:
-          {{ "[[ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -]]" }}
           requests:
             cpu: {{ "\"[[ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` ]]\"" }}
             memory: {{ "\"[[ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` ]]\"" }}
         {{ "[[ else -]]" }}
+        resources:
 {{- if .Values.global.proxy.resources }}
 {{ toYaml .Values.global.proxy.resources | indent 10 }}
 {{- end }}


### PR DESCRIPTION
While I unset resources limit in values.yaml like below:

```
  proxy:
    image: proxyv2

    # Resources for the sidecar.
    #resources:
    #  requests:
    #    cpu: 10m
```

istioctl kube-inject -f got error:
`2018-09-12T09:56:02.828500Z     warn    Failed to unmarshall template error converting YAML to JSON: yaml: line 81: did not find expected key initContainers:`

At last I found there was an error in the configmap istio-sidecar-injector, it generated injected yaml which has two more spaces, like below:

```
  resources:
    volumeMounts:
  - mountPath: /etc/istio/proxy
    name: istio-envoy
  - mountPath: /etc/certs/
    name: istio-certs
    readOnly: true
```

When I modified the template. it's ok
```
        resources: {}
        securityContext:
          readOnlyRootFilesystem: true
          runAsUser: 1337
        volumeMounts:
        - mountPath: /etc/istio/proxy
          name: istio-envoy
        - mountPath: /etc/certs/
          name: istio-certs
          readOnly: true
```
