### PR TITLE
Correct ingress path for tracing

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: /*
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
To avoid Jaeger UI not rendering, we should change ingress path to "/*"