### PR TITLE
Remove reference to helm chart repo on istio.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ export ENABLE_ISTIO_CNI ?= false
 # EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-foo"
 
 
-ISTIO_HELM_REPO := https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+#ISTIO_HELM_REPO := https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/master-latest-daily/charts
+ISTIO_HELM_REPO := https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
+
 #-----------------------------------------------------------------------------
 # Output control
 #-----------------------------------------------------------------------------

--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
     repository: file://../subcharts/security
   - name: istio-cni
     version: ">=0.0.1"
-    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    repository: "@istio.io"
     condition: istio_cni.enabled

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -57,6 +57,6 @@ dependencies:
     repository: file://../subcharts/certmanager
   - name: istio-cni
     version: ">=0.0.1"
-    repository: https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+    repository: "@istio.io"
     condition: istio_cni.enabled
 

--- a/pkg/test/deployment/helm.go
+++ b/pkg/test/deployment/helm.go
@@ -124,7 +124,7 @@ func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile strin
 
 	// Adding cni dependency as a workaround for now.
 	if _, err := exec(fmt.Sprintf("helm --home %s repo add istio.io %s",
-		helmRepoDir, "https://raw.githubusercontent.com/istio/istio.io/master/static/charts")); err != nil {
+		helmRepoDir, "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts")); err != nil {
 		return "", err
 	}
 

--- a/release/gcb/helm_charts.sh
+++ b/release/gcb/helm_charts.sh
@@ -42,7 +42,7 @@ CHARTS=(
 # Prepare helm setup
 mkdir -vp "$HELM_DIR"
 $HELM init --client-only
-$HELM repo add istio.io https://raw.githubusercontent.com/istio/istio.io/master/static/charts
+$HELM repo add istio.io https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
 
 # Create a package for each charts and build the repo index.
 mkdir -vp "$HELM_BUILD_DIR"


### PR DESCRIPTION
And replace it with daily release at https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
Also incorporated @tiswanso's changes from https://github.com/istio/istio/pull/9671.


The next step will be removing https://raw.githubusercontent.com/istio/istio.io/master/static/charts.