### PR TITLE
Fix multiple virtual services for wildcard service

### DIFF
--- a/tests/e2e/tests/pilot/externalservice_test.go
+++ b/tests/e2e/tests/pilot/externalservice_test.go
@@ -65,6 +65,24 @@ func TestServiceEntry(t *testing.T) {
 		//	url:               "https://google.com",
 		//	shouldBeReachable: false,
 		//},
+		{
+			name:              "REACHABLE_en.wikipedia.org_over_wikipedia_wildcard",
+			config:            "testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml",
+			url:               "https://en.wikipedia.org/wiki/Main_Page",
+			shouldBeReachable: true,
+		},
+		{
+			name:              "REACHABLE_de.wikipedia.org_over_wikipedia_wildcard",
+			config:            "testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml",
+			url:               "https://de.wikipedia.org/wiki/Wikipedia:Hauptseite",
+			shouldBeReachable: true,
+		},
+		{
+			name:              "UNREACHABLE_www.wikipedia.org_over_wikipedia_wildcard",
+			config:            "testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml",
+			url:               "https://www.wikipedia.org",
+			shouldBeReachable: false,
+		},
 	}
 
 	var cfgs *deployableConfig

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: wikipedia
+spec:
+  hosts:
+  - "*.wikipedia.org"
+  endpoints:
+  - address: wikipedia.org
+  location: MESH_EXTERNAL
+  resolution: DNS
+  ports:
+    - number: 443
+      name: https
+      protocol: TLS
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: en
+spec:
+  hosts:
+  - en.wikipedia.org
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - en.wikipedia.org
+    route:
+    - destination:
+        host: '*.wikipedia.org'
+        port:
+          number: 443
+      weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: de
+spec:
+  hosts:
+  - de.wikipedia.org
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - de.wikipedia.org
+    route:
+    - destination:
+        host: '*.wikipedia.org'
+        port:
+          number: 443
+      weight: 100


### PR DESCRIPTION
Fixes istio/istio.io#2766

There can be more than one VirtualService matching a wildcard service. Here's an example that is perfectly valid:
```
apiVersion: networking.istio.io/v1alpha3
kind: ServiceEntry
metadata:
  name: star
spec:
  hosts:
  - '*.googleapis.com'
  endpoints:
  - address: googleapis.com
  location: MESH_EXTERNAL
  resolution: DNS
  ports:
    - number: 443
      name: https
      protocol: TLS
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: pubsub
spec:
  hosts:
    - pubsub.googleapis.com
  tls:
    - match:
        - port: 443
          sni_hosts:
            - pubsub.googleapis.com
      route:
        - destination:
            host: '*.googleapis.com'
            port:
              number: 443
          weight: 100
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: container
spec:
  hosts:
    - container.googleapis.com
  tls:
    - match:
        - port: 443
          sni_hosts:
            - container.googleapis.com
      route:
        - destination:
            host: '*.googleapis.com'
            port:
              number: 443
          weight: 100
```