### PR TITLE
add resources to init containers

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -54,6 +54,8 @@ data:
           privileged: true
           {{ end -}}
         restartPolicy: Always
+        resources:
+{{ toYaml .Values.global.proxy_init.resources | indent 10 }}
 {{- end }}
       {{ if eq .Values.global.proxy.enableCoreDump true }}
       - name: enable-core-dump
@@ -68,7 +70,8 @@ data:
         image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
   {{- end }}
         imagePullPolicy: IfNotPresent
-        resources: {}
+        resources:
+{{ toYaml .Values.global.proxy_init.resources | indent 10 }}
         securityContext:
           privileged: true
       {{ end }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -196,6 +196,15 @@ global:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init
 
+    # Resources for init containers.
+    resources: {}
+      # requests:
+      #   cpu: 10m
+      #  memory: 128Mi
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+
   # imagePullPolicy is applied to istio control plane components.
   # local tests require IfNotPresent, to avoid uploading to dockerhub.
   # TODO: Switch to Always as default, and override in the local tests.
@@ -282,7 +291,7 @@ global:
   # NOTE: If using templates, follow the pattern in the commented example below.
   #podDNSSearchNamespaces:
   #- global
-  #- "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"  
+  #- "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"
 
   # If set to true, the pilot and citadel mtls will be exposed on the
   # ingress gateway

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -200,7 +200,7 @@ global:
     resources: {}
       # requests:
       #   cpu: 10m
-      #  memory: 128Mi
+      #   memory: 128Mi
       # limits:
       #   cpu: 100m
       #   memory: 128Mi


### PR DESCRIPTION
When you configure resources quotas limit for a namespace, you always need to specify the resource request and limit, or set a default values using a `LimitRange`. However, when working with istio sidecard injection and mutation weebhooks, the default resources will not be applied to init containers.

Don't know if this is an issue in kubernetes in general, but as far as I know, `MutatingAdmissionWebhook` happens after `LimitRanger` and before `ResourceQuota` (according to [this](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use) order) so the default resources should by applied but this is not the case.

This PR enables setting the resources for the init containers in the helm chart.

After applying this changes I was able to use sidecard injection without any issues.