### PR TITLE
Fix a new data race in the release-1.1 branch

### DIFF
--- a/mixer/pkg/config/crd/store_test.go
+++ b/mixer/pkg/config/crd/store_test.go
@@ -507,8 +507,11 @@ func TestCrdsRetryAsynchronouslyStoreClose(t *testing.T) {
 		},
 	}
 	callCount := 0
+	mutex := sync.RWMutex{}
 	fakeDiscovery.AddReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mutex.Lock()
 		callCount++
+		mutex.Unlock()
 		return true, nil, nil
 	})
 
@@ -524,7 +527,9 @@ func TestCrdsRetryAsynchronouslyStoreClose(t *testing.T) {
 	time.Sleep(30 * time.Millisecond)
 	s.Stop()
 	time.Sleep(30 * time.Millisecond)
+	mutex.RLock()
 	if callCount > 4 {
 		t.Errorf("got %v, want no more than 4 calls", callCount)
 	}
+	mutex.RUnlock()
 }


### PR DESCRIPTION
Racetest on `release-1.1` is now failing due to #9261.
This PR fixes it.

Failed example: https://gubernator.k8s.io/build/istio-circleci/racetest/225803