### PR TITLE
Add e2e options to set CNI hub/tag

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -107,6 +107,8 @@ E2E tests have multiple options available while running them as follows:
 * `--sidecar_injector_hub <hub>` - Image hub for the Sidecar Injector (default: environment $HUB)
 * `--sidecar_injector_tag <tag>` - Image tag for the Sidecar Injector (default: environment $TAG)
 * `--sidecar_injector_file <file>` - Sidecar injector YAML file name (default: istio-sidecar-injector.yaml)
+* `--istio_cni_hub <hub>` - Image hub for the CNI plugin: (defaults to using the value generate_yaml provides)
+* `--istio_cni_tag <tag>` - Image tag for the CNI plugin: (defaults to using the value generate_yaml provides)
 * `--image_pull_policy <policy>` - Specifies an override for the Docker image pull policy to be used
 * `--cluster_registry_dir <dir>` - Directory name for the cluster registry config. When provided this will trigger a multicluster test to be run across two clusters. 
 * `--installer <cmd>` - Use `helm` or `kubectl` to install Istio (default: kubectl)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -87,6 +87,8 @@ var (
 	galleyTag          = flag.String("galley_tag", os.Getenv("TAG"), "Galley tag")
 	sidecarInjectorHub = flag.String("sidecar_injector_hub", os.Getenv("HUB"), "Sidecar injector hub")
 	sidecarInjectorTag = flag.String("sidecar_injector_tag", os.Getenv("TAG"), "Sidecar injector tag")
+	cniHub             = flag.String("istio_cni_hub", "", "Hub to use to get the Istio CNI plugin")
+	cniTag             = flag.String("istio_cni_tag", "", "Tag to use to get the Istio CNI plugin")
 	authEnable         = flag.Bool("auth_enable", false, "Enable auth")
 	rbacEnable         = flag.Bool("rbac_enable", true, "Enable rbac")
 	localCluster       = flag.Bool("use_local_cluster", false,
@@ -102,7 +104,6 @@ var (
 	useMCP                   = flag.Bool("use_mcp", false, "use MCP for configuring Istio components")
 	kubeInjectCM             = flag.String("kube_inject_configmap", "",
 		"Configmap to use by the istioctl kube-inject command.")
-
 
 	addons = []string{
 		"zipkin",
@@ -948,6 +949,9 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 		if *galleyHub != "" && *galleyTag != "" {
 			//Need to be updated when the string "citadel" is changed
 			content = updateImage("galley", *galleyHub, *galleyTag, content)
+		}
+		if *cniHub != "" && *cniTag != "" {
+			content = updateImage("install-cni", *cniHub, *cniTag, content)
 		}
 		if *imagePullPolicy != "" {
 			content = updateImagePullPolicy(*imagePullPolicy, content)


### PR DESCRIPTION
This change adds the ability to override the
hub and tag value produced by the generate_yaml
operation.