### PR TITLE
Resolve Workload from ReplicationControllers owner

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources: ["replicasets"]

--- a/mixer/adapter/kubernetesenv/cache_test.go
+++ b/mixer/adapter/kubernetesenv/cache_test.go
@@ -63,3 +63,57 @@ func TestClusterInfoCache_Pod(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterInfoCache_Workload_ReplicationController(t *testing.T) {
+	controller := true
+	clientset := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-pod",
+				OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+					Controller: &controller,
+					Kind:       "ReplicationController",
+					Name:       "test-rc",
+				}},
+			},
+			Status: v1.PodStatus{PodIP: "10.1.10.1"},
+		},
+		&v1.ReplicationController{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-rc",
+				OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+					Controller: &controller,
+					Kind:       "DeploymentConfig",
+					Name:       "test-dc",
+				}},
+			},
+		},
+	)
+
+	tests := []struct {
+		name     string
+		pod      string
+		workload string
+	}{
+		{"Workload from ReplicationController", "default/test-pod", "test-dc"},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(tt *testing.T) {
+			c := newCacheController(clientset, 0, test.NewEnv(t))
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			go c.Run(stopCh)
+			if !cache.WaitForCacheSync(stopCh, c.HasSynced) {
+				tt.Fatal("Failed to sync")
+			}
+			pod, _ := c.Pod(v.pod)
+			workload, _ := c.Workload(pod)
+			if workload.name != v.workload {
+				tt.Errorf("GetWorkload() => (_, %s), wanted (_, %s)", workload.name, v.workload)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Problem:
Kubernetesenv adapter is responsible to resolve what is the workload for a specific Pod.
When Pod has a ReplicaSet as owner, Workload() is resolved from the owner of the ReplicatSet (i.e. Deployment).
When a Pod has a ReplicationController as owner, Workload() doesn't lookingo for an owner
This creates some problem in prometheus specially when an User defines an application from objects like DeploymentConfig (i.e. used in OpenShift).

Solution proposed:
Fix Workload() to resolve a ReplicationController from the owner.