### PR TITLE
Add REFRESH_GOLDEN functionality to HelmInject tests.

### DIFF
--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -533,8 +533,11 @@ func TestIntoResourceFile(t *testing.T) {
 			}
 
 			// The version string is a maintenance pain for this test. Strip the version string before comparing.
-			wantBytes := stripVersion(util.ReadFile(wantFilePath, t))
-			gotBytes := stripVersion(got.Bytes())
+			gotBytes := got.Bytes()
+			wantedBytes := util.ReadGoldenFile(gotBytes, wantFilePath, t)
+
+			wantBytes := stripVersion(wantedBytes)
+			gotBytes = stripVersion(gotBytes)
 
 			util.CompareBytes(gotBytes, wantBytes, wantFilePath, t)
 		})

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -4,10 +4,11 @@ metadata:
   creationTimestamp: null
   name: hello
 spec:
+  strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -48,10 +49,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -71,9 +68,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -110,7 +111,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -118,6 +119,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -126,10 +128,6 @@ spec:
         secret:
           optional: true
           secretName: istio.default
-  updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -1,169 +1,136 @@
-apiVersion: v1
-items:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: frontend
-  spec:
-    ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 80
-    selector:
-      app: hello
-      tier: frontend
-    type: LoadBalancer
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
-  metadata:
-    creationTimestamp: null
-    name: hello
-  spec:
-    replicas: 7
-    revisionHistoryLimit: 2
-    strategy:
-      resources: {}
-      type: Rolling
-    template:
-      metadata:
-        annotations:
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        creationTimestamp: null
-        labels:
-          app: hello
-          tier: backend
-          track: stable
-      spec:
-        containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 80
-            name: http
-          resources: {}
-        - args:
-          - proxy
-          - sidecar
-          - --configPath
-          - /etc/istio/proxy
-          - --binaryPath
-          - /usr/local/bin/envoy
-          - --serviceCluster
-          - hello.default
-          - --drainDuration
-          - 2s
-          - --parentShutdownDuration
-          - 3s
-          - --discoveryAddress
-          - istio-pilot:15007
-          - --zipkinAddress
-          - ""
-          - --connectTimeout
-          - 1s
-          - --proxyAdminPort
-          - "15000"
-          - --controlPlaneAuthPolicy
-          - NONE
-          - --statusPort
-          - "15020"
-          - --applicationPorts
-          - "80"
-          ports:
-          - name: http-envoy-prom
-            containerPort: 15090
-            protocol: TCP
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: ISTIO_META_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: REDIRECT
-          image: docker.io/istio/proxyv2:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-proxy
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-            initialDelaySeconds: 1
-            periodSeconds: 2
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-          volumeMounts:
-          - mountPath: /etc/istio/proxy
-            name: istio-envoy
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
-        initContainers:
-        - args:
-          - -p
-          - "15001"
-          - -u
-          - "1337"
-          - -m
-          - REDIRECT
-          - -i
-          - '*'
-          - -x
-          - ""
-          - -b
-          - "80"
-          - -d
-          - "15020"
-          image: docker.io/istio/proxy_init:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-init
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes:
-        - emptyDir:
-            medium: Memory
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  revisionHistoryLimit: 2
+  strategy:
+    type: Rolling
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --zipkinAddress
+        - ""
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
           name: istio-envoy
-        - name: istio-certs
-          secret:
-            optional: true
-            secretName: istio.default
-    test: false
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - helloworld
-        from:
-          kind: ImageStreamTag
-          name: hello-go-gke:1.0
-      type: ImageChange
-  status:
-    availableReplicas: 0
-    latestVersion: 0
-    observedGeneration: 0
-    replicas: 0
-    unavailableReplicas: 0
-    updatedReplicas: 0
-kind: List
-metadata: {}
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15020"
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -7,12 +7,11 @@ spec:
   replicas: 7
   revisionHistoryLimit: 2
   strategy:
-    resources: {}
     type: Rolling
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -53,10 +52,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -76,9 +71,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -115,7 +114,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -123,6 +122,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -131,22 +131,6 @@ spec:
         secret:
           optional: true
           secretName: istio.default
