### PR TITLE
Fixing few format glitches that went in before gofmt was used for lint

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 
 	"github.com/gogo/protobuf/jsonpb"
-	
+
 	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	ads "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	proto "github.com/gogo/protobuf/types"
-	
+
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	testenv "istio.io/istio/mixer/test/client/env"
 	"istio.io/istio/pilot/pkg/bootstrap"

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/types"
-	
+
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 )

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/env"
-	meshconfig "istio.io/api/mesh/v1alpha1"
 )
 
 func makeClient(t *testing.T) kubernetes.Interface {


### PR DESCRIPTION
Currently the `lint` test will fail on this branch without these.