### PR TITLE
Test failures due to assumptions on results order

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -544,8 +544,8 @@ func TestController_Service(t *testing.T) {
 			},
 		},
 	}
-	expectedSvcList[serviceHostname("svc1", "nsA", domainSuffix)] = &model.Service{
-		Hostname: serviceHostname("svc1", "nsA", domainSuffix),
+	expectedSvcList[serviceHostname("svc2", "nsA", domainSuffix)] = &model.Service{
+		Hostname: serviceHostname("svc2", "nsA", domainSuffix),
 		Address:  "10.0.0.1",
 		Ports: model.PortList{
 			&model.Port{

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -532,10 +532,9 @@ func TestController_Service(t *testing.T) {
 	createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
 	createEndpoints(controller, "svc2", "nsA", portNames, svc2Ips, t)
 
-	expectedSvcList := []*model.Service{
-		{
-			Hostname: serviceHostname("svc1", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
+	expectedSvcList := map[model.Hostname]*model.Service{
+		serviceHostname("svc1", "nsA", domainSuffix): {
+			Address: "10.0.0.1",
 			Ports: model.PortList{
 				&model.Port{
 					Name:     "test-port",
@@ -544,9 +543,8 @@ func TestController_Service(t *testing.T) {
 				},
 			},
 		},
-		{
-			Hostname: serviceHostname("svc2", "nsA", domainSuffix),
-			Address:  "10.0.0.1",
+		serviceHostname("svc2", "nsA", domainSuffix): {
+			Address: "10.0.0.1",
 			Ports: model.PortList{
 				&model.Port{
 					Name:     "test-port",
@@ -561,22 +559,17 @@ func TestController_Service(t *testing.T) {
 	if len(svcList) != len(expectedSvcList) {
 		t.Errorf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
 	}
-	for _, exp := range expectedSvcList {
-		found := false
-		for _, svc := range svcList {
-			if exp.Hostname == svc.Hostname {
-				if exp.Address != svc.Address {
-					t.Errorf("wrong address for service with hostname %s, got:\n%#v\nwanted:\n%#v\n", svc.Hostname, svc.Address, exp.Address)
-				}
-				if !reflect.DeepEqual(exp.Ports, svc.Ports) {
-					t.Errorf("wrong ports for service with hostname %s, got:\n%#v\nwanted:\n%#v\n", svc.Hostname, svc.Ports, exp.Ports)
-				}
-				found = true
-				break
-			}
-		}
+
+	for i, svc := range svcList {
+		exp, found := expectedSvcList[svc.Hostname]
 		if !found {
-			t.Errorf("no service returned with hostname %s", exp.Hostname)
+			t.Errorf("got unexpected hostname of %dst service, got:\n%#v\n", i, svcList[i].Hostname)
+		}
+		if exp.Address != svcList[i].Address {
+			t.Errorf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
+		}
+		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
+			t.Errorf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
 		}
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -533,7 +533,7 @@ func TestController_Service(t *testing.T) {
 	createEndpoints(controller, "svc2", "nsA", portNames, svc2Ips, t)
 
 	expectedSvcList := map[model.Hostname]*model.Service{
-		serviceHostname("svc1", "nsA", domainSuffix): {
+		serviceHostname("svc1", "nsA", domainSuffix): &model.Service{
 			Address: "10.0.0.1",
 			Ports: model.PortList{
 				&model.Port{
@@ -543,7 +543,7 @@ func TestController_Service(t *testing.T) {
 				},
 			},
 		},
-		serviceHostname("svc2", "nsA", domainSuffix): {
+		serviceHostname("svc2", "nsA", domainSuffix): &model.Service{
 			Address: "10.0.0.1",
 			Ports: model.PortList{
 				&model.Port{

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -561,15 +561,22 @@ func TestController_Service(t *testing.T) {
 	if len(svcList) != len(expectedSvcList) {
 		t.Errorf("Expecting %d service but got %d\r\n", len(expectedSvcList), len(svcList))
 	}
-	for i, exp := range expectedSvcList {
-		if exp.Hostname != svcList[i].Hostname {
-			t.Errorf("got hostname of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Hostname, exp.Hostname)
+	for _, exp := range expectedSvcList {
+		found := false
+		for _, svc := range svcList {
+			if exp.Hostname == svc.Hostname {
+				if exp.Address != svc.Address {
+					t.Errorf("wrong address for service with hostname %s, got:\n%#v\nwanted:\n%#v\n", svc.Hostname, svc.Address, exp.Address)
+				}
+				if !reflect.DeepEqual(exp.Ports, svc.Ports) {
+					t.Errorf("wrong ports for service with hostname %s, got:\n%#v\nwanted:\n%#v\n", svc.Hostname, svc.Ports, exp.Ports)
+				}
+				found = true
+				break
+			}
 		}
-		if exp.Address != svcList[i].Address {
-			t.Errorf("got address of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Address, exp.Address)
-		}
-		if !reflect.DeepEqual(exp.Ports, svcList[i].Ports) {
-			t.Errorf("got ports of %dst service, got:\n%#v\nwanted:\n%#v\n", i, svcList[i].Ports, exp.Ports)
+		if !found {
+			t.Errorf("no service returned with hostname %s", exp.Hostname)
 		}
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -532,25 +532,26 @@ func TestController_Service(t *testing.T) {
 	createEndpoints(controller, "svc1", "nsA", portNames, svc1Ips, t)
 	createEndpoints(controller, "svc2", "nsA", portNames, svc2Ips, t)
 
-	expectedSvcList := map[model.Hostname]*model.Service{
-		serviceHostname("svc1", "nsA", domainSuffix): &model.Service{
-			Address: "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "test-port",
-					Port:     8080,
-					Protocol: model.ProtocolTCP,
-				},
+	expectedSvcList := map[model.Hostname]*model.Service{}
+	expectedSvcList[serviceHostname("svc1", "nsA", domainSuffix)] = &model.Service{
+		Hostname: serviceHostname("svc1", "nsA", domainSuffix),
+		Address:  "10.0.0.1",
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "test-port",
+				Port:     8080,
+				Protocol: model.ProtocolTCP,
 			},
 		},
-		serviceHostname("svc2", "nsA", domainSuffix): &model.Service{
-			Address: "10.0.0.1",
-			Ports: model.PortList{
-				&model.Port{
-					Name:     "test-port",
-					Port:     8081,
-					Protocol: model.ProtocolTCP,
-				},
+	}
+	expectedSvcList[serviceHostname("svc1", "nsA", domainSuffix)] = &model.Service{
+		Hostname: serviceHostname("svc1", "nsA", domainSuffix),
+		Address:  "10.0.0.1",
+		Ports: model.PortList{
+			&model.Port{
+				Name:     "test-port",
+				Port:     8081,
+				Protocol: model.ProtocolTCP,
 			},
 		},
 	}


### PR DESCRIPTION
Sometimes the [racetest fails](https://circleci.com/gh/istio/istio/211369?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) with this error:
```sh
--- FAIL: TestController_Service (0.00s)
	controller_test.go:566: got hostname of 0st service, got:
		"svc2.nsA.svc.company.com"
		wanted:
		"svc1.nsA.svc.company.com"
	controller_test.go:572: got ports of 0st service, got:
		model.PortList{(*model.Port)(0xc4203ae7b0)}
		wanted:
		model.PortList{(*model.Port)(0xc4203ae600)}
	controller_test.go:566: got hostname of 1st service, got:
		"svc1.nsA.svc.company.com"
		wanted:
		"svc2.nsA.svc.company.com"
	controller_test.go:572: got ports of 1st service, got:
		model.PortList{(*model.Port)(0xc4203ae810)}
		wanted:
		model.PortList{(*model.Port)(0xc4203ae780)}
```

The reason is that the order of the returned results isn't guaranteed to match the expected.
This updates the validation to check the results vs expected with no order assumptions.