### PR TITLE
add nodeagent to docker_targets

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -22,7 +22,7 @@
 docker: build test-bins docker.all
 
 DOCKER_TARGETS:=docker.pilot docker.proxy_debug docker.proxytproxy docker.proxyv2 docker.app docker.test_policybackend \
-	docker.proxy_init docker.mixer docker.citadel docker.galley docker.sidecar_injector docker.kubectl
+	docker.proxy_init docker.mixer docker.citadel docker.galley docker.sidecar_injector docker.kubectl docker.node-agent-k8s
 
 $(ISTIO_DOCKER) $(ISTIO_DOCKER_TAR):
 	mkdir -p $@


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035
add nodeagent to docker_targets to that ```make.docker``` and ```make.push``` will generate/push nodeagent docker image