### PR TITLE
Remove the duplicate cluster for endpoint

### DIFF
--- a/istioctl/pkg/writer/envoy/clusters/clusters.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters.go
@@ -138,6 +138,7 @@ func (c *ConfigWriter) PrintEndpoints(filter EndpointFilter) error {
 		for _, host := range cluster.HostStatuses {
 			if filter.Verify(host, cluster.Name) {
 				filteredClusters = append(filteredClusters, cluster)
+				break
 			}
 		}
 

--- a/istioctl/pkg/writer/envoy/clusters/clusters_test.go
+++ b/istioctl/pkg/writer/envoy/clusters/clusters_test.go
@@ -126,6 +126,12 @@ func TestConfigWriter_PrintClusterDump(t *testing.T) {
 			callPrime:      true,
 		},
 		{
+			name:           "handles multi hosts cluster filtering",
+			filter:         EndpointFilter{Cluster: "outbound|9080||reviews.default.svc.cluster.local"},
+			wantOutputFile: "testdata/clustermultihostsfiltered.txt",
+			callPrime:      true,
+		},
+		{
 			name:      "errors if config writer is not primed",
 			callPrime: false,
 			wantErr:   true,

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustermultihostsfiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustermultihostsfiltered.txt
@@ -1,0 +1,83 @@
+[
+    {
+        "name": "outbound|9080||reviews.default.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.24",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            },
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.26",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            },
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.27",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
+    }
+]

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clusters.json
@@ -154,6 +154,87 @@
           }
         }
       ]
+    },
+    {
+      "name": "outbound|9080||reviews.default.svc.cluster.local",
+      "addedViaApi": true,
+      "hostStatuses": [
+        {
+          "address": {
+            "socketAddress": {
+              "address": "172.17.0.24",
+              "portValue": 9080
+            }
+          },
+          "stats": {
+            "cx_active": {
+              "type": "GAUGE"
+            },
+            "cx_connect_fail": {},
+            "cx_total": {},
+            "rq_active": {
+              "type": "GAUGE"
+            },
+            "rq_error": {},
+            "rq_success": {},
+            "rq_timeout": {},
+            "rq_total": {}
+          },
+          "healthStatus": {
+            "edsHealthStatus": "HEALTHY"
+          }
+        },
+        {
+          "address": {
+            "socketAddress": {
+              "address": "172.17.0.26",
+              "portValue": 9080
+            }
+          },
+          "stats": {
+            "cx_active": {
+              "type": "GAUGE"
+            },
+            "cx_connect_fail": {},
+            "cx_total": {},
+            "rq_active": {
+              "type": "GAUGE"
+            },
+            "rq_error": {},
+            "rq_success": {},
+            "rq_timeout": {},
+            "rq_total": {}
+          },
+          "healthStatus": {
+            "edsHealthStatus": "HEALTHY"
+          }
+        },
+        {
+          "address": {
+            "socketAddress": {
+              "address": "172.17.0.27",
+              "portValue": 9080
+            }
+          },
+          "stats": {
+            "cx_active": {
+              "type": "GAUGE"
+            },
+            "cx_connect_fail": {},
+            "cx_total": {},
+            "rq_active": {
+              "type": "GAUGE"
+            },
+            "rq_error": {},
+            "rq_success": {},
+            "rq_timeout": {},
+            "rq_total": {}
+          },
+          "healthStatus": {
+            "edsHealthStatus": "HEALTHY"
+          }
+        }
+      ]
     }
   ]
 }

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersnofiltered.txt
@@ -153,5 +153,86 @@
                 }
             }
         ]
+    },
+    {
+        "name": "outbound|9080||reviews.default.svc.cluster.local",
+        "addedViaApi": true,
+        "hostStatuses": [
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.24",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            },
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.26",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            },
+            {
+                "address": {
+                    "socketAddress": {
+                        "address": "172.17.0.27",
+                        "portValue": 9080
+                    }
+                },
+                "stats": {
+                    "cx_active": {
+                        "type": "GAUGE"
+                    },
+                    "cx_connect_fail": {},
+                    "cx_total": {},
+                    "rq_active": {
+                        "type": "GAUGE"
+                    },
+                    "rq_error": {},
+                    "rq_success": {},
+                    "rq_timeout": {},
+                    "rq_total": {}
+                },
+                "healthStatus": {
+                    "edsHealthStatus": "HEALTHY"
+                }
+            }
+        ]
     }
 ]

--- a/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
+++ b/istioctl/pkg/writer/envoy/clusters/testdata/clustersummary.txt
@@ -2,5 +2,8 @@ ENDPOINT             STATUS        CLUSTER
 172.17.0.13:443      HEALTHY       outbound|443||istio-ingressgateway.istio-system.svc.cluster.local
 172.17.0.14:9093     UNHEALTHY     outbound|9093||istio-policy.istio-system.svc.cluster.local
 172.17.0.19:443      HEALTHY       outbound|443||istio-galley.istio-system.svc.cluster.local
+172.17.0.24:9080     HEALTHY       outbound|9080||reviews.default.svc.cluster.local
+172.17.0.26:9080     HEALTHY       outbound|9080||reviews.default.svc.cluster.local
+172.17.0.27:9080     HEALTHY       outbound|9080||reviews.default.svc.cluster.local
 172.17.0.4:443       HEALTHY       outbound|443||istio-sidecar-injector.istio-system.svc.cluster.local
 172.17.0.6:443       HEALTHY       outbound|443||istio-egressgateway.istio-system.svc.cluster.local


### PR DESCRIPTION
Now in pc endpoints, if print endpoints in json, in fact print the cluster info. Cluster may have multiple hosts(ep), so when the clusterName/address/port match once, wil add this cluster to the list, then should break and stop check.