### PR TITLE
Return detailed error message when probe option is not valid

### DIFF
--- a/galley/cmd/galley/cmd/probe.go
+++ b/galley/cmd/galley/cmd/probe.go
@@ -30,8 +30,8 @@ func probeCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 		Use:   "probe",
 		Short: "Check the liveness or readiness of a locally-running server",
 		Run: func(cmd *cobra.Command, _ []string) {
-			if !probeOptions.IsValid() {
-				fatalf("some options are not valid")
+			if err := probeOptions.Validate(); err != nil {
+				fatalf("fail on validating probe options: %v", err)
 			}
 			if err := probe.NewFileClient(&probeOptions).GetStatus(); err != nil {
 				fatalf("fail on inspecting path %s: %v", probeOptions.Path, err)

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -73,10 +73,10 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 			serverArgs.CredentialOptions.KeyFile = validationArgs.KeyFile
 			serverArgs.CredentialOptions.CertificateFile = validationArgs.CertFile
 			serverArgs.LoggingOptions = loggingOptions
-			if livenessProbeOptions.IsValid() {
+			if livenessProbeOptions.Validate() == nil {
 				livenessProbeController = probe.NewFileController(&livenessProbeOptions)
 			}
-			if readinessProbeOptions.IsValid() {
+			if readinessProbeOptions.Validate() == nil {
 				readinessProbeController = probe.NewFileController(&readinessProbeOptions)
 
 			}

--- a/mixer/cmd/mixs/cmd/probe.go
+++ b/mixer/cmd/mixs/cmd/probe.go
@@ -30,8 +30,8 @@ func probeCmd(printf, fatalf shared.FormatFn) *cobra.Command {
 		Short: "Check the liveness or readiness of a locally-running server",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			if !probeOptions.IsValid() {
-				fatalf("Some options are not valid")
+			if err := probeOptions.Validate(); err != nil {
+				fatalf("Fail on validating probe options: %v", err)
 			}
 			if err := probe.NewFileClient(probeOptions).GetStatus(); err != nil {
 				fatalf("Fail on inspecting path %s: %v", probeOptions.Path, err)

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -247,13 +247,13 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	s.server = grpc.NewServer(grpcOptions...)
 	mixerpb.RegisterMixerServer(s.server, api.NewGRPCServer(s.dispatcher, s.gp, s.checkCache))
 
-	if a.LivenessProbeOptions.IsValid() {
+	if a.LivenessProbeOptions.Validate() == nil {
 		s.livenessProbe = probe.NewFileController(a.LivenessProbeOptions)
 		s.RegisterProbe(s.livenessProbe, "server")
 		s.livenessProbe.Start()
 	}
 
-	if a.ReadinessProbeOptions.IsValid() {
+	if a.ReadinessProbeOptions.Validate() == nil {
 		s.readinessProbe = probe.NewFileController(a.ReadinessProbeOptions)
 		rt.RegisterProbe(s.readinessProbe, "dispatcher")
 		st.RegisterProbe(s.readinessProbe, "store")

--- a/pilot/cmd/sidecar-injector/main.go
+++ b/pilot/cmd/sidecar-injector/main.go
@@ -101,8 +101,8 @@ var (
 		Short: "Check the liveness or readiness of a locally-running server",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !flags.probeOptions.IsValid() {
-				return errors.New("some options are not valid")
+			if err := flags.probeOptions.Validate(); err != nil {
+				return fmt.Errorf("fail on validating probe options: %v", err)
 			}
 			if err := probe.NewFileClient(&flags.probeOptions).GetStatus(); err != nil {
 				return fmt.Errorf("fail on inspecting path %s: %v", flags.probeOptions.Path, err)

--- a/pkg/probe/option.go
+++ b/pkg/probe/option.go
@@ -14,7 +14,11 @@
 
 package probe
 
-import "time"
+import (
+	"errors"
+	"github.com/hashicorp/go-multierror"
+	"time"
+)
 
 // Options customizes the parameters of a probe.
 type Options struct {
@@ -27,6 +31,16 @@ type Options struct {
 }
 
 // IsValid returns true if some values are filled into the options.
-func (o *Options) IsValid() bool {
-	return o != nil && o.Path != "" && o.UpdateInterval > 0*time.Second
+func (o *Options) Validate() error {
+	if o == nil {
+		return errors.New("option is nil")
+	}
+	var errs error
+	if o.Path == "" {
+		errs = errors.New("empty probe-path")
+	}
+	if o.UpdateInterval <= 0*time.Second {
+		errs = multierror.Append(errs, errors.New("invalid interval"))
+	}
+	return errs
 }

--- a/pkg/probe/option_test.go
+++ b/pkg/probe/option_test.go
@@ -21,23 +21,23 @@ import (
 
 func TestOption(t *testing.T) {
 	var o *Options
-	if o.IsValid() {
+	if o.Validate() == nil {
 		t.Error("nil should not be valid")
 	}
 	o = &Options{}
-	if o.IsValid() {
+	if o.Validate() == nil {
 		t.Errorf("Empty option %+v should not be valid", o)
 	}
 	o.Path = "foo"
-	if o.IsValid() {
+	if o.Validate() == nil {
 		t.Errorf("%+v should not be valid since interval is missing", o)
 	}
 	o.UpdateInterval = time.Second
-	if !o.IsValid() {
+	if o.Validate() != nil {
 		t.Errorf("%+v should be valid", o)
 	}
 	o.Path = ""
-	if o.IsValid() {
+	if o.Validate() == nil {
 		t.Errorf("%+v should not be valid since path is missing", o)
 	}
 }

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -425,7 +425,7 @@ func createCA(core corev1.SecretsGetter) *ca.IstioCA {
 		log.Errorf("Failed to create an Citadel (error: %v)", err)
 	}
 
-	if opts.LivenessProbeOptions.IsValid() {
+	if opts.LivenessProbeOptions.Validate() == nil {
 		livenessProbeChecker, err := probecontroller.NewLivenessCheckController(
 			opts.probeCheckInterval, fmt.Sprintf("%v:%v", fqdn(), opts.grpcPort), istioCA,
 			opts.LivenessProbeOptions, probecontroller.GrpcProtocolProvider)

--- a/security/pkg/cmd/probe.go
+++ b/security/pkg/cmd/probe.go
@@ -31,8 +31,8 @@ func NewProbeCmd() *cobra.Command {
 		Short: "Check the liveness or readiness of a locally-running server",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			if !probeOptions.IsValid() {
-				shared.Fatalf("probe-path or interval are not valid\n\n%s", cmd.UsageString())
+			if err := probeOptions.Validate(); err != nil {
+				shared.Fatalf("Fail on validating probe options: %v\n\n%s", err, cmd.UsageString())
 			}
 			if err := probe.NewFileClient(probeOptions).GetStatus(); err != nil {
 				shared.Fatalf("Fail on inspecting path %s: %v", probeOptions.Path, err)


### PR DESCRIPTION
`Some options` is a bit confusing for debugging, when options are invalid. 