-  test: false
-  triggers:
-  - type: ConfigChange
-  - imageChangeParams:
-      automatic: true
-      containerNames:
-      - helloworld
-      from:
-        kind: ImageStreamTag
-        name: hello-go-gke:1.0
-    type: ImageChange
-status:
-  availableReplicas: 0
-  latestVersion: 0
-  observedGeneration: 0
-  replicas: 0
-  unavailableReplicas: 0
-  updatedReplicas: 0
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -1,17 +1,3 @@
-kind: Service
-apiVersion: v1
-metadata:
-  name: frontend
-spec:
-  selector:
-    app: hello
-    tier: frontend
-  ports:
-    - protocol: "TCP"
-      port: 80
-      targetPort: 80
-  type: LoadBalancer
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -23,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -68,10 +54,6 @@ spec:
         - "15020"
         - --applicationPorts
         - ""
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -91,9 +73,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -130,7 +116,7 @@ spec:
         - ""
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -138,6 +124,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -147,4 +134,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,10 +50,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -73,9 +69,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -112,7 +112,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -120,6 +120,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -129,4 +130,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -51,10 +51,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -74,9 +70,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -113,7 +113,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -121,6 +121,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -130,8 +131,8 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
----
-apiVersion: extensions/v1beta1
+
+---apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -142,7 +143,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -184,10 +185,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "81"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -207,9 +204,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -246,7 +247,7 @@ spec:
         - "81"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -254,6 +255,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -263,4 +265,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -132,7 +132,8 @@ spec:
           secretName: istio.default
 status: {}
 
----apiVersion: extensions/v1beta1
+---
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -70,10 +70,6 @@ spec:
         - "15020"
         - --applicationPorts
         - 80,90
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -93,9 +89,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -132,7 +132,7 @@ spec:
         - 80,90
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -140,6 +140,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -149,4 +150,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -4,10 +4,11 @@ metadata:
   creationTimestamp: null
   name: pi
 spec:
+  strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       name: pi
     spec:
@@ -47,10 +48,6 @@ spec:
         - "15020"
         - --applicationPorts
         - ""
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -70,9 +67,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -109,7 +110,7 @@ spec:
         - ""
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -117,6 +118,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       restartPolicy: Never
       volumes:
       - emptyDir:
@@ -127,4 +129,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -1,153 +1,138 @@
-apiVersion: v1
-items:
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: frontend
-  spec:
-    ports:
-    - port: 80
-      protocol: TCP
-      targetPort: 80
-    selector:
-      app: hello
-      tier: frontend
-    type: LoadBalancer
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: frontend
-  spec:
-    replicas: 1
-    strategy: {}
-    template:
-      metadata:
-        annotations:
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        creationTimestamp: null
-        labels:
-          app: hello
-          tier: frontend
-          track: stable
-      spec:
-        containers:
-        - image: fake.docker.io/google-samples/hello-frontend:1.0
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                - /usr/sbin/nginx
-                - -s
-                - quit
-          name: nginx
-          resources: {}
-        - args:
-          - proxy
-          - sidecar
-          - --configPath
-          - /etc/istio/proxy
-          - --binaryPath
-          - /usr/local/bin/envoy
-          - --serviceCluster
-          - hello.default
-          - --drainDuration
-          - 2s
-          - --parentShutdownDuration
-          - 3s
-          - --discoveryAddress
-          - istio-pilot:15007
-          - --zipkinAddress
-          - ""
-          - --connectTimeout
-          - 1s
-          - --proxyAdminPort
-          - "15000"
-          - --controlPlaneAuthPolicy
-          - NONE
-          - --statusPort
-          - "15020"
-          - --applicationPorts
-          - ""
-          ports:
-          - name: http-envoy-prom
-            containerPort: 15090
-            protocol: TCP
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: ISTIO_META_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: REDIRECT
-          image: docker.io/istio/proxyv2:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-proxy
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-            initialDelaySeconds: 1
-            periodSeconds: 2
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-          volumeMounts:
-          - mountPath: /etc/istio/proxy
-            name: istio-envoy
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
-        initContainers:
-        - args:
-          - -p
-          - "15001"
-          - -u
-          - "1337"
-          - -m
-          - REDIRECT
-          - -i
-          - '*'
-          - -x
-          - ""
-          - -b
-          - ""
-          - -d
-          - "15020"
-          image: docker.io/istio/proxy_init:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-init
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes:
-        - emptyDir:
-            medium: Memory
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: frontend
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: frontend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-frontend:1.0
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/sbin/nginx
+              - -s
+              - quit
+        name: nginx
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --zipkinAddress
+        - ""
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - ""
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
           name: istio-envoy
