### PR TITLE
MemRegistry should copy labels from IstioEndpiont.

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -194,6 +194,7 @@ func (sd *MemServiceDiscovery) SetEndpoints(service string, endpoints []*model.I
 
 		instance := &model.ServiceInstance{
 			Service: svc,
+			Labels:  e.Labels,
 			Endpoint: model.NetworkEndpoint{
 				Address: e.Address,
 				ServicePort: &model.Port{


### PR DESCRIPTION
Otherwise when calling `InstanceByPort`, returned `ServiceInstances` does not include labels we pass in `SetEndpoints`.

#8601