### PR TITLE
Correct the returned message: sever->server

### DIFF
--- a/mixer/test/listbackend/cmd/main.go
+++ b/mixer/test/listbackend/cmd/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	s, err := listbackend.NewNoSessionServer(addr)
 	if err != nil {
-		fmt.Printf("unable to start sever: %v", err)
+		fmt.Printf("unable to start server: %v", err)
 		os.Exit(-1)
 	}
 

--- a/mixer/test/prometheus/cmd/main.go
+++ b/mixer/test/prometheus/cmd/main.go
@@ -75,7 +75,7 @@ func main() {
 func runServer(args *Args) {
 	s, err := prometheus.NewNoSessionServer(args.AdapterPort, args.PrometheusPort)
 	if err != nil {
-		fmt.Printf("unable to start sever: %v", err)
+		fmt.Printf("unable to start server: %v", err)
 		os.Exit(-1)
 	}
 


### PR DESCRIPTION
Correct the returned message: sever->server