-        - name: istio-certs
-          secret:
-            optional: true
-            secretName: istio.default
-  status: {}
-kind: List
-metadata: {}
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - ""
+        - -d
+        - "15020"
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -1,269 +1,269 @@
-apiVersion: v1
-items:
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: hello-v1
-  spec:
-    replicas: 3
-    strategy: {}
-    template:
-      metadata:
-        annotations:
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        creationTimestamp: null
-        labels:
-          app: hello
-          tier: backend
-          track: stable
-          version: v1
-      spec:
-        containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 80
-            name: http
-          resources: {}
-        - args:
-          - proxy
-          - sidecar
-          - --configPath
-          - /etc/istio/proxy
-          - --binaryPath
-          - /usr/local/bin/envoy
-          - --serviceCluster
-          - hello.default
-          - --drainDuration
-          - 2s
-          - --parentShutdownDuration
-          - 3s
-          - --discoveryAddress
-          - istio-pilot:15007
-          - --zipkinAddress
-          - ""
-          - --connectTimeout
-          - 1s
-          - --proxyAdminPort
-          - "15000"
-          - --controlPlaneAuthPolicy
-          - NONE
-          - --statusPort
-          - "15020"
-          - --applicationPorts
-          - "80"
-          ports:
-          - name: http-envoy-prom
-            containerPort: 15090
-            protocol: TCP
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: ISTIO_META_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: REDIRECT
-          image: docker.io/istio/proxyv2:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-proxy
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-            initialDelaySeconds: 1
-            periodSeconds: 2
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-          volumeMounts:
-          - mountPath: /etc/istio/proxy
-            name: istio-envoy
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
-        initContainers:
-        - args:
-          - -p
-          - "15001"
-          - -u
-          - "1337"
-          - -m
-          - REDIRECT
-          - -i
-          - '*'
-          - -x
-          - ""
-          - -b
-          - "80"
-          - -d
-          - "15020"
-          image: docker.io/istio/proxy_init:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-init
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes:
-        - emptyDir:
-            medium: Memory
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello-v1
+spec:
+  replicas: 3
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+        version: v1
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --zipkinAddress
+        - ""
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
           name: istio-envoy
