### PR TITLE
Change coredump path, limit number of core files and add integration …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ else
 endif
 
 export GOOS ?= $(GOOS_LOCAL)
+
+export ENABLE_COREDUMP ?= false
 #-----------------------------------------------------------------------------
 # Output control
 #-----------------------------------------------------------------------------
@@ -577,6 +579,7 @@ isti%.yaml: $(HELM)
 	$(HELM) template --name istio --set global.tag=${TAG} \
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
+		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--values install/kubernetes/helm/istio/values-$@ \
 		install/kubernetes/helm/istio >> install/kubernetes/$@
 
@@ -586,6 +589,7 @@ generate_yaml: $(HELM)
 	$(HELM) template --name istio --set global.tag=${TAG} \
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
+		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--values install/kubernetes/helm/istio/values.yaml \
 		install/kubernetes/helm/istio >> install/kubernetes/istio.yaml
 
@@ -593,10 +597,15 @@ generate_yaml: $(HELM)
 	$(HELM) template --set global.tag=${TAG} \
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
-		--values install/kubernetes/helm/istio/values.yaml \
 		--set global.mtls.enabled=true \
 		--set global.controlPlaneSecurityEnabled=true \
+		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--values install/kubernetes/helm/istio/values.yaml \
 		install/kubernetes/helm/istio >> install/kubernetes/istio-auth.yaml
+
+generate_yaml_coredump: export ENABLE_COREDUMP=true
+generate_yaml_coredump:
+	$(MAKE) generate_yaml
 
 # Generate the install files, using istioctl.
 # TODO: make sure they match, pass all tests.

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -56,15 +56,15 @@ data:
           privileged: true
           {{ end }}
         restartPolicy: Always
-      {{ if eq .Values.global.proxy.enableCoreDump true }}
-      - name: enable-core-dump
-        args:
+      {{- if .Values.global.proxy.enableCoreDump }}
+      - args:
         - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
           - /bin/sh
         image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
         imagePullPolicy: IfNotPresent
+        name: enable-core-dump
         resources: {}
         securityContext:
           privileged: true
@@ -136,7 +136,9 @@ data:
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
+          {{- if ne .Values.global.proxy.enableCoreDump true }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{ "[[ if eq (or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String) \"TPROXY\" -]]" }}
           capabilities:
             add:

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -31,7 +31,9 @@ global:
     # disable access log for sidecar.
     accessLogFile: "/dev/stdout"
 
-    # If set, newly injected sidecars will have core dumps enabled.
+    # If set, newly injected sidecars will have core dumps enabled. Core dumps will always be written to the same
+    # file to prevent storage filling up indefinitely. Add a timestamp option to core_pattern to keep all cores:
+    # e.g. sysctl -w kernel.core_pattern=/var/lib/istio/core.%e.%p.%t
     enableCoreDump: false
 
     # istio egress capture whitelist

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -29,6 +29,23 @@ spec:
 {{- if $.Values.global.priorityClassName }}
       priorityClassName: "{{ $.Values.global.priorityClassName }}"
 {{- end }}
