### PR TITLE
Replace `ISTIO_NETWORK` with `NETWORK`

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_sh_test.go
@@ -119,7 +119,7 @@ func verifySplitHorizonResponse(t *testing.T, network string, sidecarId string, 
 
 	metadata := &proto.Struct{Fields: map[string]*proto.Value{
 		"ISTIO_PROXY_VERSION": {Kind: &proto.Value_StringValue{StringValue: "1.1"}},
-		"ISTIO_NETWORK":       {Kind: &proto.Value_StringValue{StringValue: network}},
+		"NETWORK":             {Kind: &proto.Value_StringValue{StringValue: network}},
 	}}
 
 	err = sendCDSReqWithMetadata(sidecarId, metadata, edsstr)

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -33,7 +33,7 @@ type EndpointsFilterFunc func(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 // Information for the mesh networks is provided as a MeshNetwork config map.
 func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *XdsConnection, env *model.Environment) []endpoint.LocalityLbEndpoints {
 	// If the sidecar does not specify a network, ignore Split Horizon EDS and return all
-	network, found := conn.modelNode.Metadata["ISTIO_NETWORK"]
+	network, found := conn.modelNode.Metadata["NETWORK"]
 	if !found {
 
 		// TODO: try to get the network by querying the service registry to get the

--- a/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters_test.go
@@ -176,7 +176,7 @@ func TestEndpointsByNetworkFilter(t *testing.T) {
 func xdsConnection(network string) *XdsConnection {
 	var metadata map[string]string
 	if network != "" {
-		metadata = map[string]string{"ISTIO_NETWORK": network}
+		metadata = map[string]string{"NETWORK": network}
 	}
 	return &XdsConnection{
 		modelNode: &model.Proxy{


### PR DESCRIPTION
As commented in istio/api, in side car env `ISTIO_META_NETWORK` is used to specify network, so the pilot side, meta[ `NETWORK`] is right.