### PR TITLE
RFC tracing: Enable zipkinAddress host:port to be overridden in helm inst…

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -77,7 +77,9 @@ spec:
           - --serviceCluster
           - {{ $key }}
           - --zipkinAddress
-        {{- if $.Values.global.istioNamespace }}
+        {{- if $.Values.global.tracer.zipkinAddress }}
+          - {{ $.Values.global.tracer.zipkinAddress }}
+        {{- else if $.Values.global.istioNamespace }}
           - zipkin.{{ $.Values.global.istioNamespace }}:9411
         {{- else }}
           - zipkin:9411

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -40,7 +40,11 @@
           - --configStoreURL=k8s://
 {{- end }}
           - --configDefaultNamespace={{ $.Release.Namespace }}
+          {{- if $.Values.global.tracer.zipkinAddress }}
+          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkinAddress }}/api/v1/spans
+          {{- else }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+          {{- end }}
         resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
@@ -157,7 +161,11 @@
           - --configStoreURL=k8s://
 {{- end }}
           - --configDefaultNamespace={{ $.Release.Namespace }}
+          {{- if $.Values.global.tracer.zipkinAddress }}
+          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkinAddress }}/api/v1/spans
+          {{- else }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+          {{- end }}
         resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -84,7 +84,11 @@ data:
       concurrency: {{ .Values.global.proxy.concurrency }}
       #
       # Zipkin trace collector
+      {{- if .Values.global.tracer.zipkinAddress }}
+      zipkinAddress: {{ .Values.global.tracer.zipkinAddress }}
+      {{- else }}
       zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
+      {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -112,6 +112,11 @@ global:
   # EnableTracing sets the value with same name in istio config map, requires pilot restart to take effect.
   enableTracing: true
 
+  tracer:
+    # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+    # zipkin service (port 9411) in the same namespace as the other istio components.
+    zipkinAddress:
+
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:
     # Default setting for service-to-service mtls. Can be set explicitly using


### PR DESCRIPTION
…all/template

This PR provides a global property that can enable the zipkinAddress (host/port) to be overridden, to enable spans to be reported to a zipkin compatible service endpoint in another namespace.
