### PR TITLE
Use externalTrafficPolicy: Local for ingress (release-1.1).

### DIFF
--- a/install/kubernetes/helm/subcharts/ingress/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   type: {{ .Values.service.type }}
   selector:
     istio: ingress

--- a/install/kubernetes/helm/subcharts/ingress/values.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/values.yaml
@@ -9,6 +9,7 @@ service:
   annotations: {}
   loadBalancerIP: ""
   type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+  #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
   ports:
   - port: 80
     name: http


### PR DESCRIPTION
This was added to ingress and gateways in release-1.0 (#7918),
but only to gateways in master (#8941).

Fixes #7328.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>