### PR TITLE
Omit security post install on istio-remote

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -11,6 +11,7 @@ sidecarInjectorWebhook:
 #
 security:
   enabled: true
+  omitPostInstall: true
 
 # Common settings used among istio subcharts.
 global:

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.omitPostInstall }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -89,3 +90,4 @@ spec:
           configMap:
             name: istio-security-custom-resources
       restartPolicy: OnFailure
+{{- end }}


### PR DESCRIPTION
Security post install is creating custom resources.
Currently the job fails when deploying on istio-remote because Galley isn't installed and the CRDs are not defined. Therefore omitted.