### PR TITLE
[release] Fix istio/cni repo location and helm repo add for chart dependencies

### DIFF
--- a/release/gcb/helm_charts.sh
+++ b/release/gcb/helm_charts.sh
@@ -28,7 +28,7 @@ mkdir -vp "$WORK_DIR/istio"
 cp -R "./istio-${CB_VERSION}/install" "$WORK_DIR/istio/install"
 
 pushd "$WORK_DIR"
-    git clone -b master https://github.com/istio-ecosystem/cni.git
+    git clone -b master https://github.com/istio/cni.git
 popd
 
 
@@ -42,6 +42,7 @@ CHARTS=(
 # Prepare helm setup
 mkdir -vp "$HELM_DIR"
 $HELM init --client-only
+$HELM repo add istio.io https://raw.githubusercontent.com/istio/istio.io/master/static/charts
 
 # Create a package for each charts and build the repo index.
 mkdir -vp "$HELM_BUILD_DIR"


### PR DESCRIPTION
- The istio/cni is repo moved from istio-ecosystem/cni.
- helm repo add for the chart URL is required for `helm package -u ...` dependencies in the istio/istio helm required.yaml
