### PR TITLE
Add missing resources to kiali cluster role in helm chart (#9608)

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     app: kiali
     version: master
 rules:
-- apiGroups: ["","apps", "autoscaling"]
+- apiGroups: ["", "apps", "autoscaling", "batch"]
   resources:
   - configmaps
   - namespaces
@@ -17,6 +17,11 @@ rules:
   - endpoints
   - deployments
   - horizontalpodautoscalers
+  - replicasets
+  - statefulsets
+  - replicationcontrollers
+  - jobs
+  - cronjobs
   verbs:
   - get
   - list


### PR DESCRIPTION
We need to get this change into release-1.0 branch so the Istio 1.0.x releases have this. I cherry-picked from the master commit 3bcf7514c5c948b964447af6aa9a88f770c4b0a1: 

===

The kiali helm chart was recently updated to 0.9 version but the
clusterole was not updated accordingly as it now requires access to more
resources. See https://github.com/kiali/kiali/blob/b11bc05013df2457e479eb381c52e924e27db19d/deploy/kubernetes/kiali.yaml#L117