### PR TITLE
Using KUBECONFIG as default if set in Prow

### DIFF
--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -42,7 +42,7 @@ function setup_and_export_git_sha() {
     fi
 
     # Use volume mount from pilot-presubmit job's pod spec.
-    export KUBECONFIG="${HOME}/.kube/config"
+    export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 
   else
     # Use the current commit.

--- a/prow/mason_lib.sh
+++ b/prow/mason_lib.sh
@@ -37,7 +37,7 @@ function get_resource() {
     --boskos-url='http://boskos.boskos.svc.cluster.local' \
     --owner="${owner}" \
     --info-save "${info_path}" \
-    --kubeconfig-save "${HOME}/.kube/config" > "${file_log}" 2>&1 &
+    --kubeconfig-save "${KUBECONFIG}" > "${file_log}" 2>&1 &
   MASON_CLIENT_PID=$!
 
   local ready


### PR DESCRIPTION
This will allow to set env KUBECONFIG in the Prow config based on where it is mounted instead of assuming its location.