### PR TITLE
fix pod dns search namespace setting in Helm

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -239,6 +239,10 @@ data:
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
 {{- end }}
-{{- if .Values.global.podDNSConfig }}
-{{ toYaml .Values.global.podDNSConfig | indent 8 }}
+{{- if .Values.global.podDNSSearchNamespaces }}
+      dnsConfig:
+        searches:
+          {{- range .Values.global.podDNSSearchNamespaces }}
+          - {{ . }}
+          {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -267,11 +267,9 @@ global:
   # This does not apply to gateway pods as they typically need a different
   # set of DNS settings than the normal application pods (e.g., in
   # multicluster scenarios).
-  #podDNSConfig:
-  #  dnsConfig:
-  #    searches: #some dummy examples
-  #    - foo.bar.baz
-  #    - {{ "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]]" }}.bazoo
+  #podDNSSearchNamespaces:
+  # - foo.bar.baz
+  # - [[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].bazoo
 
   # If set to true, the pilot and citadel mtls will be exposed on the
   # ingress gateway

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -267,9 +267,10 @@ global:
   # This does not apply to gateway pods as they typically need a different
   # set of DNS settings than the normal application pods (e.g., in
   # multicluster scenarios).
+  # NOTE: If using templates, follow the pattern in the commented example below.
   #podDNSSearchNamespaces:
-  # - foo.bar.baz
-  # - [[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].bazoo
+  #- global
+  #- "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"  
 
   # If set to true, the pilot and citadel mtls will be exposed on the
   # ingress gateway


### PR DESCRIPTION
toYAML is very unreliable especially when we want to send go template stuff to sidecar injector.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>