### PR TITLE
Alter Mixer tracing to only generate spans when service tracespan exists

### DIFF
--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -44,13 +44,6 @@ static_resources:
         path: /sock/mixer.socket
     http2_protocol_options: {}
     name: inbound_9092
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
-        address: zipkin
-        port_value: 9411
-    name: zipkin
-    type: STRICT_DNS
   - circuit_breakers:
       thresholds:
       - max_connections: 100000
@@ -169,7 +162,6 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "15004"
-          tracing: {}
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
       tls_context:
@@ -253,12 +245,5 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "9091"
-          tracing: {}
         name: envoy.http_connection_manager
     name: "9091"
-tracing:
-  http:
-    config:
-      collector_cluster: zipkin
-      collector_endpoint: /api/v1/spans
-    name: envoy.zipkin

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -44,13 +44,6 @@ static_resources:
         path: /sock/mixer.socket
     http2_protocol_options: {}
     name: inbound_9092
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
-        address: zipkin
-        port_value: 9411
-    name: zipkin
-    type: STRICT_DNS
   listeners:
   - address:
       socket_address:
@@ -137,7 +130,6 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "15004"
-          tracing: {}
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
       tls_context:
@@ -217,12 +209,5 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "9091"
-          tracing: {}
         name: envoy.http_connection_manager
     name: "9091"
-tracing:
-  http:
-    config:
-      collector_cluster: zipkin
-      collector_endpoint: /api/v1/spans
-    name: envoy.zipkin

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -95,14 +95,7 @@ func configure(serviceName string, options *Options, nz newZipkin) (io.Closer, e
 
 	reporters := make([]jaeger.Reporter, 0, 3)
 
-	sr := options.SamplingRate
-	if sr > 1.0 {
-		sr = 1.0
-	}
-	if sr < 0.0 {
-		sr = 0.0
-	}
-	sampler, err := jaeger.NewProbabilisticSampler(sr)
+	sampler, err := jaeger.NewProbabilisticSampler(options.SamplingRate)
 	if err != nil {
 		return nil, fmt.Errorf("could not build trace sampler: %v", err)
 	}

--- a/pkg/tracing/config_test.go
+++ b/pkg/tracing/config_test.go
@@ -44,11 +44,12 @@ func TestConfigure(t *testing.T) {
 		wantLog    bool
 	}{
 		{"no options", Options{}, false, false, false},
-		{"with logging", Options{LogTraceSpans: true}, false, false, true},
-		{"with jaeger", Options{JaegerURL: jaegerServer.URL}, true, false, false},
-		{"with zipkin", Options{ZipkinURL: zipkinServer.URL}, false, true, false},
-		{"with jaeger and logging", Options{JaegerURL: jaegerServer.URL}, true, false, false},
-		{"with zipkin and logging", Options{ZipkinURL: zipkinServer.URL, LogTraceSpans: true}, false, true, true},
+		{"with logging", Options{LogTraceSpans: true, SamplingRate: 1.0}, false, false, true},
+		{"with logging and no sampling", Options{LogTraceSpans: true}, false, false, false},
+		{"with jaeger", Options{JaegerURL: jaegerServer.URL, SamplingRate: 1.0}, true, false, false},
+		{"with zipkin", Options{ZipkinURL: zipkinServer.URL, SamplingRate: 1.0}, false, true, false},
+		{"with jaeger and logging", Options{JaegerURL: jaegerServer.URL, SamplingRate: 1.0}, true, false, false},
+		{"with zipkin and logging", Options{ZipkinURL: zipkinServer.URL, LogTraceSpans: true, SamplingRate: 1.0}, false, true, true},
 	}
 
 	for _, c := range cases {

--- a/pkg/tracing/options.go
+++ b/pkg/tracing/options.go
@@ -22,14 +22,17 @@ import (
 
 // Options defines the set of options supported by Istio's component tracing package.
 type Options struct {
-	// URL of zipkin collector (example: 'http://zipkin:9411/api/v1/spans'). This enables tracing for Mixer itself.
+	// URL of zipkin collector (example: 'http://zipkin:9411/api/v1/spans').
 	ZipkinURL string
 
-	// URL of jaeger HTTP collector (example: 'http://jaeger:14268/api/traces?format=jaeger.thrift'). This enables tracing for Mixer itself.
+	// URL of jaeger HTTP collector (example: 'http://jaeger:14268/api/traces?format=jaeger.thrift').
 	JaegerURL string
 
 	// Whether or not to emit trace spans as log records.
 	LogTraceSpans bool
+
+	// SamplingRate controls the rate at which a process will decide to generate trace spans.
+	SamplingRate float64
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults
@@ -66,4 +69,7 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVarP(&o.LogTraceSpans, "trace_log_spans", "", o.LogTraceSpans,
 		"Whether or not to log trace spans.")
+
+	cmd.PersistentFlags().Float64VarP(&o.SamplingRate, "trace_sampling_rate", "", o.SamplingRate,
+		"Sampling rate for generating trace data. Should be a value between 0.0 and 1.0.")
 }

--- a/pkg/tracing/options.go
+++ b/pkg/tracing/options.go
@@ -47,6 +47,10 @@ func (o *Options) Validate() error {
 		return errors.New("can't have Jaeger and Zipkin outputs active simultaneously")
 	}
 
+	if o.SamplingRate > 1.0 || o.SamplingRate < 0.0 {
+		return errors.New("sampling rate must be in the range: [0.0, 1.0]")
+	}
+
 	return nil
 }
 
@@ -71,5 +75,5 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 		"Whether or not to log trace spans.")
 
 	cmd.PersistentFlags().Float64VarP(&o.SamplingRate, "trace_sampling_rate", "", o.SamplingRate,
-		"Sampling rate for generating trace data. Should be a value between 0.0 and 1.0.")
+		"Sampling rate for generating trace data. Must be a value in the range [0.0, 1.0].")
 }

--- a/pkg/tracing/options_test.go
+++ b/pkg/tracing/options_test.go
@@ -65,8 +65,21 @@ func TestValidate(t *testing.T) {
 	o.ZipkinURL = "https://bar"
 
 	if o.Validate() == nil {
-		t.Error("Expecting failure, got success")
+		t.Error("Validate() did not produce expected failure")
 	}
+
+	o.JaegerURL = ""
+
+	o.SamplingRate = 14.45
+	if o.Validate() == nil {
+		t.Error("Validate() did not produce expected failure for invalid sampling rate")
+	}
+
+	o.SamplingRate = -1.0234
+	if o.Validate() == nil {
+		t.Error("Validate() did not produce expected failure for invalid sampling rate")
+	}
+
 }
 
 func TestTracingEnabled(t *testing.T) {


### PR DESCRIPTION
The goal of this PR is to prevent Mixer (as well as other Istio component) processes from generating tracespan data for all received requests. It further attempts to reduce the number of spans generated during the flow through Mixer by completely disabling tracing at the proxy for Mixer.

This should have two primary benefits:
1. Reduce overall volume of trace data generated by Mixer processes
1. Enable completely disabling trace data generation for Mixer processes via deployment updates

This PR removes the tracing configuration from the static envoy config files for istio-policy and istio-telemetry and adds a SamplingRate commandline option to the pkg/tracing.Options. By default, the SamplingRate will be 0.0 -- meaning that workloads using pkg/tracing will not generate tracespan data unless an incoming request already includes tracing headers that the configured extractor can identify and use.

[Example UI of span](https://user-images.githubusercontent.com/21148125/47524422-71ea5a00-d84f-11e8-8f9b-b3bc8172a5b7.png).

Original PR: #9280 

Fixes #4227.