### PR TITLE
Fix bug causing deleted endpoints to not be updated

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -570,6 +570,7 @@ func (s *Server) makeCopilotMonitor(args *PilotArgs, configController model.Conf
 func (s *Server) createK8sServiceControllers(serviceControllers *aggregate.Controller, args *PilotArgs) (err error) {
 	clusterID := string(serviceregistry.KubernetesRegistry)
 	log.Infof("Primary Cluster name: %s", clusterID)
+	args.Config.ControllerOptions.ClusterID = string(serviceregistry.KubernetesRegistry)
 	kubectl := kube.NewController(s.kubeClient, args.Config.ControllerOptions)
 	s.kubeRegistry = kubectl
 	serviceControllers.AddRegistry(


### PR DESCRIPTION
The problem was that the 'shard' ID was not matching between incremental updates and full updates.

The 'shard' represents a registry (or in future a subset, for large registries). The registries are stored
in the aggreage map, keyed by the registry name. The bug was that the name for the default registry
was "" when constructing the registry, and "kubernetes" when adding. Adding was ok, and delete after a full push was ok too - but on incremental push, deletes were only deleting the "" shard. 

Additional cleanups on 1.1/master, as we convert the other 2 registries to incremental. 