### PR TITLE
Add podAnnotations to gateways in helm chart

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
+{{- if $spec.podAnnotations }}
+{{ toYaml $spec.podAnnotations | indent 8 }}
+{{ end }}
     spec:
       serviceAccountName: {{ $key }}-service-account
 {{- if $.Values.global.priorityClassName }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -237,6 +237,7 @@ gateways:
     loadBalancerIP: ""
     loadBalancerSourceRanges: {}
     serviceAnnotations: {}
+    podAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
 
     ports:
@@ -285,6 +286,7 @@ gateways:
     autoscaleMin: 1
     autoscaleMax: 5
     serviceAnnotations: {}
+    podAnnotations: {}
     type: ClusterIP #change to NodePort or LoadBalancer if need be
     ports:
     - port: 80
@@ -320,6 +322,7 @@ gateways:
     loadBalancerIP: ""
     serviceAnnotations:
       cloud.google.com/load-balancer-type: "internal"
+    podAnnotations: {}
     type: LoadBalancer
     ports:
     ## You can add custom gateway ports - google ILB default quota is 5 ports,


### PR DESCRIPTION
This allows adding additional annotations on any of the gateways, e.g.

--set gateways.istio-ingressgateway.podAnnotations.fluentbit\\.io/parser=envoy