### PR TITLE
Pilot's HPA is created in wrong namespace

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
     name: istio-pilot
+    namespace: {{ $.Release.Namespace }}
 spec:
     maxReplicas: {{ .Values.autoscaleMax }}
     minReplicas: {{ .Values.autoscaleMin }}


### PR DESCRIPTION
The HPA should be created in the `istio-system` namespace rather than default so it can pick the deployment.
This has already been fixed in `master`.

Fixes #9353

