### PR TITLE
Add an EnableLegacyResourceCheck flag to Pilot Discovery component.

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -107,6 +107,8 @@ func init() {
 		"comma separated list of networking plugins to enable")
 
 	// Config Controller options
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.EnableLegacyResourceCheck, "enableLegacyResourceCheck", false,
+		"Enables the legacy resource check which verifies that CRDs are registered with Kubernetes and will create them if not present.")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.WatchedNamespace, "appNamespace",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -108,7 +108,7 @@ type ConfigArgs struct {
 	CFConfig                   string
 	ControllerOptions          kube.ControllerOptions
 	FileDir                    string
-
+	EnableLegacyResourceCheck  bool
 	// Controller if specified, this controller overrides the other config settings.
 	Controller model.ConfigStoreCache
 }
@@ -514,8 +514,10 @@ func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCac
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}
 
-	if err = configClient.RegisterResources(); err != nil {
-		return nil, multierror.Prefix(err, "failed to register custom resources.")
+	if args.Config.EnableLegacyResourceCheck {
+		if err = configClient.RegisterResources(); err != nil {
+			return nil, multierror.Prefix(err, "failed to register custom resources.")
+		}
 	}
 
 	return crd.NewController(configClient, args.Config.ControllerOptions), nil


### PR DESCRIPTION
Disabled by default, this option enables the non-HA resource check which can recreate CRDs when they are not found in Kubernetes. The flag is being added to work around an open issue istio#6977