### PR TITLE
Fix mixc attribute encoding

### DIFF
--- a/mixer/cmd/mixc/cmd/util.go
+++ b/mixer/cmd/mixc/cmd/util.go
@@ -211,7 +211,7 @@ func parseAttributes(rootArgs *rootArgs) (*mixerpb.CompressedAttributes, []strin
 	}
 
 	var attrs mixerpb.CompressedAttributes
-	b.ToProto(&attrs, gb, len(gb))
+	b.ToProto(&attrs, nil, 0)
 
 	dw := make([]string, len(gb), len(gb))
 	for k, v := range gb {


### PR DESCRIPTION
This PR fixes the choice of global dictionary for compression used in the `mixc` client.

Without it, mixs panics:

```
2018-10-24T22:50:18.057003Z	debug	attributes	Creating bag with attributes:
source.ip                     : http
source.labels                 : 2018-01-29 12:12:15 +0000 UTC
source.name                   : /doug-test
source.namespace              : 2018-01-29 12:12:14 +0000 UTC
source.port                   : test
source.uid                    : kubernetes://productpage-v1-79b8db5f94-dg4pw.crazy
source.user                   : [10 60 0 26]
target.ip                     : {target.ip map[x-b3-traceid:2141234123412344abfe] 0xc4292880c0}
...
goroutine 2228 [running]:
istio.io/istio/mixer/template.(*builder_adapter_template_kubernetes_Template).build(0xc420c14690, 0x2b1fe00, 0xc420d9c900, 0xc428c4a540, 0xc4257e5348, 0x1002f2b, 0x200, 0x26e4440)
	/Users/dougreid/work/go/src/istio.io/istio/mixer/template/template.gen.go:2408 +0x464
```

With this PR and the same request:

```
2018-10-24T23:08:16.224780Z	debug	api	Attribute Bag:
context.protocol              : http
destination.service           : test
destination.uid               : kubernetes://productpage-v1-79b8db5f94-dg4pw.crazy
request.headers               : {request.headers map[x-b3-traceid:2141234123412344abfe] 0xc42bc16300}
request.path                  : /doug-test
request.time                  : 2018-01-29 12:12:14 +0000 UTC
response.time                 : 2018-01-29 12:12:15 +0000 UTC
source.ip                     : [10 60 0 26]
```