-        - name: istio-certs
-          secret:
-            optional: true
-            secretName: istio.default
-  status: {}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    creationTimestamp: null
-    name: hello-v2
-  spec:
-    replicas: 3
-    strategy: {}
-    template:
-      metadata:
-        annotations:
-          sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
-        creationTimestamp: null
-        labels:
-          app: hello
-          tier: backend
-          track: stable
-          version: v2
-      spec:
-        containers:
-        - image: fake.docker.io/google-samples/hello-go-gke:1.0
-          name: hello
-          ports:
-          - containerPort: 81
-            name: http
-          resources: {}
-        - args:
-          - proxy
-          - sidecar
-          - --configPath
-          - /etc/istio/proxy
-          - --binaryPath
-          - /usr/local/bin/envoy
-          - --serviceCluster
-          - hello.default
-          - --drainDuration
-          - 2s
-          - --parentShutdownDuration
-          - 3s
-          - --discoveryAddress
-          - istio-pilot:15007
-          - --zipkinAddress
-          - ""
-          - --connectTimeout
-          - 1s
-          - --proxyAdminPort
-          - "15000"
-          - --controlPlaneAuthPolicy
-          - NONE
-          - --statusPort
-          - "15020"
-          - --applicationPorts
-          - "81"
-          ports:
-          - name: http-envoy-prom
-            containerPort: 15090
-            protocol: TCP
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: INSTANCE_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: ISTIO_META_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: ISTIO_META_INTERCEPTION_MODE
-            value: REDIRECT
-          image: docker.io/istio/proxyv2:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-proxy
-          readinessProbe:
-            failureThreshold: 30
-            httpGet:
-              path: /healthz/ready
-              port: 15020
-            initialDelaySeconds: 1
-            periodSeconds: 2
-          resources:
-            requests:
-              cpu: 10m
-          securityContext:
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1337
-          volumeMounts:
-          - mountPath: /etc/istio/proxy
-            name: istio-envoy
-          - mountPath: /etc/certs/
-            name: istio-certs
-            readOnly: true
-        initContainers:
-        - args:
-          - -p
-          - "15001"
-          - -u
-          - "1337"
-          - -m
-          - REDIRECT
-          - -i
-          - '*'
-          - -x
-          - ""
-          - -b
-          - "81"
-          - -d
-          - "15020"
-          image: docker.io/istio/proxy_init:unittest
-          imagePullPolicy: IfNotPresent
-          name: istio-init
-          resources: {}
-          securityContext:
-            capabilities:
-              add:
-              - NET_ADMIN
-        volumes:
-        - emptyDir:
-            medium: Memory
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15020"
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+
+---apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello-v2
+spec:
+  replicas: 3
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+        version: v2
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 81
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --zipkinAddress
+        - ""
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "81"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
           name: istio-envoy
-        - name: istio-certs
-          secret:
-            optional: true
-            secretName: istio.default
-  status: {}
-kind: List
-metadata: {}
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "81"
+        - -d
+        - "15020"
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -132,7 +132,8 @@ spec:
           secretName: istio.default
 status: {}
 
----apiVersion: extensions/v1beta1
+---
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -50,10 +50,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -73,9 +69,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -126,7 +126,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -134,6 +134,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -143,4 +144,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -5,10 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 7
+  strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -47,10 +48,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -70,9 +67,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -109,7 +110,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -117,6 +118,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -125,6 +127,6 @@ spec:
         secret:
           optional: true
           secretName: istio.default
-status:
-  replicas: 0
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -5,12 +5,12 @@ metadata:
   name: nginx
 spec:
   replicas: 3
-  selector:
-    app: nginx
+  selector: {}
+  strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: nginx
@@ -49,10 +49,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -72,9 +68,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -111,7 +111,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -119,6 +119,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -127,6 +128,6 @@ spec:
         secret:
           optional: true
           secretName: istio.default
-status:
-  replicas: 0
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -9,9 +9,9 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/proxyCPU: "100m"
-        sidecar.istio.io/proxyMemory: "1Gi"
-        sidecar.istio.io/status: '{"version":"e1a9467266ca3f027bf1768c98f04fde239466e7c76fc642922c7b08cccd2025","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/proxyCPU: 100m
+        sidecar.istio.io/proxyMemory: 1Gi
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: resource
@@ -50,10 +50,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -73,9 +69,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -113,7 +113,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -121,6 +121,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -130,4 +131,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -5,11 +5,11 @@ metadata:
   name: hello
 spec:
   replicas: 3
-  serviceName: hello
+  strategy: {}
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
       creationTimestamp: null
       labels:
         app: hello
@@ -53,10 +53,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -76,9 +72,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -115,7 +115,7 @@ spec:
         - "80"
         - -d
         - "15020"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -123,6 +123,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - hostPath:
           path: /mnt/disks/ssd0
@@ -134,7 +135,6 @@ spec:
         secret:
           optional: true
           secretName: istio.default
