### PR TITLE
[WIP] Allow option to set proxy_init privilege, preserve defaults

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -50,12 +50,12 @@ data:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
-          {{- if and .Values.global.proxy_init.privileged }}
+          {{- if .Values.global.proxy_init.privileged }}
             add:
               - "NET_ADMIN"
-          {{ if .Values.global.proxy.privileged }}
+          {{- if .Values.global.proxy.privileged }}
           privileged: true
-          {{- else}}
+          {{- end}}
           {{- else }}
             drop:
              - "all"

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -50,11 +50,21 @@ data:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
+          {{- if and .Values.global.proxy_init.privileged }}
             add:
-            - NET_ADMIN
+              - "NET_ADMIN"
           {{ if .Values.global.proxy.privileged }}
           privileged: true
-          {{ end }}
+          {{- else}}
+          {{- else }}
+            drop:
+             - "all"
+            add:
+              - "NET_ADMIN"
+              - "NET_RAW"
+              - "NET_CAP_ADMIN"
+          allowPrivilegeEscalation: false
+          {{- end }}
         restartPolicy: Always
       {{- if .Values.global.proxy.enableCoreDump }}
       - args:

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -69,6 +69,7 @@ global:
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init
+    privileged: true
 
   # imagePullPolicy is applied to istio control plane components.
   # local tests require IfNotPresent, to avoid uploading to dockerhub.

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -39,9 +39,19 @@ data:
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           capabilities:
+          {{- if .Values.global.proxy_init.privileged }}
             add:
-            - NET_ADMIN
+              - "NET_ADMIN"
           privileged: true
+          {{- else }}
+            drop:
+             - "all"
+            add:
+              - "NET_ADMIN"
+              - "NET_RAW"
+              - "NET_CAP_ADMIN"
+          allowPrivilegeEscalation: false
+          {{- end }}
         restartPolicy: Always
       {{- if .Values.global.proxy.enableCoreDump }}
       - args:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -99,6 +99,8 @@ global:
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init
+    # Whether the proxy should be given the priviledged security context
+    privileged: true
 
   # imagePullPolicy is applied to istio control plane components.
   # local tests require IfNotPresent, to avoid uploading to dockerhub.


### PR DESCRIPTION
Relevant to #7488 and #7486.

* Added new value to helm charts, `global.proxy_init.privileged`
* Preserved defaults
* Compatibility with previous values maintained