### PR TITLE
enable envoy fetch root ca through SDS

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	mockCertificateChain1st    = []byte{01}
-	mockCertificateChainRemain = []byte{02}
+	mockCertChain1st    = []string{"foo", "rootcert"}
+	mockCertChainRemain = []string{"bar", "rootcert"}
 
 	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
 )
@@ -52,7 +52,8 @@ func TestGenerateSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	if got, want := gotSecret.CertificateChain, mockCertificateChain1st; bytes.Compare(got, want) != 0 {
+
+	if got, want := gotSecret.CertificateChain, convertToBytes(mockCertChain1st); bytes.Compare(got, want) != 0 {
 		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
 	}
 
@@ -63,7 +64,26 @@ func TestGenerateSecret(t *testing.T) {
 		t.Errorf("SecretExist: got: %v, want: %v", got, want)
 	}
 
-	cachedSecret, found := sc.secrets.Load(proxyID)
+	gotSecretRoot, err := sc.GenerateSecret(ctx, proxyID, RootCertReqResourceName, "jwtToken1")
+	if err != nil {
+		t.Fatalf("Failed to get secrets: %v", err)
+	}
+	if got, want := gotSecretRoot.RootCert, []byte("rootcert"); bytes.Compare(got, want) != 0 {
+		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
+	}
+
+	if got, want := sc.SecretExist(proxyID, RootCertReqResourceName, "jwtToken1", gotSecretRoot.Version), true; got != want {
+		t.Errorf("SecretExist: got: %v, want: %v", got, want)
+	}
+	if got, want := sc.SecretExist(proxyID, RootCertReqResourceName, "nonexisttoken", gotSecretRoot.Version), false; got != want {
+		t.Errorf("SecretExist: got: %v, want: %v", got, want)
+	}
+
+	key := ConnKey{
+		ProxyID:      proxyID,
+		ResourceName: fakeSpiffeID,
+	}
+	cachedSecret, found := sc.secrets.Load(key)
 	if !found {
 		t.Errorf("Failed to find secret for proxy %q from secret store: %v", proxyID, err)
 	}
@@ -76,7 +96,7 @@ func TestGenerateSecret(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
-	if got, want := gotSecret.CertificateChain, mockCertificateChainRemain; bytes.Compare(got, want) != 0 {
+	if got, want := gotSecret.CertificateChain, convertToBytes(mockCertChainRemain); bytes.Compare(got, want) != 0 {
 		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
 	}
 
@@ -135,7 +155,7 @@ func TestRefreshSecret(t *testing.T) {
 	}
 }
 
-func notifyCb(string, *model.SecretItem) error {
+func notifyCb(string, string, *model.SecretItem) error {
 	return nil
 }
 
@@ -150,12 +170,20 @@ func newMockCAClient() *mockCAClient {
 }
 
 func (c *mockCAClient) CSRSign(ctx context.Context, csrPEM []byte, subjectID string,
-	certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error) {
+	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	atomic.AddUint64(&c.signInvokeCount, 1)
 
 	if atomic.LoadUint64(&c.signInvokeCount) == 1 {
-		return mockCertificateChain1st, nil
+		return mockCertChain1st, nil
 	}
 
-	return mockCertificateChainRemain, nil
+	return mockCertChainRemain, nil
+}
+
+func convertToBytes(ss []string) []byte {
+	res := []byte{}
+	for _, s := range ss {
+		res = append(res, []byte(s)...)
+	}
+	return res
 }

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -31,7 +31,7 @@ import (
 // Client interface defines the clients need to implement to talk to CA for CSR.
 type Client interface {
 	CSRSign(ctx context.Context, csrPEM []byte, subjectID string,
-		certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error)
+		certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error)
 }
 
 type caClient struct {
@@ -65,7 +65,7 @@ func NewCAClient(endpoint string, tlsFlag bool) (Client, error) {
 }
 
 func (cl *caClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
-	certValidTTLInSec int64) ([]byte /*PEM-encoded certificate chain*/, error) {
+	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
 	req := &capb.IstioCertificateRequest{
 		Csr:              string(csrPEM),
 		ValidityDuration: certValidTTLInSec,
@@ -83,11 +83,5 @@ func (cl *caClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
 		return nil, errors.New("invalid response cert chain")
 	}
 
-	// Returns the leaf cert(Leaf cert is element '0', Root cert is element 'n').
-	ret := []byte{}
-	for _, c := range resp.CertChain {
-		ret = append(ret, []byte(c)...)
-	}
-
-	return ret, nil
+	return resp.CertChain, nil
 }

--- a/security/pkg/nodeagent/caclient/client_test.go
+++ b/security/pkg/nodeagent/caclient/client_test.go
@@ -69,12 +69,7 @@ func TestCAClient(t *testing.T) {
 		t.Fatalf("failed to call CSR sign: %v", err)
 	}
 
-	expected := []byte{}
-	for _, c := range fakeCert {
-		expected = append(expected, []byte(c)...)
-	}
-
-	if !reflect.DeepEqual(resp, expected) {
-		t.Errorf("resp: got %+v, expected %q", resp, expected)
+	if !reflect.DeepEqual(resp, fakeCert) {
+		t.Errorf("resp: got %+v, expected %q", resp, fakeCert)
 	}
 }

--- a/security/pkg/nodeagent/model/secret.go
+++ b/security/pkg/nodeagent/model/secret.go
@@ -22,8 +22,11 @@ type SecretItem struct {
 	CertificateChain []byte
 	PrivateKey       []byte
 
-	// SpiffeID passed from envoy.
-	SpiffeID string
+	RootCert []byte
+
+	// ResourceName passed from envoy SDS discovery request, spiffeID format for key/cert request.
+	// "ROOTCA" for root cert request.
+	ResourceName string
 
 	// Credential token passed from envoy, caClient uses this token to send
 	// CSR to CA to sign certificate.


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

node agent support fetching root CA through SDS instead of baking root CA into proxy docker image like in ```collab-gcp-identity``` branch today