### PR TITLE
Add support for configuring LightStep as a tracing backend

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -78,20 +78,20 @@ data:
       concurrency: {{ .Values.global.proxy.concurrency }}
       #
       tracing:
-      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+      {{- if eq .Values.global.proxy.tracer "lightstep" }}
         lightstep:
           # Address of the LightStep Satellite pool
-          address: {{ .Values.global.proxy.tracing.lightstep.address }}
+          address: {{ .Values.global.tracer.lightstep.address }}
           # Access Token used to communicate with the Satellite pool
-          accessToken: {{ .Values.global.proxy.tracing.lightstep.accessToken }}
+          accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
           # Whether communication with the Satellite pool should be secure
-          secure: {{ .Values.global.proxy.tracing.lightstep.secure }}
+          secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
-          cacertPath: {{ .Values.global.proxy.tracing.lightstep.cacertPath }}
-      {{- else if eq .Values.global.proxy.tracing.tracer "zipkin" }}
+          cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
+      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ .Values.global.proxy.tracing.zipkin.address }}
+          address: {{ .Values.global.tracer.zipkin.address }}
       {{- else if .Values.global.remoteZipkinAddress }}
         zipkin:
           address: {{ .Values.global.remoteZipkinAddress }}:9411

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -89,12 +89,15 @@ data:
           # Path to the file containing the cacert to use when verifying TLS
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
+        {{- if .Values.global.tracer.zipkin.address }}
         zipkin:
           # Address of the Zipkin collector
           address: {{ .Values.global.tracer.zipkin.address }}
-      {{- else if .Values.global.remoteZipkinAddress }}
+        {{- else if .Values.global.remoteZipkinAddress }}
         zipkin:
+          # Address of the Zipkin collector
           address: {{ .Values.global.remoteZipkinAddress }}:9411
+        {{- end }}
       {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -89,14 +89,14 @@ data:
           # Path to the file containing the cacert to use when verifying TLS
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
-        {{- if .Values.global.tracer.zipkin.address }}
         zipkin:
           # Address of the Zipkin collector
+        {{- if .Values.global.tracer.zipkin.address }}
           address: {{ .Values.global.tracer.zipkin.address }}
         {{- else if .Values.global.remoteZipkinAddress }}
-        zipkin:
-          # Address of the Zipkin collector
           address: {{ .Values.global.remoteZipkinAddress }}:9411
+        {{- else }}
+          address: zipkin.{{ .Release.Namespace }}:9411
         {{- end }}
       {{- end }}
 

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -87,7 +87,11 @@ data:
           # Whether communication with the Satellite pool should be secure
           secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
+        {{- if .Values.global.tracer.lightstep.cacertPath }}
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
+        {{- else }}
+          cacertPath: "/cacert.pem"
+        {{- end }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -87,11 +87,7 @@ data:
           # Whether communication with the Satellite pool should be secure
           secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
-        {{- if .Values.global.tracer.lightstep.cacertPath }}
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
-        {{- else }}
-          cacertPath: "/cacert.pem"
-        {{- end }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -76,12 +76,26 @@ data:
       # Set concurrency to a specific number to control the number of Proxy worker threads.
       # If set to 0 (default), then start worker thread for each CPU thread/core.
       concurrency: {{ .Values.global.proxy.concurrency }}
-
-    {{- if .Values.global.remoteZipkinAddress }}
       #
-      # Zipkin trace collector
-      zipkinAddress: {{ .Values.global.remoteZipkinAddress }}:9411
-    {{- end }}
+      tracing:
+      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+        lightstep:
+          # Address of the LightStep Satellite pool
+          address: {{ .Values.global.proxy.tracing.lightstep.address }}
+          # Access Token used to communicate with the Satellite pool
+          accessToken: {{ .Values.global.proxy.tracing.lightstep.accessToken }}
+          # Whether communication with the Satellite pool should be secure
+          secure: {{ .Values.global.proxy.tracing.lightstep.secure }}
+          # Path to the file containing the cacert to use when verifying TLS
+          cacertPath: {{ .Values.global.proxy.tracing.lightstep.cacertPath }}
+      {{- else if eq .Values.global.proxy.tracing.tracer "zipkin" }}
+        zipkin:
+          # Address of the Zipkin collector
+          address: {{ .Values.global.proxy.tracing.zipkin.address }}
+      {{- else if .Values.global.remoteZipkinAddress }}
+        zipkin:
+          address: {{ .Values.global.remoteZipkinAddress }}:9411
+      {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     disablePolicyChecks: {{ .Values.global.disablePolicyChecks }}
   {{- end }}  
 
-  {{- if .Values.global.remoteZipkinAddress }}
+  {{- if .Values.global.proxy.tracer }}
     # Set enableTracing to false to disable request tracing.
     enableTracing: {{ .Values.global.enableTracing }}
   {{- end }}  

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -99,7 +99,7 @@ data:
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
         - {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/discoveryAddress\") .ProxyConfig.DiscoveryAddress ]]" }}
-      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+      {{- if eq .Values.global.proxy.tracer "lightstep" }}
         - --lightstepAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]" }}
         - --lightstepAccessToken
@@ -107,7 +107,7 @@ data:
         - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
         - --lightstepCacertPath
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
-      {{- else if (eq .Values.global.proxy.tracing.tracer "zipkin") or .Values.global.remoteZipkinAddress }}
+      {{- else if (eq .Values.global.proxy.tracer "zipkin") or .Values.global.remoteZipkinAddress }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -99,9 +99,17 @@ data:
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
         - {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/discoveryAddress\") .ProxyConfig.DiscoveryAddress ]]" }}
-      {{- if .Values.global.zipkinAddress }}
+      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+        - --lightstepAddress
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]" }}
+        - --lightstepAccessToken
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken ]]" }}
+        - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
+        - --lightstepCacertPath
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
+      {{- else if (eq .Values.global.proxy.tracing.tracer "zipkin") or .Values.global.remoteZipkinAddress }}
         - --zipkinAddress
