### PR TITLE
Remove vestiges of statsd-to-prometheus from config and test files

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -57,12 +57,14 @@ global:
 
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
     # would be <host>:<port>).
-    # Can also be disabled (e.g. when Mixer is not installed).
-    # For remote clusters the host should be the statsd prom bridge in the primary control plane cluster.
+    # Disabled by default.
+    # The istio-statsd-prom-bridge is deprecated and should not be used moving forward.
     envoyStatsd:
+      # If enabled is set to true, host and port must also be provided. Istio no longer provides a statsd collector.
       enabled: false
-      host: ""
-      port: 9125
+      host: # example: statsd-svc
+      port: # example: 9125
+
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.

--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -21,11 +21,14 @@ global:
   proxy:
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument
     # would be <host>:<port>).
-    # Can also be disabled (e.g. when Mixer is not installed).
+    # Disabled by default.
+    # The istio-statsd-prom-bridge is deprecated and should not be used moving forward.
     envoyStatsd:
-      enabled: true
-      host: istio-statsd-prom-bridge.istio-system
-      port: 9125
+      # If enabled is set to true, host and port must also be provided. Istio no longer provides a statsd collector.
+      enabled: false
+      host: # example: statsd-svc
+      port: # example: 9125
+
 
 #
 # Gateways Configuration

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -84,12 +84,11 @@ func (k *KubeInfo) getEndpointIPForService(svc string) (ip string, err error) {
 
 func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub, proxyTag string) (err error) {
 	svcToHelmVal := map[string]string{
-		"istio-pilot":              "remotePilotAddress",
-		"istio-policy":             "remotePolicyAddress",
-		"istio-statsd-prom-bridge": "proxy.envoyStatsd.host",
-		"istio-ingressgateway":     "ingressGatewayEndpoint",
-		"istio-telemetry":          "remoteTelemetryAddress",
-		"zipkin":                   "remoteZipkinAddress",
+		"istio-pilot":          "remotePilotAddress",
+		"istio-policy":         "remotePolicyAddress",
+		"istio-ingressgateway": "ingressGatewayEndpoint",
+		"istio-telemetry":      "remoteTelemetryAddress",
+		"zipkin":               "remoteZipkinAddress",
 	}
 	var helmSetContent string
 	var ingressGatewayAddr string
@@ -99,9 +98,6 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 		if err == nil {
 			helmSetContent += " --set global." + helmVal + "=" + ip
 			log.Infof("Service %s has an endpoint IP %s", svc, ip)
-			if svc == "istio-statsd-prom-bridge" {
-				helmSetContent += " --set global.proxy.envoyStatsd.enabled=true"
-			}
 			if svc == "istio-ingressgateway" {
 				ingressGatewayAddr = ip
 			}


### PR DESCRIPTION
Previous PRs removed the refs to statsd-to-prometheus service from the mainline `values.yaml` files. This cleans up the rest.