### PR TITLE
add opencensus metrics to MCP client

### DIFF
--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -75,6 +75,6 @@ func main() {
 
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
 
-	c := client.New(cl, typeNames, u, *id, map[string]string{}, client.NewStatsContext("mcpc/"))
+	c := client.New(cl, typeNames, u, *id, map[string]string{}, client.NewStatsContext("mcpc"))
 	c.Run(context.Background())
 }

--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -75,6 +75,6 @@ func main() {
 
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
 
-	c := client.New(cl, typeNames, u, *id, map[string]string{})
+	c := client.New(cl, typeNames, u, *id, map[string]string{}, client.NewStatsContext("mcpc/"))
 	c.Run(context.Background())
 }

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -185,7 +185,7 @@ func (b *backend) Init(kinds []string) error {
 	}
 
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
-	c := client.New(cl, typeURLs, b, mixerNodeID, map[string]string{}, client.NewStatsContext("mixer/"))
+	c := client.New(cl, typeURLs, b, mixerNodeID, map[string]string{}, client.NewStatsContext("mixer"))
 	configz.Register(c)
 
 	b.state = &state{

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -185,7 +185,7 @@ func (b *backend) Init(kinds []string) error {
 	}
 
 	cl := mcp.NewAggregatedMeshConfigServiceClient(conn)
-	c := client.New(cl, typeURLs, b, mixerNodeID, map[string]string{})
+	c := client.New(cl, typeURLs, b, mixerNodeID, map[string]string{}, client.NewStatsContext("mixer/"))
 	configz.Register(c)
 
 	b.state = &state{

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -477,7 +477,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			return err
 		}
 		cl := mcpapi.NewAggregatedMeshConfigServiceClient(conn)
-		mcpClient := mcpclient.New(cl, supportedTypes, mcpController, clientNodeID, map[string]string{}, mcpclient.NewStatsContext("pilot/"))
+		mcpClient := mcpclient.New(cl, supportedTypes, mcpController, clientNodeID, map[string]string{}, mcpclient.NewStatsContext("pilot"))
 		configz.Register(mcpClient)
 
 		clients = append(clients, mcpClient)

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -477,7 +477,7 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			return err
 		}
 		cl := mcpapi.NewAggregatedMeshConfigServiceClient(conn)