-        - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
+        - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
       {{- end }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -107,7 +107,7 @@ data:
         - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
         - --lightstepCacertPath
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
-      {{- else if (eq .Values.global.proxy.tracer "zipkin") or .Values.global.remoteZipkinAddress }}
+      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -111,29 +111,8 @@ global:
       host: # example: statsd-svc
       port: # example: 9125
 
-    # This controls the stats collection for proxies. To disable stats
-    # collection, set the prometheusPort to 0.
-    stats:
-      prometheusPort: 15090
-
-    tracing:
-      # Specify which tracer to use. One of: lightstep, zipkin
-      tracer: ""
-      # Configuration for envoy to send trace data to LightStep.
-      # Disabled by default.
-      # address is the <host>:<port> of the satellite pool
-      # accessToken is required for sending data to the pool
-      # secure specifies whether data should be sent with TLS
-      # cacertPath is the path to the file containing the cacert to use when verifying TLS
-      lightstep:
-        address: ""      # example: collector.lightstep.com:443
-        accessToken: ""  # example: abcdefg1234567
-        secure: true     # example: true
-        cacertPath: ""   # example /cacert.pem
-      zipkin:
-        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-        # zipkin service (port 9411) in the same namespace as the other istio components.
-        address: ""
+    # Specify which tracer to use. One of: lightstep, zipkin
+    tracer: ""
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
@@ -159,10 +138,23 @@ global:
   # EnableTracing sets the value with same name in istio config map, requires pilot restart to take effect.
   enableTracing: true
 
+  # Configuration for each of the supported tracers
   tracer:
-    # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-    # zipkin service (port 9411) in the same namespace as the other istio components.
-    zipkinAddress:
+    # Configuration for envoy to send trace data to LightStep.
+    # Disabled by default.
+    # address is the <host>:<port> of the satellite pool
+    # accessToken is required for sending data to the pool
+    # secure specifies whether data should be sent with TLS
+    # cacertPath is the path to the file containing the cacert to use when verifying TLS
+    lightstep:
+      address: ""                # example: lightstep-satellite:443
+      accessToken: ""            # example: abcdefg1234567
+      secure: true               # example: true|false
+      cacertPath: "/cacert.pem"  # example: /cacert.pem
+    zipkin:
+      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+      # zipkin service (port 9411) in the same namespace as the other istio components.
+      address: ""
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -112,7 +112,7 @@ global:
       port: # example: 9125
 
     # Specify which tracer to use. One of: lightstep, zipkin
-    tracer: ""
+    tracer: "zipkin"
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -145,10 +145,9 @@ global:
     # address: the <host>:<port> of the satellite pool
     # accessToken: required for sending data to the pool
     # secure: specifies whether data should be sent with TLS
-    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If not specified, the default
-    #   will be to use a Bundle of CA Root Certificates from Mozilla. If a value is specified then a secret called
-    #   "lightstep.cacert" must be created in the destination namespace with the key matching the base of the provided
-    #   cacertPath and the value being the cacert itself.
+    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If secure is true, this is
+    #   required. If a value is specified then a secret called "lightstep.cacert" must be created in the destination
+    #   namespace with the key matching the base of the provided cacertPath and the value being the cacert itself.
     lightstep:
       address: ""                # example: lightstep-satellite:443
       accessToken: ""            # example: abcdefg1234567

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -142,15 +142,18 @@ global:
   tracer:
     # Configuration for envoy to send trace data to LightStep.
     # Disabled by default.
-    # address is the <host>:<port> of the satellite pool
-    # accessToken is required for sending data to the pool
-    # secure specifies whether data should be sent with TLS
-    # cacertPath is the path to the file containing the cacert to use when verifying TLS
+    # address: the <host>:<port> of the satellite pool
+    # accessToken: required for sending data to the pool
+    # secure: specifies whether data should be sent with TLS
+    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If not specified, the default
+    #   will be to use a Bundle of CA Root Certificates from Mozilla. If a value is specified then a secret called
+    #   "lightstep.cacert" must be created in the destination namespace with the key matching the base of the provided
+    #   cacertPath and the value being the cacert itself.
     lightstep:
       address: ""                # example: lightstep-satellite:443
       accessToken: ""            # example: abcdefg1234567
       secure: true               # example: true|false
-      cacertPath: "/cacert.pem"  # example: /cacert.pem
+      cacertPath: ""             # example: /etc/lightstep/cacert.pem
     zipkin:
       # Host:Port for reporting trace data in zipkin format. If not specified, will default to
       # zipkin service (port 9411) in the same namespace as the other istio components.

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -116,6 +116,25 @@ global:
     stats:
       prometheusPort: 15090
 
+    tracing:
+      # Specify which tracer to use. One of: lightstep, zipkin
+      tracer: ""
+      # Configuration for envoy to send trace data to LightStep.
+      # Disabled by default.
+      # address is the <host>:<port> of the satellite pool
+      # accessToken is required for sending data to the pool
+      # secure specifies whether data should be sent with TLS
+      # cacertPath is the path to the file containing the cacert to use when verifying TLS
+      lightstep:
+        address: ""      # example: collector.lightstep.com:443
+        accessToken: ""  # example: abcdefg1234567
+        secure: true     # example: true
+        cacertPath: ""   # example /cacert.pem
+      zipkin:
+        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+        # zipkin service (port 9411) in the same namespace as the other istio components.
+        address: ""
+
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -97,12 +97,13 @@ data:
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
+        {{- if .Values.global.tracer.zipkin.address }}
           address: {{ .Values.global.tracer.zipkin.address }}
-      {{- else }}
-        zipkin:
+        {{- else }}
           address: zipkin.{{ .Release.Namespace }}:9411
+        {{- end }}
       {{- end }}
-      #
+
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -93,7 +93,11 @@ data:
           # Whether communication with the Satellite pool should be secure
           secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
+        {{- if .Values.global.tracer.lightstep.cacertPath }}
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
+        {{- else }}
+          cacertPath: "/cacert.pem"
+        {{- end }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -84,23 +84,20 @@ data:
       concurrency: {{ .Values.global.proxy.concurrency }}
       #
       tracing:
-      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+      {{- if eq .Values.global.proxy.tracer "lightstep" }}
         lightstep:
           # Address of the LightStep Satellite pool
-          address: {{ .Values.global.proxy.tracing.lightstep.address }}
+          address: {{ .Values.global.tracer.lightstep.address }}
           # Access Token used to communicate with the Satellite pool
-          accessToken: {{ .Values.global.proxy.tracing.lightstep.accessToken }}
+          accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
           # Whether communication with the Satellite pool should be secure
-          secure: {{ .Values.global.proxy.tracing.lightstep.secure }}
+          secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
-          cacertPath: {{ .Values.global.proxy.tracing.lightstep.cacertPath }}
-      {{- else if eq .Values.global.proxy.tracing.tracer "zipkin" }}
+          cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
+      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector
-          address: {{ .Values.global.proxy.tracing.zipkin.address }}
-      {{- else if .Values.global.tracer.zipkinAddress }}
-        zipkin:
-          address: {{ .Values.global.tracer.zipkinAddress }}
+          address: {{ .Values.global.tracer.zipkin.address }}
       {{- else }}
         zipkin:
           address: zipkin.{{ .Release.Namespace }}:9411

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -83,13 +83,29 @@ data:
       # If set to 0 (default), then start worker thread for each CPU thread/core.
       concurrency: {{ .Values.global.proxy.concurrency }}
       #
-      # Zipkin trace collector
-      {{- if .Values.global.tracer.zipkinAddress }}
-      zipkinAddress: {{ .Values.global.tracer.zipkinAddress }}
+      tracing:
+      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+        lightstep:
+          # Address of the LightStep Satellite pool
+          address: {{ .Values.global.proxy.tracing.lightstep.address }}
+          # Access Token used to communicate with the Satellite pool
+          accessToken: {{ .Values.global.proxy.tracing.lightstep.accessToken }}
+          # Whether communication with the Satellite pool should be secure
+          secure: {{ .Values.global.proxy.tracing.lightstep.secure }}
+          # Path to the file containing the cacert to use when verifying TLS
+          cacertPath: {{ .Values.global.proxy.tracing.lightstep.cacertPath }}
+      {{- else if eq .Values.global.proxy.tracing.tracer "zipkin" }}
+        zipkin:
+          # Address of the Zipkin collector
+          address: {{ .Values.global.proxy.tracing.zipkin.address }}
+      {{- else if .Values.global.tracer.zipkinAddress }}
+        zipkin:
+          address: {{ .Values.global.tracer.zipkinAddress }}
       {{- else }}
-      zipkinAddress: zipkin.{{ .Release.Namespace }}:9411
+        zipkin:
+          address: zipkin.{{ .Release.Namespace }}:9411
       {{- end }}
-
+      #
     {{- if .Values.global.proxy.envoyStatsd.enabled }}
       #
       # Statsd metrics collector converts statsd metrics into Prometheus metrics.

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -93,11 +93,7 @@ data:
           # Whether communication with the Satellite pool should be secure
           secure: {{ .Values.global.tracer.lightstep.secure }}
           # Path to the file containing the cacert to use when verifying TLS
-        {{- if .Values.global.tracer.lightstep.cacertPath }}
           cacertPath: {{ .Values.global.tracer.lightstep.cacertPath }}
-        {{- else }}
-          cacertPath: "/cacert.pem"
-        {{- end }}
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         zipkin:
           # Address of the Zipkin collector

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -210,11 +210,22 @@ data:
         - mountPath: /var/run/sds
           name: sds-uds-path
         {{- end }}
+        {{ if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
+        - mountPath: {{ "[[ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
+          name: lightstep-certs
+          readOnly: true
+        {{- end }}
       volumes:
       {{ if .Values.global.sdsEnabled }}
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
+      {{- end }}
+      {{ if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
+      - name: lightstep-certs
+        secret:
+          optional: true
+          secretName: lightstep.cacert
       {{- end }}
       - emptyDir:
           medium: Memory

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -105,8 +105,18 @@ data:
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
         - {{ "[[ .ProxyConfig.DiscoveryAddress ]]" }}
+      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+        - --lightstepAddress
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]" }}
+        - --lightstepAccessToken
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken ]]" }}
+        - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
+        - --lightstepCacertPath
+        - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
+      {{- else }}
         - --zipkinAddress
-        - {{ "[[ .ProxyConfig.ZipkinAddress ]]" }}
+        - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
+      {{- end }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}
       {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -113,7 +113,7 @@ data:
         - --lightstepSecure={{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]" }}
         - --lightstepCacertPath
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
-      {{- else }}
+      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
       {{- end }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -105,7 +105,7 @@ data:
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
         - {{ "[[ .ProxyConfig.DiscoveryAddress ]]" }}
-      {{- if eq .Values.global.proxy.tracing.tracer "lightstep" }}
+      {{- if eq .Values.global.proxy.tracer "lightstep" }}
         - --lightstepAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]" }}
         - --lightstepAccessToken

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -182,7 +182,7 @@ global:
       prometheusPort: 15090
 
     # Specify which tracer to use. One of: lightstep, zipkin
-    tracer: ""
+    tracer: "zipkin"
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -182,7 +182,7 @@ global:
       prometheusPort: 15090
 
     # Specify which tracer to use. One of: lightstep, zipkin
-    tracer: "lightstep"
+    tracer: ""
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -215,10 +215,9 @@ global:
     # address: the <host>:<port> of the satellite pool
     # accessToken: required for sending data to the pool
     # secure: specifies whether data should be sent with TLS
-    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If not specified, the default
-    #   will be to use a Bundle of CA Root Certificates from Mozilla. If a value is specified then a secret called
-    #   "lightstep.cacert" must be created in the destination namespace with the key matching the base of the provided
-    #   cacertPath and the value being the cacert itself.
+    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If secure is true, this is
+    #   required. If a value is specified then a secret called "lightstep.cacert" must be created in the destination
+    #   namespace with the key matching the base of the provided cacertPath and the value being the cacert itself.
     #
     lightstep:
       address: ""                # example: lightstep-satellite:443

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -212,15 +212,19 @@ global:
   tracer:
     # Configuration for envoy to send trace data to LightStep.
     # Disabled by default.
-    # address is the <host>:<port> of the satellite pool
-    # accessToken is required for sending data to the pool
-    # secure specifies whether data should be sent with TLS
-    # cacertPath is the path to the file containing the cacert to use when verifying TLS
+    # address: the <host>:<port> of the satellite pool
+    # accessToken: required for sending data to the pool
+    # secure: specifies whether data should be sent with TLS
+    # cacertPath: the path to the file containing the cacert to use when verifying TLS. If not specified, the default
+    #   will be to use a Bundle of CA Root Certificates from Mozilla. If a value is specified then a secret called
+    #   "lightstep.cacert" must be created in the destination namespace with the key matching the base of the provided
+    #   cacertPath and the value being the cacert itself.
+    #
     lightstep:
       address: ""                # example: lightstep-satellite:443
       accessToken: ""            # example: abcdefg1234567
       secure: true               # example: true|false
-      cacertPath: "/cacert.pem"  # example: /cacert.pem
+      cacertPath: ""             # example: /etc/lightstep/cacert.pem
     zipkin:
       # Host:Port for reporting trace data in zipkin format. If not specified, will default to
       # zipkin service (port 9411) in the same namespace as the other istio components.

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -181,24 +181,8 @@ global:
     stats:
       prometheusPort: 15090
 
-    tracing:
-      # Specify which tracer to use. One of: lightstep, zipkin
-      tracer: ""
-      # Configuration for envoy to send trace data to LightStep.
-      # Disabled by default.
-      # address is the <host>:<port> of the satellite pool
-      # accessToken is required for sending data to the pool
-      # secure specifies whether data should be sent with TLS
-      # cacertPath is the path to the file containing the cacert to use when verifying TLS
-      lightstep:
-        address: ""                # example: collector.lightstep.com:443
-        accessToken: ""            # example: abcdefg1234567
-        secure: true               # example: true
-        cacertPath: "/cacert.pem"  # example /cacert.pem
-      zipkin:
-        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-        # zipkin service (port 9411) in the same namespace as the other istio components.
-        address: ""
+    # Specify which tracer to use. One of: lightstep, zipkin
+    tracer: "lightstep"
 
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
@@ -224,11 +208,23 @@ global:
   # EnableTracing sets the value with same name in istio config map, requires pilot restart to take effect.
   enableTracing: true
 
-# TODO: Should this be deprecated
+  # Configuration for each of the supported tracers
   tracer:
-    # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-    # zipkin service (port 9411) in the same namespace as the other istio components.
-    zipkinAddress: ""
+    # Configuration for envoy to send trace data to LightStep.
+    # Disabled by default.
+    # address is the <host>:<port> of the satellite pool
+    # accessToken is required for sending data to the pool
+    # secure specifies whether data should be sent with TLS
+    # cacertPath is the path to the file containing the cacert to use when verifying TLS
+    lightstep:
+      address: ""                # example: lightstep-satellite:443
+      accessToken: ""            # example: abcdefg1234567
+      secure: true               # example: true|false
+      cacertPath: "/cacert.pem"  # example: /cacert.pem
+    zipkin:
+      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+      # zipkin service (port 9411) in the same namespace as the other istio components.
+      address: ""
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -181,6 +181,25 @@ global:
     stats:
       prometheusPort: 15090
 
+    tracing:
+      # Specify which tracer to use. One of: lightstep, zipkin
+      tracer: ""
+      # Configuration for envoy to send trace data to LightStep.
+      # Disabled by default.
+      # address is the <host>:<port> of the satellite pool
+      # accessToken is required for sending data to the pool
+      # secure specifies whether data should be sent with TLS
+      # cacertPath is the path to the file containing the cacert to use when verifying TLS
+      lightstep:
+        address: ""                # example: collector.lightstep.com:443
+        accessToken: ""            # example: abcdefg1234567
+        secure: true               # example: true
+        cacertPath: "/cacert.pem"  # example /cacert.pem
+      zipkin:
+        # Host:Port for reporting trace data in zipkin format. If not specified, will default to
+        # zipkin service (port 9411) in the same namespace as the other istio components.
+        address: ""
+
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init
@@ -205,10 +224,11 @@ global:
   # EnableTracing sets the value with same name in istio config map, requires pilot restart to take effect.
   enableTracing: true
 
+# TODO: Should this be deprecated
   tracer:
     # Host:Port for reporting trace data in zipkin format. If not specified, will default to
     # zipkin service (port 9411) in the same namespace as the other istio components.
-    zipkinAddress:
+    zipkinAddress: ""
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:

--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
           - --serviceCluster
           - {{ $key }}
           - --zipkinAddress
-        {{- if $.Values.global.tracer.zipkinAddress }}
-          - {{ $.Values.global.tracer.zipkinAddress }}
+        {{- if $.Values.global.tracer.zipkin.address }}
+          - {{ $.Values.global.tracer.zipkin.address }}
         {{- else if $.Values.global.istioNamespace }}
           - zipkin.{{ $.Values.global.istioNamespace }}:9411
         {{- else }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -40,8 +40,8 @@
           - --configStoreURL=k8s://
 {{- end }}
           - --configDefaultNamespace={{ $.Release.Namespace }}
-          {{- if $.Values.global.tracer.zipkinAddress }}
-          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkinAddress }}/api/v1/spans
+          {{- if $.Values.global.tracer.zipkin.address }}
+          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkin.address }}/api/v1/spans
           {{- else }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
           {{- end }}
@@ -167,8 +167,8 @@
           - --configStoreURL=k8s://
 {{- end }}
           - --configDefaultNamespace={{ $.Release.Namespace }}
-          {{- if $.Values.global.tracer.zipkinAddress }}
-          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkinAddress }}/api/v1/spans
+          {{- if $.Values.global.tracer.zipkin.address }}
+          - --trace_zipkin_url=http://{{- $.Values.global.tracer.zipkin.address }}/api/v1/spans
           {{- else }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
           {{- end }}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -57,6 +57,10 @@ var (
 	parentShutdownDuration   time.Duration
 	discoveryAddress         string
 	zipkinAddress            string
+	lightstepAddress         string
+	lightstepAccessToken     string
+	lightstepSecure          bool
+	lightstepCacertPath      string
 	connectTimeout           time.Duration
 	statsdUDPAddress         string
 	proxyAdminPort           uint16
@@ -141,7 +145,6 @@ var (
 			proxyConfig.DrainDuration = types.DurationProto(drainDuration)
 			proxyConfig.ParentShutdownDuration = types.DurationProto(parentShutdownDuration)
 			proxyConfig.DiscoveryAddress = discoveryAddress
-			proxyConfig.ZipkinAddress = zipkinAddress
 			proxyConfig.ConnectTimeout = types.DurationProto(connectTimeout)
 			proxyConfig.StatsdUdpAddress = statsdUDPAddress
 			proxyConfig.ProxyAdminPort = int32(proxyAdminPort)
@@ -188,6 +191,28 @@ var (
 					proxyConfig.StatsdUdpAddress = ""
 				} else {
 					proxyConfig.StatsdUdpAddress = addr
+				}
+			}
+
+			// set tracing config
+			if lightstepAddress != "" {
+				proxyConfig.Tracing = &meshconfig.Tracing{
+					Tracer: &meshconfig.Tracing_Lightstep_{
+						Lightstep: &meshconfig.Tracing_Lightstep{
+							Address:     lightstepAddress,
+							AccessToken: lightstepAccessToken,
+							Secure:      lightstepSecure,
+							CacertPath:  lightstepCacertPath,
+						},
+					},
+				}
+			} else if zipkinAddress != "" {
+				proxyConfig.Tracing = &meshconfig.Tracing{
+					Tracer: &meshconfig.Tracing_Zipkin_{
+						Zipkin: &meshconfig.Tracing_Zipkin{
+							Address: zipkinAddress,
+						},
+					},
 				}
 			}
 
@@ -340,8 +365,16 @@ func init() {
 		"The time in seconds that Envoy will wait before shutting down the parent process during a hot restart")
 	proxyCmd.PersistentFlags().StringVar(&discoveryAddress, "discoveryAddress", values.DiscoveryAddress,
 		"Address of the discovery service exposing xDS (e.g. istio-pilot:8080)")
-	proxyCmd.PersistentFlags().StringVar(&zipkinAddress, "zipkinAddress", values.ZipkinAddress,
+	proxyCmd.PersistentFlags().StringVar(&zipkinAddress, "zipkinAddress", "",
 		"Address of the Zipkin service (e.g. zipkin:9411)")
+	proxyCmd.PersistentFlags().StringVar(&lightstepAddress, "lightstepAddress", "",
+		"Address of the LightStep Satellite pool")
+	proxyCmd.PersistentFlags().StringVar(&lightstepAccessToken, "lightstepAccessToken", "",
+		"Access Token for LightStep Satellite pool")
+	proxyCmd.PersistentFlags().BoolVar(&lightstepSecure, "lightstepSecure", false,
+		"Should connection to the LightStep Satellite pool be secure")
+	proxyCmd.PersistentFlags().StringVar(&lightstepCacertPath, "lightstepCacertPath", "/cacert.pem",
+		"Path to the trusted cacert used to authenticate the pool")
 	proxyCmd.PersistentFlags().DurationVar(&connectTimeout, "connectTimeout",
 		timeDuration(values.ConnectTimeout),
 		"Connection timeout used by Envoy for supporting services")

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -373,7 +373,7 @@ func init() {
 		"Access Token for LightStep Satellite pool")
 	proxyCmd.PersistentFlags().BoolVar(&lightstepSecure, "lightstepSecure", false,
 		"Should connection to the LightStep Satellite pool be secure")
-	proxyCmd.PersistentFlags().StringVar(&lightstepCacertPath, "lightstepCacertPath", "/cacert.pem",
+	proxyCmd.PersistentFlags().StringVar(&lightstepCacertPath, "lightstepCacertPath", "",
 		"Path to the trusted cacert used to authenticate the pool")
 	proxyCmd.PersistentFlags().DurationVar(&connectTimeout, "connectTimeout",
 		timeDuration(values.ConnectTimeout),

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -27,6 +27,7 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
+ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -27,7 +27,6 @@ ADD pilot-agent /usr/local/bin/pilot-agent
 ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
-ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -40,6 +40,7 @@ ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
+ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -40,7 +40,6 @@ ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
-ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -18,7 +18,6 @@ ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
-ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -18,6 +18,7 @@ ADD envoy_pilot.yaml.tmpl /etc/istio/proxy/envoy_pilot.yaml.tmpl
 ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
+ADD cacert.pem /cacert.pem
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
 

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"path"
 	"reflect"
 	"strconv"
 	"strings"
@@ -475,6 +476,11 @@ func isset(m map[string]string, key string) bool {
 	return ok
 }
 
+func directory(filepath string) string {
+	dir, _ := path.Split(filepath)
+	return dir
+}
+
 func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec, metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (*SidecarInjectionSpec, string, error) { // nolint: lll
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {
 		return nil, "", err
@@ -497,6 +503,7 @@ func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.O
 		"annotation":          annotation,
 		"valueOrDefault":      valueOrDefault,
 		"toJSON":              toJSON,
+		"directory":           directory,
 	}
 
 	var tmpl bytes.Buffer

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -103,8 +103,18 @@ containers:
   - [[ formatDuration .ProxyConfig.ParentShutdownDuration ]]
   - --discoveryAddress
   - [[ .ProxyConfig.DiscoveryAddress ]]
+  [[ if .ProxyConfig.GetTracing.GetLightstep -]]
+  - --lightstepAddress
+  - [[ .ProxyConfig.GetTracing.GetLightstep.GetAddress ]]
+  - --lightstepAccessToken
+  - [[ .ProxyConfig.GetTracing.GetLightstep.GetAccessToken ]]
+  - --lightstepSecure=[[ .ProxyConfig.GetTracing.GetLightstep.GetSecure ]]
+  - --lightstepCacertPath
+  - [[ .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]
+  [[ else if .ProxyConfig.GetTracing.GetZipkin -]]
   - --zipkinAddress
-  - [[ .ProxyConfig.ZipkinAddress ]]
+  - [[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]
+  [[ end -]]
   - --connectTimeout
   - [[ formatDuration .ProxyConfig.ConnectTimeout ]]
   - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.cert-dir.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.non-default-service-account.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/auth.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob-with-app.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob-with-app.yaml.injected
@@ -39,8 +39,6 @@ spec:
             - 3s
             - --discoveryAddress
             - istio-pilot:15007
-            - --zipkinAddress
-            - ""
             - --connectTimeout
             - 1s
             - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/cronjob.yaml.injected
@@ -37,8 +37,6 @@ spec:
             - 3s
             - --discoveryAddress
             - istio-pilot:15007
-            - --zipkinAddress
-            - ""
             - --connectTimeout
             - 1s
             - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/daemonset.yaml.injected
@@ -36,8 +36,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig-multi.yaml.injected
@@ -56,8 +56,6 @@ items:
           - 3s
           - --discoveryAddress
           - istio-pilot:15007
-          - --zipkinAddress
-          - ""
           - --connectTimeout
           - 1s
           - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/deploymentconfig.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/enable-core-dump.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/format-duration.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 42s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 42s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/frontend.yaml.injected
@@ -56,8 +56,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-always.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-config-map-name.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-ignore.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-multi.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress
@@ -168,8 +166,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-namespace.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-never.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-probes.yaml.injected
@@ -58,8 +58,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-proxy-override.yaml.injected
@@ -39,8 +39,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy-debug.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello-tproxy.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/hello.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/job.yaml.injected
@@ -35,8 +35,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list-frontend.yaml.injected
@@ -57,8 +57,6 @@ items:
           - 3s
           - --discoveryAddress
           - istio-pilot:15007
-          - --zipkinAddress
-          - ""
           - --connectTimeout
           - 1s
           - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/list.yaml.injected
@@ -41,8 +41,6 @@ items:
           - 3s
           - --discoveryAddress
           - istio-pilot:15007
-          - --zipkinAddress
-          - ""
           - --connectTimeout
           - 1s
           - --statsdUdpAddress
@@ -169,8 +167,6 @@ items:
           - 3s
           - --discoveryAddress
           - istio-pilot:15007
-          - --zipkinAddress
-          - ""
           - --connectTimeout
           - 1s
           - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/multi-init.yaml.injected
@@ -38,8 +38,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod-with-app.yaml.injected
@@ -31,8 +31,6 @@ spec:
     - 3s
     - --discoveryAddress
     - istio-pilot:15007
-    - --zipkinAddress
-    - ""
     - --connectTimeout
     - 1s
     - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/pod.yaml.injected
@@ -28,8 +28,6 @@ spec:
     - 3s
     - --discoveryAddress
     - istio-pilot:15007
-    - --zipkinAddress
-    - ""
     - --connectTimeout
     - 1s
     - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicaset.yaml.injected
@@ -35,8 +35,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/replicationcontroller.yaml.injected
@@ -37,8 +37,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_annotations.yaml.injected
@@ -41,8 +41,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/status_params.yaml.injected
@@ -36,8 +36,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-empty-includes.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations-wildcards.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-annotations.yaml.injected
@@ -40,8 +40,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params-empty-includes.yaml.injected
@@ -36,8 +36,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/traffic-params.yaml.injected
@@ -36,8 +36,6 @@ spec:
         - 3s
         - --discoveryAddress
         - istio-pilot:15007
-        - --zipkinAddress
-        - ""
         - --connectTimeout
         - 1s
         - --statsdUdpAddress

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -267,7 +267,6 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		DrainDuration:          types.DurationProto(2 * time.Second),
 		ParentShutdownDuration: types.DurationProto(3 * time.Second),
 		DiscoveryAddress:       DiscoveryPlainAddress,
-		ZipkinAddress:          "",
 		ConnectTimeout:         types.DurationProto(1 * time.Second),
 		StatsdUdpAddress:       "",
 		ProxyAdminPort:         15000,
@@ -275,6 +274,7 @@ func DefaultProxyConfig() meshconfig.ProxyConfig {
 		CustomConfigFile:       "",
 		Concurrency:            0,
 		StatNameLength:         189,
+		Tracing:                nil,
 	}
 }
 
@@ -325,6 +325,7 @@ func ApplyMeshConfigDefaults(yaml string) (*meshconfig.MeshConfig, error) {
 	if err := ValidateMeshConfig(&out); err != nil {
 		return nil, err
 	}
+
 	return &out, nil
 }
 

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -781,6 +781,26 @@ func ValidateParentAndDrain(drainTime, parentShutdown *types.Duration) (errs err
 	return
 }
 
+// ValidateLightstepCollector validates the configuration for sending envoy spans to LightStep
+func ValidateLightstepCollector(ls *meshconfig.Tracing_Lightstep) error {
+	var errs error
+	if ls.GetAddress() == "" {
+		multierror.Append(errs, errors.New("address is required"))
+	}
+	if err := ValidateProxyAddress(ls.GetAddress()); err != nil {
+		errs = multierror.Append(errs, multierror.Prefix(err, "invalid lightstep address:"))
+	}
+	if ls.GetAccessToken() == "" {
+		multierror.Append(errs, errors.New("access token is required"))
+	}
+	return errs
+}
+
+// ValidateZipkinCollector validates the configuration for sending envoy spans to Zipkin
+func ValidateZipkinCollector(z *meshconfig.Tracing_Zipkin) error {
+	return ValidateProxyAddress(z.GetAddress())
+}
+
 // ValidateConnectTimeout validates the envoy conncection timeout
 func ValidateConnectTimeout(timeout *types.Duration) error {
 	if err := ValidateDuration(timeout); err != nil {
@@ -850,9 +870,15 @@ func ValidateProxyConfig(config *meshconfig.ProxyConfig) (errs error) {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid discovery address:"))
 	}
 
-	if config.ZipkinAddress != "" {
-		if err := ValidateProxyAddress(config.ZipkinAddress); err != nil {
-			errs = multierror.Append(errs, multierror.Prefix(err, "invalid zipkin address:"))
+	if tracer := config.GetTracing().GetLightstep(); tracer != nil {
+		if err := ValidateLightstepCollector(tracer); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid lightstep config:"))
+		}
+	}
+
+	if tracer := config.GetTracing().GetZipkin(); tracer != nil {
+		if err := ValidateZipkinCollector(tracer); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid zipkin config:"))
 		}
 	}
 

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -785,13 +785,16 @@ func ValidateParentAndDrain(drainTime, parentShutdown *types.Duration) (errs err
 func ValidateLightstepCollector(ls *meshconfig.Tracing_Lightstep) error {
 	var errs error
 	if ls.GetAddress() == "" {
-		multierror.Append(errs, errors.New("address is required"))
+		errs = multierror.Append(errs, errors.New("address is required"))
 	}
 	if err := ValidateProxyAddress(ls.GetAddress()); err != nil {
 		errs = multierror.Append(errs, multierror.Prefix(err, "invalid lightstep address:"))
 	}
 	if ls.GetAccessToken() == "" {
-		multierror.Append(errs, errors.New("access token is required"))
+		errs = multierror.Append(errs, errors.New("access token is required"))
+	}
+	if ls.GetSecure() && (ls.GetCacertPath() == "") {
+		errs = multierror.Append(errs, errors.New("cacertPath is required"))
 	}
 	return errs
 }

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -690,7 +690,7 @@ func TestValidateProxyConfig(t *testing.T) {
 								Address:     "collector.lightstep:8080",
 								AccessToken: "abcdefg1234567",
 								Secure:      false,
-								CacertPath:  "/cacert.pem",
+								CacertPath:  "/etc/lightstep/cacert.pem",
 							},
 						},
 					}
@@ -708,7 +708,7 @@ func TestValidateProxyConfig(t *testing.T) {
 								Address:     "10.0.0.100",
 								AccessToken: "abcdefg1234567",
 								Secure:      false,
-								CacertPath:  "/cacert.pem",
+								CacertPath:  "/etc/lightstep/cacert.pem",
 							},
 						},
 					}
@@ -726,7 +726,25 @@ func TestValidateProxyConfig(t *testing.T) {
 								Address:     "",
 								AccessToken: "abcdefg1234567",
 								Secure:      false,
-								CacertPath:  "/cacert.pem",
+								CacertPath:  "/etc/lightstep/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep address is valid but access token is empty",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "collector.lightstep:8080",
+								AccessToken: "",
+								Secure:      false,
+								CacertPath:  "/etc/lightstep/cacert.pem",
 							},
 						},
 					}
@@ -744,7 +762,7 @@ func TestValidateProxyConfig(t *testing.T) {
 								Address:     "10.0.0.100",
 								AccessToken: "",
 								Secure:      false,
-								CacertPath:  "/cacert.pem",
+								CacertPath:  "/etc/lightstep/cacert.pem",
 							},
 						},
 					}
@@ -762,7 +780,25 @@ func TestValidateProxyConfig(t *testing.T) {
 								Address:     "",
 								AccessToken: "",
 								Secure:      false,
-								CacertPath:  "/cacert.pem",
+								CacertPath:  "/etc/lightstep/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep cacert is missing",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "collector.lightstep:8080",
+								AccessToken: "abcdefg1234567",
+								Secure:      true,
+								CacertPath:  "",
 							},
 						},
 					}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -560,8 +560,227 @@ func TestValidateMeshConfig(t *testing.T) {
 }
 
 func TestValidateProxyConfig(t *testing.T) {
-	if ValidateProxyConfig(&meshconfig.ProxyConfig{}) == nil {
-		t.Error("expected an error on an empty proxy config")
+	valid := &meshconfig.ProxyConfig{
+		ConfigPath:             "/etc/istio/proxy",
+		BinaryPath:             "/usr/local/bin/envoy",
+		DiscoveryAddress:       "istio-pilot.istio-system:15010",
+		ProxyAdminPort:         15000,
+		DrainDuration:          types.DurationProto(45 * time.Second),
+		ParentShutdownDuration: types.DurationProto(60 * time.Second),
+		ConnectTimeout:         types.DurationProto(10 * time.Second),
+		ServiceCluster:         "istio-proxy",
+		StatsdUdpAddress:       "istio-statsd-prom-bridge.istio-system:9125",
+		ControlPlaneAuthPolicy: 1,
+		Tracing:                nil,
+	}
+
+	modify := func(config *meshconfig.ProxyConfig, fieldSetter func(*meshconfig.ProxyConfig)) *meshconfig.ProxyConfig {
+		clone := proto.Clone(valid).(*meshconfig.ProxyConfig)
+		fieldSetter(clone)
+		return clone
+	}
+
+	cases := []struct {
+		name    string
+		in      *meshconfig.ProxyConfig
+		isValid bool
+	}{
+		{
+			name:    "empty proxy config",
+			in:      &meshconfig.ProxyConfig{},
+			isValid: false,
+		},
+		{
+			name:    "valid proxy config",
+			in:      valid,
+			isValid: true,
+		},
+		{
+			name:    "config path invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ConfigPath = "" }),
+			isValid: false,
+		},
+		{
+			name:    "binary path invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.BinaryPath = "" }),
+			isValid: false,
+		},
+		{
+			name:    "discovery address invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.DiscoveryAddress = "10.0.0.100" }),
+			isValid: false,
+		},
+		{
+			name:    "proxy admin port invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ProxyAdminPort = 0 }),
+			isValid: false,
+		},
+		{
+			name:    "proxy admin port invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ProxyAdminPort = 0 }),
+			isValid: false,
+		},
+		{
+			name:    "drain duration invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.DrainDuration = types.DurationProto(-1 * time.Second) }),
+			isValid: false,
+		},
+		{
+			name:    "parent shutdown duration invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ParentShutdownDuration = types.DurationProto(-1 * time.Second) }),
+			isValid: false,
+		},
+		{
+			name:    "connect timeout invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ConnectTimeout = types.DurationProto(-1 * time.Second) }),
+			isValid: false,
+		},
+		{
+			name:    "service cluster invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ServiceCluster = "" }),
+			isValid: false,
+		},
+		{
+			name:    "statsd udp address invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.StatsdUdpAddress = "10.0.0.100" }),
+			isValid: false,
+		},
+		{
+			name:    "control plane auth policy invalid",
+			in:      modify(valid, func(c *meshconfig.ProxyConfig) { c.ControlPlaneAuthPolicy = -1 }),
+			isValid: false,
+		},
+		{
+			name: "zipkin address is valid",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Zipkin_{
+							Zipkin: &meshconfig.Tracing_Zipkin{
+								Address: "zipkin.istio-system:9411",
+							},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
+		{
+			name: "zipkin config invalid",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Zipkin_{
+							Zipkin: &meshconfig.Tracing_Zipkin{
+								Address: "10.0.0.100",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep config is valid",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "collector.lightstep:8080",
+								AccessToken: "abcdefg1234567",
+								Secure:      false,
+								CacertPath:  "/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
+		{
+			name: "lightstep address invalid",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "10.0.0.100",
+								AccessToken: "abcdefg1234567",
+								Secure:      false,
+								CacertPath:  "/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep address empty but lightstep access token is not",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "",
+								AccessToken: "abcdefg1234567",
+								Secure:      false,
+								CacertPath:  "/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep access token empty but lightstep address is not",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "10.0.0.100",
+								AccessToken: "",
+								Secure:      false,
+								CacertPath:  "/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+		{
+			name: "lightstep address and lightstep token both empty",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Lightstep_{
+							Lightstep: &meshconfig.Tracing_Lightstep{
+								Address:     "",
+								AccessToken: "",
+								Secure:      false,
+								CacertPath:  "/cacert.pem",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ValidateProxyConfig(c.in); (got == nil) != c.isValid {
+				if c.isValid {
+					t.Errorf("got error %v, wanted none", got)
+				} else {
+					t.Error("got no error, wanted one")
+				}
+			}
+		})
 	}
 
 	invalid := meshconfig.ProxyConfig{
@@ -574,8 +793,14 @@ func TestValidateProxyConfig(t *testing.T) {
 		ConnectTimeout:         types.DurationProto(-1 * time.Second),
 		ServiceCluster:         "",
 		StatsdUdpAddress:       "10.0.0.100",
-		ZipkinAddress:          "10.0.0.100",
 		ControlPlaneAuthPolicy: -1,
+		Tracing: &meshconfig.Tracing{
+			Tracer: &meshconfig.Tracing_Zipkin_{
+				Zipkin: &meshconfig.Tracing_Zipkin{
+					Address: "10.0.0.100",
+				},
+			},
+		},
 	}
 
 	err := ValidateProxyConfig(&invalid)
@@ -585,7 +810,7 @@ func TestValidateProxyConfig(t *testing.T) {
 		switch err.(type) {
 		case *multierror.Error:
 			// each field must cause an error in the field
-			if len(err.(*multierror.Error).Errors) < 11 {
+			if len(err.(*multierror.Error).Errors) != 11 {
 				t.Errorf("expected an error for each field %v", err)
 			}
 		default:

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -111,6 +111,13 @@ func TestGolden(t *testing.T) {
 				return
 			}
 
+			// re-read generated file with the changes having been made
+			data, err = ioutil.ReadFile(fn)
+			if err != nil {
+				t.Error("Error reading generated file ", err)
+				return
+			}
+
 			golden, err := ioutil.ReadFile("testdata/" + c.base + "_golden.json")
 			if err != nil {
 				golden = []byte{}
@@ -170,18 +177,18 @@ func TestGolden(t *testing.T) {
 }
 
 type regexReplacement struct {
-	pattern *regexp.Regexp
+	pattern     *regexp.Regexp
 	replacement []byte
 }
 
 // correctForEnvDifference corrects the portions of a generated bootstrap config that vary depending on the environment
 // so that they match the golden file's expected value.
 func correctForEnvDifference(in []byte) []byte {
-	replacements := []regexReplacement {
+	replacements := []regexReplacement{
 		// Lightstep access tokens are written to a file and that path is dependent upon the environment variables that
 		// are set. Standardize the path so that golden files can be properly checked.
 		{
-			pattern: regexp.MustCompile(`("access_token_file": ").*(lightstep_access_token.txt")`),
+			pattern:     regexp.MustCompile(`("access_token_file": ").*(lightstep_access_token.txt")`),
 			replacement: []byte("$1/test-path/$2"),
 		},
 	}

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -112,7 +112,7 @@ func TestGolden(t *testing.T) {
 			}
 
 			// re-read generated file with the changes having been made
-			data, err = ioutil.ReadFile(fn)
+			real, err = ioutil.ReadFile(fn)
 			if err != nil {
 				t.Error("Error reading generated file ", err)
 				return

--- a/pkg/bootstrap/testdata/all.proto
+++ b/pkg/bootstrap/testdata/all.proto
@@ -4,11 +4,11 @@ service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 5}
 parent_shutdown_duration: {seconds: 6}
 discovery_address:       "mypilot:15011"
-zipkin_address:           "localhost:6000"
 connect_timeout:          {seconds: 7}
 statsd_udp_address:       "10.1.1.1:9125"
 proxy_admin_port:         15005
 control_plane_auth_policy: MUTUAL_TLS
 stat_name_length:          200
+tracing:                   { zipkin: { address: "localhost:6000" } }
 
 # Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -2,12 +2,13 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-
-    "metadata": {"istio": "sidecar"}
+    
+    "metadata": {"istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
-    "stats_tags": [{
+    "stats_tags": [
+      {
         "tag_name": "cluster_name",
         "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
@@ -34,7 +35,7 @@
       {
         "tag_name": "listener_address",
         "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
+      }
     ]
   },
   "admin": {
@@ -48,10 +49,10 @@
   },
   "dynamic_resources": {
     "lds_config": {
-        "ads": {}
+      "ads": {}
     },
     "cds_config": {
-        "ads": {}
+      "ads": {}
     },
     "ads_config": {
       "api_type": "GRPC",
@@ -66,77 +67,83 @@
   },
   "static_resources": {
     "clusters": [
-    {
-      "name": "prometheus_stats",
-      "type": "STATIC",
-      "connect_timeout": "0.250s",
-      "lb_policy": "ROUND_ROBIN",
-      "hosts": [{
-        "socket_address": {
-          "protocol": "TCP",
-          "address": "127.0.0.1",
-          "port_value": 15000,
-        }
-      }],
-    },
-    {
-    "name": "xds-grpc",
-    "type": "STRICT_DNS",
-    "connect_timeout": "7s",
-    "lb_policy": "ROUND_ROBIN",
-
-      "tls_context": {
-        "common_tls_context": {
-          "alpn_protocols": ["h2"],
-          "tls_certificates": [{
-            "certificate_chain": {
-              "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-              "filename": "/etc/certs/key.pem"
+      {
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {
+              "protocol": "TCP",
+              "address": "127.0.0.1",
+              "port_value": 15000
             }
-          }],
-          "validation_context": {
-            "trusted_ca": {
-              "filename": "/etc/certs/root-cert.pem"
-            },
-            "verify_subject_alt_name": [
-              "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-            ]
           }
-        }
-      },
-
-    "hosts": [
-    {
-    "socket_address": {"address": "mypilot", "port_value": 15011}
-    }
-    ],
-    "circuit_breakers": {
-        "thresholds": [
-      {
-        "priority": "DEFAULT",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
+        ]
       },
       {
-        "priority": "HIGH",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
-      }]
-    },
-    "upstream_connection_options": {
-      "tcp_keepalive": {
-        "keepalive_time": 300
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "connect_timeout": "7s",
+        "lb_policy": "ROUND_ROBIN",
+        
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": [
+              "h2"
+            ],
+            "tls_certificates": [
+              {
+                "certificate_chain": {
+                  "filename": "/etc/certs/cert-chain.pem"
+                },
+                "private_key": {
+                  "filename": "/etc/certs/key.pem"
+                }
+              },
+            ],
+            "validation_context": {
+              "trusted_ca": {
+                "filename": "/etc/certs/root-cert.pem"
+              },
+              "verify_subject_alt_name": [
+                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+              ]
+            }
+          }
+        },
+        
+        "hosts": [
+          {
+            "socket_address": {"address": "mypilot", "port_value": 15011}
+          }
+        ],
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "http2_protocol_options": { }
       }
-    },
-    "http2_protocol_options": { }
-    }
-
-    
-    ,
+      
+      ,
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
@@ -159,38 +166,47 @@
             "port_value": 15090,
           }
         },
-        "filter_chains": [{
-          "filters": [{
-            "name": "envoy.http_connection_manager",
-            "config": {
-              "codec_type": "AUTO",
-              "stat_prefix": "stats",
-              "route_config": {
-                "virtual_hosts": [{
-                  "name": "backend",
-                  "domains": [
-                    "*"
-                  ],
-                  "routes": [{
-                    "match": {
-                      "prefix": "/stats/prometheus"
-                    },
-                    "route": {
-                      "cluster": "prometheus_stats"
-                    }
-                  }]
-                }]
-              },
-              "http_filters": {
-                "name": "envoy.router"
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "config": {
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": {
+                    "name": "envoy.router"
+                  }
+                }
               }
-            }
-          }]
-        }],
-      },
-    ],
-  },
+            ]
+          }
+        ]
+      }
+    ]
+  }
   
+  ,
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
@@ -198,9 +214,10 @@
         "collector_cluster": "zipkin"
       }
     }
-  },
+  }
   
   
+  ,
   "stats_sinks": [
     {
       "name": "envoy.statsd",

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -101,7 +101,7 @@
                 "private_key": {
                   "filename": "/etc/certs/key.pem"
                 }
-              },
+              }
             ],
             "validation_context": {
               "trusted_ca": {
@@ -163,7 +163,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/auth.proto
+++ b/pkg/bootstrap/testdata/auth.proto
@@ -1,12 +1,11 @@
-config_path:             "/etc/istio/proxy"
-binary_path:             "/usr/local/bin/envoy"
-service_cluster:         "istio-proxy"
-drain_duration:          {seconds: 2}
-parent_shutdown_duration: {seconds: 3}
-discovery_address:       "istio-pilot:15011"
-zipkin_address:           ""
-connect_timeout:          {seconds: 1}
-proxy_admin_port:         15000
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+parent_shutdown_duration:  {seconds: 3}
+discovery_address:         "istio-pilot:15011"
+connect_timeout:           {seconds: 1}
+proxy_admin_port:          15000
 control_plane_auth_policy: MUTUAL_TLS
 
 # Same as default, but with MUTUAL_TLS enabled

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -101,7 +101,7 @@
                 "private_key": {
                   "filename": "/etc/certs/key.pem"
                 }
-              },
+              }
             ],
             "validation_context": {
               "trusted_ca": {
@@ -150,7 +150,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -2,14 +2,13 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-
-    "metadata": {
-      "istio": "sidecar"
-    }
+    
+    "metadata": {"istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
-    "stats_tags": [{
+    "stats_tags": [
+      {
         "tag_name": "cluster_name",
         "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
@@ -36,7 +35,7 @@
       {
         "tag_name": "listener_address",
         "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
+      }
     ]
   },
   "admin": {
@@ -50,10 +49,10 @@
   },
   "dynamic_resources": {
     "lds_config": {
-        "ads": {}
+      "ads": {}
     },
     "cds_config": {
-        "ads": {}
+      "ads": {}
     },
     "ads_config": {
       "api_type": "GRPC",
@@ -68,76 +67,82 @@
   },
   "static_resources": {
     "clusters": [
-    {
-      "name": "prometheus_stats",
-      "type": "STATIC",
-      "connect_timeout": "0.250s",
-      "lb_policy": "ROUND_ROBIN",
-      "hosts": [{
-        "socket_address": {
-          "protocol": "TCP",
-          "address": "127.0.0.1",
-          "port_value": 15000,
-        }
-      }],
-    },
-    {
-    "name": "xds-grpc",
-    "type": "STRICT_DNS",
-    "connect_timeout": "1s",
-    "lb_policy": "ROUND_ROBIN",
-
-      "tls_context": {
-        "common_tls_context": {
-          "alpn_protocols": ["h2"],
-          "tls_certificates":[{
-            "certificate_chain": {
-              "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-              "filename": "/etc/certs/key.pem"
+      {
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {
+              "protocol": "TCP",
+              "address": "127.0.0.1",
+              "port_value": 15000
             }
-          }],
-          "validation_context": {
-            "trusted_ca": {
-              "filename": "/etc/certs/root-cert.pem"
-            },
-            "verify_subject_alt_name": [
-              "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-            ]
           }
-        }
-      },
-
-    "hosts": [
-    {
-    "socket_address": {"address": "istio-pilot", "port_value": 15011}
-    }
-    ],
-    "circuit_breakers": {
-        "thresholds": [
-      {
-        "priority": "DEFAULT",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
+        ]
       },
       {
-        "priority": "HIGH",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
-      }]
-    },
-    "upstream_connection_options": {
-      "tcp_keepalive": {
-        "keepalive_time": 300
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": [
+              "h2"
+            ],
+            "tls_certificates": [
+              {
+                "certificate_chain": {
+                  "filename": "/etc/certs/cert-chain.pem"
+                },
+                "private_key": {
+                  "filename": "/etc/certs/key.pem"
+                }
+              },
+            ],
+            "validation_context": {
+              "trusted_ca": {
+                "filename": "/etc/certs/root-cert.pem"
+              },
+              "verify_subject_alt_name": [
+                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+              ]
+            }
+          }
+        },
+        
+        "hosts": [
+          {
+            "socket_address": {"address": "istio-pilot", "port_value": 15011}
+          }
+        ],
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "http2_protocol_options": { }
       }
-    },
-    "http2_protocol_options": { }
-    }
-
-    
+      
     ],
     "listeners":[
       {
@@ -148,37 +153,45 @@
             "port_value": 15090,
           }
         },
-        "filter_chains": [{
-          "filters": [{
-            "name": "envoy.http_connection_manager",
-            "config": {
-              "codec_type": "AUTO",
-              "stat_prefix": "stats",
-              "route_config": {
-                "virtual_hosts": [{
-                  "name": "backend",
-                  "domains": [
-                    "*"
-                  ],
-                  "routes": [{
-                    "match": {
-                      "prefix": "/stats/prometheus"
-                    },
-                    "route": {
-                      "cluster": "prometheus_stats"
-                    }
-                  }]
-                }]
-              },
-              "http_filters": {
-                "name": "envoy.router"
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "config": {
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": {
+                    "name": "envoy.router"
+                  }
+                }
               }
-            }
-          }]
-        }],
-      },
-    ],
-  },
+            ]
+          }
+        ]
+      }
+    ]
+  }
   
   
 }

