### PR TITLE
Print the grpcServer's logs to its registered scope

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -96,9 +96,9 @@ func (s *grpcServer) Check(ctx context.Context, req *mixerpb.CheckRequest) (*mix
 			}
 
 			if status.IsOK(resp.Precondition.Status) {
-				log.Debug("Check approved from cache")
+				lg.Debug("Check approved from cache")
 			} else {
-				log.Debugf("Check denied from cache: %v", resp.Precondition.Status)
+				lg.Debugf("Check denied from cache: %v", resp.Precondition.Status)
 			}
 
 			if !status.IsOK(resp.Precondition.Status) || len(req.Quotas) == 0 {


### PR DESCRIPTION
There registered a api log scope in grpcServer.go, while all the logs prints to the registered scope, except two places, I modified these two places. 