### PR TITLE
Fix MCP Legacy Mixer config conversion logic.

### DIFF
--- a/galley/pkg/kube/converter/converter.go
+++ b/galley/pkg/kube/converter/converter.go
@@ -65,9 +65,9 @@ func Get(name string) Fn {
 
 func identity(_ *Config, destination resource.Info, name resource.FullName, _ string, u *unstructured.Unstructured) ([]Entry, error) {
 	var p proto.Message
-	var err error
 	creationTime := time.Time{}
 	if u != nil {
+		var err error
 		if p, err = toProto(destination, u.Object["spec"]); err != nil {
 			return nil, err
 		}
@@ -119,9 +119,9 @@ func legacyMixerResource(_ *Config, _ resource.Info, name resource.FullName, kin
 
 func authPolicyResource(_ *Config, destination resource.Info, name resource.FullName, _ string, u *unstructured.Unstructured) ([]Entry, error) {
 	var p proto.Message
-	var err error
 	creationTime := time.Time{}
 	if u != nil {
+		var err error
 		if p, err = toProto(destination, u.Object["spec"]); err != nil {
 			return nil, err
 		}

--- a/galley/pkg/kube/converter/converter.go
+++ b/galley/pkg/kube/converter/converter.go
@@ -36,7 +36,7 @@ import (
 var scope = log.RegisterScope("kube-converter", "Kubernetes conversion related packages", 0)
 
 // Fn is a conversion function that converts the given unstructured CRD into the destination Resource.
-type Fn func(cfg *Config, destination resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]Entry, error)
+type Fn func(cfg *Config, destination resource.Info, name resource.FullName, kind string, u *unstructured.Unstructured) ([]Entry, error)
 
 // Entry is a single converted entry.
 type Entry struct {
@@ -63,118 +63,144 @@ func Get(name string) Fn {
 	return fn
 }
 
-func identity(_ *Config, destination resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]Entry, error) {
-	p, err := toProto(destination, u.Object["spec"])
-	if err != nil {
-		return nil, err
+func identity(_ *Config, destination resource.Info, name resource.FullName, _ string, u *unstructured.Unstructured) ([]Entry, error) {
+	var p proto.Message
+	var err error
+	creationTime := time.Time{}
+	if u != nil {
+		if p, err = toProto(destination, u.Object["spec"]); err != nil {
+			return nil, err
+		}
+		creationTime = u.GetCreationTimestamp().Time
 	}
 
 	e := Entry{
 		Key:          name,
-		CreationTime: u.GetCreationTimestamp().Time,
+		CreationTime: creationTime,
 		Resource:     p,
 	}
 
 	return []Entry{e}, nil
 }
 
-func nilConverter(_ *Config, _ resource.Info, _ resource.FullName, _ *unstructured.Unstructured) ([]Entry, error) {
+func nilConverter(_ *Config, _ resource.Info, _ resource.FullName, _ string, _ *unstructured.Unstructured) ([]Entry, error) {
 	return nil, nil
 }
 
-func legacyMixerResource(_ *Config, _ resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]Entry, error) {
-	spec := u.Object["spec"]
+func legacyMixerResource(_ *Config, _ resource.Info, name resource.FullName, kind string, u *unstructured.Unstructured) ([]Entry, error) {
 	s := &types.Struct{}
-	if err := toproto(s, spec); err != nil {
-		return nil, err
+	creationTime := time.Time{}
+	var res *legacy.LegacyMixerResource
+
+	if u != nil {
+		spec := u.Object["spec"]
+		if err := toproto(s, spec); err != nil {
+			return nil, err
+		}
+		creationTime = u.GetCreationTimestamp().Time
+		res = &legacy.LegacyMixerResource{
+			Name:     name.String(),
+			Kind:     kind,
+			Contents: s,
+		}
+
 	}
 
-	newName := resource.FullNameFromNamespaceAndName(u.GetKind(), name.String())
+	newName := resource.FullNameFromNamespaceAndName(kind, name.String())
 
 	e := Entry{
 		Key:          newName,
-		CreationTime: u.GetCreationTimestamp().Time,
-		Resource: &legacy.LegacyMixerResource{
-			Name:     name.String(),
-			Kind:     u.GetKind(),
-			Contents: s,
-		},
+		CreationTime: creationTime,
+		Resource:     res,
 	}
 
 	return []Entry{e}, nil
 }
 
-func authPolicyResource(_ *Config, destination resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]Entry, error) {
-	p, err := toProto(destination, u.Object["spec"])
-	if err != nil {
-		return nil, err
-	}
+func authPolicyResource(_ *Config, destination resource.Info, name resource.FullName, _ string, u *unstructured.Unstructured) ([]Entry, error) {
+	var p proto.Message
+	var err error
+	creationTime := time.Time{}
+	if u != nil {
+		if p, err = toProto(destination, u.Object["spec"]); err != nil {
+			return nil, err
+		}
+		creationTime = u.GetCreationTimestamp().Time
 
-	policy, ok := p.(*authn.Policy)
-	if !ok {
-		return nil, fmt.Errorf("object is not of type %v", destination.TypeURL)
-	}
+		policy, ok := p.(*authn.Policy)
+		if !ok {
+			return nil, fmt.Errorf("object is not of type %v", destination.TypeURL)
+		}
 
-	// The pilot authentication plugin's config handling allows the mtls
-	// peer method object value to be nil. See pilot/pkg/networking/plugin/authn/authentication.go#L68
-	//
-	// For example,
-	//
-	//     metadata:
-	//       name: d-ports-mtls-enabled
-	//     spec:
-	//       targets:
-	//       - name: d
-	//         ports:
-	//         - number: 80
-	//       peers:
-	//       - mtls:
-	//
-	// This translates to the following in-memory representation:
-	//
-	//     policy := &authn.Policy{
-	//       Peers: []*authn.PeerAuthenticationMethod{{
-	//         &authn.PeerAuthenticationMethod_Mtls{},
-	//       }},
-	//     }
-	//
-	// The PeerAuthenticationMethod_Mtls object with nil field is lost when
-	// the proto is re-encoded for transport via MCP. As a workaround, fill
-	// in the missing field value which is functionality equivalent.
-	for _, peer := range policy.Peers {
-		if mtls, ok := peer.Params.(*authn.PeerAuthenticationMethod_Mtls); ok && mtls.Mtls == nil {
-			mtls.Mtls = &authn.MutualTls{}
+		// The pilot authentication plugin's config handling allows the mtls
+		// peer method object value to be nil. See pilot/pkg/networking/plugin/authn/authentication.go#L68
+		//
+		// For example,
+		//
+		//     metadata:
+		//       name: d-ports-mtls-enabled
+		//     spec:
+		//       targets:
+		//       - name: d
+		//         ports:
+		//         - number: 80
+		//       peers:
+		//       - mtls:
+		//
+		// This translates to the following in-memory representation:
+		//
+		//     policy := &authn.Policy{
+		//       Peers: []*authn.PeerAuthenticationMethod{{
+		//         &authn.PeerAuthenticationMethod_Mtls{},
+		//       }},
+		//     }
+		//
+		// The PeerAuthenticationMethod_Mtls object with nil field is lost when
+		// the proto is re-encoded for transport via MCP. As a workaround, fill
+		// in the missing field value which is functionality equivalent.
+		for _, peer := range policy.Peers {
+			if mtls, ok := peer.Params.(*authn.PeerAuthenticationMethod_Mtls); ok && mtls.Mtls == nil {
+				mtls.Mtls = &authn.MutualTls{}
+			}
 		}
 	}
 
 	e := Entry{
 		Key:          name,
-		CreationTime: u.GetCreationTimestamp().Time,
+		CreationTime: creationTime,
 		Resource:     p,
 	}
 
 	return []Entry{e}, nil
 }
 
-func kubeIngressResource(cfg *Config, _ resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]Entry, error) {
-	json, err := u.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
+func kubeIngressResource(cfg *Config, _ resource.Info, name resource.FullName, _ string, u *unstructured.Unstructured) ([]Entry, error) {
+	creationTime := time.Time{}
+	var p *extensions.IngressSpec
+	if u != nil {
+		json, err := u.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
 
-	var p extensions.Ingress
-	if err = json2.Unmarshal(json, &p); err != nil {
-		return nil, err
-	}
+		creationTime = u.GetCreationTimestamp().Time
 
-	if !shouldProcessIngress(cfg, &p) {
-		return nil, nil
+		ing := &extensions.Ingress{}
+		if err = json2.Unmarshal(json, ing); err != nil {
+			return nil, err
+		}
+
+		if !shouldProcessIngress(cfg, ing) {
+			return nil, nil
+		}
+
+		p = &ing.Spec
 	}
 
 	e := Entry{
 		Key:          name,
-		CreationTime: u.GetCreationTimestamp().Time,
-		Resource:     &p.Spec,
+		CreationTime: creationTime,
+		Resource:     p,
 	}
 
 	return []Entry{e}, nil

--- a/galley/pkg/kube/converter/converter_test.go
+++ b/galley/pkg/kube/converter/converter_test.go
@@ -26,11 +26,13 @@ import (
 	"istio.io/istio/galley/pkg/meshconfig"
 	"istio.io/istio/pilot/pkg/model"
 	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	mcfg "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/galley/pkg/kube/converter/legacy"
 	"istio.io/istio/galley/pkg/runtime/resource"
 )
@@ -55,7 +57,7 @@ func TestGet_Panic(t *testing.T) {
 var fakeCreateTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 
 func TestNilConverter(t *testing.T) {
-	e, err := nilConverter(nil, resource.Info{}, resource.FullName{}, nil)
+	e, err := nilConverter(nil, resource.Info{}, resource.FullName{}, "", nil)
 
 	if e != nil {
 		t.Fatalf("Unexpected entries: %v", e)
@@ -86,7 +88,7 @@ func TestIdentity(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	entries, err := identity(nil, info, key, u)
+	entries, err := identity(nil, info, key, "", u)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -142,9 +144,32 @@ func TestIdentity_Error(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	_, err := identity(nil, info, key, u)
+	_, err := identity(nil, info, key, "", u)
 	if err == nil {
 		t.Fatal("Expected error not found")
+	}
+}
+
+func TestIdentity_NilResource(t *testing.T) {
+	b := resource.NewSchemaBuilder()
+	b.Register("type.googleapis.com/google.protobuf.Struct")
+	s := b.Build()
+
+	info := s.Get("type.googleapis.com/google.protobuf.Struct")
+
+	key := resource.FullNameFromNamespaceAndName("foo", "Key")
+
+	entries, err := identity(nil, info, key, "knd", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected one entry: %v", entries)
+	}
+
+	if key != entries[0].Key {
+		t.Fatalf("Keys mismatch. Wanted=%s, Got=%s", key, entries[0].Key)
 	}
 }
 
@@ -169,7 +194,7 @@ func TestLegacyMixerResource(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	entries, err := legacyMixerResource(nil, info, key, u)
+	entries, err := legacyMixerResource(nil, info, key, "k1", u)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -212,6 +237,30 @@ func TestLegacyMixerResource(t *testing.T) {
 	}
 }
 
+func TestLegacyMixerResource_NilResource(t *testing.T) {
+	b := resource.NewSchemaBuilder()
+	b.Register("type.googleapis.com/google.protobuf.Struct")
+	s := b.Build()
+
+	info := s.Get("type.googleapis.com/google.protobuf.Struct")
+
+	key := resource.FullNameFromNamespaceAndName("ns1", "Key")
+
+	entries, err := legacyMixerResource(nil, info, key, "k1", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected one entry: %v", entries)
+	}
+
+	expectedKey := "k1/" + key.String()
+	if entries[0].Key.String() != expectedKey {
+		t.Fatalf("Keys mismatch. Wanted=%s, Got=%s", expectedKey, entries[0].Key)
+	}
+}
+
 func TestLegacyMixerResource_Error(t *testing.T) {
 	b := resource.NewSchemaBuilder()
 	b.Register("type.googleapis.com/google.protobuf.Any")
@@ -228,7 +277,7 @@ func TestLegacyMixerResource_Error(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	_, err := legacyMixerResource(nil, info, key, u)
+	_, err := legacyMixerResource(nil, info, key, "", u)
 	if err == nil {
 		t.Fatalf("expected error not found")
 	}
@@ -313,12 +362,20 @@ func TestAuthPolicyResource(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name:      "nil resource",
+			in:        nil,
+			wantProto: nil,
+		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(tt *testing.T) {
-			wantKey := resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
-			entries, err := authPolicyResource(nil, info, wantKey, c.in)
+			wantKey := resource.FullNameFromNamespaceAndName("ns1", "res1")
+			if c.in != nil {
+				wantKey = resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
+			}
+			entries, err := authPolicyResource(nil, info, wantKey, "kind", c.in)
 			if err != nil {
 				tt.Fatalf("Unexpected error: %v", err)
 			}
@@ -335,6 +392,10 @@ func TestAuthPolicyResource(t *testing.T) {
 				tt.Fatalf("Keys mismatch. got=%s, want=%s", gotKey, wantKey)
 			}
 
+			if c.in == nil {
+				return
+			}
+
 			if !createTime.Equal(fakeCreateTime) {
 				tt.Fatalf("createTime mismatch: got %q want %q",
 					createTime, fakeCreateTime)
@@ -343,6 +404,151 @@ func TestAuthPolicyResource(t *testing.T) {
 			gotProto, ok := pb.(*authn.Policy)
 			if !ok {
 				tt.Fatalf("Unable to convert to authn.Policy: %v", pb)
+			}
+
+			if !reflect.DeepEqual(gotProto, c.wantProto) {
+				tt.Fatalf("Mismatch:\nGot:\n%v\nWanted:\n%v\n", gotProto, c.wantProto)
+			}
+		})
+	}
+}
+
+func TestKubeIngressResource(t *testing.T) {
+	typeURL := fmt.Sprintf("type.googleapis.com/" + proto.MessageName((*extensions.IngressSpec)(nil)))
+	b := resource.NewSchemaBuilder()
+	b.Register(typeURL)
+	s := b.Build()
+
+	info := s.Get(typeURL)
+
+	meshCfgOff := meshconfig.NewInMemory()
+	meshCfgStrict := meshconfig.NewInMemory()
+	meshCfgStrict.Set(mcfg.MeshConfig{
+		IngressClass:          "cls",
+		IngressControllerMode: mcfg.MeshConfig_STRICT,
+	})
+	meshCfgDefault := meshconfig.NewInMemory()
+	meshCfgDefault.Set(mcfg.MeshConfig{
+		IngressClass:          "cls",
+		IngressControllerMode: mcfg.MeshConfig_DEFAULT,
+	})
+
+	cases := []struct {
+		name      string
+		in        *unstructured.Unstructured
+		wantProto *extensions.IngressSpec
+		cfg       *Config
+	}{
+		{
+			name: "no-conversion",
+			in: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Ingress",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": fakeCreateTime.Format(time.RFC3339),
+						"name":              "foo",
+						"namespace":         "default",
+					},
+					"spec": map[string]interface{}{
+						"backend": map[string]interface{}{
+							"serviceName": "testsvc",
+							"servicePort": "80",
+						},
+					},
+				},
+			},
+			cfg: &Config{
+				Mesh: meshCfgOff,
+			},
+
+			wantProto: nil,
+		},
+		{
+			name: "strict",
+			in: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Ingress",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": fakeCreateTime.Format(time.RFC3339),
+						"name":              "foo",
+						"namespace":         "default",
+						"annotations": map[string]interface{}{
+							"kubernetes.io/ingress.class": "cls",
+						},
+					},
+					"spec": map[string]interface{}{
+						"backend": map[string]interface{}{
+							"serviceName": "testsvc",
+							"servicePort": "80",
+						},
+					},
+				},
+			},
+			cfg: &Config{
+				Mesh: meshCfgStrict,
+			},
+
+			wantProto: &extensions.IngressSpec{
+				Backend: &extensions.IngressBackend{
+					ServiceName: "testsvc",
+					ServicePort: intstr.IntOrString{Type: intstr.String, StrVal: "80"},
+				},
+			},
+		},
+		{
+			name: "nil",
+			in:   nil,
+			cfg: &Config{
+				Mesh: meshCfgDefault,
+			},
+
+			wantProto: &extensions.IngressSpec{},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(tt *testing.T) {
+			wantKey := resource.FullNameFromNamespaceAndName("ns1", "res1")
+			if c.in != nil {
+				wantKey = resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
+			}
+			entries, err := kubeIngressResource(c.cfg, info, wantKey, "kind", c.in)
+			if err != nil {
+				tt.Fatalf("Unexpected error: %v", err)
+			}
+
+			if c.wantProto == nil {
+
+				if len(entries) != 0 {
+					tt.Fatalf("Expected zero entries: %v", entries)
+				}
+				return
+			}
+
+			if len(entries) != 1 {
+				tt.Fatalf("Expected one entry: %v", entries)
+			}
+
+			gotKey := entries[0].Key
+			createTime := entries[0].CreationTime
+			pb := entries[0].Resource
+
+			if entries[0].Key != wantKey {
+				tt.Fatalf("Keys mismatch. got=%s, want=%s", gotKey, wantKey)
+			}
+
+			if c.in == nil {
+				return
+			}
+
+			if !createTime.Equal(fakeCreateTime) {
+				tt.Fatalf("createTime mismatch: got %q want %q",
+					createTime, fakeCreateTime)
+			}
+
+			gotProto, ok := pb.(*extensions.IngressSpec)
+			if !ok {
+				tt.Fatalf("Unable to convert to ingress spec: %v", pb)
 			}
 
 			if !reflect.DeepEqual(gotProto, c.wantProto) {

--- a/galley/pkg/kube/source/source_test.go
+++ b/galley/pkg/kube/source/source_test.go
@@ -246,7 +246,7 @@ func TestSource_ProtoConversionError(t *testing.T) {
 			Singular: "foo",
 			Plural:   "foos",
 			Target:   emptyInfo,
-			Converter: func(_ *converter.Config, info resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]converter.Entry, error) {
+			Converter: func(_ *converter.Config, info resource.Info, name resource.FullName, kind string, u *unstructured.Unstructured) ([]converter.Entry, error) {
 				return nil, fmt.Errorf("cant convert")
 			},
 		},


### PR DESCRIPTION
+ During the fixing of https://github.com/istio/istio/pull/9652, a bug was introduced that caused legacy Mixer resources to overwrite each other due to a bug in name mangling. This PR fixes the issue.
+ In addition, it is hardening the conversion code against cases where we get tombstone entries instead of full entities during delete events.

fixes https://github.com/istio/istio/issues/9872