### PR TITLE
Add MCP connection and nack rate limiting     

### DIFF
--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -17,7 +17,9 @@ package server
 import (
 	"fmt"
 	"io"
+	"os"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,8 +37,32 @@ var (
 	scope = log.RegisterScope("mcp", "mcp debugging", 0)
 )
 
-// channel depth for mcp response
-const responseChanDepth = 1
+func envInt(name string, def int) int {
+	if v := os.Getenv("NEW_CONNECTION_BURST_SIZE"); v != "" {
+		if a, err := strconv.Atoi(v); err == nil {
+			return a
+		}
+	}
+	return def
+}
+
+func envDur(name string, def time.Duration) time.Duration {
+	if v := os.Getenv("NEW_CONNECTION_FREQ"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+var (
+	newConnectionBurstSize  = envInt("NEW_CONNECTION_BURST_SIZE", 10)
+	newConnectionFreq       = envDur("NEW_CONNECTION_FREQ", 10*time.Millisecond)
+	authFailureLogFreq      = envDur("AUTH_FAILURE_LOG_FREQ", time.Minute)
+	authFailureLogBurstSize = envInt("AUTH_FAILURE_LOG_BURST_SIZE", 1)
+	nackLimitFreq           = envDur("NACK_LIMIT_FREQ", 1*time.Second)
+	retryPushDelay          = envDur("RETRY_PUSH_DELAY", 10*time.Millisecond)
+)
 
 // WatchResponse contains a versioned collection of pre-serialized resources.
 type WatchResponse struct {
@@ -51,9 +77,15 @@ type WatchResponse struct {
 	Envelopes []*mcp.Envelope
 }
 
-// CancelWatchFunc allows the consumer to cancel a previous watch,
-// terminating the watch for the request.
-type CancelWatchFunc func()
+type (
+	// CancelWatchFunc allows the consumer to cancel a previous watch,
+	// terminating the watch for the request.
+	CancelWatchFunc func()
+
+	// PushResponseFunc allows the consumer to push a response for the
+	// corresponding watch.
+	PushResponseFunc func(*WatchResponse)
+)
 
 // Watcher requests watches for configuration resources by node, last
 // applied version, and type. The watch should send the responses when
@@ -61,16 +93,9 @@ type CancelWatchFunc func()
 type Watcher interface {
 	// Watch returns a new open watch for a non-empty request.
 	//
-	// Immediate responses should be returned to the caller along
-	// with an optional cancel function. Asynchronous responses should
-	// be delivered through the write-only WatchResponse channel. If the
-	// channel is closed prior to cancellation of the watch, an
-	// unrecoverable error has occurred in the producer, and the consumer
-	// should close the corresponding stream.
-	//
 	// Cancel is an optional function to release resources in the
 	// producer. It can be called idempotently to cancel and release resources.
-	Watch(*mcp.MeshConfigRequest, chan<- *WatchResponse) (*WatchResponse, CancelWatchFunc)
+	Watch(*mcp.MeshConfigRequest, PushResponseFunc) CancelWatchFunc
 }
 
 var _ mcp.AggregatedMeshConfigServiceServer = &Server{}
@@ -86,6 +111,7 @@ type Server struct {
 	failureCountSinceLastRecord int
 	connections                 int64
 	reporter                    Reporter
+	conLimiter                  *rate.Limiter
 }
 
 // AuthChecker is used to check the transport auth info that is associated with each stream. If the function
@@ -99,11 +125,84 @@ type AuthChecker interface {
 	Check(authInfo credentials.AuthInfo) error
 }
 
+type mailboxState int
+
+const (
+	mailboxStateReady mailboxState = iota
+	mailboxStateClosed
+)
+
 // watch maintains local state of the most recent watch per-type.
 type watch struct {
-	cancel       func()
-	nonce        string
-	responseChan chan *WatchResponse
+	// only accessed from connection goroutine
+	cancel          func()
+	nonce           string // most recent nonce
+	nonceVersionMap map[string]string
+
+	// NOTE: do not hold `mu` when reading/writing to this channel
+	mailboxReadyChan chan mailboxState
+
+	mu                      sync.Mutex
+	mailbox                 *WatchResponse
+	mostRecentNackedVersion string
+	timerRunning            bool
+	timer                   *time.Timer
+}
+
+func (w *watch) schedulePush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.mailbox == nil {
+		return
+	}
+
+	retry := false
+	if w.mostRecentNackedVersion != "" && w.mailbox.Version == w.mostRecentNackedVersion {
+		if !w.timerRunning {
+			w.timerRunning = true
+			w.timer = time.AfterFunc(nackLimitFreq, func() {
+				w.mu.Lock()
+				w.timerRunning = false
+				w.mu.Unlock()
+
+				select {
+				case w.mailboxReadyChan <- mailboxStateReady:
+				default:
+					retry = true
+				}
+			})
+		}
+	} else {
+		if w.timerRunning {
+			w.timerRunning = false
+			if w.timer.Stop() {
+				<-w.timer.C
+			}
+		}
+		select {
+		case w.mailboxReadyChan <- mailboxStateReady:
+		default:
+			retry = true
+		}
+	}
+
+	if retry {
+		time.AfterFunc(retryPushDelay, w.schedulePush)
+	}
+}
+
+func (w *watch) pushResponse(response *WatchResponse) {
+	w.mu.Lock()
+	w.mailbox = response
+	w.mu.Unlock()
+
+	if response == nil {
+		w.mailboxReadyChan <- mailboxStateClosed
+		return
+	}
+
+	w.schedulePush()
 }
 
 // connection maintains per-stream connection state for a
@@ -143,11 +242,12 @@ func New(watcher Watcher, supportedTypes []string, authChecker AuthChecker, repo
 		supportedTypes: supportedTypes,
 		authCheck:      authChecker,
 		reporter:       reporter,
+		conLimiter:     rate.NewLimiter(rate.Every(newConnectionFreq), newConnectionBurstSize),
 	}
 
 	// Initialize record limiter for the auth checker.
-	limit := rate.Every(1 * time.Minute) // TODO: make this configurable?
-	limiter := rate.NewLimiter(limit, 1)
+	limit := rate.Every(authFailureLogFreq)
+	limiter := rate.NewLimiter(limit, authFailureLogBurstSize)
 	s.checkFailureRecordLimiter = limiter
 
 	return s
@@ -190,9 +290,13 @@ func (s *Server) newConnection(stream mcp.AggregatedMeshConfigService_StreamAggr
 
 	var types []string
 	for _, typeURL := range s.supportedTypes {
-		con.watches[typeURL] = &watch{
-			responseChan: make(chan *WatchResponse, responseChanDepth),
+		t := time.NewTimer(0)
+		w := &watch{
+			timer:            t,
+			mailboxReadyChan: make(chan mailboxState, 1),
+			nonceVersionMap:  make(map[string]string),
 		}
+		con.watches[typeURL] = w
 		types = append(types, typeURL)
 	}
 
@@ -218,23 +322,41 @@ func (s *Server) StreamAggregatedResources(stream mcp.AggregatedMeshConfigServic
 	go con.receive()
 
 	// fan-in per-type response channels into single response channel for the select loop below.
-	responseChan := make(chan *WatchResponse)
-	for _, ch := range con.watches {
-		go func(in chan *WatchResponse) {
-			for v := range in {
-				responseChan <- v
+	responseChan := make(chan *watch, 1)
+	for _, w := range con.watches {
+		go func(w *watch) {
+			for state := range w.mailboxReadyChan {
+				if state == mailboxStateClosed {
+					break
+				}
+				responseChan <- w
 			}
-		}(ch.responseChan)
+
+			// Any closed watch can close the overall connection. Use
+			// `nil` value to indicate a closed state to the run loop
+			// below instead of closing the channel to avoid closing
+			// the channel multiple times.
+			responseChan <- nil
+		}(w)
 	}
 
 	for {
 		select {
-		case resp, more := <-responseChan:
-			if !more || resp == nil {
-				return status.Errorf(codes.Unavailable, "server canceled watch: more=%v resp=%v",
-					more, resp)
+		case w, more := <-responseChan:
+			if !more || w == nil {
+				return status.Error(codes.Unavailable, "server canceled watch")
 			}
-			if err := con.pushServerResponse(resp); err != nil {
+
+			w.mu.Lock()
+			resp := w.mailbox
+			w.mailbox = nil
+			w.mu.Unlock()
+
+			// mailbox may have been cleared before we got to it
+			if resp == nil {
+				break
+			}
+			if err := con.pushServerResponse(w, resp); err != nil {
 				return err
 			}
 		case req, more := <-con.requestC:
@@ -308,64 +430,77 @@ func (con *connection) receive() {
 func (con *connection) close() {
 	scope.Infof("MCP: connection %v: CLOSED", con)
 
-	for _, watch := range con.watches {
-		if watch.cancel != nil {
-			watch.cancel()
+	for _, w := range con.watches {
+		if w.cancel != nil {
+			w.cancel()
 		}
 	}
 }
 
 func (con *connection) processClientRequest(req *mcp.MeshConfigRequest) error {
 	con.reporter.RecordRequestSize(req.TypeUrl, con.id, req.Size())
-	watch, ok := con.watches[req.TypeUrl]
+
+	w, ok := con.watches[req.TypeUrl]
 	if !ok {
 		return status.Errorf(codes.InvalidArgument, "unsupported type_url %q", req.TypeUrl)
 	}
 
+	// Reset on every request. Only the most recent NACK request (per
+	// nonce) is tracked.
+	w.mostRecentNackedVersion = ""
+
 	// nonces can be reused across streams; we verify nonce only if nonce is not initialized
-	if watch.nonce == "" || watch.nonce == req.ResponseNonce {
-		if watch.nonce == "" {
-			scope.Debugf("MCP: connection %v: WATCH for %v", con, req.TypeUrl)
+	if w.nonce == "" || w.nonce == req.ResponseNonce {
+		if w.nonce == "" {
+			scope.Infof("MCP: connection %v: WATCH for %v", con, req.TypeUrl)
 		} else {
-			scope.Debugf("MCP: connection %v ACK type_url=%q version=%q with nonce=%q",
-				con, req.TypeUrl, req.VersionInfo, req.ResponseNonce)
-			con.reporter.RecordRequestAck(req.TypeUrl, con.id)
+			if req.ErrorDetail != nil {
+				scope.Warnf("MCP: connection %v: NACK type_url=%v version=%v with nonce=%q (w.nonce=%q) error=%#v", // nolint: lll
+					con, req.TypeUrl, req.VersionInfo, req.ResponseNonce, w.nonce, req.ErrorDetail)
+				con.reporter.RecordRequestNack(req.TypeUrl, con.id)
+
+				if version, ok := w.nonceVersionMap[req.ResponseNonce]; ok {
+					w.mu.Lock()
+					w.mostRecentNackedVersion = version
+					w.mu.Unlock()
+				}
+			} else {
+				scope.Infof("MCP: connection %v ACK type_url=%q version=%q with nonce=%q",
+					con, req.TypeUrl, req.VersionInfo, req.ResponseNonce)
+				con.reporter.RecordRequestAck(req.TypeUrl, con.id)
+			}
 		}
 
-		if watch.cancel != nil {
-			watch.cancel()
+		if w.cancel != nil {
+			w.cancel()
 		}
-		var resp *WatchResponse
-		resp, watch.cancel = con.watcher.Watch(req, watch.responseChan)
-		if resp != nil {
-			nonce, err := con.send(resp)
-			if err != nil {
-				return err
-			}
-			watch.nonce = nonce
-		}
+		w.cancel = con.watcher.Watch(req, w.pushResponse)
 	} else {
-		scope.Warnf("MCP: connection %v: NACK type_url=%v version=%v with nonce=%q (watch.nonce=%q) error=%#v",
-			con, req.TypeUrl, req.VersionInfo, req.ResponseNonce, watch.nonce, req.ErrorDetail)
-		con.reporter.RecordRequestNack(req.TypeUrl, con.id)
+		// This error path should not happen! Skip any requests that don't match the
+		// latest watch's nonce value. These could be dup requests or out-of-order
+		// requests from a buggy client.
+		if req.ErrorDetail != nil {
+			scope.Errorf("MCP: connection %v: STALE NACK type_url=%v version=%v with nonce=%q (w.nonce=%q) error=%#v", // nolint: lll
+				con, req.TypeUrl, req.VersionInfo, req.ResponseNonce, w.nonce, req.ErrorDetail)
+			con.reporter.RecordRequestNack(req.TypeUrl, con.id)
+		} else {
+			scope.Errorf("MCP: connection %v: STALE ACK type_url=%v version=%v with nonce=%q (w.nonce=%q)", // nolint: lll
+				con, req.TypeUrl, req.VersionInfo, req.ResponseNonce, w.nonce)
+			con.reporter.RecordRequestAck(req.TypeUrl, con.id)
+		}
 	}
+
+	delete(w.nonceVersionMap, req.ResponseNonce)
+
 	return nil
 }
 
-func (con *connection) pushServerResponse(resp *WatchResponse) error {
+func (con *connection) pushServerResponse(w *watch, resp *WatchResponse) error {
 	nonce, err := con.send(resp)
 	if err != nil {
 		return err
 	}
-
-	watch, ok := con.watches[resp.TypeURL]
-	if !ok {
-		scope.Errorf("MCP: connection %v: internal error: received push response for unsupported type: %v",
-			con, resp.TypeURL)
-		return status.Errorf(codes.Internal,
-			"failed to update internal stream nonce for %v",
-			resp.TypeURL)
-	}
-	watch.nonce = nonce
+	w.nonce = nonce
+	w.nonceVersionMap[nonce] = resp.Version
 	return nil
 }

--- a/pkg/mcp/server/server_test.go
+++ b/pkg/mcp/server/server_test.go
@@ -644,7 +644,7 @@ func TestRateLimitNACK(t *testing.T) {
 
 		ackFloodRepeatDuration   = time.Millisecond * 500
 		ackFloodMaxWantResponses = math.MaxInt64
-		ackFloodMinWantResponses = int(ackFloodRepeatDuration/ackLimitFreq) + 1
+		ackFloodMinWantResponses = int(ackFloodRepeatDuration/nackLimitFreq) + 1
 	)
 
 	steps := []struct {

--- a/tests/e2e/tests/galley/galley_test.go
+++ b/tests/e2e/tests/galley/galley_test.go
@@ -185,10 +185,7 @@ func TestValidation(t *testing.T) {
 
 		{"networking-v1alpha3-DestinationRule-invalid", false},
 		{"networking-v1alpha3-DestinationRule-valid", true},
-		// TODO(https://github.com/istio/istio/issues/6689)
-		// ServiceEntry is temporarily disabled. Verify that invalid
-		// configuration is not rejected by galley.
-		{"networking-v1alpha3-ServiceEntry-invalid", true},
+		{"networking-v1alpha3-ServiceEntry-invalid", false},
 		{"networking-v1alpha3-ServiceEntry-valid", true},
 		{"networking-v1alpha3-VirtualService-invalid", false},
 		{"networking-v1alpha3-VirtualService-valid", true},

--- a/tests/e2e/tests/pilot/mock/mcp/server.go
+++ b/tests/e2e/tests/pilot/mock/mcp/server.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 
 	"google.golang.org/grpc"
-
 	mcp "istio.io/api/mcp/v1alpha1"
 	mcpserver "istio.io/istio/pkg/mcp/server"
 	"istio.io/istio/pkg/mcp/testing/monitoring"
@@ -32,10 +31,10 @@ type mockWatcher struct {
 	response WatchResponse
 }
 
-func (m mockWatcher) Watch(
-	req *mcp.MeshConfigRequest,
-	resp chan<- *mcpserver.WatchResponse) (*mcpserver.WatchResponse, mcpserver.CancelWatchFunc) {
-	return m.response(req)
+func (m mockWatcher) Watch(req *mcp.MeshConfigRequest, pushResponse mcpserver.PushResponseFunc) mcpserver.CancelWatchFunc {
+	response, cancel := m.response(req)
+	pushResponse(response)
+	return cancel
 }
 
 type Server struct {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/8471

This PR also reworks the scheduling mechanism between the snapshot and serving layers in the MCP layer. The previous logic relied on channels to buffer pending pushed responses between the snapshot and serving code. This made enforcing rate limiting trickier and was potentially subject to pushing unnecessary intermediate state if the snapshot changed at a higher rate than the downstream components ACK/NACK'd. The new scheduling mechanism uses a mailbox to store the latest snapshot and a channel for indicating that the mailbox is full. This should be more durable in cases where write_rate (new snapshot) is greater than read_rate (response pushed to client). The latest snapshot version will be pushed and any intermediate snapshots skipped in such cases.
