### PR TITLE
 Fix rotation log configuration bug

### DIFF
--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -109,8 +109,8 @@ func prepZap(options *Options) (zapcore.Core, zapcore.Core, zapcore.WriteSyncer,
 		rotaterSink = zapcore.AddSync(&lumberjack.Logger{
 			Filename:   options.RotateOutputPath,
 			MaxSize:    options.RotationMaxSize,
-			MaxBackups: options.RotationMaxAge,
-			MaxAge:     options.RotationMaxBackups,
+			MaxBackups: options.RotationMaxBackups,
+			MaxAge:     options.RotationMaxAge,
 		})
 	}
 


### PR DESCRIPTION
The 'log_rotate_max_backups' flag did not take effect as expected, because log object initialization parameters do not match the config option.