### PR TITLE
Vendor go-control-plane using its master branch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,7 +323,6 @@
   version = "v2.6.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:5dfbbc62b88f6a5203530838da87b63fb9277ea3c1128e292590874ca2a4b09e"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
@@ -361,6 +360,7 @@
   ]
   pruneopts = "T"
   revision = "e79e039496d24ae95c3fa1da70209b680ea05a91"
+  version = "v0.6.0"
 
 [[projects]]
   digest = "1:ad32dc29f37281bacb5dcedff17c9461dc1739dc8a5f63a71ab491c6e92edf8d"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,6 +323,7 @@
   version = "v2.6.0"
 
 [[projects]]
+  branch = "master"
   digest = "1:5dfbbc62b88f6a5203530838da87b63fb9277ea3c1128e292590874ca2a4b09e"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
@@ -360,7 +361,6 @@
   ]
   pruneopts = "T"
   revision = "e79e039496d24ae95c3fa1da70209b680ea05a91"
-  version = "v0.5.0"
 
 [[projects]]
   digest = "1:ad32dc29f37281bacb5dcedff17c9461dc1739dc8a5f63a71ab491c6e92edf8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -111,8 +111,8 @@ ignored = [
   version = "1.1.0"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/envoyproxy/go-control-plane"
+  version = "^0.6.0"
 
 [[constraint]]
   name = "github.com/fluent/fluent-logger-golang"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -111,8 +111,8 @@ ignored = [
   version = "1.1.0"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/envoyproxy/go-control-plane"
-  version = "^0.5.0"
 
 [[constraint]]
   name = "github.com/fluent/fluent-logger-golang"


### PR DESCRIPTION
Executing `dep ensure -update github.com/envoyproxy/go-control-plane` after updating the commit hash in `Gopkg.lock` fails if the commit isn't present on a `0.5.x` tag in the [envoyproxy/go-control-plane](https://github.com/envoyproxy/go-control-plane) repository. The error looks like the following.

```
Solving failure: No versions of github.com/envoyproxy/go-control-plane met constraints:
    v0.5.0: Could not introduce github.com/envoyproxy/go-control-plane@v0.5.0, as its subpackage github.com/envoyproxy/go-control-plane/envoy/config/filter/network/rbac/v2 is missing. (Package is required by (root).)
    v0.4: Could not introduce github.com/envoyproxy/go-control-plane@v0.4, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
    v0.3: Could not introduce github.com/envoyproxy/go-control-plane@v0.3, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
    v0.2: Could not introduce github.com/envoyproxy/go-control-plane@v0.2, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
    v0.1: Could not introduce github.com/envoyproxy/go-control-plane@v0.1, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
    master: Could not introduce github.com/envoyproxy/go-control-plane@master, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
    revert_grpc_version_update: Could not introduce github.com/envoyproxy/go-control-plane@revert_grpc_version_update, as it is not allowed by constraint ^0.5.0 from project istio.io/istio.
```

This PR is a simple workaround for the issue i.e. it ensures that `dep` vendors the `go-control-plane` package by referring to commits on its `master` branch.

Signed-off-by: Venil Noronha <veniln@vmware.com>

/cc @yangminzhu