### PR TITLE
set rbac ShadowRules only when there is permissive mode policy

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -596,7 +596,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 											},
 										},
 									},
-								} ,
+								},
 							},
 						},
 					},
@@ -1128,10 +1128,6 @@ func TestConvertRbacRulesToFilterConfigPermissive(t *testing.T) {
 
 	emptyConfig := &http_config.RBAC{
 		Rules: &policy.RBAC{
-			Action:   policy.RBAC_ALLOW,
-			Policies: map[string]*policy.Policy{},
-		},
-		ShadowRules: &policy.RBAC{
 			Action:   policy.RBAC_ALLOW,
 			Policies: map[string]*policy.Policy{},
 		},


### PR DESCRIPTION
check in https://github.com/istio/istio/pull/9486 to 1.1 branch 
If RBAC permissive mode is only set on policy level, set ShadowRules only when there is policy in permissive mode