### PR TITLE
Add telemetry-gateway subchart to helm requirements.yaml file

### DIFF
--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -59,4 +59,6 @@ dependencies:
     version: ">=0.0.1"
     repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
     condition: istio_cni.enabled
-
+  - name: telemetry-gateway
+    version: 1.1.0
+    repository: file://../subcharts/telemetry-gateway


### PR DESCRIPTION
It looks like the telemetry-gateway subchart was forgotten when the `requirements.yaml` was modified during the migration to subcharts in #9306.

This PR adds a reference to the existing telemetry-gateway subchart to the requirements.yaml file.

cc @sdake