--- a/pkg/bootstrap/testdata/default.proto
+++ b/pkg/bootstrap/testdata/default.proto
@@ -4,7 +4,6 @@ service_cluster:           "istio-proxy"
 drain_duration:            {seconds: 2}
 parent_shutdown_duration:  {seconds: 3}
 discovery_address:         "istio-pilot:15010"
-zipkin_address:            ""
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -2,14 +2,13 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-
-    "metadata": {
-      "istio": "sidecar"
-    }
+    
+    "metadata": {"istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
-    "stats_tags": [{
+    "stats_tags": [
+      {
         "tag_name": "cluster_name",
         "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
@@ -36,7 +35,7 @@
       {
         "tag_name": "listener_address",
         "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
+      }
     ]
   },
   "admin": {
@@ -50,10 +49,10 @@
   },
   "dynamic_resources": {
     "lds_config": {
-        "ads": {}
+      "ads": {}
     },
     "cds_config": {
-        "ads": {}
+      "ads": {}
     },
     "ads_config": {
       "api_type": "GRPC",
@@ -68,54 +67,56 @@
   },
   "static_resources": {
     "clusters": [
-    {
-      "name": "prometheus_stats",
-      "type": "STATIC",
-      "connect_timeout": "0.250s",
-      "lb_policy": "ROUND_ROBIN",
-      "hosts": [{
-        "socket_address": {
-          "protocol": "TCP",
-          "address": "127.0.0.1",
-          "port_value": 15000,
-        }
-      }],
-    },
-    {
-    "name": "xds-grpc",
-    "type": "STRICT_DNS",
-    "connect_timeout": "1s",
-    "lb_policy": "ROUND_ROBIN",
-
-    "hosts": [
-    {
-    "socket_address": {"address": "istio-pilot", "port_value": 15010}
-    }
-    ],
-    "circuit_breakers": {
-        "thresholds": [
       {
-        "priority": "DEFAULT",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {
+              "protocol": "TCP",
+              "address": "127.0.0.1",
+              "port_value": 15000
+            }
+          }
+        ]
       },
       {
-        "priority": "HIGH",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
-      }]
-    },
-    "upstream_connection_options": {
-      "tcp_keepalive": {
-        "keepalive_time": 300
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "connect_timeout": "1s",
+        "lb_policy": "ROUND_ROBIN",
+        
+        "hosts": [
+          {
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
+          }
+        ],
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "http2_protocol_options": { }
       }
-    },
-    "http2_protocol_options": { }
-    }
-
-    
+      
     ],
     "listeners":[
       {
@@ -126,37 +127,45 @@
             "port_value": 15090,
           }
         },
-        "filter_chains": [{
-          "filters": [{
-            "name": "envoy.http_connection_manager",
-            "config": {
-              "codec_type": "AUTO",
-              "stat_prefix": "stats",
-              "route_config": {
-                "virtual_hosts": [{
-                  "name": "backend",
-                  "domains": [
-                    "*"
-                  ],
-                  "routes": [{
-                    "match": {
-                      "prefix": "/stats/prometheus"
-                    },
-                    "route": {
-                      "cluster": "prometheus_stats"
-                    }
-                  }]
-                }]
-              },
-              "http_filters": {
-                "name": "envoy.router"
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "config": {
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": {
+                    "name": "envoy.router"
+                  }
+                }
               }
-            }
-          }]
-        }],
-      },
-    ],
-  },
+            ]
+          }
+        ]
+      }
+    ]
+  }
   
   
 }

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -124,7 +124,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/running.proto
+++ b/pkg/bootstrap/testdata/running.proto
@@ -4,11 +4,11 @@ service_cluster:         "istio-proxy"
 drain_duration:          {seconds: 5}
 parent_shutdown_duration: {seconds: 6}
 discovery_address:       "mypilot:1001"
