### PR TITLE
build: adjust GCP_OPTS format per gcloud reference guide

### DIFF
--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -78,7 +78,7 @@ else
 fi
 
 function update_gcp_opts() {
-  export GCP_OPTS="--project $PROJECT --zone $ZONE"
+  export GCP_OPTS="--project=${PROJECT} --zone=${ZONE}"
 }
 
 function Execute() {


### PR DESCRIPTION
Perf tests fail with the current GCP_OPTS format and the gcloud
reference docs suggest that these values require the equal when the
long format is specified.

Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>