### PR TITLE
Do not fail envoy health probe if a config was rejected

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -71,7 +71,9 @@ func (p *Probe) checkUpdated() error {
 		return err
 	}
 
-	if s.CDSUpdates > 0 && s.LDSUpdates > 0 {
+	CDSUpdated := s.CDSUpdatesSuccess > 0 || s.CDSUpdatesRejection > 0
+	LDSUpdated := s.LDSUpdatesSuccess > 0 || s.LDSUpdatesRejection > 0
+	if CDSUpdated && LDSUpdated {
 		return nil
 	}
 

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -1,0 +1,129 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ready
+
+import (
+	. "github.com/onsi/gomega"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var probe = Probe{AdminPort: 1234}
+
+func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyStatsIncompleteCDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "listener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("cds updates: 0"))
+}
+
+
+func TestEnvoyStatsIncompleteLDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("lds updates: 0"))
+}
+
+func TestEnvoyStatsCompleteAndRejectedCDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_rejected: 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyStatsCompleteAndRejectedLDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_rejected: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyCheckFailsIfStatsUnparsableNoSeparator(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success; 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("missing separator"))
+}
+
+func TestEnvoyCheckFailsIfStatsUnparsableNoNumber(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: a\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed parsing Envoy stat"))
+}
+
+func createAndStartServer(statsToReturn string) *httptest.Server {
+	// Start a local HTTP server
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		rw.Write([]byte(statsToReturn))
+	}))
+	l, err := net.Listen("tcp", "127.0.0.1:1234")
+	if err != nil {
+		panic("Could not create listener for test: " + err.Error())
+	}
+	server.Listener = l
+	server.Start()
+	return server
+}

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -49,7 +49,6 @@ func TestEnvoyStatsIncompleteCDS(t *testing.T) {
 	g.Expect(err.Error()).To(ContainSubstring("cds updates: 0"))
 }
 
-
 func TestEnvoyStatsIncompleteLDS(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := "cluster_manager.cds.update_success: 1"

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -40,9 +40,11 @@ type Stats struct {
 
 // String representation of the Stats.
 func (s *Stats) String() string {
-	return fmt.Sprintf("cds updates: %d, lds updates: %d",
+	return fmt.Sprintf("cds updates: %d success, %d rejected; lds updates: %d success, %d rejected",
 		s.CDSUpdatesSuccess,
-		s.LDSUpdatesSuccess)
+		s.CDSUpdatesRejection,
+		s.LDSUpdatesSuccess,
+		s.LDSUpdatesRejection)
 }
 
 // GetStats from Envoy.

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -28,7 +28,6 @@ const (
 	statCdsUpdatesRejection = "cluster_manager.cds.update_rejected"
 	statLdsUpdatesSuccess   = "listener_manager.lds.update_success"
 	statLdsUpdatesRejection = "listener_manager.lds.update_rejected"
-
 )
 
 // Stats contains values of interest from a poll of Envoy stats.

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -24,21 +24,26 @@ import (
 )
 
 const (
-	statCdsUpdates = "cluster_manager.cds.update_success"
-	statLdsUpdates = "listener_manager.lds.update_success"
+	statCdsUpdatesSuccess   = "cluster_manager.cds.update_success"
+	statCdsUpdatesRejection = "cluster_manager.cds.update_rejected"
+	statLdsUpdatesSuccess   = "listener_manager.lds.update_success"
+	statLdsUpdatesRejection = "listener_manager.lds.update_rejected"
+
 )
 
 // Stats contains values of interest from a poll of Envoy stats.
 type Stats struct {
-	CDSUpdates uint64
-	LDSUpdates uint64
+	CDSUpdatesSuccess   uint64
+	CDSUpdatesRejection uint64
+	LDSUpdatesSuccess   uint64
+	LDSUpdatesRejection uint64
 }
 
 // String representation of the Stats.
 func (s *Stats) String() string {
 	return fmt.Sprintf("cds updates: %d, lds updates: %d",
-		s.CDSUpdates,
-		s.LDSUpdates)
+		s.CDSUpdatesSuccess,
+		s.LDSUpdatesSuccess)
 }
 
 // GetStats from Envoy.
@@ -51,8 +56,10 @@ func GetStats(adminPort uint16) (*Stats, error) {
 	// Parse the Envoy stats.
 	s := &Stats{}
 	allStats := []*stat{
-		{name: statCdsUpdates, value: &s.CDSUpdates},
-		{name: statLdsUpdates, value: &s.LDSUpdates},
+		{name: statCdsUpdatesSuccess, value: &s.CDSUpdatesSuccess},
+		{name: statCdsUpdatesRejection, value: &s.CDSUpdatesRejection},
+		{name: statLdsUpdatesSuccess, value: &s.LDSUpdatesSuccess},
+		{name: statLdsUpdatesRejection, value: &s.LDSUpdatesRejection},
 	}
 	if err := parseStats(input, allStats); err != nil {
 		return nil, err
@@ -72,7 +79,7 @@ func parseStats(input *bytes.Buffer, stats []*stat) (err error) {
 	}
 	for _, stat := range stats {
 		if !stat.found {
-			err = multierror.Append(err, fmt.Errorf("envoy stat missing: %s", stat.name))
+			*stat.value = 0
 		}
 	}
 	return

--- a/pilot/cmd/pilot-agent/status/util/stats.go
+++ b/pilot/cmd/pilot-agent/status/util/stats.go
@@ -40,7 +40,7 @@ type Stats struct {
 
 // String representation of the Stats.
 func (s *Stats) String() string {
-	return fmt.Sprintf("cds updates: %d success, %d rejected; lds updates: %d success, %d rejected",
+	return fmt.Sprintf("cds updates: %d successful, %d rejected; lds updates: %d successful, %d rejected",
 		s.CDSUpdatesSuccess,
 		s.CDSUpdatesRejection,
 		s.LDSUpdatesSuccess,

--- a/pilot/cmd/pilot-agent/status/util/stats_test.go
+++ b/pilot/cmd/pilot-agent/status/util/stats_test.go
@@ -24,5 +24,5 @@ func TestStatsToString(t *testing.T) {
 	g := NewGomegaWithT(t)
 	stats := Stats{CDSUpdatesSuccess: 1, CDSUpdatesRejection: 2, LDSUpdatesSuccess: 3, LDSUpdatesRejection: 4}
 
-	g.Expect(stats.String()).To(Equal("cds updates: 1 success, 2 rejected; lds updates: 3 success, 4 rejected"))
+	g.Expect(stats.String()).To(Equal("cds updates: 1 successful, 2 rejected; lds updates: 3 successful, 4 rejected"))
 }

--- a/pilot/cmd/pilot-agent/status/util/stats_test.go
+++ b/pilot/cmd/pilot-agent/status/util/stats_test.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStatsToString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := Stats{CDSUpdatesSuccess: 1, CDSUpdatesRejection: 2, LDSUpdatesSuccess: 3, LDSUpdatesRejection: 4}
+
+	g.Expect(stats.String()).To(Equal("cds updates: 1 success, 2 rejected; lds updates: 3 success, 4 rejected"))
+}


### PR DESCRIPTION
Addressing Issue #9659

If some configuration is rejected (e.g. missing certs), the envoy must still be considered to be healthy. So the health probe is checking the state successful OR rejected. The idea is that the envoy has at least already processed the configuration.