### PR TITLE
Revert default to unset externalTrafficPolicy for 1.0

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -58,7 +58,8 @@ gateways:
     loadBalancerIP: ""
     serviceAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-    externalTrafficPolicy: Local
+    # Uncomment the following line to preserve client source ip.
+    # externalTrafficPolicy: Local
 
     ports:
       ## You can add custom gateway ports

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -196,7 +196,8 @@ ingress:
     annotations: {}
     loadBalancerIP: ""
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-    externalTrafficPolicy: Local
+    # Uncomment the following line to preserve client source ip.
+    # externalTrafficPolicy: Local
     ports:
     - port: 80
       name: http
@@ -236,7 +237,8 @@ gateways:
     loadBalancerIP: ""
     serviceAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
-    externalTrafficPolicy: Local
+    # Uncomment the following line to preserve client source ip.
+    # externalTrafficPolicy: Local
 
     ports:
       ## You can add custom gateway ports
@@ -324,7 +326,6 @@ gateways:
     serviceAnnotations:
       cloud.google.com/load-balancer-type: "internal"
     type: LoadBalancer
-    externalTrafficPolicy: Local
     ports:
     ## You can add custom gateway ports - google ILB default quota is 5 ports,
     - port: 15011


### PR DESCRIPTION
PR #7918 introduced options to set externalTrafficPolicy.
This PR restores default behaviour from 1.0