### PR TITLE
fix loadBalancerSourceRanges

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -25,7 +25,7 @@ istio-ingressgateway:
   cpu:
     targetAverageUtilization: 80
   loadBalancerIP: ""
-  loadBalancerSourceRanges: {}
+  loadBalancerSourceRanges: []
   serviceAnnotations: {}
   podAnnotations: {}
   type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
@@ -73,8 +73,8 @@ istio-ingressgateway:
   - port: 853
     targetPort: 853
     name: tcp-dns-tls
-  ####### end MESH EXPANSION PORTS ######  
-  ##############   
+  ####### end MESH EXPANSION PORTS ######
+  ##############
   secretVolumes:
   - name: ingressgateway-certs
     secretName: istio-ingressgateway-certs
@@ -194,4 +194,3 @@ istio-mcgateway:
     # this is needed to tell pilot to not generate
     # mTLS clusters for the mcgateway
     ISTIO_META_ISTIO_GATEWAY_MODE: multicluster
-


### PR DESCRIPTION
@ymesika, I am re-opening https://github.com/istio/istio/pull/9258 via my organisation for the purpose of the CLA.

To answer your question, we are encountering the error using Helm 2.10.0.

I note in the feature request (https://github.com/istio/istio/issues/7740) the nginx ingress controller Helm chart is used as an example, please see https://github.com/helm/charts/blob/master/stable/nginx-ingress/values.yaml#L169 where it is defaulted as per this PR.

For those saying the current way works, I'm not sure if they are specifying the source ranges via --set or from a values file, but using Helm 2.10.0 and entering a list under loadBalancerSourceRanges in a values file won't work, it errors as per my original PR.