### PR TITLE
WIP: Experimental load-shedding for Report calls to Mixer

### DIFF
--- a/mixer/cmd/mixc/cmd/report.go
+++ b/mixer/cmd/mixc/cmd/report.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"sync"
+	"time"
 
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -74,6 +75,7 @@ func report(rootArgs *rootArgs, printf, fatalf shared.FormatFn) {
 					rl.Wait(context.Background())
 				}
 				request := mixerpb.ReportRequest{Attributes: []mixerpb.CompressedAttributes{*attrs}}
+				ctx, _ = context.WithTimeout(ctx, 100*time.Millisecond)
 				_, err := cs.client.Report(ctx, &request)
 
 				if rootArgs.printResponse {

--- a/mixer/cmd/mixc/cmd/report.go
+++ b/mixer/cmd/mixc/cmd/report.go
@@ -75,7 +75,7 @@ func report(rootArgs *rootArgs, printf, fatalf shared.FormatFn) {
 					rl.Wait(context.Background())
 				}
 				request := mixerpb.ReportRequest{Attributes: []mixerpb.CompressedAttributes{*attrs}}
-				ctx, _ = context.WithTimeout(ctx, 100*time.Millisecond)
+				ctx, _ = context.WithTimeout(ctx, 500*time.Millisecond)
 				_, err := cs.client.Report(ctx, &request)
 
 				if rootArgs.printResponse {

--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogo/googleapis/google/rpc"
@@ -45,6 +46,9 @@ type (
 		// the global dictionary. This will eventually be writable via config
 		globalWordList []string
 		globalDict     map[string]int32
+
+		queuedRequests int64
+		queueLength    int64
 	}
 )
 
@@ -64,6 +68,7 @@ func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool, cac
 		globalWordList: list,
 		globalDict:     globalDict,
 		cache:          cache,
+		queueLength:    int64(gp.QueueLength()),
 	}
 }
 
@@ -216,16 +221,24 @@ var reportResp = &mixerpb.ReportResponse{}
 
 // Report is the entry point for the external Report method
 func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*mixerpb.ReportResponse, error) {
+	qrs := atomic.LoadInt64(&s.queuedRequests)
+	if qrs > s.queueLength {
+		return nil, grpc.Errorf(codes.Unavailable, "Work queue is full (%d pending requests). Try again later.", qrs)
+	}
+	atomic.AddInt64(&s.queuedRequests, 1)
+
 	lg.Debugf("Report (Count: %d)", len(req.Attributes))
 
 	if req.GlobalWordCount > uint32(len(s.globalWordList)) {
 		err := fmt.Errorf("inconsistent global dictionary versions used: mixer knows %d words, caller knows %d", len(s.globalWordList), req.GlobalWordCount)
 		lg.Errora("Report failed:", err.Error())
+		atomic.AddInt64(&s.queuedRequests, -1)
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
 	if len(req.Attributes) == 0 {
 		// early out
+		atomic.AddInt64(&s.queuedRequests, -1)
 		return reportResp, nil
 	}
 
@@ -307,8 +320,10 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 
 	if errors != nil {
 		lg.Errora("Report failed:", errors.Error())
+		atomic.AddInt64(&s.queuedRequests, -1)
 		return nil, grpc.Errorf(codes.Unknown, errors.Error())
 	}
 
+	atomic.AddInt64(&s.queuedRequests, -1)
 	return reportResp, nil
 }

--- a/mixer/pkg/pool/goroutine.go
+++ b/mixer/pkg/pool/goroutine.go
@@ -87,3 +87,7 @@ func (gp *GoroutinePool) AddWorkers(numWorkers int) {
 		}
 	}
 }
+
+func (gp *GoroutinePool) QueueLength() int {
+	return len(gp.queue)
+}


### PR DESCRIPTION
Exploration of one aspect of the approaches discussed in various P&T meetings around the need for load-shedding within the Mixer, particularly as it applies to handling of `Report` calls.

Testing:

```
$ KUBECONFIG=~/.kube/config ~/go/out/linux_amd64/release/mixs server --configStoreURL=fs://$(pwd)/mixer/testdata/config --apiWorkerPoolSize=1
```

```
$ mixc report -c 2 -r 4 -s context.protocol="http",destination.service="test",request.path="/doug-test",destination.uid="kubernetes://productpage-v1-79b8db5f94-dg4pw.crazy" -t request.time="2018-01-29T12:12:14Z",response.time="2018-01-29T12:12:15Z" --bytes_attributes destination.ip="a:3c:00:1a" --stringmap_attributes request.headers=x-b3-traceid:2141234123412344abfe 
...
READY
Report RPC returned Unavailable (Work queue is full (1 pending requests). Try again later.)
Report RPC returned Unavailable (Work queue is full (1 pending requests). Try again later.)
Report RPC returned OK
Report RPC returned Unavailable (Work queue is full (1 pending requests). Try again later.)
Report RPC returned OK
Report RPC returned Unavailable (Work queue is full (1 pending requests). Try again later.)
Report RPC returned Unavailable (Work queue is full (1 pending requests). Try again later.)
Report RPC returned OK

```

This is meant to provoke discussion and further exploration of the space. As such, this PR should NOT be considered for merging at this time.

/hold


