### PR TITLE
fix fortio/fortio:latest_release image change result e2e fail

### DIFF
--- a/pkg/test/framework/environments/kubernetes/fortioapp.go
+++ b/pkg/test/framework/environments/kubernetes/fortioapp.go
@@ -62,7 +62,7 @@ func (f *fortioapp) CallFortio(arg string, path string) (environment.FortioAppCa
 
 	pod := pods[0]
 
-	response, err := util.Shell("kubectl exec -n %s %s -c %s -- /usr/local/bin/fortio %s %s/%s", f.namespace, pod, f.name, f.serverAddress, arg, path)
+	response, err := util.Shell("kubectl exec -n %s %s -c %s -- /usr/bin/fortio %s %s/%s", f.namespace, pod, f.name, f.serverAddress, arg, path)
 	if err != nil {
 		return environment.FortioAppCallResult{}, err
 	}

--- a/samples/rawvm/demo.sh
+++ b/samples/rawvm/demo.sh
@@ -36,7 +36,7 @@ echo "*** non istio client to (istio) svc calls (from $cli)"
 kubectl exec "$cli" "$singlecall" "$url1"
 kubectl exec "$cli" "$singlecall" "$url2"
 echo "*** grpc calls (from $cli)"
-grpcping="/usr/local/bin/fortio -- grpcping -loglevel warning -n 100"
+grpcping="/usr/bin/fortio -- grpcping -loglevel warning -n 100"
 kubectl exec "$cli" "$grpcping" "$cliIp" # localhost call
 kubectl exec "$cli" "$grpcping" "$srv1"
 kubectl exec "$cli" "$grpcping" "$srv2"

--- a/samples/rawvm/k8cli.yaml.in
+++ b/samples/rawvm/k8cli.yaml.in
@@ -13,7 +13,7 @@ spec:
       containers:
       - name: fortio
         # That image runs the servers (so it will run forever) but has the
-        # /usr/local/bin/fortio client
+        # /usr/bin/fortio client
         image: FORTIO_IMAGE
         imagePullPolicy: Always
 ---

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -578,7 +578,7 @@ func logMixerMetrics(t *testing.T, service string, port int) {
 		t.Logf("Failure getting metrics for '%s:%d': %v", service, port, err)
 		return
 	}
-	resp, err := util.ShellMuteOutput("kubectl exec -n %s %s -c echosrv -- /usr/local/bin/fortio curl http://%s.%s:%d/metrics", ns, pods[0], service, ns, port)
+	resp, err := util.ShellMuteOutput("kubectl exec -n %s %s -c echosrv -- /usr/bin/fortio curl http://%s.%s:%d/metrics", ns, pods[0], service, ns, port)
 	if err != nil {
 		t.Logf("could not retrieve metrics: %v", err)
 		return

--- a/tests/e2e/tests/simple/a_simple_1_test.go
+++ b/tests/e2e/tests/simple/a_simple_1_test.go
@@ -149,7 +149,7 @@ func TestSvc2Svc(t *testing.T) {
 		}
 		ready := 0
 		for i, pod := range podList {
-			res, err := util.Shell("kubectl exec -n %s %s -c echosrv -- /usr/local/bin/fortio curl http://echosrv:8080/echo", ns, pod)
+			res, err := util.Shell("kubectl exec -n %s %s -c echosrv -- /usr/bin/fortio curl http://echosrv:8080/echo", ns, pod)
 			if err != nil {
 				log.Infof("Pod %d %s not ready: %s", i, pod, res)
 			} else {
@@ -166,7 +166,7 @@ func TestSvc2Svc(t *testing.T) {
 	// TODO: use the fortio 0.3.1 web/api endpoint instead and get JSON results (across this file)
 	for _, pod := range podList {
 		log.Infof("From pod \"%s\"", pod)
-		_, err := util.Shell("kubectl exec -n %s %s -c echosrv -- /usr/local/bin/fortio load -qps 0 -t 10s http://echosrv.%s:8080/echo", ns, pod, ns)
+		_, err := util.Shell("kubectl exec -n %s %s -c echosrv -- /usr/bin/fortio load -qps 0 -t 10s http://echosrv.%s:8080/echo", ns, pod, ns)
 		if err != nil {
 			t.Fatalf("kubectl failure to run fortio %v", err)
 		}
@@ -187,7 +187,7 @@ func TestAuth(t *testing.T) {
 	}
 	pod := podList[0]
 	log.Infof("From client, non istio injected pod \"%s\"", pod)
-	res, err := util.Shell("kubectl exec -n %s %s -- /usr/local/bin/fortio curl http://echosrv.%s:8080/debug", ns, pod, ns)
+	res, err := util.Shell("kubectl exec -n %s %s -- /usr/bin/fortio curl http://echosrv.%s:8080/debug", ns, pod, ns)
 	if tc.Kube.AuthEnabled {
 		if err == nil {
 			t.Errorf("Running with auth on yet able to connect from non istio to istio (insecure): %v", res)
@@ -227,7 +227,7 @@ func TestAuthWithHeaders(t *testing.T) {
 	podIstioIP := podList[0]
 	log.Infof("From client, non istio injected pod \"%s\" to istio pod \"%s\"", podNoIstio, podIstioIP)
 	// TODO: ipv6 fix
-	res, err := util.Shell("kubectl exec -n %s %s -- /usr/local/bin/fortio curl -H Host:echosrv-extrap.%s:8088 http://%s:8088/debug",
+	res, err := util.Shell("kubectl exec -n %s %s -- /usr/bin/fortio curl -H Host:echosrv-extrap.%s:8088 http://%s:8088/debug",
 		ns, podNoIstio, ns, podIstioIP)
 	if tc.Kube.AuthEnabled {
 		if err == nil {

--- a/tests/e2e/tests/simple/testdata/v1alpha3/servicesNotInjected.yaml
+++ b/tests/e2e/tests/simple/testdata/v1alpha3/servicesNotInjected.yaml
@@ -26,6 +26,6 @@ spec:
       containers:
       - name: fortio-noistio
         # That image runs the servers (so it will run forever) but has the
-        # /usr/local/bin/fortio client
+        # /usr/bin/fortio client
         image: {{.FortioImage}}
         imagePullPolicy: Always


### PR DESCRIPTION
fix fortio/fortio:latest_release image change result e2e fail.

Change container exec command from `/usr/local/bin/fortio` to `/usr/bin/fortio`