### PR TITLE
add `hzxuzhonghu` into pilot owners

### DIFF
--- a/pilot/OWNERS
+++ b/pilot/OWNERS
@@ -3,8 +3,9 @@ approvers:
   - ayj
   - costinm
   - GregHanson
-  - kyessenov
+  - hzxuzhonghu
   - ijsnellf
+  - kyessenov
   - nmittler
   - rshriram
   - vadimeisenbergibm


### PR DESCRIPTION
1. add myself into pilot owners to take more responsibilities on reviewing and approve some entry-level prs, for some critical prs, I will cc @rshriram @costinm @ZackButcher or any other experienced.

1. sort owners in alphabetical order