### PR TITLE
Move value identityDomain to global scope.

### DIFF
--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -42,8 +42,8 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           {{- end }}
-          {{- if .Values.identityDomain }}
-            - --identity-domain={{ .Values.identityDomain }}
+          {{- if .Values.global.identityDomain }}
+            - --identity-domain={{ .Values.global.identityDomain }}
           {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -42,8 +42,8 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           {{- end }}
-          {{- if .Values.global.identityDomain }}
-            - --identity-domain={{ .Values.global.identityDomain }}
+          {{- if .Values.global.trustDomain }}
+            - --identity-domain={{ .Values.global.trustDomain }}
           {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -110,8 +110,8 @@ global:
   # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.
   sdsEnabled: false
 
-  # indicate the domain used in SPIFFE identity URL
-  identityDomain: cluster.local 
+  # indicate the trust domain used in SPIFFE identity URL
+  trustDomain: cluster.local 
 
   # disablePolicyChecks disables mixer policy checks.
   # Will set the value with same name in istio config map - pilot needs to be restarted to take effect.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -106,9 +106,12 @@ global:
   # propagated, not recommended for tests.
   controlPlaneSecurityEnabled: false
 
-  # SDS enabled. IF set to true, mTLS certificates for the sidecars will be 
+  # SDS enabled. IF set to true, mTLS certificates for the sidecars will be
   # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.
   sdsEnabled: false
+
+  # indicate the domain used in SPIFFE identity URL
+  identityDomain: cluster.local 
 
   # disablePolicyChecks disables mixer policy checks.
   # Will set the value with same name in istio config map - pilot needs to be restarted to take effect.
@@ -491,7 +494,6 @@ security:
   replicaCount: 1
   image: citadel
   selfSigned: true # indicate if self-signed CA is used.
-  identityDomain: cluster.local # indicate the domain used in SPIFFE identity URL
 
 #
 # nodeagent configuration


### PR DESCRIPTION
We need to move value identityDomain to global scope as it needs to be consumed by other deployments, e.g. pilot.

This is part of #8661