### PR TITLE
Adding integration tests to circle periodic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -844,6 +844,12 @@ workflows:
       - e2e-pilot-auth-v1alpha3-v2-mcp: # auth+v1alpha3+v2 with MCP
           requires:
             - build
+      - test-integration-local:
+          requires:
+            - build
+      - test-integration-kubernetes:
+          requires:
+            - build
 
   all:
     jobs:
@@ -880,8 +886,5 @@ workflows:
           requires:
             - build
       - test-integration-local:
-          requires:
-            - build
-      - test-integration-kubernetes:
           requires:
             - build


### PR DESCRIPTION
and temporarily remove kubernetes tests from presubmit since it keeps
failing to reduce noise. Will restore after it is fixed.