### PR TITLE
refactor logging scopes for galley and mcp

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -35,7 +35,7 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-var scope = log.RegisterScope("kube", "kube-specific debugging", 0)
+var scope = log.RegisterScope("validation", "CRD validation debugging", 0)
 
 // Run an informer that watches the current webhook configuration
 // for changes.

--- a/galley/pkg/crd/validation/endpoint.go
+++ b/galley/pkg/crd/validation/endpoint.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"istio.io/istio/pkg/log"
 )
 
 type endpointReadiness int
@@ -43,7 +42,7 @@ func endpointReady(store cache.Store, queue workqueue.RateLimitingInterface, nam
 	}
 	endpoints := item.(*v1.Endpoints)
 	if len(endpoints.Subsets) == 0 {
-		log.Warnf("%s/%v endpoint not ready: no subsets", namespace, name)
+		scope.Warnf("%s/%v endpoint not ready: no subsets", namespace, name)
 		return endpointCheckNotReady
 	}
 	for _, subset := range endpoints.Subsets {
@@ -51,19 +50,19 @@ func endpointReady(store cache.Store, queue workqueue.RateLimitingInterface, nam
 			return endpointCheckReady
 		}
 	}
-	log.Warnf("%s/%v endpoint not ready: no ready addresses", namespace, name)
+	scope.Warnf("%s/%v endpoint not ready: no ready addresses", namespace, name)
 	return endpointCheckNotReady
 }
 
 func (wh *Webhook) waitForEndpointReady(stopCh <-chan struct{}) (shutdown bool) {
-	log.Infof("Checking if %s/%s is ready before registering webhook configuration ",
+	scope.Infof("Checking if %s/%s is ready before registering webhook configuration ",
 		wh.deploymentAndServiceNamespace, wh.deploymentName)
 
 	defer func() {
 		if shutdown {
-			log.Info("Endpoint readiness check stopped - controller shutting down")
+			scope.Info("Endpoint readiness check stopped - controller shutting down")
 		} else {
-			log.Infof("Endpoint %s/%s is ready", wh.deploymentAndServiceNamespace, wh.deploymentName)
+			scope.Infof("Endpoint %s/%s is ready", wh.deploymentAndServiceNamespace, wh.deploymentName)
 		}
 	}()
 

--- a/galley/pkg/fs/fssource.go
+++ b/galley/pkg/fs/fssource.go
@@ -39,7 +39,7 @@ var supportedExtensions = map[string]bool{
 	".yaml": true,
 	".yml":  true,
 }
-var scope = log.RegisterScope("runtime", "Galley runtime", 0)
+var scope = log.RegisterScope("fs", "File system source debugging", 0)
 
 //fsSource is source implementation for filesystem.
 type fsSource struct {

--- a/galley/pkg/fs/fssource.go
+++ b/galley/pkg/fs/fssource.go
@@ -39,7 +39,7 @@ var supportedExtensions = map[string]bool{
 	".yaml": true,
 	".yml":  true,
 }
-var scope = log.RegisterScope("file-source", "Source for File System", 0)
+var scope = log.RegisterScope("runtime", "Galley runtime", 0)
 
 //fsSource is source implementation for filesystem.
 type fsSource struct {

--- a/galley/pkg/kube/source/source.go
+++ b/galley/pkg/kube/source/source.go
@@ -30,7 +30,7 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
-var scope = log.RegisterScope("kube-source", "Source for Kubernetes", 0)
+var scope = log.RegisterScope("kube", "kube-specific debugging", 0)
 
 // source is an implementation of runtime.Source.
 type sourceImpl struct {

--- a/galley/pkg/server/configmap.go
+++ b/galley/pkg/server/configmap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"gopkg.in/yaml.v2"
 
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/mcp/server"
 )
 
@@ -94,7 +93,7 @@ func watchAccessList(stopCh <-chan struct{}, accessListFile string) (*server.Lis
 			case e := <-watcher.Events():
 				if e.Op&fsnotify.Write == fsnotify.Write {
 					if list, err = readAccessList(accessListFile); err != nil {
-						log.Errorf("Error reading access list %q: %v", accessListFile, err)
+						scope.Errorf("Error reading access list %q: %v", accessListFile, err)
 					} else {
 						checker.Set(list.Allowed...)
 					}
@@ -116,7 +115,7 @@ func watchAccessList(stopCh <-chan struct{}, accessListFile string) (*server.Lis
 		for {
 			select {
 			case e := <-watcher.Errors():
-				log.Errorf("error event while watching access list file: %v", e)
+				scope.Errorf("error event while watching access list file: %v", e)
 
 			case <-stopCh:
 				return

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -41,6 +41,8 @@ import (
 	"istio.io/istio/pkg/version"
 )
 
+var scope = log.RegisterScope("runtime", "Galley runtime", 0)
+
 // Server is the main entry point into the Galley code.
 type Server struct {
 	shutdown chan error

--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -185,7 +185,7 @@ func New(mcpClient mcp.AggregatedMeshConfigServiceClient, supportedTypeURLs []st
 var handleResponseDoneProbe = func() {}
 
 func (c *Client) sendNACKRequest(response *mcp.MeshConfigResponse, version string, err error) *mcp.MeshConfigRequest {
-	log.Errorf("MCP: sending NACK for version=%v nonce=%v: error=%q", version, response.Nonce, err)
+	scope.Errorf("MCP: sending NACK for version=%v nonce=%v: error=%q", version, response.Nonce, err)
 
 	c.reporter.RecordRequestNack(response.TypeUrl, err)
 	errorDetails, _ := status.FromError(err)
@@ -277,15 +277,15 @@ func (c *Client) Run(ctx context.Context) {
 			case <-retry:
 			}
 
-			log.Info("(re)trying to establish new MCP stream")
+			scope.Info("(re)trying to establish new MCP stream")
 			var err error
 			if c.stream, err = c.client.StreamAggregatedResources(ctx); err == nil {
 				c.reporter.RecordStreamCreateSuccess()
-				log.Info("New MCP stream created")
+				scope.Info("New MCP stream created")
 				break
 			}
 
-			log.Errorf("Failed to create a new MCP stream: %v", err)
+			scope.Errorf("Failed to create a new MCP stream: %v", err)
 			retry = time.After(reestablishStreamDelay)
 		}
 
@@ -310,7 +310,7 @@ func (c *Client) Run(ctx context.Context) {
 				if err != nil {
 					if err != io.EOF {
 						c.reporter.RecordRecvError(err, status.Code(err))
-						log.Errorf("Error receiving MCP response: %v", err)
+						scope.Errorf("Error receiving MCP response: %v", err)
 					}
 					break
 				}
@@ -323,7 +323,7 @@ func (c *Client) Run(ctx context.Context) {
 
 			if err := c.stream.Send(req); err != nil {
 				c.reporter.RecordSendError(err, status.Code(err))
-				log.Errorf("Error sending MCP request: %v", err)
+				scope.Errorf("Error sending MCP request: %v", err)
 
 				// (from https://godoc.org/google.golang.org/grpc#ClientConn.NewStream)
 				//

--- a/pkg/mcp/creds/watcher.go
+++ b/pkg/mcp/creds/watcher.go
@@ -63,7 +63,7 @@ var (
 	watchKeyEventHandledProbe  func()
 )
 
-var scope = log.RegisterScope("mcp-creds", "MCP Credential utilities", 0)
+var scope = log.RegisterScope("mcp", "mcp debugging", 0)
 
 const (
 	// defaultCertDir is the default directory in which MCP options reside.

--- a/pkg/mcp/server/server.go
+++ b/pkg/mcp/server/server.go
@@ -160,7 +160,7 @@ func (s *Server) newConnection(stream mcp.AggregatedMeshConfigService_StreamAggr
 	if ok {
 		peerAddr = peerInfo.Addr.String()
 	} else {
-		log.Warnf("No peer info found on the incoming stream.")
+		scope.Warnf("No peer info found on the incoming stream.")
 		peerInfo = nil
 	}
 
@@ -172,7 +172,7 @@ func (s *Server) newConnection(stream mcp.AggregatedMeshConfigService_StreamAggr
 	if err := s.authCheck.Check(authInfo); err != nil {
 		s.failureCountSinceLastRecord++
 		if s.checkFailureRecordLimiter.Allow() {
-			log.Warnf("NewConnection: auth check failed: %v (repeated %d times).", err, s.failureCountSinceLastRecord)
+			scope.Warnf("NewConnection: auth check failed: %v (repeated %d times).", err, s.failureCountSinceLastRecord)
 			s.failureCountSinceLastRecord = 0
 		}
 		return nil, status.Errorf(codes.Unauthenticated, "Authentication failure: %v", err)

--- a/pkg/mcp/snapshot/snapshot.go
+++ b/pkg/mcp/snapshot/snapshot.go
@@ -23,7 +23,7 @@ import (
 	"istio.io/istio/pkg/mcp/server"
 )
 
-var scope = log.RegisterScope("snapshot", "mcp snapshot", 0)
+var scope = log.RegisterScope("mcp", "mcp debugging", 0)
 
 // Snapshot provides an immutable view of versioned envelopes.
 type Snapshot interface {
@@ -136,7 +136,7 @@ func (c *Cache) Watch(request *mcp.MeshConfigRequest, responseC chan<- *server.W
 	c.watchCount++
 	watchID := c.watchCount
 
-	log.Infof("Watch(): created watch %d for %s from group %q, version %q",
+	scope.Infof("Watch(): created watch %d for %s from group %q, version %q",
 		watchID, request.TypeUrl, group, request.VersionInfo)
 
 	info.mu.Lock()
@@ -169,7 +169,7 @@ func (c *Cache) SetSnapshot(group string, snapshot Snapshot) {
 		for id, watch := range info.watches {
 			version := snapshot.Version(watch.request.TypeUrl)
 			if version != watch.request.VersionInfo {
-				log.Infof("SetSnapshot(): respond to watch %d with new version %q", id, version)
+				scope.Infof("SetSnapshot(): respond to watch %d with new version %q", id, version)
 
 				response := &server.WatchResponse{
 					TypeURL:   watch.request.TypeUrl,
@@ -181,7 +181,7 @@ func (c *Cache) SetSnapshot(group string, snapshot Snapshot) {
 				// discard the responseWatch
 				delete(info.watches, id)
 
-				log.Debugf("SetSnapshot(): watch %d with version %q complete", id, version)
+				scope.Debugf("SetSnapshot(): watch %d with version %q complete", id, version)
 			}
 		}
 		info.mu.Unlock()


### PR DESCRIPTION
There are now three log scopes around Galley code:

1. mcp is the logging scope for all MCP client and server code.
2. kube is the logging scope for all Kubernetes-specific code (crd and
   kube packages).
3. runtime is the logging scope for all platform-independent Galley
   code.