### PR TITLE
Re-introduce test framework logging flags.

### DIFF
--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -312,23 +312,45 @@ func convertScopedLevel(sl string) (string, Level, error) {
 // the necessary set of flags to expose a CLI to let the user control all
 // logging options.
 func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringArrayVar(&o.OutputPaths, "log_target", o.OutputPaths,
+	o.AttachFlags(
+		cmd.PersistentFlags().StringArrayVar,
+		cmd.PersistentFlags().StringVar,
+		cmd.PersistentFlags().IntVar,
+		cmd.PersistentFlags().BoolVar)
+}
+
+// AttachFlags allows attaching of flags through a set of lambda functions.
+func (o *Options) AttachFlags(
+	stringArrayVar func(p *[]string, name string, value []string, usage string),
+	stringVar func(p *string, name string, value string, usage string),
+	intVar func(p *int, name string, value int, usage string),
+	boolVar func(p *bool, name string, value bool, usage string)) {
+
+	stringArrayVar(&o.OutputPaths, "log_target", o.OutputPaths,
 		"The set of paths where to output the log. This can be any path as well as the special values stdout and stderr")
 
-	cmd.PersistentFlags().StringVar(&o.RotateOutputPath, "log_rotate", o.RotateOutputPath,
+	stringVar(&o.RotateOutputPath, "log_rotate", o.RotateOutputPath,
 		"The path for the optional rotating log file")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxAge, "log_rotate_max_age", o.RotationMaxAge,
+	intVar(&o.RotationMaxAge, "log_rotate_max_age", o.RotationMaxAge,
 		"The maximum age in days of a log file beyond which the file is rotated (0 indicates no limit)")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxSize, "log_rotate_max_size", o.RotationMaxSize,
+	intVar(&o.RotationMaxSize, "log_rotate_max_size", o.RotationMaxSize,
 		"The maximum size in megabytes of a log file beyond which the file is rotated")
 
-	cmd.PersistentFlags().IntVar(&o.RotationMaxBackups, "log_rotate_max_backups", o.RotationMaxBackups,
+	intVar(&o.RotationMaxBackups, "log_rotate_max_backups", o.RotationMaxBackups,
 		"The maximum number of log file backups to keep before older files are deleted (0 indicates no limit)")
 
-	cmd.PersistentFlags().BoolVar(&o.JSONEncoding, "log_as_json", o.JSONEncoding,
+	boolVar(&o.JSONEncoding, "log_as_json", o.JSONEncoding,
 		"Whether to format output as JSON or in plain console-friendly format")
+
+	levelListString := fmt.Sprintf("[%s, %s, %s, %s, %s, %s]",
+		levelToString[DebugLevel],
+		levelToString[InfoLevel],
+		levelToString[WarnLevel],
+		levelToString[ErrorLevel],
+		levelToString[FatalLevel],
+		levelToString[NoneLevel])
 
 	allScopes := Scopes()
 	if len(allScopes) > 1 {
@@ -339,50 +361,28 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 		sort.Strings(keys)
 		s := strings.Join(keys, ", ")
 
-		cmd.PersistentFlags().StringVar(&o.outputLevels, "log_output_level", o.outputLevels,
+		stringVar(&o.outputLevels, "log_output_level", o.outputLevels,
 			fmt.Sprintf("Comma-separated minimum per-scope logging level of messages to output, in the form of "+
-				"<scope>:<level>,<scope>:<level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s, %s]",
-				s,
-				levelToString[DebugLevel],
-				levelToString[InfoLevel],
-				levelToString[WarnLevel],
-				levelToString[ErrorLevel],
-				levelToString[FatalLevel],
-				levelToString[NoneLevel]))
+				"<scope>:<level>,<scope>:<level>,... where scope can be one of [%s] and level can be one of %s",
+				s, levelListString))
 
-		cmd.PersistentFlags().StringVar(&o.stackTraceLevels, "log_stacktrace_level", o.stackTraceLevels,
+		stringVar(&o.stackTraceLevels, "log_stacktrace_level", o.stackTraceLevels,
 			fmt.Sprintf("Comma-separated minimum per-scope logging level at which stack traces are captured, in the form of "+
-				"<scope>:<level>,<scope:level>,... where scope can be one of [%s] and level can be one of [%s, %s, %s, %s, %s, %s]",
-				s,
-				levelToString[DebugLevel],
-				levelToString[InfoLevel],
-				levelToString[WarnLevel],
-				levelToString[ErrorLevel],
-				levelToString[FatalLevel],
-				levelToString[NoneLevel]))
+				"<scope>:<level>,<scope:level>,... where scope can be one of [%s] and level can be one of %s",
+				s, levelListString))
 
-		cmd.PersistentFlags().StringVar(&o.logCallers, "log_caller", o.logCallers,
+		stringVar(&o.logCallers, "log_caller", o.logCallers,
 			fmt.Sprintf("Comma-separated list of scopes for which to include caller information, scopes can be any of [%s]", s))
 	} else {
-		cmd.PersistentFlags().StringVar(&o.outputLevels, "log_output_level", o.outputLevels,
-			fmt.Sprintf("The minimum logging level of messages to output,  can be one of [%s, %s, %s, %s, %s, %s]",
-				levelToString[DebugLevel],
-				levelToString[InfoLevel],
-				levelToString[WarnLevel],
-				levelToString[ErrorLevel],
-				levelToString[FatalLevel],
-				levelToString[NoneLevel]))
+		stringVar(&o.outputLevels, "log_output_level", o.outputLevels,
+			fmt.Sprintf("The minimum logging level of messages to output,  can be one of %s",
+				levelListString))
 
-		cmd.PersistentFlags().StringVar(&o.stackTraceLevels, "log_stacktrace_level", o.stackTraceLevels,
-			fmt.Sprintf("The minimum logging level at which stack traces are captured, can be one of [%s, %s, %s, %s, %s, %s]",
-				levelToString[DebugLevel],
-				levelToString[InfoLevel],
-				levelToString[WarnLevel],
-				levelToString[ErrorLevel],
-				levelToString[FatalLevel],
-				levelToString[NoneLevel]))
+		stringVar(&o.stackTraceLevels, "log_stacktrace_level", o.stackTraceLevels,
+			fmt.Sprintf("The minimum logging level at which stack traces are captured, can be one of %s",
+				levelListString))
 
-		cmd.PersistentFlags().StringVar(&o.logCallers, "log_caller", o.logCallers,
+		stringVar(&o.logCallers, "log_caller", o.logCallers,
 			"Comma-separated list of scopes for which to include called information, scopes can be any of [default]")
 	}
 

--- a/pkg/test/framework/driver.go
+++ b/pkg/test/framework/driver.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/log"
-
 	"istio.io/istio/pkg/test/framework/components"
 	"istio.io/istio/pkg/test/framework/components/registry"
 	"istio.io/istio/pkg/test/framework/dependency"
@@ -46,11 +45,6 @@ const (
 
 	// the driver has completed running tests.
 	completed
-)
-
-var (
-	// TODO(nmittler): Add logging options to flags.
-	logOptions = log.DefaultOptions()
 )
 
 type driver struct {
@@ -189,9 +183,6 @@ func (d *driver) initialize(testID string) (int, error) {
 
 	// Parse flags and init logging.
 	flag.Parse()
-	if err := log.Configure(logOptions); err != nil {
-		return -1, err
-	}
 
 	// Initialize settings
 	s, err := settings.New(testID)
@@ -199,6 +190,10 @@ func (d *driver) initialize(testID string) (int, error) {
 		return -1, err
 	}
 	scope.Debugf("driver settings: %+v", s)
+
+	if err := log.Configure(s.LogOptions); err != nil {
+		return -1, err
+	}
 
 	// Initialize the environment.
 	var impl internal.EnvironmentController

--- a/pkg/test/framework/settings/flags.go
+++ b/pkg/test/framework/settings/flags.go
@@ -29,4 +29,12 @@ func init() {
 			Local, Kubernetes))
 	flag.BoolVar(&globalSettings.NoCleanup, "istio.test.noCleanup", globalSettings.NoCleanup,
 		"Do not cleanup resources after test completion")
+
+	globalSettings.LogOptions.AttachFlags(
+		func(p *[]string, name string, value []string, usage string) {
+			// TODO(ozben): Implement string array method for capturing the complete set of log settings.
+		},
+		flag.StringVar,
+		flag.IntVar,
+		flag.BoolVar)
 }


### PR DESCRIPTION
- Cleanup the settings/logging code.
- Refactor Istio logging code to allow injecting of logging lambdas.
- Wire-up the log options to test-framework flags.