### PR TITLE
Racetest fix - Remove a redundant assignment of the push context

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -359,7 +359,6 @@ func (s *DiscoveryServer) Push(full bool, edsUpdates map[string]*EndpointShardsB
 	s.updateMutex.Unlock()
 
 	s.mutex.Lock()
-	s.Env.PushContext = push
 	versionLocal := time.Now().Format(time.RFC3339) + "/" + strconv.Itoa(versionNum)
 	versionNum++
 	initContextTime := time.Since(t0)


### PR DESCRIPTION
The second assignment (1st one is few lines earlier) is protected by a different lock than the one in line 420: https://github.com/istio/istio/blob/fc3c71f340d534063b6495b6254b191dadbcaab6/pilot/pkg/proxy/envoy/v2/discovery.go#L420
This can be fixed by double RLock on both mutexes but the second assignment seems redundant.

Unless you expect the context to be updated between the update lock and the global lock?

Currently it causes a race test failure. Example: https://circleci.com/gh/istio/istio/219089