### PR TITLE
use DNS srv format for istio sni names in mTLS connections

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -317,7 +317,7 @@ func convertIstioMutual(service *model.Service, port *model.Port, serviceAccount
 			// SNI for subset cluster when using Istio MTLS
 			sni := fmt.Sprintf("%s_.%d_.%s_.%s", model.TrafficDirectionOutbound, port.Port, subset.Name, service.Hostname)
 			converter(subset.TrafficPolicy.Tls, sni)
-			portLevelConverter(port, destinationRule.TrafficPolicy.PortLevelSettings, sni)
+			portLevelConverter(port, subset.TrafficPolicy.PortLevelSettings, sni)
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -157,7 +157,7 @@ func TestBuildSidecarClustersWithIstioMutualAndSNI(t *testing.T) {
 
 	cluster = clusters[1]
 	g.Expect(cluster.Name).To(gomega.Equal("outbound|8080|foobar|foo.example.org"))
-	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal(cluster.Name))
+	g.Expect(cluster.TlsContext.GetSni()).To(gomega.Equal("outbound_.8080_.foobar_.foo.example.org"))
 }
 
 func buildEnvForClustersWithIstioMutualWithSNI(sniValue string) *model.Environment {


### PR DESCRIPTION
We were previously using cluster name as SNI, but cluster names
cannot be used in Gateway/virtual service routing.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>