### PR TITLE
use NewSharedInformerFactoryWithOptions to init shared informer factory 

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -146,7 +146,7 @@ func NewController(client kubernetes.Interface, options ControllerOptions) *Cont
 		ranger:       cidranger.NewPCTrieRanger(),
 	}
 
-	sharedInformers := informers.NewFilteredSharedInformerFactory(client, options.ResyncPeriod, options.WatchedNamespace, nil)
+	sharedInformers := informers.NewSharedInformerFactoryWithOptions(client, options.ResyncPeriod, informers.WithNamespace(options.WatchedNamespace))
 
 	svcInformer := sharedInformers.Core().V1().Services().Informer()
 	out.services = out.createCacheHandler(svcInformer, "Services")


### PR DESCRIPTION
As NewFilteredSharedInformerFactory was deprecated in 1.11, should update NewSharedInformerFactoryWithOptions .