### PR TITLE
fail nodeagent if CA provider isn't supported

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -83,7 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&serverOptions.UDSPath, "sdsUdsPath",
 		"/var/run/sds/uds_path", "Unix domain socket through which SDS server communicates with proxies")
 
-	rootCmd.PersistentFlags().StringVar(&serverOptions.CAEndpoint, "caProvider", caProvider, "CA provider")
+	rootCmd.PersistentFlags().StringVar(&serverOptions.CAProviderName, "caProvider", caProvider, "CA provider")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.CAEndpoint, "caEndpoint", caAddr, "CA endpoint")
 
 	rootCmd.PersistentFlags().StringVar(&serverOptions.CertFile, "sdsCertFile", "", "SDS gRPC TLS server-side certificate")

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -18,6 +18,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -54,6 +55,6 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 	case googleCA:
 		return gca.NewGoogleCAClient(conn), nil
 	default:
-		return nil, fmt.Errorf("CA provider %q isn't supported", CAProviderName)
+		return nil, fmt.Errorf("CA provider %q isn't supported, only support %q", CAProviderName, strings.Join([]string{googleCA}, ","))
 	}
 }

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -54,6 +54,6 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 	case googleCA:
 		return gca.NewGoogleCAClient(conn), nil
 	default:
-		return nil, nil
+		return nil, fmt.Errorf("CA provider %q isn't supported", CAProviderName)
 	}
 }

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -55,6 +55,6 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 	case googleCA:
 		return gca.NewGoogleCAClient(conn), nil
 	default:
-		return nil, fmt.Errorf("CA provider %q isn't supported, only support %q", CAProviderName, strings.Join([]string{googleCA}, ","))
+		return nil, fmt.Errorf("CA provider %q isn't supported. Currently Istio only supports %q", CAProviderName, strings.Join([]string{googleCA}, ","))
 	}
 }


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

fail nodeagent if CA provider isn't supported, and fix a bug in my previous PR