-zipkin_address:           "localhost:6000"
 connect_timeout:          {seconds: 7}
 statsd_udp_address:       "10.1.1.1:9125"
 proxy_admin_port:         15005
 control_plane_auth_policy: MUTUAL_TLS
 stat_name_length:          200
+tracing:                   { zipkin: { address: "localhost:6000" } }
 
 # Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -2,20 +2,13 @@
   "node": {
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
-
-    "metadata": {
-          "INTERCEPTION_MODE": "REDIRECT",
-          "ISTIO_PROXY_SHA": "istio-proxy:sha",
-          "ISTIO_PROXY_VERSION": "istio-proxy:version",
-          "ISTIO_VERSION": "release-3.1",
-          "POD_NAME": "svc-0-0-0-6944fb884d-4pgx8",
-          "istio.io/insecurepath": "{\"paths\":[\"/metrics\",\"/live\"]}",
-          "istio": "sidecar"
-    }
+    
+    "metadata": {"INTERCEPTION_MODE":"REDIRECT","ISTIO_PROXY_SHA":"istio-proxy:sha","ISTIO_PROXY_VERSION":"istio-proxy:version","ISTIO_VERSION":"release-3.1","POD_NAME":"svc-0-0-0-6944fb884d-4pgx8","istio":"sidecar","istio.io/insecurepath":"{\"paths\":[\"/metrics\",\"/live\"]}"}
   },
   "stats_config": {
     "use_all_default_tags": false,
-    "stats_tags": [{
+    "stats_tags": [
+      {
         "tag_name": "cluster_name",
         "regex": "^cluster\\.((.+?(\\..+?\\.svc\\.cluster\\.local)?)\\.)"
       },
@@ -42,7 +35,7 @@
       {
         "tag_name": "listener_address",
         "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
-      },
+      }
     ]
   },
   "admin": {
@@ -56,10 +49,10 @@
   },
   "dynamic_resources": {
     "lds_config": {
-        "ads": {}
+      "ads": {}
     },
     "cds_config": {
-        "ads": {}
+      "ads": {}
     },
     "ads_config": {
       "api_type": "GRPC",
@@ -74,77 +67,83 @@
   },
   "static_resources": {
     "clusters": [
-    {
-      "name": "prometheus_stats",
-      "type": "STATIC",
-      "connect_timeout": "0.250s",
-      "lb_policy": "ROUND_ROBIN",
-      "hosts": [{
-        "socket_address": {
-          "protocol": "TCP",
-          "address": "127.0.0.1",
-          "port_value": 15000,
-        }
-      }],
-    },
-    {
-    "name": "xds-grpc",
-    "type": "STRICT_DNS",
-    "connect_timeout": "7s",
-    "lb_policy": "ROUND_ROBIN",
-
-      "tls_context": {
-        "common_tls_context": {
-          "alpn_protocols": ["h2"],
-          "tls_certificates": [{
-            "certificate_chain": {
-              "filename": "/etc/certs/cert-chain.pem"
-            },
-            "private_key": {
-              "filename": "/etc/certs/key.pem"
+      {
+        "name": "prometheus_stats",
+        "type": "STATIC",
+        "connect_timeout": "0.250s",
+        "lb_policy": "ROUND_ROBIN",
+        "hosts": [
+          {
+            "socket_address": {
+              "protocol": "TCP",
+              "address": "127.0.0.1",
+              "port_value": 15000
             }
-          }],
-          "validation_context": {
-            "trusted_ca": {
-              "filename": "/etc/certs/root-cert.pem"
-            },
-            "verify_subject_alt_name": [
-              "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
-            ]
           }
-        }
-      },
-
-    "hosts": [
-    {
-    "socket_address": {"address": "mypilot", "port_value": 1001}
-    }
-    ],
-    "circuit_breakers": {
-        "thresholds": [
-      {
-        "priority": "DEFAULT",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
+        ]
       },
       {
-        "priority": "HIGH",
-        "max_connections": 100000,
-        "max_pending_requests": 100000,
-        "max_requests": 100000
-      }]
-    },
-    "upstream_connection_options": {
-      "tcp_keepalive": {
-        "keepalive_time": 300
+        "name": "xds-grpc",
+        "type": "STRICT_DNS",
+        "connect_timeout": "7s",
+        "lb_policy": "ROUND_ROBIN",
+        
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": [
+              "h2"
+            ],
+            "tls_certificates": [
+              {
+                "certificate_chain": {
+                  "filename": "/etc/certs/cert-chain.pem"
+                },
+                "private_key": {
+                  "filename": "/etc/certs/key.pem"
+                }
+              },
+            ],
+            "validation_context": {
+              "trusted_ca": {
+                "filename": "/etc/certs/root-cert.pem"
+              },
+              "verify_subject_alt_name": [
+                "spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account"
+              ]
+            }
+          }
+        },
+        
+        "hosts": [
+          {
+            "socket_address": {"address": "mypilot", "port_value": 1001}
+          }
+        ],
+        "circuit_breakers": {
+          "thresholds": [
+            {
+              "priority": "DEFAULT",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            },
+            {
+              "priority": "HIGH",
+              "max_connections": 100000,
+              "max_pending_requests": 100000,
+              "max_requests": 100000
+            }
+          ]
+        },
+        "upstream_connection_options": {
+          "tcp_keepalive": {
+            "keepalive_time": 300
+          }
+        },
+        "http2_protocol_options": { }
       }
-    },
-    "http2_protocol_options": { }
-    }
-
-    
-    ,
+      
+      ,
       {
         "name": "zipkin",
         "type": "STRICT_DNS",
@@ -167,38 +166,47 @@
             "port_value": 15090,
           }
         },
-        "filter_chains": [{
-          "filters": [{
-            "name": "envoy.http_connection_manager",
-            "config": {
-              "codec_type": "AUTO",
-              "stat_prefix": "stats",
-              "route_config": {
-                "virtual_hosts": [{
-                  "name": "backend",
-                  "domains": [
-                    "*"
-                  ],
-                  "routes": [{
-                    "match": {
-                      "prefix": "/stats/prometheus"
-                    },
-                    "route": {
-                      "cluster": "prometheus_stats"
-                    }
-                  }]
-                }]
-              },
-              "http_filters": {
-                "name": "envoy.router"
+        "filter_chains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.http_connection_manager",
+                "config": {
+                  "codec_type": "AUTO",
+                  "stat_prefix": "stats",
+                  "route_config": {
+                    "virtual_hosts": [
+                      {
+                        "name": "backend",
+                        "domains": [
+                          "*"
+                        ],
+                        "routes": [
+                          {
+                            "match": {
+                              "prefix": "/stats/prometheus"
+                            },
+                            "route": {
+                              "cluster": "prometheus_stats"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "http_filters": {
+                    "name": "envoy.router"
+                  }
+                }
               }
-            }
-          }]
-        }],
-      },
-    ],
-  },
+            ]
+          }
+        ]
+      }
+    ]
+  }
   
