### PR TITLE
[Ansible Installer] bump up kiali version to v0.8

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: v0.7
+      kiali_version: v0.8
 
   - name: Install Kiali on Openshift
     shell: |


### PR DESCRIPTION
Kiali is up to 0.8 - bumping up ansible installer to use it.
This is in preparation for Kiali to replace servicegraph - see Issue https://github.com/istio/istio/issues/9066