### PR TITLE
Use pool for protobags

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -25,7 +25,6 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"google.golang.org/grpc/codes"
 	grpc "google.golang.org/grpc/status"
-
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/checkcache"
@@ -79,7 +78,7 @@ func (s *grpcServer) Check(ctx context.Context, req *mixerpb.CheckRequest) (*mix
 	}
 
 	// bag around the input proto that keeps track of reference attributes
-	protoBag := attribute.NewProtoBag(&req.Attributes, s.globalDict, s.globalWordList)
+	protoBag := attribute.GetProtoBag(&req.Attributes, s.globalDict, s.globalWordList)
 
 	if s.cache != nil {
 		if value, ok := s.cache.Get(protoBag); ok {
@@ -237,7 +236,7 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 	}
 
 	// bag around the input proto that keeps track of reference attributes
-	protoBag := attribute.NewProtoBag(&req.Attributes[0], s.globalDict, s.globalWordList)
+	protoBag := attribute.GetProtoBag(&req.Attributes[0], s.globalDict, s.globalWordList)
 
 	// This tracks the delta attributes encoded in the individual report entries
 	accumBag := attribute.GetMutableBag(protoBag)

--- a/mixer/pkg/attribute/bag_test.go
+++ b/mixer/pkg/attribute/bag_test.go
@@ -175,7 +175,7 @@ func TestEmptyRoundTrip(t *testing.T) {
 }
 
 func mutableBagFromProtoForTesing() *MutableBag {
-	b := NewProtoBag(protoAttrsForTesting())
+	b := GetProtoBag(protoAttrsForTesting())
 	return GetMutableBag(b)
 }
 
@@ -234,7 +234,7 @@ func TestProtoBag(t *testing.T) {
 					t.Fatalf("GetBagFromProto failed with %v", err)
 				}
 			} else {
-				b := NewProtoBag(attrs, globalDict, globalWordList)
+				b := GetProtoBag(attrs, globalDict, globalWordList)
 				pb = GetMutableBag(b)
 			}
 
@@ -608,7 +608,7 @@ func TestBogusProto(t *testing.T) {
 		StringMaps: map[int32]mixerpb.StringMap{-1: sm1, -2: sm2},
 	}
 
