### PR TITLE
Mixer loadshedding for 1.0 branch

### DIFF
--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -78,6 +78,7 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 	sa.LoggingOptions.AttachCobraFlags(serverCmd)
 	sa.TracingOptions.AttachCobraFlags(serverCmd)
 	sa.IntrospectionOptions.AttachCobraFlags(serverCmd)
+	sa.LoadSheddingOptions.AttachCobraFlags(serverCmd)
 
 	return serverCmd
 }

--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -74,6 +74,10 @@ func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool, cac
 
 // Check is the entry point for the external Check method
 func (s *grpcServer) Check(ctx context.Context, req *mixerpb.CheckRequest) (*mixerpb.CheckResponse, error) {
+	if s.throttler.Throttle(loadshedding.RequestInfo{PredictedCost: 1.0}) {
+		return nil, grpc.Errorf(codes.Unavailable, "Server is currently overloaded. Please try again.")
+	}
+
 	lg.Debugf("Check (GlobalWordCount:%d, DeduplicationID:%s, Quota:%v)", req.GlobalWordCount, req.DeduplicationId, req.Quotas)
 	lg.Debug("Dispatching Preprocess Check")
 

--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -29,6 +29,7 @@ import (
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/checkcache"
+	"istio.io/istio/mixer/pkg/loadshedding"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/dispatcher"
 	"istio.io/istio/mixer/pkg/status"
@@ -45,13 +46,16 @@ type (
 		// the global dictionary. This will eventually be writable via config
 		globalWordList []string
 		globalDict     map[string]int32
+
+		// load shedding
+		throttler *loadshedding.Throttler
 	}
 )
 
 var lg = log.RegisterScope("api", "API dispatcher messages.", 0)
 
 // NewGRPCServer creates a gRPC serving stack.
-func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool, cache *checkcache.Cache) mixerpb.MixerServer {
+func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool, cache *checkcache.Cache, throttler *loadshedding.Throttler) mixerpb.MixerServer {
 	list := attribute.GlobalList()
 	globalDict := make(map[string]int32, len(list))
 	for i := 0; i < len(list); i++ {
@@ -64,6 +68,7 @@ func NewGRPCServer(dispatcher dispatcher.Dispatcher, gp *pool.GoroutinePool, cac
 		globalWordList: list,
 		globalDict:     globalDict,
 		cache:          cache,
+		throttler:      throttler,
 	}
 }
 
@@ -210,6 +215,11 @@ var reportResp = &mixerpb.ReportResponse{}
 
 // Report is the entry point for the external Report method
 func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*mixerpb.ReportResponse, error) {
+
+	if s.throttler.Throttle(loadshedding.RequestInfo{PredictedCost: float64(len(req.Attributes))}) {
+		return nil, grpc.Errorf(codes.Unavailable, "Server is currently overloaded. Please try again.")
+	}
+
 	lg.Debugf("Report (Count: %d)", len(req.Attributes))
 
 	if len(req.Attributes) == 0 {

--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -30,6 +30,7 @@ import (
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/checkcache"
+	"istio.io/istio/mixer/pkg/loadshedding"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/dispatcher"
 	"istio.io/istio/mixer/pkg/status"
@@ -73,7 +74,7 @@ func (ts *testState) createGRPCServer() (string, error) {
 	ts.gp = pool.NewGoroutinePool(128, false)
 	ts.gp.AddWorkers(32)
 
-	ms := NewGRPCServer(ts, ts.gp, checkcache.New(10))
+	ms := NewGRPCServer(ts, ts.gp, checkcache.New(10), loadshedding.NewThrottler(loadshedding.DefaultOptions()))
 	ts.s = ms.(*grpcServer)
 	mixerpb.RegisterMixerServer(ts.gs, ts.s)
 

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -27,6 +27,7 @@ import (
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/attribute"
+	"istio.io/istio/mixer/pkg/loadshedding"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime/dispatcher"
 	"istio.io/istio/mixer/pkg/status"
@@ -53,7 +54,7 @@ func (bs *benchState) createGRPCServer() (string, error) {
 	bs.gp = pool.NewGoroutinePool(32, false)
 	bs.gp.AddWorkers(32)
 
-	ms := NewGRPCServer(bs, bs.gp, nil)
+	ms := NewGRPCServer(bs, bs.gp, nil, loadshedding.NewThrottler(loadshedding.DefaultOptions()))
 	bs.s = ms.(*grpcServer)
 	mixerpb.RegisterMixerServer(bs.gs, bs.s)
 

--- a/mixer/pkg/loadshedding/evaluator.go
+++ b/mixer/pkg/loadshedding/evaluator.go
@@ -1,0 +1,50 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+// LoadEvaluator evaluates the current request against a threshold. LoadEvaluators
+// may calculate load on an on-going basis or through some external mechanism.
+type LoadEvaluator interface {
+	// Name returns a canonical name for the LoadEvaluator.
+	Name() string
+
+	// EvaluateAgainst compares the current request and known load against the supplied
+	// threshold to determine if the threshold is/will be exceeded.
+	EvaluateAgainst(ri RequestInfo, threshold float64) LoadEvaluation
+}
+
+// LoadEvaluation holds the result of the evaluation of a current request against a threshold.
+type LoadEvaluation struct {
+	// Status indicates whether or not the threshold was exceeded.
+	Status LoadStatus
+
+	// Message enables LoadEvaluators to provide custom error messages when the threshold is
+	// exceeded.
+	Message string
+}
+
+func shouldThrottle(eval LoadEvaluation) bool {
+	return eval.Status == ExceedsThreshold
+}
+
+// LoadStatus records the determination of a LoadEvaluation.
+type LoadStatus int
+
+const (
+	// BelowThreshold indicates that a given request will not exceed a threshold.
+	BelowThreshold LoadStatus = iota
+	// ExceedsThreshold indicates that a given request will exceed a threshold.
+	ExceedsThreshold
+)

--- a/mixer/pkg/loadshedding/evaluator.go
+++ b/mixer/pkg/loadshedding/evaluator.go
@@ -35,7 +35,8 @@ type LoadEvaluation struct {
 	Message string
 }
 
-func shouldThrottle(eval LoadEvaluation) bool {
+// ShouldThrottle determines if a load evaluation status is `ExceedsThreshold`.
+func ShouldThrottle(eval LoadEvaluation) bool {
 	return eval.Status == ExceedsThreshold
 }
 

--- a/mixer/pkg/loadshedding/evaluator.go
+++ b/mixer/pkg/loadshedding/evaluator.go
@@ -35,8 +35,8 @@ type LoadEvaluation struct {
 	Message string
 }
 
-// ShouldThrottle determines if a load evaluation status is `ExceedsThreshold`.
-func ShouldThrottle(eval LoadEvaluation) bool {
+// ThresholdExceeded determines if a load evaluation status is `ExceedsThreshold`.
+func ThresholdExceeded(eval LoadEvaluation) bool {
 	return eval.Status == ExceedsThreshold
 }
 

--- a/mixer/pkg/loadshedding/exponentialmovingaverage.go
+++ b/mixer/pkg/loadshedding/exponentialmovingaverage.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// exponentialMovingAverage is smoothing function used to continously average
+// a stream of samples, based on a given decay rate. Those samples may be
+// irregularly spaced (in time). It  applies this smoothing as though the input
+// is constant (at the same value as the previous sample) between samples.
+//
+// exponentialMovingAverage can be applied by sampling a noisy or variable signal
+// but its accuracy will depend greatly on the sampling rate and the rate of change
+// of the original signal.
+//
+// EMA(t) := EMA(s) * alpha(t-s) + X[s] * (1-alpha(t-s)) where alpha(t-s) is the
+// smoothing factor.
+//
+// alpha can be expressed in terms of a half-life h using the following:
+// alpha(t-s) := (1/2)^((t-s)/h) = 2^(-(t-s)/h) = exp((t-s) * -log(2)/h)
+//
+// Here, we rewrite EMA(t) as: EMA(t) = alpha(t-s) * (EMA(s) - X[s]) + X[s]
+// so we can store (EMA(s) - X[s]) instead of EMA(s) and save 2 ops per
+// currentValue().
+//
+// See also: http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average.
+type exponentialMovingAverage struct {
+	sync.Mutex
+	decay                 float64
+	lastSampleTime        time.Time
+	lastSmoothedDeviation float64
+	lastSampleValue       float64
+}
+
+func newExponentialMovingAverage(halfLife time.Duration, initialValue float64, initialTime time.Time) *exponentialMovingAverage {
+	return &exponentialMovingAverage{
+		decay:                 -math.Log(2) / halfLife.Seconds(),
+		lastSampleTime:        initialTime,
+		lastSmoothedDeviation: 0,
+		lastSampleValue:       initialValue,
+	}
+}
+
+func (ema *exponentialMovingAverage) currentValueLocked(now time.Time) float64 {
+	alpha := 1.0
+	if now.After(ema.lastSampleTime) {
+		alpha = math.Exp(ema.decay * now.Sub(ema.lastSampleTime).Seconds())
+	}
+	return alpha*ema.lastSmoothedDeviation + ema.lastSampleValue
+}
+
+func (ema *exponentialMovingAverage) currentValue(now time.Time) float64 {
+	ema.Lock()
+	curVal := ema.currentValueLocked(now)
+	ema.Unlock()
+	return curVal
+}
+
+func (ema *exponentialMovingAverage) addSample(sample float64, now time.Time) {
+	ema.Lock()
+	smoothedValue := ema.currentValueLocked(now)
+	ema.lastSmoothedDeviation = smoothedValue - sample
+	ema.lastSampleValue = sample
+	ema.lastSampleTime = now
+	ema.Unlock()
+}

--- a/mixer/pkg/loadshedding/exponentialmovingaverage.go
+++ b/mixer/pkg/loadshedding/exponentialmovingaverage.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-// exponentialMovingAverage is smoothing function used to continously average
+// exponentialMovingAverage is smoothing function used to continuously average
 // a stream of samples, based on a given decay rate. Those samples may be
 // irregularly spaced (in time). It  applies this smoothing as though the input
 // is constant (at the same value as the previous sample) between samples.

--- a/mixer/pkg/loadshedding/exponentialmovingaverage_test.go
+++ b/mixer/pkg/loadshedding/exponentialmovingaverage_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExponentialMovingAverage(t *testing.T) {
+
+	// test initial value
+	ema := newExponentialMovingAverage(1*time.Second, 0.0, time.Unix(0, 0))
+	if got, want := ema.currentValue(time.Unix(0, 0)), 0.0; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+
+	// test decay over seconds (initial 0 value + new sample of 1 decaying )
+	ema.addSample(1, time.Unix(1, 0))
+	if got, want := ema.currentValue(time.Unix(2, 0)), 0.5; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+	if got, want := ema.currentValue(time.Unix(3, 0)), 0.75; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+	if got, want := ema.currentValue(time.Unix(4, 0)), 0.875; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+
+	// test decay over seconds (initial 0, 1 + new sample of 2 decaying)
+	ema.addSample(2, time.Unix(2, 0))
+	if got, want := ema.currentValue(time.Unix(3, 0)), 1.25; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+	if got, want := ema.currentValue(time.Unix(4, 0)), 1.625; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+	if got, want := ema.currentValue(time.Unix(5, 0)), 1.8125; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+
+	// multiple samples at same instant
+	ema.addSample(3.5, time.Unix(2, 0))
+	if got, want := ema.currentValue(time.Unix(3, 0)), 2.0; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+
+	// adding samples from the past (going backwards)
+	ema.addSample(2.5, time.Unix(1, 0))
+	if got, want := ema.currentValue(time.Unix(3, 0)), 2.0; got != want {
+		t.Errorf("currentValue() => %v, want %v", got, want)
+	}
+}

--- a/mixer/pkg/loadshedding/grpclatency.go
+++ b/mixer/pkg/loadshedding/grpclatency.go
@@ -1,0 +1,111 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/stats"
+)
+
+const (
+	// DefaultSampleFrequency controls the base sampling rate of latency averaging calculation.
+	DefaultSampleFrequency = rate.Inf
+	// DefaultHalfLife controls the decay rate of an individual sample.
+	DefaultHalfLife = 1 * time.Second // Impact of each sample is expected to last ~2s.
+
+	// GRPCLatencyEvaluatorName is the name of the gRPC Response Latency LoadEvaluator.
+	GRPCLatencyEvaluatorName = "grpcResponseLatency"
+)
+
+var (
+	_ stats.Handler = &GRPCLatencyEvaluator{}
+	_ LoadEvaluator = &GRPCLatencyEvaluator{}
+)
+
+// GRPCLatencyEvaluator calculates the moving average of response latency (as reported via the gRPC stats.Handler interface).
+// It then evaluates incoming requests by comparing the average response latency against a threshold.
+type GRPCLatencyEvaluator struct {
+	sampler     *rate.Limiter
+	loadAverage *exponentialMovingAverage
+}
+
+// NewGRPCLatencyEvaluator creates a new LoadEvaluator that uses an average of gRPC Response Latency.
+func NewGRPCLatencyEvaluator(sampleFrequency rate.Limit, averageHalfLife time.Duration) *GRPCLatencyEvaluator {
+
+	sf := sampleFrequency
+	if sf == 0 {
+		sf = DefaultSampleFrequency
+	}
+
+	hl := averageHalfLife
+	if hl == 0 {
+		hl = DefaultHalfLife
+	}
+
+	return &GRPCLatencyEvaluator{
+		sampler:     rate.NewLimiter(sf, 0), // no need to support burstiness
+		loadAverage: newExponentialMovingAverage(hl, 0, time.Now()),
+	}
+}
+
+// Name implements the LoadEvaluator interface.
+func (g GRPCLatencyEvaluator) Name() string {
+	return GRPCLatencyEvaluatorName
+}
+
+// EvaluateAgainst implements the LoadEvaluator interface.
+func (g *GRPCLatencyEvaluator) EvaluateAgainst(ri RequestInfo, threshold float64) LoadEvaluation {
+	load := g.currentLoad()
+	if load < threshold {
+		return LoadEvaluation{Status: BelowThreshold}
+	}
+	return LoadEvaluation{
+		Status:  ExceedsThreshold,
+		Message: fmt.Sprintf("Current observed average latency (%f) exceeds specified threshold (%f). Please retry request.", load, threshold),
+	}
+}
+
+// HandleRPC processes the RPC stats.
+func (g *GRPCLatencyEvaluator) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	if !g.sampler.Allow() {
+		return
+	}
+	switch st := rs.(type) {
+	case *stats.End:
+		dur := st.EndTime.Sub(st.BeginTime)
+		g.loadAverage.addSample(dur.Seconds(), st.EndTime)
+	}
+}
+
+// TagRPC can attach some information to the given context.
+func (g *GRPCLatencyEvaluator) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// TagConn can attach some information to the given context.
+func (g *GRPCLatencyEvaluator) TagConn(ctx context.Context, cti *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// HandleConn processes the Conn stats.
+func (g *GRPCLatencyEvaluator) HandleConn(context.Context, stats.ConnStats) {}
+
+func (g *GRPCLatencyEvaluator) currentLoad() float64 {
+	return g.loadAverage.currentValue(time.Now())
+}

--- a/mixer/pkg/loadshedding/grpclatency.go
+++ b/mixer/pkg/loadshedding/grpclatency.go
@@ -59,7 +59,7 @@ func NewGRPCLatencyEvaluator(sampleFrequency rate.Limit, averageHalfLife time.Du
 	}
 
 	return &GRPCLatencyEvaluator{
-		sampler:     rate.NewLimiter(sf, 0), // no need to support burstiness
+		sampler:     rate.NewLimiter(sf, 1), // no need to support burstiness beyond 1 event per Allow()
 		loadAverage: newExponentialMovingAverage(hl, 0, time.Now()),
 	}
 }

--- a/mixer/pkg/loadshedding/grpclatency_test.go
+++ b/mixer/pkg/loadshedding/grpclatency_test.go
@@ -75,13 +75,13 @@ func TestEvaluateAgainst_GRPCLatency(t *testing.T) {
 			failingThreshold := 0.5 // simulates a threshold of 0.5 secs (which we should be above)
 
 			le := e.EvaluateAgainst(pc, passingThreshold)
-			if loadshedding.ShouldThrottle(le) {
+			if loadshedding.ThresholdExceeded(le) {
 				tt.Logf("Got: %#v", le)
 				tt.Errorf("EvaluateAgainst(%#v, %f) => Status: %v; wanted %v", pc, passingThreshold, le.Status, loadshedding.BelowThreshold)
 			}
 
 			le = e.EvaluateAgainst(pc, failingThreshold)
-			if !loadshedding.ShouldThrottle(le) {
+			if !loadshedding.ThresholdExceeded(le) {
 				tt.Logf("Got: %#v", le)
 				tt.Errorf("EvaluateAgainst(%#v, %f) => Status: %v; wanted %v", pc, failingThreshold, le.Status, loadshedding.ExceedsThreshold)
 			}

--- a/mixer/pkg/loadshedding/grpclatency_test.go
+++ b/mixer/pkg/loadshedding/grpclatency_test.go
@@ -1,0 +1,91 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/stats"
+
+	"istio.io/istio/mixer/pkg/loadshedding"
+)
+
+var (
+	start, _ = time.Parse(time.RFC3339, time.RFC3339)
+
+	oneSec = &stats.End{
+		BeginTime: start,
+		EndTime:   start.Add(1 * time.Second),
+	}
+)
+
+// The exponential moving average stuff will be tested in other
+// tests. This test is about validating behavior in broad strokes
+// (do the defaults work? what happens when overrides are provided?).
+func TestEvaluateAgainst_GRPCLatency(t *testing.T) {
+
+	cases := []struct {
+		name         string
+		samplingRate rate.Limit
+		halfLife     time.Duration
+	}{
+		{"Defaults", 0, 0},
+		{"Once every 100ms", rate.Every(100 * time.Millisecond), 100 * time.Millisecond},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			e := loadshedding.NewGRPCLatencyEvaluator(v.samplingRate, v.halfLife)
+			stop := make(chan bool)
+			for i := 0; i < 10; i++ {
+				go func(ch chan bool) {
+					for {
+						select {
+						case <-ch:
+							return
+						default:
+							// establish an average latency of 1s
+							e.HandleRPC(context.Background(), oneSec)
+						}
+
+					}
+				}(stop)
+			}
+
+			// allow collection of some latency measurements
+			time.Sleep(500 * time.Millisecond)
+
+			pc := loadshedding.RequestInfo{PredictedCost: 1.0}
+			passingThreshold := 2.0 // simulates a threshold of 2 secs (which we should be well-below)
+			failingThreshold := 0.5 // simulates a threshold of 0.5 secs (which we should be above)
+
+			le := e.EvaluateAgainst(pc, passingThreshold)
+			if loadshedding.ShouldThrottle(le) {
+				tt.Logf("Got: %#v", le)
+				tt.Errorf("EvaluateAgainst(%#v, %f) => Status: %v; wanted %v", pc, passingThreshold, le.Status, loadshedding.BelowThreshold)
+			}
+
+			le = e.EvaluateAgainst(pc, failingThreshold)
+			if !loadshedding.ShouldThrottle(le) {
+				tt.Logf("Got: %#v", le)
+				tt.Errorf("EvaluateAgainst(%#v, %f) => Status: %v; wanted %v", pc, failingThreshold, le.Status, loadshedding.ExceedsThreshold)
+			}
+			close(stop)
+		})
+	}
+}

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -55,12 +55,21 @@ type Options struct {
 
 	// BurstSize controls the number of requests that are permitted beyond the
 	// configured maximum for a period of time. This allows for handling bursty
-	// traffic patterns.
+	// traffic patterns. If this is set to 0, no traffic will be allowed.
 	BurstSize int
 }
 
-// DefaultOptions is the set of default load-shedding configuration parameters.
-var DefaultOptions = &Options{}
+// DefaultOptions returns a new set of options, initialized to the defaults
+func DefaultOptions() *Options {
+	return &Options{
+		AverageLatencyThreshold: 0,
+		SamplesPerSecond:        DefaultSampleFrequency,
+		SampleHalfLife:          DefaultHalfLife,
+		MaxRequestsPerSecond:    0,
+		BurstSize:               0,
+		Mode:                    Disabled,
+	}
+}
 
 // AttachCobraFlags attaches a set of Cobra flags to the given Cobra command.
 //

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -78,19 +78,19 @@ func DefaultOptions() Options {
 // tracing options.
 func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().VarP(newModeValue("disabled", &o.Mode), "loadsheddingMode", "",
-		"When enabled, the server will log violations but not to enforce load limits.")
+		"When enabled, the server will log violations but will not enforce load limits.")
 
 	cmd.PersistentFlags().DurationVarP(&o.AverageLatencyThreshold, "averageLatencyThreshold", "", 0,
-		"Average response latency threshold to use for loadshedding. Setting this to a non-zero Duration will enable the gRPC Response Latency evaluator.")
+		"Maximum average response time supported by the server. When this limit is exceeded, the server will drop traffic.")
 
 	cmd.PersistentFlags().VarP(newLimitValue(DefaultSampleFrequency, &o.SamplesPerSecond), "latencySamplesPerSecond", "",
-		"Controls the frequency at which the server will sample response latencies to calculate the average response latency.")
+		"Controls the frequency at which the server will sample response times to calculate the average response latency.")
 
 	cmd.PersistentFlags().DurationVarP(&o.SampleHalfLife, "latencySampleHalflife", "", DefaultHalfLife,
 		"Decay rate of samples in calculation of average response latency.")
 
 	cmd.PersistentFlags().VarP(newLimitValue(0, &o.MaxRequestsPerSecond), "maxRequestsPerSecond", "",
-		"Maximum requests per second supported by the server. Any requests above this limit will be dropped. A non-zero value enables the rate limiter.")
+		"Maximum requests per second supported by the server. Any requests above this limit will be dropped.")
 
 	cmd.PersistentFlags().IntVarP(&o.BurstSize, "burstSize", "", 0,
 		"Number of requests that are permitted beyond the configured maximum for a period of time. Only valid when used with 'maxRequestsPerSecond'.")

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -1,0 +1,124 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
+)
+
+// Options define the set of configuration parameters for controlling
+// loadshedding behavior.
+type Options struct {
+	// Mode controls the server loadshedding behavior.
+	Mode ThrottlerMode
+
+	// Options for the gRPC Average Latency evaluator
+
+	// AverageLatencyThreshold is the threshold for response times
+	// over which the server will start rejecting requests (Unavailable).
+	// Providing a value for AverageLatencyThreshold will enable the gRPC
+	// Latency evaluator.
+	AverageLatencyThreshold time.Duration
+
+	// SamplesPerSecond controls how often gRPC response latencies are
+	// recorded for calculating the average response latency.
+	SamplesPerSecond rate.Limit
+
+	// SampleHalfLife controls the decay rate of observations of response latencies.
+	SampleHalfLife time.Duration
+
+	// Options for the rate limit evaluator
+
+	// MaxRequestsPerSecond controls the rate of requests over which the
+	// server will start rejecting requests (Unavailable). Providing a value
+	// for MaxRequestsPerSecond will enable the rate limit evaluator.
+	//
+	// In Mixer, a single Report() request may translate to multiple requests
+	// counted against this limit, depending on batch size of the Report.
+	MaxRequestsPerSecond rate.Limit
+
+	// BurstSize controls the number of requests that are permitted beyond the
+	// configured maximum for a period of time. This allows for handling bursty
+	// traffic patterns.
+	BurstSize int
+}
+
+// DefaultOptions is the set of default load-shedding configuration parameters.
+var DefaultOptions = &Options{}
+
+// AttachCobraFlags attaches a set of Cobra flags to the given Cobra command.
+//
+// Cobra is the command-line processor that Istio uses. This command attaches
+// the necessary set of flags to expose a CLI to let the user control all
+// tracing options.
+func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().VarP(newModeValue("disabled", &o.Mode), "loadsheddingMode", "",
+		"When enabled, the server will log violations but not to enforce load limits.")
+
+	cmd.PersistentFlags().DurationVarP(&o.AverageLatencyThreshold, "averageLatencyThreshold", "", 0,
+		"Average response latency threshold to use for loadshedding. Setting this to a non-zero Duration will enable the gRPC Response Latency evaluator.")
+
+	cmd.PersistentFlags().VarP(newLimitValue(DefaultSampleFrequency, &o.SamplesPerSecond), "latencySamplesPerSecond", "",
+		"Controls the frequency at which the server will sample response latencies to calculate the average response latency.")
+
+	cmd.PersistentFlags().DurationVarP(&o.SampleHalfLife, "latencySampleHalflife", "", DefaultHalfLife,
+		"Decay rate of samples in calculation of average response latency.")
+
+	cmd.PersistentFlags().VarP(newLimitValue(0, &o.MaxRequestsPerSecond), "maxRequestsPerSecond", "",
+		"Maximum requests per second supported by the server. Any requests above this limit will be dropped. A non-zero value enables the rate limiter.")
+
+	cmd.PersistentFlags().IntVarP(&o.BurstSize, "burstSize", "", 0,
+		"Number of requests that are permitted beyond the configured maximum for a period of time. Only valid when used with 'maxRequestsPerSecond'.")
+}
+
+type modeValue ThrottlerMode
+
+func newModeValue(val string, p *ThrottlerMode) *modeValue {
+	*p = stringToModes[val]
+	return (*modeValue)(p)
+}
+
+func (mv *modeValue) Set(val string) error {
+	*mv = modeValue(stringToModes[val])
+	return nil
+}
+func (mv *modeValue) Type() string {
+	return "throttlermode"
+}
+
+func (mv *modeValue) String() string { return modesToString[ThrottlerMode(*mv)] }
+
+type limitValue rate.Limit
+
+func newLimitValue(val rate.Limit, p *rate.Limit) *limitValue {
+	*p = val
+	return (*limitValue)(p)
+}
+
+func (lv *limitValue) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*lv = limitValue(v)
+	return err
+}
+
+func (lv *limitValue) Type() string {
+	return "ratelimit"
+}
+
+func (lv *limitValue) String() string { return strconv.FormatFloat(float64(*lv), 'g', -1, 64) }

