### PR TITLE
Remove sbezverk from the OWNERS file

### DIFF
--- a/install/OWNERS
+++ b/install/OWNERS
@@ -1,10 +1,9 @@
 approvers:
   - andraxylia
   - costinm
-  - GregHanson
   - gyliu513
   - ijsnellf
   - linsun
-  - sbezverk
-  - sdake
   - ostromart
+  - sdake
+  - GregHanson


### PR DESCRIPTION
Serguei has done great work kicking off the inital Helm implementation
for Istio.  Serguei has indicated to me personally he doesn't have
capacity to review nor approve install related changes.  As the
istio-bot offers assignment suggestions based upon the OWNERS file
this could result in sbezverk being assigned a deployment issue
and being unable to properly review the PR.

Serguei has indicated he will be available for consulting on very difficult
PRs that other folks in the OWNERS file can't handle.

In the process, Ascii-betical-ize the OWNERS file.