### PR TITLE
helm: requirements.yaml to use helm repo alias for istio-cni dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ export ENABLE_ISTIO_CNI ?= false
 # EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-foo"
 
 
-ISTIO_HELM_REPO := https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+ISTIO_HELM_REPO ?= https://raw.githubusercontent.com/istio/istio.io/master/static/charts
 #-----------------------------------------------------------------------------
 # Output control
 #-----------------------------------------------------------------------------

--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
     repository: file://../subcharts/security
   - name: istio-cni
     version: ">=0.0.1"
-    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    repository: "@istio.io"
     condition: istio_cni.enabled

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -57,6 +57,6 @@ dependencies:
     repository: file://../subcharts/certmanager
   - name: istio-cni
     version: ">=0.0.1"
-    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    repository: "@istio.io"
     condition: istio_cni.enabled
 


### PR DESCRIPTION
Also, allow Makefile to use an env var ISTIO_HELM_REPO for URL.

- This works as long as each environment that does helm package updates, e.g. `helm dependency update`, adds a helm repo called `istio.io` with an arbitrary URL
   - Makefile does this
   - release/helm_charts.sh does this
   - fix for https://github.com/istio/istio.io/scripts/grab_charts.sh will do it with merge of PR https://github.com/istio/istio.io/pull/2827

This allows the release scripts to be free to choose a release specific istio-cni chart URL to create the helm repo.