### PR TITLE
Moving to CircleCI 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 # Docker environment.
 defaults: &defaults
@@ -27,42 +27,44 @@ integrationDefaults: &integrationDefaults
     - TEST_ENV: minikube-none
 
 # Common procedure to initialize working directory
-initWorkingDir: &initWorkingDir
-  type: shell
-  name: Initialize Working Directory
-  pwd: /
-  command: |
-    sudo mkdir -p /go/src/istio.io/istio
-    sudo chown -R circleci /go
-    mkdir -p /go/out/tests
-    mkdir -p /go/out/logs
-    mkdir -p /home/circleci/logs
-
-recordZeroExitCodeIfTestPassed: &recordZeroExitCodeIfTestPassed
-  run:
-    when: on_success
-    name: Record zero exit code as test passed
-    command: echo 0 > exit_code
-
-recordNonzeroExitCodeIfTestFailed: &recordNonzeroExitCodeIfTestFailed
-  run:
-    when: on_fail
-    name: Record nonzero exit code as test failed
-    command: echo 1 > exit_code
-
-markJobStartsOnGCS: &markJobStartsOnGCS
-  run:
-    when: always
-    command: bin/ci2gubernator.sh --job_starts
-
-markJobFinishesOnGCS: &markJobFinishesOnGCS
-  run:
-    when: always
-    command: |
-      make dumpsys || true
-      make junit-report || true
-      # TODO: upload the artifacts as well, for debugging !
-      bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
+commands:
+  init-working-dir:
+    steps:
+      - run:
+          name: Initialize Working Directory
+          pwd: /
+          command: |
+            sudo mkdir -p /go/src/istio.io/istio
+            sudo chown -R circleci /go
+            mkdir -p /go/out/tests
+            mkdir -p /go/out/logs
+            mkdir -p /home/circleci/logs
+  record-zero-exit-code-if-test-passed:
+    steps:
+      - run:
+          when: on_success
+          name: Record zero exit code as test passed
+          command: echo 0 > exit_code
+  record-non-zero-exit-code-if-test-failed:
+    steps:
+      - run:
+          when: on_fail
+          name: Record nonzero exit code as test failed
+          command: echo 1 > exit_code
+  mark-job-starts-on-gcs:
+    steps:
+      - run:
+          when: always
+          command: bin/ci2gubernator.sh --job_starts
+  mark-job-finishes-on-gcs:
+    steps:
+      - run:
+          when: always
+          command: |
+            make dumpsys || true
+            make junit-report || true
+            # TODO: upload the artifacts as well, for debugging !
+            bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
 
 jobs:
   e2e-simple:
@@ -72,11 +74,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -89,9 +91,9 @@ jobs:
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
       - run: make test/local/auth/e2e_simple
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -108,11 +110,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -125,9 +127,9 @@ jobs:
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
       - run: E2E_ARGS="--use_mcp" make test/local/auth/e2e_simple
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -144,11 +146,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -166,9 +168,9 @@ jobs:
             E2E_ARGS="--skip_cleanup -use_local_cluster -test.v" \
             set -o pipefail
             make e2e_dashboard | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -183,11 +185,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -205,9 +207,9 @@ jobs:
             E2E_ARGS="--skip_cleanup -use_local_cluster --use_mcp -test.v" \
             set -o pipefail
             make e2e_dashboard | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -218,11 +220,11 @@ jobs:
   e2e-mixer-noauth-v1alpha3-v2:
     <<: *integrationDefaults
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -241,9 +243,9 @@ jobs:
           name: make e2e_mixer
           command: |
             make test/local/noauth/e2e_mixer_envoyv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -254,11 +256,11 @@ jobs:
   e2e-mixer-noauth-v1alpha3-v2-mcp:
     <<: *integrationDefaults
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -278,9 +280,9 @@ jobs:
           command: |
             E2E_ARGS="--use_mcp" \
             make test/local/noauth/e2e_mixer_envoyv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -295,11 +297,11 @@ jobs:
             - TEST_ENV: minikube-none
             - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -318,9 +320,9 @@ jobs:
           name: make e2e_galley
           command: |
             make test/local/e2e_galley
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -331,7 +333,7 @@ jobs:
   e2e-pilot-cloudfoundry-v1alpha3-v2:
     <<: *integrationDefaults
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at: /go
@@ -343,9 +345,9 @@ jobs:
             export PATH=$GOPATH/bin:$PATH
             make localTestEnv
             make test/local/cloudfoundry/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /go/out/logs
       - store_artifacts:
