### PR TITLE
Test Framework logging scopes refactoring.

### DIFF
--- a/pkg/test/framework/driver.go
+++ b/pkg/test/framework/driver.go
@@ -81,9 +81,9 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 	}
 
 	// Call m.Run() while not holding the lock.
-	scopes.Lab.Infof(">>> Beginning test run for: '%s'", testID)
+	scopes.CI.Infof(">>> Beginning test run for: '%s'", testID)
 	rt = m.Run()
-	scopes.Lab.Infof("<<< Completing test run for: '%s'", testID)
+	scopes.CI.Infof("<<< Completing test run for: '%s'", testID)
 
 	d.lock.Lock()
 	defer d.lock.Unlock()
@@ -94,7 +94,7 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 		if closer, ok := d.context.Environment().(io.Closer); ok {
 			err := closer.Close()
 			if err != nil {
-				scopes.Lab.Warnf("Error during environment close: %v", err)
+				scopes.CI.Warnf("Error during environment close: %v", err)
 			}
 		}
 	}
@@ -197,7 +197,7 @@ func (d *driver) initialize(testID string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	scopes.Lab.Infof("driver settings: %+v", s)
+	scopes.CI.Infof("driver settings: %+v", s)
 
 	if err := log.Configure(s.LogOptions); err != nil {
 		return -1, err

--- a/pkg/test/framework/driver.go
+++ b/pkg/test/framework/driver.go
@@ -94,7 +94,7 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 		if closer, ok := d.context.Environment().(io.Closer); ok {
 			err := closer.Close()
 			if err != nil {
-				scopes.CI.Warnf("Error during environment close: %v", err)
+				scopes.Framework.Warnf("Error during environment close: %v", err)
 			}
 		}
 	}
@@ -147,7 +147,6 @@ func (d *driver) SuiteRequires(dependencies []dependency.Instance) error {
 // Requires implements same-named Driver method.
 func (d *driver) Requires(t testing.TB, dependencies []dependency.Instance) {
 	t.Helper()
-	scopes.Framework.Debugf("Enter: driver.Requires (%s)", d.context.Settings().TestID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
 

--- a/pkg/test/framework/driver.go
+++ b/pkg/test/framework/driver.go
@@ -94,7 +94,7 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 		if closer, ok := d.context.Environment().(io.Closer); ok {
 			err := closer.Close()
 			if err != nil {
-				lab.Warnf("Error during environment close: %v", err)
+				scopes.Lab.Warnf("Error during environment close: %v", err)
 			}
 		}
 	}

--- a/pkg/test/framework/driver.go
+++ b/pkg/test/framework/driver.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pkg/test/framework/environments/kubernetes"
 	"istio.io/istio/pkg/test/framework/environments/local"
 	"istio.io/istio/pkg/test/framework/internal"
+	"istio.io/istio/pkg/test/framework/scopes"
 	"istio.io/istio/pkg/test/framework/settings"
 )
 
@@ -80,9 +81,9 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 	}
 
 	// Call m.Run() while not holding the lock.
-	lab.Infof(">>> Beginning test run for: '%s'", testID)
+	scopes.Lab.Infof(">>> Beginning test run for: '%s'", testID)
 	rt = m.Run()
-	lab.Infof("<<< Completing test run for: '%s'", testID)
+	scopes.Lab.Infof("<<< Completing test run for: '%s'", testID)
 
 	d.lock.Lock()
 	defer d.lock.Unlock()
@@ -104,7 +105,7 @@ func (d *driver) Run(testID string, m *testing.M) (int, error) {
 // AcquireEnvironment implementation
 func (d *driver) AcquireEnvironment(t testing.TB) env.Environment {
 	t.Helper()
-	scope.Debugf("Enter: driver.AcquireEnvironment (%s)", d.context.Settings().TestID)
+	scopes.Framework.Debugf("Enter: driver.AcquireEnvironment (%s)", d.context.Settings().TestID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
@@ -146,7 +147,7 @@ func (d *driver) SuiteRequires(dependencies []dependency.Instance) error {
 // Requires implements same-named Driver method.
 func (d *driver) Requires(t testing.TB, dependencies []dependency.Instance) {
 	t.Helper()
-	scope.Debugf("Enter: driver.Requires (%s)", d.context.Settings().TestID)
+	scopes.Framework.Debugf("Enter: driver.Requires (%s)", d.context.Settings().TestID)
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
@@ -173,7 +174,7 @@ func (d *driver) Requires(t testing.TB, dependencies []dependency.Instance) {
 				t.Skipf("unable to locate dependency '%v' in environment %s", dep, envID)
 			}
 			if _, err := d.context.Tracker.Initialize(d.context, c); err != nil {
-				scope.Errorf("Failed to initialize dependency '%s': %v", dep, err)
+				scopes.Framework.Errorf("Failed to initialize dependency '%s': %v", dep, err)
 				t.Fatalf("unable to satisfy dependency '%v': %v", dep, err)
 			}
 		}
@@ -196,7 +197,7 @@ func (d *driver) initialize(testID string) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	scope.Debugf("driver settings: %+v", s)
+	scopes.Lab.Infof("driver settings: %+v", s)
 
 	if err := log.Configure(s.LogOptions); err != nil {
 		return -1, err
@@ -231,7 +232,7 @@ func (d *driver) initialize(testID string) (int, error) {
 			return -3, fmt.Errorf("dependency %s not available for environment %s", dep, impl.EnvironmentID())
 		}
 		if _, err := d.context.Tracker.Initialize(d.context, c); err != nil {
-			scope.Errorf("driver.Run: Dependency error '%s': %v", dep, err)
+			scopes.Framework.Errorf("driver.Run: Dependency error '%s': %v", dep, err)
 			return -3, err
 		}
 	}

--- a/pkg/test/framework/environment.go
+++ b/pkg/test/framework/environment.go
@@ -22,7 +22,6 @@ import (
 	"istio.io/istio/pkg/test/framework/dependency"
 	env "istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/internal"
-	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 type environment struct {
@@ -34,7 +33,6 @@ var _ env.Environment = &environment{}
 
 func (e *environment) CreateTmpDirectory(t testing.TB, name string) string {
 	t.Helper()
-	scopes.Framework.Debugf("Enter: Enter.CreateTmpDirectory (%s)", name)
 
 	//	return createTmpDirectory(t.workDir, t.runID, name)
 	s, err := internal.CreateTmpDirectory(e.ctx.Settings().WorkDir, e.ctx.Settings().RunID, name)

--- a/pkg/test/framework/environment.go
+++ b/pkg/test/framework/environment.go
@@ -22,6 +22,7 @@ import (
 	"istio.io/istio/pkg/test/framework/dependency"
 	env "istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/internal"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 type environment struct {
@@ -33,7 +34,7 @@ var _ env.Environment = &environment{}
 
 func (e *environment) CreateTmpDirectory(t testing.TB, name string) string {
 	t.Helper()
-	scope.Debugf("Enter: Enter.CreateTmpDirectory (%s)", name)
+	scopes.Framework.Debugf("Enter: Enter.CreateTmpDirectory (%s)", name)
 
 	//	return createTmpDirectory(t.workDir, t.runID, name)
 	s, err := internal.CreateTmpDirectory(e.ctx.Settings().WorkDir, e.ctx.Settings().RunID, name)

--- a/pkg/test/framework/environments/kubernetes/implementation.go
+++ b/pkg/test/framework/environments/kubernetes/implementation.go
@@ -23,15 +23,14 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/client-go/rest"
 
-	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/test/framework/scopes"
+
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/internal"
 	"istio.io/istio/pkg/test/framework/settings"
 	"istio.io/istio/pkg/test/framework/tmpl"
 	"istio.io/istio/pkg/test/kube"
 )
-
-var scope = log.RegisterScope("testframework", "General scope for the test framework", 0)
 
 // Implementation is the implementation of a kubernetes environment. It implements environment.Implementation,
 // and also hosts publicly accessible methods that are specific to cluster environment.
@@ -119,7 +118,7 @@ func (e *Implementation) Initialize(ctx *internal.TestContext) error {
 
 // Configure applies the given configuration to the mesh.
 func (e *Implementation) Configure(config string) error {
-	scope.Debugf("Applying configuration: \n%s\n", config)
+	scopes.Framework.Debugf("Applying configuration: \n%s\n", config)
 	err := kube.ApplyContents(e.kube.KubeConfig, e.systemNamespace.allocatedName, config)
 	if err != nil {
 		return err
@@ -145,7 +144,7 @@ func (e *Implementation) Evaluate(template string) (string, error) {
 
 // Reset the environment before starting another test.
 func (e *Implementation) Reset() error {
-	scope.Debug("Resetting environment")
+	scopes.Framework.Debug("Resetting environment")
 
 	// Re-allocate the test namespace.
 	if err := e.testNamespace.allocate(); err != nil {

--- a/pkg/test/framework/internal/tmp.go
+++ b/pkg/test/framework/internal/tmp.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 // TempFile represents a temporary file that was created.
@@ -83,7 +84,7 @@ func CreateTmpDirectory(workdir string, runID string, name string) (string, erro
 		return "", err
 	}
 
-	scope.Debugf("Created a temp dir: runID='%s', name='%s', location='%s'", runID, name, dir)
+	scopes.Framework.Debugf("Created a temp dir: runID='%s', name='%s', location='%s'", runID, name, dir)
 
 	return dir, nil
 }

--- a/pkg/test/framework/internal/tracker.go
+++ b/pkg/test/framework/internal/tracker.go
@@ -19,16 +19,15 @@ import (
 
 	"go.uber.org/multierr"
 
+	"istio.io/istio/pkg/test/framework/scopes"
+
 	"fmt"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/framework/component"
 	"istio.io/istio/pkg/test/framework/components/registry"
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 )
-
-var scope = log.RegisterScope("testframework", "General scope for the test framework", 0)
 
 // Tracker keeps track of the state information for dependencies
 type Tracker struct {
@@ -99,9 +98,9 @@ func (t *Tracker) Reset() error {
 
 	for k, v := range t.depMap {
 		if cl, ok := v.(Resettable); ok {
-			scope.Debugf("Resetting state for dependency: %s", k)
+			scopes.Framework.Debugf("Resetting state for dependency: %s", k)
 			if err := cl.Reset(); err != nil {
-				scope.Errorf("Error resetting dependency state: %s: %v", k, err)
+				scopes.Framework.Errorf("Error resetting dependency state: %s: %v", k, err)
 				er = multierr.Append(er, err)
 			}
 		}
@@ -114,9 +113,9 @@ func (t *Tracker) Reset() error {
 func (t *Tracker) Cleanup() {
 	for k, v := range t.depMap {
 		if cl, ok := v.(io.Closer); ok {
-			scope.Debugf("Cleaning up state for dependency: %s", k)
+			scopes.Framework.Debugf("Cleaning up state for dependency: %s", k)
 			if err := cl.Close(); err != nil {
-				scope.Errorf("Error cleaning up dependency state: %s: %v", k, err)
+				scopes.Framework.Errorf("Error cleaning up dependency state: %s: %v", k, err)
 			}
 		}
 	}

--- a/pkg/test/framework/operations.go
+++ b/pkg/test/framework/operations.go
@@ -18,13 +18,10 @@ import (
 	"os"
 	"testing"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/framework/dependency"
 	env "istio.io/istio/pkg/test/framework/environment"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
-
-var scope = log.RegisterScope("testframework", "General scope for the test framework", 0)
-var lab = log.RegisterScope("testframework-lab", "Scope for normal log reporting to be used by the lab", 0)
 
 var d = newDriver()
 
@@ -33,7 +30,7 @@ var d = newDriver()
 func Run(testID string, m *testing.M) {
 	exitcode, err := d.Run(testID, m)
 	if err != nil {
-		scope.Errorf("test.Run: %v", err)
+		scopes.Framework.Errorf("test.Run: %v", err)
 	}
 	os.Exit(exitcode)
 }

--- a/pkg/test/framework/scopes/scopes.go
+++ b/pkg/test/framework/scopes/scopes.go
@@ -1,0 +1,25 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package scopes
+
+import "istio.io/istio/pkg/log"
+
+var (
+	// Framework is the general logging scope for the framework.
+	Framework = log.RegisterScope("tf", "General scope for the test framework", 0)
+
+	// Lab is the CI system specific logging scope.
+	Lab = log.RegisterScope("lab", "Scope for normal log reporting to be used by the lab", 0)
+)

--- a/pkg/test/framework/scopes/scopes.go
+++ b/pkg/test/framework/scopes/scopes.go
@@ -20,6 +20,6 @@ var (
 	// Framework is the general logging scope for the framework.
 	Framework = log.RegisterScope("tf", "General scope for the test framework", 0)
 
-	// Lab is the CI system specific logging scope.
-	Lab = log.RegisterScope("lab", "Scope for normal log reporting to be used by the lab", 0)
+	// CI system specific logging scope.
+	CI = log.RegisterScope("lab", "Scope for normal log reporting to be used in CI systems", 0)
 )

--- a/pkg/test/framework/scopes/scopes.go
+++ b/pkg/test/framework/scopes/scopes.go
@@ -21,5 +21,5 @@ var (
 	Framework = log.RegisterScope("tf", "General scope for the test framework", 0)
 
 	// CI system specific logging scope.
-	CI = log.RegisterScope("lab", "Scope for normal log reporting to be used in CI systems", 0)
+	CI = log.RegisterScope("CI", "Scope for normal log reporting to be used in CI systems", 0)
 )

--- a/pkg/test/framework/settings/settings.go
+++ b/pkg/test/framework/settings/settings.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"istio.io/istio/pkg/test/framework/scopes"
+
 	"istio.io/istio/pkg/log"
 )
 
@@ -64,9 +66,14 @@ type Settings struct {
 
 // defaultSettings returns a default settings instance.
 func defaultSettings() *Settings {
+	o := log.DefaultOptions()
+
+	// Disable lab logging for the default run.
+	o.SetOutputLevel(scopes.Lab.Name(), log.NoneLevel)
+
 	return &Settings{
 		Environment: Local,
-		LogOptions:  log.DefaultOptions(),
+		LogOptions:  o,
 	}
 }
 

--- a/pkg/test/framework/settings/settings.go
+++ b/pkg/test/framework/settings/settings.go
@@ -69,7 +69,7 @@ func defaultSettings() *Settings {
 	o := log.DefaultOptions()
 
 	// Disable lab logging for the default run.
-	o.SetOutputLevel(scopes.Lab.Name(), log.NoneLevel)
+	o.SetOutputLevel(scopes.CI.Name(), log.NoneLevel)
 
 	return &Settings{
 		Environment: Local,


### PR DESCRIPTION
- Unify different implementations of the logging scopes.
- Establish the two different scopes: Framework, CI: Framework is the general logging scope for the Test Framework, and will print out messages that are more user facing. CI is meant for publishing additional info that helps with diagnosing issues that occur in the CI system, but would otherwise be too noisy for regular use.