### PR TITLE
Add missing resources to kiali cluster role in helm chart

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 rules:
-- apiGroups: ["","apps", "autoscaling"]
+- apiGroups: ["", "apps", "autoscaling", "batch"]
   resources:
   - configmaps
   - namespaces
@@ -19,6 +19,11 @@ rules:
   - endpoints
   - deployments
   - horizontalpodautoscalers
+  - replicasets
+  - statefulsets
+  - replicationcontrollers
+  - jobs
+  - cronjobs
   verbs:
   - get
   - list


### PR DESCRIPTION
The kiali helm chart was recently updated to 0.9 version but the ClusterRole was not updated accordingly as it now requires access to more resources. See https://github.com/kiali/kiali/blob/b11bc05013df2457e479eb381c52e924e27db19d/deploy/kubernetes/kiali.yaml#L117

This PR adds the missing resources to the kiali chart ClusterRole.