@@ -358,11 +360,11 @@ jobs:
             - KUBECONFIG: /go/out/minikube.conf
             - TEST_ENV: minikube-none
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -380,9 +382,9 @@ jobs:
           when: always
           command: |
                 make test/local/noauth/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
       - store_artifacts:
@@ -397,11 +399,11 @@ jobs:
             - KUBECONFIG: /go/out/minikube.conf
             - TEST_ENV: minikube-none
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -420,9 +422,9 @@ jobs:
           command: |
                 E2E_ARGS="--use_mcp" \
                 make test/local/noauth/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
       - store_artifacts:
@@ -433,11 +435,11 @@ jobs:
   e2e-pilot-auth-v1alpha3-v2:
     <<: *integrationDefaults
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -455,9 +457,9 @@ jobs:
           when: always
           command: |
                 make test/local/auth/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
       - store_artifacts:
@@ -472,7 +474,7 @@ jobs:
       resource_class: xlarge
       steps:
         - checkout
-        - <<: *markJobStartsOnGCS
+        - mark-job-starts-on-gcs
         - run: make sync
         - run:
             command: |
@@ -481,9 +483,9 @@ jobs:
               make localTestEnv
               set -o pipefail
               make test.integration T=-v | tee -a /go/out/tests/build-log.txt
-        - <<: *recordZeroExitCodeIfTestPassed
-        - <<: *recordNonzeroExitCodeIfTestFailed
-        - <<: *markJobFinishesOnGCS
+        - record-zero-exit-code-if-test-passed
+        - record-non-zero-exit-code-if-test-failed
+        - mark-job-finishes-on-gcs
         - store_test_results:
             path: /go/out/tests
         - store_artifacts:
@@ -496,11 +498,11 @@ jobs:
       - TEST_ENV: minikube-none
       - GOPATH: /go
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -519,9 +521,9 @@ jobs:
           name: make test.integration.kube
           command: |
             make test.integration.kube T=-v | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_artifacts:
           path: /home/circleci/logs
       - store_artifacts:
@@ -532,11 +534,11 @@ jobs:
   e2e-pilot-auth-v1alpha3-v2-mcp:
     <<: *integrationDefaults
     steps:
-      - <<: *initWorkingDir
+      - init-working-dir
       - checkout
       - attach_workspace:
           at:  /go
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run: bin/testEnvRootMinikube.sh start
       - run:
@@ -555,9 +557,9 @@ jobs:
           command: |
                 E2E_ARGS="--use_mcp" \
                 make test/local/auth/e2e_pilotv2
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
       - store_artifacts:
@@ -612,7 +614,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run:
           command: |
@@ -621,9 +623,9 @@ jobs:
             make localTestEnv
             set -o pipefail
             make test T=-v | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
 
@@ -635,7 +637,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - <<: *markJobStartsOnGCS
+      - mark-job-starts-on-gcs
       - run: make sync
       - run:
           command: |
@@ -644,9 +646,9 @@ jobs:
             make localTestEnv
             set -o pipefail
             make -k pilot-racetest mixer-racetest security-racetest T=-v | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
+      - record-zero-exit-code-if-test-passed
+      - record-non-zero-exit-code-if-test-failed
+      - mark-job-finishes-on-gcs
       - store_test_results:
           path: /go/out/tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+# This is version 2.1 preview mode.
+# Please see CircleCI SDK docs for more info
+# https://github.com/CircleCI-Public/config-preview-sdk/blob/master/docs/getting-started.md
+
 # Docker environment.
 defaults: &defaults
   working_directory: /go/src/istio.io/istio

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,7 +753,6 @@ jobs:
           path: /go/bin
 
 workflows:
-  version: 2
   nightly:
     triggers:
        - schedule:


### PR DESCRIPTION
Migrating our configs to CircleCI 2.1 (preview) format. While we shouldn't be testing previews for CIs, the major benefit of 2.1 is the ability to auto cancel redundant workflows (including VMs!). This will free up a lot of resources by automatically cancelling on-going tests when a new commit is pushed to the PR (similar to how prow does things today).

The other benefit is the ability to use APIs to trigger builds. 
IF we use the new config format, we should be able to cut down quite a bit of redundant stuff in our YAMLs - but this is for future work. as of now, the ability to auto cancel redundant workflows is good enough ( I tested this!).

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>
