### PR TITLE
Consistent istioctl proxy-status and proxy-config namespace behaviour

### DIFF
--- a/istioctl/cmd/istioctl/handlers.go
+++ b/istioctl/cmd/istioctl/handlers.go
@@ -1,0 +1,30 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+)
+
+// Uses proxyName to infer namespace if the passed proxyName contains namespace information.
+// Otherwise uses the namespace value passed into the function
+func inferPodInfo(proxyName, namespace string) (string, string) {
+	parsedProxy := strings.Split(proxyName, ".")
+
+	if len(parsedProxy) == 1 {
+		return proxyName, namespace
+	}
+	return parsedProxy[0], parsedProxy[1]
+}

--- a/istioctl/cmd/istioctl/handlers_test.go
+++ b/istioctl/cmd/istioctl/handlers_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestInferPodInfo(t *testing.T) {
+	tests := []struct {
+		proxyName     string
+		namespace     string
+		wantPodName   string
+		wantNamespace string
+	}{
+		{
+			proxyName:     "istio-ingressgateway-8d9697654-qdzgh.istio-system",
+			namespace:     "kube-system",
+			wantPodName:   "istio-ingressgateway-8d9697654-qdzgh",
+			wantNamespace: "istio-system",
+		},
+		{
+			proxyName:     "istio-ingressgateway-8d9697654-qdzgh.istio-system",
+			namespace:     "",
+			wantPodName:   "istio-ingressgateway-8d9697654-qdzgh",
+			wantNamespace: "istio-system",
+		},
+		{
+			proxyName:     "istio-ingressgateway-8d9697654-qdzgh",
+			namespace:     "kube-system",
+			wantPodName:   "istio-ingressgateway-8d9697654-qdzgh",
+			wantNamespace: "kube-system",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s", strings.Split(tt.proxyName, ".")[0]), func(t *testing.T) {
+			gotPodName, gotNamespace := inferPodInfo(tt.proxyName, tt.namespace)
+			if gotPodName != tt.wantPodName || gotNamespace != tt.wantNamespace {
+				t.Errorf("unexpected podName and namespace: wanted %v %v got %v %v", tt.wantPodName, tt.wantNamespace, gotPodName, gotNamespace)
+			}
+		})
+	}
+}

--- a/istioctl/cmd/istioctl/proxyconfig.go
+++ b/istioctl/cmd/istioctl/proxyconfig.go
@@ -60,8 +60,7 @@ var (
 		Aliases: []string{"clusters", "c"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			podName := args[0]
-			ns := handleNamespace()
+			podName, ns := inferPodInfo(args[0], handleNamespace())
 			configWriter, err := setupConfigdumpEnvoyConfigWriter(podName, ns, c.OutOrStdout())
 			if err != nil {
 				return err
@@ -101,8 +100,7 @@ var (
 		Aliases: []string{"listeners", "l"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			podName := args[0]
-			ns := handleNamespace()
+			podName, ns := inferPodInfo(args[0], handleNamespace())
 			configWriter, err := setupConfigdumpEnvoyConfigWriter(podName, ns, c.OutOrStdout())
 			if err != nil {
 				return err
@@ -142,8 +140,7 @@ var (
 		Aliases: []string{"routes", "r"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			podName := args[0]
-			ns := handleNamespace()
+			podName, ns := inferPodInfo(args[0], handleNamespace())
 			configWriter, err := setupConfigdumpEnvoyConfigWriter(podName, ns, c.OutOrStdout())
 			if err != nil {
 				return err
@@ -172,8 +169,7 @@ var (
 		Aliases: []string{"b"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			podName := args[0]
-			ns := handleNamespace()
+			podName, ns := inferPodInfo(args[0], handleNamespace())
 			configWriter, err := setupConfigdumpEnvoyConfigWriter(podName, ns, c.OutOrStdout())
 			if err != nil {
 				return err
@@ -204,8 +200,7 @@ var (
 		Aliases: []string{"endpoints", "ep"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(c *cobra.Command, args []string) error {
-			podName := args[0]
-			ns := handleNamespace()
+			podName, ns := inferPodInfo(args[0], handleNamespace())
 			configWriter, err := setupClustersEnvoyConfigWriter(podName, ns, c.OutOrStdout())
 			if err != nil {
 				return err

--- a/istioctl/cmd/istioctl/proxystatus.go
+++ b/istioctl/cmd/istioctl/proxystatus.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -47,12 +46,9 @@ Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in t
 				return err
 			}
 			if len(args) > 0 {
-				parsedProxy := strings.Split(args[0], ".")
-				if len(parsedProxy) != 2 {
-					return fmt.Errorf("unable to parse %v into a pod name and namespace", args[0])
-				}
+				podName, ns := inferPodInfo(args[0], handleNamespace())
 				path := fmt.Sprintf("config_dump")
-				envoyDump, err := kubeClient.EnvoyDo(parsedProxy[0], parsedProxy[1], "GET", path, nil)
+				envoyDump, err := kubeClient.EnvoyDo(podName, ns, "GET", path, nil)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
It's a PR for issue: https://github.com/istio/istio/issues/8008.

Here it will support both the behavior:

* `istioctl proxy-config listeners istio-ingressgateway-8d9697654-qdzgh -n istio-system`
* `istioctl proxy-config listeners istio-ingressgateway-8d9697654-qdzgh.istio-system`

Similar to proxystatus: 
* `istioctl ps istio-ingressgateway-8d9697654-qdzgh -n istio-system`
*  `istioctl ps istio-ingressgateway-8d9697654-qdzgh.istio-system`