### PR TITLE
Add concurrency and rate to mixc

### DIFF
--- a/mixer/cmd/mixc/cmd/check.go
+++ b/mixer/cmd/mixc/cmd/check.go
@@ -27,7 +27,6 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/spf13/cobra"
-
 	"golang.org/x/time/rate"
 
 	mixerpb "istio.io/api/mixer/v1"

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -79,7 +79,7 @@ func addAttributeFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
 		"Sends the specified number of requests in quick succession")
 	cmd.PersistentFlags().IntVarP(&rootArgs.concurrency, "concurrency", "c", 1,
-		"Controls the numbers of workers used to send requests to Mixer concurrently.")
+		"Controls the number of workers used to send requests to Mixer concurrently.")
 	cmd.PersistentFlags().IntVarP(&rootArgs.rate, "rate", "", -1,
 		"Maximum number of requests per second sent by each worker.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.printResponse, "print_response", "", true,

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -79,9 +79,9 @@ func addAttributeFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
 		"Sends the specified number of requests in quick succession")
 	cmd.PersistentFlags().IntVarP(&rootArgs.concurrency, "concurrency", "c", 1,
-		"Controls the number of workers to send requests to Mixer conrrently.")
+		"Controls the numbers of workers used to send requests to Mixer concurrently.")
 	cmd.PersistentFlags().IntVarP(&rootArgs.rate, "rate", "", -1,
-		"Rate limit of requests per second for each worker.")
+		"Maximum number of requests per second sent by each worker.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.printResponse, "print_response", "", true,
 		"Whether to print mixer's response, useful when generating heavy load with mixc.")
 

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -61,10 +61,10 @@ type rootArgs struct {
 	// # times to repeat the operation
 	repeat int
 
-	// # goroutins to send requests concurrently.
+	// # workers to send requests concurrently.
 	concurrency int
 
-	// rate limit of requests per second for each goroutine.
+	// rate limit of requests per second for each worker.
 	rate int
 
 	// whether to print mixer's response. It is useful when using mixc to generate heavy load.
@@ -79,9 +79,9 @@ func addAttributeFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 	cmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
 		"Sends the specified number of requests in quick succession")
 	cmd.PersistentFlags().IntVarP(&rootArgs.concurrency, "concurrency", "c", 1,
-		"Number of concurrent goroutines sending requests to Mixer.")
+		"Controls the number of workers to send requests to Mixer conrrently.")
 	cmd.PersistentFlags().IntVarP(&rootArgs.rate, "rate", "", -1,
-		"Rate limit of requests per second for each goroutine.")
+		"Rate limit of requests per second for each worker.")
 	cmd.PersistentFlags().BoolVarP(&rootArgs.printResponse, "print_response", "", true,
 		"Whether to print mixer's response, useful when generating heavy load with mixc.")
 

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -61,6 +61,15 @@ type rootArgs struct {
 	// # times to repeat the operation
 	repeat int
 
+	// # goroutins to send requests concurrently.
+	concurrency int
+
+	// rate limit of requests per second for each goroutine.
+	rate int
+
+	// whether to print mixer's response. It is useful when using mixc to generate heavy load.
+	printResponse bool
+
 	tracingOptions *tracing.Options
 }
 
@@ -69,6 +78,12 @@ func addAttributeFlags(cmd *cobra.Command, rootArgs *rootArgs) {
 		"Address and port of a running Mixer instance")
 	cmd.PersistentFlags().IntVarP(&rootArgs.repeat, "repeat", "r", 1,
 		"Sends the specified number of requests in quick succession")
+	cmd.PersistentFlags().IntVarP(&rootArgs.concurrency, "concurrency", "c", 1,
+		"Number of concurrent goroutines sending requests to Mixer.")
+	cmd.PersistentFlags().IntVarP(&rootArgs.rate, "rate", "", -1,
+		"Rate limit of requests per second for each goroutine.")
+	cmd.PersistentFlags().BoolVarP(&rootArgs.printResponse, "print_response", "", true,
+		"Whether to print mixer's response, useful when generating heavy load with mixc.")
 
 	cmd.PersistentFlags().StringVarP(&rootArgs.attributes, "attributes", "a", "",
 		"List of name/value auto-sensed attributes specified as name1=value1,name2=value2,...")

--- a/mixer/cmd/mixc/cmd/root.go
+++ b/mixer/cmd/mixc/cmd/root.go
@@ -58,10 +58,10 @@ type rootArgs struct {
 	// mixerAddress is the full address (including port) of a mixer instance to call.
 	mixerAddress string
 
-	// # times to repeat the operation
+	// number of times to repeat the operation
 	repeat int
 
-	// # workers to send requests concurrently.
+	// number of workers to send requests concurrently.
 	concurrency int
 
 	// rate limit of requests per second for each worker.


### PR DESCRIPTION
This is to make mixc binary to generate controllable load to facilitate mixer perf test (for instance, #8829)