### PR TITLE
Adding mixer policy remote helm charts (#9161)

### DIFF
--- a/install/kubernetes/helm/istio-remote/charts/policy/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/policy/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: policy
+version: 1.1.0
+appVersion: 1.1.0
+tillerVersion: ">=2.7.2"
+description: Helm chart for istio policy
+keywords:
+  - istio
+  - policy
+sources:
+  - http://github.com/istio/istio
+engine: gotpl
+icon: https://istio.io/favicons/android-192x192.png

--- a/install/kubernetes/helm/istio-remote/charts/policy/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio-remote/charts/policy/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "policy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "policy.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/install/kubernetes/helm/istio-remote/charts/policy/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/policy/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-mixer-admin-role-binding-istio-system
+  labels:
+    app: mixer
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-mixer-istio-system
+subjects:
+- kind: ServiceAccount
+  name: istio-mixer-service-account
+  namespace: {{ .Release.Namespace }}
+
+---

--- a/install/kubernetes/helm/istio-remote/charts/policy/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/policy/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    istio: mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: policy
+        istio: mixer
+        istio-mixer-type: policy
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-mixer-service-account
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-mixer-service-account
+          optional: true
+      - name: uds-socket
+        emptyDir: {}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+      containers:
+      - name: mixer
+        image: "{{ .Values.global.hub }}/{{ .Values.image }}:{{ .Values.global.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        ports:
+        - containerPort: 9093
+        - containerPort: 42422
+        args:
+          - --address
+          - unix:///sock/mixer.socket
+          - --configStoreURL=k8s://
+          - --configDefaultNamespace={{ .Release.Namespace }}
+          - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+        resources:
+          requests:
+            cpu: 10m
+
+        volumeMounts:   
+        - name: uds-socket
+          mountPath: /sock
+
+---

--- a/install/kubernetes/helm/istio-remote/charts/policy/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/policy/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-policy
+  namespace: {{ .Release.Namespace }}
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    istio: mixer
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  selector:
+    istio: mixer
+    istio-mixer-type: policy
+
+---
+
+

--- a/install/kubernetes/helm/istio-remote/charts/policy/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/policy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-mixer-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: mixer
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+
+---

--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -11,3 +11,6 @@ dependencies:
     version: ">=0.0.1"
     repository: "@istio.io"
     condition: istio_cni.enabled
+  - name: policy
+    version: 1.1.0
+    condition: policy.enabled

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -26,6 +26,12 @@ data:
     enableTracing: {{ .Values.global.enableTracing }}
   {{- end }}  
 
+  {{- if .Values.global.remotePolicyAddress }}
+    # Set the following variable to true to disable policy checks by the Mixer.
+    # Note that metrics will still be reported to the Mixer.
+    disablePolicyChecks: {{ .Values.global.disablePolicyChecks }}
+  {{- end }}
+
     # TODO: not clear if this is used - pilot generates config based on the main cluster config.
     # Set accessLogFile to empty string to disable access log.
     accessLogFile: "{{ .Values.global.proxy.accessLogFile }}"

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -265,3 +265,9 @@ global:
 #
 istio_cni:
   enabled: false
+
+policy:
+  enabled: true
+  replicaCount: 1
+  image: mixer
+  selfSigned: true


### PR DESCRIPTION
This commit adds the ability to optionally select running
mixer policy pods on the remote cluster using the istio-remote
helm charts.