### PR TITLE
Extend NetworkEndpoint with more fields to support workload oriented policy enforcement

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -291,6 +291,16 @@ type NetworkEndpoint struct {
 	// catalog.mystore.com)
 	ServicePort *Port
 
+	// Namespace for the workload on this network endpoint.
+	// For the platforms without namespace, it will be empty.
+	Namespace string
+
+	// Service account for the workload on this network endpoint.
+	ServiceAccount string
+
+	// Labels for the workload on this network endpoint.
+	Labels Labels
+
 	// Defines a platform-specific workload instance identifier (optional).
 	UID string
 }

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -298,7 +298,6 @@ type NetworkEndpoint struct {
 	UID string
 }
 
-
 // EndpointAttributes defines the service related attributes in a network endpoint.
 type EndpointAttributes struct {
 	// Namespace for the workload on this network endpoint.

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -286,11 +286,21 @@ type NetworkEndpoint struct {
 	// Ignored for `AddressFamilyUnix`.
 	Port int
 
+	// The service related attributes for this endpoint.
+	Attributes EndpointAttributes
+
 	// Port declaration from the service declaration This is the port for
 	// the service associated with this instance (e.g.,
 	// catalog.mystore.com)
 	ServicePort *Port
 
+	// Defines a platform-specific workload instance identifier (optional).
+	UID string
+}
+
+
+// EndpointAttributes defines the service related attributes in a network endpoint.
+type EndpointAttributes struct {
 	// Namespace for the workload on this network endpoint.
 	// For the platforms without namespace, it will be empty.
 	Namespace string
@@ -300,9 +310,6 @@ type NetworkEndpoint struct {
 
 	// Labels for the workload on this network endpoint.
 	Labels Labels
-
-	// Defines a platform-specific workload instance identifier (optional).
-	UID string
 }
 
 // Labels is a non empty set of arbitrary strings. Each version of a service can

--- a/pilot/pkg/serviceregistry/consul/conversion.go
+++ b/pilot/pkg/serviceregistry/consul/conversion.go
@@ -126,6 +126,10 @@ func convertInstance(instance *api.CatalogService) *model.ServiceInstance {
 			Address:     addr,
 			Port:        instance.ServicePort,
 			ServicePort: port,
+			Attributes: model.EndpointAttributes{
+				Namespace: model.IstioDefaultConfigNamespace,
+				Labels:    labels,
+			},
 		},
 		AvailabilityZone: instance.Datacenter,
 		Service: &model.Service{

--- a/pilot/pkg/serviceregistry/external/conversion.go
+++ b/pilot/pkg/serviceregistry/external/conversion.go
@@ -129,6 +129,9 @@ func convertEndpoint(service *model.Service, servicePort *networking.Port,
 			Family:      family,
 			Port:        int(instancePort),
 			ServicePort: convertPort(servicePort),
+			Attributes: model.EndpointAttributes{
+				Labels: endpoint.Labels,
+			},
 		},
 		// TODO AvailabilityZone, ServiceAccount
 		Service: service,

--- a/pilot/pkg/serviceregistry/external/conversion_test.go
+++ b/pilot/pkg/serviceregistry/external/conversion_test.go
@@ -247,6 +247,9 @@ func makeInstance(serviceEntry *networking.ServiceEntry, address string, port in
 				Port:     int(svcPort.Number),
 				Protocol: model.ParseProtocol(svcPort.Protocol),
 			},
+			Attributes: model.EndpointAttributes{
+				Labels: labels,
+			},
 		},
 		Labels: model.Labels(labels),
 	}

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -373,11 +373,12 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 					}
 
 					pod, exists := c.pods.getPodByIP(ea.IP)
-					az, sa, uid := "", "", ""
+					az, sa, uid, podNamespace := "", "", "", ""
 					if exists {
 						az, _ = c.GetPodAZ(pod)
 						sa = kubeToIstioServiceAccount(pod.Spec.ServiceAccountName, pod.GetNamespace(), c.domainSuffix)
 						uid = fmt.Sprintf("kubernetes://%s.%s", pod.Name, pod.Namespace)
+						podNamespace = pod.GetNamespace()
 					}
 
 					// identify the port by name. K8S EndpointPort uses the service port name
@@ -391,6 +392,11 @@ func (c *Controller) InstancesByPort(hostname model.Hostname, reqSvcPort int,
 									Port:        int(port.Port),
 									ServicePort: svcPortEntry,
 									UID:         uid,
+									Attributes: model.EndpointAttributes{
+										Namespace:      podNamespace,
+										ServiceAccount: sa,
+										Labels:         labels,
+									},
 								},
 								Service:          svc,
 								Labels:           labels,

--- a/pilot/pkg/serviceregistry/memory/discovery.go
+++ b/pilot/pkg/serviceregistry/memory/discovery.go
@@ -115,6 +115,10 @@ func MakeInstance(service *model.Service, port *model.Port, version int, az stri
 			Address:     MakeIP(service, version),
 			Port:        target,
 			ServicePort: port,
+			Attributes: model.EndpointAttributes{
+				Namespace: model.IstioDefaultConfigNamespace,
+				Labels:    map[string]string{"version": fmt.Sprintf("v%d", version)},
+			},
 		},
 		Service:          service,
 		Labels:           map[string]string{"version": fmt.Sprintf("v%d", version)},


### PR DESCRIPTION
Extend NetworkEndpoint with more fields to support workload oriented policy enforcement:
the namespace of the workload, the service account of the workload, and the labels
of the workload.