### PR TITLE
Adding support for global imagePullSecrets in some subcharts SvcAccounts

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: istio-grafana-post-install-account
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -9,6 +9,12 @@
 
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: istio-cleanup-secrets-service-account
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: istio-security-post-install-account
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
fix: when using a different global.hub, kubectl is failing if the hub 
requires credentials