### PR TITLE
Update Proxy SHA to c9fad2b2

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "ea9e05a766e5ecf301c44b5f779cbccd675b644d"
+		"lastStableSHA": "c9fad2b22bb3794664d6b10ab3c4f954170e322f"
 	}
 ]


### PR DESCRIPTION
This commit updates the Proxy SHA to [c9fad2b2](https://github.com/istio/proxy/commit/c9fad2b22bb3794664d6b10ab3c4f954170e322f) to bring in the Envoy TCP Cluster Rewrite filter.