+  ,
   "tracing": {
     "http": {
       "name": "envoy.zipkin",
@@ -206,7 +214,10 @@
         "collector_cluster": "zipkin"
       }
     }
-  },
+  }
+  
+  
+  ,
   "stats_sinks": [
     {
       "name": "envoy.statsd",
@@ -217,4 +228,5 @@
       }
     }
   ]
+  
 }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -101,7 +101,7 @@
                 "private_key": {
                   "filename": "/etc/certs/key.pem"
                 }
-              },
+              }
             ],
             "validation_context": {
               "trusted_ca": {
@@ -163,7 +163,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/tracing_lightstep.proto
+++ b/pkg/bootstrap/testdata/tracing_lightstep.proto
@@ -7,4 +7,4 @@ discovery_address:         "istio-pilot:15010"
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE
-tracing:                   { lightstep: { address: "lightstep-satellite:8080", access_token: "abcdefg1234567", secure: true, cacert_path: "/cacert.pem" } }
+tracing:                   { lightstep: { address: "lightstep-satellite:8080", access_token: "abcdefg1234567", secure: true, cacert_path: "/etc/lightstep/cacert.pem" } }

--- a/pkg/bootstrap/testdata/tracing_lightstep.proto
+++ b/pkg/bootstrap/testdata/tracing_lightstep.proto
@@ -4,11 +4,7 @@ service_cluster:           "istio-proxy"
 drain_duration:            {seconds: 2}
 parent_shutdown_duration:  {seconds: 3}
 discovery_address:         "istio-pilot:15010"
-zipkin_address:            ""
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE
-
-#
-# This matches the default configuration hardcoded in model.DefaultProxyConfig
-# Flags may override this configuration, as specified by the injector configs.
+tracing:                   { lightstep: { address: "lightstep-satellite:8080", access_token: "abcdefg1234567", secure: false, cacert_path: "/cacert.pem" } }

--- a/pkg/bootstrap/testdata/tracing_lightstep.proto
+++ b/pkg/bootstrap/testdata/tracing_lightstep.proto
@@ -7,4 +7,4 @@ discovery_address:         "istio-pilot:15010"
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE
-tracing:                   { lightstep: { address: "lightstep-satellite:8080", access_token: "abcdefg1234567", secure: false, cacert_path: "/cacert.pem" } }
+tracing:                   { lightstep: { address: "lightstep-satellite:8080", access_token: "abcdefg1234567", secure: true, cacert_path: "/cacert.pem" } }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -127,7 +127,7 @@
             "alpn_protocols": "h2",
             "validation_context": {
               "trusted_ca": {
-                "filename": "/cacert.pem"
+                "filename": "/etc/lightstep/cacert.pem"
               }
             }
           }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -122,6 +122,17 @@
         "name": "lightstep",
         "http2_protocol_options": {},
         
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": "h2",
+            "validation_context": {
+              "trusted_ca": {
+                "filename": "/cacert.pem"
+              }
+            }
+          }
+        },
+        
         "type": "LOGICAL_DNS",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
