### PR TITLE
bump up Kiali version to v0.9 in the Istio 1.0 branch

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: istio-release-1.0
+      kiali_version: v0.9
 
   - name: Install Kiali on Openshift
     shell: |

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for detail.
 name: kiali
 version: 1.0.3
-appVersion: 0.6.0
+appVersion: 0.9
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -36,8 +36,6 @@ rules:
   - servicecontrols
   - solarwindses
   - stackdrivers
-  - cloudwatches
-  - dogstatsds
   - statsds
   - stdios
   - apikeys

--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -9,4 +9,8 @@ data:
   config.yaml: |
     server:
       port: 20001
-      static_content_root_directory: /opt/kiali/console
+    external_services:
+      jaeger:
+        url: {{ .Values.dashboard.jaegerURL }}
+      grafana:
+        url: {{ .Values.dashboard.grafanaURL }}

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -52,20 +52,6 @@ spec:
               key: passphrase
         - name: PROMETHEUS_SERVICE_URL
           value: http://prometheus:9090
-{{- if .Values.dashboard.grafanaURL }}
-        - name: GRAFANA_URL
-          value: {{ .Values.dashboard.grafanaURL }}
-{{- end }}
-        - name: GRAFANA_DASHBOARD
-          value: istio-service-dashboard
-        - name: GRAFANA_VAR_SERVICE_SOURCE
-          value: var-service
-        - name: GRAFANA_VAR_SERVICE_DEST
-          value: var-service
-{{- if .Values.dashboard.jaegerURL }}
-        - name: JAEGER_URL
-          value: {{ .Values.dashboard.jaegerURL }}
-{{- end }}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -538,7 +538,7 @@ kiali:
   enabled: false
   replicaCount: 1
   hub: docker.io/kiali
-  tag: istio-release-1.0
+  tag: v0.9
   ingress:
     enabled: false
     ## Used to create an Ingress record.


### PR DESCRIPTION
as discussed in PR #9230 which is part of https://github.com/istio/istio/issues/9066 this bumps up to the latest Kiali release in the Istio 1.0 release branch.

(note, I have been able to run Kiali after installing with this PR - so it looks good from that perspective, however, I am unable to visualize meshes in Kiali because at the current time I'm not able to install things like bookinfo or other test meshes I have available due to https://github.com/istio/istio/issues/8049 - see https://github.com/istio/istio/issues/8049#issuecomment-428971789) 