### PR TITLE
reused dead NewMemstore() function

### DIFF
--- a/mixer/pkg/config/storetest/storetest.go
+++ b/mixer/pkg/config/storetest/storetest.go
@@ -109,7 +109,7 @@ func (m *Memstore) Delete(k store.Key) {
 // data with the specified specs, and returns a new store with the backend.
 // Note that this store can't change, Watch does not emit any events.
 func SetupStoreForTest(data ...string) (store.Store, error) {
-	m := &Memstore{data: map[store.Key]*store.BackEndResource{}, donec: make(chan struct{})}
+	m := NewMemstore()
 	var errs error
 	for i, d := range data {
 		for j, chunk := range strings.Split(d, "\n---\n") {


### PR DESCRIPTION
should not reconstruct a new `Memstore` objective, and `NewMemstore()` function is dead function, 