### PR TITLE
Fix data race in the kubernetesenv test

### DIFF
--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -352,6 +352,9 @@ func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface,
 }
 
 func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID string) error {
+	b.Lock()
+	defer b.Unlock()
+
 	controller, err := runNewController(b, k8sInterface, b.kubeHandler.env)
 	if err == nil {
 		b.controllers[clusterID] = controller
@@ -365,6 +368,9 @@ func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID st
 }
 
 func (b *builder) deleteCacheController(clusterID string) error {
+	b.Lock()
+	defer b.Unlock()
+
 	b.kubeHandler.k8sCache[clusterID].StopControlChannel()
 	delete(b.controllers, clusterID)
 	delete(b.kubeHandler.k8sCache, clusterID)

--- a/mixer/adapter/kubernetesenv/kubernetesenv.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv.go
@@ -353,8 +353,6 @@ func newKubernetesClient(kubeconfigPath string, env adapter.Env) (k8s.Interface,
 
 func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID string) error {
 	b.Lock()
-	defer b.Unlock()
-
 	controller, err := runNewController(b, k8sInterface, b.kubeHandler.env)
 	if err == nil {
 		b.controllers[clusterID] = controller
@@ -363,19 +361,19 @@ func (b *builder) createCacheController(k8sInterface k8s.Interface, clusterID st
 	} else {
 		b.kubeHandler.env.Logger().Errorf("error on creating remote controller %s err = %v", clusterID, err)
 	}
+	b.Unlock()
 
 	return err
 }
 
 func (b *builder) deleteCacheController(clusterID string) error {
 	b.Lock()
-	defer b.Unlock()
-
 	b.kubeHandler.k8sCache[clusterID].StopControlChannel()
 	delete(b.controllers, clusterID)
 	delete(b.kubeHandler.k8sCache, clusterID)
 
 	b.kubeHandler.env.Logger().Infof("deleted remote controller %s", clusterID)
+	b.Unlock()
 
 	return nil
 }

--- a/mixer/adapter/kubernetesenv/kubernetesenv_test.go
+++ b/mixer/adapter/kubernetesenv/kubernetesenv_test.go
@@ -422,6 +422,8 @@ func deleteMultiClusterSecret(k8s *fake.Clientset) error {
 
 func verifyControllers(t *testing.T, b *builder, expectedControllerCount int, timeoutName string) {
 	pkgtest.NewEventualOpts(10*time.Millisecond, 5*time.Second).Eventually(t, timeoutName, func() bool {
+		b.Lock()
+		defer b.Unlock()
 		return len(b.controllers) == expectedControllerCount
 	})
 }


### PR DESCRIPTION
Due to recent changes.
[Example for a failed racetest](https://circleci.com/gh/istio/istio/210027?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).