### PR TITLE
Per mcp client per store and aggregate all caches

### DIFF
--- a/pilot/pkg/config/aggregate/config.go
+++ b/pilot/pkg/config/aggregate/config.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"fmt"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -95,12 +95,22 @@ func (cr *store) List(typ, namespace string) ([]model.Config, error) {
 	}
 	var errs *multierror.Error
 	var configs []model.Config
+	// Used to remove duplicated config
+	configMap := make(map[string]struct{})
+
 	for _, store := range cr.stores[typ] {
 		storeConfigs, err := store.List(typ, namespace)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		}
-		configs = append(configs, storeConfigs...)
+		for _, config := range storeConfigs {
+			key := config.Type + config.Namespace + config.Name
+			if _, exist := configMap[key]; exist {
+				continue
+			}
+			configs = append(configs, config)
+			configMap[key] = struct{}{}
+		}
 	}
 	return configs, errs.ErrorOrNil()
 }


### PR DESCRIPTION
based on #9482, and fixes comment: https://github.com/istio/istio/pull/9482#issuecomment-432507431

Aggregate all the mcp client caches, and remove duplicated config when `List`.