### PR TITLE
fix 1.0.3 => 1.1.0 upgrade with default helm options

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -44,7 +44,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-grafana-post-install
+  name: istio-grafana-post-install-v1.1.0
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -274,6 +274,15 @@ metadata:
     istio: mixer
 spec:
   replicas: {{ $.Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "mixer.name" $ }}
+      chart: {{ template "mixer.chart" $ }}
+      heritage: {{ $.Release.Service }}
+      release: {{ $.Release.Name }}
+      version: {{ $.Chart.Version }}
+      istio: mixer
+      istio-mixer-type: {{ $mname }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-cleanup-secrets
+  name: istio-cleanup-secrets-v1.1.0
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -54,7 +54,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-security-post-install
+  name: istio-security-post-install-v1.1.0
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install


### PR DESCRIPTION
*) The image for post-install jobs changed from hyperkube to our own
 custom image. Job specs are immutable, hence we need to change the
 job name.

*) Additional labels were added to the mixer policy and telemetry
 deployments. This results in mismatch between the deployments
 selector's matchLabels and the pod template spec's labels. Fix the
 problem by explicitly updated the selector matchLabels to be
 consistent with the pod template specs.