### PR TITLE
use pkg/filewatcher package for watching MCP credentials and accesslist

### DIFF
--- a/galley/pkg/server/configmap_test.go
+++ b/galley/pkg/server/configmap_test.go
@@ -21,36 +21,9 @@ import (
 	"testing"
 
 	"github.com/fsnotify/fsnotify"
-
+	"istio.io/istio/pkg/filewatcher"
 	"istio.io/istio/pkg/mcp/server"
 )
-
-type fakeWatcher struct {
-	events chan fsnotify.Event
-	errors chan error
-	added  chan string
-}
-
-func (w *fakeWatcher) Add(path string) error {
-	w.added <- path
-	return nil
-}
-
-func (w *fakeWatcher) Close() error                { return nil }
-func (w *fakeWatcher) Events() chan fsnotify.Event { return w.events }
-func (w *fakeWatcher) Errors() chan error          { return w.errors }
-
-func newFakeWatcherFunc() (func() (fileWatcher, error), *fakeWatcher) {
-	w := &fakeWatcher{
-		events: make(chan fsnotify.Event, 1),
-		errors: make(chan error, 1),
-		added:  make(chan string, 1),
-	}
-	newWatcher := func() (fileWatcher, error) {
-		return w, nil
-	}
-	return newWatcher, w
-}
 
 func TestWatchAccessList_Basic(t *testing.T) {
 	initial := `
@@ -99,10 +72,11 @@ func TestWatchAccessList_Initial_NotExists(t *testing.T) {
 }
 
 func TestWatchAccessList_Update(t *testing.T) {
-	var fake *fakeWatcher
-	newFileWatcher, fake = newFakeWatcherFunc()
+	added := make(chan string, 10)
+	var fake *filewatcher.FakeWatcher
+	newFileWatcher, fake = filewatcher.NewFakeWatcher(func(path string, _ bool) { added <- path })
 	defer func() {
-		newFileWatcher = newFsnotifyWatcher
+		newFileWatcher = filewatcher.NewWatcher
 		readFile = ioutil.ReadFile
 		watchEventHandledProbe = nil
 	}()
@@ -119,7 +93,7 @@ allowed:
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	gotAddedFile := <-fake.added
+	gotAddedFile := <-added
 	if gotAddedFile != file {
 		t.Fatalf("access list watcher read the wrong file: got %v want %v", gotAddedFile, file)
 	}
@@ -140,10 +114,10 @@ allowed:
 	// fake the watch `Write` event and wait for the event to be handled and the accesslist updated.
 	watchEventHandled := make(chan struct{})
 	watchEventHandledProbe = func() { close(watchEventHandled) }
-	fake.events <- fsnotify.Event{
+	fake.InjectEvent(file, fsnotify.Event{
 		Name: file,
 		Op:   fsnotify.Write,
-	}
+	})
 	<-watchEventHandled
 
 	if !checker.Allowed("spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account") {

--- a/pkg/filewatcher/fakefilewatcher.go
+++ b/pkg/filewatcher/fakefilewatcher.go
@@ -1,0 +1,143 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filewatcher
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// NewFileWatcherFunc returns a functions which creates a new file
+// watcher. This may be used to provide test hooks for using the
+// FakeWatcher implementation below.
+type NewFileWatcherFunc func() FileWatcher
+
+// FakeWatcher provides a fake file watcher implementation for unit
+// tests. Production code should use the `NewWatcher()`.
+type FakeWatcher struct {
+	sync.Mutex
+
+	events      map[string]chan fsnotify.Event
+	errors      map[string]chan error
+	changedFunc func(path string, added bool)
+}
+
+// InjectEvent injects an event into the fake file watcher.
+func (w *FakeWatcher) InjectEvent(path string, event fsnotify.Event) {
+	w.Lock()
+	ch, ok := w.events[path]
+	w.Unlock()
+
+	if ok {
+		ch <- event
+	}
+}
+
+// InjectError injects an error into the fake file watcher.
+func (w *FakeWatcher) InjectError(path string, err error) {
+	w.Lock()
+	ch, ok := w.errors[path]
+	w.Unlock()
+
+	if ok {
+		ch <- err
+	}
+}
+
+// NewFakeWatcher returns a function which creates a new fake watcher for unit
+// testing. This allows observe callers to inject events and errors per-watched
+// path. changedFunc() provides a callback notification when a new watch is added
+// or removed. Production code should use `NewWatcher()`.
+func NewFakeWatcher(changedFunc func(path string, added bool)) (NewFileWatcherFunc, *FakeWatcher) {
+	w := &FakeWatcher{
+		events:      make(map[string]chan fsnotify.Event),
+		errors:      make(map[string]chan error),
+		changedFunc: changedFunc,
+	}
+	return func() FileWatcher {
+		return w
+	}, w
+}
+
+// Add is a fake implementation of the FileWatcher interface.
+func (w *FakeWatcher) Add(path string) error {
+	w.Lock()
+
+	// w.events and w.errors are always updated togeather. We only check
+	// the first to determine existence.
+	if _, ok := w.events[path]; ok {
+		w.Unlock()
+		return fmt.Errorf("path %v already exists", path)
+	}
+
+	w.events[path] = make(chan fsnotify.Event, 1000)
+	w.errors[path] = make(chan error, 1000)
+
+	w.Unlock()
+
+	if w.changedFunc != nil {
+		w.changedFunc(path, true)
+	}
+	return nil
+}
+
+// Remove is a fake implementation of the FileWatcher interface.
+func (w *FakeWatcher) Remove(path string) error {
+	w.Lock()
+	defer w.Unlock()
+
+	if _, ok := w.events[path]; !ok {
+		return errors.New("path doesn't exist")
+	}
+
+	delete(w.events, path)
+	delete(w.errors, path)
+	if w.changedFunc != nil {
+		w.changedFunc(path, false)
+	}
+	return nil
+}
+
+// Close is a fake implementation of the FileWatcher interface.
+func (w *FakeWatcher) Close() error {
+	w.Lock()
+	for path, ch := range w.events {
+		close(ch)
+		delete(w.events, path)
+	}
+	for path, ch := range w.errors {
+		close(ch)
+		delete(w.errors, path)
+	}
+	defer w.Unlock()
+	return nil
+}
+
+// Events is a fake implementation of the FileWatcher interface.
+func (w *FakeWatcher) Events(path string) chan fsnotify.Event {
+	w.Lock()
+	defer w.Unlock()
+	return w.events[path]
+}
+
+// Errors is a fake implementation of the FileWatcher interface.
+func (w *FakeWatcher) Errors(path string) chan error {
+	w.Lock()
+	defer w.Unlock()
+	return w.errors[path]
+}

--- a/pkg/filewatcher/fakefilewatcher_test.go
+++ b/pkg/filewatcher/fakefilewatcher_test.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filewatcher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestFakeFileWatcher(t *testing.T) {
+	addedChan := make(chan string, 10)
+	removedChan := make(chan string, 10)
+
+	changed := func(path string, added bool) {
+		if added {
+			addedChan <- path
+		} else {
+			removedChan <- path
+		}
+	}
+
+	newWatcher, fakeWatcher := NewFakeWatcher(changed)
+	watcher := newWatcher()
+
+	// verify Add()/Remove()
+	for _, file := range []string{"foo", "bar", "baz"} {
+		if err := watcher.Add(file); err != nil {
+			t.Fatalf("Add() returned error: %v", err)
+		}
+		gotAdd := <-addedChan
+		if gotAdd != file {
+			t.Fatalf("Add() failed: got %v want %v", gotAdd, file)
+		}
+		select {
+		case <-removedChan:
+			t.Fatal("Add() failed: callback invoked with added=false")
+		default:
+		}
+
+		wantEvent := fsnotify.Event{file, fsnotify.Write}
+		fakeWatcher.InjectEvent(file, wantEvent)
+		gotEvent := <-watcher.Events(file)
+		if gotEvent != wantEvent {
+			t.Fatalf("Events() failed: got %v want %v", gotEvent, wantEvent)
+		}
+
+		wantError := fmt.Errorf("error=%v", file)
+		fakeWatcher.InjectError(file, wantError)
+		gotError := <-watcher.Errors(file)
+		if gotError != wantError {
+			t.Fatalf("Errors() failed: got %v want %v", gotError, wantError)
+		}
+
+		if err := watcher.Remove(file); err != nil {
+			t.Fatalf("Remove() returned error: %v", err)
+		}
+		gotRemove := <-removedChan
+		if gotRemove != file {
+			t.Fatalf("Remove() failed: got %v want %v", gotRemove, file)
+		}
+		select {
+		case <-addedChan:
+			t.Fatal("Remove() failed: callback invoked with added=false")
+		default:
+		}
+
+		wantEvent = fsnotify.Event{file, fsnotify.Write}
+		fakeWatcher.InjectEvent(file, wantEvent)
+		select {
+		case gotEvent := <-watcher.Events(file):
+			t.Fatalf("Unexpected Events() after Remove(): got %v", gotEvent)
+		default:
+		}
+
+		wantError = fmt.Errorf("error=%v", file)
+		fakeWatcher.InjectError(file, wantError)
+		select {
+		case gotError := <-watcher.Errors(file):
+			t.Fatalf("Unexpected Errors() after Remove(): got %v", gotError)
+		default:
+		}
+	}
+
+	// verify double Add() / Remove()
+	for _, file := range []string{"foo2", "bar2", "baz2"} {
+		if err := watcher.Add(file); err != nil {
+			t.Fatalf("Add() returned error: %v", err)
+		}
+		if err := watcher.Add(file); err == nil {
+			t.Fatal("Adding a path that already exists should fail")
+		}
+		if err := watcher.Remove(file); err != nil {
+			t.Fatalf("Remove() returned error: %v", err)
+		}
+		if err := watcher.Remove(file); err == nil {
+			t.Fatal("Removing a path that doesn't exist should fail")
+		}
+	}
+
+	// verify Close()
+	for _, file := range []string{"foo3", "bar3", "baz3"} {
+		watcher.Add(file)
+	}
+	if err := watcher.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	for _, file := range []string{"foo2", "bar2", "baz2"} {
+		wantEvent := fsnotify.Event{file, fsnotify.Write}
+		fakeWatcher.InjectEvent(file, wantEvent)
+		select {
+		case gotEvent := <-watcher.Events(file):
+			t.Fatalf("Unexpected Events() after Remove(): got %v", gotEvent)
+		default:
+		}
+
+		wantError := fmt.Errorf("error=%v", file)
+		fakeWatcher.InjectError(file, wantError)
+		select {
+		case gotError := <-watcher.Errors(file):
+			t.Fatalf("Unexpected Errors() after Remove(): got %v", gotError)
+		default:
+		}
+	}
+}


### PR DESCRIPTION
MCP client/server packages and Galley's accesslist both watch local
files for configuration and credentials updates. The previous code did
not properly handle symlinks (e.g. k8s secrets/configmaps). This PR
uses the newly introduced pkg/filewatcher package to solve this problem.

This PR also adds a FakeFileWatcher to the pkg/filewatcher package for
unit testing packages that depend on file watches.

fixes https://github.com/istio/istio/issues/7877
