### PR TITLE
Fix labels unmatch issue during chart upgrade.

### DIFF
--- a/install/kubernetes/helm/subcharts/tracing/templates/gateway.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/gateway.yaml
@@ -3,6 +3,11 @@ kind: Gateway
 metadata:
   name: istio-tracing-gateway
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-tracing
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   selector:
     istio: {{ .Values.gatewayName }}
@@ -19,6 +24,11 @@ kind: DestinationRule
 metadata:
   name: tracing
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-tracing
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   host: tracing.{{ .Release.Namespace }}.svc.cluster.local
   trafficPolicy:
@@ -30,6 +40,11 @@ kind: VirtualService
 metadata:
   name: tracing-virtual-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: istio-tracing
+    chart: {{ template "tracing.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   hosts:
   - "*"


### PR DESCRIPTION
Fix chart upgrade/rollback issue: 
```
root@mcubt:~/istio/install/kubernetes/helm# helm upgrade istio ./istio --tls
Error: UPGRADE FAILED: Deployment.apps "istio-telemetry" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"version":"1.1.0", "istio-mixer-type":"telemetry", "app":"mixer", "istio":"mixer", "chart":"mixer", "heritage":"Tiller", "release":"istio"}: `selector` does not match template `labels` && Deployment.apps "istio-policy" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"istio-mixer-type":"policy", "chart":"mixer", "heritage":"Tiller", "release":"istio", "version":"1.1.0", "app":"mixer", "istio":"mixer"}: `selector` does not match template `labels
```

After apply this patch, istio chart can be upgraded from `v1.0.2` to `master` and also rollback is smooth:
```
root@xaubt1:~/istio/install/kubernetes/helm# helm history istio --tls
REVISION	UPDATED                 	STATUS    	CHART      	DESCRIPTION
1       	Tue Oct 16 03:39:09 2018	SUPERSEDED	istio-1.0.1	Install complete
2       	Tue Oct 16 03:40:49 2018	SUPERSEDED	istio-1.1.0	Upgrade complete
3       	Tue Oct 16 03:43:26 2018	DEPLOYED  	istio-1.0.1	Rollback to 1
```