### PR TITLE
Rename identity-domain to trust-domain.

### DIFF
--- a/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
@@ -48,8 +48,8 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           {{- end }}
-          {{- if .Values.identityDomain }}
-            - --identity-domain={{ .Values.identityDomain }}
+          {{- if .Values.trustDomain }}
+            - --trust-domain={{ .Values.trustDomain }}
           {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/install/kubernetes/helm/subcharts/security/values.yaml
+++ b/install/kubernetes/helm/subcharts/security/values.yaml
@@ -5,5 +5,5 @@ enabled: true
 replicaCount: 1
 image: citadel
 selfSigned: true # indicate if self-signed CA is used.
-identityDomain: cluster.local # indicate the domain used in SPIFFE identity URL
+trustDomain: cluster.local # indicate the domain used in SPIFFE identity URL
 

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -95,7 +95,7 @@ type cliOptions struct { // nolint: maligned
 	customDNSNames string
 
 	// domain to use in SPIFFE identity URLs
-	identityDomain string
+	trustDomain string
 
 	// Enable dual-use certs - SPIFFE in SAN and in CommonName
 	dualUse bool
@@ -161,8 +161,8 @@ func init() {
 			"When set to true, the '--signing-cert' and '--signing-key' options are ignored.")
 	flags.DurationVar(&opts.selfSignedCACertTTL, "self-signed-ca-cert-ttl", cmd.DefaultSelfSignedCACertTTL,
 		"The TTL of self-signed CA root certificate")
-	flags.StringVar(&opts.identityDomain, "identity-domain", controller.DefaultIdentityDomain,
-		fmt.Sprintf("The domain to use for identities (default: %s)", controller.DefaultIdentityDomain))
+	flags.StringVar(&opts.trustDomain, "trust-domain", controller.DefaultTrustDomain,
+		fmt.Sprintf("The domain serves to identify the system with spiffe (default: %s)", controller.DefaultTrustDomain))
 
 	// Upstream CA configuration if Citadel interacts with upstream CA.
 	flags.StringVar(&opts.cAClientConfig.CAAddress, "upstream-ca-address", "", "The IP:port address of the upstream "+
@@ -294,7 +294,7 @@ func runCA() {
 	ca := createCA(cs.CoreV1())
 	// For workloads in K8s, we apply the configured workload cert TTL.
 	sc, err := controller.NewSecretController(ca,
-		opts.workloadCertTTL, opts.identityDomain,
+		opts.workloadCertTTL, opts.trustDomain,
 		opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod, opts.dualUse,
 		cs.CoreV1(), opts.signCACerts, opts.listenedNamespace, webhooks)
 	if err != nil {
@@ -403,7 +403,7 @@ func createCA(core corev1.SecretsGetter) *ca.IstioCA {
 	if opts.selfSignedCA {
 		log.Info("Use self-signed certificate as the CA certificate")
 		caOpts, err = ca.NewSelfSignedIstioCAOptions(opts.selfSignedCACertTTL, opts.workloadCertTTL,
-			opts.maxWorkloadCertTTL, opts.identityDomain, opts.dualUse,
+			opts.maxWorkloadCertTTL, opts.trustDomain, opts.dualUse,
 			opts.istioCaStorageNamespace, core)
 		if err != nil {
 			fatalf("Failed to create a self-signed Citadel (error: %v)", err)

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -49,8 +49,8 @@ const (
 	// The key to specify corresponding service account in the annotation of K8s secrets.
 	ServiceAccountNameAnnotationKey = "istio.io/service-account.name"
 
-	// The default SPIFFE URL value for identity domain
-	DefaultIdentityDomain = "cluster.local"
+	// The default SPIFFE URL value for trust domain
+	DefaultTrustDomain = "cluster.local"
 
 	secretNamePrefix   = "istio."
 	secretResyncPeriod = time.Minute
@@ -84,7 +84,7 @@ type DNSNameEntry struct {
 type SecretController struct {
 	ca             ca.CertificateAuthority
 	certTTL        time.Duration
-	identityDomain string
+	trustDomain    string
 	core           corev1.CoreV1Interface
 	minGracePeriod time.Duration
 	// Length of the grace period for the certificate rotation.
@@ -111,7 +111,7 @@ type SecretController struct {
 }
 
 // NewSecretController returns a pointer to a newly constructed SecretController instance.
-func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, identityDomain string,
+func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, trustDomain string,
 	gracePeriodRatio float32, minGracePeriod time.Duration, dualUse bool,
 	core corev1.CoreV1Interface, forCA bool, namespace string, dnsNames map[string]DNSNameEntry) (*SecretController, error) {
 
@@ -123,14 +123,14 @@ func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, iden
 			gracePeriodRatio, recommendedMinGracePeriodRatio, recommendedMaxGracePeriodRatio)
 	}
 
-	if identityDomain == "" {
-		identityDomain = DefaultIdentityDomain
+	if trustDomain == "" {
+		trustDomain = DefaultTrustDomain
 	}
 
 	c := &SecretController{
 		ca:               ca,
 		certTTL:          certTTL,
-		identityDomain:   identityDomain,
+		trustDomain:      trustDomain,
 		gracePeriodRatio: gracePeriodRatio,
 		minGracePeriod:   minGracePeriod,
 		dualUse:          dualUse,
@@ -300,7 +300,7 @@ func (sc *SecretController) scrtDeleted(obj interface{}) {
 }
 
 func (sc *SecretController) generateKeyAndCert(saName string, saNamespace string) ([]byte, []byte, error) {
-	id := fmt.Sprintf("%s://%s/ns/%s/sa/%s", util.URIScheme, sc.identityDomain, saNamespace, saName)
+	id := fmt.Sprintf("%s://%s/ns/%s/sa/%s", util.URIScheme, sc.trustDomain, saNamespace, saName)
 	if sc.dnsNames != nil {
 		// Control plane components in same namespace.
 		if e, ok := sc.dnsNames[saName]; ok {

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -161,7 +161,7 @@ func TestSecretController(t *testing.T) {
 				Namespace:   "test-ns",
 			},
 		}
-		controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultIdentityDomain,
+		controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultTrustDomain,
 			tc.gracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
 			metav1.NamespaceAll, webhooks)
 		if tc.shouldFail {
@@ -202,7 +202,7 @@ func TestSecretContent(t *testing.T) {
 	saName := "test-serviceaccount"
 	saNamespace := "test-namespace"
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultIdentityDomain,
+	controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultTrustDomain,
 		defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
 		metav1.NamespaceAll, map[string]DNSNameEntry{})
 	if err != nil {
@@ -224,7 +224,7 @@ func TestSecretContent(t *testing.T) {
 }
 func TestDeletedIstioSecret(t *testing.T) {
 	client := fake.NewSimpleClientset()
-	controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultIdentityDomain,
+	controller, err := NewSecretController(createFakeCA(), defaultTTL, DefaultTrustDomain,
 		defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
 		metav1.NamespaceAll, nil)
 	if err != nil {
@@ -343,7 +343,7 @@ func TestUpdateSecret(t *testing.T) {
 
 	for k, tc := range testCases {
 		client := fake.NewSimpleClientset()
-		controller, err := NewSecretController(createFakeCA(), time.Hour, DefaultIdentityDomain,
+		controller, err := NewSecretController(createFakeCA(), time.Hour, DefaultTrustDomain,
 			tc.gracePeriodRatio, tc.minGracePeriod, false, client.CoreV1(), false, metav1.NamespaceAll, nil)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)


### PR DESCRIPTION
Trust domain seems to be the correct term for spiffe:
https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
This PR is related to #8661 
As there was a lot of discussion about the flag name in our other PR #9059 we want to rename here.

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>