### PR TITLE
Support $TAG and $ISTIOCTL_BIN overide in e2e tests (#9232)

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -71,7 +71,7 @@ fi
 ISTIO_GO=$(cd $(dirname $0)/..; pwd)
 
 export HUB=${HUB:-"gcr.io/istio-testing"}
-export TAG="${GIT_SHA}"
+export TAG="${TAG:-${GIT_SHA}}"
 
 make init
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -46,8 +46,10 @@ endif
 # If set outside, it appears it is not possible to modify the variable.
 E2E_ARGS ?=
 
+ISTIOCTL_BIN ?= ${ISTIO_OUT}/istioctl
+
 DEFAULT_EXTRA_E2E_ARGS = ${MINIKUBE_FLAGS}
-DEFAULT_EXTRA_E2E_ARGS += --istioctl=${ISTIO_OUT}/istioctl
+DEFAULT_EXTRA_E2E_ARGS += --istioctl=${ISTIOCTL_BIN}
 DEFAULT_EXTRA_E2E_ARGS += --mixer_tag=${TAG}
 DEFAULT_EXTRA_E2E_ARGS += --pilot_tag=${TAG}
 DEFAULT_EXTRA_E2E_ARGS += --proxy_tag=${TAG}


### PR DESCRIPTION
Needed this to fix release qualification tests discrepancy which had been fixed in master. 