### PR TITLE
e2e: do not run minikube with sudo by default.

### DIFF
--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -24,8 +24,13 @@ minikube delete
 echo "Starting Minikube."
 
 # Start minikube
-# When minikube runs in `--vm-driver=none` mode, it requires root permission.
-sudo -E minikube start \
+SUDO_PREFIX=""
+if [[ "${VM_DRIVER}" == "none" ]]; then
+  # When minikube runs in `--vm-driver=none` mode, it requires root permission.
+  SUDO_PREFIX="sudo -E"
+fi
+
+$SUDO_PREFIX minikube start \
     --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
     --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota" \


### PR DESCRIPTION
We should only run `sudo` when necessary and not by default.

Also note even with `-E`, this command still fails in my local environment for unable to find `minikube`. This is because my local environment has a stricter security policy that restricts the PATH to only a few directories which doesn't include `minikube` when running with `sudo -E`.
