### PR TITLE
Correct Kiali ingress path

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/ingress.yaml
@@ -16,7 +16,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: kiali
               servicePort: 20001


### PR DESCRIPTION
To avoid Kiali UI not rendering, we should modify its ingress path to "/*"