### PR TITLE
add fields to envoy default access log

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -485,7 +485,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, env *model.Envir
 					return nil
 				}
 
-				return buildOutboundNetworkFilters(node,
+				return buildOutboundNetworkFilters(env, node,
 					istio_route.GetDestinationCluster(upstream, destSvc, int(server.Port.Number)),
 					"", port)
 			}
@@ -538,7 +538,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, env *model.Envir
 					filterChains = append(filterChains, &filterChainOpts{
 						sniHosts:   match.SniHosts,
 						tlsContext: nil, // NO TLS context because this is passthrough
-						networkFilters: buildOutboundNetworkFilters(node,
+						networkFilters: buildOutboundNetworkFilters(env, node,
 							istio_route.GetDestinationCluster(upstream, destSvc, int(server.Port.Number)),
 							"", port),
 					})

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -57,12 +57,17 @@ const (
 	// LocalhostAddress for local binding
 	LocalhostAddress = "127.0.0.1"
 
-	// EnvoyLogFormat format for envoy access logs
-	EnvoyLogFormat = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" +
+	// EnvoyHTTPLogFormat format for envoy access logs
+	EnvoyHTTPLogFormat = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" +
 		"%PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% " +
 		"%DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" " +
 		"\"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" " +
 		"%UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% " +
+		"%DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
+
+	// EnvoyTCPLogFormat format for envoy access logs
+	EnvoyTCPLogFormat = "[%START_TIME%] %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% " +
+		"%DURATION% \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% " +
 		"%DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
 )
 
@@ -127,7 +132,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		listeners = append(listeners, inbound...)
 		listeners = append(listeners, outbound...)
 
-		mgmtListeners := buildSidecarInboundMgmtListeners(managementPorts, node.IPAddress)
+		mgmtListeners := buildSidecarInboundMgmtListeners(env, managementPorts, node.IPAddress)
 		// If management listener port and service port are same, bad things happen
 		// when running in kubernetes, as the probes stop responding. So, append
 		// non overlapping listeners only.
@@ -273,7 +278,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				},
 			}
 		case plugin.ListenerProtocolTCP:
-			tcpNetworkFilters = buildInboundNetworkFilters(instance)
+			tcpNetworkFilters = buildInboundNetworkFilters(env, instance)
 
 		default:
 			log.Warnf("Unsupported inbound protocol %v for port %#v", protocol, endpoint.ServicePort)
@@ -534,7 +539,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 					// The conflict resolution is done later in this code
 				}
 
