### PR TITLE
Add kube-inject configmap option

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -110,3 +110,4 @@ E2E tests have multiple options available while running them as follows:
 * `--image_pull_policy <policy>` - Specifies an override for the Docker image pull policy to be used
 * `--cluster_registry_dir <dir>` - Directory name for the cluster registry config. When provided this will trigger a multicluster test to be run across two clusters. 
 * `--installer <cmd>` - Use `helm` or `kubectl` to install Istio (default: kubectl)
+* `--kube_inject_configmap <configmap>` - Istioctl will use the specified configmap when running kube-inject (default: ""). This will normally be used with the CNI option to override the embedded initContainers insertion.

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -100,6 +100,9 @@ var (
 	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", false, "Use galley configuration validation webhook")
 	installer                = flag.String("installer", "kubectl", "Istio installer, default to kubectl, or helm")
 	useMCP                   = flag.Bool("use_mcp", false, "use MCP for configuring Istio components")
+	kubeInjectCM             = flag.String("kube_inject_configmap", "",
+		"Configmap to use by the istioctl kube-inject command.")
+
 
 	addons = []string{
 		"zipkin",
@@ -182,7 +185,7 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 		}
 	}
 	yamlDir := filepath.Join(tmpDir, "yaml")
-	i, err := NewIstioctl(yamlDir, *namespace, *proxyHub, *proxyTag, *imagePullPolicy, "")
+	i, err := NewIstioctl(yamlDir, *namespace, *proxyHub, *proxyTag, *imagePullPolicy, *kubeInjectCM)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change is needed to the e2e tests to
allow the istio-sidecar-injector configmap
to be used during the tests vs. the embedded
inject options.  This is needed when running
e2e tests with the CNI option.