### PR TITLE
Switch to pstauffer/curl image

### DIFF
--- a/samples/sleep/sleep.yaml
+++ b/samples/sleep/sleep.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: sleep
       containers:
       - name: sleep
-        image: tutum/curl
+        image: pstauffer/curl
         command: ["/bin/sleep","infinity"]
         imagePullPolicy: IfNotPresent
 ---


### PR DESCRIPTION
`tutum/curl` image has been deleted from docker hub.