### PR TITLE
Clear Pilot Cache on cluster removal

### DIFF
--- a/pilot/pkg/config/clusterregistry/secretcontroller.go
+++ b/pilot/pkg/config/clusterregistry/secretcontroller.go
@@ -269,6 +269,7 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 			<-c.cs.rc[clusterID].ControlChannel
 			// Deleting remote cluster entry from clusters store
 			delete(c.cs.rc, clusterID)
+			c.discoveryServer.ClearCacheFunc()()
 		}
 	}
 	log.Infof("Number of clusters in the cluster store: %d", len(c.cs.rc))


### PR DESCRIPTION
When a secret is removed, which causes a
cluster to be removed, the cache is not
cleared. Services and endpoints from remote
clusters are then not removed. Fixes:
https://github.com/istio/istio/issues/8554