### PR TITLE
fix deadlock in mcp server

### DIFF
--- a/galley/pkg/runtime/strategy.go
+++ b/galley/pkg/runtime/strategy.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// Maximum wait time before deciding to publish the events.
-	defaultMaxWaitDuration = 5 * time.Second
+	defaultMaxWaitDuration = time.Second
 
 	// Minimum time distance between two events for deciding on the quiesce point. If the time delay
 	// between two events is larger than this, then we can deduce that we hit a quiesce point.
@@ -102,16 +102,16 @@ func (s *publishingStrategy) onTimer() {
 	// If there has been a long time since the first event, or if there was a quiesce since last event,
 	// then fire publish to create new snapshots.
 	// Otherwise, reset the timer and get a call again.
+
 	maxTime := s.firstEvent.Add(s.maxWaitDuration)
 	quiesceTime := s.latestEvent.Add(s.quiesceDuration)
 
+	var published bool
 	if now.After(maxTime) || now.After(quiesceTime) {
 		// Try to send to the channel
 		select {
 		case s.publish <- struct{}{}:
-			s.timer.Stop()
-			s.timer = nil
-			return
+			published = true
 		default:
 			// If the calling code is not draining the publish channel, then we can potentially cause
 			// a deadlock here. Avoid the deadlock by going through the timer loop again.
@@ -119,7 +119,11 @@ func (s *publishingStrategy) onTimer() {
 		}
 	}
 
-	s.timer.Reset(s.timerFrequency)
+	if published {
+		s.timer = nil
+	} else {
+		s.timer.Reset(s.timerFrequency)
+	}
 }
 
 func (s *publishingStrategy) reset() {

--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -198,6 +198,7 @@ func (c *Controller) Apply(change *mcpclient.Change) error {
 	dispatch := func(model model.Config, event model.Event) {}
 	if handlers, ok := c.eventHandlers[descriptor.Type]; ok {
 		dispatch = func(model model.Config, event model.Event) {
+			log.Debugf("MCP event dispatch: key=%v event=%v", model.Key(), event.String())
 			for _, handler := range handlers {
 				handler(model, event)
 			}

--- a/pkg/mcp/snapshot/snapshot.go
+++ b/pkg/mcp/snapshot/snapshot.go
@@ -166,6 +166,8 @@ func (c *Cache) SetSnapshot(node string, snapshot Snapshot) {
 
 				// discard the responseWatch
 				delete(info.watches, id)
+
+				log.Debugf("SetSnapshot(): watch %d with version %q complete", id, version)
 			}
 		}
 		info.mu.Unlock()


### PR DESCRIPTION
The integration point between the MCP server and snapshot used a
single channel (per-client). This could lead to a deadlock during
configuration pushes.

Address the immediate issues by introduce a dedicated buffered channel
per type.

Longer term we may consider storing pending config pushes in a ring
buffer and only using the channel for indicating when config is ready
to be sent.