-	b := NewProtoBag(&attrs, globalDict, globalWordList)
+	b := GetProtoBag(&attrs, globalDict, globalWordList)
 
 	cases := []struct {
 		name string
@@ -647,7 +647,7 @@ func TestMessageDictEdge(t *testing.T) {
 		Strings: map[int32]int32{0: -2},
 	}
 
-	b := NewProtoBag(&attrs, globalDict, globalWordList)
+	b := GetProtoBag(&attrs, globalDict, globalWordList)
 	v, ok := b.Get("G0")
 	if !ok {
 		t.Error("Expecting true, got false")
@@ -684,7 +684,7 @@ func TestDoubleStrings(t *testing.T) {
 			var b Bag
 
 			if i == 0 {
-				b = NewProtoBag(&attrs, globalDict, globalWordList)
+				b = GetProtoBag(&attrs, globalDict, globalWordList)
 			} else {
 				var err error
 				b, err = GetBagFromProto(&attrs, globalWordList)
@@ -738,7 +738,7 @@ func TestReferenceTracking(t *testing.T) {
 		{"DUD", -1, ""}, // not referenced, so shouldn't be a match
 	}
 
-	b := NewProtoBag(&attrs, globalDict, globalWordList)
+	b := GetProtoBag(&attrs, globalDict, globalWordList)
 
 	// reference some attributes
 	_, _ = b.Get("G0")  // from global word list
@@ -839,7 +839,7 @@ func TestGlobalWordCount(t *testing.T) {
 			var err error
 
 			if i == 0 {
-				b2 = NewProtoBag(&output, shortGlobalDict, shortGlobalWordList)
+				b2 = GetProtoBag(&output, shortGlobalDict, shortGlobalWordList)
 			} else {
 				b2, err = GetBagFromProto(&output, shortGlobalWordList)
 			}

--- a/mixer/pkg/attribute/protoBag.go
+++ b/mixer/pkg/attribute/protoBag.go
@@ -23,8 +23,6 @@ import (
 	mixerpb "istio.io/api/mixer/v1"
 )
 
-// TODO: consider implementing a pool of proto bags
-
 type attributeRef struct {
 	Name   string
 	MapKey string
@@ -52,25 +50,33 @@ type ProtoBag struct {
 	referencedAttrsMutex sync.Mutex
 }
 
-// NewProtoBag creates a new proto-based attribute bag.
-func NewProtoBag(proto *mixerpb.CompressedAttributes, globalDict map[string]int32, globalWordList []string) *ProtoBag {
+var protoBags = sync.Pool{
+	New: func() interface{} {
+		return &ProtoBag{
+			referencedAttrs: make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, 16),
+		}
+	},
+}
+
+// GetProtoBag returns a proto-based attribute bag.
+// When you are done using the proto bag, call the Done method to recycle it.
+func GetProtoBag(proto *mixerpb.CompressedAttributes, globalDict map[string]int32, globalWordList []string) *ProtoBag {
+	pb := protoBags.Get().(*ProtoBag)
+
 	// build the message-level dictionary
 	d := make(map[string]int32, len(proto.Words))
 	for i, name := range proto.Words {
 		d[name] = slotToIndex(i)
 	}
 
-	out := &ProtoBag{
-		proto:           proto,
-		globalDict:      globalDict,
-		globalWordList:  globalWordList,
-		messageDict:     d,
-		referencedAttrs: make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, 16),
-	}
+	pb.proto = proto
+	pb.globalDict = globalDict
+	pb.globalWordList = globalWordList
+	pb.messageDict = d
 
-	scope.Debugf("Creating bag with attributes: %v", out)
+	scope.Debugf("Creating bag with attributes: %v", pb)
 
-	return out
+	return pb
 }
 
 // StringMap wraps a map[string]string and reference counts it
@@ -421,7 +427,20 @@ func (pb *ProtoBag) Names() []string {
 
 // Done indicates the bag can be reclaimed.
 func (pb *ProtoBag) Done() {
-	// NOP
+	pb.Reset()
+	protoBags.Put(pb)
+}
+
+// Reset removes all local state.
+func (pb *ProtoBag) Reset() {
+	pb.proto = nil
+	pb.globalDict = make(map[string]int32)
+	pb.globalWordList = nil
+	pb.messageDict = make(map[string]int32)
+	pb.convertedStringMaps = make(map[int32]StringMap)
+	pb.referencedAttrs = make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, 16)
+	pb.stringMapMutex = sync.RWMutex{}
+	pb.referencedAttrsMutex = sync.Mutex{}
 }
 
 // String runs through the named attributes, looks up their values,

--- a/mixer/pkg/attribute/protoBag.go
+++ b/mixer/pkg/attribute/protoBag.go
@@ -50,10 +50,13 @@ type ProtoBag struct {
 	referencedAttrsMutex sync.Mutex
 }
 
+// referencedAttrsSize is the size of referenced attributes.
+const referencedAttrsSize = 16
+
 var protoBags = sync.Pool{
 	New: func() interface{} {
 		return &ProtoBag{
-			referencedAttrs: make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, 16),
+			referencedAttrs: make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, referencedAttrsSize),
 		}
 	},
 }
@@ -74,7 +77,7 @@ func GetProtoBag(proto *mixerpb.CompressedAttributes, globalDict map[string]int3
 	pb.globalWordList = globalWordList
 	pb.messageDict = d
 
-	scope.Debugf("Creating bag with attributes: %v", pb)
+	scope.Debugf("Returning bag with attributes: %v", pb)
 
 	return pb
 }
@@ -438,7 +441,7 @@ func (pb *ProtoBag) Reset() {
 	pb.globalWordList = nil
 	pb.messageDict = make(map[string]int32)
 	pb.convertedStringMaps = make(map[int32]StringMap)
-	pb.referencedAttrs = make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, 16)
+	pb.referencedAttrs = make(map[attributeRef]mixerpb.ReferencedAttributes_Condition, referencedAttrsSize)
 	pb.stringMapMutex = sync.RWMutex{}
 	pb.referencedAttrsMutex = sync.Mutex{}
 }

--- a/mixer/pkg/mockapi/server.go
+++ b/mixer/pkg/mockapi/server.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/status"
@@ -95,7 +94,7 @@ func (a *AttributesServer) Check(ctx context.Context, req *mixerpb.CheckRequest)
 		return nil, fmt.Errorf("global dictionary mismatch: proxy %d and mixer %d", req.GlobalWordCount, len(a.GlobalDict))
 	}
 
-	requestBag := attribute.NewProtoBag(&req.Attributes, a.GlobalDict, attribute.GlobalList())
+	requestBag := attribute.GetProtoBag(&req.Attributes, a.GlobalDict, attribute.GlobalList())
 	defer requestBag.Done()
 
 	result := a.Handler.Check(requestBag)
@@ -157,7 +156,7 @@ func (a *AttributesServer) Report(ctx context.Context, req *mixerpb.ReportReques
 		}
 	}
 
