### PR TITLE
fix flake TestRotateMaxBackups

### DIFF
--- a/pkg/log/config_test.go
+++ b/pkg/log/config_test.go
@@ -250,6 +250,10 @@ func TestRotateMaxBackups(t *testing.T) {
 		}
 	}
 
+	// TODO: find other graceful way to prevent flake
+	// lumberjack.Logger rotate in a separate goroutine, could not know when rotation done.
+	time.Sleep(500 * time.Millisecond)
+
 	rd, err := ioutil.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("Unable to read dir: %v", err)


### PR DESCRIPTION
**Note**: There are so many flakes on `TestRotateMaxBackups` . That's all because the rotate is done in a separate go routine, and there is no mechanism to know when the rotation is done. So here temporarily wait a short time 500ms.