### PR TITLE
Add initial metrics for tracking tcp conn open/close

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -537,6 +537,60 @@ spec:
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpconnectionsopened
+  namespace: istio-system
+spec:
+  value: "1"
+  dimensions:
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
+    source_namespace: source.namespace | "unknown"
+    source_workload: source.workload.name | "unknown"
+    source_workload_namespace: source.workload.namespace | "unknown"
+    source_principal: source.principal | "unknown"
+    source_app: source.labels["app"] | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_namespace: destination.namespace | "unknown"
+    destination_workload: destination.workload.name | "unknown"
+    destination_workload_namespace: destination.workload.namespace | "unknown"
+    destination_principal: destination.principal | "unknown"
+    destination_app: destination.labels["app"] | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
+    destination_service: destination.service.host | "unknown"
+    destination_service_name: destination.service.name | "unknown"
+    destination_service_namespace: destination.service.namespace | "unknown"
+    connection_mtls: connection.mtls | false
+  monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpconnectionsclosed
+  namespace: istio-system
+spec:
+  value: "1"
+  dimensions:
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
+    source_namespace: source.namespace | "unknown"
+    source_workload: source.workload.name | "unknown"
+    source_workload_namespace: source.workload.namespace | "unknown"
+    source_principal: source.principal | "unknown"
+    source_app: source.labels["app"] | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_namespace: destination.namespace | "unknown"
+    destination_workload: destination.workload.name | "unknown"
+    destination_workload_namespace: destination.workload.namespace | "unknown"
+    destination_principal: destination.principal | "unknown"
+    destination_app: destination.labels["app"] | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
+    destination_service: destination.service.host | "unknown"
+    destination_service_name: destination.service.name | "unknown"
+    destination_service_namespace: destination.service.namespace | "unknown"
+    connection_mtls: connection.mtls | false
+  monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
   name: prometheus
@@ -695,6 +749,48 @@ spec:
       - destination_service_name
       - destination_service_namespace
       - connection_security_policy
+    - name: tcp_connections_opened_total
+      instance_name: tcpconnectionsopened.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_namespace
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_namespace
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_mtls
+    - name: tcp_connections_closed_total
+      instance_name: tcpconnectionsclosed.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_namespace
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_namespace
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_mtls
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -733,6 +829,30 @@ spec:
     instances:
     - tcpbytesent.metric
     - tcpbytereceived.metric
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionopen
+  namespace: istio-system
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsopened.metric
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionclosed
+  namespace: istio-system
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsclosed.metric
 ---
 
 apiVersion: "config.istio.io/v1alpha2"

--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -540,54 +540,50 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: metric
 metadata:
   name: tcpconnectionsopened
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
 spec:
   value: "1"
   dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
-    source_namespace: source.namespace | "unknown"
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
     source_principal: source.principal | "unknown"
     source_app: source.labels["app"] | "unknown"
     source_version: source.labels["version"] | "unknown"
-    destination_namespace: destination.namespace | "unknown"
     destination_workload: destination.workload.name | "unknown"
     destination_workload_namespace: destination.workload.namespace | "unknown"
     destination_principal: destination.principal | "unknown"
     destination_app: destination.labels["app"] | "unknown"
     destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
+    destination_service: destination.service.name | "unknown"
     destination_service_name: destination.service.name | "unknown"
     destination_service_namespace: destination.service.namespace | "unknown"
-    connection_mtls: connection.mtls | false
+    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
 metadata:
   name: tcpconnectionsclosed
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
 spec:
   value: "1"
   dimensions:
-    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
-    source_namespace: source.namespace | "unknown"
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
     source_workload: source.workload.name | "unknown"
     source_workload_namespace: source.workload.namespace | "unknown"
     source_principal: source.principal | "unknown"
     source_app: source.labels["app"] | "unknown"
     source_version: source.labels["version"] | "unknown"
-    destination_namespace: destination.namespace | "unknown"
     destination_workload: destination.workload.name | "unknown"
     destination_workload_namespace: destination.workload.namespace | "unknown"
     destination_principal: destination.principal | "unknown"
     destination_app: destination.labels["app"] | "unknown"
     destination_version: destination.labels["version"] | "unknown"
-    destination_service: destination.service.host | "unknown"
+    destination_service: destination.service.name | "unknown"
     destination_service_name: destination.service.name | "unknown"
     destination_service_namespace: destination.service.namespace | "unknown"
-    connection_mtls: connection.mtls | false
+    connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
   monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -750,18 +746,16 @@ spec:
       - destination_service_namespace
       - connection_security_policy
     - name: tcp_connections_opened_total
