### PR TITLE
Resolve root controller for ReplicationController based workloads

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
-  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets"]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces", "secrets", "replicationcontrollers"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["extensions"]
   resources: ["replicasets"]

--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -45,7 +45,7 @@ type (
 		stopChan chan struct{}
 		pods     cache.SharedIndexInformer
 		rs       cache.SharedIndexInformer
-		rc   cache.SharedIndexInformer
+		rc       cache.SharedIndexInformer
 	}
 
 	workload struct {
@@ -81,7 +81,7 @@ func newCacheController(clientset kubernetes.Interface, refreshDuration time.Dur
 		stopChan: stopChan,
 		pods:     podInformer,
 		rs:       sharedInformers.Apps().V1().ReplicaSets().Informer(),
-		rc:   sharedInformers.Core().V1().ReplicationControllers().Informer(),
+		rc:       sharedInformers.Core().V1().ReplicationControllers().Informer(),
 	}
 }
 

--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -45,6 +45,7 @@ type (
 		stopChan chan struct{}
 		pods     cache.SharedIndexInformer
 		rs       cache.SharedIndexInformer
+		rc   cache.SharedIndexInformer
 	}
 
 	workload struct {
@@ -80,6 +81,7 @@ func newCacheController(clientset kubernetes.Interface, refreshDuration time.Dur
 		stopChan: stopChan,
 		pods:     podInformer,
 		rs:       sharedInformers.Apps().V1().ReplicaSets().Informer(),
+		rc:   sharedInformers.Core().V1().ReplicationControllers().Informer(),
 	}
 }
 
@@ -88,7 +90,7 @@ func (c *controllerImpl) StopControlChannel() {
 }
 
 func (c *controllerImpl) HasSynced() bool {
-	if c.pods.HasSynced() && c.rs.HasSynced() {
+	if c.pods.HasSynced() && c.rs.HasSynced() && c.rc.HasSynced() {
 		return true
 	}
 	return false
@@ -98,6 +100,7 @@ func (c *controllerImpl) Run(stop <-chan struct{}) {
 	// TODO: scheduledaemon
 	c.env.ScheduleDaemon(func() { c.pods.Run(stop) })
 	c.env.ScheduleDaemon(func() { c.rs.Run(stop) })
+	c.env.ScheduleDaemon(func() { c.rc.Run(stop) })
 	<-stop
 	// TODO: logging?
 }
@@ -150,7 +153,15 @@ func (c *controllerImpl) rootController(obj *metav1.ObjectMeta) (metav1.OwnerRef
 						return rootRef, true
 					}
 				}
+			case "ReplicationController":
+				indexer := c.rc.GetIndexer()
+				if rc, found := c.objectMeta(indexer, key(obj.Namespace, ref.Name)); found {
+					if rootRef, ok := c.rootController(rc); ok {
+						return rootRef, true
+					}
+				}
 			}
+
 			return ref, true
 		}
 	}
@@ -163,6 +174,8 @@ func (c *controllerImpl) objectMeta(keyGetter cache.KeyGetter, key string) (*met
 		return nil, false
 	}
 	switch v := item.(type) {
+	case *v1.ReplicationController:
+		return &v.ObjectMeta, true
 	case *appsv1.ReplicaSet:
 		return &v.ObjectMeta, true
 	}

