### PR TITLE
update consul docker image to 1.3.0

### DIFF
--- a/install/consul/consul_config/agent-loglevel.json
+++ b/install/consul/consul_config/agent-loglevel.json
@@ -1,0 +1,3 @@
+{
+        "log_level": "INFO"
+}

--- a/install/consul/consul_config/agent.json
+++ b/install/consul/consul_config/agent.json
@@ -1,0 +1,8 @@
+{
+        "client_addr": "0.0.0.0",
+        "leave_on_terminate": true,
+        "dns_config": {
+                "allow_stale": true,
+                "max_stale": "1s"
+        }
+}

--- a/install/consul/consul_config/disable_update_check.json
+++ b/install/consul/consul_config/disable_update_check.json
@@ -1,0 +1,3 @@
+{
+        "disable_update_check": true
+}

--- a/install/consul/consul_config/server.json
+++ b/install/consul/consul_config/server.json
@@ -1,0 +1,6 @@
+{
+        "ui": true,
+        "dns_config": {
+                "allow_stale": false
+        }
+}

--- a/install/consul/templates/istio.yaml.tmpl
+++ b/install/consul/templates/istio.yaml.tmpl
@@ -29,7 +29,7 @@ services:
     command: ["kube-apiserver", "--etcd-servers", "http://etcd:2379", "--service-cluster-ip-range", "10.99.0.0/16", "--insecure-port", "8080", "-v", "2", "--insecure-bind-address", "0.0.0.0"]
 
   consul:
-    image: gliderlabs/consul-server
+    image: consul:1.3.0
     networks:
       istiomesh:
         aliases:
@@ -38,9 +38,20 @@ services:
       - "8500:8500"
       - "${DOCKER_GATEWAY}53:8600/udp"
       - "8400:8400"
+      - "8502:8502"
     environment:
       - SERVICE_IGNORE=1
-    command: ["-bootstrap"]
+      - DNS_RESOLVES=consul
+      - DNS_PORT=8600
+      - CONSUL_DATA_DIR=/consul/data
+      - CONSUL_CONFIG_DIR=/consul/config
+    entrypoint:
+      - "docker-entrypoint.sh"
+    command: ["agent", "-bootstrap", "-server", "-ui",
+              "-grpc-port", "8502"
+              ]
+    volumes:
+      - ./consul_config:/consul/config
 
   registrator:
     image: gliderlabs/registrator:latest


### PR DESCRIPTION
This will update the consul to am image supported by Hashicorp. I did not see guidelines on where to put the config files in this pull request. Most of the config was taken from the old container. The container image license is here. http://raw.githubusercontent.com/hashicorp/consul/master/LICENSE . The copied config files fall under this license https://github.com/gliderlabs/docker-consul/blob/master/LICENSE. https://github.com/gliderlabs/docker-consul/blob/master/0.7/consul-agent/config/agent.json , https://github.com/gliderlabs/docker-consul/blob/master/0.7/consul-server/config/server.json