### PR TITLE
[release-1.0] Update helm chart version to 1.0.4

### DIFF
--- a/install/kubernetes/helm/istio-remote/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio-remote
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart needed for remote Kubernetes clusters to join the main Istio control plane
 keywords:

--- a/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/security/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: security
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio authentication
 keywords:

--- a/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/charts/sidecarInjectorWebhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sidecarInjectorWebhook
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for sidecar injector webhook deployment
 keywords:

--- a/install/kubernetes/helm/istio-remote/requirements.yaml
+++ b/install/kubernetes/helm/istio-remote/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: sidecarInjectorWebhook
-    version: 1.0.3
+    version: 1.0.4
     condition: sidecarInjectorWebhook.enabled
   - name: security
-    version: 1.0.3
+    version: 1.0.4

--- a/install/kubernetes/helm/istio/Chart.yaml
+++ b/install/kubernetes/helm/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:

--- a/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: certmanager
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.3.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/galley/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: galley
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for galley deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/gateways/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: gateways
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for deploying Istio gateways
 keywords:

--- a/install/kubernetes/helm/istio/charts/grafana/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: grafana
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/ingress/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: ingress
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for ingress deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for detail.
 name: kiali
-version: 1.0.3
+version: 1.0.4
 appVersion: 0.9
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/mixer/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mixer
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for mixer deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/pilot/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pilot
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for pilot deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/prometheus/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: prometheus
-version: 1.0.3
+version: 1.0.4
 appVersion: 2.3.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/security/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/security/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: security
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for istio authentication
 keywords:

--- a/install/kubernetes/helm/istio/charts/servicegraph/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: servicegraph
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: sidecarInjectorWebhook
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for sidecar injector webhook deployment
 keywords:

--- a/install/kubernetes/helm/istio/charts/telemetry-gateway/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/telemetry-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: telemetry-gateway
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4
 tillerVersion: ">=2.7.2"
 description: Helm chart for configuring a gateway for Istio telemetry addons
 icon: https://istio.io/favicons/android-192x192.png

--- a/install/kubernetes/helm/istio/charts/tracing/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: tracing
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.5.1
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -1,40 +1,40 @@
 dependencies:
   - name: sidecarInjectorWebhook
-    version: 1.0.3
+    version: 1.0.4
     condition: sidecarInjectorWebhook.enabled
   - name: security
-    version: 1.0.3
+    version: 1.0.4
     condition: security.enabled
   - name: ingress
-    version: 1.0.3
+    version: 1.0.4
     condition: ingress.enabled
   - name: gateways
-    version: 1.0.3
+    version: 1.0.4
     condition: gateways.enabled
   - name: mixer
-    version: 1.0.3
+    version: 1.0.4
     condition: mixer.enabled
   - name: pilot
-    version: 1.0.3
+    version: 1.0.4
     condition: pilot.enabled
   - name: grafana
-    version: 1.0.3
+    version: 1.0.4
     condition: grafana.enabled
   - name: prometheus
-    version: 1.0.3
+    version: 1.0.4
     condition: prometheus.enabled
   - name: servicegraph
-    version: 1.0.3
+    version: 1.0.4
     condition: servicegraph.enabled
   - name: tracing
-    version: 1.0.3
+    version: 1.0.4
     condition: tracing.enabled
   - name: galley
-    version: 1.0.3
+    version: 1.0.4
     condition: galley.enabled
   - name: kiali
-    version: 1.0.3
+    version: 1.0.4
     condition: kiali.enabled
   - name: certmanager
-    version: 1.0.3
+    version: 1.0.4
     condition: certmanager.enabled


### PR DESCRIPTION
This is to prepare the upcoming 1.0.4 release to be cut from release-1.0.