### PR TITLE
Add newline into mixer debug information

### DIFF
--- a/mixer/pkg/attribute/protoBag.go
+++ b/mixer/pkg/attribute/protoBag.go
@@ -77,7 +77,7 @@ func GetProtoBag(proto *mixerpb.CompressedAttributes, globalDict map[string]int3
 	pb.globalWordList = globalWordList
 	pb.messageDict = d
 
-	scope.Debugf("Returning bag with attributes: %v", pb)
+	scope.Debugf("Returning bag with attributes:\n%v", pb)
 
 	return pb
 }


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

**Before:**
```
2018-11-07T07:27:29.672428Z	debug	attributes	Creating bag with: context.protocol              : http
destination.labels            : {destination.labels map[app:ratings] 0xc42036b440}
destination.port              : 8080
destination.service           : abc.ns.svc.cluster.local
request.headers               : {request.headers map[source:abcd clnt:abcd] 0xc42036b440}
request.time                  : 2017-07-04 00:01:10 +0000 UTC
source.ip                     : [192 0 0 2]
source.labels                 : {source.labels map[version:v2] 0xc42036b440}
source.name                   : myservice
```
**After:**
```
Starting gRPC server on port 9091
2018-11-07T07:31:31.255878Z	debug	attributes	Creating bag with attributes:
context.protocol              : http
destination.labels            : {destination.labels map[app:ratings] 0xc42a01de60}
destination.port              : 8080
destination.service           : abc.ns.svc.cluster.local
request.headers               : {request.headers map[source:abcd clnt:abcd] 0xc42a01de60}
request.time                  : 2017-07-04 00:01:10 +0000 UTC
source.ip                     : [192 0 0 2]
source.labels                 : {source.labels map[version:v2] 0xc42a01de60}
source.name                   : myservice
```