### PR TITLE
increase test timeout, use local manifest file

### DIFF
--- a/release/airflow/cloud_publish.template.json
+++ b/release/airflow/cloud_publish.template.json
@@ -9,10 +9,22 @@
       "args": [ "chmod", "u+x", "./istio_checkout_code.sh" ]
     },
     {
+      "volumes": [
+	{
+          "name": "buildoutput",
+          "path": "/output"
+	}
+      ],
       "name": "gcr.io/istio-testing/istio-builder:0.5.10",
       "args": [ "./istio_checkout_code.sh", "-b", "$_BRANCH", "-r", "$_GCS_RELEASE_TOOLS_PATH" ]
     },
     {
+      "volumes": [
+	{
+          "name": "buildoutput",
+          "path": "/output"
+	}
+      ],
       "name": "gcr.io/istio-testing/istio-builder:0.5.10",
       "dir": "go/src/istio.io/istio",
       "args": [ "./release/publish_release.sh", "-q", "-g", "$_GCS_SOURCE", "-l", "$_GCS_SECRET", "-m", "-o", "$_ORG", "-r", "$_REPO", "-v", "$_VER_STRING", "-c", "-d", "$_DOCKER_DST", "-i", "$_GCR_DST", "-h", "$_GCS_DST" ]

--- a/release/airflow/cloud_tag.template.json
+++ b/release/airflow/cloud_tag.template.json
@@ -9,10 +9,22 @@
       "args": [ "chmod", "u+x", "./istio_checkout_code.sh" ]
     },
     {
+      "volumes": [
+	{
+          "name": "buildoutput",
+          "path": "/output"
+	}
+      ],
       "name": "gcr.io/istio-testing/istio-builder:0.5.10",
       "args": [ "./istio_checkout_code.sh", "-b", "$_BRANCH", "-r", "$_GCS_RELEASE_TOOLS_PATH" ]
     },
     {
+      "volumes": [
+	{
+          "name": "buildoutput",
+          "path": "/output"
+	}
+      ],
       "name": "gcr.io/istio-testing/istio-builder:0.5.10",
       "dir": "go/src/istio.io/istio",
       "args": [ "./release/publish_release.sh", "-w", "-x", "-y", "-z", "-e", "$_USER_EMAIL", "-n", "$_USER_NAME", "-g", "$_GCS_SOURCE", "-l", "$_GCS_SECRET", "-m", "-o", "$_ORG", "-v", "$_VER_STRING" ]

--- a/release/airflow/cloud_test.template.json
+++ b/release/airflow/cloud_test.template.json
@@ -16,5 +16,5 @@
   "options": {
     "machineType": "N1_HIGHCPU_8"
   },
-  "timeout": "22h",
+  "timeout": "86400s",
 }

--- a/release/airflow/cloud_test.template.json
+++ b/release/airflow/cloud_test.template.json
@@ -16,5 +16,5 @@
   "options": {
     "machineType": "N1_HIGHCPU_8"
   },
-  "timeout": "3600s",
+  "timeout": "22h",
 }

--- a/release/publish_release.sh
+++ b/release/publish_release.sh
@@ -210,7 +210,8 @@ if [[ -n "${GCS_SOURCE}" ]]; then
     gsutil -m cp gs://"${GCS_SOURCE}"/deb/istio*.deb.sha256 "${UPLOAD_DIR}/deb/"
   fi
   if [[ "${DO_GITHUB_TAG}" == "true" || "${DO_GITHUB_REL}" == "true" ]]; then
-    gsutil -m cp "gs://${GCS_SOURCE}/manifest.xml" "${UPLOAD_DIR}/"
+    # previously copied to the /output dir by istio_checkout_code.sh
+    cp "/output/manifest.xml" "${UPLOAD_DIR}/"
   fi
   if [[ "${DO_GITHUB_REL}" == "true" ]]; then
     gsutil -m cp gs://"${GCS_SOURCE}"/docker.io/istio-*.zip "${UPLOAD_DIR}/"


### PR DESCRIPTION
increase test timeout to 22h instead of 1 hour
use local (previously copied) manifest file for publish_release script