-				listenerOpts.filterChainOpts = buildSidecarOutboundTCPTLSFilterChainOpts(node, push, configs,
+				listenerOpts.filterChainOpts = buildSidecarOutboundTCPTLSFilterChainOpts(env, node, push, configs,
 					destinationIPAddress, service, servicePort, proxyLabels, meshGateway)
 			default:
 				// UDP or other protocols: no need to log, it's too noisy
@@ -694,7 +699,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 // the pod.
 // So, if a user wants to use kubernetes probes with Istio, she should ensure
 // that the health check ports are distinct from the service ports.
-func buildSidecarInboundMgmtListeners(managementPorts model.PortList, managementIP string) []*xdsapi.Listener {
+func buildSidecarInboundMgmtListeners(env *model.Environment, managementPorts model.PortList, managementIP string) []*xdsapi.Listener {
 	listeners := make([]*xdsapi.Listener, 0, len(managementPorts))
 
 	if managementIP == "" {
@@ -722,7 +727,7 @@ func buildSidecarInboundMgmtListeners(managementPorts model.PortList, management
 				port:     mPort.Port,
 				protocol: model.ProtocolTCP,
 				filterChainOpts: []*filterChainOpts{{
-					networkFilters: buildInboundNetworkFilters(instance),
+					networkFilters: buildInboundNetworkFilters(env, instance),
 				}},
 			}
 			l := buildListener(listenerOpts)
@@ -828,7 +833,7 @@ func buildHTTPConnectionManager(env *model.Environment, node *model.Proxy, httpO
 	if env.Mesh.AccessLogFile != "" {
 		fl := &fileaccesslog.FileAccessLog{
 			Path:   env.Mesh.AccessLogFile,
-			Format: EnvoyLogFormat,
+			Format: EnvoyHTTPLogFormat,
 		}
 
 		connectionManager.AccessLog = []*accesslog.AccessLog{

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -56,6 +56,14 @@ const (
 
 	// LocalhostAddress for local binding
 	LocalhostAddress = "127.0.0.1"
+
+	// EnvoyLogFormat format for envoy access logs
+	EnvoyLogFormat = "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%" +
+		"%PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% " +
+		"%DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" " +
+		"\"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" " +
+		"%UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% " +
+		"%DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n"
 )
 
 var (
@@ -819,7 +827,8 @@ func buildHTTPConnectionManager(env *model.Environment, node *model.Proxy, httpO
 
 	if env.Mesh.AccessLogFile != "" {
 		fl := &fileaccesslog.FileAccessLog{
-			Path: env.Mesh.AccessLogFile,
+			Path:   env.Mesh.AccessLogFile,
+			Format: EnvoyLogFormat,
 		}
 
 		connectionManager.AccessLog = []*accesslog.AccessLog{

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -119,7 +119,8 @@ func buildDeprecatedTCPProxyFilter(clusterName string, addr string) (*listener.F
 // buildOutboundNetworkFilters generates TCP proxy network filter for outbound connections. In addition, it generates
 // protocol specific filters (e.g., Mongo filter)
 // this function constructs deprecated_v1 routes, until the filter chain match is ready
-func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy, clusterName string, deprecatedTCPFilterMatchAddress string, port *model.Port) []listener.Filter {
+func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy, clusterName string,
+	deprecatedTCPFilterMatchAddress string, port *model.Port) []listener.Filter {
 
 	var tcpFilter *listener.Filter
 	var err error

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	fileaccesslog "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
+	accesslog "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2"
 	mongo_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/mongo_proxy/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
@@ -32,12 +34,26 @@ import (
 )
 
 // buildInboundNetworkFilters generates a TCP proxy network filter on the inbound path
-func buildInboundNetworkFilters(instance *model.ServiceInstance) []listener.Filter {
+func buildInboundNetworkFilters(env *model.Environment, instance *model.ServiceInstance) []listener.Filter {
 	clusterName := model.BuildSubsetKey(model.TrafficDirectionInbound, "", instance.Service.Hostname, instance.Endpoint.ServicePort.Port)
 	config := &tcp_proxy.TcpProxy{
 		StatPrefix: clusterName,
 		Cluster:    clusterName,
 	}
+
+	if env.Mesh.AccessLogFile != "" {
+		fl := &fileaccesslog.FileAccessLog{
+			Path:   env.Mesh.AccessLogFile,
+			Format: EnvoyTCPLogFormat,
+		}
+		config.AccessLog = []*accesslog.AccessLog{
+			{
+				Config: util.MessageToStruct(fl),
+				Name:   xdsutil.FileAccessLog,
+			},
+		}
+	}
+
 	return []listener.Filter{
 		{
 			Name:   xdsutil.TCPProxy,
@@ -103,7 +119,7 @@ func buildDeprecatedTCPProxyFilter(clusterName string, addr string) (*listener.F
 // buildOutboundNetworkFilters generates TCP proxy network filter for outbound connections. In addition, it generates
 // protocol specific filters (e.g., Mongo filter)
 // this function constructs deprecated_v1 routes, until the filter chain match is ready
-func buildOutboundNetworkFilters(node *model.Proxy, clusterName string, deprecatedTCPFilterMatchAddress string, port *model.Port) []listener.Filter {
+func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy, clusterName string, deprecatedTCPFilterMatchAddress string, port *model.Port) []listener.Filter {
 
 	var tcpFilter *listener.Filter
 	var err error
@@ -118,6 +134,19 @@ func buildOutboundNetworkFilters(node *model.Proxy, clusterName string, deprecat
 			StatPrefix: clusterName,
 			Cluster:    clusterName,
 			// TODO: Need to set other fields such as Idle timeouts
+		}
+
+		if env.Mesh.AccessLogFile != "" {
+			fl := &fileaccesslog.FileAccessLog{
+				Path:   env.Mesh.AccessLogFile,
+				Format: EnvoyTCPLogFormat,
+			}
+			config.AccessLog = []*accesslog.AccessLog{
+				{
+					Config: util.MessageToStruct(fl),
+					Name:   xdsutil.FileAccessLog,
+				},
+			}
 		}
 
 		tcpFilter = &listener.Filter{

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -247,8 +247,9 @@ func buildSidecarOutboundTCPFilterChainOpts(env *model.Environment, node *model.
 	return out
 }
 
-func buildSidecarOutboundTCPTLSFilterChainOpts(env *model.Environment, node *model.Proxy, push *model.PushContext, configs []model.Config, destinationIPAddress string,
-	service *model.Service, listenPort *model.Port, proxyLabels model.LabelsCollection, gateways map[string]bool) []*filterChainOpts {
+func buildSidecarOutboundTCPTLSFilterChainOpts(env *model.Environment, node *model.Proxy, push *model.PushContext,
+	configs []model.Config, destinationIPAddress string, service *model.Service, listenPort *model.Port,
+	proxyLabels model.LabelsCollection, gateways map[string]bool) []*filterChainOpts {
 
 	virtualService := getVirtualServiceForHost(service.Hostname, configs)
 


### PR DESCRIPTION
Adds 5 more fields to the default access log

https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#config-access-log
Original access log format:
```
[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%"\n
```

proposed new format:
```
[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME%\n
```

Sample access log comparing old and new formats:
```
[2018-09-20T16:28:43.348Z] "GET /headers HTTP/1.1" 200 - 0 539 14 9 "10.171.53.49, 172.30.201.1" "curl/7.54.0" "dd33e3aa-0a60-9d87-8c6e-795898629907" "istio-consul.us-south.containers.appdomain.cloud" "172.30.246.176:8000"

[2018-09-21T13:25:07.815Z] "GET /headers HTTP/1.1" 200 - 0 541 2 2 "10.171.53.49, 172.30.246.130" "curl/7.54.0" "a1ddf6f5-a5f6-9c4f-9f70-15c92c8e8574" "istio-consul.us-south.containers.appdomain.cloud" "127.0.0.1:8000" inbound|8000||httpbin.default.svc.cluster.local - 172.30.246.189:8000 172.30.246.130:0 -
```
