### PR TITLE
Add pilot integration tests using new framework

### DIFF
--- a/tests/integration2/pilot/http_test.go
+++ b/tests/integration2/pilot/http_test.go
@@ -15,9 +15,8 @@
 package pilot
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework"
@@ -70,11 +69,4 @@ func testHTTP(t *testing.T) {
 			}
 		}
 	}
-}
-
-// Capturing TestMain allows us to:
-// - Do cleanup before exit
-// - process testing specific flags
-func TestMain(m *testing.M) {
-	framework.Run("pilot_test", m)
 }

--- a/tests/integration2/pilot/main_test.go
+++ b/tests/integration2/pilot/main_test.go
@@ -1,0 +1,25 @@
+//  Copyright 2018 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package pilot
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.Run("pilot_test", m)
+}

--- a/tests/integration2/tests.mk
+++ b/tests/integration2/tests.mk
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 
 # The names of the integration test folders at ROOT/tests/integration2/*.
-INTEGRATION_TEST_NAMES = galley mixer
+INTEGRATION_TEST_NAMES = galley mixer pilot
 
 # Generate the names of the integration test targets that use local environment (i.e. test.integration.galley)
 INTEGRATION_TESTS_LOCAL = $(addprefix test.integration., $(INTEGRATION_TEST_NAMES))


### PR DESCRIPTION
This is the trivial PR moving pilot tests from examples to the outside directory.

This is my first shoot and will gradually add more e2e/integration test cases using the new framework.

Also, it would be great if I can find some guidances/examples about how to use the new test framework.

cc @nmittler @ozevren @hklai 