### PR TITLE
Update Proxy SHA to 2e4df0d4

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "ea9e05a766e5ecf301c44b5f779cbccd675b644d"
+		"lastStableSHA": "2e4df0d45b1efbd1f525d88ae1d1bf24eedd3c64"
 	}
 ]


### PR DESCRIPTION
This commit updates the Proxy SHA to [2e4df0d4](https://github.com/istio/proxy/commit/2e4df0d45b1efbd1f525d88ae1d1bf24eedd3c64) in order to bring in the TCP Cluster Rewrite filter for Envoy.

Signed-off-by: Venil Noronha <veniln@vmware.com>