### PR TITLE
Use scratch base for tcp-echo sample

### DIFF
--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -18,8 +18,8 @@ WORKDIR /go/src/istio.io/tcp-echo-server/
 COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 
-# copy the tcp-echo binary to a separate container based on ubuntu
-FROM ubuntu:18.04
+# copy the tcp-echo binary to a separate container based on scratch
+FROM scratch
 WORKDIR /bin/
 COPY --from=builder /go/src/istio.io/tcp-echo-server/tcp-echo .
 ENTRYPOINT [ "/bin/tcp-echo" ]


### PR DESCRIPTION
This updates the base OS to `scratch` for the `tcp-echo-server` sample.