### PR TITLE
Update prow jobs to work with both pod-utils and current image

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -30,9 +30,7 @@ function setup_and_export_git_sha() {
 
       # Set artifact dir based on checkout
       export ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
-    fi
-
-    if [[ "${CI:-}" == 'prow' ]]; then
+    elif [[ "${CI:-}" == 'prow' ]]; then
       # Set artifact dir based on checkout
       export ARTIFACTS_DIR="${ARTIFACTS}"
     fi

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -15,17 +15,26 @@
 # limitations under the License.
 
 function setup_and_export_git_sha() {
-  if [ "${CI:-}" == 'bootstrap' ]; then
-    # Handle prow environment and checkout
-    export USER=Prow
+  if [[ -n "${CI:-}" ]]; then
+    if [[ "${CI:-}" == 'bootstrap' ]]; then
+      # TODO: Remove after update to pod-utils
 
-    # Make sure we are in the right directory
-    # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
-    # but we depend on being at path $GOPATH/src/istio.io/istio for imports
-    if [[ ! $PWD = ${GOPATH}/src/istio.io/istio ]]; then
-      mv "${GOPATH}/src/github.com/${REPO_OWNER:-istio}" "${GOPATH}/src/istio.io"
-      export ROOT=${GOPATH}/src/istio.io/istio
-      cd "${GOPATH}/src/istio.io/istio" || return
+      # Make sure we are in the right directory
+      # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
+      # but we depend on being at path $GOPATH/src/istio.io/istio for imports
+      if [[ ! $PWD = ${GOPATH}/src/istio.io/istio ]]; then
+        mv "${GOPATH}/src/github.com/${REPO_OWNER:-istio}" "${GOPATH}/src/istio.io"
+        export ROOT=${GOPATH}/src/istio.io/istio
+        cd "${GOPATH}/src/istio.io/istio" || return
+      fi
+
+      # Set artifact dir based on checkout
+      export ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
+    fi
+
+    if [[ "${CI:-}" == 'prow' ]]; then
+      # Set artifact dir based on checkout
+      export ARTIFACTS_DIR="${ARTIFACTS}"
     fi
 
     if [ -z "${PULL_PULL_SHA:-}" ]; then
@@ -37,8 +46,6 @@ function setup_and_export_git_sha() {
     # Use volume mount from pilot-presubmit job's pod spec.
     export KUBECONFIG="${HOME}/.kube/config"
 
-    # Set artifact dir based on checkout
-    export ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
   else
     # Use the current commit.
     GIT_SHA="$(git rev-parse --verify HEAD)"


### PR DESCRIPTION
Update prow jobs to work with both pod-utils and current image to ease update.

Old Prow istio image used embedded boostrap code. The pod-utils feature, externalize the checkout and log gathering, meaning the test container can focus on tools related to build and test istio.

More info about [pod-utils](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md)