### PR TITLE
Added a smaller base image for the debug container

### DIFF
--- a/docker/Dockerfile.buster_debug
+++ b/docker/Dockerfile.buster_debug
@@ -1,0 +1,23 @@
+FROM debian:buster-slim
+# Base image for debug builds.
+# Built manually uploaded as "istionightly/base_debug"
+
+# Do not add more stuff to this list that isn't small or critically useful.
+# If you occasionally need something on the container do
+# sudo apt-get update && apt-get whichever
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      curl \
+      iptables \
+      iproute2 \
+      iputils-ping \
+      dnsutils \
+      netcat \
+      tcpdump \
+      net-tools \
+      libc6-dbg gdb \
+      elvis-tiny \
+      lsof \
+      sudo && apt-get upgrade -y  && \
+      apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/log/*log /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old


### PR DESCRIPTION
Looking at the sizes from xenial and buster...

```
FROM ubuntu:xenial
<none>               <none>              9d98cc446dfe        10 seconds ago      249MB

FROM debian:buster-slim
<none>               <none>              46e4a9c6a849        4 seconds ago       181MB
```

Signed-off-by: JJ Asghar <jja@ibm.com>