### PR TITLE
Be able to set the minimum and maximum supported TLS protocol version…

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -392,6 +392,10 @@ func buildGatewayListenerTLSContext(server *networking.Server) *auth.DownstreamT
 				ValidationContext: certValidationContext,
 			},
 			AlpnProtocols: ListenersALPNProtocols,
+			TlsParams: &auth.TlsParameters {
+				TlsMinimumProtocolVersion: auth.TlsParameters_TlsProtocol(server.Tls.TlsMinimumProtocolVersion),
+				TlsMaximumProtocolVersion: auth.TlsParameters_TlsProtocol(server.Tls.TlsMaximumProtocolVersion),
+			},
 		},
 		RequireClientCertificate: &types.BoolValue{
 			Value: requireClientCert,


### PR DESCRIPTION
Be able to set the minimum and maximum supported TLS protocol versions on Gateway servers. The respective changes on the API are under: https://github.com/istio/api/pull/636