### PR TITLE
Add a network value to the Istio charts

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -144,6 +144,8 @@ data:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
+        - name: ISTIO_META_NETWORK
+          value: "{{ .Values.global.proxy.network }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           {{ if eq .Values.global.proxy.privileged true }}

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -144,8 +144,10 @@ data:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
+        {{- if .Values.global.proxy.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.proxy.network }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         securityContext:
           {{ if eq .Values.global.proxy.privileged true }}

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -114,6 +114,15 @@ global:
     # Specify which tracer to use. One of: lightstep, zipkin
     tracer: "zipkin"
 
+    # Sets an identifier for the remote network to be used for Split Horizon EDS. The network will be sent
+    # to the Pilot when connected by the sidecar and will affect the results returned in EDS requests.
+    # Based on the network identifier Pilot will return all local endpoints + endpoints of gateways to
+    # other networks.
+    # When value is an empty string (default) the Split Horizon EDS won't activate and behave like a
+    # normal EDS (i.e. endpoints from all networks returned).
+    #
+    network: ""
+
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -156,8 +156,10 @@ data:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
+        {{- if .Values.global.proxy.network }}
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.proxy.network }}"
+        {{- end }}
         {{ "[[ if .ObjectMeta.Annotations ]]" }}
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -156,6 +156,8 @@ data:
               fieldPath: metadata.name
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
+        - name: ISTIO_META_NETWORK
+          value: "{{ .Values.global.proxy.network }}"
         {{ "[[ if .ObjectMeta.Annotations ]]" }}
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -184,6 +184,15 @@ global:
     # Specify which tracer to use. One of: lightstep, zipkin
     tracer: "zipkin"
 
+    # Sets an identifier for the remote network to be used for Split Horizon EDS. The network will be sent
+    # to the Pilot when connected by the sidecar and will affect the results returned in EDS requests.
+    # Based on the network identifier Pilot will return all local endpoints + endpoints of gateways to
+    # other networks.
+    # When value is an empty string (default) the Split Horizon EDS won't activate and behave like a
+    # normal EDS (i.e. endpoints from all networks returned).
+    #
+    network: ""
+
   proxy_init:
     # Base name for the proxy_init container, used to configure iptables.
     image: proxy_init


### PR DESCRIPTION
This network value can be specified when creating the Istio remote for configuring the network where it is deployed.
The network is an environment variable sent by the sidecar (if set) and enables the Split Horizon EDS.

By default it's an empty string which doesn't activate the Split Horizon EDS.