### PR TITLE
Expose envoy prom port for metrics scraping instead of using annotations

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -23,11 +23,6 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
-{{ if ne $.Values.global.proxy.stats.prometheusPort 0. }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ $.Values.global.proxy.stats.prometheusPort }}"
-        prometheus.io/path: /stats/prometheus
-{{ end}}
     spec:
       serviceAccountName: {{ $key }}-service-account
 {{- if $.Values.global.priorityClassName }}
@@ -58,6 +53,11 @@ spec:
             {{- range $key, $val := $spec.ports }}
             - containerPort: {{ $val.port }}
             {{- end }}
+{{ if ne $.Values.global.proxy.stats.prometheusPort 0. }}
+            - containerPort: {{ $.Values.global.proxy.stats.prometheusPort }}
+              protocol: TCP
+              name: http-envoy-prom
+{{ end }}
           args:
           - proxy
           - router

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -63,6 +63,12 @@
         ports:
         - containerPort: 9091
         - containerPort: 15004
+{{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
+        ports:
+        - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
+          protocol: TCP
+          name: http-envoy-prom
+{{ end }}
         args:
         - proxy
         - --serviceCluster
@@ -170,6 +176,12 @@
         ports:
         - containerPort: 9091
         - containerPort: 15004
+{{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
+        ports:
+        - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
+          protocol: TCP
+          name: http-envoy-prom
+{{ end }}
         args:
         - proxy
         - --serviceCluster
@@ -237,11 +249,6 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
-{{ if ne $.Values.global.proxy.stats.prometheusPort 0. }}
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ $.Values.global.proxy.stats.prometheusPort }}"
-        prometheus.io/path: /stats/prometheus
-{{ end}}
 {{- with $.Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -29,22 +29,63 @@ data:
         action: keep
         regex: istio-telemetry;prometheus
 
-    - job_name: 'envoy'
-      # Override the global default and scrape targets from this job every 5 seconds.
-      scrape_interval: 5s
-      # metrics_path defaults to '/metrics'
-      # scheme defaults to 'http'.
-
+{{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
+    # Scrape config for envoy stats
+    - job_name: 'envoy-stats'
+      metrics_path: /stats/prometheus
       kubernetes_sd_configs:
-      - role: endpoints
-        namespaces:
-          names:
-          - {{ .Release.Namespace }}
+      - role: pod
 
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
         action: keep
-        regex: istio-statsd-prom-bridge;statsd-prom
+        regex: '.*-envoy-prom'
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:{{ .Values.global.proxy.stats.prometheusPort }}
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod_name
+
+      metric_relabel_configs:
+      # Exclude some of the envoy metrics that have massive cardinality
+      # This list may need to be pruned further moving forward, as informed
+      # by performance and scalability testing.
+      - source_labels: [ cluster_name ]
+        regex: '(outbound|inbound|prometheus_stats).*'
+        action: drop
+      - source_labels: [ tcp_prefix ]
+        regex: '(outbound|inbound|prometheus_stats).*'
+        action: drop
+      - source_labels: [ listener_address ]
+        regex: '(.+)'
+        action: drop
+      - source_labels: [ http_conn_manager_listener_prefix ]
+        regex: '(.+)'
+        action: drop
+      - source_labels: [ http_conn_manager_prefix ]
+        regex: '(.+)'
+        action: drop
+      - source_labels: [ __name__ ]
+        regex: 'envoy_tls.*'
+        action: drop
+      - source_labels: [ __name__ ]
+        regex: 'envoy_tcp_downstream.*'
+        action: drop
+      - source_labels: [ __name__ ]
+        regex: 'envoy_http_(stats|admin).*'
+        action: drop
+      - source_labels: [ __name__ ]
+        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
+        action: drop
+{{ end}}
 
     - job_name: 'istio-policy'
       # Override the global default and scrape targets from this job every 5 seconds.
@@ -236,35 +277,3 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: pod_name
-
-      metric_relabel_configs:
-      # Blacklist some of the envoy metrics that have massive cardinality
-      # This list may need to be pruned further moving forward, as informed
-      # by performance and scalability testing.
-      - source_labels: [ cluster_name ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ tcp_prefix ]
-        regex: '(outbound|inbound|prometheus_stats).*'
-        action: drop
-      - source_labels: [ listener_address ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_listener_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ http_conn_manager_prefix ]
-        regex: '(.+)'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tls.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_tcp_downstream.*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_http_(stats|admin).*'
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: 'envoy_cluster_(lb|retry|bind|internal|max|original).*'
-        action: drop

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -14,12 +14,6 @@ data:
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
     template: |-
-      annotations:
-{{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
-        "prometheus.io/scrape": "true"
-        "prometheus.io/port": "{{ .Values.global.proxy.stats.prometheusPort }}"
-        "prometheus.io/path": "/stats/prometheus"
-{{ end}}
       initContainers:
       - name: istio-init
 {{- if contains "/" .Values.global.proxy_init.image }}
@@ -69,6 +63,12 @@ data:
       containers:
       - name: istio-proxy
         image: {{ "[[ annotation .ObjectMeta `sidecar.istio.io/proxyImage` " }} "{{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}" {{ " ]]" }}
+{{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
+        ports:
+        - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
+          protocol: TCP
+          name: http-envoy-prom
+{{ end }}
         args:
         - proxy
         - sidecar

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -144,7 +144,6 @@ const (
 // SidecarInjectionSpec collects all container types and volumes for
 // sidecar mesh injection
 type SidecarInjectionSpec struct {
-	Annotations      map[string]string             `yaml:"annotations"`
 	InitContainers   []corev1.Container            `yaml:"initContainers"`
 	Containers       []corev1.Container            `yaml:"containers"`
 	Volumes          []corev1.Volume               `yaml:"volumes"`
@@ -463,10 +462,6 @@ func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.O
 		return nil, "", err
 	}
 
-	if sic.Annotations == nil {
-		sic.Annotations = make(map[string]string)
-	}
-
 	status := &SidecarInjectionStatus{Version: version}
 	for _, c := range sic.InitContainers {
 		status.InitContainers = append(status.InitContainers, c.Name)
@@ -633,9 +628,6 @@ func intoObject(sidecarTemplate string, meshconfig *meshconfig.MeshConfig, in ru
 
 	if metadata.Annotations == nil {
 		metadata.Annotations = make(map[string]string)
-	}
-	for k, v := range spec.Annotations {
-		metadata.Annotations[k] = v
 	}
 	metadata.Annotations[annotationStatus.name] = status
 

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -36,7 +36,6 @@ const (
 [[- $readinessPeriodValue           := (annotation .ObjectMeta $readinessPeriodKey "{{ .ReadinessPeriodSeconds }}") ]]
 [[- $readinessFailureThresholdValue := (annotation .ObjectMeta $readinessFailureThresholdKey {{ .ReadinessFailureThreshold }}) -]]
 [[- $readinessApplicationPortsValue := (annotation .ObjectMeta $readinessApplicationPortsKey (applicationPorts .Spec.Containers)) -]]
-annotations:
 initContainers:
 - name: istio-init
   image: {{ .InitImage }}

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -7,9 +7,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -53,6 +50,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -27,9 +27,6 @@ items:
     template:
       metadata:
         annotations:
-          prometheus.io/path: /stats/prometheus
-          prometheus.io/port: "15090"
-          prometheus.io/scrape: "true"
           sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
@@ -73,6 +70,10 @@ items:
           - "15020"
           - --applicationPorts
           - "80"
+          ports:
+          - name: http-envoy-prom
+            containerPort: 15090
+            protocol: TCP
           env:
           - name: POD_NAME
             valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -12,9 +12,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -58,6 +55,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -23,9 +23,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -73,6 +70,10 @@ spec:
         - "15020"
         - --applicationPorts
         - ""
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -55,6 +52,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -56,6 +53,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -143,9 +144,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -190,6 +188,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "81"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -75,6 +72,10 @@ spec:
         - "15020"
         - --applicationPorts
         - 80,90
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -7,9 +7,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
@@ -52,6 +49,10 @@ spec:
         - "15020"
         - --applicationPorts
         - ""
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -24,9 +24,6 @@ items:
     template:
       metadata:
         annotations:
-          prometheus.io/path: /stats/prometheus
-          prometheus.io/port: "15090"
-          prometheus.io/scrape: "true"
           sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
@@ -74,6 +71,10 @@ items:
           - "15020"
           - --applicationPorts
           - ""
+          ports:
+          - name: http-envoy-prom
+            containerPort: 15090
+            protocol: TCP
           env:
           - name: POD_NAME
             valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -11,9 +11,6 @@ items:
     template:
       metadata:
         annotations:
-          prometheus.io/path: /stats/prometheus
-          prometheus.io/port: "15090"
-          prometheus.io/scrape: "true"
           sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
@@ -58,6 +55,10 @@ items:
           - "15020"
           - --applicationPorts
           - "80"
+          ports:
+          - name: http-envoy-prom
+            containerPort: 15090
+            protocol: TCP
           env:
           - name: POD_NAME
             valueFrom:
@@ -144,9 +145,6 @@ items:
     template:
       metadata:
         annotations:
-          prometheus.io/path: /stats/prometheus
-          prometheus.io/port: "15090"
-          prometheus.io/scrape: "true"
           sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         creationTimestamp: null
         labels:
@@ -191,6 +189,10 @@ items:
           - "15020"
           - --applicationPorts
           - "81"
+          ports:
+          - name: http-envoy-prom
+            containerPort: 15090
+            protocol: TCP
           env:
           - name: POD_NAME
             valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -55,6 +52,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -8,9 +8,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -52,6 +49,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -10,9 +10,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -54,6 +51,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
@@ -58,6 +55,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         readiness.status.sidecar.istio.io/applicationPorts: 1,2,3
         readiness.status.sidecar.istio.io/failureThreshold: "300"
         readiness.status.sidecar.istio.io/initialDelaySeconds: "100"
@@ -58,6 +55,10 @@ spec:
         - "123"
         - --applicationPorts
         - 1,2,3
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
@@ -57,6 +54,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
@@ -57,6 +54,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -9,9 +9,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
@@ -57,6 +54,10 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
+        ports:
+        - name: http-envoy-prom
+          containerPort: 15090
+          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -508,9 +508,6 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 
 	applyDefaultsWorkaround(spec.InitContainers, spec.Containers, spec.Volumes)
 	annotations := map[string]string{annotationStatus.name: status}
-	for k, v := range spec.Annotations {
-		annotations[k] = v
-	}
 
 	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	if err != nil {


### PR DESCRIPTION
This PR moves away from an annotation-based discovery for individual envoy prometheus scrape
targets. Instead, it exposes the `http-envoy-prom` port in the podSpec for the injected
containers and adds config to the Prometheus addon to look for pods with a matching port
name for metrics ingest.

This PR is needed to prevent collisions between pods that have existing annotations for prometheus
scraping of a workload target and annotations for envoy scraping. Istio should not monopolize
the prometheus annotations and prevent existing use cases.