### PR TITLE
Do not check for services when generating cluster names

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -232,6 +232,10 @@ func GetDestinationCluster(destination *networking.Destination, service *model.S
 		if service != nil && len(service.Ports) == 1 {
 			port = service.Ports[0].Port
 		}
+		// Do not return blackhole cluster for service==nil case as there is a legitimate use case for
+		// calling this function with nil service: to route to a pre-defined statically configured cluster
+		// declared as part of the bootstrap.
+		// If blackhole cluster is needed, do the check on the caller side. See gateway and tls.go for examples.
 	}
 
 	return model.BuildSubsetKey(model.TrafficDirectionOutbound, destination.Subset, model.Hostname(destination.Host), port)


### PR DESCRIPTION
Needed for multi-cluster over gateway and in general to allow
users to define custom clusters in the static bootstrap config.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>