### PR TITLE
add istioctl validate command

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/istioctl/cmd/istioctl/gendeployment"
+	"istio.io/istio/istioctl/pkg/validate"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/collateral"
@@ -122,6 +123,8 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(contextCmd)
+
+	rootCmd.AddCommand(validate.NewValidateCommand())
 }
 
 func getRemoteInfo() (*version.MeshInfo, error) {

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -1,0 +1,158 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	// TODO use k8s.io/cli-runtime when we switch to v1.12 k8s dependency
+	// k8s.io/cli-runtime was created for k8s v.12. Prior to that release,
+	// the genericclioptions packages are organized under kubectl.
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
+	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+/*
+
+TODO(https://github.com/istio/istio/issues/4887)
+
+Reusing the existing mixer validation code pulls in all of the mixer
+adapter packages into istioctl. Not only is this not ideal (see
+issue), but it also breaks the istioctl build on windows as some mixer
+adapters use linux specific packges (e.g. syslog).
+
+func createMixerValidator() store.BackendValidator {
+	info := generatedTmplRepo.SupportedTmplInfo
+	templates := make(map[string]*template.Info, len(info))
+	for k := range info {
+		t := info[k]
+		templates[k] = &t
+	}
+	adapters := config.AdapterInfoMap(adapter.Inventory(), template.NewRepository(info).SupportsTemplate)
+	return store.NewValidator(nil, runtimeConfig.KindMap(adapters, templates))
+}
+
+var mixerValidator = createMixerValidator()
+*/
+
+type validateArgs struct {
+	filenames []string
+	// TODO validateObjectStream namespace/object?
+}
+
+func (args validateArgs) validate() error {
+	var errs *multierror.Error
+	if len(args.filenames) == 0 {
+		errs = multierror.Append(errs, errors.New("no filenames set (see --filename/-f)"))
+	}
+	return errs.ErrorOrNil()
+}
+
+func validateResource(un *unstructured.Unstructured) error {
+	schema, exists := model.IstioConfigTypes.GetByType(crd.CamelCaseToKebabCase(un.GetKind()))
+	if exists {
+		obj, err := crd.ConvertObjectFromUnstructured(schema, un, "")
+		if err != nil {
+			return fmt.Errorf("cannot parse proto message: %v", err)
+		}
+		return schema.Validate(obj.Name, obj.Namespace, obj.Spec)
+	} else {
+		return fmt.Errorf("mixer API validation is not supported")
+		/*
+			TODO(https://github.com/istio/istio/issues/4887)
+
+			ev := &store.BackendEvent{
+				Key: store.Key{
+					Name:      un.GetName(),
+					Namespace: un.GetNamespace(),
+					Kind:      un.GetKind(),
+				},
+				Value: mixerCrd.ToBackEndResource(un),
+			}
+			return mixerValidator.Validate(ev)
+		*/
+	}
+}
+
+func validateObjects(restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
+	r := resource.NewBuilder(restClientGetter).
+		Unstructured().
+		FilenameParam(false, &options).
+		Flatten().
+		Local().
+		Do()
+	if err := r.Err(); err != nil {
+		return err
+	}
+
+	return r.Visit(func(info *resource.Info, err error) error {
+		content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(info.Object)
+		if err != nil {
+			return err
+		}
+
+		un := &unstructured.Unstructured{Object: content}
+		if err := validateResource(un); err != nil {
+			return fmt.Errorf("error validating resource (%v Name=%v Namespace=%v): %v",
+				un.GetObjectKind().GroupVersionKind(), un.GetName(), un.GetNamespace(), err)
+		}
+		return nil
+	})
+}
+
+var (
+	stdinReaderHook io.Reader = os.Stdin
+)
+
+// NewValidateCommand creates a new command for validating Istio k8s resources.
+func NewValidateCommand() *cobra.Command {
+	var (
+		filenames       = []string{}
+		recursive       = true
+		kubeConfigFlags *genericclioptions.ConfigFlags
+		fileNameFlags   = genericclioptions.FileNameFlags{
+			Filenames: &filenames,
+			Recursive: &recursive,
+		}
+	)
+
+	c := &cobra.Command{
+		Use:     "validate -f FILENAME [options]",
+		Short:   "Validate Istio policy and rules",
+		Example: `istioctl validateObjectStream -f bookinfo-gateway.yaml`,
+		Args:    cobra.NoArgs,
+		RunE: func(c *cobra.Command, _ []string) error {
+			return validateObjects(kubeConfigFlags, fileNameFlags.ToOptions(), c.OutOrStderr())
+		},
+	}
+
+	flags := c.PersistentFlags()
+	kubeConfigFlags = genericclioptions.NewConfigFlags()
+	kubeConfigFlags.AddFlags(flags)
+	fileNameFlags.AddFlags(flags)
+
+	return c
+}

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -291,11 +290,6 @@ func TestValidateCommand(t *testing.T) {
 		t.Run(fmt.Sprintf("[%v] %v ", i, c.name), func(tt *testing.T) {
 			validateCmd := NewValidateCommand()
 			validateCmd.SetArgs(c.args)
-
-			if c.stdin != nil {
-				stdinReaderHook = c.stdin
-				defer func() { stdinReaderHook = os.Stdin }()
-			}
 
 			// capture output to keep test logs clean
 			var out bytes.Buffer

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -1,0 +1,311 @@
+// Copyright 2018 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	delimiter           = `---`
+	validVirtualService = `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: valid-virtual-service
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75
+      - destination:
+          host: c
+          subset: v2
+        weight: 25`
+	validVirtualService1 = `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: valid-virtual-service1
+spec:
+  hosts:
+    - d
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75
+      - destination:
+          host: c
+          subset: v2
+        weight: 25`
+	invalidVirtualService = `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: invalid-virtual-service
+spec:
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75
+      - destination:
+          host: c
+          subset: v2
+        weight: 25`
+	validMixerRule = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: valid-rule
+spec:
+  match: request.headers["clnt"] == "abc"
+  actions:
+  - handler: handler-for-valid-rule.denier
+    instances:
+    - instance-for-valid-rule.checknothing`
+	invalidMixerRule = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: valid-rule
+spec:
+  badField: oops
+  match: request.headers["clnt"] == "abc"
+  actions:
+  - handler: handler-for-valid-rule.denier
+    instances:
+    - instance-for-valid-rule.checknothing`
+	invalidNoGroup = `
+apiVersion: /v1alpha3
+kind: VirtualService
+metadata:
+  name: invalid-no-group
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75`
+	invalidNoVersion = `
+apiVersion: networking.istio.io/
+kind: VirtualService
+metadata:
+  name: invalid-no-group
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75`
+	invalidNoKind = `
+apiVersion: networking.istio.io/v1alpha3
+metadata:
+  name: invalid-no-group
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75`
+	invalidNoName = `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  typo-name: invalid-no-group
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75`
+	badYAML = `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: { valid-virtual-service
+spec:
+  hosts:
+    - c
+  http:
+    - route:
+      - destination:
+          host: c
+          subset: v1
+        weight: 75`
+)
+
+func fromYAML(in string) *unstructured.Unstructured {
+	var un unstructured.Unstructured
+	if err := yaml.Unmarshal([]byte(in), &un); err != nil {
+		panic(err)
+	}
+	return &un
+}
+
+func TestValidateResource(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		valid bool
+	}{
+		{
+			name:  "valid pilot configuration",
+			in:    validVirtualService,
+			valid: true,
+		},
+		{
+			name:  "invalid pilot configuration",
+			in:    invalidVirtualService,
+			valid: false,
+		},
+		{
+			name:  "valid mixer configuration",
+			in:    validMixerRule,
+			valid: false, // TODO(https://github.com/istio/istio/issues/4887)
+		},
+		{
+			name:  "invalid mixer configuration",
+			in:    invalidMixerRule,
+			valid: false, // TODO(https://github.com/istio/istio/issues/4887)
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%v] %v ", i, c.name), func(tt *testing.T) {
+			err := validateResource(fromYAML(c.in))
+			if (err == nil) != c.valid {
+				tt.Fatalf("unexpected validation result: got %v want %v: err=%q", err == nil, c.valid, err)
+			}
+		})
+	}
+}
+
+func buildMultiDocYAML(docs []string) string {
+	var b strings.Builder
+	for _, r := range docs {
+		if r != "" {
+			b.WriteString(strings.Trim(r, " \t\n"))
+		}
+		b.WriteString("\n---\n")
+	}
+	return b.String()
+}
+
+func createTestFile(t *testing.T, data string) (string, io.Closer) {
+	t.Helper()
+	validFile, err := ioutil.TempFile("", "TestValidateCommand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := validFile.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	return validFile.Name(), validFile
+}
+
+func TestValidateCommand(t *testing.T) {
+	valid := buildMultiDocYAML([]string{validVirtualService, validVirtualService1})
+	invalid := buildMultiDocYAML([]string{invalidVirtualService, validVirtualService1})
+	unsupportedMixerRule := buildMultiDocYAML([]string{validVirtualService, validMixerRule})
+
+	validFilename, closeValidFile := createTestFile(t, valid)
+	defer closeValidFile.Close()
+
+	invalidFilename, closeInvalidFile := createTestFile(t, invalid)
+	defer closeInvalidFile.Close()
+
+	cases := []struct {
+		name      string
+		args      []string
+		stdin     *bytes.Buffer
+		in        []string
+		wantError bool
+	}{
+		{
+			name:      "filename missing",
+			wantError: true,
+		},
+		{
+			name: "valid resources from file",
+			args: []string{"--filename", validFilename},
+		},
+		{
+			name:      "extra args",
+			args:      []string{"--filename", validFilename, "extra-arg"},
+			wantError: true,
+		},
+		{
+			name:      "invalid resources from file",
+			args:      []string{"--filename", invalidFilename},
+			wantError: true,
+		},
+		{
+			name:      "unsupported mixer rule",
+			args:      []string{"--filename", unsupportedMixerRule},
+			wantError: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%v] %v ", i, c.name), func(tt *testing.T) {
+			validateCmd := NewValidateCommand()
+			validateCmd.SetArgs(c.args)
+
+			if c.stdin != nil {
+				stdinReaderHook = c.stdin
+				defer func() { stdinReaderHook = os.Stdin }()
+			}
+
+			// capture output to keep test logs clean
+			var out bytes.Buffer
+			validateCmd.SetOutput(&out)
+
+			err := validateCmd.Execute()
+			if (err != nil) != c.wantError {
+				tt.Fatalf("unexpected validate return status: got %v want %v: \nerr=%v",
+					err != nil, c.wantError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a dedicated command for offline validation of Istio kubernetes resources. This new command is intended to replace existing usage of the deprecated `istioctl create` command.

This command leverages k8s's genericclioptions for improved consistency with kubectl. For example, client-side validation supports validating directories of files and remote sources, e.g.

```bash
istioctl validate -f samples/bookinfo/networking/virtual-service-all-v1.yaml 
istioctl validate -f samples/bookinfo/networking/
istioctl validate -f https://raw.githubusercontent.com/istio/istio/master/tests/e2e/tests/galley/testdata/networking-v1alpha3-VirtualService-invalid.yaml

```
