### PR TITLE
Enable proxy version check during access log setup

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -137,7 +137,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env *model.Environme
 		}
 
 		// Filters are serialized one time into an opaque struct once we have the complete list.
-		if err = marshalFilters(mutable.Listener, opts, mutable.FilterChains); err != nil {
+		if err = marshalFilters(node, mutable.Listener, opts, mutable.FilterChains); err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("gateway omitting listener %q due to: %v", mutable.Listener.Name, err.Error()))
 			continue
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -121,7 +121,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		listeners = append(listeners, inbound...)
 		listeners = append(listeners, outbound...)
 
-		mgmtListeners := buildSidecarInboundMgmtListeners(env, managementPorts, node.IPAddress)
+		mgmtListeners := buildSidecarInboundMgmtListeners(node, env, managementPorts, node.IPAddress)
 		// If management listener port and service port are same, bad things happen
 		// when running in kubernetes, as the probes stop responding. So, append
 		// non overlapping listeners only.
@@ -201,7 +201,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 			bindToPort: true,
 		}
 		l := buildListener(opts)
-		if err := marshalFilters(l, opts, []plugin.FilterChain{{}}); err != nil {
+		if err := marshalFilters(node, l, opts, []plugin.FilterChain{{}}); err != nil {
 			log.Warna("buildSidecarListeners ", err.Error())
 		} else {
 			listeners = append(listeners, l)
@@ -264,7 +264,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				},
 			}
 		case plugin.ListenerProtocolTCP:
-			tcpNetworkFilters = buildInboundNetworkFilters(env, instance)
+			tcpNetworkFilters = buildInboundNetworkFilters(env, node, instance)
 
 		default:
 			log.Warnf("Unsupported inbound protocol %v for port %#v", protocol, endpoint.ServicePort)
@@ -325,7 +325,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 			}
 		}
 		// Filters are serialized one time into an opaque struct once we have the complete list.
-		if err := marshalFilters(mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
+		if err := marshalFilters(node, mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
 			log.Warna("buildSidecarInboundListeners ", err.Error())
 		} else {
 			listeners = append(listeners, mutable.Listener)
@@ -541,7 +541,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 			}
 
 			// Filters are serialized one time into an opaque struct once we have the complete list.
-			if err := marshalFilters(mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
+			if err := marshalFilters(node, mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
 				log.Warna("buildSidecarOutboundListeners: ", err.Error())
 				continue
 			}
@@ -664,7 +664,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 // the pod.
 // So, if a user wants to use kubernetes probes with Istio, she should ensure
 // that the health check ports are distinct from the service ports.
-func buildSidecarInboundMgmtListeners(env *model.Environment, managementPorts model.PortList, managementIP string) []*xdsapi.Listener {
+func buildSidecarInboundMgmtListeners(node *model.Proxy, env *model.Environment, managementPorts model.PortList, managementIP string) []*xdsapi.Listener {
 	listeners := make([]*xdsapi.Listener, 0, len(managementPorts))
 
 	if managementIP == "" {
@@ -691,12 +691,12 @@ func buildSidecarInboundMgmtListeners(env *model.Environment, managementPorts mo
 				ip:   managementIP,
 				port: mPort.Port,
 				filterChainOpts: []*filterChainOpts{{
-					networkFilters: buildInboundNetworkFilters(env, instance),
+					networkFilters: buildInboundNetworkFilters(env, node, instance),
 				}},
 			}
 			l := buildListener(listenerOpts)
 			// TODO: should we call plugins for the admin port listeners too? We do everywhere else we construct listeners.
-			if err := marshalFilters(l, listenerOpts, []plugin.FilterChain{{}}); err != nil {
+			if err := marshalFilters(node, l, listenerOpts, []plugin.FilterChain{{}}); err != nil {
 				log.Warna("buildSidecarInboundMgmtListeners ", err.Error())
 			} else {
 				listeners = append(listeners, l)
@@ -747,7 +747,7 @@ type buildListenerOpts struct {
 	filterChainOpts []*filterChainOpts
 }
 
-func buildHTTPConnectionManager(env *model.Environment, httpOpts *httpListenerOpts,
+func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpOpts *httpListenerOpts,
 	httpFilters []*http_conn.HttpFilter) *http_conn.HttpConnectionManager {
 	filters := append(httpFilters,
 		&http_conn.HttpFilter{Name: xdsutil.CORS},
@@ -794,9 +794,12 @@ func buildHTTPConnectionManager(env *model.Environment, httpOpts *httpListenerOp
 	if env.Mesh.AccessLogFile != "" {
 		fl := &fileaccesslog.FileAccessLog{
 			Path: env.Mesh.AccessLogFile,
-			AccessLogFormat: &fileaccesslog.FileAccessLog_Format{
+		}
+
+		if util.Is11Proxy(node) {
+			fl.AccessLogFormat = &fileaccesslog.FileAccessLog_Format{
 				Format: EnvoyHTTPLogFormat,
-			},
+			}
 		}
 
 		connectionManager.AccessLog = []*accesslog.AccessLog{
@@ -919,7 +922,7 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 // TODO: given how tightly tied listener.FilterChains, opts.filterChainOpts, and mutable.FilterChains are to eachother
 // we should encapsulate them some way to ensure they remain consistent (mainly that in each an index refers to the same
 // chain)
-func marshalFilters(l *xdsapi.Listener, opts buildListenerOpts, chains []plugin.FilterChain) error {
+func marshalFilters(node *model.Proxy, l *xdsapi.Listener, opts buildListenerOpts, chains []plugin.FilterChain) error {
 	if len(opts.filterChainOpts) == 0 {
 		return fmt.Errorf("must have more than 0 chains in listener: %#v", l)
 	}
@@ -939,7 +942,7 @@ func marshalFilters(l *xdsapi.Listener, opts buildListenerOpts, chains []plugin.
 
 		if opt.httpOpts != nil {
 			opt.httpOpts.statPrefix = l.Name
-			connectionManager := buildHTTPConnectionManager(opts.env, opt.httpOpts, chain.HTTP)
+			connectionManager := buildHTTPConnectionManager(node, opts.env, opt.httpOpts, chain.HTTP)
 			l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, listener.Filter{
 				Name:   xdsutil.HTTPConnectionManager,
 				Config: util.MessageToStruct(connectionManager),


### PR DESCRIPTION
This PR enables a proxy version check prior to setting Envoy `AccessLog` format.