### PR TITLE
Add admissionv1beta1 to scheme to decode AdmissionReview

### DIFF
--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -49,6 +49,10 @@ var (
 	deserializer  = codecs.UniversalDeserializer()
 )
 
+func init() {
+	v1beta1.AddToScheme(runtimeScheme)
+}
+
 const (
 	watchDebounceDelay = 100 * time.Millisecond
 )

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/howeyc/fsnotify"
 	"k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,14 +45,14 @@ var (
 	deserializer  = codecs.UniversalDeserializer()
 )
 
+func init() {
+	_ = corev1.AddToScheme(runtimeScheme)
+	_ = v1beta1.AddToScheme(runtimeScheme)
+}
+
 const (
 	watchDebounceDelay = 100 * time.Millisecond
 )
-
-func init() {
-	_ = corev1.AddToScheme(runtimeScheme)
-	_ = admissionregistrationv1beta1.AddToScheme(runtimeScheme)
-}
 
 // Webhook implements a mutating webhook for automatic proxy injection.
 type Webhook struct {


### PR DESCRIPTION
This is a bug, in order to decode `AdmissionReview` we need to register `admission.k8s.io/v1beta1` instead of `admissionregistration.k8s.io/v1beta1`