### PR TITLE
Add top level pilot metrics

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -92,7 +92,7 @@ var (
 	})
 	totalInternalErrors = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pilot_total_internal_errors",
-		Help: "Total number of internal pilot errors.",
+		Help: "Total number of internal pilot errors, excluding xDS errors.",
 	})
 )
 

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -90,11 +90,16 @@ var (
 		Name: "pilot_conf_filter_chains",
 		Help: "Number of conflicting filter chains.",
 	})
+	totalInternalErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pilot_total_internal_errors",
+		Help: "Total number of internal pilot errors.",
+	})
 )
 
 func init() {
 	prometheus.MustRegister(invalidOutboundListeners)
 	prometheus.MustRegister(filterChainsConflict)
+	prometheus.MustRegister(totalInternalErrors)
 }
 
 // ListenersALPNProtocols denotes the the list of ALPN protocols that the listener

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -78,7 +78,7 @@ var (
 
 	edsInstances = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pilot_xds_eds_instances",
-		Help: "Instances for each cluster, as of last push. Zero instances is an error",
+		Help: "Instances for each cluster, as of last push. Zero instances is an error.",
 	}, []string{"cluster"})
 
 	ldsReject = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -91,40 +91,61 @@ var (
 		Help: "Pilot rejected RDS.",
 	}, []string{"node", "err"})
 
+	totalXDSRejects = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pilot_total_xds_rejects",
+		Help: "Total number of XDS responses from pilot rejected by proxy.",
+	})
+
 	monServices = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "pilot_services",
-		Help: "Total services known to pilot",
+		Help: "Total services known to pilot.",
 	})
 
 	monVServices = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "pilot_virt_services",
-		Help: "Total virtual services known to pilot",
+		Help: "Total virtual services known to pilot.",
 	})
 
 	xdsClients = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "pilot_xds",
-		Help: "Number of endpoints connected to this pilot using XDS",
+		Help: "Number of endpoints connected to this pilot using XDS.",
 	})
 
-	writeTimeout = prometheus.NewCounter(prometheus.CounterOpts{
+	xdsResponseWriteTimeouts = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pilot_xds_write_timeout",
-		Help: "Pilot write timeout",
+		Help: "Pilot XDS response write timeouts.",
 	})
 
 	pushTimeouts = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "pilot_xds_push_timeout",
-		Help: "Pilot push timeout",
+		Help: "Pilot push timeout, will retry.",
 	})
 
+	pushTimeoutFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pilot_xds_push_timeout_failures",
+		Help: "Pilot push timeout failures after repeated attempts.",
+	})
+
+	// Covers xds_builderr and xds_senderr for xds in {lds, rds, cds, eds}.
 	pushes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pilot_xds_pushes",
-		Help: "Pilot push timeout",
+		Help: "Pilot build and send errors for lds, rds, cds and eds.",
 	}, []string{"type"})
 
 	pushErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "pilot_xds_push_errors",
 		Help: "Number of errors (timeouts) pushing to sidecars.",
 	}, []string{"type"})
+
+	pushContextErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pilot_xds_push_context_errors",
+		Help: "Number of errors (timeouts) initiating push context.",
+	})
+
+	totalXDSInternalErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "pilot_total_xds_internal_errors",
+		Help: "Total number of internal XDS errors in pilot (check logs).",
+	})
 )
 
 func init() {
@@ -132,14 +153,18 @@ func init() {
 	prometheus.MustRegister(edsReject)
 	prometheus.MustRegister(ldsReject)
 	prometheus.MustRegister(rdsReject)
+	prometheus.MustRegister(totalXDSRejects)
 	prometheus.MustRegister(edsInstances)
 	prometheus.MustRegister(monServices)
 	prometheus.MustRegister(monVServices)
 	prometheus.MustRegister(xdsClients)
-	prometheus.MustRegister(writeTimeout)
+	prometheus.MustRegister(xdsResponseWriteTimeouts)
 	prometheus.MustRegister(pushTimeouts)
+	prometheus.MustRegister(pushTimeoutFailures)
 	prometheus.MustRegister(pushes)
 	prometheus.MustRegister(pushErrors)
+	prometheus.MustRegister(pushContextErrors)
+	prometheus.MustRegister(totalXDSInternalErrors)
 
 	// Experimental env to disable push suppression
 	// By default a pod will not receive a push from an older version if a
@@ -362,6 +387,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:CDS: ACK ERROR %v %s %v", peerAddr, con.ConID, discReq.String())
 						cdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ClusterNonceAcked = discReq.ResponseNonce
 					}
@@ -384,6 +410,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:LDS: ACK ERROR %v %s %v", peerAddr, con.modelNode.ID, discReq.String())
 						ldsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						totalXDSRejects.Add(1)
 					} else if discReq.ResponseNonce != "" {
 						con.ListenerNonceAcked = discReq.ResponseNonce
 					}
@@ -404,6 +431,7 @@ func (s *DiscoveryServer) StreamAggregatedResources(stream ads.AggregatedDiscove
 					if discReq.ErrorDetail != nil {
 						adsLog.Warnf("ADS:RDS: ACK ERROR %v %s (%s) %v", peerAddr, con.ConID, con.modelNode, discReq.String())
 						rdsReject.With(prometheus.Labels{"node": discReq.Node.Id, "err": discReq.ErrorDetail.Message}).Add(1)
+						totalXDSRejects.Add(1)
 					}
 					// Not logging full request, can be very long.
 					adsLog.Debugf("ADS:RDS: ACK %s %s (%s) %s %s", peerAddr, con.ConID, con.modelNode, discReq.VersionInfo, discReq.ResponseNonce)
@@ -655,6 +683,7 @@ func (s *DiscoveryServer) AdsPushAll(version string, push *model.PushContext) {
 					adsLog.Warnf("Repeated failure to push %d %s", len(pending), client.ConID)
 					// unfortunately grpc go doesn't allow closing (unblocking) the stream.
 					pushErrors.With(prometheus.Labels{"type": "long"}).Add(1)
+					pushTimeoutFailures.Add(1)
 				}
 			}
 		}
