### PR TITLE
Use master-latest-daily as the default Istio image for master branch.

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -6,7 +6,7 @@ global:
   hub: gcr.io/istio-release
 
   # Default tag for Istio images.
-  tag: release-1.0-latest-daily
+  tag: master-latest-daily
 
   proxy:
     image: proxyv2

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -6,7 +6,7 @@ global:
   hub: gcr.io/istio-release
 
   # Default tag for Istio images.
-  tag: release-1.0-latest-daily
+  tag: master-latest-daily
 
   # Gateway used for legacy k8s Ingress resources. By default it is
   # using 'istio:ingress', to match 0.8 config. It requires that

--- a/istioctl/cmd/istioctl/gendeployment/cmd.go
+++ b/istioctl/cmd/istioctl/gendeployment/cmd.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultTag          = "release-1.0-latest-daily"
+	defaultTag          = "master-latest-daily"
 	defaultHyperkubeTag = "v1.7.6_coreos.0"
 )
 

--- a/release/modify_values.sh
+++ b/release/modify_values.sh
@@ -30,7 +30,7 @@ function fix_values_yaml() {
   rm                       "${tarball_name}"
 
   sed -i     "s|hub: gcr.io/istio-release|hub: ${HUB}|g" ./"${folder_name}"/install/kubernetes/helm/istio*/values.yaml
-  sed -i "s|tag: release-1.0-latest-daily|tag: ${TAG}|g" ./"${folder_name}"/install/kubernetes/helm/istio*/values.yaml
+  sed -i "s|tag: master-latest-daily|tag: ${TAG}|g" ./"${folder_name}"/install/kubernetes/helm/istio*/values.yaml
 
   eval "$zip_cmd" "${tarball_name}" "${folder_name}"
   rm -rf                            "${folder_name}"


### PR DESCRIPTION
Attempt to fix #8030 which is caused by #7849.

I'm not sure why we use the `release-1.0` image on master branch. It seems the right way is to use the `master` image on master branch and `release-1.0` image on release-1.0 branch. So that the source code checked out (i.e. those generated install yaml) will be in sync with the Istio image used for install.

/cc @myidpt @hklai @elevran @tmc 