### PR TITLE
Update gometalinter installation method

### DIFF
--- a/lintconfig_base.json
+++ b/lintconfig_base.json
@@ -59,6 +59,7 @@
         "_test\\.go:.*\\bdefer .*\\(errcheck\\)$",
         "should have a package comment",
         "composite literal uses unkeyed fields",
-        "genfiles"
+        "genfiles",
+        "vendor"
     ]
 }


### PR DESCRIPTION
Installing via `go get -u gopkg.in/alecthomas/gometalinter.v2`
is deprecated and subject to errors like

```
$ gometalinter.v2 --install # this is deprecated as well
...
can't load package: package github.com/mdempsky/maligned: cannot find package "github.com/mdempsky/maligned" in any of:
	/usr/lib/golang/src/github.com/mdempsky/maligned (from $GOROOT)
	/home/jwendell/go/src/github.com/alecthomas/gometalinter/_linters/src/github.com/mdempsky/maligned (from $GOPATH)
...
```

Also added a check to avoid reinstallation if we already have the
latest version locally, since a new installation takes some time
to complete.