### PR TITLE
Cherry pick into release-1.0 - Fix a data race

### DIFF
--- a/mixer/pkg/config/crd/store_test.go
+++ b/mixer/pkg/config/crd/store_test.go
@@ -499,8 +499,11 @@ func TestCrdsRetryAsynchronouslyStoreClose(t *testing.T) {
 		},
 	}
 	callCount := 0
+	mutex := sync.RWMutex{}
 	fakeDiscovery.AddReactor("get", "resource", func(k8stesting.Action) (bool, runtime.Object, error) {
+		mutex.Lock()
 		callCount++
+		mutex.Unlock()
 		return true, nil, nil
 	})
 
@@ -516,7 +519,9 @@ func TestCrdsRetryAsynchronouslyStoreClose(t *testing.T) {
 	time.Sleep(30 * time.Millisecond)
 	s.Stop()
 	time.Sleep(30 * time.Millisecond)
+	mutex.RLock()
 	if callCount > 4 {
 		t.Errorf("got %v, want no more than 4 calls", callCount)
 	}
+	mutex.RUnlock()
 }


### PR DESCRIPTION
Cherry picked #9497 to `release-1.0` to avoid data races in that branch too.