### PR TITLE
Fix the gate

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,11 +68,11 @@ ignored = [
 
 [[constraint]]
   name = "go.opencensus.io"
-  version = ">=0.11.0"
+  version = "0.12.0"
 
 [[constraint]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  version = ">=0.2.0"
+  version = "0.3.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
stackdriver 0.6.0 brings in a slew of dependencies which
are incompatible or otherwise not usable by Istio or its
transitive dependencies.  Pin stackdriver to 0.5.0.