### PR TITLE
Fix by pass check-go-version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,6 +574,7 @@ DIRS_TO_CLEAN+=${ISTIO_OUT}
 clean: clean.go
 	rm -rf $(DIRS_TO_CLEAN)
 	rm -f $(FILES_TO_CLEAN)
+	rm -f ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)
 
 clean.go: ; $(info $(H) cleaning...)
 	$(eval GO_CLEAN_FLAGS := -i -r)


### PR DESCRIPTION
Fix by pass `check-go-version` in `Makefile` . Fix issue https://github.com/istio/istio/issues/9396

Remove `${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED)` file in `clean` target