### PR TITLE
Add env var GLIBC_PATH to enable mix build test on CentOS - issue 9358

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -75,6 +75,13 @@ func (s *TestSetup) NewEnvoy() (*Envoy, error) {
 	if path, exists := os.LookupEnv("ENVOY_PATH"); exists {
 		envoyPath = path
 	}
+
+	// glibc_path is the location of customized glibc library path (/opt/glibc-2.18/lib)
+	if glibc_path := os.Getenv("GLIBC_PATH"); glibc_path != "" {
+		glibc_args := []string{"--library-path", glibc_path, envoyPath}
+		envoyPath = filepath.Join(glibc_path, "ld-linux-x86-64.so.2")
+		args = append(glibc_args, args...)
+	}
 	cmd := exec.Command(envoyPath, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Fix issue https://github.com/istio/istio/issues/9358

- Let user to build a separate `glibc-2.18` in CentOS

```
wget http://ftp.gnu.org/gnu/glibc/glibc-2.18.tar.gz
tar zxvf glibc-2.18.tar.gz
cd glibc-2.18
mkdir build
cd build
../configure --prefix=/opt/glibc-2.18
make -j4
make install
```

- Specify customized `glibc-2.18` path to environment variable `GLIBC_PATH`
  - `export GLIBC_PATH=/opt/glibc-2.18/lib`
- Modify `mixer/test/client/env/envoy.go` to accept environment variable `GLIBC_PATH` by this patch
- Then build will go smoothly

Environment in which glibc-2.18 is installed does not necessary to set environment variable `GLIBC_PATH`