### PR TITLE
Fix missing inbound listener for multiport ServiceEntry 

### DIFF
--- a/pilot/pkg/serviceregistry/external/servicediscovery.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery.go
@@ -206,7 +206,7 @@ func (d *ServiceEntryStore) update() {
 			out = append(out, instance)
 			di[key] = out
 
-			byip, found := di[instance.Endpoint.Address]
+			byip, found := dip[instance.Endpoint.Address]
 			if !found {
 				byip = []*model.ServiceInstance{}
 			}

--- a/pilot/pkg/serviceregistry/external/servicediscovery_test.go
+++ b/pilot/pkg/serviceregistry/external/servicediscovery_test.go
@@ -124,9 +124,20 @@ func TestServiceDiscoveryGetProxyServiceInstances(t *testing.T) {
 	tnow := time.Now()
 	createServiceEntries([]*networking.ServiceEntry{httpStatic, tcpStatic}, store, t, tnow)
 
-	_, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddress: "2.2.2.2"})
+	expectedInstances := []*model.ServiceInstance{
+		makeInstance(httpStatic, "2.2.2.2", 7080, httpStatic.Ports[0], nil, tnow),
+		makeInstance(httpStatic, "2.2.2.2", 18080, httpStatic.Ports[1], nil, tnow),
+		makeInstance(tcpStatic, "2.2.2.2", 444, tcpStatic.Ports[0], nil, tnow),
+	}
+
+	instances, err := sd.GetProxyServiceInstances(&model.Proxy{IPAddress: "2.2.2.2"})
 	if err != nil {
 		t.Errorf("GetProxyServiceInstances() encountered unexpected error: %v", err)
+	}
+	sortServiceInstances(instances)
+	sortServiceInstances(expectedInstances)
+	if err := compare(t, instances, expectedInstances); err != nil {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
For ServiceEntry of type `resolution: NONE` and containing an endpoint with a single port, the Envoy config dump shows a listener that matches the "VM_IP:Port" wired to an inbound cluster with socket address "127.0.0.1:Port". This configuration is as expected. However, for the ServiceEntry Endpoint with multiple ports, only one port has the correct wiring as above whereas the other port is missing the inbound cluster.

For more details, see this [issue](https://github.com/istio/istio/issues/8883#issuecomment-423762452)