### PR TITLE
Specify cluster domain for citadel service

### DIFF
--- a/security/pkg/cmd/constants.go
+++ b/security/pkg/cmd/constants.go
@@ -51,4 +51,7 @@ const (
 
 	// ListenedNamespaceKey is the key for the environment variable that specifies the namespace.
 	ListenedNamespaceKey = "NAMESPACE"
+
+	// IstioCaClusterDomainKey is the key for the environment variable that specifies the cluster domain.
+	IstioCaClusterDomainKey = "DNS_DOMAIN"
 )


### PR DESCRIPTION
The cluster domamin of my kubernetes cluster is not 'cluster.local',
let's add a opt to allow user to specify it.