### PR TITLE
construct sdsconfig in cluster.tls_context

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -27,11 +27,14 @@ import (
 )
 
 const (
-	// CARootCertPath is the path of ca root cert that envoy uses to validate cert got from SDS service.
-	CARootCertPath = "/etc/istio/certs/ca-root-cert.pem"
-
 	// SDSStatPrefix is the human readable prefix to use when emitting statistics for the SDS service.
 	SDSStatPrefix = "sdsstat"
+
+	// SDSDefaultResourceName is the default name in sdsconfig, used for fetching normal key/cert.
+	SDSDefaultResourceName = "default"
+
+	// SDSRootResourceName is the sdsconfig name for root CA, used for fetching root cert.
+	SDSRootResourceName = "ROOTCA"
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.
@@ -52,13 +55,13 @@ func GetConsolidateAuthenticationPolicy(store IstioConfigStore, service *Service
 }
 
 // ConstructSdsSecretConfig constructs SDS Sececret Configuration.
-func ConstructSdsSecretConfig(serviceAccount string, sdsUdsPath string) *auth.SdsSecretConfig {
-	if serviceAccount == "" || sdsUdsPath == "" {
+func ConstructSdsSecretConfig(name string, sdsUdsPath string) *auth.SdsSecretConfig {
+	if name == "" || sdsUdsPath == "" {
 		return nil
 	}
 
 	return &auth.SdsSecretConfig{
-		Name: serviceAccount,
+		Name: name,
 		SdsConfig: &core.ConfigSource{
 			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 				ApiConfigSource: &core.ApiConfigSource{

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -471,6 +471,10 @@ func applyUpstreamTLSSettings(cluster *v2.Cluster, tls *networking.TLSSettings, 
 			Sni:              tls.Sni,
 		}
 
+		if sdsUdsPath == "" {
+			log.Debuga("SDS isn't enabled")
+		}
+
 		// Fallback to file mount secret instead of SDS if meshConfig.sdsUdsPath isn't set or tls.mode is TLSSettings_MUTUAL.
 		if sdsUdsPath == "" || tls.Mode == networking.TLSSettings_MUTUAL {
 			cluster.TlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContext{

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -104,6 +104,8 @@ func setupFilterChains(authnPolicy *authn.Policy, sdsUdsPath string) []plugin.Fi
 		},
 	}
 	if sdsUdsPath == "" {
+		log.Debuga("SDS isn't enabled")
+
 		tls.CommonTlsContext.ValidationContextType = model.ConstructValidationContext(model.AuthCertsPath+model.RootCertFilename, []string{} /*subjectAltNames*/)
 		tls.CommonTlsContext.TlsCertificates = []*auth.TlsCertificate{
 			{

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -86,7 +86,7 @@ func GetMutualTLS(policy *authn.Policy) *authn.MutualTls {
 }
 
 // setupFilterChains sets up filter chains based on authentication policy.
-func setupFilterChains(authnPolicy *authn.Policy, serviceAccount string, sdsUdsPath string) []plugin.FilterChain {
+func setupFilterChains(authnPolicy *authn.Policy, sdsUdsPath string) []plugin.FilterChain {
 	if authnPolicy == nil || len(authnPolicy.Peers) == 0 {
 		return nil
 	}
@@ -120,9 +120,12 @@ func setupFilterChains(authnPolicy *authn.Policy, serviceAccount string, sdsUdsP
 			},
 		}
 	} else {
-		tls.CommonTlsContext.ValidationContextType = model.ConstructValidationContext(model.CARootCertPath, []string{} /*subjectAltNames*/)
+		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+			ValidationContextSdsSecretConfig: model.ConstructSdsSecretConfig(model.SDSRootResourceName, sdsUdsPath),
+		}
+
 		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
-			model.ConstructSdsSecretConfig(serviceAccount, sdsUdsPath),
+			model.ConstructSdsSecretConfig(model.SDSDefaultResourceName, sdsUdsPath),
 		}
 	}
 	mtls := GetMutualTLS(authnPolicy)
@@ -161,7 +164,7 @@ func setupFilterChains(authnPolicy *authn.Policy, serviceAccount string, sdsUdsP
 func (Plugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
 	port := in.ServiceInstance.Endpoint.ServicePort
 	authnPolicy := model.GetConsolidateAuthenticationPolicy(in.Env.IstioConfigStore, in.ServiceInstance.Service, port)
-	return setupFilterChains(authnPolicy, in.ServiceInstance.ServiceAccount, in.Env.Mesh.SdsUdsPath)
+	return setupFilterChains(authnPolicy, in.Env.Mesh.SdsUdsPath)
 }
 
 // CollectJwtSpecs returns a list of all JWT specs (pointers) defined the policy. This

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -548,11 +548,10 @@ func TestOnInboundFilterChains(t *testing.T) {
 		RequireClientCertificate: &types.BoolValue{Value: true},
 	}
 	cases := []struct {
-		name           string
-		in             *authn.Policy
-		serviceAccount string
-		sdsUdsPath     string
-		expected       []plugin.FilterChain
+		name       string
+		in         *authn.Policy
+		sdsUdsPath string
+		expected   []plugin.FilterChain
 	}{
 		{
 			name: "NoAuthnPolicy",
@@ -651,54 +650,16 @@ func TestOnInboundFilterChains(t *testing.T) {
 					},
 				},
 			},
-			sdsUdsPath:     "/tmp/sdsuds.sock",
-			serviceAccount: "spiffe://cluster.local/ns/bar/sa/foo",
+			sdsUdsPath: "/tmp/sdsuds.sock",
 			expected: []plugin.FilterChain{
 				{
 					TLSContext: &auth.DownstreamTlsContext{
 						CommonTlsContext: &auth.CommonTlsContext{
 							TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
-								{
-									Name: "spiffe://cluster.local/ns/bar/sa/foo",
-									SdsConfig: &core.ConfigSource{
-										ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
-											ApiConfigSource: &core.ApiConfigSource{
-												ApiType: core.ApiConfigSource_GRPC,
-												GrpcServices: []*core.GrpcService{
-													{
-														TargetSpecifier: &core.GrpcService_GoogleGrpc_{
-															GoogleGrpc: &core.GrpcService_GoogleGrpc{
-																TargetUri:  "/tmp/sdsuds.sock",
-																StatPrefix: model.SDSStatPrefix,
-																ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
-																	CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
-																		LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
-																	},
-																},
-																CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
-																	&core.GrpcService_GoogleGrpc_CallCredentials{
-																		CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{
-																			GoogleComputeEngine: &types.Empty{},
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
+								constructSDSConfig(model.SDSDefaultResourceName, "/tmp/sdsuds.sock"),
 							},
-							ValidationContextType: &auth.CommonTlsContext_ValidationContext{
-								ValidationContext: &auth.CertificateValidationContext{
-									TrustedCa: &core.DataSource{
-										Specifier: &core.DataSource_Filename{
-											Filename: model.CARootCertPath,
-										},
-									},
-								},
+							ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+								ValidationContextSdsSecretConfig: constructSDSConfig(model.SDSRootResourceName, "/tmp/sdsuds.sock"),
 							},
 							AlpnProtocols: []string{"h2", "http/1.1"},
 						},
@@ -709,8 +670,43 @@ func TestOnInboundFilterChains(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		if got := setupFilterChains(c.in, c.serviceAccount, c.sdsUdsPath); !reflect.DeepEqual(got, c.expected) {
+		if got := setupFilterChains(c.in, c.sdsUdsPath); !reflect.DeepEqual(got, c.expected) {
 			t.Errorf("[%v] unexpected filter chains, got %v, want %v", c.name, got, c.expected)
 		}
+	}
+}
+
+func constructSDSConfig(name, sdsudspath string) *auth.SdsSecretConfig {
+	return &auth.SdsSecretConfig{
+		Name: name,
+		SdsConfig: &core.ConfigSource{
+			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+				ApiConfigSource: &core.ApiConfigSource{
+					ApiType: core.ApiConfigSource_GRPC,
+					GrpcServices: []*core.GrpcService{
+						{
+							TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+								GoogleGrpc: &core.GrpcService_GoogleGrpc{
+									TargetUri:  sdsudspath,
+									StatPrefix: model.SDSStatPrefix,
+									ChannelCredentials: &core.GrpcService_GoogleGrpc_ChannelCredentials{
+										CredentialSpecifier: &core.GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials{
+											LocalCredentials: &core.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
+										},
+									},
+									CallCredentials: []*core.GrpcService_GoogleGrpc_CallCredentials{
+										&core.GrpcService_GoogleGrpc_CallCredentials{
+											CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine{
+												GoogleComputeEngine: &types.Empty{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035 

This PR includes:
1. construct sdsconfig in cluster.tls_context
2. fetch root cert(validate_context) through SDS instead of baked root cert in proxy docker image in ```collab-gcp-identity``` branch today