### PR TITLE
WIP: Use k8s session affinity for istio-telemetry

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -20,6 +20,7 @@ spec:
 {{- if eq $mname "telemetry" }}
   - name: prometheus
     port: 42422
+  sessionAffinity: ClientIP
 {{- end }}
   selector:
     istio: mixer

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -133,7 +133,13 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 // OnOutboundCluster implements the Plugin interface method.
 func (mixerplugin) OnOutboundCluster(env *model.Environment, push *model.PushContext,
 	service *model.Service, servicePort *model.Port, cluster *xdsapi.Cluster) {
-	// do nothing
+	withoutPort := strings.Split(env.Mesh.MixerReportServer, ":")
+	if strings.Contains(cluster.Name, withoutPort[0]) {
+		cluster.Type = xdsapi.Cluster_STRICT_DNS
+		addr := util.BuildAddress(service.Address, uint32(servicePort.Port))
+		cluster.Hosts = []*core.Address{&addr}
+		cluster.EdsClusterConfig = nil
+	}
 }
 
 // OnInboundCluster implements the Plugin interface method.


### PR DESCRIPTION
This PR alters the mixer plugin for Pilot by listening for outbound
clusters and then altering the definition of the mixer_report_server
cluster to use STRICT_DNS instead of EDS for service discovery. The
service address and port are provided as a singular host for use in
the cluster config. Finally, `sessionAffinity: ClientIP` is added to
the `service.spec` for `istio-telemetry`.

This PR is intended to provide sticky sessions between reporting pods
and the `istio-telemetry` service. This is motivated by requirements
from some telemetry systems (ex: Stackdriver) to receive telemetry for
a certain resource (here, the pod being monitored) **in-order**. While
this PR can help mitigate those requirements as a workaround, it is not
a complete solution and should not be viewed as such.

This PR is exploratory at the moment.

/hold