@@ -188,7 +199,7 @@
       "name": "envoy.lightstep",
       "config": {
         "collector_cluster": "lightstep",
-        "access_token_file": "/tmp/bootstrap/tracing_lightstep/lightstep_access_token.txt"
+        "access_token_file": "/test-path/lightstep_access_token.txt"
       }
     }
   }

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -124,7 +124,9 @@
         
         "tls_context": {
           "common_tls_context": {
-            "alpn_protocols": "h2",
+            "alpn_protocols": [
+              "h2"
+            ],
             "validation_context": {
               "trusted_ca": {
                 "filename": "/etc/lightstep/cacert.pem"
@@ -150,7 +152,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -1,13 +1,9 @@
 {
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
-    {{ if .zone }}
-    "locality": {
-      "zone": "{{ .zone }}"
-    },
-    {{ end }}
-    "metadata": {{ .meta_json_str }}
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    
+    "metadata": {"istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -89,40 +85,12 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "connect_timeout": "{{ .connect_timeout }}",
+        "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        {{ if eq .config.ControlPlaneAuthPolicy 1 }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
-                }
-              },
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": [
-                {{- range $a, $s := .pilot_SAN }}
-                "{{$s}}"
-                {{- end}}
-              ]
-            }
-          }
-        },
-        {{ end }}
+        
         "hosts": [
           {
-            "socket_address": {{ .pilot_grpc_address }}
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
           }
         ],
         "circuit_breakers": {
@@ -148,46 +116,22 @@
         },
         "http2_protocol_options": { }
       }
