### PR TITLE
Fix and enable format linter

### DIFF
--- a/bin/linters.sh
+++ b/bin/linters.sh
@@ -119,8 +119,7 @@ function check_grafana_dashboards() {
 }
 
 ensure_pilot_types
-# Below format check is temporarily disabled until https://github.com/golang/go/issues/28200 is resolved
-#format
+format
 check_licenses
 check_spelling
 install_gometalinter

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -28,9 +28,8 @@ import (
 	istiocmd "istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/version"
-
 	"istio.io/istio/pkg/probe"
+	"istio.io/istio/pkg/version"
 )
 
 var (

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -31,7 +31,6 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/kube"
-
 	"istio.io/istio/pkg/probe"
 )
 

--- a/galley/pkg/fs/fssource.go
+++ b/galley/pkg/fs/fssource.go
@@ -17,7 +17,6 @@ package fs
 import (
 	"crypto/sha1"
 	"fmt"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,13 +25,12 @@ import (
 	"github.com/howeyc/fsnotify"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"istio.io/istio/pkg/log"
-
 	"istio.io/istio/galley/pkg/kube"
 	"istio.io/istio/galley/pkg/kube/source"
 	kube_meta "istio.io/istio/galley/pkg/metadata/kube"
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/pkg/log"
 )
 
 var supportedExtensions = map[string]bool{

--- a/galley/pkg/kube/source/source.go
+++ b/galley/pkg/kube/source/source.go
@@ -24,7 +24,6 @@ import (
 
 	"istio.io/istio/galley/pkg/kube"
 	kube_meta "istio.io/istio/galley/pkg/metadata/kube"
-
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/pkg/log"

--- a/galley/pkg/runtime/monitoring.go
+++ b/galley/pkg/runtime/monitoring.go
@@ -15,11 +15,12 @@
 package runtime
 
 import (
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
-	"go.opencensus.io/stats/view"
 	"context"
 	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 const typeURL = "typeURL"
@@ -69,9 +70,8 @@ var (
 		"The number of type instances per type URL",
 		stats.UnitDimensionless)
 
-	durationDistributionMs =
-		view.Distribution(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8193, 16384, 32768, 65536,
-			131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608)
+	durationDistributionMs = view.Distribution(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8193, 16384, 32768, 65536,
+		131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608)
 )
 
 func recordStrategyOnChange() {

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -15,13 +15,14 @@
 package runtime
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/mcp/snapshot"
-	"time"
 )
 
 var scope = log.RegisterScope("runtime", "Galley runtime", 0)

--- a/galley/pkg/runtime/resource/schema_test.go
+++ b/galley/pkg/runtime/resource/schema_test.go
@@ -20,8 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	// Pull in gogo well-known types
-	_ "github.com/gogo/protobuf/types"
+	_ "github.com/gogo/protobuf/types" // Pull in gogo well-known types
 )
 
 func TestSchema_All(t *testing.T) {

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -23,18 +23,16 @@ import (
 
 	"google.golang.org/grpc"
 
-	"istio.io/istio/pkg/mcp/creds"
-
 	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/galley/cmd/shared"
 	"istio.io/istio/galley/pkg/fs"
+	"istio.io/istio/galley/pkg/kube"
 	"istio.io/istio/galley/pkg/kube/source"
 	"istio.io/istio/galley/pkg/metadata"
-
-	"istio.io/istio/galley/cmd/shared"
-	"istio.io/istio/galley/pkg/kube"
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/istio/pkg/probe"

--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -25,11 +25,9 @@ import (
 	"google.golang.org/grpc"
 
 	mcp "istio.io/api/mcp/v1alpha1"
+	_ "istio.io/istio/galley/pkg/kube/converter/legacy" // Import the resource package to pull in all proto types.
+	_ "istio.io/istio/galley/pkg/metadata"              // Import the resource package to pull in all proto types.
 	"istio.io/istio/pkg/mcp/client"
-
-	// Import the resource package to pull in all proto types.
-	_ "istio.io/istio/galley/pkg/kube/converter/legacy"
-	_ "istio.io/istio/galley/pkg/metadata"
 )
 
 var (

--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -21,9 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"k8s.io/api/core/v1"
-
-	// import all known client auth plugins
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // import all known client auth plugins
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/istioctl/cmd/istioctl/gendeployment"

--- a/istioctl/cmd/istioctl/metrics.go
+++ b/istioctl/cmd/istioctl/metrics.go
@@ -66,9 +66,9 @@ istioctl experimental metrics productpage-v1
 # Retrieve workload metrics for various services in the different namespaces
 istioctl experimental metrics productpage-v1.foo reviews-v1.bar ratings-v1.baz
 `,
-		Aliases: []string{"m"},
-		Args:    cobra.MinimumNArgs(1),
-		RunE:    run,
+		Aliases:               []string{"m"},
+		Args:                  cobra.MinimumNArgs(1),
+		RunE:                  run,
 		DisableFlagsInUseLine: true,
 	}
 )

--- a/istioctl/pkg/validate/validate.go
+++ b/istioctl/pkg/validate/validate.go
@@ -20,14 +20,15 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"istio.io/istio/pilot/pkg/config/kube/crd"
-	"istio.io/istio/pilot/pkg/model"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime" // TODO use k8s.io/cli-runtime when we switch to v1.12 k8s dependency
 	// k8s.io/cli-runtime was created for k8s v.12. Prior to that release,
 	// the genericclioptions packages are organized under kubectl.
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions"
 	"k8s.io/kubernetes/pkg/kubectl/genericclioptions/resource"
+
+	"istio.io/istio/pilot/pkg/config/kube/crd"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 /*

--- a/istioctl/pkg/writer/pilot/auth_test.go
+++ b/istioctl/pkg/writer/pilot/auth_test.go
@@ -103,8 +103,8 @@ func TestTLSCheckWriter_PrintSingle(t *testing.T) {
 func authInput() []v2.AuthenticationDebug {
 	return []v2.AuthenticationDebug{
 		{
-			Host: "host1",
-			Port: 1,
+			Host:                     "host1",
+			Port:                     1,
 			AuthenticationPolicyName: "auth-policy1/namespace1",
 			DestinationRuleName:      "destination-rule1/namespace1",
 			ServerProtocol:           "HTTP",
@@ -112,8 +112,8 @@ func authInput() []v2.AuthenticationDebug {
 			TLSConflictStatus:        "OK",
 		},
 		{
-			Host: "host2",
-			Port: 2,
+			Host:                     "host2",
+			Port:                     2,
 			AuthenticationPolicyName: "auth-policy2/namespace2",
 			DestinationRuleName:      "destination-rule2/namespace2",
 			ServerProtocol:           "HTTP",
@@ -121,8 +121,8 @@ func authInput() []v2.AuthenticationDebug {
 			TLSConflictStatus:        "OK",
 		},
 		{
-			Host: "",
-			Port: 9999,
+			Host:                     "",
+			Port:                     9999,
 			AuthenticationPolicyName: "auth-policy/namespace",
 			DestinationRuleName:      "destination-rule/namespace",
 			ServerProtocol:           "HTTP",

--- a/mixer/adapter/circonus/circonus.go
+++ b/mixer/adapter/circonus/circonus.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"log" //nolint:adapterlinter
-
 	"net/url"
 	"time"
 

--- a/mixer/adapter/memquota/memquota_test.go
+++ b/mixer/adapter/memquota/memquota_test.go
@@ -84,7 +84,7 @@ func TestAllocAndRelease(t *testing.T) {
 
 	cfg := config.Params{
 		MinDeduplicationDuration: 3600 * time.Second,
-		Quotas: limits,
+		Quotas:                   limits,
 	}
 	info := GetInfo()
 	b := info.NewBuilder()
@@ -237,7 +237,7 @@ func TestReaper(t *testing.T) {
 
 	cfg := config.Params{
 		MinDeduplicationDuration: 3600 * time.Second,
-		Quotas: limits,
+		Quotas:                   limits,
 	}
 	info := GetInfo()
 	b := info.NewBuilder()

--- a/mixer/adapter/rbac/rbac.go
+++ b/mixer/adapter/rbac/rbac.go
@@ -32,9 +32,8 @@ import (
 	"net/url"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/gogo/protobuf/proto"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
 	"istio.io/istio/mixer/adapter/rbac/config"

--- a/mixer/adapter/redisquota/redisquota.go
+++ b/mixer/adapter/redisquota/redisquota.go
@@ -332,7 +332,7 @@ func (h *handler) HandleQuota(context context.Context, instance *quota.Instance,
 					key + ".meta", // KEY[1]
 					key + ".data", // KEY[2]
 				},
-				maxAmount, // ARGV[1] credit
+				maxAmount,                               // ARGV[1] credit
 				limit.GetValidDuration().Nanoseconds(),  // ARGV[2] window length
 				limit.GetBucketDuration().Nanoseconds(), // ARGV[3] bucket length
 				args.BestEffort,                         // ARGV[4] best effort

--- a/mixer/adapter/servicecontrol/servicecontrol_test.go
+++ b/mixer/adapter/servicecontrol/servicecontrol_test.go
@@ -137,7 +137,7 @@ func getTestAdapterConfig() *config.Params {
 				GoogleServiceName: "service_a.googleapi.com",
 				Quotas: []*config.Quota{
 					{
-						Name: "request-count",
+						Name:                  "request-count",
 						GoogleQuotaMetricName: "request-metric",
 						Expiration: &pbtypes.Duration{
 							Seconds: 10,

--- a/mixer/adapter/stackdriver/log/log_test.go
+++ b/mixer/adapter/stackdriver/log/log_test.go
@@ -343,7 +343,7 @@ func TestProjectMetadata(t *testing.T) {
 			"filled",
 			[]*logentry.Instance{
 				{
-					Name: "log",
+					Name:                  "log",
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
 						"project_id":   "id",
@@ -365,7 +365,7 @@ func TestProjectMetadata(t *testing.T) {
 			"empty",
 			[]*logentry.Instance{
 				{
-					Name: "log",
+					Name:                  "log",
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
 						"project_id":   "",

--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -473,8 +473,8 @@ func TestProjectMetadata(t *testing.T) {
 			"filled",
 			[]*metrict.Instance{
 				{
-					Name:  "metric",
-					Value: int64(1),
+					Name:                  "metric",
+					Value:                 int64(1),
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
 						"project_id":   "id",
@@ -496,8 +496,8 @@ func TestProjectMetadata(t *testing.T) {
 			"empty",
 			[]*metrict.Instance{
 				{
-					Name:  "metric",
-					Value: int64(1),
+					Name:                  "metric",
+					Value:                 int64(1),
 					MonitoredResourceType: "mr-type",
 					MonitoredResourceDimensions: map[string]interface{}{
 						"project_id":   "",

--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -24,8 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"istio.io/istio/pkg/mcp/snapshot"
-
 	"github.com/gogo/protobuf/proto"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,6 +36,7 @@ import (
 	"istio.io/istio/pkg/mcp/client"
 	"istio.io/istio/pkg/mcp/configz"
 	"istio.io/istio/pkg/mcp/creds"
+	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/istio/pkg/probe"
 )
 

--- a/mixer/pkg/protobuf/yaml/dynamic/handler.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/atomic"
 	"google.golang.org/grpc"
+
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	policypb "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"

--- a/mixer/pkg/protobuf/yaml/dynamic/handler_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	attributeV1beta1 "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"

--- a/mixer/pkg/runtime/config/ephemeral.go
+++ b/mixer/pkg/runtime/config/ephemeral.go
@@ -30,13 +30,11 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-
-	"go.opencensus.io/tag"
-
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/types"
 	multierror "github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	config "istio.io/api/policy/v1beta1"
@@ -779,7 +777,7 @@ func (e *Ephemeral) processDynamicTemplateConfigs(ctx context.Context, errs *mul
 		}
 
 		result[templateName] = &Template{
-			Name: templateName,
+			Name:                       templateName,
 			InternalPackageDerivedName: name,
 			FileDescSet:                fds,
 			PackageName:                desc.GetPackage(),

--- a/mixer/pkg/runtime/config/snapshot.go
+++ b/mixer/pkg/runtime/config/snapshot.go
@@ -17,11 +17,10 @@ package config
 import (
 	"context"
 
-	"go.opencensus.io/tag"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/types"
+	"go.opencensus.io/tag"
 
 	adptTmpl "istio.io/api/mixer/adapter/model/v1beta1"
 	"istio.io/api/policy/v1beta1"

--- a/mixer/pkg/runtime/dispatcher/dispatcher_test.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher_test.go
@@ -274,7 +274,7 @@ ident                         : dest.istio-system
 	{
 		name: "BasicReportError",
 		templates: []data.FakeTemplateSettings{{
-			Name: "treport",
+			Name:                  "treport",
 			ErrorOnDispatchReport: true,
 		}},
 		config: []string{
@@ -579,7 +579,7 @@ ident                         : dest.istio-system
 	{
 		name: "BasicPreprocessError",
 		templates: []data.FakeTemplateSettings{{
-			Name: "tapa",
+			Name:                    "tapa",
 			ErrorOnDispatchGenAttrs: true,
 		}},
 		config: []string{

--- a/mixer/pkg/runtime/routing/builder.go
+++ b/mixer/pkg/runtime/routing/builder.go
@@ -54,6 +54,7 @@ import (
 	"strings"
 
 	"go.opencensus.io/stats"
+
 	tpb "istio.io/api/mixer/adapter/model/v1beta1"
 	descriptor "istio.io/api/policy/v1beta1"
 	"istio.io/istio/mixer/pkg/adapter"
@@ -113,8 +114,8 @@ func BuildTable(
 			entries: make(map[tpb.TemplateVariety]*varietyTable, 4),
 		},
 
-		handlers: handlers,
-		expb:     expb,
+		handlers:               handlers,
+		expb:                   expb,
 		defaultConfigNamespace: defaultConfigNamespace,
 		nextIDCounter:          1,
 

--- a/mixer/test/spybackend/nosession_integration_test.go
+++ b/mixer/test/spybackend/nosession_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	istio_mixer_v1 "istio.io/api/mixer/v1"
 	policy_v1beta1 "istio.io/api/policy/v1beta1"

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -43,7 +43,6 @@ import (
 
 	mcpapi "istio.io/api/mcp/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
-
 	_ "istio.io/istio/galley/pkg/metadata" // TODO: why do we need this ?
 	"istio.io/istio/pilot/cmd"
 	configaggregate "istio.io/istio/pilot/pkg/config/aggregate"

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/test/util"

--- a/pilot/pkg/model/authorization_test.go
+++ b/pilot/pkg/model/authorization_test.go
@@ -123,21 +123,21 @@ func TestRolesForNamespace(t *testing.T) {
 		expectedRolesServiceRoleBinding []model.Config
 	}{
 		{
-			name:          "authzPolicies is nil",
-			authzPolicies: nil,
-			ns:            model.NamespaceAll,
+			name:                            "authzPolicies is nil",
+			authzPolicies:                   nil,
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: []model.Config{},
 		},
 		{
-			name:          "the NamespaceToPolicies of authzPolicies is nil",
-			authzPolicies: &model.AuthorizationPolicies{},
-			ns:            model.NamespaceAll,
+			name:                            "the NamespaceToPolicies of authzPolicies is nil",
+			authzPolicies:                   &model.AuthorizationPolicies{},
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: []model.Config{},
 		},
 		{
-			name:          "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
-			authzPolicies: &model.AuthorizationPolicies{map[string]*model.RolesAndBindings{}, nil},
-			ns:            model.NamespaceAll,
+			name:                            "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
+			authzPolicies:                   &model.AuthorizationPolicies{map[string]*model.RolesAndBindings{}, nil},
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: []model.Config{},
 		},
 		{
@@ -151,7 +151,7 @@ func TestRolesForNamespace(t *testing.T) {
 				},
 				nil,
 			},
-			ns: model.NamespaceAll,
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: []model.Config{},
 		},
 		{
@@ -165,7 +165,7 @@ func TestRolesForNamespace(t *testing.T) {
 				},
 				nil,
 			},
-			ns: model.NamespaceAll,
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: []model.Config{roleCfg, bindingCfg},
 		},
 	}
@@ -197,21 +197,21 @@ func TestRoleToBindingsForNamespace(t *testing.T) {
 		expectedRolesServiceRoleBinding map[string][]*rbacproto.ServiceRoleBinding
 	}{
 		{
-			name:          "authzPolicies is nil",
-			authzPolicies: nil,
-			ns:            model.NamespaceAll,
+			name:                            "authzPolicies is nil",
+			authzPolicies:                   nil,
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
 		},
 		{
-			name:          "the NamespaceToPolicies of authzPolicies is nil",
-			authzPolicies: &model.AuthorizationPolicies{},
-			ns:            model.NamespaceAll,
+			name:                            "the NamespaceToPolicies of authzPolicies is nil",
+			authzPolicies:                   &model.AuthorizationPolicies{},
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
 		},
 		{
-			name:          "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
-			authzPolicies: &model.AuthorizationPolicies{map[string]*model.RolesAndBindings{}, nil},
-			ns:            model.NamespaceAll,
+			name:                            "the namespaces of authzPolicies in NamespaceToPolicies is not exist",
+			authzPolicies:                   &model.AuthorizationPolicies{map[string]*model.RolesAndBindings{}, nil},
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
 		},
 		{
@@ -225,7 +225,7 @@ func TestRoleToBindingsForNamespace(t *testing.T) {
 				},
 				nil,
 			},
-			ns: model.NamespaceAll,
+			ns:                              model.NamespaceAll,
 			expectedRolesServiceRoleBinding: map[string][]*rbacproto.ServiceRoleBinding{},
 		},
 		{

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	mpb "istio.io/api/mixer/v1"

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -25,6 +25,7 @@ import (
 	v2_cluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
+
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"

--- a/pilot/pkg/networking/core/v1alpha3/configgen.go
+++ b/pilot/pkg/networking/core/v1alpha3/configgen.go
@@ -57,4 +57,3 @@ func (configgen *ConfigGeneratorImpl) CanUsePrecomputedCDS(proxy *model.Proxy) b
 
 	return networkView[model.UnnamedNetwork]
 }
-

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -749,7 +749,7 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		converter = func(v string) (*policyproto.Permission, error) {
 			return &policyproto.Permission{
 				Rule: &policyproto.Permission_RequestedServerName{
-					RequestedServerName: createStringMatcher(v, /* forceRegexPattern */ false, /* forTCPFilter */ false),
+					RequestedServerName: createStringMatcher(v /* forceRegexPattern */, false /* forTCPFilter */, false),
 				},
 			}, nil
 		}

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -596,7 +596,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 											},
 										},
 									},
-								} ,
+								},
 							},
 						},
 					},

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/gogo/protobuf/jsonpb"
+
 	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/test/util/diff.go
+++ b/pilot/test/util/diff.go
@@ -93,7 +93,7 @@ func ReadGoldenFile(content []byte, goldenFile string, t *testing.T) []byte {
 }
 
 // RefreshGoldenFile updates the golden file with the given content
-func RefreshGoldenFile( content []byte, goldenFile string, t *testing.T) {
+func RefreshGoldenFile(content []byte, goldenFile string, t *testing.T) {
 	if Refresh() {
 		t.Logf("Refreshing golden file %s", goldenFile)
 		if err := ioutil.WriteFile(goldenFile, content, 0644); err != nil {

--- a/pkg/ctrlz/ctrlz.go
+++ b/pkg/ctrlz/ctrlz.go
@@ -27,17 +27,15 @@
 package ctrlz
 
 import (
+	"fmt"
 	"html/template"
 	"net"
 	"net/http"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
-
-	"sync"
-
-	"fmt"
-	"time"
 
 	"istio.io/istio/pkg/ctrlz/fw"
 	"istio.io/istio/pkg/ctrlz/topics"

--- a/pkg/mcp/server/monitoring.go
+++ b/pkg/mcp/server/monitoring.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"strconv"
-
 	"strings"
 
 	"go.opencensus.io/stats"

--- a/pkg/mcp/testing/server.go
+++ b/pkg/mcp/testing/server.go
@@ -20,10 +20,9 @@ import (
 	"net"
 	"net/url"
 
-	mcp "istio.io/api/mcp/v1alpha1"
-
 	"google.golang.org/grpc"
 
+	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/snapshot"
 	"istio.io/istio/pkg/mcp/testing/monitoring"

--- a/pkg/test/docker/registry/cmd/main.go
+++ b/pkg/test/docker/registry/cmd/main.go
@@ -21,15 +21,13 @@ import (
 	"os/signal"
 	"syscall"
 
-	testKube "istio.io/istio/pkg/test/kube"
-
 	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"istio.io/istio/mixer/cmd/shared"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/docker/registry"
-
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	testKube "istio.io/istio/pkg/test/kube"
 )
 
 type localRegistrySetupArgs struct {

--- a/pkg/test/docker/registry/incluster.go
+++ b/pkg/test/docker/registry/incluster.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"text/template"
 
-	"istio.io/istio/pkg/test/kube"
-
 	"github.com/hashicorp/go-multierror"
+
+	"istio.io/istio/pkg/test/kube"
 )
 
 const (

--- a/pkg/test/env/istio.go
+++ b/pkg/test/env/istio.go
@@ -19,9 +19,8 @@ import (
 	"go/build"
 	"os"
 	"path"
-	"strings"
-
 	"runtime"
+	"strings"
 
 	"istio.io/istio/pkg/log"
 )

--- a/pkg/test/fakes/policy/backend.go
+++ b/pkg/test/fakes/policy/backend.go
@@ -26,10 +26,9 @@ import (
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 
-	"istio.io/istio/mixer/template/checknothing"
-
 	"istio.io/api/mixer/adapter/model/v1beta1"
 	istio_mixer_adapter_model_v1beta11 "istio.io/api/mixer/adapter/model/v1beta1"
+	"istio.io/istio/mixer/template/checknothing"
 	"istio.io/istio/mixer/template/metric"
 	"istio.io/istio/pkg/log"
 )

--- a/pkg/test/framework/components/apps/kube/client.go
+++ b/pkg/test/framework/components/apps/kube/client.go
@@ -24,15 +24,14 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/environments/kubernetes"
-	"istio.io/istio/pkg/test/util"
-
 	corev1 "k8s.io/api/core/v1"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/kube"
 	"istio.io/istio/pkg/test/application/echo"
 	"istio.io/istio/pkg/test/framework/environment"
+	"istio.io/istio/pkg/test/framework/environments/kubernetes"
+	"istio.io/istio/pkg/test/util"
 )
 
 const (

--- a/pkg/test/framework/components/apps/local/agent/agent.go
+++ b/pkg/test/framework/components/apps/local/agent/agent.go
@@ -18,11 +18,9 @@ import (
 	"fmt"
 	"io"
 
-	"istio.io/istio/pkg/test/framework/environments/local/service"
-
-	"istio.io/istio/pkg/test/application"
-
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/application"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 )
 
 // Agent is a wrapper around an Envoy proxy that has been configured for a particular backend Application.

--- a/pkg/test/framework/components/apps/local/agent/pilot_agent.go
+++ b/pkg/test/framework/components/apps/local/agent/pilot_agent.go
@@ -33,10 +33,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/gogo/protobuf/proto"
-
-	"istio.io/istio/pkg/test/framework/environments/local/service"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdsapiCore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	xdsapiListener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
@@ -44,6 +40,7 @@ import (
 	envoyFilterTcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	envoyUtil "github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 	googleProtobuf6 "github.com/gogo/protobuf/types"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-multierror"
@@ -54,6 +51,7 @@ import (
 	"istio.io/istio/pkg/test/application"
 	"istio.io/istio/pkg/test/envoy"
 	"istio.io/istio/pkg/test/envoy/discovery"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 	"istio.io/istio/pkg/test/util/reserveport"
 )
 

--- a/pkg/test/framework/components/apps/local/agent/pilot_agent_test.go
+++ b/pkg/test/framework/components/apps/local/agent/pilot_agent_test.go
@@ -23,16 +23,14 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/environments/local/service"
-
-	"istio.io/istio/pkg/test/application"
-
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	proxyEnvoy "istio.io/istio/pilot/pkg/proxy/envoy"
+	"istio.io/istio/pkg/test/application"
 	"istio.io/istio/pkg/test/application/echo"
 	"istio.io/istio/pkg/test/application/echo/proto"
 	"istio.io/istio/pkg/test/envoy"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 )
 
 const (

--- a/pkg/test/framework/components/apps/local/app.go
+++ b/pkg/test/framework/components/apps/local/app.go
@@ -17,19 +17,19 @@ package local
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"net"
 	"net/url"
 	"strconv"
 	"testing"
 
-	"istio.io/istio/pkg/test/framework/environments/local/service"
+	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/application/echo"
 	"istio.io/istio/pkg/test/application/echo/proto"
 	"istio.io/istio/pkg/test/framework/components/apps/local/agent"
 	"istio.io/istio/pkg/test/framework/environment"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 )
 
 var (

--- a/pkg/test/framework/components/apps/local/apps.go
+++ b/pkg/test/framework/components/apps/local/apps.go
@@ -20,8 +20,6 @@ import (
 	"net"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/environments/local/service"
-
 	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pkg/test/envoy"
@@ -30,6 +28,7 @@ import (
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/local"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 )
 
 const (

--- a/pkg/test/framework/components/bookinfo/bookinfo.go
+++ b/pkg/test/framework/components/bookinfo/bookinfo.go
@@ -19,13 +19,12 @@ import (
 	"path"
 	"reflect"
 
-	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/test/framework/scopes"
-
 	"istio.io/istio/pkg/test/deployment"
+	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/kubernetes"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 var (

--- a/pkg/test/framework/components/citadel/citadel.go
+++ b/pkg/test/framework/components/citadel/citadel.go
@@ -16,11 +16,9 @@ package citadel
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/go-multierror"
-
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"k8s.io/api/core/v1"
 	mv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/pkg/test/framework/components/pilot/pilot.go
+++ b/pkg/test/framework/components/pilot/pilot.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 	"net"
 
-	meshConfig "istio.io/api/mesh/v1alpha1"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	adsapi "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 
-	"github.com/hashicorp/go-multierror"
-
+	meshConfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy"

--- a/pkg/test/framework/components/pilot/pilot_test.go
+++ b/pkg/test/framework/components/pilot/pilot_test.go
@@ -18,16 +18,14 @@ import (
 	"io"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/config/memory"
-
-	"istio.io/istio/pkg/test"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core1 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/config/memory"
 	"istio.io/istio/pilot/pkg/model"
 	envoy_proxy_v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
+	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 )
 

--- a/pkg/test/framework/components/policybackend/policybackend.go
+++ b/pkg/test/framework/components/policybackend/policybackend.go
@@ -17,6 +17,7 @@ package policybackend
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -25,19 +26,16 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 
-	"istio.io/istio/pkg/test/framework/internal"
-	"istio.io/istio/pkg/test/framework/scopes"
-	"istio.io/istio/pkg/test/util"
-
-	"io"
-
 	"istio.io/istio/pkg/test/fakes/policy"
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/kubernetes"
 	"istio.io/istio/pkg/test/framework/environments/local"
+	"istio.io/istio/pkg/test/framework/internal"
+	"istio.io/istio/pkg/test/framework/scopes"
 	"istio.io/istio/pkg/test/framework/tmpl"
 	"istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/util"
 )
 
 var (

--- a/pkg/test/framework/components/prometheus/prometheus.go
+++ b/pkg/test/framework/components/prometheus/prometheus.go
@@ -25,13 +25,12 @@ import (
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 
-	"istio.io/istio/pkg/test/util"
-
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/kubernetes"
 	"istio.io/istio/pkg/test/framework/scopes"
 	"istio.io/istio/pkg/test/kube"
+	"istio.io/istio/pkg/test/util"
 )
 
 const (

--- a/pkg/test/framework/environment/environment.go
+++ b/pkg/test/framework/environment/environment.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	prom "github.com/prometheus/common/model"
-
 	corev1 "k8s.io/api/core/v1"
 
 	istio_mixer_v1 "istio.io/api/mixer/v1"

--- a/pkg/test/framework/environments/kubernetes/settings.go
+++ b/pkg/test/framework/environments/kubernetes/settings.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"istio.io/istio/pkg/test/env"
-
 	kubeCore "k8s.io/api/core/v1"
+
+	"istio.io/istio/pkg/test/env"
 )
 
 const (

--- a/pkg/test/framework/internal/tracker.go
+++ b/pkg/test/framework/internal/tracker.go
@@ -15,18 +15,16 @@
 package internal
 
 import (
+	"fmt"
 	"io"
 
 	"go.uber.org/multierr"
-
-	"istio.io/istio/pkg/test/framework/scopes"
-
-	"fmt"
 
 	"istio.io/istio/pkg/test/framework/component"
 	"istio.io/istio/pkg/test/framework/components/registry"
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 // Tracker keeps track of the state information for dependencies

--- a/pkg/test/framework/settings/settings.go
+++ b/pkg/test/framework/settings/settings.go
@@ -22,9 +22,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"istio.io/istio/pkg/test/framework/scopes"
-
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 // EnvironmentID is a unique identifier for a testing environment.

--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -16,13 +16,13 @@ package kube
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"strings"
 	"time"
 
 	kubeApiCore "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	kubeApiMeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	kubeClient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	kubeClientCore "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/security/pkg/adapter/vault/ca.go
+++ b/security/pkg/adapter/vault/ca.go
@@ -147,7 +147,7 @@ func signCsr(client *api.Client, csrPath string, csr string) (*api.Secret, error
 		"name":                "workload_role",
 		"format":              "pem",
 		"use_csr_common_name": true,
-		"csr": csr,
+		"csr":                 csr,
 	}
 
 	res, err := client.Logical().Write(csrPath, m)

--- a/security/pkg/caclient/protocol/protocol.go
+++ b/security/pkg/caclient/protocol/protocol.go
@@ -21,9 +21,6 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-
-	//"istio.io/istio/pkg/log"
-
 	pb "istio.io/istio/security/proto"
 )
 

--- a/security/pkg/caclient/protocol/protocol.go
+++ b/security/pkg/caclient/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
 	pb "istio.io/istio/security/proto"
 )
 

--- a/security/pkg/nodeagent/vm/nodeagent_test.go
+++ b/security/pkg/nodeagent/vm/nodeagent_test.go
@@ -33,10 +33,10 @@ import (
 func TestStartWithArgs(t *testing.T) {
 	generalConfig := Config{
 		CAClientConfig: caclient.Config{
-			CAAddress:  "ca_addr",
-			Org:        "Google Inc.",
-			RSAKeySize: 512,
-			Env:        "onprem",
+			CAAddress:                 "ca_addr",
+			Org:                       "Google Inc.",
+			RSAKeySize:                512,
+			Env:                       "onprem",
 			CSRInitialRetrialInterval: time.Millisecond,
 			CSRMaxRetries:             3,
 			CSRGracePeriodPercentage:  50,
@@ -89,10 +89,10 @@ func TestStartWithArgs(t *testing.T) {
 
 			config: &Config{
 				CAClientConfig: caclient.Config{
-					CAAddress:  "ca_addr",
-					Org:        "Google Inc.",
-					RSAKeySize: 128,
-					Env:        "onprem",
+					CAAddress:                 "ca_addr",
+					Org:                       "Google Inc.",
+					RSAKeySize:                128,
+					Env:                       "onprem",
 					CSRInitialRetrialInterval: time.Millisecond,
 					CSRMaxRetries:             3,
 					CSRGracePeriodPercentage:  50,

--- a/security/pkg/pki/util/generate_cert.go
+++ b/security/pkg/pki/util/generate_cert.go
@@ -186,13 +186,13 @@ func genCertTemplateFromCSR(csr *x509.CertificateRequest, subjectIDs []string, t
 	}
 
 	return &x509.Certificate{
-		SerialNumber: serialNum,
-		Subject:      subject,
-		NotBefore:    now,
-		NotAfter:     now.Add(ttl),
-		KeyUsage:     keyUsage,
-		ExtKeyUsage:  extKeyUsages,
-		IsCA:         isCA,
+		SerialNumber:          serialNum,
+		Subject:               subject,
+		NotBefore:             now,
+		NotAfter:              now.Add(ttl),
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           extKeyUsages,
+		IsCA:                  isCA,
 		BasicConstraintsValid: true,
 		ExtraExtensions:       exts,
 		SignatureAlgorithm:    csr.SignatureAlgorithm}, nil
@@ -250,13 +250,13 @@ func genCertTemplateFromOptions(options CertOptions) (*x509.Certificate, error) 
 	}
 
 	return &x509.Certificate{
-		SerialNumber: serialNum,
-		Subject:      subject,
-		NotBefore:    notBefore,
-		NotAfter:     notBefore.Add(options.TTL),
-		KeyUsage:     keyUsage,
-		ExtKeyUsage:  extKeyUsages,
-		IsCA:         options.IsCA,
+		SerialNumber:          serialNum,
+		Subject:               subject,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(options.TTL),
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           extKeyUsages,
+		IsCA:                  options.IsCA,
 		BasicConstraintsValid: true,
 		ExtraExtensions:       exts}, nil
 }

--- a/security/pkg/platform/client.go
+++ b/security/pkg/platform/client.go
@@ -17,10 +17,10 @@ package platform
 import (
 	"fmt"
 
+	"google.golang.org/grpc"
 	// Temporarily disable ID token authentication on CSR API.
 	// [TODO](myidpt): enable when the Citadel authz can work correctly.
 	// "cloud.google.com/go/compute/metadata"
-	"google.golang.org/grpc"
 )
 
 // Client is the interface for implementing the client to access platform metadata.

--- a/security/pkg/platform/onprem.go
+++ b/security/pkg/platform/onprem.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-
-	"strings"
 
 	"istio.io/istio/security/pkg/pki/util"
 )

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -363,9 +363,9 @@ func TestRun(t *testing.T) {
 				"input after skipping PEM blocks of the following types: [CERTIFICATE REQUEST]",
 		},
 		"Multiple hostname": {
-			ca:       &mockca.FakeCA{SignedCert: []byte(csr)},
-			hostname: []string{"localhost", "fancyhost"},
-			port:     0,
+			ca:                        &mockca.FakeCA{SignedCert: []byte(csr)},
+			hostname:                  []string{"localhost", "fancyhost"},
+			port:                      0,
 			expectedAuthenticatorsLen: 1, // 3 when ID token authenticators are enabled.
 			applyServerCertificateError: "tls: failed to find \"CERTIFICATE\" PEM block in certificate " +
 				"input after skipping PEM blocks of the following types: [CERTIFICATE REQUEST]",

--- a/security/tests/integration/kubernetes_utils.go
+++ b/security/tests/integration/kubernetes_utils.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // to avoid 'No Auth Provider found for name "gcp"'
-
 	"k8s.io/client-go/tools/clientcmd"
 
 	"istio.io/istio/pkg/log"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -103,7 +103,6 @@ var (
 	kubeInjectCM             = flag.String("kube_inject_configmap", "",
 		"Configmap to use by the istioctl kube-inject command.")
 
-
 	addons = []string{
 		"zipkin",
 	}

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -28,12 +28,11 @@ import (
 	"testing"
 	"time"
 
+	"fortio.org/fortio/fhttp"
+	"fortio.org/fortio/periodic"
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-
-	"fortio.org/fortio/fhttp"
-	"fortio.org/fortio/periodic"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/kube"

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -31,14 +31,11 @@ import (
 	"testing"
 	"time"
 
+	"fortio.org/fortio/fhttp"
+	"fortio.org/fortio/periodic"
 	"github.com/prometheus/client_golang/api"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-
-	"fortio.org/fortio/fhttp"
-
-	// flog "fortio.org/fortio/log"
-	"fortio.org/fortio/periodic"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/kube"

--- a/tests/e2e/tests/pilot/istio_rbac_test.go
+++ b/tests/e2e/tests/pilot/istio_rbac_test.go
@@ -16,9 +16,8 @@ package pilot
 
 import (
 	"fmt"
-	"testing"
-
 	"strings"
+	"testing"
 
 	"istio.io/istio/tests/util"
 )

--- a/tests/e2e/tests/pilot/listener_conflict_test.go
+++ b/tests/e2e/tests/pilot/listener_conflict_test.go
@@ -15,13 +15,12 @@
 package pilot
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 	"testing"
-
-	"bytes"
 	"text/template"
 	"time"
 

--- a/tests/e2e/tests/pilot/mcp_test.go
+++ b/tests/e2e/tests/pilot/mcp_test.go
@@ -30,16 +30,14 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	_ "istio.io/istio/galley/pkg/metadata" // Import the resource package to pull in all proto types.
 	mixerEnv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	mcpserver "istio.io/istio/pkg/mcp/server"
+	"istio.io/istio/pkg/test/env"
 	mockmcp "istio.io/istio/tests/e2e/tests/pilot/mock/mcp"
 	"istio.io/istio/tests/util"
-
-	// Import the resource package to pull in all proto types.
-	_ "istio.io/istio/galley/pkg/metadata"
-	"istio.io/istio/pkg/test/env"
 )
 
 const (

--- a/tests/integration2/qualification/loadbalancing_test.go
+++ b/tests/integration2/qualification/loadbalancing_test.go
@@ -26,12 +26,11 @@ import (
 	"github.com/prometheus/common/model"
 
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/test/framework/environment"
-
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/bookinfo"
 	"istio.io/istio/pkg/test/framework/dependency"
+	"istio.io/istio/pkg/test/framework/environment"
 )
 
 const (

--- a/tests/util/checker/flaky_test_finder/flaky_test_finder_test.go
+++ b/tests/util/checker/flaky_test_finder/flaky_test_finder_test.go
@@ -15,10 +15,9 @@
 package flakytestfinder
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
-
-	"path/filepath"
 )
 
 func getAbsPath(path string) string {

--- a/tests/util/helm_utils.go
+++ b/tests/util/helm_utils.go
@@ -25,6 +25,7 @@ func HelmClientInit() error {
 	_, err := Shell("helm init --client-only")
 	return err
 }
+
 // HelmDepUpdate helm dep update to update dependencies for umrella charts
 func HelmDepUpdate(chartDir string) error {
 	_, err := Shell("helm dep update %s", chartDir)

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -24,12 +24,13 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/env"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var (


### PR DESCRIPTION
We disabled the format check (#9424) due to a goimports bug of wrong placement of import comments.
However, putting the comment inline with referenced import won't separate the comment. I moved the comments to be in the same lines of the imports.

Re-enabling the format check and adding all formatting fixes.