### PR TITLE
Fix lint errors

### DIFF
--- a/mixer/adapter/rbac/rbac.go
+++ b/mixer/adapter/rbac/rbac.go
@@ -26,7 +26,7 @@ import (
 )
 
 type (
-	builder struct {}
+	builder struct{}
 )
 
 const (
@@ -60,7 +60,7 @@ func GetInfo() adapter.Info {
 		SupportedTemplates: []string{
 			authorization.TemplateName,
 		},
-		NewBuilder: func() adapter.HandlerBuilder { return &builder{} },
+		NewBuilder:    func() adapter.HandlerBuilder { return &builder{} },
 		DefaultConfig: &config.Params{},
 	}
 }


### PR DESCRIPTION
There are linter errors in release-1.1 so that any PRs in release-1.1 cannot pass the format linter checking.

The master format linter check was disabled temporarily in https://github.com/istio/istio/pull/9424

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>