### PR TITLE
Stop Pilot correctly in MCP test

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -390,7 +390,7 @@ func udsRequest(server *bootstrap.Server, t *testing.T) {
 
 func TestEds(t *testing.T) {
 	initLocalPilotTestEnv(t)
-	server := util.EnsureTestServer()
+	server, _ := util.EnsureTestServer()
 
 	t.Run("DirectRequest", func(t *testing.T) {
 		directRequest(server, t)

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -115,7 +115,7 @@ func initLocalPilotTestEnv(t *testing.T) *bootstrap.Server {
 		return pilotServer
 	}
 	testEnv = testenv.NewTestSetup(testenv.XDSTest, t)
-	server := util.EnsureTestServer()
+	server, _ := util.EnsureTestServer()
 	pilotServer = server
 
 	testEnv.Ports().PilotGrpcPort = uint16(util.MockPilotGrpcPort)

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -16,6 +16,7 @@ package pilot
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -48,8 +49,8 @@ func TestPilotMCPClient(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	defer mcpServer.Close()
 
-	stopPilot := initLocalPilotTestEnv(t, mcpServerAddr, pilotGrpcPort, pilotDebugPort)
-	defer stopPilot()
+	pilot := initLocalPilotTestEnv(t, mcpServerAddr, pilotGrpcPort, pilotDebugPort)
+	defer pilot.Close()
 
 	g.Eventually(func() (string, error) {
 		return curlPilot(fmt.Sprintf("http://127.0.0.1:%d/debug/configz", pilotDebugPort))
@@ -111,7 +112,7 @@ func runEnvoy(t *testing.T, grpcPort, debugPort uint16) *mixerEnv.TestSetup {
 	return gateway
 }
 
-func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int) func() {
+func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int) io.Closer {
 	mixerEnv.NewTestSetup(mixerEnv.PilotMCPTest, t)
 	debugAddr := fmt.Sprintf("127.0.0.1:%d", debugPort)
 	grpcAddr := fmt.Sprintf("127.0.0.1:%d", grpcPort)

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -46,8 +46,10 @@ func TestPilotMCPClient(t *testing.T) {
 	t.Log("building & starting mock mcp server...")
 	mcpServer, err := runMcpServer(g, t)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+	defer mcpServer.Close()
 
-	initLocalPilotTestEnv(t, mcpServerAddr, pilotGrpcPort, pilotDebugPort)
+	stopPilot := initLocalPilotTestEnv(t, mcpServerAddr, pilotGrpcPort, pilotDebugPort)
+	defer stopPilot()
 
 	g.Eventually(func() (string, error) {
 		return curlPilot(fmt.Sprintf("http://127.0.0.1:%d/debug/configz", pilotDebugPort))
@@ -55,11 +57,7 @@ func TestPilotMCPClient(t *testing.T) {
 
 	t.Log("run edge router envoy...")
 	gateway := runEnvoy(t, pilotGrpcPort, pilotDebugPort)
-
-	defer func() {
-		mcpServer.Close()
-		gateway.TearDown()
-	}()
+	defer gateway.TearDown()
 
 	t.Log("check that envoy is listening on the configured gateway...")
 	gatewayResource := fmt.Sprintf("127.0.0.1:%s", "8099")
@@ -113,11 +111,12 @@ func runEnvoy(t *testing.T, grpcPort, debugPort uint16) *mixerEnv.TestSetup {
 	return gateway
 }
 
-func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int) {
+func initLocalPilotTestEnv(t *testing.T, mcpAddr string, grpcPort, debugPort int) func() {
 	mixerEnv.NewTestSetup(mixerEnv.PilotMCPTest, t)
 	debugAddr := fmt.Sprintf("127.0.0.1:%d", debugPort)
 	grpcAddr := fmt.Sprintf("127.0.0.1:%d", grpcPort)
-	util.EnsureTestServer(addMcpAddrs(mcpAddr), setupPilotDiscoveryHTTPAddr(debugAddr), setupPilotDiscoveryGrpcAddr(grpcAddr))
+	_, cancel := util.EnsureTestServer(addMcpAddrs(mcpAddr), setupPilotDiscoveryHTTPAddr(debugAddr), setupPilotDiscoveryGrpcAddr(grpcAddr))
+	return cancel
 }
 
 func addMcpAddrs(mcpServerAddr string) func(*bootstrap.PilotArgs) {

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -60,18 +60,20 @@ var (
 
 // EnsureTestServer will ensure a pilot server is running in process and initializes
 // the MockPilotUrl and MockPilotGrpcAddr to allow connections to the test pilot.
-func EnsureTestServer(args ...func(*bootstrap.PilotArgs)) *bootstrap.Server {
+func EnsureTestServer(args ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, func()) {
+	var cancel func()
+	var err error
 	if MockTestServer == nil {
-		err := setup(args...)
+		cancel, err = setup(args...)
 		if err != nil {
 			log.Errora("Failed to start in-process server", err)
 			panic(err)
 		}
 	}
-	return MockTestServer
+	return MockTestServer, cancel
 }
 
-func setup(additionalArgs ...func(*bootstrap.PilotArgs)) error {
+func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (func(), error) {
 	// TODO: point to test data directory
 	// Setting FileDir (--configDir) disables k8s client initialization, including for registries,
 	// and uses a 100ms scan. Must be used with the mock registry (or one of the others)
@@ -123,34 +125,34 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) error {
 	// Create and setup the controller.
 	s, err := bootstrap.NewServer(args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	MockTestServer = s
 
 	// Start the server.
 	if err := s.Start(stop); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Extract the port from the network address.
 	_, port, err := net.SplitHostPort(s.HTTPListeningAddr.String())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	MockPilotURL = "http://localhost:" + port
 	MockPilotHTTPPort, _ = strconv.Atoi(port)
 
 	_, port, err = net.SplitHostPort(s.GRPCListeningAddr.String())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	MockPilotGrpcAddr = "localhost:" + port
 	MockPilotGrpcPort, _ = strconv.Atoi(port)
 
 	_, port, err = net.SplitHostPort(s.SecureGRPCListeningAddr.String())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	MockPilotSecureAddr = "localhost:" + port
 	MockPilotSecurePort, _ = strconv.Atoi(port)
@@ -170,5 +172,5 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) error {
 		return false, nil
 	})
 
-	return err
+	return func() { close(stop) }, err
 }


### PR DESCRIPTION
This addresses an issue where  pilot mcp integration test completed but the client (pilot) was never stopped therefore this can sometimes lead into pilot trying to reconnect to the mcp server while the mcp server is stopped.