### PR TITLE
Makefile: Restrict $KUBECONFIG definition to 'test' target (#8697)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,7 @@ JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 test: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
+	KUBECONFIG="$${KUBECONFIG:-$${GO_TOP}/src/istio.io/istio/.circleci/config}" \
 	$(MAKE) --keep-going common-test pilot-test mixer-test security-test galley-test istioctl-test \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -34,9 +34,6 @@ function setup_and_export_git_sha() {
       export GIT_SHA="${PULL_PULL_SHA}"
     fi
 
-    # Use volume mount from pilot-presubmit job's pod spec.
-    export KUBECONFIG="${HOME}/.kube/config"
-
     # Set artifact dir based on checkout
     export ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
   else


### PR DESCRIPTION
Instead of making it global. It was causing issues on some e2e
tests.