### PR TITLE
pilot: add support for weighted TCP/TLS clusters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1566,7 +1566,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f3a214ab14a95cad67943ac834ceecd5b54ca693dc4ff94c95dfae6d5607d556"
+  digest = "1:b5469aaa184eec3b2995629d48dd8621f2ed25564728425762df037737cd03c7"
   name = "istio.io/api"
   packages = [
     "authentication/v1alpha1",
@@ -1582,7 +1582,7 @@
     "rbac/v1alpha1",
   ]
   pruneopts = "T"
-  revision = "63c5c7780fbba17bc03f00fa480f1bc4537e7fe7"
+  revision = "2acfd9afd0638131e3664f0e4f3ee71b3fd21663"
 
 [[projects]]
   digest = "1:1e22c9d898674522a6155619142b4691dd225441168faa2b5a4eb88ee327a243"

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1524,10 +1524,10 @@ func validateRouteDestinations(weights []*networking.RouteDestination) (errs err
 		}
 		errs = appendErrors(errs, validateDestination(weight.Destination))
 		errs = appendErrors(errs, ValidatePercent(weight.Weight))
+		if len(weights) > 1 && weight.Weight < 1 {
+			errs = multierror.Append(errs, errors.New("positive weight is required"))
+		}
 		totalWeight += weight.Weight
-	}
-	if len(weights) > 1 && totalWeight != 100 {
-		errs = appendErrors(errs, fmt.Errorf("total destination weight %v != 100", totalWeight))
 	}
 	return
 }

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1350,15 +1350,11 @@ func validateTLSRoute(tls *networking.TLSRoute, context *networking.VirtualServi
 	if tls == nil {
 		return nil
 	}
-
 	if len(tls.Match) == 0 {
 		errs = appendErrors(errs, errors.New("TLS route must have at least one match condition"))
 	}
 	for _, match := range tls.Match {
 		errs = appendErrors(errs, validateTLSMatch(match, context))
-	}
-	if len(tls.Route) != 1 {
-		errs = appendErrors(errs, errors.New("TLS route must have exactly one destination"))
 	}
 	errs = appendErrors(errs, validateRouteDestinations(tls.Route))
 	return
@@ -1410,9 +1406,6 @@ func validateTCPRoute(tcp *networking.TCPRoute) (errs error) {
 	for _, match := range tcp.Match {
 		errs = appendErrors(errs, validateTCPMatch(match))
 	}
-	if len(tcp.Route) != 1 {
-		errs = appendErrors(errs, errors.New("TCP route must have exactly one destination"))
-	}
 	errs = appendErrors(errs, validateRouteDestinations(tcp.Route))
 	return
 }
@@ -1421,7 +1414,6 @@ func validateTCPMatch(match *networking.L4MatchAttributes) (errs error) {
 	for _, destinationSubnet := range match.DestinationSubnets {
 		errs = appendErrors(errs, ValidateIPv4Subnet(destinationSubnet))
 	}
-
 	if len(match.SourceSubnet) > 0 {
 		errs = appendErrors(errs, ValidateIPv4Subnet(match.SourceSubnet))
 	}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -500,7 +500,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, env *model.Envir
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
 			if l4MultiMatch(tcp.Match, server, gatewaysForWorkload) {
-				return buildOutboundNetworkFilters(env, node, tcp.Route, push, port)
+				return buildOutboundNetworkFilters(env, node, tcp.Route, push, port, spec.ConfigMeta)
 			}
 		}
 	}
