### PR TITLE
Scrape prometheus application metrics with mtls enabled

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -251,19 +251,19 @@ data:
         action: replace
         target_label: kubernetes_name
 
-    - job_name: 'kubernetes-pods-non-istio'
+    - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:  # If first two labels are present, pod should be scraped  by the istio-secure job.
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
         action: drop
         regex: (.+)
       - source_labels: [__meta_kubernetes_pod_annotation_istio_mtls]
         action: drop
         regex: (true)
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         action: replace
         target_label: __metrics_path__
@@ -292,14 +292,14 @@ data:
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
       # sidecar status annotation is added by sidecar injector and
       # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
       - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
         action: keep
         regex: (([^;]+);([^;]*))|(([^;]*);(true))
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         action: replace
         target_label: __metrics_path__

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -251,12 +251,16 @@ data:
         action: replace
         target_label: kubernetes_name
 
-    # Example scrape config for pods
-    - job_name: 'kubernetes-pods'
+    - job_name: 'kubernetes-pods-non-istio'
       kubernetes_sd_configs:
       - role: pod
-
-      relabel_configs:
+      relabel_configs:  # If first two labels are present, pod should be scraped  by the istio-secure job.
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
+        action: drop
+        regex: (.+)
+      - source_labels: [__meta_kubernetes_pod_label_istio_workload_mtls_ability]
+        action: drop
+        regex: (true)
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
@@ -264,6 +268,45 @@ data:
         action: replace
         target_label: __metrics_path__
         regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod_name
+
+    - job_name: 'kubernetes-pods-istio-secure'
+      scheme: https
+      tls_config:
+        ca_file: /etc/istio-certs/root-cert.pem
+        cert_file: /etc/istio-certs/cert-chain.pem
+        key_file: /etc/istio-certs/key.pem
+        insecure_skip_verify: true  # prometheus does not support secure naming.
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      # sidecar status annotation is added by sidecar injector and
+      # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_label_istio_workload_mtls_ability]
+        action: keep
+        regex: (([^;]+);([^;]*))|(([^;]*);(true))
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__]  # Only keep address that is host:port
+        action: keep    # otherwise an extra target with ':443' is added for https scheme
+        regex: ([^:]+):(\d+)
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
         action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -258,7 +258,7 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
         action: drop
         regex: (.+)
-      - source_labels: [__meta_kubernetes_pod_label_istio_workload_mtls_ability]
+      - source_labels: [__meta_kubernetes_pod_annotation_istio_mtls]
         action: drop
         regex: (true)
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
@@ -294,7 +294,7 @@ data:
       relabel_configs:
       # sidecar status annotation is added by sidecar injector and
       # istio_workload_mtls_ability can be specifically placed on a pod to indicate its ability to receive mtls traffic.
-      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_label_istio_workload_mtls_ability]
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
         action: keep
         regex: (([^;]+);([^;]*))|(([^;]*);(true))
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -52,9 +52,16 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /etc/prometheus
+          - mountPath: /etc/istio-certs
+            name: istio-certs
       volumes:
       - name: config-volume
         configMap:
           name: prometheus
+      - name: istio-certs
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: istio.default
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
1. Add istio certs into prometheus deployment so prometheus tls config can use them
2. Add  pod job to scrape istio/mtls pods securely
3. Update existing pod job to exclude pods contained in #2, and scrape normally.

Note: Since prometheus does not support istio secure naming, prometheus client is unable to verify server identity. This configuration enables metrics collection on the same port, however it is not suitable for true secure metrics scraping. That will follow in other PRs.