-      {{ if .zipkin }}
-      ,
-      {
-        "name": "zipkin",
-        "type": "STRICT_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .zipkin }}
-          }
-        ]
-      }
-      {{ else if .lightstep }}
+      
       ,
       {
         "name": "lightstep",
         "http2_protocol_options": {},
-        {{ if .lightstepSecure }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": "h2",
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "{{ .lightstepCacertPath }}"
-              }
-            }
-          }
-        },
-        {{ end }}
+        
         "type": "LOGICAL_DNS",
         "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
-            "socket_address": {{ .lightstep }}
+            "socket_address": {"address": "lightstep-satellite", "port_value": 8080}
           }
         ]
       }
-      {{ end }}
+      
     ],
     "listeners":[
       {
@@ -237,39 +181,17 @@
       }
     ]
   }
-  {{ if .zipkin }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.zipkin",
-      "config": {
-        "collector_cluster": "zipkin"
-      }
-    }
-  }
-  {{ else if .lightstep }}
+  
   ,
   "tracing": {
     "http": {
       "name": "envoy.lightstep",
       "config": {
         "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
+        "access_token_file": "/tmp/bootstrap/tracing_lightstep/lightstep_access_token.txt"
       }
     }
   }
-  {{ end }}
-  {{ if .statsd }}
-  ,
-  "stats_sinks": [
-    {
-      "name": "envoy.statsd",
-      "config": {
-        "address": {
-          "socket_address": {{ .statsd }}
-        }
-      }
-    }
-  ]
-  {{ end }}
+  
+  
 }

