### PR TITLE
Update codecov job to build on its own.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,6 +338,8 @@ jobs:
       ISTIO_BIN: /go/bin
     steps:
       - checkout
+      - run: make init
+      - run: make build test-bins /go/bin/go-junit-report
       - run:
           name: Starting Kubernetes API Server standalone and running tests
           command: |
@@ -579,8 +581,6 @@ workflows:
       - build
       - test
       - codecov:
-          requires:
-            - build
       - e2e-mixer-noauth-v1alpha3-v2:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,7 +580,7 @@ workflows:
       - lint
       - build
       - test
-      - codecov:
+      - codecov
       - e2e-mixer-noauth-v1alpha3-v2:
           requires:
             - build

--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,11 @@ check-tree:
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile
 init: check-tree check-go-version $(ISTIO_OUT)/istio_is_init
+	mkdir -p ${OUT_DIR}/logs
 
 # Sync target will pull from master and sync the modules. It is the first step of the
 # circleCI build, developers should call it periodically.
 sync: init git.pullmaster
-	mkdir -p ${OUT_DIR}/logs
 
 # Merge master. To be used in CI or by developers, assumes the
 # remote is called 'origin' (git default). Will fail on conflicts

--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -121,4 +121,6 @@ go get -u istio.io/test-infra/toolbox/pkg_check
 pkg_check \
   --report_file="${FINAL_CODECOV_DIR}/codecov.report" \
   --alsologtostderr \
-  --requirement_file=codecov.requirement "${PKG_CHECK_ARGS[@]}"
+  --requirement_file=codecov.requirement "${PKG_CHECK_ARGS[@]}" \
+  || echo "Package check has failed"
+


### PR DESCRIPTION
Since the default circle build step rebase from master, the codecov report is skewed after rebase,

Also updated codecov.sh to ignore return code from pkg_check, so that the codecov job will not fail. Otherwise, PR authors can be easily confused since job failure can be caused by others and the error
is not actionable by the PR author.

The error messages are thus informational only, and we will figure out a plan to fail if the actual delta before and after a PR is large.