### PR TITLE
set rbac ShadowRules only when there is permissive mode policy

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -528,7 +528,12 @@ func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption)
 			ShadowRules: permissiveRbac}
 	}
 
-	return &http_config.RBAC{Rules: rbac, ShadowRules: permissiveRbac}
+	// If RBAC permissive mode is only set on policy level, set ShadowRules only when there is policy in permissive mode.
+	if len(permissiveRbac.Policies) > 0 {
+		return &http_config.RBAC{Rules: rbac, ShadowRules: permissiveRbac}
+	}
+
+	return &http_config.RBAC{Rules: rbac}
 }
 
 // convertToPermission converts a single AccessRule to a Permission.
@@ -725,7 +730,7 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		converter = func(v string) (*policyproto.Permission, error) {
 			return &policyproto.Permission{
 				Rule: &policyproto.Permission_RequestedServerName{
-					RequestedServerName: createStringMatcher(v, /* forceRegexPattern */ false, /* forTCPFilter */ false),
+					RequestedServerName: createStringMatcher(v, false /* forceRegexPattern */, false /* forTCPFilter */),
 				},
 			}, nil
 		}

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -597,7 +597,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 											},
 										},
 									},
-								} ,
+								},
 							},
 						},
 					},
@@ -1129,10 +1129,6 @@ func TestConvertRbacRulesToFilterConfigPermissive(t *testing.T) {
 
 	emptyConfig := &http_config.RBAC{
 		Rules: &policy.RBAC{
-			Action:   policy.RBAC_ALLOW,
-			Policies: map[string]*policy.Policy{},
-		},
-		ShadowRules: &policy.RBAC{
 			Action:   policy.RBAC_ALLOW,
 			Policies: map[string]*policy.Policy{},
 		},


### PR DESCRIPTION
If RBAC permissive mode is only set on policy level, set ShadowRules only when there is policy in permissive mode

https://github.com/istio/istio/issues/5345