### PR TITLE
Permit port to domain validation.

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -268,7 +268,19 @@ func checkDNS1123Preconditions(name string) error {
 
 func validateDNS1123Labels(domain string) error {
 	parts := strings.Split(domain, ".")
-	topLevelDomain := parts[len(parts)-1]
+	lastPart := parts[len(parts)-1]
+	lastPartArray := strings.SplitN(lastPart, ":", 2)
+	
+	// Allow port in domain name
+	if len(lastPartArray) > 1 {
+		port, err := strconv.Atoi(lastPartArray[1])
+		if err != nil {
+			return fmt.Errorf("port (%s) is not a number: %v", lastPartArray[1], err)
+		}
+		return ValidatePort(int(port))
+	}
+
+	topLevelDomain := lastPartArray[0]
 	if _, err := strconv.Atoi(topLevelDomain); err == nil {
 		return fmt.Errorf("domain name %q invalid (top level domain %q cannot be all-numeric)", domain, topLevelDomain)
 	}

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -270,7 +270,7 @@ func validateDNS1123Labels(domain string) error {
 	parts := strings.Split(domain, ".")
 	lastPart := parts[len(parts)-1]
 	lastPartArray := strings.SplitN(lastPart, ":", 2)
-	
+
 	// Allow port in domain name
 	if len(lastPartArray) > 1 {
 		port, err := strconv.Atoi(lastPartArray[1])


### PR DESCRIPTION
According to RFC, `host` of HTTP header can be the plain `host` or `host`:`port`. 
Although https://github.com/istio/istio/pull/7994 https://github.com/istio/istio/pull/7995 have fixed that, but galley validation still blocks adding `port` to `host`, see: https://github.com/istio/istio/issues/6469