### PR TITLE
Add helm option to control prom adapter expiry default

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -549,6 +549,8 @@ metadata:
 spec:
   compiledAdapter: prometheus
   params:
+    metricsExpirationPolicy:
+      metricsExpiryDuration: "{{ .Values.adapters.prometheus.metricsExpiryDuration }}"
     metrics:
     - name: requests_total
       instance_name: requestcount.metric.{{ .Release.Namespace }}

--- a/install/kubernetes/helm/subcharts/mixer/values.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/values.yaml
@@ -23,3 +23,7 @@ istio-telemetry:
     targetAverageUtilization: 80
 
 podAnnotations: {}
+
+adapters:
+  prometheus:
+    metricsExpiryDuration: 10m


### PR DESCRIPTION
At scale, it is not desirable to have a Mixer instance hold on to metrics data forever. This PR establishes a default expiration policy and provides a mechanism for operators to control the retention period on the `istio-telemetry` pods.  This is a separate control from the `retention` param for Prometheus (which controls server-side expiry).

Example usage:

```
helm template install/kubernetes/helm/istio --name istio --set mixer.adapters.prometheus.metricsExpiryDuration=1h ...
```