### PR TITLE
Enable istio-cni helm chart integration from istio.io repo

### DIFF
--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
     version: 1.1.0
     condition: security.enabled
     repository: file://../subcharts/security
+  - name: istio-cni
+    version: ">=0.0.1"
+    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    condition: istio_cni.enabled

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -14,7 +14,9 @@ data:
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
     template: |-
+{{- if or (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
+{{- if not .Values.istio_cni.enabled }}
       - name: istio-init
         image: {{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}
         args:
@@ -56,6 +58,7 @@ data:
           privileged: true
           {{ end }}
         restartPolicy: Always
+{{- end }}
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - name: enable-core-dump
         args:
@@ -69,6 +72,7 @@ data:
         securityContext:
           privileged: true
       {{ end }}
+{{- end }}
       containers:
       - name: istio-proxy
         image: {{ "[[ if (isset .ObjectMeta.Annotations \"sidecar.istio.io/proxyImage\") -]]" }}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -225,3 +225,11 @@ global:
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
   useMCP: false
+
+#
+# Istio CNI plugin enabled
+#   If true, the privileged initContainer istio-init is not needed to perform the traffic redirect
+#   settings for the istio-proxy.
+#
+istio_cni:
+  enabled: false

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -55,3 +55,8 @@ dependencies:
     version: 1.1.0
     condition: certmanager.enabled
     repository: file://../subcharts/certmanager
+  - name: istio-cni
+    version: ">=0.0.1"
+    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    condition: istio_cni.enabled
+

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -14,7 +14,9 @@ data:
   config: |-
     policy: {{ .Values.global.proxy.autoInject }}
     template: |-
+{{- if or (not .Values.istio_cni.enabled) .Values.global.proxy.enableCoreDump }}
       initContainers:
+{{- if not .Values.istio_cni.enabled }}
       - name: istio-init
 {{- if contains "/" .Values.global.proxy_init.image }}
         image: "{{ .Values.global.proxy_init.image }}"
@@ -52,6 +54,7 @@ data:
           privileged: true
           {{ end -}}
         restartPolicy: Always
+{{- end }}
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - name: enable-core-dump
         args:
@@ -69,6 +72,7 @@ data:
         securityContext:
           privileged: true
       {{ end }}
+{{- end }}
       containers:
       - name: istio-proxy
 {{- if contains "/" .Values.global.proxy.image }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -79,6 +79,14 @@ tracing:
 kiali:
   enabled: false
 
+#
+# Istio CNI plugin enabled
+#   If true, the privileged initContainer istio-init is not needed to perform the traffic redirect
+#   settings for the istio-proxy.
+#
+istio_cni:
+  enabled: false
+
 # Common settings used among istio subcharts.
 global:
   # Default hub for Istio images.


### PR DESCRIPTION
- requirements.yaml to point to official istio helm repo
- Make istio-cni enable and initContainer template flag a single option
- Makefile: add helm extra settings to generate_yaml.

Background:
- istio/istio.io PR for hosting istio-cni chart:  https://github.com/istio/istio.io/pull/2777
- istio-cni chart:  https://github.com/istio-ecosystem/cni/tree/master/deployments/kubernetes/install/helm/istio-cni

Signed-off-by: Tim Swanson <tiswanso@cisco.com>