### PR TITLE
kube registry `GetProxyServiceInstances` optimization

### DIFF
--- a/pilot/pkg/serviceregistry/kube/util.go
+++ b/pilot/pkg/serviceregistry/kube/util.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+func hasProxyIP(addresses []v1.EndpointAddress, proxyIP string) bool {
+	for _, addr := range addresses {
+		if addr.IP == proxyIP {
+			return true
+		}
+	}
+	return false
+}

--- a/pilot/pkg/serviceregistry/kube/util_test.go
+++ b/pilot/pkg/serviceregistry/kube/util_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	"k8s.io/api/core/v1"
+)
+
+func TestHasProxyIP(t *testing.T) {
+	var tests = []struct {
+		name      string
+		addresses []v1.EndpointAddress
+		proxyIP   string
+		expected  bool
+	}{
+		{
+			"has proxy ip",
+			[]v1.EndpointAddress{{IP: "172.17.0.1"}, {IP: "172.17.0.2"}},
+			"172.17.0.1",
+			true,
+		},
+		{
+			"has no proxy ip",
+			[]v1.EndpointAddress{{IP: "172.17.0.1"}, {IP: "172.17.0.2"}},
+			"172.17.0.100",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := hasProxyIP(test.addresses, test.proxyIP)
+			if test.expected != got {
+				t.Errorf("Expected %v, but got %v", test.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
optimize on `GetProxyServiceInstances`:

1. get service by label selector and get endpoint by name instead of loop over all endpoints in the cluster.

1. If can not find any service with selector matches labels, then there maybe headless services. fail over to previous logic.

fixes: #9296