### PR TITLE
nodeagent support for pluggabe CA 

### DIFF
--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -1,8 +1,8 @@
 #
 # nodeagent configuration
 #
-enabled: true
+enabled: false
 image: node-agent-k8s
 env:
-  CA_PROVIDER: "GoogleCA"
-  CA_ADDR: "istioca.googleapis.com:443"
+  CA_PROVIDER: ""
+  CA_ADDR: ""

--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -1,7 +1,7 @@
 #
 # nodeagent configuration
 #
-enabled: false
+enabled: true
 image: node-agent-k8s
 env:
-  CA_ADDR: ""
+  CA_ADDR: "istioca.googleapis.com:443"

--- a/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/values.yaml
@@ -4,4 +4,5 @@
 enabled: true
 image: node-agent-k8s
 env:
+  CA_PROVIDER: "GoogleCA"
   CA_ADDR: "istioca.googleapis.com:443"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -41,7 +41,7 @@ security:
 # nodeagent configuration
 #
 nodeagent:
-  enabled: false
+  enabled: true
 
 #
 # ingress configuration

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -41,7 +41,7 @@ security:
 # nodeagent configuration
 #
 nodeagent:
-  enabled: true
+  enabled: false
 
 #
 # ingress configuration

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -45,7 +45,7 @@ var (
 
 			stop := make(chan struct{})
 
-			caClient, err := ca.NewCAClient(serverOptions.CAEndpoint, true)
+			caClient, err := ca.NewCAClient(serverOptions.CAEndpoint, "GoogleCA", true)
 			if err != nil {
 				log.Errorf("failed to create caClient: %v", err)
 				return fmt.Errorf("failed to create caClient")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -45,7 +45,7 @@ var (
 
 			stop := make(chan struct{})
 
-			caClient, err := ca.NewCAClient(serverOptions.CAEndpoint, "GoogleCA", true)
+			caClient, err := ca.NewCAClient(serverOptions.CAEndpoint, serverOptions.CAProviderName, true)
 			if err != nil {
 				log.Errorf("failed to create caClient: %v", err)
 				return fmt.Errorf("failed to create caClient")
@@ -68,6 +68,12 @@ var (
 )
 
 func init() {
+	caProvider := os.Getenv("CA_PROVIDER")
+	if caProvider == "" {
+		log.Error("CA Provider is missing")
+		os.Exit(1)
+	}
+
 	caAddr := os.Getenv("CA_ADDR")
 	if caAddr == "" {
 		log.Error("CA Endpoint is missing")
@@ -77,6 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&serverOptions.UDSPath, "sdsUdsPath",
 		"/var/run/sds/uds_path", "Unix domain socket through which SDS server communicates with proxies")
 
+	rootCmd.PersistentFlags().StringVar(&serverOptions.CAEndpoint, "caProvider", caProvider, "CA provider")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.CAEndpoint, "caEndpoint", caAddr, "CA endpoint")
 
 	rootCmd.PersistentFlags().StringVar(&serverOptions.CertFile, "sdsCertFile", "", "SDS gRPC TLS server-side certificate")

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"istio.io/istio/pkg/log"
-	ca "istio.io/istio/security/pkg/nodeagent/caclient"
+	ca "istio.io/istio/security/pkg/nodeagent/caclient/interface"
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/pki/util"
 )

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -33,54 +33,9 @@ const (
 	cidatel  = "Citadel"
 )
 
-// Client interface defines the clients need to implement to talk to CA for CSR.
-/*
-type Client interface {
-	CSRSign(ctx context.Context, csrPEM []byte, subjectID string,
-		certValidTTLInSec int64) ([]string, error)
-} */
-
 type caClient struct {
 	client caClientInterface.Client
 }
-
-/*
-type caClient struct {
-	providerName  string
-	googleClient  gcapb.IstioCertificateServiceClient
-	cidatelClient ccapb.IstioCertificateServiceClient
-}
-
-type caClient struct {
-	client Client
-}*/
-
-// NewCAClient create an CA client.
-/*
-func NewCAClient(endpoint string, tlsFlag bool) (Client, error) {
-	var opts grpc.DialOption
-	if tlsFlag {
-		pool, err := x509.SystemCertPool()
-		if err != nil {
-			log.Errorf("could not get SystemCertPool: %v", err)
-			return nil, errors.New("could not get SystemCertPool")
-		}
-		creds := credentials.NewClientTLSFromCert(pool, "")
-		opts = grpc.WithTransportCredentials(creds)
-	} else {
-		opts = grpc.WithInsecure()
-	}
-
-	conn, err := grpc.Dial(endpoint, opts)
-	if err != nil {
-		log.Errorf("Failed to connect to endpoint %q: %v", endpoint, err)
-		return nil, fmt.Errorf("failed to connect to endpoint %q", endpoint)
-	}
-
-	return &caClient{
-		client: gcapb.NewIstioCertificateServiceClient(conn),
-	}, nil
-} */
 
 // NewCAClient create an CA client.
 func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterface.Client, error) {
@@ -105,7 +60,6 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 
 	switch CAProviderName {
 	case googleCA:
-		log.Infof("******provider is google ca")
 		return gca.NewGoogleCAClient(conn), nil
 	default:
 		return nil, nil

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -15,7 +15,6 @@
 package caclient
 
 import (
-	"context"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -28,14 +27,7 @@ import (
 	gca "istio.io/istio/security/pkg/nodeagent/caclient/providers/google"
 )
 
-const (
-	googleCA = "GoogleCA"
-	cidatel  = "Citadel"
-)
-
-type caClient struct {
-	client caClientInterface.Client
-}
+const googleCA = "GoogleCA"
 
 // NewCAClient create an CA client.
 func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterface.Client, error) {
@@ -64,9 +56,4 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 	default:
 		return nil, nil
 	}
-}
-
-func (cl *caClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
-	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
-	return cl.CSRSign(ctx, csrPEM, token, certValidTTLInSec)
 }

--- a/security/pkg/nodeagent/caclient/client_test.go
+++ b/security/pkg/nodeagent/caclient/client_test.go
@@ -23,7 +23,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	capb "istio.io/istio/security/proto"
+	gcapb "istio.io/istio/security/proto/providers/google"
 )
 
 const mockServerAddress = "localhost:0"
@@ -35,8 +35,8 @@ var (
 
 type mockCAServer struct{}
 
-func (ca *mockCAServer) CreateCertificate(ctx context.Context, in *capb.IstioCertificateRequest) (*capb.IstioCertificateResponse, error) {
-	return &capb.IstioCertificateResponse{CertChain: fakeCert}, nil
+func (ca *mockCAServer) CreateCertificate(ctx context.Context, in *gcapb.IstioCertificateRequest) (*gcapb.IstioCertificateResponse, error) {
+	return &gcapb.IstioCertificateResponse{CertChain: fakeCert}, nil
 }
 
 func TestCAClient(t *testing.T) {
@@ -50,7 +50,7 @@ func TestCAClient(t *testing.T) {
 	serv := mockCAServer{}
 
 	go func() {
-		capb.RegisterIstioCertificateServiceServer(s, &serv)
+		gcapb.RegisterIstioCertificateServiceServer(s, &serv)
 		if err := s.Serve(lis); err != nil {
 			t.Fatalf("failed to serve: %v", err)
 		}
@@ -59,7 +59,7 @@ func TestCAClient(t *testing.T) {
 	// The goroutine starting the server may not be ready, results in flakiness.
 	time.Sleep(1 * time.Second)
 
-	cli, err := NewCAClient(lis.Addr().String(), false)
+	cli, err := NewCAClient(lis.Addr().String(), googleCA, false)
 	if err != nil {
 		t.Fatalf("failed to create ca client: %v", err)
 	}

--- a/security/pkg/nodeagent/caclient/interface/iclient.go
+++ b/security/pkg/nodeagent/caclient/interface/iclient.go
@@ -1,0 +1,16 @@
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iclient
+
+import (
+	"context"
+)
+
+// Client interface defines the clients need to implement to talk to CA for CSR.
+type Client interface {
+	CSRSign(ctx context.Context, csrPEM []byte, subjectID string,
+		certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error)
+}

--- a/security/pkg/nodeagent/caclient/interface/iclient.go
+++ b/security/pkg/nodeagent/caclient/interface/iclient.go
@@ -1,3 +1,12 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package caclient
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"istio.io/istio/pkg/log"
+	caClientInterface "istio.io/istio/security/pkg/nodeagent/caclient/interface"
+	gcapb "istio.io/istio/security/proto/providers/google"
+)
+
+type googleCAClient struct {
+	client gcapb.IstioCertificateServiceClient
+}
+
+// NewGoogleCAClient create an CA client for Google CA.
+func NewGoogleCAClient(conn *grpc.ClientConn) caClientInterface.Client {
+	return &googleCAClient{
+		client: gcapb.NewIstioCertificateServiceClient(conn),
+	}
+}
+
+func (cl *googleCAClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
+	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
+	log.Infof("******google ca take CSR")
+
+	req := &gcapb.IstioCertificateRequest{
+		Csr:              string(csrPEM),
+		ValidityDuration: certValidTTLInSec,
+	}
+
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", token))
+	resp, err := cl.client.CreateCertificate(ctx, req)
+	if err != nil {
+		log.Errorf("Failed to create certificate: %v", err)
+		return nil, err
+	}
+
+	if len(resp.CertChain) <= 1 {
+		log.Errorf("CertChain length is %d, expected more than 1", len(resp.CertChain))
+		return nil, errors.New("invalid response cert chain")
+	}
+
+	return resp.CertChain, nil
+}

--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -39,8 +39,6 @@ func NewGoogleCAClient(conn *grpc.ClientConn) caClientInterface.Client {
 
 func (cl *googleCAClient) CSRSign(ctx context.Context, csrPEM []byte, token string,
 	certValidTTLInSec int64) ([]string /*PEM-encoded certificate chain*/, error) {
-	log.Infof("******google ca take CSR")
-
 	req := &gcapb.IstioCertificateRequest{
 		Csr:              string(csrPEM),
 		ValidityDuration: certValidTTLInSec,

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -41,6 +41,9 @@ type Options struct {
 
 	// CAEndpoint is the CA endpoint to which node agent sends CSR request.
 	CAEndpoint string
+
+	// The CA provider name.
+	CAProviderName string
 }
 
 // Server is the gPRC server that exposes SDS through UDS.


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

any CA could be plugged in to take CSR as long as they provide caclient that implement caClientInterface.Client interface. 