### PR TITLE
Update generate_cert_test.go

### DIFF
--- a/security/pkg/pki/util/generate_cert_test.go
+++ b/security/pkg/pki/util/generate_cert_test.go
@@ -442,7 +442,7 @@ func TestLoadSignerCredsFromFiles(t *testing.T) {
 		}
 
 		if cert == nil || key == nil {
-			t.Errorf("[%s] Faild to load signer credeitials from files: %v, %v", id, tc.certFile, tc.keyFile)
+			t.Errorf("[%s] Failed to load signer credentials from files: %v, %v", id, tc.certFile, tc.keyFile)
 		}
 	}
 }


### PR DESCRIPTION
Correct the typos in error message:
Line 445: Faild->Failed,  credeitials->credentials