### PR TITLE
Use CIRCLE_PR_NUMBER to determine presubmit.

### DIFF
--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -48,7 +48,7 @@ ARGS=(
 	"--pr_number=${CIRCLE_PR_NUMBER:-0}"
 )
 
-if [ -n "$CIRCLE_PR_NUMBER" ]; then
+if [ -n "$CIRCLE_PR_NUMBER" ] || [ -n "$CIRCLE_PULL_REQUEST" ]; then
 	ARGS+=("--stage=presubmit")
 fi
 

--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -48,6 +48,8 @@ ARGS=(
 	"--pr_number=${CIRCLE_PR_NUMBER:-0}"
 )
 
+# CIRCLE_PR_NUMBER is set for PRs that originate from a fork.
+# CIRCLE_PULL_REQUEST is set for PRs that originate from a branch.
 if [ -n "$CIRCLE_PR_NUMBER" ] || [ -n "$CIRCLE_PULL_REQUEST" ]; then
 	ARGS+=("--stage=presubmit")
 fi

--- a/bin/ci2gubernator.sh
+++ b/bin/ci2gubernator.sh
@@ -48,7 +48,7 @@ ARGS=(
 	"--pr_number=${CIRCLE_PR_NUMBER:-0}"
 )
 
-if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+if [ -n "$CIRCLE_PR_NUMBER" ]; then
 	ARGS+=("--stage=presubmit")
 fi
 


### PR DESCRIPTION
According to circle doc:

CIRCLE_PR_NUMBER | Integer | The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
CIRCLE_PULL_REQUEST | String | The URL of the associated pull request. If there are multiple associated pull requests, one URL is randomly chosen.

So, it looks like CIRCLE_PULL_REQUEST is set if the PR is created from a branch in the same repo, while CIRCLE_PR_NUMBER is created if the PR originates from a fork.

So, I suppose both should be in the presubmit tab, and PR coming from a fork is definitely more common these days.