-  updateStrategy: {}
-status:
-  replicas: 0
+status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -13,7 +13,7 @@ spec:
         readiness.status.sidecar.istio.io/failureThreshold: "300"
         readiness.status.sidecar.istio.io/initialDelaySeconds: "100"
         readiness.status.sidecar.istio.io/periodSeconds: "200"
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         status.sidecar.istio.io/port: "123"
       creationTimestamp: null
       labels:
@@ -53,10 +53,6 @@ spec:
         - "123"
         - --applicationPorts
         - 1,2,3
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -76,9 +72,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 300
           httpGet:
@@ -115,7 +115,7 @@ spec:
         - "80"
         - -d
         - "123"
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -123,6 +123,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -132,4 +133,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: ""
@@ -52,10 +52,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -75,9 +71,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -114,7 +114,7 @@ spec:
         - ""
         - -d
         - 4,5,6,15020
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -122,6 +122,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -131,4 +132,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: '*'
@@ -52,10 +52,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -75,9 +71,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -114,7 +114,7 @@ spec:
         - '*'
         - -d
         - 4,5,6,15020
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -122,6 +122,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -131,4 +132,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       annotations:
-        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
         traffic.sidecar.istio.io/excludeInboundPorts: 4,5,6
         traffic.sidecar.istio.io/excludeOutboundIPRanges: 10.96.0.2/24,10.96.0.3/24
         traffic.sidecar.istio.io/includeInboundPorts: 1,2,3
@@ -52,10 +52,6 @@ spec:
         - "15020"
         - --applicationPorts
         - "80"
-        ports:
-        - name: http-envoy-prom
-          containerPort: 15090
-          protocol: TCP
         env:
         - name: POD_NAME
           valueFrom:
@@ -75,9 +71,13 @@ spec:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
-        image: docker.io/istio/proxyv2:unittest
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
         readinessProbe:
           failureThreshold: 30
           httpGet:
@@ -114,7 +114,7 @@ spec:
         - 1,2,3
         - -d
         - 4,5,6,15020
-        image: docker.io/istio/proxy_init:unittest
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
         imagePullPolicy: IfNotPresent
         name: istio-init
         resources: {}
@@ -122,6 +122,7 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
+          privileged: true
       volumes:
       - emptyDir:
           medium: Memory
@@ -131,4 +132,5 @@ spec:
           optional: true
           secretName: istio.default
 status: {}
+
 ---

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -890,9 +890,9 @@ func writeYamlsToGoldenFile(yamls [][]byte, goldenFile string, t *testing.T) {
 	for _, part := range(yamls) {
 		content = append(content, part...)
 		content = append(content, []byte(yamlSeparator)...)
+		content = append(content, '\n')
 	}
 
-	content = append(content, '\n')
 	util.RefreshGoldenFile(content, goldenFile, t)
 }
 func getInjectableYamlDocs(yamlDoc string, t *testing.T) [][]byte {

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -87,14 +87,18 @@ func CompareContent(content []byte, goldenFile string, t *testing.T) {
 // ReadGoldenFile reads the content of the golden file and fails the test if an error is encountered
 func ReadGoldenFile(content []byte, goldenFile string, t *testing.T) []byte {
 	t.Helper()
+	RefreshGoldenFile(content, goldenFile, t)
+
+	return ReadFile(goldenFile, t)
+}
+
+func RefreshGoldenFile( content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
 		if err := ioutil.WriteFile(goldenFile, content, 0644); err != nil {
 			t.Errorf(err.Error())
 		}
 	}
-
-	return ReadFile(goldenFile, t)
 }
 
 // ReadFile reads the content of the given file or fails the test if an error is encountered.

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -92,6 +92,7 @@ func ReadGoldenFile(content []byte, goldenFile string, t *testing.T) []byte {
 	return ReadFile(goldenFile, t)
 }
 
+// RefreshGoldenFile updates the golden file with the given content
 func RefreshGoldenFile( content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)


### PR DESCRIPTION
Issue #9313

If the helm templating is changed, the env REFRESH_GOLDEN can be used to
update the HelmInject/webhook tests as well as the other pilot tests.

Golden artifact files have a slightly different format since they are created
via yaml.Marshal.

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>