--- a/pkg/bootstrap/testdata/tracing_zipkin.proto
+++ b/pkg/bootstrap/testdata/tracing_zipkin.proto
@@ -4,7 +4,6 @@ service_cluster:           "istio-proxy"
 drain_duration:            {seconds: 2}
 parent_shutdown_duration:  {seconds: 3}
 discovery_address:         "istio-pilot:15010"
-zipkin_address:            "localhost:6000"
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE

--- a/pkg/bootstrap/testdata/tracing_zipkin.proto
+++ b/pkg/bootstrap/testdata/tracing_zipkin.proto
@@ -4,11 +4,10 @@ service_cluster:           "istio-proxy"
 drain_duration:            {seconds: 2}
 parent_shutdown_duration:  {seconds: 3}
 discovery_address:         "istio-pilot:15010"
-zipkin_address:            ""
+zipkin_address:            "localhost:6000"
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE
+tracing:                   { zipkin: { address: "localhost:6000" } }
 
-#
-# This matches the default configuration hardcoded in model.DefaultProxyConfig
-# Flags may override this configuration, as specified by the injector configs.
+# Sets all relevant options to values different than default

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -137,7 +137,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -1,13 +1,9 @@
 {
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
-    {{ if .zone }}
-    "locality": {
-      "zone": "{{ .zone }}"
-    },
-    {{ end }}
-    "metadata": {{ .meta_json_str }}
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    
+    "metadata": {"istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -89,40 +85,12 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "connect_timeout": "{{ .connect_timeout }}",
+        "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        {{ if eq .config.ControlPlaneAuthPolicy 1 }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
-                }
-              },
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": [
-                {{- range $a, $s := .pilot_SAN }}
-                "{{$s}}"
-                {{- end}}
-              ]
-            }
-          }
-        },
-        {{ end }}
+        
         "hosts": [
           {
-            "socket_address": {{ .pilot_grpc_address }}
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
           }
         ],
         "circuit_breakers": {
@@ -148,7 +116,7 @@
         },
         "http2_protocol_options": { }
       }
-      {{ if .zipkin }}
+      
       ,
       {
         "name": "zipkin",
@@ -157,37 +125,11 @@
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
-            "socket_address": {{ .zipkin }}
+            "socket_address": {"address": "localhost", "port_value": 6000}
           }
         ]
       }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "http2_protocol_options": {},
-        {{ if .lightstepSecure }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": "h2",
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "{{ .lightstepCacertPath }}"
-              }
-            }
-          }
-        },
-        {{ end }}
-        "type": "LOGICAL_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .lightstep }}
-          }
-        ]
-      }
-      {{ end }}
+      
     ],
     "listeners":[
       {
@@ -237,7 +179,7 @@
       }
     ]
   }
-  {{ if .zipkin }}
+  
   ,
   "tracing": {
     "http": {
@@ -247,29 +189,6 @@
       }
     }
   }
-  {{ else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.lightstep",
-      "config": {
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if .statsd }}
-  ,
-  "stats_sinks": [
-    {
-      "name": "envoy.statsd",
-      "config": {
-        "address": {
-          "socket_address": {{ .statsd }}
-        }
-      }
-    }
-  ]
-  {{ end }}
+  
+  
 }

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -105,7 +105,7 @@
                 "private_key": {
                   "filename": "/etc/certs/key.pem"
                 }
-              },
+              }
             ],
             "validation_context": {
               "trusted_ca": {
@@ -169,7 +169,9 @@
         {{ if .lightstepSecure }}
         "tls_context": {
           "common_tls_context": {
-            "alpn_protocols": "h2",
+            "alpn_protocols": [
+              "h2"
+            ],
             "validation_context": {
               "trusted_ca": {
                 "filename": "{{ .lightstepCacertPath }}"
@@ -195,7 +197,7 @@
           "socket_address": {
             "protocol": "TCP",
             "address": "0.0.0.0",
-            "port_value": 15090,
+            "port_value": 15090
           }
         },
         "filter_chains": [

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -97,6 +97,7 @@ docker.proxy_debug: pilot/docker/Dockerfile.proxyv2
 docker.proxy_debug: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxy_debug: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxy_debug: pilot/docker/envoy_telemetry.yaml.tmpl
+docker.proxy_debug: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 # The file must be named 'envoy', depends on the release.
@@ -114,6 +115,7 @@ docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxyv2: tools/deb/istio-iptables.sh
 docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
+docker.proxyv2: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 # Proxy using TPROXY interception - but no core dumps
@@ -126,6 +128,7 @@ docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxytproxy: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxytproxy: tools/deb/istio-iptables.sh
 docker.proxytproxy: pilot/docker/envoy_telemetry.yaml.tmpl
+docker.proxytproxy: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 docker.pilot: $(ISTIO_OUT)/pilot-discovery

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -97,7 +97,6 @@ docker.proxy_debug: pilot/docker/Dockerfile.proxyv2
 docker.proxy_debug: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxy_debug: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxy_debug: pilot/docker/envoy_telemetry.yaml.tmpl
-docker.proxy_debug: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 # The file must be named 'envoy', depends on the release.
@@ -115,7 +114,6 @@ docker.proxyv2: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxyv2: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxyv2: tools/deb/istio-iptables.sh
 docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
-docker.proxyv2: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 # Proxy using TPROXY interception - but no core dumps
@@ -128,7 +126,6 @@ docker.proxytproxy: pilot/docker/envoy_pilot.yaml.tmpl
 docker.proxytproxy: pilot/docker/envoy_policy.yaml.tmpl
 docker.proxytproxy: tools/deb/istio-iptables.sh
 docker.proxytproxy: pilot/docker/envoy_telemetry.yaml.tmpl
-docker.proxytproxy: pilot/docker/certs/cacert.pem
 	$(DOCKER_RULE)
 
 docker.pilot: $(ISTIO_OUT)/pilot-discovery


### PR DESCRIPTION
This PR follows from https://github.com/istio/api/pull/638 with the goal of exposing Envoy's LightStep configuration through Istio ([envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/trace/v2/trace.proto#config-trace-v2-lightstepconfig)).

Thank you in advance for reviewing!

One question: In the current iteration of this PR, Mixer and Ingress Gateway spans aren't sent to LightStep. The absence of the Mixer spans was expected since we didn't alter the internal instrumentation but the missing Ingress Gateway span was a surprise. Can you identify what we missed?

<img width="1663" alt="screen shot 2018-10-11 at 11 36 07 am" src="https://user-images.githubusercontent.com/4634933/46830040-5a41aa80-cd54-11e8-8581-cdd7b4973462.png">

