### PR TITLE
include grafana dashboards in the release-archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ H = $(shell printf "\033[34;1m=>\033[0m")
 goVerStr := $(shell $(GO) version | awk '{split($$0,a," ")}; {print a[3]}')
 goVerNum := $(shell echo $(goVerStr) | awk '{split($$0,a,"go")}; {print a[2]}')
 goVerMajor := $(shell echo $(goVerNum) | awk '{split($$0, a, ".")}; {print a[1]}')
-goVerMinor := $(shell echo $(goVerNum) | awk '{split($$0, a, ".")}; {print a[2]}')
+goVerMinor := $(shell echo $(goVerNum) | awk '{split($$0, a, ".")}; {print a[2]}' | sed -e 's/\([0-9]\+\).*/\1/')
 gcflagsPattern := $(shell ( [ $(goVerMajor) -ge 1 ] && [ ${goVerMinor} -ge 10 ] ) && echo 'all=' || echo '')
 
 ifeq ($(origin DEBUG), undefined)

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -108,6 +108,7 @@ ${CP} istio.VERSION LICENSE README.md "${COMMON_FILES_DIR}"/
 find samples install -type f \( \
   -name "*.yaml" \
   -o -name "*.yml" \
+  -o -name "*.json" \
   -o -name "*.cfg" \
   -o -name "*.j2" \
   -o -name "cleanup*" \


### PR DESCRIPTION
*.json files were previously excluded from the archive, this fixes that.

Broke grafana dashboards.

Also fixes issues with go version checking.
For `goVerMinor` it will only look for \d+.* and ignore the non numeric suffix.