+{{- if $.Values.global.proxy.enableCoreDump }}
+      initContainers:
+        - name: enable-core-dump
+{{- if contains "/" $.Values.global.proxy_init.image }}
+          image: "{{ $.Values.global.proxy_init.image }}"
+{{- else }}
+          image: "{{ $.Values.global.hub }}/{{ $.Values.global.proxy_init.image }}:{{ $.Values.global.tag }}"
+{{- end }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
+          securityContext:
+            privileged: true
+{{- end }}
       containers:
         - name: istio-proxy
           image: "{{ $.Values.global.hub }}/proxyv2:{{ $.Values.global.tag }}"

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -41,19 +41,17 @@ data:
           capabilities:
             add:
             - NET_ADMIN
-          {{ if .Values.global.proxy.privileged }}
           privileged: true
-          {{ end -}}
         restartPolicy: Always
-      {{ if eq .Values.global.proxy.enableCoreDump true }}
-      - name: enable-core-dump
-        args:
+      {{- if .Values.global.proxy.enableCoreDump }}
+      - args:
         - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
           - /bin/sh
         image: {{ .Values.global.hub }}/proxy_init:{{ .Values.global.tag }}
         imagePullPolicy: IfNotPresent
+        name: enable-core-dump
         resources: {}
         securityContext:
           privileged: true
@@ -143,7 +141,9 @@ data:
           {{ if .Values.global.proxy.privileged }}
           privileged: true
           {{ end -}}
+          {{- if ne .Values.global.proxy.enableCoreDump true }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{ "[[ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) \"TPROXY\" -]]" }}
           capabilities:
             add:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -44,7 +44,9 @@ global:
     #If set to true, istio-proxy container will have privileged securityContext
     privileged: false
 
-    # If set, newly injected sidecars will have core dumps enabled.
+    # If set, newly injected sidecars will have core dumps enabled. Core dumps will always be written to the same
+    # file to prevent storage filling up indefinitely. Add a timestamp option to core_pattern to keep all cores:
+    # e.g. sysctl -w kernel.core_pattern=/var/lib/istio/core.%e.%p.%t
     enableCoreDump: false
 
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -43,7 +43,6 @@ ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 
-
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -71,7 +71,7 @@ initContainers:
 - name: enable-core-dump
   args:
   - -c
-  - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c unlimited
+  - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
   command:
   - /bin/sh
   image: {{ .InitImage }}

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -125,8 +125,7 @@ spec:
             - NET_ADMIN
       - args:
         - -c
-        - sysctl -w kernel.core_pattern=/etc/istio/proxy/core.%e.%p.%t && ulimit -c
-          unlimited
+        - sysctl -w kernel.core_pattern=/var/lib/istio/core.proxy && ulimit -c unlimited
         command:
         - /bin/sh
         image: docker.io/istio/proxy_init:unittest

--- a/pilot/test/util/kubernetes.go
+++ b/pilot/test/util/kubernetes.go
@@ -119,6 +119,17 @@ func CopyPodFiles(container, pod, ns, source, dest string) {
 	log.Errorf("%s\n%s", cmd, output)
 }
 
+// CopyFilesToPod copies files from a machine to a pod.
+func CopyFilesToPod(container, pod, ns, source, dest string) error {
+	// kubectl cp /tmp/bar  <some-namespace>/<some-pod>:/tmp/foo -c container
+	cmd := fmt.Sprintf("kubectl cp %s %s/%s:%s", source, ns, pod, dest)
+	if container != "" {
+		cmd += " -c " + container
+	}
+	_, err := Shell(cmd)
+	return err
+}
+
 // GetAppPods awaits till all pods are running in a namespace, and returns a map
 // from "app" label value to the pod names.
 func GetAppPods(cl kubernetes.Interface, kubeconfig string, nslist []string) (map[string][]string, error) {

--- a/tests/e2e/tests/pilot/pilot_test.go
+++ b/tests/e2e/tests/pilot/pilot_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/multierr"
 
 	"istio.io/istio/pilot/pkg/kube/inject"
+	util2 "istio.io/istio/pilot/test/util"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/e2e/framework"
 	"istio.io/istio/tests/util"
@@ -70,6 +71,73 @@ func TestMain(m *testing.M) {
 	check(setTestConfig(), "could not create TestConfig")
 	tc.Cleanup.RegisterCleanable(tc)
 	os.Exit(tc.RunTest(m))
+}
+
+func TestCoreDumpGenerated(t *testing.T) {
+	if strings.Contains(os.Getenv("TEST_ENV"), "minikube") {
+		t.Skipf("Skipping %s in minikube environment", t.Name())
+	}
+	// Simplest way to create out of process core file.
+	crashContainer := "istio-proxy"
+	crashProgPath := "/tmp/crashing_program"
+	coreDir := "var/lib/istio"
+	script := `#!/bin/bash
+kill -SIGSEGV $$
+`
+	err := ioutil.WriteFile(crashProgPath, []byte(script), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ingressGatewayPod, err := getIngressGatewayPodName()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := util2.CopyFilesToPod(crashContainer, ingressGatewayPod, tc.Kube.Namespace, crashProgPath, crashProgPath); err != nil {
+		t.Fatalf("could not copy file to pod %s: %v", ingressGatewayPod, err)
+	}
+
+	out, err := util.PodExec(tc.Kube.Namespace, ingressGatewayPod, crashContainer, crashProgPath, false, "")
+	if !strings.HasPrefix(out, "command terminated with exit code 139") {
+		t.Fatalf("did not get expected crash error for %s in pod %s, got: %v", crashProgPath, ingressGatewayPod, err)
+	}
+
+	// No easy way to look for a specific core file.
+	response, err := util.PodExec(tc.Kube.Namespace, ingressGatewayPod, crashContainer, "find "+coreDir, false, "")
+	if !strings.Contains(response, "core.") {
+		t.Fatalf("%s did not contain core file, contents: %s, err:%v", coreDir, response, err)
+	}
+
+	response, err = util.PodExec(tc.Kube.Namespace, ingressGatewayPod, crashContainer, "rm "+getCorefilename(response), false, "")
+	if err != nil {
+		t.Fatalf("could not remove core file, response:%s, err:%v", response, err)
+	}
+}
+
+func getIngressGatewayPodName() (string, error) {
+	label := "istio=ingressgateway"
+	res, err := util.Shell("kubectl -n %s -l=%s get pods -o=jsonpath='{range .items[*]}{.metadata.name}{\" \"}{"+
+		".metadata.labels.%s}{\"\\n\"}{end}'", tc.Kube.Namespace, label, label)
+	if err != nil {
+		return "", err
+	}
+
+	rv := strings.Split(res, "\n")
+	if len(rv) < 2 {
+		return "", fmt.Errorf("bad response for get ingressgateway: %s", res)
+	}
+
+	return strings.TrimSpace(rv[0]), nil
+}
+
+func getCorefilename(resp string) string {
+	for _, line := range strings.Split(resp, "\n") {
+		if strings.Contains(line, "core.") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
 }
 
 func setTestConfig() error {

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -101,7 +101,7 @@ e2e_simple_noauth_run: out_dir
 	--rbac_enable=false --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 e2e_mixer_run: out_dir
-	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/mixer \
+	set -o pipefail; go test -v -timeout 35m ./tests/e2e/tests/mixer \
 	--auth_enable=false --egress=false --ingress=false --rbac_enable=false \
 	--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
@@ -176,7 +176,7 @@ test/local/e2e_galley: out_dir istioctl generate_yaml
 	${CAPTURE_LOG}
 
 # v1alpha3+envoyv2 test without MTLS
-test/local/noauth/e2e_pilotv2: out_dir generate_yaml
+test/local/noauth/e2e_pilotv2: out_dir generate_yaml_coredump
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/pilot \
 		--auth_enable=false --ingress=false --rbac_enable=true --cluster_wide \
 		${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
@@ -184,7 +184,7 @@ test/local/noauth/e2e_pilotv2: out_dir generate_yaml
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/controller ${CAPTURE_LOG}
 
 # v1alpha3+envoyv2 test with MTLS
-test/local/auth/e2e_pilotv2: out_dir generate_yaml
+test/local/auth/e2e_pilotv2: out_dir generate_yaml_coredump
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/pilot \
 		--auth_enable=true --ingress=false --rbac_enable=true --cluster_wide \
 		${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}

--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -7,6 +7,8 @@
 #   definitions, configmaps, secrets (names only) and "all" as defined by
 #   kubectl.
 
+COREDUMP_DIR="/var/lib/istio"
+
 error() {
   echo "$*" >&2
 }
@@ -118,13 +120,14 @@ copy_core_dumps_if_istio_proxy() {
   local namespace="${1}"
   local pod="${2}"
   local container="${3}"
+  local got_core_dump=false
 
   if [ "istio-proxy" = "${container}" ]; then
     local out_dir="${LOG_DIR}/${namespace}/${pod}"
     mkdir -p "${out_dir}"
     local core_dumps
     core_dumps=$(kubectl exec -n "${namespace}" "${pod}" -c "${container}" -- \
-        find /etc/istio/proxy /var/istio/proxy -name 'core.*')
+        find ${COREDUMP_DIR} -name 'core.*')
     for f in ${core_dumps}; do
       local out_file
       out_file="${out_dir}/$(basename "${f}")"
@@ -133,12 +136,18 @@ copy_core_dumps_if_istio_proxy() {
           cat "${f}" > "${out_file}"
 
       log "Copied ${namespace}/${pod}/${container}:${f} to ${out_file}"
+      got_core_dump=true
     done
+  fi
+  if [ "${got_core_dump}" = true ]; then
+    return 254
   fi
 }
 
 # Run functions on each container. Each argument should be a function which
 # takes 3 args: ${namespace} ${pod} ${container}.
+# If any of the called functions returns error, tap_containers returns
+# immediately with that error.
 tap_containers() {
   local functions=( "$@" )
 
@@ -156,12 +165,14 @@ tap_containers() {
       for container in ${containers}; do
 
         for f in "${functions[@]}"; do
-          "${f}" "${namespace}" "${pod}" "${container}"
+          "${f}" "${namespace}" "${pod}" "${container}" || return $?
         done
 
       done
     done
   done
+
+  return 0
 }
 
 dump_kubernetes_resources() {
@@ -249,14 +260,14 @@ check_logs_for_errors() {
 }
 
 main() {
+  local exit_code=0
   parse_args "$@"
   check_prerequisites kubectl
   dump_time
   dump_pilot
   dump_resources
-  tap_containers dump_logs_for_container copy_core_dumps_if_istio_proxy
+  exit_code=tap_containers dump_logs_for_container copy_core_dumps_if_istio_proxy
 
-  local exit_code=0
   if [ "${SHOULD_CHECK_LOGS_FOR_ERRORS}" = true ]; then
     if ! check_logs_for_errors; then
       exit_code=255


### PR DESCRIPTION
Cherry pick of pr/8043

* Change coredump path and add integration test

* Modify API with maxNumCoreDumps

* Update test goldens

* Review comments

* readOnlyRootFilesystem true only if coredump disabled

* Review comments

* Update unit test goldens

* Go back to original proposal of one core file, default disabled

* Change core path dir to /var/lib/istio

* Enable coredump for e2e pilot test

* Review comments, add example