### PR TITLE
Add shared filewatcher mechanism

### DIFF
--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -1,0 +1,179 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filewatcher
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/hashicorp/go-multierror"
+)
+
+type FileWatcher interface {
+	Add(path string) error
+	Remove(path string) error
+	Close() error
+	Events(path string) chan fsnotify.Event
+	Errors(path string) chan error
+}
+
+type fsNotifyWatcher struct {
+	mu sync.RWMutex
+	// The watcher maintain a map of fsnotify watchers,
+	// keyed by path.
+	watchers map[string]*fsnotify.Watcher
+	// The watcher maintain a map of event channel,
+	// keyed by path.
+	// The watcher watches parent path of given path,
+	// and filter out events of given path, then redirect
+	// to the result channel.
+	// Note that for symlink files, the content in received events
+	// do not have to be related to the file itself.
+	events map[string]chan fsnotify.Event
+}
+
+// NewWatcher return with a FileWatcher instance that implemented with fsnotify.
+func NewWatcher() FileWatcher {
+	w := &fsNotifyWatcher{
+		watchers: map[string]*fsnotify.Watcher{},
+		events:   map[string]chan fsnotify.Event{},
+	}
+
+	return w
+}
+
+// Add is implementation of Add interface of FileWatcher.
+func (w *fsNotifyWatcher) Add(path string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, exist := w.watchers[path]; exist {
+		return fmt.Errorf("path %s already added", path)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	events := make(chan fsnotify.Event, 1)
+
+	cleanedPath := filepath.Clean(path)
+	parentPath, _ := filepath.Split(cleanedPath)
+	// Ignore the error here as the file can be an "usual" file.
+	realPath, _ := filepath.EvalSymlinks(path)
+
+	watcher.Add(parentPath)
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok { // 'Events' channel is closed
+					return
+				}
+				// Ignore the error here as the file can be an "usual" file.
+				currentRealPath, _ := filepath.EvalSymlinks(path)
+
+				// Filter out events that related to the path to watch:
+				// for usual files, event name should be equal to its path;
+				// For k8s configmap/secret file, real path of the symlink
+				// would change on update.
+				if filepath.Clean(event.Name) == cleanedPath ||
+					currentRealPath != "" && currentRealPath != realPath {
+					realPath = currentRealPath
+					events <- event
+				}
+			case <-watcher.Errors:
+				return
+			}
+		}
+	}()
+
+	w.watchers[path] = watcher
+	w.events[path] = events
+
+	return nil
+}
+
+// Remove is implementation of Remove interface of FileWatcher.
+func (w *fsNotifyWatcher) Remove(path string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.remove(path)
+}
+
+func (w *fsNotifyWatcher) remove(path string) error {
+	var errors *multierror.Error
+
+	// Remove its watcher from the map.
+	watcher, exist := w.watchers[path]
+	if !exist {
+		return fmt.Errorf("path %s already removed", path)
+	}
+	err := watcher.Close()
+	delete(w.watchers, path)
+	errors = multierror.Append(errors, err)
+
+	// Remove its event channel from the map.
+	events, exist := w.events[path]
+	if !exist {
+		// This should never happen.
+		err := fmt.Errorf("path %s already removed", path)
+		errors = multierror.Append(errors, err)
+		return errors.ErrorOrNil()
+	}
+	delete(w.events, path)
+	close(events)
+
+	return errors.ErrorOrNil()
+}
+
+// Close is implementation of Close interface of FileWatcher.
+func (w *fsNotifyWatcher) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	var errors *multierror.Error
+	for path := range w.watchers {
+		errors = multierror.Append(errors, w.remove(path))
+	}
+
+	return errors.ErrorOrNil()
+}
+
+// Events is implementation of Events interface of FileWatcher.
+func (w *fsNotifyWatcher) Events(path string) chan fsnotify.Event {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	return w.events[path]
+}
+
+// Errors is implementation of Errors interface of FileWatcher.
+func (w *fsNotifyWatcher) Errors(path string) chan error {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	watcher, exist := w.watchers[path]
+	if !exist {
+		return nil
+	}
+
+	return watcher.Errors
+}

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -104,11 +104,13 @@ func (w *fsNotifyWatcher) Add(path string) error {
 		return err
 	}
 	if err = watcher.Add(parentPath); err != nil {
+		watcher.Close()
 		return err
 	}
 
 	md5Sum, err := getMd5Sum(cleanedPath)
 	if err != nil {
+		watcher.Close()
 		return fmt.Errorf("failed to get md5 sum for %s: %v", path, err)
 	}
 	wk := &worker{

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// FileWatcher is an interface that watches a set of files,
+// delivering events to related channel.
 type FileWatcher interface {
 	Add(path string) error
 	Remove(path string) error

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -206,7 +206,7 @@ func TestWatcherLifecycle(t *testing.T) {
 	events1 = w.Events(watchFile1)
 	g.Expect(events1).To(BeNil())
 	errors1 = w.Errors(watchFile1)
-	g.Expect(errors1).NotTo(BeNil())
+	g.Expect(errors1).To(BeNil())
 	events2 = w.Events(watchFile2)
 	g.Expect(events2).NotTo(BeNil())
 	errors2 = w.Errors(watchFile2)

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -127,6 +127,7 @@ func TestWatchFile(t *testing.T) {
 
 		// Overwriting the file and waiting its event to be received.
 		err = ioutil.WriteFile(watchFile, []byte("foo: baz\n"), 0640)
+		g.Expect(err).NotTo(HaveOccurred())
 		wg.Wait()
 	})
 

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -1,0 +1,206 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filewatcher
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"runtime"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func newWatchFile(t *testing.T) (string, func()) {
+	g := NewGomegaWithT(t)
+
+	watchDir, err := ioutil.TempDir("", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	watchFile := path.Join(watchDir, "test.conf")
+	err = ioutil.WriteFile(watchFile, []byte("foo: bar\n"), 0640)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+
+	return watchFile, cleanup
+}
+
+// newSymlinkedWatchFile simulates the behavior of k8s configmap/secret.
+// Path structure looks like:
+//      <watchDir>/test.conf
+//                   ^
+//                   |
+// <watchDir>/data/test.conf
+//             ^
+//             |
+// <watchDir>/data1/test.conf
+func newSymlinkedWatchFile(t *testing.T) (string, string, func()) {
+	g := NewGomegaWithT(t)
+
+	watchDir, err := ioutil.TempDir("", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	dataDir1 := path.Join(watchDir, "data1")
+	err = os.Mkdir(dataDir1, 0777)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	realTestFile := path.Join(dataDir1, "test.conf")
+	t.Logf("Real test file location: %s\n", realTestFile)
+	err = ioutil.WriteFile(realTestFile, []byte("foo: bar\n"), 0640)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+	// Now, symlink the tmp `data1` dir to `data` in the baseDir
+	os.Symlink(dataDir1, path.Join(watchDir, "data"))
+	// And link the `<watchdir>/datadir/test.conf` to `<watchdir>/test.conf`
+	watchFile := path.Join(watchDir, "test.conf")
+	os.Symlink(path.Join(watchDir, "data", "test.conf"), watchFile)
+	fmt.Printf("Watch file location: %s\n", path.Join(watchDir, "test.conf"))
+	return watchDir, watchFile, cleanup
+}
+
+func TestWatchFile(t *testing.T) {
+	t.Run("file content changed", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Given a file being watched
+		watchFile, cleanup := newWatchFile(t)
+		defer cleanup()
+		_, err := os.Stat(watchFile)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		w := NewWatcher()
+		w.Add(watchFile)
+		events := w.Events(watchFile)
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			select {
+			case <-events:
+				wg.Done()
+			}
+		}()
+
+		// Overwriting the file and waiting its event to be received.
+		err = ioutil.WriteFile(watchFile, []byte("foo: baz\n"), 0640)
+		wg.Wait()
+	})
+
+	t.Run("link to real file changed (for k8s configmap/secret path)", func(t *testing.T) {
+		// skip if not executed on Linux
+		if runtime.GOOS != "linux" {
+			t.Skipf("Skipping test as symlink replacements don't work on non-linux environment...")
+		}
+		g := NewGomegaWithT(t)
+
+		watchDir, watchFile, cleanup := newSymlinkedWatchFile(t)
+		defer cleanup()
+
+		w := NewWatcher()
+		w.Add(watchFile)
+		events := w.Events(watchFile)
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			select {
+			case <-events:
+				wg.Done()
+			}
+		}()
+
+		// Link to another `test.conf` file
+		dataDir2 := path.Join(watchDir, "data2")
+		err := os.Mkdir(dataDir2, 0777)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		watchFile2 := path.Join(dataDir2, "test.conf")
+		err = ioutil.WriteFile(watchFile2, []byte("foo: baz\n"), 0640)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// change the symlink using the `ln -sfn` command
+		err = exec.Command("ln", "-sfn", dataDir2, path.Join(watchDir, "data")).Run()
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Wait its event to be received.
+		wg.Wait()
+	})
+}
+
+func TestWatcherLifecycle(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	watchFile1, cleanup1 := newWatchFile(t)
+	defer cleanup1()
+	watchFile2, cleanup2 := newWatchFile(t)
+	defer cleanup2()
+
+	w := NewWatcher()
+
+	// Validate Add behavior
+	err := w.Add(watchFile1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = w.Add(watchFile2)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = w.Add(watchFile2)
+	g.Expect(err).To(HaveOccurred())
+
+	// Validate events and errors channel are fulfilled.
+	events1 := w.Events(watchFile1)
+	g.Expect(events1).NotTo(BeNil())
+	events2 := w.Events(watchFile2)
+	g.Expect(events2).NotTo(BeNil())
+
+	errors1 := w.Errors(watchFile1)
+	g.Expect(errors1).NotTo(BeNil())
+	errors2 := w.Errors(watchFile2)
+	g.Expect(errors2).NotTo(BeNil())
+
+	// Validate Remove behavior
+	err = w.Remove(watchFile1)
+	g.Expect(err).NotTo(HaveOccurred())
+	err = w.Remove(watchFile1)
+	g.Expect(err).To(HaveOccurred())
+	events1 = w.Events(watchFile1)
+	g.Expect(events1).To(BeNil())
+	errors1 = w.Errors(watchFile1)
+	g.Expect(errors1).To(BeNil())
+	events2 = w.Events(watchFile2)
+	g.Expect(events2).NotTo(BeNil())
+	errors2 = w.Errors(watchFile2)
+	g.Expect(errors2).NotTo(BeNil())
+
+	// Validate Close behavior
+	err = w.Close()
+	g.Expect(err).NotTo(HaveOccurred())
+	events1 = w.Events(watchFile1)
+	g.Expect(events1).To(BeNil())
+	errors1 = w.Errors(watchFile1)
+	g.Expect(errors1).To(BeNil())
+	events2 = w.Events(watchFile2)
+	g.Expect(events2).To(BeNil())
+	errors2 = w.Errors(watchFile2)
+	g.Expect(errors2).To(BeNil())
+}


### PR DESCRIPTION
Fix: #7877

The PR
1. Provide shared filewatcher mechanism for usage
2. handles symlinks properly for k8s secrets/configmaps.

TODO: add a fake implementation for testing purposes.