### PR TITLE
Add configuration of externalTrafficPolicy in helm ingressgateway

### DIFF
--- a/install/kubernetes/helm/subcharts/ingress/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
+{{- end }}
   type: {{ .Values.service.type }}
   selector:
     istio: ingress

--- a/install/kubernetes/helm/subcharts/ingress/values.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/values.yaml
@@ -9,6 +9,7 @@ service:
   annotations: {}
   loadBalancerIP: ""
   type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+  externalTrafficPolicy: Cluster
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
When istio-ingressgateway is type LoadBalancer, one can configure externalTrafficPolicy to one of Cluster or Local. Expose this variable as service.externalTrafficPolicy.

Signed-off-by: Don Bowman <db@donbowman.ca>