### PR TITLE
Remove busybox

### DIFF
--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -18,7 +18,6 @@ RUN apt-get update && \
       libc6-dbg gdb \
       elvis-tiny \
       lsof \
-      busybox \
       linux-tools-generic \
       sudo &&  apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
A step towards being completely GPL free.
I believe we don't need this now since we have pretty good debug tool coverage and all essential core utils are in the distro.