### PR TITLE
Extend status pkg to expose all grpc status codes

### DIFF
--- a/mixer/pkg/status/status.go
+++ b/mixer/pkg/status/status.go
@@ -67,6 +67,56 @@ func WithDeadlineExceeded(message string) rpc.Status {
 	return rpc.Status{Code: int32(rpc.DEADLINE_EXCEEDED), Message: message}
 }
 
+// WithUnknown returns an initialized status with the rpc.UNKNOWN code and the given message.
+func WithUnknown(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.UNKNOWN), Message: message}
+}
+
+// WithNotFound returns an initialized status with the rpc.NOT_FOUND code and the given message.
+func WithNotFound(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.NOT_FOUND), Message: message}
+}
+
+// WithAlreadyExists returns an initialized status with the rpc.ALREADY_EXISTS code and the given message.
+func WithAlreadyExists(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.ALREADY_EXISTS), Message: message}
+}
+
+// WithFailedPrecondition returns an initialized status with the rpc.FAILED_PRECONDITION code and the given message.
+func WithFailedPrecondition(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.FAILED_PRECONDITION), Message: message}
+}
+
+// WithAborted returns an initialized status with the rpc.ABORTED code and the given message.
+func WithAborted(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.ABORTED), Message: message}
+}
+
+// WithOutOfRange returns an initialized status with the rpc.OUT_OF_RANGE code and the given message.
+func WithOutOfRange(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.OUT_OF_RANGE), Message: message}
+}
+
+// WithUnimplemented returns an initialized status with the rpc.UNIMPLEMENTED code and the given message.
+func WithUnimplemented(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.UNIMPLEMENTED), Message: message}
+}
+
+// WithUnavailable returns an initialized status with the rpc.UNAVAILABLE code and the given message.
+func WithUnavailable(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.UNAVAILABLE), Message: message}
+}
+
+// WithDataLoss returns an initialized status with the rpc.DATA_LOSS code and the given message.
+func WithDataLoss(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.DATA_LOSS), Message: message}
+}
+
+// WithUnauthenticated returns an initialized status with the rpc.UNAUTHENTICATED code and the given message.
+func WithUnauthenticated(message string) rpc.Status {
+	return rpc.Status{Code: int32(rpc.UNAUTHENTICATED), Message: message}
+}
+
 // IsOK returns true is the given status has the code rpc.OK
 func IsOK(status rpc.Status) bool {
 	return status.Code == int32(rpc.OK)

--- a/mixer/pkg/status/status_test.go
+++ b/mixer/pkg/status/status_test.go
@@ -71,6 +71,61 @@ func TestStatus(t *testing.T) {
 		t.Errorf("Got %v %v, expected rpc.DEADLINE_EXCEEDED Aborted!", s.Code, s.Message)
 	}
 
+	s = WithUnknown("Aborted!")
+	if s.Code != int32(rpc.UNKNOWN) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.UNKNOWN Aborted!", s.Code, s.Message)
+	}
+
+	s = WithNotFound("Aborted!")
+	if s.Code != int32(rpc.NOT_FOUND) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.NOT_FOUND Aborted!", s.Code, s.Message)
+	}
+
+	s = WithAlreadyExists("Aborted!")
+	if s.Code != int32(rpc.ALREADY_EXISTS) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.ALREADY_EXISTS Aborted!", s.Code, s.Message)
+	}
+
+	s = WithFailedPrecondition("Aborted!")
+	if s.Code != int32(rpc.FAILED_PRECONDITION) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.FAILED_PRECONDITION Aborted!", s.Code, s.Message)
+	}
+
+	s = WithAborted("Aborted!")
+	if s.Code != int32(rpc.ABORTED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.ABORTED Aborted!", s.Code, s.Message)
+	}
+
+	s = WithOutOfRange("Aborted!")
+	if s.Code != int32(rpc.OUT_OF_RANGE) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.OUT_OF_RANGE Aborted!", s.Code, s.Message)
+	}
+
+	s = WithUnimplemented("Aborted!")
+	if s.Code != int32(rpc.UNIMPLEMENTED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.UNIMPLEMENTED Aborted!", s.Code, s.Message)
+	}
+
+	s = WithUnavailable("Aborted!")
+	if s.Code != int32(rpc.UNAVAILABLE) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.UNAVAILABLE Aborted!", s.Code, s.Message)
+	}
+
+	s = WithOutOfRange("Aborted!")
+	if s.Code != int32(rpc.OUT_OF_RANGE) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.OUT_OF_RANGE Aborted!", s.Code, s.Message)
+	}
+
+	s = WithDataLoss("Aborted!")
+	if s.Code != int32(rpc.DATA_LOSS) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.DATA_LOSS Aborted!", s.Code, s.Message)
+	}
+
+	s = WithUnauthenticated("Aborted!")
+	if s.Code != int32(rpc.UNAUTHENTICATED) || s.Message != "Aborted!" {
+		t.Errorf("Got %v %v, expected rpc.UNAUTHENTICATED Aborted!", s.Code, s.Message)
+	}
+
 	msg := String(s)
 	if msg == "" {
 		t.Errorf("Expecting valid string, got nothing")


### PR DESCRIPTION
When writing an out of process adapter, it can be useful to use these wrapper functions for clarity on the return code