### PR TITLE
include grafana dashboards in the release-archive

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -112,6 +112,7 @@ ${CP} istio.VERSION LICENSE README.md "${COMMON_FILES_DIR}"/
 find samples install -type f \( \
   -name "*.yaml" \
   -o -name "*.yml" \
+  -o -name "*.json" \
   -o -name "*.cfg" \
   -o -name "*.j2" \
   -o -name "cleanup*" \


### PR DESCRIPTION
*.json files were previously excluded from the archive, this fixes that.

Broke grafana dashboards.