### PR TITLE
WIP: Incremental EDS

### DIFF
--- a/pilot/pkg/config/clusterregistry/secretcontroller.go
+++ b/pilot/pkg/config/clusterregistry/secretcontroller.go
@@ -230,6 +230,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 				WatchedNamespace: c.watchedNamespace,
 				ResyncPeriod:     c.resyncInterval,
 				DomainSuffix:     c.domainSufix,
+				ClusterID:        clusterID,
 			})
 			c.cs.rc[clusterID].Controller = kubectl
 			c.serviceController.AddRegistry(
@@ -242,8 +243,8 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 				})
 			stopCh := make(chan struct{})
 			c.cs.rc[clusterID].ControlChannel = stopCh
-			_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { c.discoveryServer.ClearCacheFunc()() })
-			_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { c.discoveryServer.ClearCacheFunc()() })
+			_ = kubectl.AppendServiceHandler(func(*model.Service, model.Event) { c.discoveryServer.ClearCacheFunc()(true, nil) })
+			_ = kubectl.AppendInstanceHandler(func(*model.ServiceInstance, model.Event) { c.discoveryServer.ClearCacheFunc()(true, nil) })
 			go kubectl.Run(stopCh)
 		} else {
 			log.Infof("Cluster %s in the secret %s in namespace %s already exists",

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -621,7 +621,7 @@ func (l Labels) Equals(that Labels) bool {
 // HasSubsetOf returns true if the input labels are a super set of one labels in a
 // collection or if the tag collection is empty
 func (labels LabelsCollection) HasSubsetOf(that Labels) bool {
-	if len(labels) == 0 {
+	if labels == nil || len(labels) == 0 {
 		return true
 	}
 	for _, label := range labels {

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -240,7 +240,7 @@ type XdsEvent struct {
 
 	// If not empty, it is used to indicate the event is caused by a change in the clusters.
 	// Only EDS for the listed clusters will be sent.
-	clusters []string
+	edsUpdatedServices []string
 
 	push *model.PushContext
 
@@ -299,17 +299,17 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 	// check works, since it assumes ClearCache is called (and as such PushContext
 	// is initialized)
 	// InitContext returns immediately if the context was already initialized.
-	err := s.env.PushContext.InitContext(s.env)
+	err := s.Env.PushContext.InitContext(s.Env)
 	if err != nil {
 		// Error accessing the data - log and close, maybe a different pilot replica
 		// has more luck
 		adsLog.Warnf("Error reading config %v", err)
 		return err
 	}
-	if s.env.PushContext.Services == nil {
+	if s.Env.PushContext.Services == nil {
 		// Error accessing the data - log and close, maybe a different pilot replica
 		// has more luck
-		adsLog.Warnf("Not initialized %v", s.env.PushContext)
+		adsLog.Warnf("Not initialized %v", s.Env.PushContext)
 		return err
 	}
 
@@ -373,7 +373,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				// soon as the CDS push is returned.
 				adsLog.Infof("ADS:CDS: REQ %v %s %v raw: %s", peerAddr, con.ConID, time.Since(t0), discReq.String())
 				con.CDSWatch = true
-				err := s.pushCds(con, s.env.PushContext, versionInfo())
+				err := s.pushCds(con, s.Env.PushContext, versionInfo())
 				if err != nil {
 					return err
 				}
@@ -393,7 +393,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				// too verbose - sent immediately after EDS response is received
 				adsLog.Debugf("ADS:LDS: REQ %s %v", con.ConID, peerAddr)
 				con.LDSWatch = true
-				err := s.pushLds(con, s.env.PushContext, true, versionInfo())
+				err := s.pushLds(con, s.Env.PushContext, true, versionInfo())
 				if err != nil {
 					return err
 				}
@@ -419,7 +419,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				}
 				con.Routes = routes
 				adsLog.Debugf("ADS:RDS: REQ %s %s  routes: %d", peerAddr, con.ConID, len(con.Routes))
-				err := s.pushRoute(con, s.env.PushContext)
+				err := s.pushRoute(con, s.Env.PushContext)
 				if err != nil {
 					return err
 				}
@@ -429,6 +429,11 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 				if discReq.ErrorDetail != nil {
 					adsLog.Warnf("ADS:EDS: ACK ERROR %v %s %v", peerAddr, con.ConID, discReq.String())
 					edsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+				}
+				if clusters == nil && discReq.ResponseNonce != "" {
+					// There is no requirement that ACK includes clusters. The test doesn't.
+					con.EndpointNonceAcked = discReq.ResponseNonce
+					continue
 				}
 
 				sort.Strings(clusters)
@@ -455,7 +460,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 
 				con.Clusters = clusters
 				adsLog.Debugf("ADS:EDS: REQ %s %s clusters: %d", peerAddr, con.ConID, len(con.Clusters))
-				err := s.pushEds(s.env.PushContext, con)
+				err := s.pushEds(s.Env.PushContext, con)
 				if err != nil {
 					return err
 				}
@@ -490,6 +495,18 @@ func (s *DiscoveryServer) IncrementalAggregatedResources(stream ads.AggregatedDi
 // Compute and send the new configuration. This is blocking and may be slow
 // for large configs.
 func (s *DiscoveryServer) pushAll(con *XdsConnection, pushEv *XdsEvent) error {
+	if pushEv.edsUpdatedServices != nil {
+		// Push only EDS. This is indexed already - push immediately
+		// (may need a throttle)
+		if len(con.Clusters) > 0 {
+			err := s.pushEds(pushEv.push, con)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	<-s.throttle // rate limit the actual push
 
 	// Prevent 2 overlapping pushes. Disabled if push suppression is disabled
@@ -553,20 +570,23 @@ func adsClientCount() int {
 
 // AdsPushAll is used only by tests (after refactoring)
 func AdsPushAll(s *DiscoveryServer) {
-	s.AdsPushAll(versionInfo(), s.env.PushContext)
+	s.AdsPushAll(versionInfo(), s.Env.PushContext, true, nil)
 }
 
 // AdsPushAll implements old style invalidation, generated when any rule or endpoint changes.
 // Primary code path is from v1 discoveryService.clearCache(), which is added as a handler
 // to the model ConfigStorageCache and Controller.
-func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext) {
+func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext, full bool, edsServices []string) {
+	if !full {
+		s.edsIncremental(version, push, edsServices)
+		return
+	}
+
 	adsLog.Infof("XDS: Pushing %s Services: %d, "+
-		"VirtualServices: %d, ConnectedEndpoints: %d", version,
+			"VirtualServices: %d, ConnectedEndpoints: %d", version,
 		len(push.Services), len(push.VirtualServiceConfigs), adsClientCount())
 	monServices.Set(float64(len(push.Services)))
 	monVServices.Set(float64(len(push.VirtualServiceConfigs)))
-
-	pushContext := s.env.PushContext
 
 	t0 := time.Now()
 
@@ -584,13 +604,19 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext) {
 	// the update may be duplicated if multiple goroutines compute at the same time).
 	// In general this code is called from the 'event' callback that is throttled.
 	for clusterName, edsCluster := range cMap {
-		if err := s.updateCluster(push, clusterName, edsCluster); err != nil {
+		if err := s.updateCluster(push, clusterName, edsCluster, edsServices); err != nil {
 			adsLog.Errorf("updateCluster failed with clusterName %s", clusterName)
 		}
 	}
 	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
+	s.startPush(version, push, full, edsServices)
 
-	// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
+}
+
+// Send a signal to all connections, with a push event.
+func (s *DiscoveryServer) startPush(version string, push *model.PushContext, full bool, edsServices []string) {
+
+		// Push config changes, iterating over connected envoys. This cover ADS and EDS(0.7), both share
 	// the same connection table
 	adsClientsMutex.RLock()
 	// Create a temp map to avoid locking the add/remove
@@ -616,7 +642,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext) {
 		}
 		currentVersion := versionInfo()
 		// Stop attempting to push
-		if !allowConcurrentPush && version != currentVersion {
+		if !allowConcurrentPush && version != currentVersion && full {
 			adsLog.Infof("PushAll abort %s, push with newer version %s in progress %v", version, currentVersion, time.Since(tstart))
 			return
 		}
@@ -630,9 +656,10 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext) {
 		to := time.After(PushTimeout)
 		select {
 		case client.pushChannel <- &XdsEvent{
-			push:    pushContext,
-			pending: &pendingPush,
-			version: version,
+			push:               push,
+			pending:            &pendingPush,
+			version:            version,
+			edsUpdatedServices: edsServices,
 		}:
 			client.LastPush = time.Now()
 			client.LastPushFailure = timeZero

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -70,7 +70,7 @@ func (s *DiscoveryServer) pushCds(con *XdsConnection, push *model.PushContext, v
 }
 
 func (s *DiscoveryServer) generateRawClusters(con *XdsConnection, push *model.PushContext) ([]*xdsapi.Cluster, error) {
-	rawClusters, err := s.ConfigGenerator.BuildClusters(s.env, con.modelNode, push)
+	rawClusters, err := s.ConfigGenerator.BuildClusters(s.Env, con.modelNode, push)
 	if err != nil {
 		adsLog.Warnf("CDS: Failed to generate clusters for node %s: %v", con.modelNode, err)
 		pushes.With(prometheus.Labels{"type": "cds_builderr"}).Add(1)

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -27,10 +27,9 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/grpc/peer"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 )
 
 // EDS returns the list of endpoints (IP:port and in future labels) associated with a real
@@ -62,6 +61,8 @@ var (
 
 	// Tracks connections, increment on each new connection.
 	connectionNumber = int64(0)
+
+	errIncomplete = errors.New("EDS incremental: incomplete information")
 )
 
 // EdsCluster tracks eds-related info for monitored clusters. In practice it'll include
@@ -112,6 +113,41 @@ func loadAssignment(c *EdsCluster) *xdsapi.ClusterLoadAssignment {
 	return c.LoadAssignment
 }
 
+func serviceEntry2Endpoint(UID, address string, port uint32) *endpoint.LbEndpoint {
+	addr := core.Address{
+		Address: &core.Address_SocketAddress{
+			SocketAddress: &core.SocketAddress{
+				Address: address,
+				PortSpecifier: &core.SocketAddress_PortValue{
+					PortValue: port,
+				},
+			},
+		},
+	}
+	ep := &endpoint.LbEndpoint{
+		Endpoint: &endpoint.Endpoint{
+			Address: &addr,
+		},
+	}
+
+	// Istio telemetry depends on the metadata value being set for endpoints in the mesh.
+	// Do not remove: mixerfilter depends on this logic.
+	if UID != "" {
+		ep.Metadata = &core.Metadata{
+			FilterMetadata: map[string]*types.Struct{
+				"istio": {
+					Fields: map[string]*types.Value{
+						"uid": {Kind: &types.Value_StringValue{StringValue: UID}},
+					},
+				},
+			},
+		}
+	}
+
+	//log.Infoa("EDS: endpoint ", ipAddr, ep.String())
+	return ep
+}
+
 func newEndpoint(e *model.NetworkEndpoint) (*endpoint.LbEndpoint, error) {
 	err := model.ValidateNetworkEndpointAddress(e)
 	if err != nil {
@@ -142,9 +178,162 @@ func newEndpoint(e *model.NetworkEndpoint) (*endpoint.LbEndpoint, error) {
 	return ep, nil
 }
 
+// updateClusterInc computes an envoy cluster assignment from the service shards.
+func (s *DiscoveryServer) updateClusterInc(push *model.PushContext, clusterName string,
+	edsCluster *EdsCluster, edsChangedServices []string) error {
+
+	var hostname model.Hostname
+	//var ports model.PortList
+	var err error
+
+	var port int
+	var subsetName string
+	_, subsetName, hostname, port = model.ParseSubsetKey(clusterName)
+	labels := push.SubsetToLabels(subsetName, hostname)
+
+	portMap, f := push.ServicePort2Name[string(hostname)]
+	if !f {
+		return s.updateCluster(push, clusterName, edsCluster, edsChangedServices)
+	}
+	portName, f := portMap[uint32(port)]
+	if !f {
+		return s.updateCluster(push, clusterName, edsCluster, edsChangedServices)
+	}
+
+	se, f := s.EndpointShardsByService[string(hostname)]
+	if !f {
+		return s.updateCluster(push, clusterName, edsCluster, edsChangedServices)
+	}
+
+	cnt := 0
+	localityEpMap := make(map[string]*endpoint.LocalityLbEndpoints)
+
+	// The shards are updated independently, now need to filter and merge
+	// for this cluster
+	for _, es := range se.Shards {
+		for _, el := range es.Entries {
+			if portName != el.ServicePortName {
+				continue
+			}
+			// Port labels
+			ll := model.Labels(*el.Labels)
+			if !labels.HasSubsetOf(ll) {
+				continue
+			}
+			cnt++
+
+			// TODO: Need to accommodate region, zone and subzone. Older Pilot datamodel only has zone = availability zone.
+			// Once we do that, the key must be a | separated tupple.
+			locality := (*el.Labels)[model.AZLabel] // may be ""
+			locLbEps, found := localityEpMap[locality]
+			if !found {
+				locLbEps = &endpoint.LocalityLbEndpoints{
+					Locality: &core.Locality{
+						Zone: locality,
+					},
+				}
+				localityEpMap[locality] = locLbEps
+			}
+			if el.EnvoyEndpoint == nil {
+				el.EnvoyEndpoint = serviceEntry2Endpoint(el.UID, el.Address, el.EndpointPort)
+			}
+			locLbEps.LbEndpoints = append(locLbEps.LbEndpoints, *el.EnvoyEndpoint)
+		}
+	}
+	locEps := make([]endpoint.LocalityLbEndpoints, 0, len(localityEpMap))
+	for _, locLbEps := range localityEpMap {
+		locEps = append(locEps, *locLbEps)
+	}
+
+	if cnt == 0 {
+		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
+		//adsLog.Infof("EDS: no instances %s (host=%s ports=%v labels=%v)", clusterName, hostname, p, labels)
+	}
+	edsInstances.With(prometheus.Labels{"cluster": clusterName}).Set(float64(cnt))
+	if err != nil {
+		adsLog.Warnf("endpoints for service cluster %q returned error %q", clusterName, err)
+		return err
+	}
+
+	// There is a chance multiple goroutines will update the cluster at the same time.
+	// This could be prevented by a lock - but because the update may be slow, it may be
+	// better to accept the extra computations.
+	// We still lock the access to the LoadAssignments.
+	edsCluster.mutex.Lock()
+	defer edsCluster.mutex.Unlock()
+
+	edsCluster.LoadAssignment = &xdsapi.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints:   locEps,
+	}
+	if len(locEps) > 0 && edsCluster.NonEmptyTime.IsZero() {
+		edsCluster.NonEmptyTime = time.Now()
+	}
+	return nil
+}
+
+// updateServiceShards will list the endpoints and create the shards.
+// This is used to reconcile and to support non-k8s registries (until they migrate).
+// Note that aggreaged list is expensive (for large numbers) - we want to replace
+// it with a model where DiscoveryServer keeps track of all endpoint registries
+// directly, and calls them one by one.
+func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
+
+	// TODO: if ServiceDiscovery is aggregate, and all members support direct, use
+	// the direct interface.
+	var regs []aggregate.Registry
+	agg, ok := s.Env.ServiceDiscovery.(*aggregate.Controller)
+	if ok {
+		regs = agg.GetRegistries()
+	} else {
+		regs = []aggregate.Registry{
+			aggregate.Registry{
+				ServiceDiscovery: s.Env.ServiceDiscovery,
+			},
+		}
+	}
+	for _, reg := range regs {
+		// Each registry acts as a shard - we don't want to combine them because some
+		// may individually update their endpoints incrementally
+		for _, svc := range push.Services {
+			entries := []*model.IstioEndpoint{}
+			for _, port := range svc.Ports {
+				if port.Protocol == model.ProtocolUDP {
+					continue
+				}
+
+				// This loses track of grouping (shards)
+				epi, err := reg.InstancesByPort(svc.Hostname, port.Port, model.LabelsCollection{})
+				if err != nil {
+					return err
+				}
+
+				for _, ep := range epi {
+					//shard := ep.AvailabilityZone
+					l := map[string]string(ep.Labels)
+					entries = append(entries, &model.IstioEndpoint{
+						Address: ep.Endpoint.Address,
+						EndpointPort: uint32(ep.Endpoint.Port),
+						ServicePortName: port.Name,
+						Labels:  &l,
+						UID: ep.Endpoint.UID,
+					})
+				}
+			}
+
+			s.EDSUpdate(reg.ClusterID, string(svc.Hostname), entries)
+
+		}
+
+	}
+
+	return nil
+}
+
 // updateCluster is called from the event (or global cache invalidation) to update
 // the endpoints for the cluster.
-func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName string, edsCluster *EdsCluster) error {
+func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName string,
+	edsCluster *EdsCluster, edsChangedServices []string) error {
 	// TODO: should we lock this as well ? Once we move to event-based it may not matter.
 	var hostname model.Hostname
 	//var ports model.PortList
@@ -156,8 +345,13 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 		var p int
 		var subsetName string
 		_, subsetName, hostname, p = model.ParseSubsetKey(clusterName)
+		// TODO: if edsChangedServices != nil -> filter out cluster that didn't change.
+
 		labels = push.SubsetToLabels(subsetName, hostname)
-		instances, err = edsCluster.discovery.env.ServiceDiscovery.InstancesByPort(hostname, p, labels)
+
+		// TODO: k8s adapter should use EdsUpdate. This would return non-k8s stuff, needs to
+		// be merged with k8s. This returns ServiceEntries.
+		instances, err = edsCluster.discovery.Env.ServiceDiscovery.InstancesByPort(hostname, p, labels)
 		if len(instances) == 0 {
 			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
 			//adsLog.Infof("EDS: no instances %s (host=%s ports=%v labels=%v)", clusterName, hostname, p, labels)
@@ -185,6 +379,115 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 	}
 	return nil
 }
+
+// SvcUpdate is a callback from service discovery to update the port mapping.
+func (s *DiscoveryServer) SvcUpdate(cluster, hostname string, ports map[string]uint32, rports map[uint32]string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if cluster == "" {
+		s.Env.PushContext.ServiceName2Ports[hostname] = ports
+		s.Env.PushContext.ServicePort2Name[hostname] = rports
+	}
+	// TODO: for updates from other clusters, warn if they don't match primary.
+}
+
+// Update clusters for an incremental EDS push, and initiate the push.
+// Only clusters that changed are updated/pushed.
+func (s *DiscoveryServer) edsIncremental(version string, push *model.PushContext,
+	edsServices []string) {
+	adsLog.Infof("XDS:EDSInc Pushing %s Services: %v, "+
+		"VirtualServices: %d, ConnectedEndpoints: %d", version, edsServices,
+		len(push.VirtualServiceConfigs), adsClientCount())
+	t0 := time.Now()
+
+	// First update all cluster load assignments. This is computed for each cluster once per config change
+	// instead of once per endpoint.
+	edsClusterMutex.Lock()
+	// Create a temp map to avoid locking the add/remove
+	cMap := make(map[string]*EdsCluster, len(edsClusters))
+	for k, v := range edsClusters {
+		//_, _, hostname, _ := model.ParseSubsetKey(k)
+		//if string(hostname) != edsServices {
+		//	continue
+		//}
+		cMap[k] = v
+	}
+	edsClusterMutex.Unlock()
+
+	// UpdateCluster updates the cluster with a mutex, this code is safe ( but computing
+	// the update may be duplicated if multiple goroutines compute at the same time).
+	// In general this code is called from the 'event' callback that is throttled.
+	for clusterName, edsCluster := range cMap {
+		if err := s.updateClusterInc(push, clusterName, edsCluster, edsServices); err != nil {
+			adsLog.Errorf("updateCluster failed with clusterName %s", clusterName)
+		}
+	}
+	adsLog.Infof("Cluster init time %v %s", time.Since(t0), version)
+
+	s.startPush(version, push, false, edsServices)
+}
+
+// EDSUpdate computes destination address membership across all clusters and networks.
+// This is the main method implementing EDS.
+// It replaces InstancesByPort in model - instead of iterating over all endpoints it uses
+// the hostname-keyed map. And it avoids the conversion from Endpoint to ServiceEntry to envoy
+// on each step: instead the conversion happens once, when an endpoint is first discovered.
+func (s *DiscoveryServer) EDSUpdate(shard, serviceName string,
+	entries []*model.IstioEndpoint) error {
+	// edsShardUpdate replaces a subset (shard) of endpoints, as result of an incremental
+	// update. The endpoint updates may be grouped by K8S clusters, other service registries
+	// or by deployment. Multiple updates are debounced, to avoid too frequent pushes.
+	// After debounce, the services are merged and pushed.
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// Update the data structures for the service.
+	// 1. Find the 'per service' data
+	ep, f := s.EndpointShardsByService[serviceName]
+	if !f {
+		ep = ServiceShards{
+			Shards: map[string]*EndpointShard{},
+			//AllEndpoints: []EndpointShard{},
+		}
+		s.EndpointShardsByService[serviceName] = ep
+	}
+
+	// 2. Update data for the specific cluster. Each cluster gets independent
+	// updates containing the full list of endpoints for the service in that cluster.
+	ce := &EndpointShard{
+		Shard:   shard,
+		Entries: []*model.IstioEndpoint{},
+	}
+
+	for _, e := range entries {
+		ce.Entries = append(ce.Entries, e)
+	}
+	ep.Shards[shard] = ce
+	s.Updates[serviceName] = &ep
+
+	adsLog.Infof("EDS Entries: %s %s %v", shard, serviceName, entries)
+	return nil
+}
+
+//// update the 'byPort' structure by merging info from all clusters.
+//func (s *DiscoveryServer) updateByPort(ep *ServiceShards)  {
+//	ep.ByPort = map[uint32][]*IstioEndpoint{}
+//
+//	// 3. Based on the updated list, merge the cluster data ( including previously
+//	// received data from the other clusters )
+//	for _, ce := range ep.ByCluster {
+//		for _, ee := range ce.Entries {
+//			// Each ee represents a Pod - with IP address, labels and ports.
+//			//for svcPortName, epPort := range ee.Ports {
+//			byPort, f := ep.ByPort[ee.servicePort]
+//			if !f {
+//				byPort = []*IstioEndpoint{}
+//				ep.ByPort[ee.servicePort] = byPort
+//			}
+//			byPort = append(byPort, ee)
+//		}
+//	}
+//}
 
 // LocalityLbEndpointsFromInstances returns a list of Envoy v2 LocalityLbEndpoints.
 // Envoy v2 Endpoints are constructed from Pilot's older data structure involving
@@ -227,92 +530,6 @@ func connectionID(node string) string {
 	return node + "-" + strconv.Itoa(int(c))
 }
 
-// StreamEndpoints implements xdsapi.EndpointDiscoveryServiceServer.StreamEndpoints().
-func (s *DiscoveryServer) StreamEndpoints(stream xdsapi.EndpointDiscoveryService_StreamEndpointsServer) error {
-	peerInfo, ok := peer.FromContext(stream.Context())
-	peerAddr := "Unknown peer address"
-	if ok {
-		peerAddr = peerInfo.Addr.String()
-	}
-	var discReq *xdsapi.DiscoveryRequest
-	var receiveError error
-	reqChannel := make(chan *xdsapi.DiscoveryRequest, 1)
-
-	initialRequestReceived := false
-
-	con := newXdsConnection(peerAddr, stream)
-	defer close(con.doneChannel)
-
-	// node is the key used in the cluster map. It includes the pod name and an unique identifier,
-	// since multiple envoys may connect from the same pod.
-	go receiveThread(con, reqChannel, &receiveError)
-
-	for {
-		// Block until either a request is received or the ticker ticks
-		select {
-		case discReq, ok = <-reqChannel:
-			if !ok {
-				return receiveError
-			}
-
-			// Should not change. A node monitors multiple clusters
-			if con.ConID == "" && discReq.Node != nil {
-				con.ConID = connectionID(discReq.Node.Id)
-			}
-
-			clusters2 := discReq.GetResourceNames()
-			if initialRequestReceived {
-				if len(clusters2) > len(con.Clusters) {
-					// This doesn't happen with current envoy - but should happen in future, there is no reason
-					// to keep so many open grpc streams (one per cluster, for each envoy)
-					adsLog.Infof("EDS: Multiple clusters monitoring %v -> %v %s", con.Clusters, clusters2, discReq.String())
-					initialRequestReceived = false // treat this as an initial request (updates monitoring state)
-				}
-			}
-
-			// Given that Pilot holds an eventually consistent data model, Pilot ignores any acknowledgements
-			// from Envoy, whether they indicate ack success or ack failure of Pilot's previous responses.
-			if initialRequestReceived {
-				// TODO: once the deps are updated, log the ErrorCode if set (missing in current version)
-				if discReq.ErrorDetail != nil {
-					adsLog.Warnf("EDS: ACK ERROR %v %s %v", peerAddr, con.ConID, discReq.String())
-				}
-				adsLog.Debugf("EDS: ACK %s %s %s", con.ConID, discReq.VersionInfo, con.Clusters)
-				if len(con.Clusters) > 0 {
-					continue
-				}
-			}
-			adsLog.Infof("EDS: REQ %s %v %v raw: %s ", con.ConID, con.Clusters, peerAddr, discReq.String())
-			con.Clusters = discReq.GetResourceNames()
-			initialRequestReceived = true
-
-			// In 0.7 EDS only listens for 1 cluster for each stream. In 0.8 EDS is no longer
-			// used.
-			for _, c := range con.Clusters {
-				s.addEdsCon(c, con.ConID, con)
-			}
-
-			// Keep track of active EDS client. In 0.7 EDS push happened by pushing for all
-			// tracked clusters. In 0.8+ push happens by iterating active connections, in ADS.
-			if !con.added {
-				con.added = true
-				s.addCon(con.ConID, con)
-				defer s.removeCon(con.ConID, con)
-			}
-
-		case <-con.pushChannel:
-		}
-
-		if len(con.Clusters) > 0 {
-			err := s.pushEds(s.env.PushContext, con)
-			if err != nil {
-				adsLog.Errorf("Closing EDS connection, failure to push %v", err)
-				return err
-			}
-		}
-
-	}
-}
 
 func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection) error {
 	resAny := []types.Any{}
@@ -330,7 +547,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection) e
 
 		l := loadAssignment(c)
 		if l == nil { // fresh cluster
-			if err := s.updateCluster(push, clusterName, c); err != nil {
+			if err := s.updateCluster(push, clusterName, c, nil); err != nil {
 				adsLog.Errorf("error returned from updateCluster for cluster name %s, skipping it.", clusterName)
 				continue
 			}

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -14,7 +14,6 @@
 package v2_test
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -26,133 +25,118 @@ import (
 	"testing"
 	"time"
 
-	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"google.golang.org/grpc"
+	_ "net/http/pprof"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/tests/util"
+	"istio.io/istio/pkg/adsc"
 )
 
-func connect(t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
-	req := &xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
-			Id: sidecarId(app3Ip, "app3"),
-		},
-		ResourceNames: []string{"outbound|80||hello.default.svc.cluster.local"},
-	}
-	return connectWithRequest(req, t)
+// The connect and reconnect tests are removed - ADS already has coverage, and the
+// StreamEndpoints is not used in 1.0+
+
+func TestEds(t *testing.T) {
+	initLocalPilotTestEnv(t)
+	server := util.MockTestServer
+
+	// will be checked in the direct request test
+	addUdsEndpoint(server)
+
+	adsc := adsConnectAndWait(t, 0x0a0a0a0a)
+	defer adsc.Close()
+
+	go http.ListenAndServe(":9900", nil)
+
+	t.Run("TCPEndpoints", func(t *testing.T) {
+		testTCPEndpoints("127.0.0.1", adsc, t)
+	})
+	t.Run("UDSEndpoints", func(t *testing.T) {
+		testUdsEndpoints(server, adsc, t)
+	})
+	t.Run("PushIncremental", func(t *testing.T) {
+		edsUpdateInc(server, adsc, t)
+	})
+	t.Run("Push", func(t *testing.T) {
+		edsUpdates(server, adsc, t)
+	})
+	t.Run("MultipleRequest", func(t *testing.T) {
+		multipleRequest(server, false, t)
+	})
+	t.Run("MultipleRequestIncremental", func(t *testing.T) {
+		multipleRequest(server, true, t)
+	})
+	t.Run("edsz", func(t *testing.T) {
+		testEdsz(t)
+	})
+
 }
 
-func reconnect(res *xdsapi.DiscoveryResponse, t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
-	req := &xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
-			Id: sidecarId(app3Ip, "app3"),
-		},
-		VersionInfo:   res.VersionInfo,
-		ResponseNonce: res.Nonce,
-		ResourceNames: []string{"outbound|80||hello.default.svc.cluster.local"},
-	}
-	return connectWithRequest(req, t)
-}
-
-func connectWithRequest(r *xdsapi.DiscoveryRequest, t *testing.T) xdsapi.EndpointDiscoveryService_StreamEndpointsClient {
-	conn, err := grpc.Dial(util.MockPilotGrpcAddr, grpc.WithInsecure())
+func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
+	adsc, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.ADSCOpt{
+		IP: testIp(uint32(ip)),
+	})
 	if err != nil {
-		t.Fatal("Connection failed", err)
+		t.Fatal("Error connecting ", err)
 	}
-
-	xds := xdsapi.NewEndpointDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamEndpoints(context.Background())
+	adsc.Watch()
+	_, err = adsc.Wait("rds", 5 * time.Second)
 	if err != nil {
-		t.Fatal("Rpc failed", err)
+		t.Fatal("Error getting initial config ", err)
 	}
-	err = edsstr.Send(r)
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-	return edsstr
-}
 
-// Regression for envoy restart and overlapping connections
-func TestReconnectWithNonce(t *testing.T) {
-	_ = initLocalPilotTestEnv(t)
-	edsstr := connect(t)
-	res, _ := edsstr.Recv()
-
-	// closes old process
-	_ = edsstr.CloseSend()
-
-	edsstr = reconnect(res, t)
-	res, _ = edsstr.Recv()
-	_ = edsstr.CloseSend()
-
-	t.Log("Received ", res)
-}
-
-// Regression for envoy restart and overlapping connections
-func TestReconnect(t *testing.T) {
-	s := initLocalPilotTestEnv(t)
-	edsstr := connect(t)
-	_, _ = edsstr.Recv()
-
-	// envoy restarts and reconnects
-	edsstr2 := connect(t)
-	_, _ = edsstr2.Recv()
-
-	// closes old process
-	_ = edsstr.CloseSend()
-
-	time.Sleep(1 * time.Second)
-
-	// event happens
-	v2.AdsPushAll(s.EnvoyXdsServer)
-
-	// will trigger recompute and push (we may need to make a change once diff is implemented
-
-	done := make(chan struct{}, 1)
-	go func() {
-		t := time.NewTimer(3 * time.Second)
-		select {
-		case <-t.C:
-			_ = edsstr2.CloseSend()
-		case <-done:
-			if !t.Stop() {
-				<-t.C
-			}
-		}
-	}()
-
-	m, err := edsstr2.Recv()
-	if err != nil {
-		t.Fatal("Recv failed", err)
-	}
-	t.Log("Received ", m)
-}
-
-// Make a direct EDS grpc request to pilot, verify the result is as expected.
-func directRequest(server *bootstrap.Server, t *testing.T) {
-	edsstr, cla := connectAndSend(1, t)
-	defer edsstr.CloseSend()
-	// TODO: validate VersionInfo and nonce once we settle on a scheme
-
-	ep := cla.Endpoints
-	if len(ep) == 0 {
+	if len(adsc.EDS) == 0 {
 		t.Fatal("No endpoints")
 	}
-	lbe := ep[0].LbEndpoints
-	if len(lbe) == 0 {
+	return adsc
+}
+
+
+// Verify server sends the TCP endpoint
+func testTCPEndpoints(expected string, adsc *adsc.ADSC, t *testing.T) {
+	lbe, f := adsc.EDS["outbound|80||hello.default.svc.cluster.local"]
+	if !f || len(lbe.Endpoints) == 0 {
 		t.Fatal("No lb endpoints")
 	}
-	if "127.0.0.1" != lbe[0].Endpoint.Address.GetSocketAddress().Address {
-		t.Error("Expecting 127.0.0.1 got ", lbe[0].Endpoint.Address.GetSocketAddress().Address)
+	for _, e := range lbe.Endpoints[0].LbEndpoints {
+		if expected == e.Endpoint.Address.GetSocketAddress().Address {
+			return
+		}
 	}
+	t.Errorf("Expecting %s got %v", expected, lbe.Endpoints[0].LbEndpoints)
 
+}
+
+
+// Verify server sends UDS endpoints
+func testUdsEndpoints(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+	// Check the UDS endpoint ( used to be separate test - but using old unused GRPC method)
+	// The new test also verifies CDS is pusing the UDS cluster, since adsc.EDS is
+	// populated using CDS response
+	lbe, f := adsc.EDS["outbound|0||localuds.cluster.local"]
+	if !f || len(lbe.Endpoints) == 0 {
+		t.Error("No UDS lb endpoints")
+	} else {
+		ep0 := lbe.Endpoints[0]
+		if len(ep0.LbEndpoints) != 1 {
+			t.Fatalf("expected 1 LB endpoint but got %d", len(ep0.LbEndpoints))
+		}
+		lbep := ep0.LbEndpoints[0]
+		path := lbep.GetEndpoint().GetAddress().GetPipe().GetPath()
+		if path != udsPath {
+			t.Fatalf("expected Pipe to %s, got %s", udsPath, path)
+		}
+	}
+}
+
+// Update
+func edsUpdates(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+
+	// Old style (non-incremental)
 	server.EnvoyXdsServer.MemRegistry.AddInstance("hello.default.svc.cluster.local", &model.ServiceInstance{
 		Endpoint: model.NetworkEndpoint{
-			Address: "127.0.0.2",
+			Address: "127.0.0.3",
 			Port:    int(testEnv.Ports().BackendPort),
 			ServicePort: &model.Port{
 				Name:     "http",
@@ -167,60 +151,58 @@ func directRequest(server *bootstrap.Server, t *testing.T) {
 	v2.AdsPushAll(server.EnvoyXdsServer)
 	// will trigger recompute and push
 
+	_, err := adsc.Wait("eds", 5 * time.Second)
+	if err != nil {
+		t.Fatal("EDS push failed", err)
+	}
+	testTCPEndpoints("127.0.0.3", adsc, t)
+}
+
+// Update
+func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+
+	// TODO: set endpoints for a different cluster (new shard)
+
+	// Equivalent with K8S watching the Service.
+	server.EnvoyXdsServer.MemRegistry.SetEndpoints(
+		"hello.default.svc.cluster.local",
+		[]*model.IstioEndpoint {
+			&model.IstioEndpoint{
+				Address: "127.0.0.2",
+				ServicePortName: "http",
+				EndpointPort: 80,
+				Labels: &map[string]string{"version": "v1"},
+				UID: "uid1",
+			},
+		})
+
 	// This should happen in 15 seconds, for the periodic refresh
 	// TODO: verify push works
-	_, err := edsstr.Recv()
+	upd, err := adsc.Wait("", 5 * time.Second)
 	if err != nil {
-		t.Fatal("Recv2 failed", err)
+		t.Fatal("Incremental push failed", err)
+	}
+	if upd != "eds" {
+		t.Error("Expecting EDS only update")
+		upd, err = adsc.Wait("eds", 5 * time.Second)
+		if err != nil {
+			t.Fatal("Incremental push failed", err)
+		}
 	}
 
-	// Need to run the debug test before we close - close will remove the cluster since
-	// nobody is watching.
-	testEdsz(t)
+	testTCPEndpoints("127.0.0.2", adsc, t)
 }
 
 // Make a direct EDS grpc request to pilot, verify the result is as expected.
-// id should be unique to avoid interference between tests.
-func connectAndSend(id uint32, t *testing.T) (xdsapi.EndpointDiscoveryService_StreamEndpointsClient,
-	*xdsapi.ClusterLoadAssignment) {
-
-	conn, err := grpc.Dial(util.MockPilotGrpcAddr, grpc.WithInsecure())
-	if err != nil {
-		t.Fatal("Connection failed", err)
-	}
-
-	xds := xdsapi.NewEndpointDiscoveryServiceClient(conn)
-	edsstr, err := xds.StreamEndpoints(context.Background())
-	if err != nil {
-		t.Fatal("Rpc failed", err)
-	}
-	err = edsstr.Send(&xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
-			Id: sidecarId(testIp(uint32(0x0a100000+id)), "app3"),
-		},
-		ResourceNames: []string{"outbound|80||hello.default.svc.cluster.local"}})
-	if err != nil {
-		t.Fatal("Send failed", err)
-	}
-
-	res1, err := edsstr.Recv()
-	if err != nil {
-		t.Fatal("Recv failed", err)
-	}
-	cla, err := getLoadAssignment(res1)
-	if err != nil {
-		t.Fatal("Invalid EDS ", err)
-	}
-	return edsstr, cla
-}
-
-// Make a direct EDS grpc request to pilot, verify the result is as expected.
-func multipleRequest(server *bootstrap.Server, t *testing.T) {
+// This test includes a 'bad client' regression test, which fails to read on the
+// stream.
+func multipleRequest(server *bootstrap.Server, inc bool, t *testing.T) {
 	wgConnect := &sync.WaitGroup{}
 	wg := &sync.WaitGroup{}
 
 	// Bad client - will not read any response. This triggers Write to block, which should
 	// be detected
+	// This is not using adsc, which consumes the events automatically.
 	ads, err := connectADS(util.MockPilotGrpcAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -231,9 +213,8 @@ func multipleRequest(server *bootstrap.Server, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 1000 clients * 100 pushes = ~4 sec
-	n := 10 // clients
-	nPushes := 10
+	n := 100 // clients
+	nPushes := 2
 	wg.Add(n)
 	wgConnect.Add(n)
 	rcvPush := int32(0)
@@ -242,16 +223,33 @@ func multipleRequest(server *bootstrap.Server, t *testing.T) {
 		current := i
 		go func(id int) {
 			// Connect and get initial response
-			edsstr, _ := connectAndSend(uint32(id+2), t)
-			defer edsstr.CloseSend()
+			adsc, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.ADSCOpt{
+				IP: testIp(uint32(0x0a100000+id)),
+			})
+			if err != nil {
+				t.Fatal("Error connecting ", err)
+			}
+			defer adsc.Close()
+			adsc.Watch()
+			_, err = adsc.Wait("rds", 5 * time.Second)
+			if err != nil {
+				t.Fatal("Error getting initial config ", err)
+			}
+
+			if len(adsc.EDS) == 0 {
+				t.Fatal("No endpoints")
+			}
+
+			defer adsc.Close()
 			wgConnect.Done()
 			defer wg.Done()
+
 			// Check we received all pushes
 			log.Println("Waiting for pushes ", id)
 			for j := 0; j < nPushes; j++ {
 				// The time must be larger than write timeout: if we run all tests
 				// and some are leaving uncleaned state the push will be slower.
-				_, err := edsReceive(edsstr, 15*time.Second)
+				_, err := adsc.Wait("eds", 15*time.Second)
 				atomic.AddInt32(&rcvPush, 1)
 				if err != nil {
 					log.Println("Recv failed", err, id, j)
@@ -263,13 +261,19 @@ func multipleRequest(server *bootstrap.Server, t *testing.T) {
 			atomic.AddInt32(&rcvClients, 1)
 		}(current)
 	}
-	ok := waitTimeout(wgConnect, 10*time.Second)
+	ok := waitTimeout(wgConnect, 20*time.Second)
 	if !ok {
 		t.Fatal("Failed to connect")
 	}
 	log.Println("Done connecting")
 	for j := 0; j < nPushes; j++ {
-		v2.AdsPushAll(server.EnvoyXdsServer)
+		if inc {
+			server.EnvoyXdsServer.AdsPushAll("v1",
+				server.EnvoyXdsServer.Env.PushContext,
+				false, []string{"hello.default.svc.cluster.local"})
+		} else {
+			v2.AdsPushAll(server.EnvoyXdsServer)
+		}
 		log.Println("Push done ", j)
 	}
 
@@ -282,22 +286,6 @@ func multipleRequest(server *bootstrap.Server, t *testing.T) {
 	}
 }
 
-func edsReceive(eds xdsapi.EndpointDiscoveryService_StreamEndpointsClient, to time.Duration) (*xdsapi.DiscoveryResponse, error) {
-	done := make(chan int, 1)
-	t := time.NewTimer(to)
-	defer func() {
-		done <- 1
-	}()
-	go func() {
-		select {
-		case <-t.C:
-			_ = eds.CloseSend() // will result in adsRecv closing as well, interrupting the blocking recv
-		case <-done:
-			_ = t.Stop()
-		}
-	}()
-	return eds.Recv()
-}
 
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	c := make(chan struct{})
@@ -313,8 +301,9 @@ func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
-func udsRequest(server *bootstrap.Server, t *testing.T) {
-	udsPath := "/var/run/test/socket"
+const udsPath = "/var/run/test/socket"
+
+func addUdsEndpoint(server *bootstrap.Server) {
 	server.EnvoyXdsServer.MemRegistry.AddService("localuds.cluster.local", &model.Service{
 		Hostname: "localuds.cluster.local",
 		Ports: model.PortList{
@@ -342,66 +331,9 @@ func udsRequest(server *bootstrap.Server, t *testing.T) {
 		AvailabilityZone: "localhost",
 	})
 
-	req := &xdsapi.DiscoveryRequest{
-		Node: &envoy_api_v2_core1.Node{
-			Id: sidecarId(app3Ip, "app3"),
-		},
-		ResourceNames: []string{"outbound|0||localuds.cluster.local"},
-	}
-	edsstr := connectWithRequest(req, t)
-
-	cla := &xdsapi.ClusterLoadAssignment{}
-	// Race condition in the server might cause it to send a Resource with no endpoints at first, so retry once more if
-	// that happens.
-	for i := 0; i < 2; i++ {
-		res, err := edsstr.Recv()
-		if err != nil {
-			t.Fatal("Recv2 failed", err)
-		}
-		t.Log(res.String())
-		if len(res.Resources) != 1 {
-			t.Fatalf("expected 1 resources got %d", len(res.Resources))
-		}
-		err = cla.Unmarshal(res.Resources[0].Value)
-		if err != nil {
-			t.Fatal("Failed to parse proto ", err)
-		}
-		t.Log(cla.String())
-		if len(cla.Endpoints) != 1 {
-			if i == 1 {
-				// Second attempt, fail test case
-				t.Fatalf("expected 1 endpoint but got %d", len(cla.Endpoints))
-			}
-			log.Println(fmt.Sprintf("expected 1 endpoint but got %d, retrying", len(cla.Endpoints)))
-			continue
-		}
-		break
-	}
-	ep0 := cla.Endpoints[0]
-	if len(ep0.LbEndpoints) != 1 {
-		t.Fatalf("expected 1 LB endpoint but got %d", len(ep0.LbEndpoints))
-	}
-	lbep := ep0.LbEndpoints[0]
-	path := lbep.GetEndpoint().GetAddress().GetPipe().GetPath()
-	if path != udsPath {
-		t.Fatalf("expected Pipe to %s, got %s", udsPath, path)
-	}
+	server.EnvoyXdsServer.Push(true, nil)
 }
 
-func TestEds(t *testing.T) {
-	initLocalPilotTestEnv(t)
-	server := util.EnsureTestServer()
-
-	t.Run("DirectRequest", func(t *testing.T) {
-		directRequest(server, t)
-	})
-	t.Run("MultipleRequest", func(t *testing.T) {
-		multipleRequest(server, t)
-	})
-	t.Run("UDSRequest", func(t *testing.T) {
-		udsRequest(server, t)
-	})
-}
 
 // Verify the endpoint debug interface is installed and returns some string.
 // TODO: parse response, check if data captured matches what we expect.

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -51,12 +51,13 @@ func (s *DiscoveryServer) pushLds(con *XdsConnection, push *model.PushContext, o
 	}
 	pushes.With(prometheus.Labels{"type": "lds"}).Add(1)
 
-	adsLog.Infof("LDS: PUSH for node:%s addr:%q listeners:%d", con.modelNode.ID, con.PeerAddr, len(rawListeners))
+	adsLog.Infof("LDS: PUSH for node:%s addr:%q listeners:%d %d", con.modelNode.ID, con.PeerAddr, len(rawListeners),
+		response.Size())
 	return nil
 }
 
 func (s *DiscoveryServer) generateRawListeners(con *XdsConnection, push *model.PushContext) ([]*xdsapi.Listener, error) {
-	rawListeners, err := s.ConfigGenerator.BuildListeners(s.env, con.modelNode, push)
+	rawListeners, err := s.ConfigGenerator.BuildListeners(s.Env, con.modelNode, push)
 	if err != nil {
 		adsLog.Warnf("LDS: Failed to generate listeners for node %s: %v", con.modelNode, err)
 		pushes.With(prometheus.Labels{"type": "lds_builderr"}).Add(1)

--- a/pilot/pkg/proxy/envoy/v2/rds.go
+++ b/pilot/pkg/proxy/envoy/v2/rds.go
@@ -70,7 +70,7 @@ func (s *DiscoveryServer) generateRawRoutes(con *XdsConnection, push *model.Push
 
 	// TODO: once per config update
 	for _, routeName := range con.Routes {
-		r, err := s.ConfigGenerator.BuildHTTPRoutes(s.env, con.modelNode, push, routeName)
+		r, err := s.ConfigGenerator.BuildHTTPRoutes(s.Env, con.modelNode, push, routeName)
 		if err != nil {
 			retErr := fmt.Errorf("RDS: Failed to generate route %s for node %v: %v", routeName, con.modelNode, err)
 			adsLog.Warnf("RDS: Failed to generate routes for route %s for node %s: %v", routeName, con.modelNode, err)

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -262,7 +262,7 @@ func initLocalPilotTestEnv(t *testing.T) *bootstrap.Server {
 	})
 
 	// Update cache
-	server.EnvoyXdsServer.ClearCacheFunc()()
+	server.EnvoyXdsServer.Push(true, nil)
 
 	return server
 }

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -1,0 +1,467 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adsc
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"net"
+	"fmt"
+	"log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/jsonpb"
+	"sync"
+	"errors"
+)
+
+type ADSCOpt struct {
+	// Namespace defaults to 'default'
+	Namespace string
+
+	// Workload defaults to 'test'
+	Workload string
+
+	// Meta includes additional metadata for the node
+	Meta map[string]string
+
+	// NodeType defaults to sidecar. "ingress" and "router" are also supported.
+	NodeType string
+	IP       string
+}
+
+// ADSC implements a basic client for ADS, for use in stress tests and tools
+// or libraries that need to connect to Istio pilot or other ADS servers.
+type ADSC struct {
+	// Stream is the GRPC connection stream, allowing direct GRPC send operations.
+	// Set after Dial is called.
+	stream ads.AggregatedDiscoveryService_StreamAggregatedResourcesClient
+
+	// NodeID is the node identity sent to Pilot.
+	nodeID string
+
+	done chan error
+
+	watchTime time.Time
+
+	InitialLoad time.Duration
+
+	TCPListeners map[string]*xdsapi.Listener
+	HTTPListeners map[string]*xdsapi.Listener
+	Clusters  map[string]*xdsapi.Cluster
+	Routes    map[string]*xdsapi.RouteConfiguration
+	EDS       map[string]*xdsapi.ClusterLoadAssignment
+
+	rdsNames []string
+	clusterNames []string
+
+	// Updates includes the type of the last update received from the server.
+	Updates     chan string
+	VersionInfo map[string]string
+
+	mutex sync.Mutex
+}
+
+const (
+	typePrefix = "type.googleapis.com/envoy.api.v2."
+
+	// Constants used for XDS
+
+	// ClusterType is used for cluster discovery. Typically first request received
+	clusterType = typePrefix + "Cluster"
+	// EndpointType is used for EDS and ADS endpoint discovery. Typically second request.
+	endpointType = typePrefix + "ClusterLoadAssignment"
+	// ListenerType is sent after clusters and endpoints.
+	listenerType = typePrefix + "Listener"
+	// RouteType is sent after listeners.
+	routeType = typePrefix + "RouteConfiguration"
+)
+
+// Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
+func Dial(url string, certDir string, opts *ADSCOpt ) (*ADSC, error) {
+	adsc := &ADSC{
+		done: make(chan error),
+		Updates: make(chan string, 10),
+		VersionInfo: map[string]string{},
+	}
+	var conn *grpc.ClientConn
+	var err error
+	if len(certDir) > 0 {
+		tlsCfg, err := tlsConfig(certDir)
+		if err != nil {
+			return nil, err
+		}
+		creds := credentials.NewTLS(tlsCfg)
+
+		opts := []grpc.DialOption{
+			// Verify Pilot cert and service account
+			grpc.WithTransportCredentials(creds),
+		}
+		conn, err = grpc.Dial(url, opts...)
+	} else {
+		conn, err = grpc.Dial(url, grpc.WithInsecure())
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	xds := ads.NewAggregatedDiscoveryServiceClient(conn)
+	edsstr, err := xds.StreamAggregatedResources(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	adsc.stream = edsstr
+
+	if opts.Namespace == "" {
+		opts.Namespace = "default"
+	}
+	if opts.NodeType == "" {
+		opts.NodeType = "sidecar"
+	}
+	if opts.IP == "" {
+		opts.IP =  getPrivateIPIfAvailable().String()
+	}
+	if opts.Workload == "" {
+		opts.Workload = "test-1"
+	}
+
+	adsc.nodeID = fmt.Sprintf("sidecar~%s~%s.%s~%s.svc.cluster.local",opts.IP,
+		opts.Workload, opts.Namespace, opts.Namespace)
+
+	go adsc.handleRecv()
+	return adsc, nil
+}
+
+// Returns a private IP address, or unspecified IP (0.0.0.0) if no IP is available
+func getPrivateIPIfAvailable() net.IP {
+	addrs, _ := net.InterfaceAddrs()
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		default:
+			continue
+		}
+		if !ip.IsLoopback() {
+			return ip
+		}
+	}
+	return net.IPv4zero
+}
+
+func tlsConfig(certDir string) (*tls.Config, error) {
+	clientCert, err := tls.LoadX509KeyPair(certDir+"/cert-chain.pem",
+		certDir+"/key.pem")
+	if err != nil {
+		return nil, err
+	}
+
+	serverCABytes, err := ioutil.ReadFile(certDir + "/root-cert.pem")
+	if err != nil {
+		return nil, err
+	}
+	serverCAs := x509.NewCertPool()
+	if ok := serverCAs.AppendCertsFromPEM(serverCABytes); !ok {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      serverCAs,
+		ServerName:   "istio-pilot.istio-system",
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			return nil
+		},
+	}, nil
+}
+
+func (a *ADSC) Close() {
+	if a.stream != nil {
+		a.stream.CloseSend()
+	}
+}
+
+func (a *ADSC) Reconnect() {
+}
+
+func (a *ADSC) handleRecv() {
+	for {
+		msg, err := a.stream.Recv()
+		if err != nil {
+			log.Println("Connection closed ", err, a.nodeID)
+			a.Close()
+			return
+		}
+
+		listeners := []*xdsapi.Listener{}
+		clusters := []*xdsapi.Cluster{}
+		routes := []*xdsapi.RouteConfiguration{}
+		eds := []*xdsapi.ClusterLoadAssignment{}
+		for _, rsc := range msg.Resources { // Any
+			a.VersionInfo[rsc.TypeUrl] = msg.VersionInfo
+			valBytes := rsc.Value
+			if rsc.TypeUrl == listenerType {
+				ll := &xdsapi.Listener{}
+				proto.Unmarshal(valBytes, ll)
+				listeners = append(listeners, ll)
+			} else if rsc.TypeUrl == clusterType {
+					ll := &xdsapi.Cluster{}
+					proto.Unmarshal(valBytes, ll)
+					clusters = append(clusters, ll)
+			} else if rsc.TypeUrl == endpointType {
+				ll := &xdsapi.ClusterLoadAssignment{}
+				proto.Unmarshal(valBytes, ll)
+				eds = append(eds, ll)
+			} else if rsc.TypeUrl == routeType {
+				ll := &xdsapi.RouteConfiguration{}
+				proto.Unmarshal(valBytes, ll)
+				routes = append(routes, ll)
+			}
+		}
+
+		// TODO: add hook to inject nacks
+		a.ack(msg)
+
+		if len(listeners) > 0 {
+			a.handleLDS(listeners)
+		}
+		if len(clusters) > 0 {
+			a.handleCDS(clusters)
+		}
+		if len(eds) > 0 {
+			a.handleEDS(eds)
+		}
+		if len(routes) > 0 {
+			a.handleRDS(routes)
+		}
+	}
+
+}
+
+func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
+	lh := map[string]*xdsapi.Listener{}
+	lt := map[string]*xdsapi.Listener{}
+
+	clusters := []string{}
+	routes := []string{}
+	ldsSize :=0
+
+	for _, l := range ll {
+		ldsSize += l.Size()
+		f0 := l.FilterChains[0].Filters[0]
+		if f0.Name == "mixer" {
+			f0 = l.FilterChains[0].Filters[1]
+		}
+		if f0.Name == "envoy.tcp_proxy" {
+			lt[l.Name] = l
+			c:= f0.Config.Fields["cluster"].GetStringValue()
+			clusters = append(clusters, c)
+			//log.Printf("TCP: %s -> %s", l.Name, c)
+		} else if f0.Name == "envoy.http_connection_manager" {
+			lh[l.Name] = l
+
+			// Getting from config is too painful..
+			port := l.Address.GetSocketAddress().GetPortValue()
+			routes = append(routes, fmt.Sprintf("%d",port))
+			//log.Printf("HTTP: %s -> %d", l.Name, port)
+		} else if f0.Name == "envoy.mongo_proxy" {
+			// ignore for now
+		} else {
+			tm := &jsonpb.Marshaler{Indent: "  "}
+			log.Println(tm.MarshalToString(l))
+		}
+	}
+
+	log.Println("LDS: http=", len(lh), "tcp=", len(lt), "size=", ldsSize)
+	if len(routes) > 0 {
+		a.sendRsc(routeType, routes)
+	}
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	a.HTTPListeners = lh
+	a.TCPListeners = lt
+
+	select {
+		case a.Updates <- "lds":
+			default:
+	}
+}
+
+func (a *ADSC) handleCDS(ll []*xdsapi.Cluster) {
+
+	cn := []string{}
+	cdsSize := 0
+	cds := map[string]*xdsapi.Cluster{}
+	for _, c := range ll {
+		cdsSize += c.Size()
+		if c.Type != xdsapi.Cluster_EDS {
+			// TODO: save them
+			continue
+		}
+		cn = append(cn, c.Name)
+		cds[c.Name] = c
+	}
+
+	log.Println("CDS: ", len(cn), "size=", cdsSize)
+
+	if len(cn) > 0 {
+		a.sendRsc(endpointType, cn)
+	}
+
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	a.Clusters = cds
+
+	select {
+	case a.Updates <- "cds":
+	default:
+	}
+}
+
+func (a *ADSC) handleEDS(eds []*xdsapi.ClusterLoadAssignment) {
+	clas := map[string]*xdsapi.ClusterLoadAssignment{}
+	edsSize := 0
+	for _, cla := range eds {
+		edsSize += cla.Size()
+		clas[cla.ClusterName] = cla
+	}
+
+	log.Println("EDS: ", len(eds), "size=", edsSize)
+
+	if a.InitialLoad == 0 {
+		// first load - Envoy loads listeners after endpoints
+		a.stream.Send(&xdsapi.DiscoveryRequest{
+			ResponseNonce: time.Now().String(),
+			Node: &core.Node{
+				Id: a.nodeID,
+			},
+			TypeUrl: listenerType,
+		})
+	}
+
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	a.EDS = clas
+
+	select {
+	case a.Updates <- "eds":
+	default:
+	}
+}
+
+func (a *ADSC) handleRDS(configurations []*xdsapi.RouteConfiguration) {
+
+	vh := 0
+	rcount := 0
+	size := 0
+
+	httpClusters := []string{}
+	rds := map[string]*xdsapi.RouteConfiguration{}
+
+	for _, r := range configurations {
+		for _, h := range r.VirtualHosts {
+			vh++
+			for _, rt := range h.Routes {
+				rcount++
+				// Example: match:<prefix:"/" > route:<cluster:"outbound|9154||load-se-154.local" ...
+				//log.Println(rt.String())
+				httpClusters = append(httpClusters, rt.GetRoute().GetCluster())
+			}
+		}
+		rds[r.Name] = r
+		size += r.Size()
+	}
+	if a.InitialLoad == 0 {
+		a.InitialLoad = time.Since(a.watchTime)
+		log.Println("RDS: ", len(configurations), "size=", size, "vhosts=", vh, "routes=", rcount, " time=", a.InitialLoad)
+	} else {
+		log.Println("RDS: ", len(configurations), "size=", size, "vhosts=", vh, "routes=", rcount)
+	}
+
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+	a.Routes = rds
+
+	select {
+	case a.Updates <- "rds":
+	default:
+	}
+	}
+
+
+// Wait for an update of the specified type. If type is empty, wait for next update.
+func (a *ADSC) Wait(update string, to time.Duration) (string, error) {
+
+	t := time.NewTimer(to)
+
+	for {
+		select {
+		case t := <-a.Updates:
+			if len(update) == 0 || update == t {
+				return t, nil
+			}
+		case <-t.C:
+			return "", errors.New("Timeout")
+
+		}
+	}
+}
+
+// Watch will start watching resources, starting with LDS. Based on the LDS response
+// it will start watching RDS and CDS.
+func (a *ADSC) Watch() {
+	a.watchTime = time.Now()
+	a.stream.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &core.Node{
+			Id: a.nodeID,
+		},
+		TypeUrl: clusterType,
+	})
+}
+
+func (a *ADSC) sendRsc(typeurl string, rsc []string) {
+	a.stream.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: time.Now().String(),
+		Node: &core.Node{
+			Id: a.nodeID,
+		},
+		TypeUrl:       typeurl,
+		ResourceNames: rsc,
+	})
+}
+
+func (a *ADSC) ack(msg *xdsapi.DiscoveryResponse) {
+	a.stream.Send(&xdsapi.DiscoveryRequest{
+		ResponseNonce: msg.Nonce,
+		TypeUrl:       msg.TypeUrl,
+		Node: &core.Node{
+			Id: a.nodeID,
+		},
+	})
+}
+


### PR DESCRIPTION
- added a mechanism for service discovery to update 'shards' of endpoints
- new data structures optimized for endpoint update ( IstioEndpoint has minimum info needed and allows caching the proto )
- optimized the update path - only affected shard will be changed without triggering a full cache invalidation
- rewrote the EDS tests - which were testing the 0.7 method, no longer used
- added a ADS client mirroring envoy behavior, to simplify testing (the load tester using this will be in separate PR)
- optimized the incremental push update path.