### PR TITLE
Turn off accesslog for admin

### DIFF
--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -1,5 +1,5 @@
 admin:
-  access_log_path: /dev/stdout
+  access_log_path: /dev/null
   address:
     socket_address:
       address: 127.0.0.1

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -1,5 +1,5 @@
 admin:
-  access_log_path: /dev/stdout
+  access_log_path: /dev/null
   address:
     socket_address:
       address: 127.0.0.1

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -1,5 +1,5 @@
 admin:
-  access_log_path: /dev/stdout
+  access_log_path: /dev/null
   address:
     socket_address:
       address: 127.0.0.1

--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -38,7 +38,7 @@
     ]
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -40,7 +40,7 @@
     ]
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -40,7 +40,7 @@
     ]
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -46,7 +46,7 @@
     ]
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -42,7 +42,7 @@
     ]
   },
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": {
       "socket_address": {
         "address": "127.0.0.1",


### PR DESCRIPTION
In adding prometheus scraping of Envoy to eliminate the overhead of the `statsd-to-prometheus` process, we have increased the logging of each proxy, due to the access log configuration of the admin cluster.

This PR turns that access logging off (sends to `/dev/null` per [Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/bootstrap/v2/bootstrap.proto#envoy-api-msg-config-bootstrap-v2-admin)).

> If no access log is desired specify ‘/dev/null’.

This should be a "good enough" fix for now, as the only access to the admin cluster exposed beyond localhost is the metrics path. Any localhost access to the admin cluster should be executed by an admin.

Related issues: 
- https://github.com/istio/istio/issues/8415
- https://github.com/istio/istio/issues/9099