### PR TITLE
fix vulnerability in istio proxy_init image for 1.0

### DIFF
--- a/pilot/docker/Dockerfile.proxy_init
+++ b/pilot/docker/Dockerfile.proxy_init
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     iproute2 \
     iptables \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Merge https://github.com/istio/istio/pull/8495 to `release-1.0`

Fix vulnerability issues in istio proxy_init image:
![image](https://user-images.githubusercontent.com/5468682/45085416-3971ae00-b133-11e8-8722-f3d036176998.png)