### PR TITLE
Adding "kind/test failure" to stalebot exempt list

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -42,5 +42,6 @@ issues:
   exemptLabels:
     - help wanted
     - kind/customer issue
+    - kind/test failure
     - Epic
     - no stalebot


### PR DESCRIPTION
so that we do not close the test failure issues automatically.