### PR TITLE
Add sample YAMLs for weighted TCP echo routing

### DIFF
--- a/samples/tcp-echo/README.md
+++ b/samples/tcp-echo/README.md
@@ -21,7 +21,7 @@ To run the TCP Echo Service sample:
 3. Test by running the `nc` command from a `busybox` container from within the cluster.
 
    ```console
-   $ kubectl run -i --rm --restart=Never busybox --image=busybox -- sh -c "echo world | nc tcp-echo 9000"
+   $ kubectl run -i --rm --restart=Never dummy --image=busybox -- sh -c "echo world | nc tcp-echo 9000"
    hello world
    pod "busybox" deleted
    ```

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# build a tcp-echo binary using the golang container
+FROM golang:1.11 as builder
+WORKDIR /go/src/istio.io/tcp-echo-server/
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
+
+# copy the tcp-echo binary to a separate container based on ubuntu
+FROM ubuntu:18.04
+WORKDIR /bin/
+COPY --from=builder /go/src/istio.io/tcp-echo-server/tcp-echo .
+ENTRYPOINT [ "/bin/tcp-echo" ]
+CMD [ "9000", "hello" ]
+EXPOSE 9000

--- a/samples/tcp-echo/src/main.go
+++ b/samples/tcp-echo/src/main.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+// main serves as the program entry point
+func main() {
+	// obtain the port and prefix via program arguments
+	port := fmt.Sprintf(":%s", os.Args[1])
+	prefix := os.Args[2]
+
+	// create a tcp listener on the given port
+	listener, err := net.Listen("tcp", port)
+	if err != nil {
+		fmt.Println("failed to create listener, err:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("listening on %s, prefix: %s\n", listener.Addr(), prefix)
+
+	// listen for new connections
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Println("failed to accept connection, err:", err)
+			continue
+		}
+
+		// pass an accepted connection to a handler goroutine
+		go handleConnection(conn, prefix)
+	}
+}
+
+// handleConnection handles the lifetime of a connection
+func handleConnection(conn net.Conn, prefix string) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	for {
+		// read client request data
+		bytes, err := reader.ReadBytes(byte('\n'))
+		if err != nil {
+			if err != io.EOF {
+				fmt.Println("failed to read data, err:", err)
+			}
+			return
+		}
+		fmt.Printf("request: %s", bytes)
+
+		// prepend prefix and send as response
+		line := fmt.Sprintf("%s %s", prefix, bytes)
+		fmt.Printf("response: %s", line)
+		conn.Write([]byte(line))
+	}
+}

--- a/samples/tcp-echo/src/main_test.go
+++ b/samples/tcp-echo/src/main_test.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTcpEchoServer tests the behavior of the TCP Echo Server.
+func TestTcpEchoServer(t *testing.T) {
+	// set up test parameters
+	prefix := "hello"
+	request := "world"
+	want := prefix + " " + request
+
+	// start the TCP Echo Server
+	os.Args = []string{"main", "9000", prefix}
+	go main()
+
+	// wait for the TCP Echo Server to start
+	time.Sleep(2 * time.Second)
+
+	// connect to the TCP Echo Server
+	conn, err := net.Dial("tcp", ":9000")
+	if err != nil {
+		t.Fatalf("couldn't connect to the server: %v", err)
+	}
+	defer conn.Close()
+
+	// test the TCP Echo Server output
+	if _, err := conn.Write([]byte(request + "\n")); err != nil {
+		t.Fatalf("couldn't send request: %v", err)
+	} else {
+		reader := bufio.NewReader(conn)
+		if response, err := reader.ReadBytes(byte('\n')); err != nil {
+			t.Fatalf("couldn't read server response: %v", err)
+		} else if !strings.HasPrefix(string(response), want) {
+			t.Errorf("output doesn't match, wanted: %s, got: %s", want, response)
+		}
+	}
+}

--- a/samples/tcp-echo/tcp-echo-20-v2.yaml
+++ b/samples/tcp-echo/tcp-echo-20-v2.yaml
@@ -1,0 +1,39 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tcp-echo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - tcp-echo-gateway
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1
+      weight: 80
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v2
+      weight: 20

--- a/samples/tcp-echo/tcp-echo-all-v1.yaml
+++ b/samples/tcp-echo/tcp-echo-all-v1.yaml
@@ -1,0 +1,61 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: tcp-echo-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 31400
+      name: tcp
+      protocol: TCP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tcp-echo-destination
+spec:
+  host: tcp-echo
+  subsets:
+  - name: v1
+    labels:
+      version: v1
+  - name: v2
+    labels:
+      version: v2
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tcp-echo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - tcp-echo-gateway
+  tcp:
+  - match:
+    - port: 31400
+    route:
+    - destination:
+        host: tcp-echo
+        port:
+          number: 9000
+        subset: v1

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -1,0 +1,67 @@
+# Copyright 2018 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  labels:
+    app: tcp-echo
+    istio: ingressgateway # use istio default controller
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+  selector:
+    app: tcp-echo
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tcp-echo-v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v1
+    spec:
+      containers:
+      - name: tcp-echo
+        image: docker.io/venilnoronha/tcp-echo-server
+        imagePullPolicy: IfNotPresent
+        args: [ "9000", "one" ]
+        ports:
+        - containerPort: 9000
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tcp-echo-v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v2
+    spec:
+      containers:
+      - name: tcp-echo
+        image: docker.io/venilnoronha/tcp-echo-server
+        imagePullPolicy: IfNotPresent
+        args: [ "9000", "two" ]
+        ports:
+        - containerPort: 9000

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -18,7 +18,6 @@ metadata:
   name: tcp-echo
   labels:
     app: tcp-echo
-    istio: ingressgateway # use istio default controller
 spec:
   ports:
   - name: tcp

--- a/samples/tcp-echo/tcp-echo-services.yaml
+++ b/samples/tcp-echo/tcp-echo-services.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/venilnoronha/tcp-echo-server
+        image: istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "one" ]
         ports:
@@ -60,7 +60,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/venilnoronha/tcp-echo-server
+        image: istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "two" ]
         ports:

--- a/samples/tcp-echo/tcp-echo.yaml
+++ b/samples/tcp-echo/tcp-echo.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: tcp-echo
-        image: docker.io/venilnoronha/tcp-echo-server
+        image: istio/tcp-echo-server:1.1
         imagePullPolicy: IfNotPresent
         args: [ "9000", "hello" ]
         ports:


### PR DESCRIPTION
This PR adds sample YAMLs for deploying and testing weighted TCP routing on Istio.

/cc @andraxylia