### PR TITLE
[Helm] Kiali - support different namespace

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/configmap.yaml
@@ -10,6 +10,7 @@ metadata:
     release: {{ .Release.Name }}
 data:
   config.yaml: |
+    istio_namespace: {{ .Release.Namespace }}
     server:
       port: 20001
     external_services:


### PR DESCRIPTION
Because Kiali supports running in a different namespace than Istio, it needs to be told where Istio is if not in the default "istio-system" namespace (from Kiali's point of view, it cannot assume Istio is in the same namespace as Kiali itself).

However, since the Istio helm chart installs Kiali in the same namespace as Istio, this PR simply adds the necessary config setting to the Kiali configmap, but sets it to the release namespace as-is since we know that is where Istio is installed, too.

https://issues.jboss.org/browse/KIALI-1868