--- a/mixer/adapter/kubernetesenv/cache_test.go
+++ b/mixer/adapter/kubernetesenv/cache_test.go
@@ -102,8 +102,8 @@ func TestClusterInfoCache_Workload_ReplicationController(t *testing.T) {
 
 	for _, v := range tests {
 		t.Run(v.name, func(tt *testing.T) {
-			c := newCacheController(clientset, 0, test.NewEnv(t))
 			stopCh := make(chan struct{})
+			c := newCacheController(clientset, 0, test.NewEnv(t), stopCh)
 			defer close(stopCh)
 			go c.Run(stopCh)
 			if !cache.WaitForCacheSync(stopCh, c.HasSynced) {

--- a/mixer/adapter/kubernetesenv/cache_test.go
+++ b/mixer/adapter/kubernetesenv/cache_test.go
@@ -63,3 +63,57 @@ func TestClusterInfoCache_Pod(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterInfoCache_Workload_ReplicationController(t *testing.T) {
+	controller := true
+	clientset := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-pod",
+				OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+					Controller: &controller,
+					Kind:       "ReplicationController",
+					Name:       "test-rc",
+				}},
+			},
+			Status: v1.PodStatus{PodIP: "10.1.10.1"},
+		},
+		&v1.ReplicationController{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "test-rc",
+				OwnerReferences: []metav1.OwnerReference{metav1.OwnerReference{
+					Controller: &controller,
+					Kind:       "DeploymentConfig",
+					Name:       "test-dc",
+				}},
+			},
+		},
+	)
+
+	tests := []struct {
+		name     string
+		pod      string
+		workload string
+	}{
+		{"Workload from ReplicationController", "default/test-pod", "test-dc"},
+	}
+
+	for _, v := range tests {
+		t.Run(v.name, func(tt *testing.T) {
+			c := newCacheController(clientset, 0, test.NewEnv(t))
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			go c.Run(stopCh)
+			if !cache.WaitForCacheSync(stopCh, c.HasSynced) {
+				tt.Fatal("Failed to sync")
+			}
+			pod, _ := c.Pod(v.pod)
+			workload, _ := c.Workload(pod)
+			if workload.name != v.workload {
+				tt.Errorf("GetWorkload() => (_, %s), wanted (_, %s)", workload.name, v.workload)
+			}
+		})
+	}
+}

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -357,6 +357,30 @@ func TestKubegen_Generate(t *testing.T) {
 	containerNameOut.SetDestinationWorkloadNamespace("testns")
 	containerNameOut.SetDestinationWorkloadUid("istio://testns/workloads/test-container-deployment")
 
+	ipToDeploymentConfigIn := &kubernetes_apa_tmpl.Instance{
+		SourceIp:       net.ParseIP("192.168.234.3"),
+		DestinationUid: "kubernetes://pod-deploymentconfig.testns",
+	}
+
+	ipToDeploymentConfigOut := kubernetes_apa_tmpl.NewOutput()
+	ipToDeploymentConfigOut.SetSourceLabels(map[string]string{"app": "ipAddr"})
+	ipToDeploymentConfigOut.SetSourceNamespace("testns")
+	ipToDeploymentConfigOut.SetSourcePodName("ip-svc-pod")
+	ipToDeploymentConfigOut.SetSourcePodUid("kubernetes://ip-svc-pod.testns")
+	ipToDeploymentConfigOut.SetSourcePodIp(net.ParseIP("192.168.234.3"))
+	ipToDeploymentConfigOut.SetSourceOwner("kubernetes://apis/apps/v1/namespaces/testns/deployments/test-deployment")
+	ipToDeploymentConfigOut.SetSourceWorkloadName("test-deployment")
+	ipToDeploymentConfigOut.SetSourceWorkloadNamespace("testns")
+	ipToDeploymentConfigOut.SetSourceWorkloadUid("istio://testns/workloads/test-deployment")
+	ipToDeploymentConfigOut.SetDestinationPodName("pod-deploymentconfig")
+	ipToDeploymentConfigOut.SetDestinationNamespace("testns")
+	ipToDeploymentConfigOut.SetDestinationPodUid("kubernetes://pod-deploymentconfig.testns")
+	ipToDeploymentConfigOut.SetDestinationOwner("kubernetes://apis/apps.openshift.io/v1/namespaces/testns/deploymentconfigs/test-deploymentconfig")
+	ipToDeploymentConfigOut.SetDestinationLabels(map[string]string{"app": "some-app"})
+	ipToDeploymentConfigOut.SetDestinationWorkloadName("test-deploymentconfig")
+	ipToDeploymentConfigOut.SetDestinationWorkloadNamespace("testns")
+	ipToDeploymentConfigOut.SetDestinationWorkloadUid("istio://testns/workloads/test-deploymentconfig")
+
 	tests := []struct {
 		name   string
 		inputs *kubernetes_apa_tmpl.Instance
@@ -372,6 +396,7 @@ func TestKubegen_Generate(t *testing.T) {
 		{"replicasets with no deployments", replicasetToReplicaSetIn, replicaSetToReplicaSetOut, conf},
 		{"not-k8s", notKubernetesIn, kubernetes_apa_tmpl.NewOutput(), conf},
 		{"ip-svc-pod to pod-with-container", containerNameIn, containerNameOut, conf},
+		{"ip-svc-pod to deploymentconfig", ipToDeploymentConfigIn, ipToDeploymentConfigOut, conf},
 	}
 
 	for _, v := range tests {
@@ -545,6 +570,21 @@ var k8sobjs = []runtime.Object{
 					Controller: &trueVar,
 					Kind:       "Deployment",
 					Name:       "test-container-deployment",
+				},
+			},
+		},
+	},
+	// replicationcontrollers
+	&v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-replicationcontroller-with-deploymentconfig",
+			Namespace: "testns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps.openshift.io/v1",
+					Controller: &trueVar,
+					Kind:       "DeploymentConfig",
+					Name:       "test-deploymentconfig",
 				},
 			},
 		},
@@ -735,6 +775,21 @@ var k8sobjs = []runtime.Object{
 			Containers: []v1.Container{
 				{Name: "container1", Ports: []v1.ContainerPort{{ContainerPort: 123}, {ContainerPort: 234}}},
 				{Name: "container2", Ports: []v1.ContainerPort{{ContainerPort: 80}}},
+			},
+		},
+	},
+	&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-deploymentconfig",
+			Namespace: "testns",
+			Labels:    map[string]string{"app": "some-app"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "core/v1",
+					Controller: &trueVar,
+					Kind:       "ReplicationController",
+					Name:       "test-replicationcontroller-with-deploymentconfig",
+				},
 			},
 		},
 	},


### PR DESCRIPTION
- ReplicationController can be created from higher controllers as DeploymentConfig
- Prometheus adds an RC identifier as workload, so Kiali can not resolve correctly nodes generated from DeploymentConfig controllers

This PR is similar as https://github.com/istio/istio/pull/9061 but for master branch.