### PR TITLE
Remove outdated istio/mixerclient ref in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,6 @@ management services, and monitoring services.
 - [istio/api](https://github.com/istio/api). This repository defines
 component-level APIs and common configuration formats for the Istio platform.
 
-- [istio/mixerclient](https://github.com/istio/mixerclient). Client libraries
-(currently supports C++) for Mixer's API.
-
 - [istio/proxy](https://github.com/istio/proxy). The Istio proxy contains
 extensions to the [Envoy proxy](https://github.com/envoyproxy/envoy) (in the form of
 Envoy filters), that allow the proxy to delegate policy enforcement


### PR DESCRIPTION
`istio/mixerclient` is no longer used (and redirects to `istio/old_mixerclient` now). It should be removed.