### PR TITLE
Update Proxy SHA to 65087d0e

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "65087d0ebc8ccf3b967e03683db37304b7d0b10d"
+		"lastStableSHA": "4d8eb98dee59b8cd57962230c0430fa2a486c05e"
 	}
 ]

--- a/istio.deps
+++ b/istio.deps
@@ -4,6 +4,6 @@
 		"name": "PROXY_REPO_SHA",
 		"repoName": "proxy",
 		"file": "",
-		"lastStableSHA": "67a0375be569f9158b361e8f5c2a76a0c1b0a02e"
+		"lastStableSHA": "65087d0ebc8ccf3b967e03683db37304b7d0b10d"
 	}
 ]

--- a/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
@@ -111,6 +111,28 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
+  "istio_authn": {
+    "request.auth.raw_claims": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    },
+    "request.auth.principal": "issuer@foo.com/sub@foo.com",
+    "request.auth.audiences": "aud1"
+  },
+  "jwt-auth": {
+    "issuer@foo.com": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    }
+  },
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_origin/authn_report_test.go
@@ -111,28 +111,8 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
-  "istio_authn": {
-    "request.auth.raw_claims": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    },
-    "request.auth.principal": "issuer@foo.com/sub@foo.com",
-    "request.auth.audiences": "aud1"
-  },
-  "jwt-auth": {
-    "issuer@foo.com": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    }
-  },
+  "istio_authn": "*",
+  "jwt-auth": "*",
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
@@ -109,6 +109,27 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
+  "istio_authn": {
+    "request.auth.raw_claims": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    },
+    "request.auth.audiences": "aud1"
+  },
+  "jwt-auth": {
+    "issuer@foo.com": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    }
+  },
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_origin_jwt_bound_peer/authn_report_test.go
@@ -109,27 +109,8 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
-  "istio_authn": {
-    "request.auth.raw_claims": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    },
-    "request.auth.audiences": "aud1"
-  },
-  "jwt-auth": {
-    "issuer@foo.com": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    }
-  },
+  "istio_authn": "*",
+  "jwt-auth": "*",
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
@@ -115,27 +115,8 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
-  "istio_authn": {
-    "request.auth.raw_claims": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    },
-    "request.auth.audiences": "aud1"
-  },
-  "jwt-auth": {
-    "issuer@foo.com": {
-      "aud": "aud1",
-      "exp": 20000000000,
-      "iat": 1500000000,
-      "iss": "issuer@foo.com",
-      "some-other-string-claims": "some-claims-kept",
-      "sub": "sub@foo.com"
-    }
-  },
+  "istio_authn": "*",
+  "jwt-auth": "*",
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
+++ b/mixer/test/client/istio_authn_peer_jwt_bound_peer/authn_report_test.go
@@ -115,6 +115,27 @@ var reportAttributesOkGet = `
   "destination.port": "*",
   "destination.uid": "",
   "destination.namespace": "",
+  "istio_authn": {
+    "request.auth.raw_claims": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    },
+    "request.auth.audiences": "aud1"
+  },
+  "jwt-auth": {
+    "issuer@foo.com": {
+      "aud": "aud1",
+      "exp": 20000000000,
+      "iat": 1500000000,
+      "iss": "issuer@foo.com",
+      "some-other-string-claims": "some-claims-kept",
+      "sub": "sub@foo.com"
+    }
+  },
   "target.name": "target-name",
   "target.user": "target-user",
   "target.uid": "POD222",

--- a/mixer/test/client/rbac_permissive_global/rbac_permissive_global_test.go
+++ b/mixer/test/client/rbac_permissive_global/rbac_permissive_global_test.go
@@ -33,6 +33,9 @@ const reportAttributes = `
   "destination.namespace" : "",
   "destination.port": "*",
   "destination.uid": "",
+  "envoy.filters.http.rbac": {
+    "shadow_response_code": "403"
+  },
   "mesh1.ip": "*",
   "mesh2.ip": "*",
   "mesh3.ip": "*",

--- a/mixer/test/client/rbac_permissive_policy/rbac_permissive_policy_test.go
+++ b/mixer/test/client/rbac_permissive_policy/rbac_permissive_policy_test.go
@@ -30,6 +30,10 @@ const reportAttributes = `
   "context.reporter.uid" : "",
   "destination.namespace" : "",
   "destination.uid": "",
+  "envoy.filters.http.rbac": {
+    "shadow_effective_policyID": "details-reviews-viewer",
+    "shadow_response_code": "200"
+  },
   "mesh1.ip": "*",
   "mesh2.ip": "*",
   "mesh3.ip": "*",


### PR DESCRIPTION
This commit updates the Proxy SHA to [65087d0e](https://github.com/istio/proxy/commit/65087d0ebc8ccf3b967e03683db37304b7d0b10d) to import the Envoy TCP RBAC filter.