### PR TITLE
[Cherry-pick] Fix bad column name in mesh dashboard for TCP

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/dashboards/istio-mesh-dashboard.json
+++ b/install/kubernetes/helm/subcharts/grafana/dashboards/istio-mesh-dashboard.json
@@ -676,7 +676,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
-          "pattern": "Value #B",
+          "pattern": "Value #C",
           "thresholds": [],
           "type": "number",
           "unit": "Bps"


### PR DESCRIPTION
Moving #9337 to `master`.