### PR TITLE
cleanup: remove proxyType parameter in GetMutualTLS

### DIFF
--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -90,7 +90,7 @@ func TestRequireTls(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if params := GetMutualTLS(c.in, model.Sidecar); !reflect.DeepEqual(c.expectedParams, params) {
+		if params := GetMutualTLS(c.in); !reflect.DeepEqual(c.expectedParams, params) {
 			t.Errorf("%s: requireTLS(%v): got(%v) != want(%v)\n", c.name, c.in, params, c.expectedParams)
 		}
 	}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -530,7 +530,7 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 			var serverProtocol, clientProtocol authProtocol
 			if authnConfig != nil {
 				policy := authnConfig.Spec.(*authn.Policy)
-				mtls := authn_plugin.GetMutualTLS(policy, model.Sidecar)
+				mtls := authn_plugin.GetMutualTLS(policy)
 				serverProtocol = getServerAuthProtocol(mtls)
 			} else {
 				serverProtocol = getServerAuthProtocol(nil)


### PR DESCRIPTION
Fix TODO: remove proxyType parameter and handle the checking from callers.