-	protoBag := attribute.NewProtoBag(&req.Attributes[0], a.GlobalDict, attribute.GlobalList())
+	protoBag := attribute.GetProtoBag(&req.Attributes[0], a.GlobalDict, attribute.GlobalList())
 	requestBag := attribute.GetMutableBag(protoBag)
 	defer requestBag.Done()
 	defer protoBag.Done()

--- a/mixer/pkg/mockapi/server_test.go
+++ b/mixer/pkg/mockapi/server_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-
 	mixerpb "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/status"
@@ -89,7 +88,7 @@ func TestCheck(t *testing.T) {
 
 	client := mixerpb.NewMixerClient(conn)
 
-	srcBag := attribute.NewProtoBag(&attrs, attrSrv.GlobalDict, attribute.GlobalList())
+	srcBag := attribute.GetProtoBag(&attrs, attrSrv.GlobalDict, attribute.GlobalList())
 	wantBag := attribute.CopyBag(srcBag)
 
 	noQuotaReq := &mixerpb.CheckRequest{Attributes: attrs}
@@ -229,7 +228,7 @@ func TestReport(t *testing.T) {
 
 	words := []string{"foo", "bar", "baz"}
 
-	baseBag := attribute.CopyBag(attribute.NewProtoBag(&attrs[0], attrSrv.GlobalDict, attribute.GlobalList()))
+	baseBag := attribute.CopyBag(attribute.GetProtoBag(&attrs[0], attrSrv.GlobalDict, attribute.GlobalList()))
 	middleBag := attribute.CopyBag(baseBag)
 	if err = middleBag.UpdateBagFromProto(&attrs[1], attribute.GlobalList()); err != nil {
 		t.Fatalf("Could not set up attribute bags for testing: %v", err)

--- a/mixer/pkg/perf/run.go
+++ b/mixer/pkg/perf/run.go
@@ -178,10 +178,10 @@ func runDispatcherOnly(b benchmark, setup *Setup, settings *Settings) {
 	for i, r := range requests {
 		switch req := r.(type) {
 		case *istio_mixer_v1.ReportRequest:
-			bags[i] = attribute.NewProtoBag(&req.Attributes[0], globalDict, attribute.GlobalList())
+			bags[i] = attribute.GetProtoBag(&req.Attributes[0], globalDict, attribute.GlobalList())
 
 		case *istio_mixer_v1.CheckRequest:
-			bags[i] = attribute.NewProtoBag(&req.Attributes, globalDict, attribute.GlobalList())
+			bags[i] = attribute.GetProtoBag(&req.Attributes, globalDict, attribute.GlobalList())
 
 		default:
 			b.fatalf("unknown request type: %v", r)


### PR DESCRIPTION
Implement a pool of proto bags:
* Keep consistent with mutable bags, and completely implement Bag interface
* Use pool to cache and reuse allocated proto bags to reduce the pressure of GC