### PR TITLE
Ignore stderr for istioclt podExec

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -159,8 +159,9 @@ func (client *Client) ExtractExecResult(podName, podNamespace, container string,
 	stdout, stderr, err := client.PodExec(podName, podNamespace, container, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, err)
-	} else if stderr.String() != "" {
-		return nil, fmt.Errorf("error execing into %v/%v %v container: %v", podName, podNamespace, container, stderr.String())
+	}
+	if stderr.String() != "" {
+		fmt.Printf("Warning! error execing into %v/%v %v container: %v\n", podName, podNamespace, container, stderr.String())
 	}
 	return stdout.Bytes(), nil
 }

--- a/pilot/cmd/pilot-discovery/request.go
+++ b/pilot/cmd/pilot-discovery/request.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"istio.io/istio/pilot/pkg/request"
-	"istio.io/istio/pkg/cmd"
 )
 
 var (
@@ -30,7 +29,6 @@ var (
 		Short: "Makes an HTTP request to Pilot metrics/debug endpoint",
 		Args:  cobra.MinimumNArgs(2),
 		RunE: func(c *cobra.Command, args []string) error {
-			cmd.PrintFlags(c.Flags())
 			command := &request.Command{
 				Address: "127.0.0.1:9093",
 				Client: &http.Client{


### PR DESCRIPTION
Remote command in podExec may receive debug log (e.g, for 8583 issue, GODEBUG=gctrace=2 was turn on). The logic before this PR treated it as error and ignore legit output.

This PR changes podExec to print stderr content, if available, and continue as usual.

This is more or less the same as [8723](https://github.com/istio/istio/pull/8723) on release 1.0.

Fix:  #8583 