### PR TITLE
ci: fix shellcheck errors and warnings

### DIFF
--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -14,8 +14,9 @@ case "${OSTYPE}" in
   *) echo "unsupported: ${OSTYPE}" ;;
 esac
 
+# shellcheck disable=SC2153
 if [ ! -z "$VM_DRIVER" ]; then
-  vm_driver=$VM_DRIVER
+  vm_driver="$VM_DRIVER"
 fi
 
 echo "Using $vm_driver as VM for Minikube."
@@ -35,7 +36,7 @@ sudo -E minikube start \
     --insecure-registry="localhost:5000" \
     --cpus=4 \
     --memory=8192 \
-    --vm-driver=$vm_driver
+    --vm-driver="$vm_driver"
 
 #Setup docker to talk to minikube
 eval "$(minikube docker-env)"

--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -270,13 +270,13 @@ function get_istio_ingressgateway_ip() {
 }
 
 # Set default QPS to max qps
-if [ -z ${QPS+x} ] || [ "$QPS" == "" ]; then
+if [ -z "${QPS+x}" ] || [ "$QPS" == "" ]; then
   echo "Setting default qps"
   QPS=-1
 fi
 
 # Set default run duration to 30s
-if [ -z ${DUR+x} ] || [ "$DUR" == "" ]; then
+if [ -z "${DUR+x}" ] || [ "$DUR" == "" ]; then
   DUR="30s"
 fi
 


### PR DESCRIPTION
The vm-driver is ignored since it is a flag to minikube and I cannot
think of a better variable/env name.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>