### PR TITLE
update proxy to include fix for peerIsOptional/originIsOptional

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "99cfc3f74c414dd4fa4aa784a0f8b13e22b81893"
+		"lastStableSHA": "6953ca783697da07ebe565322d12e969280d8b03"
 	}
 ]


### PR DESCRIPTION
The fix is to be cherrypicked into Istio 1.0.3 and the proxy update includes only 1 commit https://github.com/istio/proxy/pull/1969.

Update Proxy SHA to latest.

Pulling the following changes from github.com/istio/proxy:

6953ca7 Back port the fix for peerIsOptional/originIsOptional to 1.0 branch  (#1969)