### PR TITLE
set ChannelCredentials to be LocalCredentials in SdsSecretConfig

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -69,6 +69,11 @@ func ConstructSdsSecretConfig(serviceAccount string, sdsUdsPath string) *auth.Sd
 								GoogleGrpc: &core.GrpcService_GoogleGrpc{
 									TargetUri:  sdsUdsPath,
 									StatPrefix: SDSStatPrefix,
+									ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+										CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+											LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+										},
+									},
 									CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
 										&core.GrpcService_GoogleGrpc_CallCredentials{
 											CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -108,6 +108,11 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 										GoogleGrpc: &core.GrpcService_GoogleGrpc{
 											TargetUri:  "/tmp/sdsuds.sock",
 											StatPrefix: SDSStatPrefix,
+											ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+												CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+													LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+												},
+											},
 											CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
 												&core.GrpcService_GoogleGrpc_CallCredentials{
 													CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -670,6 +670,11 @@ func TestOnInboundFilterChains(t *testing.T) {
 															GoogleGrpc: &core.GrpcService_GoogleGrpc{
 																TargetUri:  "/tmp/sdsuds.sock",
 																StatPrefix: model.SDSStatPrefix,
+																ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+																	CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+																		LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+																	},
+																},
 																CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
 																	&core.GrpcService_GoogleGrpc_CallCredentials{
 																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

recently envoy add the constraint that ```ChannelCredentials``` needs to set to ```LocalCredentials``` in SdsSecretConfig gRPC setting, so that envoy could pass through oauth token to node agent. 

