### PR TITLE
Multi-Cluster: add mock variables to secret controller for unit testing

### DIFF
--- a/pkg/kube/secretcontroller/secretcontroller_test.go
+++ b/pkg/kube/secretcontroller/secretcontroller_test.go
@@ -72,7 +72,7 @@ func mockLoadKubeConfig(kubeconfig []byte) (*clientcmdapi.Config, error) {
 }
 
 func Test_SecretController(t *testing.T) {
-	loadKubeConfig = mockLoadKubeConfig
+	LoadKubeConfig = mockLoadKubeConfig
 
 	clientset := fake.NewSimpleClientset()
 


### PR DESCRIPTION
Add mock variables to secretcontroller.go so that consumers of this package do not have to create a kubernetes configuation file for unit testing purposes. (e2e tests have been created for the consumers of this pkg which use kubernetes config files.)