### PR TITLE
Remove permissions check test for fsstore

### DIFF
--- a/mixer/pkg/config/store/fsstore_test.go
+++ b/mixer/pkg/config/store/fsstore_test.go
@@ -15,7 +15,6 @@
 package store
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -313,13 +312,6 @@ spec:
 		title   string
 		prepare func(fsroot string) error
 	}{
-		{
-			"wrong permission",
-			func(fsroot string) error {
-				path := filepath.Join(fsroot, "aa.yaml")
-				return ioutil.WriteFile(path, []byte(fmt.Sprintf(tmpl, "Handler", "aa", "foo: bar\n")), 0300)
-			},
-		},
 		{
 			"illformed yaml",
 			func(fsroot string) error {

--- a/mixer/pkg/config/store/fsstore_test.go
+++ b/mixer/pkg/config/store/fsstore_test.go
@@ -35,6 +35,7 @@ func getTempFSStore2() (*fsStore, string) {
 }
 
 func cleanupRootIfOK(t *testing.T, fsroot string) {
+	t.Helper()
 	if t.Failed() {
 		t.Errorf("Test failed. The data remains at %s", fsroot)
 		return

--- a/mixer/pkg/config/store/fsstore_test.go
+++ b/mixer/pkg/config/store/fsstore_test.go
@@ -353,7 +353,7 @@ spec:
 			want := map[Key]*BackEndResource{k: {Spec: data}}
 			got := s.List()
 			if len(got) != len(want) {
-				tt.Fatalf("data length does not match, want %d, got %d", len(got), len(want))
+				tt.Fatalf("data length does not match, got %d, want %d", len(got), len(want))
 			}
 			for k, v := range got {
 				vwant := want[k]


### PR DESCRIPTION
Devs running as superuser (`root`) are reporting failures for this test, as
the permission settings are not applicable. This PR removes it, as testing
the functionality of file system permissions is not critical to fsstore 
behavior.