### PR TITLE
Fixed wrong directory and delete not required kubectl command

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/bookinfo_cmd.j2
+++ b/install/kubernetes/ansible/istio/tasks/bookinfo_cmd.j2
@@ -2,4 +2,3 @@
 {{ cmd_path }} adm policy add-scc-to-user privileged -z default -n {{ sample_namespace }}
 {% endif %}
 {{ cmd_path }} apply -n {{ sample_namespace }} -f <({{ istio_dir }}/bin/istioctl kube-inject -f {{ istio_dir }}/samples/bookinfo/platform/kube/bookinfo.yaml)
-{{ cmd_path }} expose svc productpage -n {{ sample_namespace }}

--- a/install/kubernetes/ansible/istio/tasks/install_samples.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_samples.yml
@@ -28,6 +28,6 @@
   include_tasks: install_sample.yml
   vars:
     sample_cmd_template: bookinfo_cmd.j2
-    sample_path: bookinfo/kube/bookinfo.yaml
+    sample_path: bookinfo/platform/kube/bookinfo.yaml
     sample_namespace: bookinfo
   when: bookinfo_selected == true


### PR DESCRIPTION
When trying to move Ansible playbook, an error occurs. Because kubernetes yaml file's directory has changed. Also, I deleted a line in the jinja2 file in order to avoid the error caused by productpage already existing.