-      instance_name: tcpconnectionsopened.metric.istio-system
+      instance_name: tcpconnectionsopened.metric.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
       - source_app
-      - source_namespace
       - source_principal
       - source_workload
       - source_workload_namespace
       - source_version
       - destination_app
-      - destination_namespace
       - destination_principal
       - destination_workload
       - destination_workload_namespace
@@ -769,20 +763,18 @@ spec:
       - destination_service
       - destination_service_name
       - destination_service_namespace
-      - connection_mtls
+      - connection_security_policy
     - name: tcp_connections_closed_total
-      instance_name: tcpconnectionsclosed.metric.istio-system
+      instance_name: tcpconnectionsclosed.metric.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
       - source_app
-      - source_namespace
       - source_principal
       - source_workload
       - source_workload_namespace
       - source_version
       - destination_app
-      - destination_namespace
       - destination_principal
       - destination_workload
       - destination_workload_namespace
@@ -790,7 +782,7 @@ spec:
       - destination_service
       - destination_service_name
       - destination_service_namespace
-      - connection_mtls
+      - connection_security_policy
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -834,7 +826,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promtcpconnectionopen
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
   actions:
@@ -846,7 +838,7 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: promtcpconnectionclosed
-  namespace: istio-system
+  namespace: {{ .Release.Namespace }}
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
   actions:

--- a/mixer/testdata/config/prometheus.yaml
+++ b/mixer/testdata/config/prometheus.yaml
@@ -157,6 +157,48 @@ spec:
       - destination_service_name
       - destination_service_namespace
       - connection_mtls
+    - name: tcp_connections_opened_total
+      instance_name: tcpconnectionsopened.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_namespace
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_namespace
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_mtls
+    - name: tcp_connections_closed_total
+      instance_name: tcpconnectionsclosed.metric.istio-system
+      kind: COUNTER
+      label_names:
+      - reporter
+      - source_app
+      - source_namespace
+      - source_principal
+      - source_workload
+      - source_workload_namespace
+      - source_version
+      - destination_app
+      - destination_namespace
+      - destination_principal
+      - destination_workload
+      - destination_workload_namespace
+      - destination_version
+      - destination_service
+      - destination_service_name
+      - destination_service_namespace
+      - connection_mtls
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
@@ -182,7 +224,30 @@ spec:
   match: context.protocol == "tcp"
   actions:
   - handler: prometheus
-    instances:    
+    instances:
     - tcpbytesent.metric
     - tcpbytereceived.metric
 ---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionopen
+  namespace: istio-system
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsopened.metric
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: promtcpconnectionclosed
+  namespace: istio-system
+spec:
+  match: context.protocol == "tcp" && ((connection.event | "na") == "closed")
+  actions:
+  - handler: prometheus
+    instances:
+    - tcpconnectionsclosed.metric

--- a/mixer/testdata/config/tcpmetrics.yaml
+++ b/mixer/testdata/config/tcpmetrics.yaml
@@ -55,3 +55,57 @@ spec:
     destination_service_namespace: destination.service.namespace | "unknown"
     connection_mtls: connection.mtls | false
   monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpconnectionsopened
+  namespace: istio-system
+spec:
+  value: "1"
+  dimensions:
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
+    source_namespace: source.namespace | "unknown"
+    source_workload: source.workload.name | "unknown"
+    source_workload_namespace: source.workload.namespace | "unknown"
+    source_principal: source.principal | "unknown"
+    source_app: source.labels["app"] | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_namespace: destination.namespace | "unknown"
+    destination_workload: destination.workload.name | "unknown"
+    destination_workload_namespace: destination.workload.namespace | "unknown"
+    destination_principal: destination.principal | "unknown"
+    destination_app: destination.labels["app"] | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
+    destination_service: destination.service.host | "unknown"
+    destination_service_name: destination.service.name | "unknown"
+    destination_service_namespace: destination.service.namespace | "unknown"
+    connection_mtls: connection.mtls | false
+  monitored_resource_type: '"UNSPECIFIED"'
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: metric
+metadata:
+  name: tcpconnectionsclosed
+  namespace: istio-system
+spec:
+  value: "1"
+  dimensions:
+    reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
+    source_namespace: source.namespace | "unknown"
+    source_workload: source.workload.name | "unknown"
+    source_workload_namespace: source.workload.namespace | "unknown"
+    source_principal: source.principal | "unknown"
+    source_app: source.labels["app"] | "unknown"
+    source_version: source.labels["version"] | "unknown"
+    destination_namespace: destination.namespace | "unknown"
+    destination_workload: destination.workload.name | "unknown"
+    destination_workload_namespace: destination.workload.namespace | "unknown"
+    destination_principal: destination.principal | "unknown"
+    destination_app: destination.labels["app"] | "unknown"
+    destination_version: destination.labels["version"] | "unknown"
+    destination_service: destination.service.host | "unknown"
+    destination_service_name: destination.service.name | "unknown"
+    destination_service_namespace: destination.service.namespace | "unknown"
+    connection_mtls: connection.mtls | false
+  monitored_resource_type: '"UNSPECIFIED"'

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -559,41 +559,35 @@ func TestTcpMetrics(t *testing.T) {
 		fatalf(t, "Could not build prometheus API client: %v", err)
 	}
 	query := fmt.Sprintf("istio_tcp_sent_bytes_total{destination_app=\"%s\"}", "mongodb")
