### PR TITLE
Add variable for inlined Mutex

### DIFF
--- a/pilot/pkg/config/clusterregistry/multicluster_test.go
+++ b/pilot/pkg/config/clusterregistry/multicluster_test.go
@@ -71,8 +71,8 @@ func mockLoadKubeConfig(kubeconfig []byte) (*clientcmdapi.Config, error) {
 
 func verifyControllers(t *testing.T, m *Multicluster, expectedControllerCount int, timeoutName string) {
 	pkgtest.NewEventualOpts(10*time.Millisecond, 5*time.Second).Eventually(t, timeoutName, func() bool {
-		m.Lock()
-		defer m.Unlock()
+		m.m.Lock()
+		defer m.m.Unlock()
 		return len(m.remoteKubeControllers) == expectedControllerCount
 	})
 }


### PR DESCRIPTION
Sorry I missed the original PR that added this. We almost never want a mutex inlined directly into an object: that makes the mutex's `Lock` and `Unlock` methods part of the type's public interface. i.e. a user of `Multicluster` can call `Lock` on the object, then call some methods on it which themselves attempt to call `Lock`, resulting in a deadlock at runtime. Instead, the mutex should be a private variable so that only the methods in this package can manipulate it.