### PR TITLE
Added a new disable-install-crds flag to Pilot Discovery.  (#8813)

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -116,6 +116,9 @@ func init() {
 	serverArgs.MCPCredentialOptions.AttachCobraFlags(discoveryCmd)
 
 	// Config Controller options
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.DisableInstallCRDs, "disable-install-crds", false,
+		"Disable discovery service from verifying the existence of CRDs at startup and then installing if not detected.  "+
+			"It is recommended to be disable for highly available setups.")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.FileDir, "configDir", "",
 		"Directory to watch for updates to config yaml files. If specified, the files will be used as the source of config, rather than a CRD client.")
 	discoveryCmd.PersistentFlags().StringVarP(&serverArgs.Config.ControllerOptions.WatchedNamespace, "appNamespace",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -127,6 +127,7 @@ type ConfigArgs struct {
 	CFConfig                   string
 	ControllerOptions          kube.ControllerOptions
 	FileDir                    string
+	DisableInstallCRDs         bool
 
 	// Controller if specified, this controller overrides the other config settings.
 	Controller model.ConfigStoreCache
@@ -618,8 +619,10 @@ func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCac
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}
 
-	if err = configClient.RegisterResources(); err != nil {
-		return nil, multierror.Prefix(err, "failed to register custom resources.")
+	if !args.Config.DisableInstallCRDs {
+		if err = configClient.RegisterResources(); err != nil {
+			return nil, multierror.Prefix(err, "failed to register custom resources.")
+		}
 	}
 
 	return crd.NewController(configClient, args.Config.ControllerOptions), nil

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -284,10 +284,7 @@ func (rc *restClient) registerResources() error {
 	})
 
 	if errPoll != nil {
-		deleteErr := rc.deregisterResources()
-		if deleteErr != nil {
-			return multierror.Append(errPoll, deleteErr)
-		}
+		log.Error("failed to verify CRD creation")
 		return errPoll
 	}
 


### PR DESCRIPTION
* Added a new disable-install-crds flag to Pilot Discovery.  This flag when passed disables creation of CRDs when they cannot be detected.  In the case of a failure during CRDs creation, the call to deregister CRDs has been removed.

* Updating disable-install-crds ucommand usage documentation

* Add new line to disable-install-crds usage message line

* Run fmt.sh against main.go