### PR TITLE
sds service reads k8s sa jwt from request header if exists

### DIFF
--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -42,9 +42,13 @@ const (
 	// SecretType is used for secret discovery service to construct response.
 	SecretType = "type.googleapis.com/envoy.api.v2.auth.Secret"
 
-	// CredentialTokenHeaderKey is the header key in gPRC header which is used to
+	// credentialTokenHeaderKey is the header key in gPRC header which is used to
 	// pass credential token from envoy's SDS request to SDS service.
-	CredentialTokenHeaderKey = "authorization"
+	credentialTokenHeaderKey = "authorization"
+
+	// k8sSAJwtTokenHeaderKey is the request header key, header value is k8s sa jwt, which is set in
+	// https://github.com/istio/istio/blob/master/pilot/pkg/model/authentication.go
+	k8sSAJwtTokenHeaderKey = "istio_sds_credentail_header-bin"
 )
 
 var (
@@ -242,9 +246,17 @@ func getCredentialToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("unable to get metadata from incoming context")
 	}
 
-	if h, ok := metadata[CredentialTokenHeaderKey]; ok {
+	// Get credential token from request k8sSAJwtTokenHeader(`istio_sds_credentail_header`) if it exists, otherwise fallback to credentialTokenHeader('authorization').
+	if h, ok := metadata[k8sSAJwtTokenHeaderKey]; ok {
 		if len(h) != 1 {
-			return "", fmt.Errorf("credential token must have 1 value in gRPC metadata but got %d", len(h))
+			return "", fmt.Errorf("credential token from %q must have 1 value in gRPC metadata but got %d", k8sSAJwtTokenHeaderKey, len(h))
+		}
+		return h[0], nil
+	}
+
+	if h, ok := metadata[credentialTokenHeaderKey]; ok {
+		if len(h) != 1 {
+			return "", fmt.Errorf("credential token from %q must have 1 value in gRPC metadata but got %d", credentialTokenHeaderKey, len(h))
 		}
 		return h[0], nil
 	}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -246,7 +246,8 @@ func getCredentialToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("unable to get metadata from incoming context")
 	}
 
-	// Get credential token from request k8sSAJwtTokenHeader(`istio_sds_credentail_header`) if it exists, otherwise fallback to credentialTokenHeader('authorization').
+	// Get credential token from request k8sSAJwtTokenHeader(`istio_sds_credentail_header`) if it exists;
+	// otherwise fallback to credentialTokenHeader('authorization').
 	if h, ok := metadata[k8sSAJwtTokenHeaderKey]; ok {
 		if len(h) != 1 {
 			return "", fmt.Errorf("credential token from %q must have 1 value in gRPC metadata but got %d", k8sSAJwtTokenHeaderKey, len(h))

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -152,7 +152,7 @@ func TestStreamSecretsPush(t *testing.T) {
 	defer conn.Close()
 
 	sdsClient := sds.NewSecretDiscoveryServiceClient(conn)
-	header := metadata.Pairs(CredentialTokenHeaderKey, fakeCredentialToken)
+	header := metadata.Pairs(credentialTokenHeaderKey, fakeCredentialToken)
 	ctx := metadata.NewOutgoingContext(context.Background(), header)
 	stream, err := sdsClient.StreamSecrets(ctx)
 	if err != nil {
@@ -255,7 +255,7 @@ func sdsRequestStream(socket string, req *api.DiscoveryRequest) (*api.DiscoveryR
 	defer conn.Close()
 
 	sdsClient := sds.NewSecretDiscoveryServiceClient(conn)
-	header := metadata.Pairs(CredentialTokenHeaderKey, fakeCredentialToken)
+	header := metadata.Pairs(credentialTokenHeaderKey, fakeCredentialToken)
 	ctx := metadata.NewOutgoingContext(context.Background(), header)
 	stream, err := sdsClient.StreamSecrets(ctx)
 	if err != nil {
@@ -280,7 +280,7 @@ func sdsRequestFetch(socket string, req *api.DiscoveryRequest) (*api.DiscoveryRe
 	defer conn.Close()
 
 	sdsClient := sds.NewSecretDiscoveryServiceClient(conn)
-	header := metadata.Pairs(CredentialTokenHeaderKey, fakeCredentialToken)
+	header := metadata.Pairs(credentialTokenHeaderKey, fakeCredentialToken)
 	ctx := metadata.NewOutgoingContext(context.Background(), header)
 	resp, err := sdsClient.FetchSecrets(ctx, req)
 	if err != nil {


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

sds service gets credential token from request k8sSAJwtTokenHeader(```istio_sds_credentail_header```) if it exists, otherwise fallback to credentialTokenHeader(```authorization```).