### PR TITLE
Use cluster name as SNI when using Istio mTLS

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -113,7 +113,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 
 			if config != nil {
 				destinationRule := config.Spec.(*networking.DestinationRule)
-				convertIstioMutual(destinationRule, service, upstreamServiceAccounts)
+				convertIstioMutual(destinationRule, upstreamServiceAccounts)
 				applyTrafficPolicy(defaultCluster, destinationRule.TrafficPolicy, port)
 
 				for _, subset := range destinationRule.Subsets {
@@ -232,19 +232,13 @@ func convertResolution(resolution model.Resolution) v2.Cluster_DiscoveryType {
 }
 
 // convertIstioMutual fills key cert fields for all TLSSettings when the mode is `ISTIO_MUTUAL`.
-func convertIstioMutual(destinationRule *networking.DestinationRule, service *model.Service, upstreamServiceAccount []string) {
+func convertIstioMutual(destinationRule *networking.DestinationRule, upstreamServiceAccount []string) {
 	converter := func(tls *networking.TLSSettings) {
 		if tls == nil {
 			return
 		}
 		if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
-			// Allow user specified SNIs in the istio mtls settings - which is useful
-			// for routing via gateways. If there is no SNI, set the SNI as the service Hostname
-			sni := tls.Sni
-			if len(sni) == 0 {
-				sni = string(service.Hostname)
-			}
-			*tls = *buildIstioMutualTLS(upstreamServiceAccount, sni)
+			*tls = *buildIstioMutualTLS(upstreamServiceAccount, tls.Sni)
 		}
 	}
 
@@ -272,7 +266,9 @@ func buildIstioMutualTLS(upstreamServiceAccount []string, sni string) *networkin
 		ClientCertificate: path.Join(model.AuthCertsPath, model.CertChainFilename),
 		PrivateKey:        path.Join(model.AuthCertsPath, model.KeyFilename),
 		SubjectAltNames:   upstreamServiceAccount,
-		Sni:               sni,
+		// Allow user specified SNIs in the istio mtls settings - which is useful
+		// for routing via gateways
+		Sni: sni,
 	}
 }
 
@@ -490,6 +486,10 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings) 
 			Sni: tls.Sni,
 		}
 
+		// Set default SNI of cluster name for istio_mutual if sni is not set.
+		if len(tls.Sni) == 0 && tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
+			cluster.TlsContext.Sni = cluster.Name
+		}
 		if cluster.Http2ProtocolOptions != nil {
 			// This is HTTP/2 in-mesh cluster, advertise it with ALPN.
 			if tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -157,7 +157,7 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(gomega.Equal("outbound|8080|foobar|foo.example.org"))
-	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal("foo.example.org"))
+	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal(cluster.Name))
 }
 
 func buildEnvForClustersWithIstioMutualWithSNI(sniValue string) *model.Environment {


### PR DESCRIPTION
Reverts #7692
Using the cluster name will be needed to do SNI-based cluster routing
at the gateway in multi-cluster scenarios, where the client
and server use citadel minted certs.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>