@@ -542,7 +542,7 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, env *model.Envir
 					filterChains = append(filterChains, &filterChainOpts{
 						sniHosts:       match.SniHosts,
 						tlsContext:     nil, // NO TLS context because this is passthrough
-						networkFilters: buildOutboundNetworkFilters(env, node, tls.Route, push, port),
+						networkFilters: buildOutboundNetworkFilters(env, node, tls.Route, push, port, spec.ConfigMeta),
 					})
 				}
 			}

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -472,7 +472,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayTCPFilterChainOpts(
 
 // buildGatewayNetworkFiltersFromTCPRoutes builds tcp proxy routes for all VirtualServices with TCP blocks.
 // It first obtains all virtual services bound to the set of Gateways for this workload, filters them by this
-// server's port and hostnames, and produces network filters for each destination from the filtered services
+// server's port and hostnames, and produces network filters for each destination from the filtered services.
 func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, env *model.Environment, push *model.PushContext, server *networking.Server,
 	gatewaysForWorkload map[string]bool) []listener.Filter {
 	port := &model.Port{
@@ -487,7 +487,6 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, env *model.Envir
 	}
 
 	virtualServices := push.VirtualServices(gatewaysForWorkload)
-	var upstream *networking.Destination
 	for _, spec := range virtualServices {
 		vsvc := spec.Spec.(*networking.VirtualService)
 		matchingHosts := pickMatchingGatewayHosts(gatewayServerHosts, vsvc.Hosts)
@@ -501,9 +500,7 @@ func buildGatewayNetworkFiltersFromTCPRoutes(node *model.Proxy, env *model.Envir
 		// based on the match port/server port and the gateway name
 		for _, tcp := range vsvc.Tcp {
 			if l4MultiMatch(tcp.Match, server, gatewaysForWorkload) {
-				upstream = tcp.Route[0].Destination // We pick first destination because TCP has no weighted cluster
-				clusterName := istio_route.GetDestinationCluster(upstream, push.ServiceByHostname[model.Hostname(upstream.Host)], int(server.Port.Number))
-				return buildOutboundNetworkFilters(env, node, clusterName, port)
+				return buildOutboundNetworkFilters(env, node, tcp.Route, push, port)
 			}
 		}
 	}
@@ -542,15 +539,10 @@ func buildGatewayNetworkFiltersFromTLSRoutes(node *model.Proxy, env *model.Envir
 			for _, match := range tls.Match {
 				if l4SingleMatch(convertTLSMatchToL4Match(match), server, gatewaysForWorkload) {
 					// the sni hosts in the match will become part of a filter chain match
-					// We ignore all the weighted destinations and pick the first one
-					// since TCP has no weighted cluster
-					upstream := tls.Route[0].Destination
-					clusterName := istio_route.GetDestinationCluster(upstream, push.ServiceByHostname[model.Hostname(upstream.Host)], int(server.Port.Number))
-
 					filterChains = append(filterChains, &filterChainOpts{
 						sniHosts:       match.SniHosts,
 						tlsContext:     nil, // NO TLS context because this is passthrough
-						networkFilters: buildOutboundNetworkFilters(env, node, clusterName, port),
+						networkFilters: buildOutboundNetworkFilters(env, node, tls.Route, push, port),
 					})
 				}
 			}

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -193,6 +193,30 @@ func TestRoutes(t *testing.T) {
 			expectedCount: map[string]int{"v1": 100, "v2": 0},
 			operation:     "",
 		},
+		{
+			testName:      "a->c[v2=100]_tcp_single",
+			description:   "routing tcp traffic from a to single dest c-v2",
+			config:        "virtualservice-route-tcp-weighted.yaml",
+			scheme:        "http",
+			src:           "a",
+			dst:           "c:90",
+			headerKey:     "",
+			headerVal:     "",
+			expectedCount: map[string]int{"v1": 0, "v2": 100},
+			operation:     "",
+		},
+		{
+			testName:      "b->c[v1=30,v2=70]_tcp_weighted",
+			description:   "routing 30 percent to c-v1, 70 percent to c-v2",
+			config:        "virtualservice-route-tcp-weighted.yaml",
+			scheme:        "http",
+			src:           "a",
+			dst:           "c:90",
+			headerKey:     "",
+			headerVal:     "",
+			expectedCount: map[string]int{"v1": 30, "v2": 70},
+			operation:     "",
+		},
 	}
 
 	t.Run("v1alpha3", func(t *testing.T) {

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -210,7 +210,7 @@ func TestRoutes(t *testing.T) {
 			description:   "routing 30 percent to c-v1, 70 percent to c-v2",
 			config:        "virtualservice-route-tcp-weighted.yaml",
 			scheme:        "http",
-			src:           "a",
+			src:           "b",
 			dst:           "c:90",
 			headerKey:     "",
 			headerVal:     "",

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/virtualservice-route-tcp-weighted.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/virtualservice-route-tcp-weighted.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: default-route
+  namespace: istio-system
+spec:
+  hosts:
+  - c
+  tcp:
+  - match:
+    - port: 90
+      source_labels:
+        app: a
+    route:
+    - destination:
+        host: c
+        subset: v2
+        port:
+          number: 90
+  - match:
+    - port: 90
+    route:
+    - destination:
+        host: c
+        subset: v1
+        port:
+          number: 90
+      weight: 15
+    - destination:
+        host: c
+        subset: v2
+        port:
+          number: 90
+      weight: 35

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/virtualservice-route-tcp-weighted.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/virtualservice-route-tcp-weighted.yaml
@@ -25,10 +25,10 @@ spec:
         subset: v1
         port:
           number: 90
-      weight: 15
+      weight: 30
     - destination:
         host: c
         subset: v2
         port:
           number: 90
-      weight: 35
+      weight: 70

--- a/vendor/istio.io/api/networking/v1alpha3/istio.networking.v1alpha3.pb.html
+++ b/vendor/istio.io/api/networking/v1alpha3/istio.networking.v1alpha3.pb.html
@@ -2402,9 +2402,8 @@ to which the request/connection should be forwarded to.</p>
 <td><code>int32</code></td>
 <td>
 <p>REQUIRED. The proportion of traffic to be forwarded to the service
-version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-If there is only one destination in a rule, the weight value is assumed to
-be 100.</p>
+version. If there is only one destination in a rule, all traffic will be
+routed to it irrespective of the weight.</p>
 
 </td>
 </tr>

--- a/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.go
+++ b/vendor/istio.io/api/networking/v1alpha3/virtual_service.pb.go
@@ -934,9 +934,8 @@ type RouteDestination struct {
 	// to which the request/connection should be forwarded to.
 	Destination *Destination `protobuf:"bytes,1,opt,name=destination" json:"destination,omitempty"`
 	// REQUIRED. The proportion of traffic to be forwarded to the service
-	// version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-	// If there is only one destination in a rule, the weight value is assumed to
-	// be 100.
+	// version. If there is only one destination in a rule, all traffic will be
+	// routed to it irrespective of the weight.
 	Weight int32 `protobuf:"varint,2,opt,name=weight,proto3" json:"weight,omitempty"`
 }
 

--- a/vendor/istio.io/api/networking/v1alpha3/virtual_service.proto
+++ b/vendor/istio.io/api/networking/v1alpha3/virtual_service.proto
@@ -682,9 +682,8 @@ message RouteDestination {
   Destination destination = 1;
 
   // REQUIRED. The proportion of traffic to be forwarded to the service
-  // version. (0-100). Sum of weights across destinations SHOULD BE == 100.
-  // If there is only one destination in a rule, the weight value is assumed to
-  // be 100.
+  // version. If there is only one destination in a rule, all traffic will be
+  // routed to it irrespective of the weight.
   int32 weight = 2;
 }
 


### PR DESCRIPTION
This PR adds support for weighted clusters in TCP and TLS implementations as supported in Envoy.

Signed-off-by: Venil Noronha <veniln@vmware.com>