### PR TITLE
Cherrypick: Clear Pilot Cache on cluster removal (#8882)

### DIFF
--- a/pilot/pkg/config/clusterregistry/secretcontroller.go
+++ b/pilot/pkg/config/clusterregistry/secretcontroller.go
@@ -233,6 +233,7 @@ func (c *Controller) deleteMemberCluster(secretName string) {
 			close(c.cs.rc[clusterID].ControlChannel)
 			// Deleting remote cluster entry from clusters store
 			delete(c.cs.rc, clusterID)
+			c.discoveryServer.ClearCacheFunc()()
 		}
 	}
 	log.Infof("Number of clusters in the cluster store: %d", len(c.cs.rc))


### PR DESCRIPTION
When a secret is removed, which causes a
cluster to be removed, the cache is not
cleared. Services and endpoints from remote
clusters are then not removed. Fixes:
https://github.com/istio/istio/issues/8554