### PR TITLE
remove the constraint of sds request.resource must be in spiffe format

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -29,7 +29,7 @@ var (
 	mockCertChain1st    = []string{"foo", "rootcert"}
 	mockCertChainRemain = []string{"bar", "rootcert"}
 
-	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
+	testResourceName = "default"
 )
 
 func TestGenerateSecret(t *testing.T) {
@@ -48,7 +48,7 @@ func TestGenerateSecret(t *testing.T) {
 
 	proxyID := "proxy1-id"
 	ctx := context.Background()
-	gotSecret, err := sc.GenerateSecret(ctx, proxyID, fakeSpiffeID, "jwtToken1")
+	gotSecret, err := sc.GenerateSecret(ctx, proxyID, testResourceName, "jwtToken1")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -57,10 +57,10 @@ func TestGenerateSecret(t *testing.T) {
 		t.Errorf("CertificateChain: got: %v, want: %v", got, want)
 	}
 
-	if got, want := sc.SecretExist(proxyID, fakeSpiffeID, "jwtToken1", gotSecret.Version), true; got != want {
+	if got, want := sc.SecretExist(proxyID, testResourceName, "jwtToken1", gotSecret.Version), true; got != want {
 		t.Errorf("SecretExist: got: %v, want: %v", got, want)
 	}
-	if got, want := sc.SecretExist(proxyID, fakeSpiffeID, "nonexisttoken", gotSecret.Version), false; got != want {
+	if got, want := sc.SecretExist(proxyID, testResourceName, "nonexisttoken", gotSecret.Version), false; got != want {
 		t.Errorf("SecretExist: got: %v, want: %v", got, want)
 	}
 
@@ -81,7 +81,7 @@ func TestGenerateSecret(t *testing.T) {
 
 	key := ConnKey{
 		ProxyID:      proxyID,
-		ResourceName: fakeSpiffeID,
+		ResourceName: testResourceName,
 	}
 	cachedSecret, found := sc.secrets.Load(key)
 	if !found {
@@ -92,7 +92,7 @@ func TestGenerateSecret(t *testing.T) {
 	}
 
 	// Try to get secret again using different jwt token, verify secret is re-generated.
-	gotSecret, err = sc.GenerateSecret(ctx, proxyID, fakeSpiffeID, "newToken")
+	gotSecret, err = sc.GenerateSecret(ctx, proxyID, testResourceName, "newToken")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestRefreshSecret(t *testing.T) {
 		atomic.StoreUint32(&sc.skipTokenExpireCheck, 1)
 	}()
 
-	_, err := sc.GenerateSecret(context.Background(), "proxy1-id", fakeSpiffeID, "jwtToken1")
+	_, err := sc.GenerateSecret(context.Background(), "proxy1-id", testResourceName, "jwtToken1")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}

--- a/security/pkg/nodeagent/model/secret.go
+++ b/security/pkg/nodeagent/model/secret.go
@@ -24,15 +24,15 @@ type SecretItem struct {
 
 	RootCert []byte
 
-	// ResourceName passed from envoy SDS discovery request, spiffeID format for key/cert request.
-	// "ROOTCA" for root cert request.
+	// ResourceName passed from envoy SDS discovery request.
+	// "ROOTCA" for root cert request, "default" for key/cert request.
 	ResourceName string
 
 	// Credential token passed from envoy, caClient uses this token to send
 	// CSR to CA to sign certificate.
 	Token string
 
-	// Version is used(together with token and SpiffeID) to identify discovery request from
+	// Version is used(together with token and ResourceName) to identify discovery request from
 	// envoy which is used only for confirm purpose.
 	Version string
 

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -36,7 +35,6 @@ import (
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/model"
-	"istio.io/istio/security/pkg/pki/util"
 )
 
 const (
@@ -223,11 +221,7 @@ func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceN
 		return "", fmt.Errorf("discovery request %+v missing node id", discReq)
 	}
 
-	if len(discReq.ResourceNames) == 1 && strings.HasPrefix(discReq.ResourceNames[0], util.URIScheme) {
-		return discReq.ResourceNames[0], nil
-	}
-
-	if len(discReq.ResourceNames) == 1 && strings.Contains(discReq.ResourceNames[0], cache.RootCertReqResourceName) {
+	if len(discReq.ResourceNames) == 1 {
 		return discReq.ResourceNames[0], nil
 	}
 

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -43,13 +43,12 @@ var (
 	fakePushPrivateKey       = []byte{04}
 
 	fakeCredentialToken = "faketoken"
-
-	fakeSpiffeID = "spiffe://cluster.local/ns/bar/sa/foo"
+	testResourceName    = "default"
 
 	fakeSecret = &model.SecretItem{
 		CertificateChain: fakeCertificateChain,
 		PrivateKey:       fakePrivateKey,
-		ResourceName:     fakeSpiffeID,
+		ResourceName:     testResourceName,
 		Version:          time.Now().String(),
 	}
 
@@ -86,7 +85,7 @@ func testHelper(t *testing.T, testSocket string, cb secretCallback) {
 
 	proxyID := "sidecar~127.0.0.1~id1~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{fakeSpiffeID},
+		ResourceNames: []string{testResourceName},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -140,7 +139,7 @@ func TestStreamSecretsPush(t *testing.T) {
 
 	proxyID := "sidecar~127.0.0.1~id2~local"
 	req := &api.DiscoveryRequest{
-		ResourceNames: []string{fakeSpiffeID},
+		ResourceNames: []string{testResourceName},
 		Node: &core.Node{
 			Id: proxyID,
 		},
@@ -172,7 +171,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	if err = NotifyProxy(proxyID, req.ResourceNames[0], &model.SecretItem{
 		CertificateChain: fakePushCertificateChain,
 		PrivateKey:       fakePushPrivateKey,
-		ResourceName:     fakeSpiffeID,
+		ResourceName:     testResourceName,
 	}); err != nil {
 		t.Errorf("failed to send push notificiation to proxy %q", proxyID)
 	}
@@ -203,7 +202,7 @@ func verifySDSSResponse(t *testing.T, resp *api.DiscoveryResponse, expectedPriva
 	}
 
 	expectedResponseSecret := authapi.Secret{
-		Name: fakeSpiffeID,
+		Name: testResourceName,
 		Type: &authapi.Secret_TlsCertificate{
 			TlsCertificate: &authapi.TlsCertificate{
 				CertificateChain: &core.DataSource{
@@ -314,7 +313,7 @@ func (*mockSecretStore) GenerateSecret(ctx context.Context, proxyID, resourceNam
 		return nil, fmt.Errorf("unexpected token %q", token)
 	}
 
-	if resourceName == fakeSpiffeID {
+	if resourceName == testResourceName {
 		return fakeSecret, nil
 	}
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

previous in ```collab-gcp-identity``` branch, we set constraint that SDS discoveryRequest.ResourceName must be in spiffe format; this isn't necessary since CA uses identity parsed from oauth token; this PR removes this constraint so that SDS could support for envoy bootstrap case(with controlplanesecurity enabled).