@@ -685,6 +714,7 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 
 	if adsClients[conID] == nil {
 		adsLog.Errorf("ADS: Removing connection for non-existing node %v.", s)
+		totalXDSInternalErrors.Add(1)
 	}
 	delete(adsClients, conID)
 	xdsClients.Set(float64(len(adsClients)))
@@ -729,7 +759,7 @@ func (conn *XdsConnection) send(res *xdsapi.DiscoveryResponse) error {
 	case <-t.C:
 		// TODO: wait for ACK
 		adsLog.Infof("Timeout writing %s", conn.ConID)
-		writeTimeout.Add(1)
+		xdsResponseWriteTimeouts.Add(1)
 		return errors.New("timeout sending")
 	case err, _ := <-done:
 		_ = t.Stop()

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -82,6 +82,7 @@ func (s *DiscoveryServer) generateRawClusters(con *XdsConnection, push *model.Pu
 			retErr := fmt.Errorf("CDS: Generated invalid cluster for node %v: %v", con.modelNode, err)
 			adsLog.Errorf("CDS: Generated invalid cluster for node %s: %v, %v", con.modelNode, err, c)
 			pushes.With(prometheus.Labels{"type": "cds_builderr"}).Add(1)
+			totalXDSInternalErrors.Add(1)
 			// Generating invalid clusters is a bug.
 			// Panic instead of trying to recover from that, since we can't
 			// assume anything about the state.

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -227,6 +227,7 @@ func (s *DiscoveryServer) ClearCacheFunc() func() {
 
 		if err = s.ConfigGenerator.BuildSharedPushState(s.env, push); err != nil {
 			adsLog.Errorf("XDS: Failed to rebuild share state in configgen: %v", err)
+			totalXDSInternalErrors.Add(1)
 			return
 		}
 

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -166,6 +166,7 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 	}
 	if err != nil {
 		adsLog.Warnf("endpoints for service cluster %q returned error %q", clusterName, err)
+		totalXDSInternalErrors.Add(1)
 		return err
 	}
 	locEps := localityLbEndpointsFromInstances(instances)
@@ -196,6 +197,7 @@ func localityLbEndpointsFromInstances(instances []*model.ServiceInstance) []endp
 		lbEp, err := newEndpoint(&instance.Endpoint)
 		if err != nil {
 			adsLog.Errorf("EDS: unexpected pilot model endpoint v1 to v2 conversion: %v", err)
+			totalXDSInternalErrors.Add(1)
 			continue
 		}
 		// TODO: Need to accommodate region, zone and subzone. Older Pilot datamodel only has zone = availability zone.
@@ -307,6 +309,7 @@ func (s *DiscoveryServer) StreamEndpoints(stream xdsapi.EndpointDiscoveryService
 			err := s.pushEds(s.env.PushContext, con)
 			if err != nil {
 				adsLog.Errorf("Closing EDS connection, failure to push %v", err)
+				pushErrors.With(prometheus.Labels{"type": "unrecoverable"}).Add(1)
 				return err
 			}
 		}
@@ -324,6 +327,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection) e
 	for _, clusterName := range con.Clusters {
 		c := s.getEdsCluster(clusterName)
 		if c == nil {
+			totalXDSInternalErrors.Add(1)
 			adsLog.Errorf("cluster %s was nil skipping it.", clusterName)
 			continue
 		}
@@ -332,6 +336,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection) e
 		if l == nil { // fresh cluster
 			if err := s.updateCluster(push, clusterName, c); err != nil {
 				adsLog.Errorf("error returned from updateCluster for cluster name %s, skipping it.", clusterName)
+				totalXDSInternalErrors.Add(1)
 				continue
 			}
 			l = loadAssignment(c)

--- a/pilot/pkg/proxy/envoy/v2/lds.go
+++ b/pilot/pkg/proxy/envoy/v2/lds.go
@@ -87,6 +87,7 @@ func ldsDiscoveryResponse(ls []*xdsapi.Listener, node model.Proxy, version strin
 	for _, ll := range ls {
 		if ll == nil {
 			adsLog.Errora("Nil listener ", ll)
+			totalXDSInternalErrors.Add(1)
 			continue
 		}
 		lr, _ := types.MarshalAny(ll)


### PR DESCRIPTION
(copy of https://github.com/istio/istio/pull/9033)

Restructure pilot metrics somewhat to get something more usable to SRE/oncall playbook. Added top level gauges that can be used for alerting:

pilot_total_internal_errors
Total internal Pilot errors.
Effect: can lead to incorrect operation or inconsistent mesh state.

pilot_total_xds_rejects
Total number of times an XDS (LDS, RDS, CDS or EDS) response from Pilot was rejected by proxy.
Effect: proxy configuration may be inconsistent with user config. Verify with istio-ctl proxy-status.

pilot_xds_write_timeout
Total number of timeouts for XDS response from pilot.
Effect: proxy configuration may be inconsistent with user config. Verify with istio-ctl proxy-status.

pilot_total_xds_internal_errors
Total number of internal XDS errors in pilot.
Effect: mesh operation may be impacted. Check pilot logs.

I've preserved the current metrics for backwards compatibility.