+	want := float64(1)
+	validateMetric(t, promAPI, query, "istio_tcp_sent_bytes_total", want)
+
+	query = fmt.Sprintf("istio_tcp_received_bytes_total{destination_app=\"%s\"}", "mongodb")
+	validateMetric(t, promAPI, query, "istio_tcp_received_bytes_total", want)
+
+	query = fmt.Sprintf("sum(istio_tcp_connections_opened_total{destination_app=\"%s\"})", "mongodb")
+	validateMetric(t, promAPI, query, "istio_tcp_connections_opened_total", want)
+
+	query = fmt.Sprintf("sum(istio_tcp_connections_closed_total{destination_app=\"%s\"})", "mongodb")
+	validateMetric(t, promAPI, query, "istio_tcp_connections_closed_total", want)
+}
+
+func validateMetric(t *testing.T, promAPI v1.API, query, metricName string, want float64) {
+	t.Helper()
 	t.Logf("prometheus query: %s", query)
 	value, err := promAPI.Query(context.Background(), query, time.Now())
 	if err != nil {
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
-	log.Infof("promvalue := %s", value.String())
 
 	got, err := vectorValue(value, map[string]string{})
 	if err != nil {
-		t.Logf("prometheus values for istio_tcp_sent_bytes_total:\n%s", promDump(promAPI, "istio_tcp_sent_bytes_total"))
+		t.Logf("prometheus values for %s:\n%s", metricName, promDump(promAPI, metricName))
 		fatalf(t, "Could not find metric value: %v", err)
 	}
-	t.Logf("tcp_sent_bytes_total: %f", got)
-	want := float64(1)
+	t.Logf("%s: %f", metricName, got)
 	if got < want {
-		t.Logf("prometheus values for istio_tcp_sent_bytes_total:\n%s", promDump(promAPI, "istio_tcp_sent_bytes_total"))
-		errorf(t, "Bad metric value: got %f, want at least %f", got, want)
-	}
-
-	query = fmt.Sprintf("istio_tcp_received_bytes_total{destination_app=\"%s\"}", "mongodb")
-	t.Logf("prometheus query: %s", query)
-	value, err = promAPI.Query(context.Background(), query, time.Now())
-	if err != nil {
-		fatalf(t, "Could not get metrics from prometheus: %v", err)
-	}
-	log.Infof("promvalue := %s", value.String())
-
-	got, err = vectorValue(value, map[string]string{})
-	if err != nil {
-		t.Logf("prometheus values for istio_tcp_received_bytes_total:\n%s", promDump(promAPI, "istio_tcp_received_bytes_total"))
-		fatalf(t, "Could not find metric value: %v", err)
-	}
-	t.Logf("tcp_received_bytes_total: %f", got)
-	if got < want {
-		t.Logf("prometheus values for istio_tcp_received_bytes_total:\n%s", promDump(promAPI, "istio_tcp_received_bytes_total"))
+		t.Logf("prometheus values for %s:\n%s", metricName, promDump(promAPI, metricName))
 		errorf(t, "Bad metric value: got %f, want at least %f", got, want)
 	}
 }


### PR DESCRIPTION
For a long while now, we've wanted to introduce metrics that allow for tracking the rate of new TCP connections (as well as estimate the number of current open connections). This PR offers metrics for that purpose, based on the `connection.event` attribute that was introduced around the 1.0 cutoff timeframe.

This PR enables issues promql queries like:
- `sum(istio_tcp_connections_opened_total) by (reporter, destination_app, destination_version, source_version, source_app)`
- `sum(istio_tcp_connections_opened_total - istio_tcp_connections_closed_total) by (destination_app)`

