### PR TITLE
Added option to add configmaps and secrets to jaeger  using helm.

### DIFF
--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment.yaml
@@ -56,6 +56,15 @@ spec:
             value: "9411"
           - name: MEMORY_MAX_TRACES
             value: "{{ .Values.jaeger.memory.max_traces }}"
+          envFrom:
+{{- if .Values.jaeger.resources.configFileEnabled }}
+          - configMapRef:
+              name: "{{ .Values.jaeger.resources.configFileEnabled  }}"
+{{- end }}
+{{- if .Values.jaeger.resources.secretFileEnabled }}
+          - secretRef:
+              name: "{{ .Values.jaeger.resources.secretFileEnabled }}"
+{{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -8,6 +8,9 @@ jaeger:
   tag: 1.7
   memory:
     max_traces: 50000
+  resources: {}
+#    configFileEnabled: "jaeger-configmap"
+#    secretFileEnabled: "jaeger-secrets"
   ingress:
     enabled: false
     # Used to create an Ingress record.


### PR DESCRIPTION
Hello,  In our use case we need to add  custom environment variables and secret variables (username/password) to our jaeger all-in-one inside Istio helm installation but the current chart template does not allow the possibility of adding those. So I made the changes to let the user add ( if they want, default is disabled) configmap resources or secrets resources to the jaeger deployment.
