### PR TITLE
Add a destination rule to make security work

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.global.meshExpansion }}
-{{ $istioNamespace := .Release.Namespace }}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -7,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   hosts:
-  - "pilot.$istioNamespace"
+  - "pilot.{{ .Release.Namespace }}"
   gateways:
   - meshexpansion-gateway
   tcp:
@@ -15,11 +14,27 @@ spec:
     - port: 15011
     route:
     - destination:
-        host: istio-pilot.$istioNamespace.svc.cluster.local
+        host: istio-pilot.{{ .Release.Namespace }}.svc.cluster.local
         port:
           number: 15011
 
-
+---
+{{- if .Values.global.controlPlaneSecurityEnabled }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: meshexpansion-pilot-dr
+  namespace: istio-system
+spec:
+  host: pilot.{{ .Release.Namespace }}.svc.cluster.local
+  trafficPolicy:
+    portLevelSettings:
+    - port:
+        number: 15011
+      tls:
+        mode: DISABLE
+---
+{{- end }}
 {{- end }}
 
 


### PR DESCRIPTION
Control plane security does not work properly with either
mesh expansion or multicluster with controlPlaneSecurityEnabled=true
and pilot connectivity to port 15011 of the ingressgateway.

In addition, $istioNamespace was not converting into a variable
and instead rendering directly as $istioNamespace.