### PR TITLE
Add some people to tests OWNERS

### DIFF
--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,6 +1,8 @@
 approvers:
   - chxchx
   - costinm
+  - hklai
+  - nmittler
   - sebastienvas
   - yutongz
   - baodongli


### PR DESCRIPTION
Adding @hklai(testing & release wg chair) and @nmittler(new test framework) to tests OWNERS for the sake of reviewing/approving testing-related PRs as we are currently busy with switching new test framework and kubeclient in tests everywhere.