### PR TITLE
Missing ControlPanelAuth ifs in pilot envoy template

### DIFF
--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -201,6 +201,7 @@ static_resources:
                   timeout: 0.000s
           stat_prefix: "15011"
         name: envoy.http_connection_manager
+{{- if .ControlPlaneAuth }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -214,6 +215,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
     name: "15011"
   - address:
       socket_address:
@@ -276,6 +278,7 @@ static_resources:
                   timeout: 0.000s
           stat_prefix: "15005"
         name: envoy.http_connection_manager
+{{- if .ControlPlaneAuth }}
       tls_context:
         common_tls_context:
           alpn_protocols:
@@ -289,6 +292,7 @@ static_resources:
             trusted_ca:
               filename: /etc/certs/root-cert.pem
         require_client_certificate: true
+{{- end }}
     name: "15005"
   - address:
       socket_address:


### PR DESCRIPTION
Hi guys. We don't use TLS in control plane in our setup. And it turned out that pilot doesn't work out of the box with  default envoy template. It looks like two conditionals missing in it.