### PR TITLE
Add critical kinds to crd store

### DIFF
--- a/mixer/adapter/rbac/rbac.go
+++ b/mixer/adapter/rbac/rbac.go
@@ -95,7 +95,7 @@ func (b *builder) SetAuthorizationTypes(types map[string]*authorization.Type) {}
 func (b *builder) Build(ctx context.Context, env adapter.Env) (adapter.Handler, error) {
 	reg := store.NewRegistry(mixerconfig.StoreInventory()...)
 	groupVersion := &schema.GroupVersion{Group: apiGroup, Version: apiVersion}
-	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion)
+	s, err := reg.NewStore(b.adapterConfig.ConfigStoreUrl, groupVersion, []string{})
 	if err != nil {
 		return nil, env.Logger().Errorf("Unable to connect to the configuration server: %v", err)
 	}

--- a/mixer/pkg/config/crd/init.go
+++ b/mixer/pkg/config/crd/init.go
@@ -83,6 +83,7 @@ func NewStore(u *url.URL, gv *schema.GroupVersion, ck []string) (store.Backend, 
 	s := &Store{
 		conf:                 conf,
 		retryTimeout:         retryTimeout,
+		retryInterval:        crdRetryInterval,
 		donec:                make(chan struct{}),
 		discoveryBuilder:     defaultDiscoveryBuilder,
 		listerWatcherBuilder: newDynamicListenerWatcherBuilder,

--- a/mixer/pkg/config/crd/init.go
+++ b/mixer/pkg/config/crd/init.go
@@ -62,7 +62,7 @@ func (b *dynamicListerWatcherBuilder) build(res metav1.APIResource) cache.Lister
 }
 
 // NewStore creates a new Store instance.
-func NewStore(u *url.URL, gv *schema.GroupVersion) (store.Backend, error) {
+func NewStore(u *url.URL, gv *schema.GroupVersion, ck []string) (store.Backend, error) {
 	kubeconfig := u.Path
 	namespaces := u.Query().Get("ns")
 	retryTimeout := crdRetryTimeout
@@ -88,6 +88,7 @@ func NewStore(u *url.URL, gv *schema.GroupVersion) (store.Backend, error) {
 		listerWatcherBuilder: newDynamicListenerWatcherBuilder,
 		Probe:                probe.NewProbe(),
 		apiGroupVersion:      gv.String(),
+		criticalKinds:        ck,
 	}
 	if len(namespaces) > 0 {
 		s.ns = map[string]bool{}

--- a/mixer/pkg/config/crd/store.go
+++ b/mixer/pkg/config/crd/store.go
@@ -156,15 +156,13 @@ func (s *Store) Init(kinds []string) error {
 	timeout := time.After(s.retryTimeout)
 	tick := time.Tick(s.retryInterval)
 	stopRetry := false
-	if tick != nil {
-		for len(s.extractCriticalKinds(remaining)) != 0 && !stopRetry {
-			select {
-			case <-timeout:
-				stopRetry = true
-			case <-tick:
-				remaining = s.checkAndCreateCaches(d, lwBuilder, remaining)
-			default:
-			}
+	for len(s.extractCriticalKinds(remaining)) != 0 && !stopRetry {
+		select {
+		case <-timeout:
+			stopRetry = true
+		case <-tick:
+			remaining = s.checkAndCreateCaches(d, lwBuilder, remaining)
+		default:
 		}
 	}
 	if len(remaining) > 0 {

--- a/mixer/pkg/config/crd/store_test.go
+++ b/mixer/pkg/config/crd/store_test.go
@@ -297,6 +297,21 @@ func TestStoreFailToInit(t *testing.T) {
 	s.Stop()
 }
 
+func TestCriticalCrdsAreNotReady(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("want mixer to be panic with critical kind not ready.")
+		}
+	}()
+	emptyDiscovery := &fake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	s, _, _ := getTempClient()
+	s.discoveryBuilder = func(*rest.Config) (discovery.DiscoveryInterface, error) {
+		return emptyDiscovery, nil
+	}
+	s.criticalKinds = []string{"Handler"}
+	_ = s.Init([]string{"Handler", "Action"})
+}
+
 func TestCrdsAreNotReady(t *testing.T) {
 	t.Skip("https://github.com/istio/istio/issues/7958")
 	emptyDiscovery := &fake.FakeDiscovery{Fake: &k8stesting.Fake{}}

--- a/mixer/pkg/config/crd/store_test.go
+++ b/mixer/pkg/config/crd/store_test.go
@@ -297,42 +297,78 @@ func TestStoreFailToInit(t *testing.T) {
 	s.Stop()
 }
 
-func TestCriticalCrdsAreNotReady(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("want mixer to be panic with critical kind not ready.")
-		}
-	}()
-	emptyDiscovery := &fake.FakeDiscovery{Fake: &k8stesting.Fake{}}
-	s, _, _ := getTempClient()
-	s.discoveryBuilder = func(*rest.Config) (discovery.DiscoveryInterface, error) {
-		return emptyDiscovery, nil
+func TestCriticalCrdsAreReady(t *testing.T) {
+	fakeDiscovery := &fake.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{GroupVersion: apiGroupVersion},
+			},
+		},
 	}
-	s.criticalKinds = []string{"Handler"}
-	_ = s.Init([]string{"Handler", "Action"})
-}
+	callCount := 0
+	fakeDiscovery.AddReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		fakeDiscovery.Resources[0].APIResources = append(
+			fakeDiscovery.Resources[0].APIResources,
+			metav1.APIResource{Name: "handlers", SingularName: "handler", Kind: "Handler", Namespaced: true},
+		)
+		fakeDiscovery.Resources[0].APIResources = append(
+			fakeDiscovery.Resources[0].APIResources,
+			metav1.APIResource{Name: "actions", SingularName: "action", Kind: "Action", Namespaced: true},
+		)
+		return true, nil, nil
+	})
 
-func TestCrdsAreNotReady(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/7958")
-	emptyDiscovery := &fake.FakeDiscovery{Fake: &k8stesting.Fake{}}
 	s, _, _ := getTempClient()
 	s.discoveryBuilder = func(*rest.Config) (discovery.DiscoveryInterface, error) {
-		return emptyDiscovery, nil
+		return fakeDiscovery, nil
 	}
-	start := time.Now()
-	err := s.Init([]string{"Handler", "Action"})
-	d := time.Since(start)
+	s.criticalKinds = []string{"Handler", "Action"}
+	err := s.Init([]string{"Handler", "Action", "Whatever"})
 	if err != nil {
-		t.Errorf("Got %v, Want nil", err)
+		t.Errorf("Got error %v from Init", err)
 	}
-	if d < testingRetryTimeout {
-		t.Errorf("Duration for Init %v is too short, maybe not retrying", d)
+	if callCount != 1 {
+		t.Errorf("callCount is not expected, got %v wang 1", callCount)
 	}
 	s.Stop()
 }
 
-func TestCrdsRetryMakeSucceed(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/7958")
+func TestCriticalCrdsAreNotReadyRetryTimeout(t *testing.T) {
+	fakeDiscovery := &fake.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: []*metav1.APIResourceList{
+				{GroupVersion: apiGroupVersion},
+			},
+		},
+	}
+	callCount := 0
+	fakeDiscovery.AddReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		callCount++
+		return true, nil, nil
+	})
+
+	s, _, _ := getTempClient()
+	s.discoveryBuilder = func(*rest.Config) (discovery.DiscoveryInterface, error) {
+		return fakeDiscovery, nil
+	}
+	s.criticalKinds = []string{"Handler"}
+	s.retryTimeout = 2 * time.Second
+	s.retryInterval = time.Second
+	err := s.Init([]string{"Handler", "Action"})
+	errorMsg := "failed to discover critical kinds: [Handler]"
+	if err == nil {
+		t.Errorf("got no error from Init, want Init to fail")
+	} else if err.Error() != errorMsg {
+		t.Errorf("got Init error message %v, want %v", err.Error(), errorMsg)
+	}
+	if callCount < 1 || callCount > 3 {
+		t.Errorf("got callCount %v, want call count to be more than 1 and less than 3 times", callCount)
+	}
+	s.Stop()
+}
+
+func TestCriticalCrdsRetryMakeSucceed(t *testing.T) {
 	fakeDiscovery := &fake.FakeDiscovery{
 		Fake: &k8stesting.Fake{
 			Resources: []*metav1.APIResourceList{
@@ -364,12 +400,33 @@ func TestCrdsRetryMakeSucceed(t *testing.T) {
 	}
 	// Should set a longer timeout to avoid early quitting retry loop due to lack of computational power.
 	s.retryTimeout = 2 * time.Second
+	s.retryInterval = 10 * time.Millisecond
+	s.criticalKinds = []string{"Handler", "Action"}
 	err := s.Init([]string{"Handler", "Action"})
 	if err != nil {
 		t.Errorf("Got %v, Want nil", err)
 	}
 	if callCount != 3 {
 		t.Errorf("Got %d, Want 3", callCount)
+	}
+	s.Stop()
+}
+
+func TestCrdsAreNotReady(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/7958")
+	emptyDiscovery := &fake.FakeDiscovery{Fake: &k8stesting.Fake{}}
+	s, _, _ := getTempClient()
+	s.discoveryBuilder = func(*rest.Config) (discovery.DiscoveryInterface, error) {
+		return emptyDiscovery, nil
+	}
+	start := time.Now()
+	err := s.Init([]string{"Handler", "Action"})
+	d := time.Since(start)
+	if err != nil {
+		t.Errorf("Got %v, Want nil", err)
+	}
+	if d < testingRetryTimeout {
+		t.Errorf("Duration for Init %v is too short, maybe not retrying", d)
 	}
 	s.Stop()
 }

--- a/mixer/pkg/config/store/store.go
+++ b/mixer/pkg/config/store/store.go
@@ -262,7 +262,7 @@ func WithBackend(b Backend) Store {
 }
 
 // Builder is the type of function to build a Backend.
-type Builder func(u *url.URL, gv *schema.GroupVersion) (Backend, error)
+type Builder func(u *url.URL, gv *schema.GroupVersion, ck []string) (Backend, error)
 
 // RegisterFunc is the type to register a builder for URL scheme.
 type RegisterFunc func(map[string]Builder)
@@ -289,7 +289,7 @@ const (
 )
 
 // NewStore creates a new Store instance with the specified backend.
-func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion) (Store, error) {
+func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion, criticalKinds []string) (Store, error) {
 	u, err := url.Parse(configURL)
 
 	if err != nil {
@@ -302,7 +302,7 @@ func (r *Registry) NewStore(configURL string, groupVersion *schema.GroupVersion)
 		b = newFsStore(u.Path)
 	default:
 		if builder, ok := r.builders[u.Scheme]; ok {
-			b, err = builder(u, groupVersion)
+			b, err = builder(u, groupVersion, criticalKinds)
 			if err != nil {
 				return nil, err
 			}

--- a/mixer/pkg/config/store/store_test.go
+++ b/mixer/pkg/config/store/store_test.go
@@ -79,7 +79,7 @@ func newTestBackend() *testStore {
 }
 
 func registerTestStore(builders map[string]Builder) {
-	builders["test"] = func(u *url.URL, gv *schema.GroupVersion) (Backend, error) {
+	builders["test"] = func(u *url.URL, gv *schema.GroupVersion, ck []string) (Backend, error) {
 		return newTestBackend(), nil
 	}
 }
@@ -226,7 +226,7 @@ func TestRegistry(t *testing.T) {
 		{"://", false},
 		{"test://", true},
 	} {
-		_, err := r.NewStore(c.u, groupVersion)
+		_, err := r.NewStore(c.u, groupVersion, []string{})
 		ok := err == nil
 		if ok != c.ok {
 			t.Errorf("Want %v, Got %v, Err %v", c.ok, ok, err)

--- a/mixer/pkg/runtime/config/kinds.go
+++ b/mixer/pkg/runtime/config/kinds.go
@@ -52,3 +52,15 @@ func KindMap(adapterInfo map[string]*adapter.Info, templateInfo map[string]*temp
 	log.Debugf("Handler config kind: %s", constant.HandlerKind)
 	return kindMap
 }
+
+// CriticalKinds returns kinds which are critical for mixer's function and have to be ready for mixer config watch.
+func CriticalKinds() []string {
+	ck := make([]string, 0, 6)
+	ck = append(ck, constant.RulesKind)
+	ck = append(ck, constant.AttributeManifestKind)
+	ck = append(ck, constant.AdapterKind)
+	ck = append(ck, constant.TemplateKind)
+	ck = append(ck, constant.InstanceKind)
+	ck = append(ck, constant.HandlerKind)
+	return ck
+}

--- a/mixer/pkg/runtime/config/kinds_test.go
+++ b/mixer/pkg/runtime/config/kinds_test.go
@@ -56,3 +56,12 @@ func TestKindMap(t *testing.T) {
 		t.Fatalf("Got %v\nwant %v", km, want)
 	}
 }
+
+func TestCriticalKind(t *testing.T) {
+	ck := CriticalKinds()
+	want := []string{constant.RulesKind, constant.AttributeManifestKind, constant.AdapterKind,
+		constant.TemplateKind, constant.InstanceKind, constant.HandlerKind}
+	if !reflect.DeepEqual(ck, want) {
+		t.Errorf("critical kinds are not expected: got %v want %v", ck, want)
+	}
+}

--- a/mixer/pkg/runtime/config/validator/validator_test.go
+++ b/mixer/pkg/runtime/config/validator/validator_test.go
@@ -84,7 +84,7 @@ func getValidatorForTest() (*Validator, error) {
 		return nil, err
 	}
 	groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion)
+	s, err := store.NewRegistry(config.StoreInventory()...).NewStore("fs://"+path, groupVersion, []string{})
 	if err != nil {
 		return nil, err
 	}

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -41,6 +41,7 @@ import (
 	"istio.io/istio/mixer/pkg/config/store"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime"
+	rc "istio.io/istio/mixer/pkg/runtime/config"
 	"istio.io/istio/mixer/pkg/runtime/dispatcher"
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/ctrlz"
@@ -185,7 +186,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 
 		reg := store.NewRegistry(config.StoreInventory()...)
 		groupVersion := &schema.GroupVersion{Group: crd.ConfigAPIGroup, Version: crd.ConfigAPIVersion}
-		if st, err = reg.NewStore(configStoreURL, groupVersion); err != nil {
+		if st, err = reg.NewStore(configStoreURL, groupVersion, rc.CriticalKinds()); err != nil {
 			_ = s.Close()
 			return nil, fmt.Errorf("unable to connect to the configuration server: %v", err)
 		}


### PR DESCRIPTION
Check that all critical kinds are ready when initializing crd store. Currently critical kinds include rule, template, instance, handler, adapter and attributesmanifest. Address #8839 