-		mcpClient := mcpclient.New(cl, supportedTypes, mcpController, clientNodeID, map[string]string{})
+		mcpClient := mcpclient.New(cl, supportedTypes, mcpController, clientNodeID, map[string]string{}, mcpclient.NewStatsContext("pilot/"))
 		configz.Register(mcpClient)
 
 		clients = append(clients, mcpClient)

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -124,7 +124,7 @@ type Reporter interface {
 	RecordRecvError(err error, code codes.Code)
 	RecordRequestAck(typeURL string)
 	RecordRequestNack(typeURL string, err error)
-	RecordReconnect()
+	RecordStreamCreateSuccess()
 }
 
 func (r *recentRequestsJournal) record(req *mcp.MeshConfigRequest) { // nolint:interfacer
@@ -281,7 +281,7 @@ func (c *Client) Run(ctx context.Context) {
 			var err error
 			if c.stream, err = c.client.StreamAggregatedResources(ctx); err == nil {
 				// This technically counts the initial connection as well.
-				c.reporter.RecordReconnect()
+				c.reporter.RecordStreamCreateSuccess()
 				log.Info("New MCP stream created")
 				break
 			}

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -98,7 +98,7 @@ type Client struct {
 
 	journal  recentRequestsJournal
 	metadata map[string]string
-	reporter Reporter
+	reporter MetricReporter
 }
 
 // RecentRequestInfo is metadata about a request that the client has sent.
@@ -118,8 +118,8 @@ type recentRequestsJournal struct {
 	items      []RecentRequestInfo
 }
 
-// Reporter is used to report metrics for an MCP server.
-type Reporter interface {
+// MetricReporter is used to report metrics for an MCP client.
+type MetricReporter interface {
 	RecordSendError(err error, code codes.Code)
 	RecordRecvError(err error, code codes.Code)
 	RecordRequestAck(typeURL string)
@@ -153,7 +153,7 @@ func (r *recentRequestsJournal) snapshot() []RecentRequestInfo {
 }
 
 // New creates a new instance of the MCP client for the specified message types.
-func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedTypeURLs []string, updater Updater, id string, metadata map[string]string, reporter Reporter) *Client { // nolint: lll
+func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedTypeURLs []string, updater Updater, id string, metadata map[string]string, reporter MetricReporter) *Client { // nolint: lll
 	clientInfo := &mcp.Client{
 		Id: id,
 		Metadata: &types.Struct{

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -280,7 +280,6 @@ func (c *Client) Run(ctx context.Context) {
 			log.Info("(re)trying to establish new MCP stream")
 			var err error
 			if c.stream, err = c.client.StreamAggregatedResources(ctx); err == nil {
-				// This technically counts the initial connection as well.
 				c.reporter.RecordStreamCreateSuccess()
 				log.Info("New MCP stream created")
 				break

--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 type testStream struct {
@@ -277,7 +278,7 @@ func makeResponse(typeURL, version, nonce string, envelopes ...*mcp.Envelope) *m
 func TestSingleTypeCases(t *testing.T) {
 	ts := newTestStream()
 
-	c := New(ts, supportedTypeUrls, ts, key, metadata)
+	c := New(ts, supportedTypeUrls, ts, key, metadata, mcptestmon.NewInMemoryClientStatsContext())
 	ctx, cancelClient := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup
@@ -475,7 +476,7 @@ func TestSingleTypeCases(t *testing.T) {
 func TestReconnect(t *testing.T) {
 	ts := newTestStream()
 
-	c := New(ts, []string{fakeType0TypeURL}, ts, key, metadata)
+	c := New(ts, []string{fakeType0TypeURL}, ts, key, metadata, mcptestmon.NewInMemoryClientStatsContext())
 	ctx, cancelClient := context.WithCancel(context.Background())
 
 	var wg sync.WaitGroup

--- a/pkg/mcp/client/monitoring.go
+++ b/pkg/mcp/client/monitoring.go
@@ -1,0 +1,164 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"strings"
+	"google.golang.org/grpc/codes"
+	"strconv"
+	"context"
+)
+
+const (
+	typeURL   = "typeURL"
+	errorCode = "code"
+	errorStr  = "error"
+)
+
+type StatsContext struct {
+	requestAcksTotal   *stats.Int64Measure
+	requestNacksTotal  *stats.Int64Measure
+	sendFailuresTotal  *stats.Int64Measure
+	recvFailuresTotal  *stats.Int64Measure
+	reconnectionsTotal *stats.Int64Measure
+}
+
+func (s *StatsContext) recordError(err error, code codes.Code, stat *stats.Int64Measure) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(ErrorTag, err.Error()),
+		tag.Insert(ErrorCodeTag, strconv.FormatUint(uint64(code), 10)))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %v", ctxErr)
+		return
+	}
+	stats.Record(ctx, stat.M(1))
+}
+
+// RecordSendError records an error during a network send with its error
+// string and code.
+func (s *StatsContext) RecordSendError(err error, code codes.Code) {
+	s.recordError(err, code, s.sendFailuresTotal)
+}
+
+// RecordRecvError records an error during a network recv with its error
+// string and code.
+func (s *StatsContext) RecordRecvError(err error, code codes.Code) {
+	s.recordError(err, code, s.recvFailuresTotal)
+}
+
+// RecordRequestAck records an ACK message for a type URL on a connection.
+func (s *StatsContext) RecordRequestAck(typeURL string) {
+	ctx, ctxErr := tag.New(context.Background(), tag.Insert(TypeURLTag, typeURL))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %v", ctxErr)
+		return
+	}
+	stats.Record(ctx, s.requestAcksTotal.M(1))
+}
+
+// RecordRequestNack records a NACK message for a type URL on a connection.
+func (s *StatsContext) RecordRequestNack(typeURL string, err error) {
+	ctx, ctxErr := tag.New(context.Background(),
+		tag.Insert(TypeURLTag, typeURL),
+		tag.Insert(ErrorTag, err.Error()))
+	if ctxErr != nil {
+		scope.Errorf("MCP: error creating monitoring context. %v", ctxErr)
+		return
+	}
+	stats.Record(ctx, s.requestNacksTotal.M(1))
+}
+
+func (s *StatsContext) RecordReconnect() {
+	stats.Record(context.Background(), s.reconnectionsTotal.M(1))
+}
+
+func NewStatsContext(prefix string) *StatsContext {
+	if len(prefix) == 0 {
+		panic("must specify prefix for MCP client monitoring.")
+	} else if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	ctx := &StatsContext{
+		requestAcksTotal: stats.Int64(
+			prefix+"mcp/client/request_acks",
+			"The number of request acks sent by the client.",
+			stats.UnitDimensionless),
+
+		requestNacksTotal: stats.Int64(
+			prefix+"mcp/client/request_nacks",
+			"The number of request nacks sent by the client.",
+			stats.UnitDimensionless),
+
+		sendFailuresTotal: stats.Int64(
+			prefix+"mcp/client/send_failures",
+			"The number of send failures in the client.",
+			stats.UnitDimensionless),
+
+		recvFailuresTotal: stats.Int64(
+			prefix+"mcp/client/recv_failures",
+			"The number of recv failures in the client.",
+			stats.UnitDimensionless),
+
+		reconnectionsTotal: stats.Int64(
+			prefix+"mcp/client/reconnections",
+			"The number of times the client has reconnected.",
+			stats.UnitDimensionless),
+	}
+
+	err := view.Register(
+		newView(ctx.requestAcksTotal, []tag.Key{TypeURLTag}, view.Count()),
+		newView(ctx.requestNacksTotal, []tag.Key{ErrorTag, TypeURLTag}, view.Count()),
+		newView(ctx.sendFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+		newView(ctx.recvFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
+		newView(ctx.reconnectionsTotal, []tag.Key{}, view.Count()),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+	return ctx
+}
+
+var (
+	TypeURLTag   tag.Key
+	ErrorCodeTag tag.Key
+	ErrorTag     tag.Key
+)
+
+func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
+	return &view.View{
+		Name:        measure.Name(),
+		Description: measure.Description(),
+		Measure:     measure,
+		TagKeys:     keys,
+		Aggregation: aggregation,
+	}
+}
+
+func init() {
+	var err error
+	if TypeURLTag, err = tag.NewKey(typeURL); err != nil {
+		panic(err)
+	}
+	if ErrorCodeTag, err = tag.NewKey(errorCode); err != nil {
+		panic(err)
+	}
+	if ErrorTag, err = tag.NewKey(errorStr); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/mcp/client/monitoring.go
+++ b/pkg/mcp/client/monitoring.go
@@ -31,11 +31,11 @@ const (
 )
 
 type StatsContext struct {
-	requestAcksTotal   *stats.Int64Measure
-	requestNacksTotal  *stats.Int64Measure
-	sendFailuresTotal  *stats.Int64Measure
-	recvFailuresTotal  *stats.Int64Measure
-	reconnectionsTotal *stats.Int64Measure
+	requestAcksTotal         *stats.Int64Measure
+	requestNacksTotal        *stats.Int64Measure
+	sendFailuresTotal        *stats.Int64Measure
+	recvFailuresTotal        *stats.Int64Measure
+	streamCreateSuccessTotal *stats.Int64Measure
 }
 
 func (s *StatsContext) recordError(err error, code codes.Code, stat *stats.Int64Measure) {
@@ -83,8 +83,8 @@ func (s *StatsContext) RecordRequestNack(typeURL string, err error) {
 	stats.Record(ctx, s.requestNacksTotal.M(1))
 }
 
-func (s *StatsContext) RecordReconnect() {
-	stats.Record(context.Background(), s.reconnectionsTotal.M(1))
+func (s *StatsContext) RecordStreamCreateSuccess() {
+	stats.Record(context.Background(), s.streamCreateSuccessTotal.M(1))
 }
 
 func NewStatsContext(prefix string) *StatsContext {
@@ -114,7 +114,7 @@ func NewStatsContext(prefix string) *StatsContext {
 			"The number of recv failures in the client.",
 			stats.UnitDimensionless),
 
-		reconnectionsTotal: stats.Int64(
+		streamCreateSuccessTotal: stats.Int64(
 			prefix+"mcp/client/reconnections",
 			"The number of times the client has reconnected.",
 			stats.UnitDimensionless),
@@ -125,7 +125,7 @@ func NewStatsContext(prefix string) *StatsContext {
 		newView(ctx.requestNacksTotal, []tag.Key{ErrorTag, TypeURLTag}, view.Count()),
 		newView(ctx.sendFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
 		newView(ctx.recvFailuresTotal, []tag.Key{ErrorCodeTag, ErrorTag}, view.Count()),
-		newView(ctx.reconnectionsTotal, []tag.Key{}, view.Count()),
+		newView(ctx.streamCreateSuccessTotal, []tag.Key{}, view.Count()),
 	)
 
 	if err != nil {

--- a/pkg/mcp/client/monitoring.go
+++ b/pkg/mcp/client/monitoring.go
@@ -15,13 +15,14 @@
 package client
 
 import (
+	"context"
+	"strconv"
+	"strings"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"strings"
 	"google.golang.org/grpc/codes"
-	"strconv"
-	"context"
 )
 
 const (
@@ -30,6 +31,7 @@ const (
 	errorStr  = "error"
 )
 
+// StatsContext enables metric collection backed by OpenCensus.
 type StatsContext struct {
 	requestAcksTotal         *stats.Int64Measure
 	requestNacksTotal        *stats.Int64Measure
@@ -83,10 +85,14 @@ func (s *StatsContext) RecordRequestNack(typeURL string, err error) {
 	stats.Record(ctx, s.requestNacksTotal.M(1))
 }
 
+// RecordStreamCreateSuccess records a successful stream connection.
 func (s *StatsContext) RecordStreamCreateSuccess() {
 	stats.Record(context.Background(), s.streamCreateSuccessTotal.M(1))
 }
 
+// NewStatsContext creates a new context for recording metrics using
+// OpenCensus. The specified prefix is prepended to all metric names and must
+// be a non-empty string.
 func NewStatsContext(prefix string) *StatsContext {
 	if len(prefix) == 0 {
 		panic("must specify prefix for MCP client monitoring.")
@@ -135,9 +141,12 @@ func NewStatsContext(prefix string) *StatsContext {
 }
 
 var (
-	TypeURLTag   tag.Key
+	// TypeURLTag holds the type URL for the context.
+	TypeURLTag tag.Key
+	// ErrorCodeTag holds the gRPC error code for the context.
 	ErrorCodeTag tag.Key
-	ErrorTag     tag.Key
+	// ErrorTag holds the error string for the context.
+	ErrorTag tag.Key
 )
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {

--- a/pkg/mcp/configz/configz_test.go
+++ b/pkg/mcp/configz/configz_test.go
@@ -33,6 +33,7 @@ import (
 	"istio.io/istio/pkg/mcp/client"
 	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/istio/pkg/mcp/testing"
+	"istio.io/istio/pkg/mcp/testing/monitoring"
 )
 
 type updater struct {
@@ -56,7 +57,7 @@ func TestConfigZ(t *testing.T) {
 
 	u := &updater{}
 	clnt := mcp.NewAggregatedMeshConfigServiceClient(cc)
-	cl := client.New(clnt, []string{"type.googleapis.com/google.protobuf.Empty"}, u, snapshot.DefaultGroup, map[string]string{"foo": "bar"})
+	cl := client.New(clnt, []string{"type.googleapis.com/google.protobuf.Empty"}, u, snapshot.DefaultGroup, map[string]string{"foo": "bar"}, mcptestmon.NewInMemoryClientStatsContext())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cl.Run(ctx)

--- a/pkg/mcp/configz/configz_test.go
+++ b/pkg/mcp/configz/configz_test.go
@@ -57,7 +57,9 @@ func TestConfigZ(t *testing.T) {
 
 	u := &updater{}
 	clnt := mcp.NewAggregatedMeshConfigServiceClient(cc)
-	cl := client.New(clnt, []string{"type.googleapis.com/google.protobuf.Empty"}, u, snapshot.DefaultGroup, map[string]string{"foo": "bar"}, mcptestmon.NewInMemoryClientStatsContext())
+	cl := client.New(clnt, []string{"type.googleapis.com/google.protobuf.Empty"}, u,
+		snapshot.DefaultGroup, map[string]string{"foo": "bar"},
+		mcptestmon.NewInMemoryClientStatsContext())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cl.Run(ctx)

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -104,6 +104,8 @@ type nackKey struct {
 	typeURL string
 }
 
+// InMemoryClientStatsContext enables MCP client metric collection which is
+// stored in memory for testing purposes.
 type InMemoryClientStatsContext struct {
 	mutex                    sync.Mutex
 	RequestAcksTotal         map[string]int64
@@ -143,6 +145,7 @@ func (s *InMemoryClientStatsContext) RecordRequestNack(typeURL string, err error
 	s.mutex.Unlock()
 }
 
+// RecordStreamCreateSuccess records a successful stream connection.
 func (s *InMemoryClientStatsContext) RecordStreamCreateSuccess() {
 	s.mutex.Lock()
 	s.StreamCreateSuccessTotal++

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -33,13 +33,13 @@ type requestKey struct {
 // InMemoryServerStatsContext enables MCP server metric collection which is
 // stored in memory for testing purposes.
 type InMemoryServerStatsContext struct {
+	mutex             sync.Mutex
 	ClientsTotal      int64
 	RequestSizesBytes map[requestKey][]int64
 	RequestAcksTotal  map[requestKey]int64
 	RequestNacksTotal map[requestKey]int64
 	SendFailuresTotal map[errorCodeKey]int64
 	RecvFailuresTotal map[errorCodeKey]int64
-	mutex             *sync.Mutex
 }
 
 // SetClientsTotal updates the current client count to the given argument.
@@ -96,7 +96,6 @@ func NewInMemoryServerStatsContext() *InMemoryServerStatsContext {
 		RequestNacksTotal: make(map[requestKey]int64),
 		SendFailuresTotal: make(map[errorCodeKey]int64),
 		RecvFailuresTotal: make(map[errorCodeKey]int64),
-		mutex:             &sync.Mutex{},
 	}
 }
 
@@ -106,12 +105,12 @@ type nackKey struct {
 }
 
 type InMemoryClientStatsContext struct {
+	mutex              sync.Mutex
 	RequestAcksTotal   map[string]int64
 	RequestNacksTotal  map[nackKey]int64
 	SendFailuresTotal  map[errorCodeKey]int64
 	RecvFailuresTotal  map[errorCodeKey]int64
 	ReconnectionsTotal int64
-	mutex              *sync.Mutex
 }
 
 // RecordSendError records an error during a network send with its error
@@ -158,6 +157,5 @@ func NewInMemoryClientStatsContext() *InMemoryClientStatsContext {
 		RequestNacksTotal: make(map[nackKey]int64),
 		SendFailuresTotal: make(map[errorCodeKey]int64),
 		RecvFailuresTotal: make(map[errorCodeKey]int64),
-		mutex:             &sync.Mutex{},
 	}
 }

--- a/pkg/mcp/testing/monitoring/reporter.go
+++ b/pkg/mcp/testing/monitoring/reporter.go
@@ -105,12 +105,12 @@ type nackKey struct {
 }
 
 type InMemoryClientStatsContext struct {
-	mutex              sync.Mutex
-	RequestAcksTotal   map[string]int64
-	RequestNacksTotal  map[nackKey]int64
-	SendFailuresTotal  map[errorCodeKey]int64
-	RecvFailuresTotal  map[errorCodeKey]int64
-	ReconnectionsTotal int64
+	mutex                    sync.Mutex
+	RequestAcksTotal         map[string]int64
+	RequestNacksTotal        map[nackKey]int64
+	SendFailuresTotal        map[errorCodeKey]int64
+	RecvFailuresTotal        map[errorCodeKey]int64
+	StreamCreateSuccessTotal int64
 }
 
 // RecordSendError records an error during a network send with its error
@@ -143,9 +143,9 @@ func (s *InMemoryClientStatsContext) RecordRequestNack(typeURL string, err error
 	s.mutex.Unlock()
 }
 
-func (s *InMemoryClientStatsContext) RecordReconnect() {
+func (s *InMemoryClientStatsContext) RecordStreamCreateSuccess() {
 	s.mutex.Lock()
-	s.ReconnectionsTotal++
+	s.StreamCreateSuccessTotal++
 	s.mutex.Unlock()
 }
 


### PR DESCRIPTION
This largely follows the same structure as the server metrics. Part of #3311.