### PR TITLE
Allow additional node affinity expressions in helm charts

### DIFF
--- a/install/kubernetes/helm/istio/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/templates/_affinity.tpl
@@ -11,6 +11,9 @@
 {{- define "nodeAffinityRequiredDuringScheduling" }}
       nodeSelectorTerms:
       - matchExpressions:
+{{- if .Values.global.affinityMatchExpressions }}
+{{ toYaml .Values.global.affinityMatchExpressions | indent 8 }}
+{{- end }}
         - key: beta.kubernetes.io/arch
           operator: In
           values:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -373,3 +373,13 @@ global:
   #       port: 443
   #
   meshNetworks:
+
+  # Extra node affinity terms, these entries will be added to the
+  # matchExpressions field inside the
+  # requiredDuringSchedulingIgnoredDuringExecution node affinity.
+  affinityMatchExpressions: []
+  # - key: my.org/nodetype
+  #   operator: In
+  #   values:
+  #     - value1
+  #     - value2

--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -65,6 +65,8 @@ spec:
         release: {{ .Release.Name }}
         version: {{ .Chart.Version }}
     spec:
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       serviceAccountName: istio-grafana-post-install-account
       containers:
         - name: kubectl

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 10 }}
 {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       volumes:
       - name: kiali-configuration
         configMap:

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -143,6 +143,8 @@
       nodeSelector:
 {{ toYaml $.Values.nodeSelector | indent 8 }}
     {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       containers:
       - name: mixer
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -87,6 +87,8 @@ spec:
         release: {{ .Release.Name }}
         version: {{ .Chart.Version }}
     spec:
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       serviceAccountName: istio-cleanup-secrets-service-account
       containers:
         - name: kubectl

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -76,6 +76,8 @@ spec:
         release: {{ .Release.Name }}
         version: {{ .Chart.Version }}
     spec:
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       serviceAccountName: istio-security-post-install-account
       containers:
         - name: kubectl


### PR DESCRIPTION
This PR allows specifying custom node affinity expressions by configuring the new `global.affinityMatchExpressions` config value. To ensure this works as expected this PR also adds calls to the `nodeaffinity` helper to some pod templates that were missing it.

This is needed in situations where it would be desirable to ensure all istio components are running on a certain subset of available nodes.

Related to #9074.