### PR TITLE
Fix lint errors due to recent changes

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -102,7 +102,7 @@ gocovmerge "${COVERAGEDIR}"/*.cov > coverage.cov
 cat "${COVERAGEDIR}"/*.report > codecov.report
 popd
 
-echo "Intermedite files were written to ${COVERAGEDIR}"
+echo "Intermediate files were written to ${COVERAGEDIR}"
 echo "Final reports are stored in ${FINAL_CODECOV_DIR}"
 
 if ls "${COVERAGEDIR}"/*.err 1> /dev/null 2>&1; then

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -652,7 +652,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 		case model.EventDelete:
 			c.Lock()
 			delete(c.servicesMap, svcConv.Hostname)
-		  c.Unlock()
+		    c.Unlock()
 		default:
 			c.Lock()
 			c.servicesMap[svcConv.Hostname] = svcConv

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -652,7 +652,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 		case model.EventDelete:
 			c.Lock()
 			delete(c.servicesMap, svcConv.Hostname)
-		    c.Unlock()
+			c.Unlock()
 		default:
 			c.Lock()
 			c.servicesMap[svcConv.Hostname] = svcConv

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -178,7 +178,7 @@ func TestServices(t *testing.T) {
 	var sds model.ServiceDiscovery = ctl
 	// "test", ports: http-example on 80
 	makeService(testService, ns, ctl.client, t)
-	<- fx.Events
+	<-fx.Events
 
 	test.Eventually(t, "successfully added a service", func() bool {
 		out, clientErr := sds.Services()


### PR DESCRIPTION
Recent PRs (#9165, #9341) brought in new lint errors which weren't detected because currently the lint test is not required. 