--- a/mixer/pkg/loadshedding/options.go
+++ b/mixer/pkg/loadshedding/options.go
@@ -60,8 +60,8 @@ type Options struct {
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults
-func DefaultOptions() *Options {
-	return &Options{
+func DefaultOptions() Options {
+	return Options{
 		AverageLatencyThreshold: 0,
 		SamplesPerSecond:        DefaultSampleFrequency,
 		SampleHalfLife:          DefaultHalfLife,

--- a/mixer/pkg/loadshedding/options_test.go
+++ b/mixer/pkg/loadshedding/options_test.go
@@ -76,7 +76,7 @@ func TestOpts(t *testing.T) {
 				tt.Errorf("Got %v, expecting success", err)
 			}
 
-			if !reflect.DeepEqual(c.result, *o) {
+			if !reflect.DeepEqual(c.result, o) {
 				tt.Errorf("Got %v, expected %v", o, c.result)
 			}
 		})

--- a/mixer/pkg/loadshedding/options_test.go
+++ b/mixer/pkg/loadshedding/options_test.go
@@ -1,0 +1,84 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"istio.io/istio/mixer/pkg/loadshedding"
+)
+
+func TestOpts(t *testing.T) {
+	cases := []struct {
+		cmdLine string
+		result  loadshedding.Options
+	}{
+		{"--loadsheddingMode logonly", loadshedding.Options{
+			Mode:             loadshedding.LogOnly,
+			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:   loadshedding.DefaultHalfLife,
+		}},
+
+		{"--averageLatencyThreshold 1s", loadshedding.Options{
+			AverageLatencyThreshold: 1 * time.Second,
+			SamplesPerSecond:        loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:          loadshedding.DefaultHalfLife,
+		}},
+
+		{"--latencySamplesPerSecond 1000", loadshedding.Options{
+			SamplesPerSecond: 1000,
+			SampleHalfLife:   loadshedding.DefaultHalfLife,
+		}},
+
+		{"--latencySampleHalflife 10s", loadshedding.Options{
+			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:   10 * time.Second,
+		}},
+
+		{"--maxRequestsPerSecond 100", loadshedding.Options{
+			MaxRequestsPerSecond: 100,
+			SamplesPerSecond:     loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:       loadshedding.DefaultHalfLife,
+		}},
+
+		{"--burstSize 10", loadshedding.Options{
+			BurstSize:        10,
+			SamplesPerSecond: loadshedding.DefaultSampleFrequency,
+			SampleHalfLife:   loadshedding.DefaultHalfLife,
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.cmdLine, func(tt *testing.T) {
+			o := loadshedding.DefaultOptions()
+			tt.Logf("defaults: %#v", o)
+			cmd := &cobra.Command{}
+			o.AttachCobraFlags(cmd)
+			cmd.SetArgs(strings.Split(c.cmdLine, " "))
+
+			if err := cmd.Execute(); err != nil {
+				tt.Errorf("Got %v, expecting success", err)
+			}
+
+			if !reflect.DeepEqual(c.result, *o) {
+				tt.Errorf("Got %v, expected %v", o, c.result)
+			}
+		})
+	}
+}

--- a/mixer/pkg/loadshedding/options_test.go
+++ b/mixer/pkg/loadshedding/options_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
 	"istio.io/istio/mixer/pkg/loadshedding"
 )
 

--- a/mixer/pkg/loadshedding/ratelimit.go
+++ b/mixer/pkg/loadshedding/ratelimit.go
@@ -1,0 +1,60 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+const (
+	// RateLimitEvaluatorName is the canonical name of the RateLimitEvaluator.
+	RateLimitEvaluatorName = "RateLimit"
+)
+
+var (
+	_ LoadEvaluator = &RateLimitEvaluator{}
+)
+
+// RateLimitEvaluator enforces a configured rate limit, using a rate.Limiter.
+type RateLimitEvaluator struct {
+	limiter *rate.Limiter
+}
+
+// NewRateLimitEvaluator builds a new RateLimitEvaluator.
+func NewRateLimitEvaluator(limit rate.Limit, burstSize int) *RateLimitEvaluator {
+	return &RateLimitEvaluator{
+		limiter: rate.NewLimiter(limit, burstSize),
+	}
+}
+
+// Name implements the LoadEvaluator interface.
+func (r RateLimitEvaluator) Name() string {
+	return RateLimitEvaluatorName
+}
+
+// EvaluateAgainst implements the LoadEvaluator interface.
+func (r *RateLimitEvaluator) EvaluateAgainst(ri RequestInfo, threshold float64) LoadEvaluation {
+	if r.limiter.AllowN(time.Now(), int(ri.PredictedCost)) {
+		return LoadEvaluation{Status: BelowThreshold}
+	}
+	return LoadEvaluation{
+		Status: ExceedsThreshold,
+		Message: fmt.Sprintf(
+			"Too many requests have been received by this server in the current time window (limit: %f). Please retry request later.", r.limiter.Limit()),
+	}
+}

--- a/mixer/pkg/loadshedding/ratelimit_test.go
+++ b/mixer/pkg/loadshedding/ratelimit_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding_test
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"istio.io/istio/mixer/pkg/loadshedding"
+)
+
+var (
+	pc1  = loadshedding.RequestInfo{PredictedCost: 1}
+	pc11 = loadshedding.RequestInfo{PredictedCost: 11}
+
+	rateLimitThreshold = 0.1 // this value is not used by the evaluator
+)
+
+// this test is not meant to exercise fully the underlying
+// `rate.Limiter`. Rather, it is meant to exercise the basic
+// creation mechanism and simple boundary conditions.
+func TestEvaluateAgainst_RateLimit(t *testing.T) {
+	// with no limit (rate.Inf), everything should be allowed.
+	e := loadshedding.NewRateLimitEvaluator(rate.Inf, 0)
+	le := e.EvaluateAgainst(pc1, rateLimitThreshold)
+	if loadshedding.ShouldThrottle(le) {
+		t.Errorf("rate.Inf: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.BelowThreshold)
+	}
+
+	// with limit, but burst size == 0, nothing should be allowed.
+	e = loadshedding.NewRateLimitEvaluator(rate.Every(1*time.Millisecond), 0)
+	le = e.EvaluateAgainst(pc1, rateLimitThreshold)
+	if !loadshedding.ShouldThrottle(le) {
+		t.Errorf("no burst: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.ExceedsThreshold)
+	}
+
+	// allow 10 events per second, try with 11, should fail
+	e = loadshedding.NewRateLimitEvaluator(rate.Every(100*time.Millisecond), 1)
+	le = e.EvaluateAgainst(pc11, rateLimitThreshold)
+	if !loadshedding.ShouldThrottle(le) {
+		t.Errorf("every 100ms: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.ExceedsThreshold)
+	}
+}

--- a/mixer/pkg/loadshedding/ratelimit_test.go
+++ b/mixer/pkg/loadshedding/ratelimit_test.go
@@ -37,21 +37,21 @@ func TestEvaluateAgainst_RateLimit(t *testing.T) {
 	// with no limit (rate.Inf), everything should be allowed.
 	e := loadshedding.NewRateLimitEvaluator(rate.Inf, 0)
 	le := e.EvaluateAgainst(pc1, rateLimitThreshold)
-	if loadshedding.ShouldThrottle(le) {
+	if loadshedding.ThresholdExceeded(le) {
 		t.Errorf("rate.Inf: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.BelowThreshold)
 	}
 
 	// with limit, but burst size == 0, nothing should be allowed.
 	e = loadshedding.NewRateLimitEvaluator(rate.Every(1*time.Millisecond), 0)
 	le = e.EvaluateAgainst(pc1, rateLimitThreshold)
-	if !loadshedding.ShouldThrottle(le) {
+	if !loadshedding.ThresholdExceeded(le) {
 		t.Errorf("no burst: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.ExceedsThreshold)
 	}
 
 	// allow 10 events per second, try with 11, should fail
 	e = loadshedding.NewRateLimitEvaluator(rate.Every(100*time.Millisecond), 1)
 	le = e.EvaluateAgainst(pc11, rateLimitThreshold)
-	if !loadshedding.ShouldThrottle(le) {
+	if !loadshedding.ThresholdExceeded(le) {
 		t.Errorf("every 100ms: EvaluateAgainst() => %#v; wanted a status of: %v", le, loadshedding.ExceedsThreshold)
 	}
 }

--- a/mixer/pkg/loadshedding/throttler.go
+++ b/mixer/pkg/loadshedding/throttler.go
@@ -1,0 +1,147 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding
+
+import (
+	"context"
+	"fmt"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+
+	"istio.io/istio/pkg/log"
+)
+
+const (
+	// Disabled removes all throttling behavior for the server.
+	Disabled ThrottlerMode = iota
+	// LogOnly enables an advisory mode for throttling behavior on the server.
+	LogOnly
+	// Enforce turns the throttling behavior on for the server.
+	Enforce
+)
+
+type (
+	// ThrottlerMode controls the behavior a throttler.
+	ThrottlerMode int
+
+	// RequestInfo is used to hold information related to a request that
+	// could be relevant to a LoadEvaluator.
+	RequestInfo struct {
+		// PredictedCost enables the server to pass information about the relative
+		// size (or impact) of the request into the throttler. For instance, it can
+		// be used to distinguish between Check() and Report() calls by setting the
+		// value to the size of the batch.
+		PredictedCost float64
+	}
+
+	// Throttler provides the loadshedding behavior by evaluating current request information
+	// against a set of configured LoadEvaluators.
+	Throttler struct {
+		mode       ThrottlerMode
+		evaluators map[string]LoadEvaluator
+		thresholds map[string][]float64
+	}
+)
+
+var (
+	scope = log.RegisterScope("loadshedding", "Information related to loadshedding", 0)
+
+	modesToString = map[ThrottlerMode]string{
+		Disabled: "disabled",
+		LogOnly:  "logonly",
+		Enforce:  "enforce",
+	}
+
+	stringToModes = map[string]ThrottlerMode{
+		"disabled": Disabled,
+		"logonly":  LogOnly,
+		"enforce":  Enforce,
+	}
+
+	throttled = stats.Int64(
+		"loadshedding/requests_throttled",
+		"The number of requests that have been dropped by the loadshedder.",
+		stats.UnitDimensionless)
+
+	throttledView = &view.View{
+		Name:        "mixer/" + throttled.Name(),
+		Measure:     throttled,
+		Aggregation: view.Count(),
+	}
+)
+
+func init() {
+	if err := view.Register(throttledView); err != nil {
+		panic(err)
+	}
+}
+
+// NewThrottler builds a Throttler based on the configured options.
+func NewThrottler(opts Options) *Throttler {
+	t := &Throttler{
+		mode:       opts.Mode,
+		evaluators: make(map[string]LoadEvaluator),
+		thresholds: make(map[string][]float64),
+	}
+
+	if opts.AverageLatencyThreshold > 0 {
+		e := NewGRPCLatencyEvaluator(opts.SamplesPerSecond, opts.SampleHalfLife)
+		t.evaluators[e.Name()] = e
+		t.thresholds[e.Name()] = append(t.thresholds[e.Name()], opts.AverageLatencyThreshold.Seconds())
+	}
+
+	if opts.MaxRequestsPerSecond > 0 {
+		e := NewRateLimitEvaluator(opts.MaxRequestsPerSecond, opts.BurstSize)
+		t.evaluators[e.Name()] = e
+		t.thresholds[e.Name()] = append(t.thresholds[e.Name()], float64(opts.MaxRequestsPerSecond))
+	}
+
+	scope.Debugf("Built Throttler(%#v) from opts(%#v)", t, opts)
+	return t
+}
+
+// Evaluator returns a configured LoadEvaluator based on the supplied name. If no
+// LoadEvaluator with the given name is known to the Throttler, a nil value will
+// be returned.
+func (t *Throttler) Evaluator(name string) LoadEvaluator {
+	return t.evaluators[name]
+}
+
+// Throttle returns a verdict on whether or not the server should drop the request, based on
+// the current set of configured LoadEvaluators.
+func (t *Throttler) Throttle(ri RequestInfo) bool {
+	if t.mode == Disabled {
+		return false
+	}
+
+	for _, e := range t.evaluators {
+		for _, thres := range t.thresholds[e.Name()] {
+			scope.Debugf("Evaluating load with %s against threshold %f", e.Name(), thres)
+			eval := e.EvaluateAgainst(ri, thres)
+			if shouldThrottle(eval) {
+				msg := fmt.Sprintf("Throttled (%s): '%s'", e.Name(), eval.Message)
+				if t.mode == LogOnly {
+					scope.Infoa("LogOnly - ", msg)
+					continue
+				}
+				stats.Record(context.Background(), throttled.M(1))
+				scope.Warn(msg)
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/mixer/pkg/loadshedding/throttler_test.go
+++ b/mixer/pkg/loadshedding/throttler_test.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadshedding_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"istio.io/istio/mixer/pkg/loadshedding"
+)
+
+var (
+	maxRPS = rate.Every(10 * time.Millisecond)
+	burst  = 1
+
+	rateLimitOpts = loadshedding.Options{
+		Mode:                 loadshedding.LogOnly,
+		MaxRequestsPerSecond: maxRPS,
+		BurstSize:            burst,
+	}
+
+	rateLimitEval = loadshedding.NewRateLimitEvaluator(maxRPS, burst)
+
+	samplesPerSec = 100000
+
+	grpcLatencyOpts = loadshedding.Options{
+		Mode: loadshedding.Enforce,
+		AverageLatencyThreshold: 1 * time.Nanosecond,
+		SampleHalfLife:          1 * time.Millisecond,
+		SamplesPerSecond:        rate.Every(1 * time.Nanosecond),
+	}
+
+	grpcLatencyEval = loadshedding.NewGRPCLatencyEvaluator(rate.Every(1*time.Nanosecond), 1*time.Millisecond)
+)
+
+type evalComparisonFn func(got loadshedding.LoadEvaluator) bool
+type evalMap map[string]evalComparisonFn
+
+func TestNewThrottler(t *testing.T) {
+
+	rateLimitEvalFn := func(got loadshedding.LoadEvaluator) bool {
+		return reflect.DeepEqual(got, rateLimitEval)
+	}
+
+	latencyEvalFn := func(got loadshedding.LoadEvaluator) bool {
+		_, ok := got.(*loadshedding.GRPCLatencyEvaluator)
+		return ok
+	}
+
+	cases := []struct {
+		name       string
+		opts       loadshedding.Options
+		evaluators evalMap
+	}{
+		{"default", *loadshedding.DefaultOptions(), evalMap{}},
+		{"rate limit", rateLimitOpts, evalMap{loadshedding.RateLimitEvaluatorName: rateLimitEvalFn}},
+		{"latency", grpcLatencyOpts, evalMap{loadshedding.GRPCLatencyEvaluatorName: latencyEvalFn}},
+	}
+
+	for _, v := range cases {
+		t.Run(v.name, func(tt *testing.T) {
+			thr := loadshedding.NewThrottler(v.opts)
+			for name, wantFn := range v.evaluators {
+				got := thr.Evaluator(name)
+				if got == nil {
+					tt.Errorf("Evaluator(%s) => nil; wanted LoadEvaluator.", name)
+				}
+				if wantFn != nil && !wantFn(got) {
+					tt.Errorf("Evaluator(%s) => %#v, which did not pass supplied validation function", name, got)
+				}
+			}
+		})
+	}
+}

--- a/mixer/pkg/loadshedding/throttler_test.go
+++ b/mixer/pkg/loadshedding/throttler_test.go
@@ -83,7 +83,7 @@ func TestNewThrottler(t *testing.T) {
 		opts       loadshedding.Options
 		evaluators evalMap
 	}{
-		{"default", *loadshedding.DefaultOptions(), evalMap{}},
+		{"default", loadshedding.DefaultOptions(), evalMap{}},
 		{"rate limit", rateLimitOpts, evalMap{loadshedding.RateLimitEvaluatorName: rateLimitEvalFn}},
 		{"latency", grpcLatencyOpts, evalMap{loadshedding.GRPCLatencyEvaluatorName: latencyEvalFn}},
 		{"hybrid", hybridOpts, evalMap{loadshedding.RateLimitEvaluatorName: rateLimitEvalFn, loadshedding.GRPCLatencyEvaluatorName: latencyEvalFn}},

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -99,7 +99,7 @@ type Args struct {
 	// Maximum number of entries in the check cache
 	NumCheckCacheEntries int32
 
-	LoadSheddingOptions *loadshedding.Options
+	LoadSheddingOptions loadshedding.Options
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
@@ -158,7 +158,7 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "TracingOptions: %#v\n", *a.TracingOptions)
 	fmt.Fprintf(buf, "IntrospectionOptions: %#v\n", *a.IntrospectionOptions)
-	fmt.Fprintf(buf, "LoadSheddingOptions: %#v\n", *a.LoadSheddingOptions)
+	fmt.Fprintf(buf, "LoadSheddingOptions: %#v\n", a.LoadSheddingOptions)
 
 	return buf.String()
 }

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -20,6 +20,7 @@ import (
 
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/mixer/pkg/loadshedding"
 	"istio.io/istio/mixer/pkg/runtime/config/constant"
 	"istio.io/istio/mixer/pkg/template"
 	"istio.io/istio/pkg/ctrlz"
@@ -97,6 +98,8 @@ type Args struct {
 
 	// Maximum number of entries in the check cache
 	NumCheckCacheEntries int32
+
+	LoadSheddingOptions *loadshedding.Options
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
@@ -116,6 +119,7 @@ func DefaultArgs() *Args {
 		IntrospectionOptions:   ctrlz.DefaultOptions(),
 		EnableProfiling:        true,
 		NumCheckCacheEntries:   5000 * 5 * 60, // 5000 QPS with average TTL of 5 minutes
+		LoadSheddingOptions:    loadshedding.DefaultOptions,
 	}
 }
 
@@ -154,6 +158,7 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
 	fmt.Fprintf(buf, "TracingOptions: %#v\n", *a.TracingOptions)
 	fmt.Fprintf(buf, "IntrospectionOptions: %#v\n", *a.IntrospectionOptions)
+	fmt.Fprintf(buf, "LoadSheddingOptions: %#v\n", *a.LoadSheddingOptions)
 
 	return buf.String()
 }

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -119,7 +119,7 @@ func DefaultArgs() *Args {
 		IntrospectionOptions:   ctrlz.DefaultOptions(),
 		EnableProfiling:        true,
 		NumCheckCacheEntries:   5000 * 5 * 60, // 5000 QPS with average TTL of 5 minutes
-		LoadSheddingOptions:    loadshedding.DefaultOptions,
+		LoadSheddingOptions:    loadshedding.DefaultOptions(),
 	}
 }
 

--- a/mixer/pkg/server/monitoring.go
+++ b/mixer/pkg/server/monitoring.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -22,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc/stats"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/version"
@@ -101,4 +103,44 @@ L:
 		}
 	}
 	return err
+}
+
+type multiStatsHandler struct {
+	handlers []stats.Handler
+}
+
+// HandleRPC processes the RPC stats.
+func (m *multiStatsHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	for _, h := range m.handlers {
+		h.HandleRPC(ctx, rs)
+	}
+}
+
+// TagRPC can attach some information to the given context.
+func (m *multiStatsHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	c := ctx
+	for _, h := range m.handlers {
+		c = h.TagRPC(c, rti)
+	}
+	return c
+}
+
+// TagConn can attach some information to the given context.
+func (m *multiStatsHandler) TagConn(ctx context.Context, cti *stats.ConnTagInfo) context.Context {
+	c := ctx
+	for _, h := range m.handlers {
+		c = h.TagConn(c, cti)
+	}
+	return c
+}
+
+// HandleConn processes the Conn stats.
+func (m *multiStatsHandler) HandleConn(ctx context.Context, cs stats.ConnStats) {
+	for _, h := range m.handlers {
+		h.HandleConn(ctx, cs)
+	}
+}
+
+func newMultiStatsHandler(handlers ...stats.Handler) stats.Handler {
+	return &multiStatsHandler{handlers: handlers}
 }

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -221,7 +221,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 	// get the grpc server wired up
 	grpc.EnableTracing = a.EnableGRPCTracing
 
-	throttler := loadshedding.NewThrottler(*a.LoadSheddingOptions)
+	throttler := loadshedding.NewThrottler(a.LoadSheddingOptions)
 	if eval := throttler.Evaluator(loadshedding.GRPCLatencyEvaluatorName); eval != nil {
 		grpcOptions = append(grpcOptions, grpc.StatsHandler(eval.(*loadshedding.GRPCLatencyEvaluator)))
 	}

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -18,27 +18,25 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"time"
-
-	"istio.io/istio/mixer/pkg/config/crd"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	ot "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
-
-	"os"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/api"
 	"istio.io/istio/mixer/pkg/checkcache"
 	"istio.io/istio/mixer/pkg/config"
+	"istio.io/istio/mixer/pkg/config/crd"
 	"istio.io/istio/mixer/pkg/config/store"
+	"istio.io/istio/mixer/pkg/loadshedding"
 	"istio.io/istio/mixer/pkg/pool"
 	"istio.io/istio/mixer/pkg/runtime"
 	rc "istio.io/istio/mixer/pkg/runtime/config"
@@ -222,8 +220,15 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 
 	// get the grpc server wired up
 	grpc.EnableTracing = a.EnableGRPCTracing
+
+	throttler := loadshedding.NewThrottler(*a.LoadSheddingOptions)
+	if eval := throttler.Evaluator(loadshedding.GRPCLatencyEvaluatorName); eval != nil {
+		grpcOptions = append(grpcOptions, grpc.StatsHandler(eval.(*loadshedding.GRPCLatencyEvaluator)))
+	}
+
 	s.server = grpc.NewServer(grpcOptions...)
-	mixerpb.RegisterMixerServer(s.server, api.NewGRPCServer(s.dispatcher, s.gp, s.checkCache))
+
+	mixerpb.RegisterMixerServer(s.server, api.NewGRPCServer(s.dispatcher, s.gp, s.checkCache, throttler))
 
 	if a.LivenessProbeOptions.IsValid() {
 		s.livenessProbe = probe.NewFileController(a.LivenessProbeOptions)


### PR DESCRIPTION
Per request, I've cherry-picked changes from the in-flight PR for adding load-shedding to Mixer to the `release-1.0` branch.