### PR TITLE
add dynamic_state attribute to attribute manifest

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -41,7 +41,7 @@ spec:
     request.useragent:
       valueType: STRING
     request.dynamic_state:
-      valueType: BYTES
+      valueType: STRING
     response.code:
       valueType: INT64
     response.duration:
@@ -89,7 +89,7 @@ spec:
     connection.requested_server_name:
       valueType: STRING
     connection.dynamic_state:
-      valueType: BYTES
+      valueType: STRING
     context.protocol:
       valueType: STRING
     context.timestamp:

--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -40,6 +40,8 @@ spec:
       valueType: TIMESTAMP
     request.useragent:
       valueType: STRING
+    request.dynamic_state:
+      valueType: BYTES
     response.code:
       valueType: INT64
     response.duration:
@@ -86,6 +88,8 @@ spec:
       valueType: BOOL
     connection.requested_server_name:
       valueType: STRING
+    connection.dynamic_state:
+      valueType: BYTES
     context.protocol:
       valueType: STRING
     context.timestamp:

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -36,7 +36,7 @@ spec:
       request.useragent:
         valueType: STRING
       request.dynamic_state:
-        valueType: BYTES
+        valueType: STRING
       response.code:
         valueType: INT64
       response.duration:
@@ -78,7 +78,7 @@ spec:
       connection.requested_server_name:
         valueType: STRING
       connection.dynamic_state:
-        valueType: BYTES
+        valueType: STRING
       context.protocol:
         valueType: STRING
       context.timestamp:

--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -35,6 +35,8 @@ spec:
         valueType: TIMESTAMP
       request.useragent:
         valueType: STRING
+      request.dynamic_state:
+        valueType: BYTES
       response.code:
         valueType: INT64
       response.duration:
@@ -75,6 +77,8 @@ spec:
         valueType: BOOL
       connection.requested_server_name:
         valueType: STRING
+      connection.dynamic_state:
+        valueType: BYTES
       context.protocol:
         valueType: STRING
       context.timestamp:


### PR DESCRIPTION
this attribute is sent only in the report calls.
related to https://github.com/istio/istio/issues/9613

Note: I explicitly refrained from dumping this via access log
as the dynamic state is essentially envoy metadata. A mixer adapter
can choose to decode and extract the desired info from envoy report calls.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>