### PR TITLE
add some packages to skip codecov check

### DIFF
--- a/codecov.skip
+++ b/codecov.skip
@@ -1,3 +1,4 @@
+istio.io/istio/istioctl/pkg/util/clusters
 istio.io/istio/mixer/pkg/adapter/test
 istio.io/istio/mixer/pkg/config/storetest
 istio.io/istio/mixer/pkg/mockapi
@@ -9,6 +10,7 @@ istio.io/istio/mixer/tools/codegen
 istio.io/istio/pilot/test
 istio.io/istio/pkg/mcp/testing
 istio.io/istio/pkg/test
+istio.io/istio/security/pkg/nodeagent/model
 istio.io/istio/security/tests/integration
 istio.io/istio/tests
 istio.io/istio/tools/githubContrib


### PR DESCRIPTION
xref #8568 

Add some packages to `codecov.skip` to skip codecov check:

1. In `istio.io/istio/security/pkg/nodeagent/model` packages, just a struct :https://github.com/istio/istio/blob/master/security/pkg/nodeagent/model/secret.go
,so it's no need to match the codecov requirement.

4. In packages, just two mashall function, no need also:
https://github.com/istio/istio/blob/master/istioctl/pkg/util/clusters/wrapper.go
