### PR TITLE
Configure max message size received by mcp client

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -110,6 +110,8 @@ func init() {
 		"comma separated list of MCP server addresses with "+
 			"mcp:// (insecure) or mcps:// (secure) schema, e.g. mcps://istio-galley.istio-system.svc:9901")
 	serverArgs.MCPCredentialOptions.AttachCobraFlags(discoveryCmd)
+	discoveryCmd.PersistentFlags().IntVar(&serverArgs.MCPMaxMessageSize, "mcpMaxMsgSize", bootstrap.DefaultMCPMaxMsgSize,
+		"Max message size received by MCP's grpc client")
 
 	// Config Controller options
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Config.DisableInstallCRDs, "disable-install-crds", false,

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -80,6 +80,8 @@ const (
 	ConfigMapKey = "mesh"
 
 	requiredMCPCertCheckFreq = 500 * time.Millisecond
+
+	DefaultMCPMaxMsgSize = 1024 * 1024 * 4
 )
 
 var (
@@ -155,6 +157,7 @@ type PilotArgs struct {
 	Plugins              []string
 	MCPServerAddrs       []string
 	MCPCredentialOptions *creds.Options
+	MCPMaxMessageSize    int
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -455,7 +458,8 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			credentials := creds.CreateForClient(u.Hostname(), watcher)
 			securityOption = grpc.WithTransportCredentials(credentials)
 		}
-		conn, err := grpc.DialContext(ctx, u.Host, securityOption)
+		msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(args.MCPMaxMessageSize))
+		conn, err := grpc.DialContext(ctx, u.Host, securityOption, msgSizeOption)
 		if err != nil {
 			log.Errorf("Unable to dial MCP Server %q: %v", u.Host, err)
 			return err

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -24,13 +24,12 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/env"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (
@@ -122,6 +121,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (io.Closer, error) {
 			Registries: []string{
 				string(serviceregistry.MockRegistry)},
 		},
+		MCPMaxMessageSize: bootstrap.DefaultMCPMaxMsgSize,
 	}
 	// Static testdata, should include all configs we want to test.
 	args.Config.FileDir = env.IstioSrc + "/tests/testdata/config"


### PR DESCRIPTION
This allows us to configure the maximum message size that MCP's underlying grpc client can receive. We discovered the following errors during our scaling tests

```
Error receiving MCP response: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4623689 vs. 4194304)
``` 
This change allows MCP client in pilot to receive bigger payloads from the MCP server, if no value provided the default underlying grpc maxMessageSize is taken into account.