### PR TITLE
Improve robustness of validation readiness checks in galley and test framework

### DIFF
--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -129,7 +129,7 @@ func RunValidation(vc *WebhookParameters, printf, faltaf shared.FormatFn, kubeCo
 			for {
 				if err := webhookHTTPSHandlerReady(vc); err != nil {
 					validationReadinessProbe.SetAvailable(errors.New("not ready"))
-					scope.Infof("https handler for validation webhook  is not ready: %v", err)
+					scope.Infof("https handler for validation webhook is not ready: %v", err)
 					ready = false
 				} else {
 					validationReadinessProbe.SetAvailable(nil)

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -15,11 +15,15 @@
 package validation
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"regexp"
+	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
 
 	"istio.io/istio/galley/cmd/shared"
 	"istio.io/istio/mixer/adapter"
@@ -37,6 +41,8 @@ import (
 const (
 	dns1123LabelMaxLength int    = 63
 	dns1123LabelFmt       string = "[a-zA-Z0-9]([-a-z-A-Z0-9]*[a-zA-Z0-9])?"
+
+	httpsHandlerReadinessFreq = time.Second
 )
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
@@ -54,6 +60,38 @@ func createMixerValidator() store.BackendValidator {
 	}
 	adapters := config.AdapterInfoMap(adapter.Inventory(), template.NewRepository(info).SupportsTemplate)
 	return store.NewValidator(nil, runtimeConfig.KindMap(adapters, templates))
+}
+
+func webhookHTTPSHandlerReady(vc *WebhookParameters) error {
+	client := &http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	readinessURL := &url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("localhost:%v", vc.Port),
+		Path:   httpsHandlerReadyPath,
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    readinessURL,
+	}
+
+	response, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request to %v failed: %v", readinessURL, err)
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %v returned non-200 status=%v",
+			readinessURL, response.StatusCode)
+	}
+	return nil
 }
 
 //RunValidation start running Galley validation mode
@@ -77,14 +115,40 @@ func RunValidation(vc *WebhookParameters, printf, faltaf shared.FormatFn, kubeCo
 		validationLivenessProbe.RegisterProbe(livenessProbeController, "validationLiveness")
 		defer validationLivenessProbe.SetAvailable(errors.New("stopped"))
 	}
-	if readinessProbeController != nil {
-		validationReadinessProbe := probe.NewProbe()
-		validationReadinessProbe.SetAvailable(nil)
-		validationReadinessProbe.RegisterProbe(readinessProbeController, "validationReadiness")
-		defer validationReadinessProbe.SetAvailable(errors.New("stopped"))
-	}
+
 	// Create the stop channel for all of the servers.
 	stop := make(chan struct{})
+
+	if readinessProbeController != nil {
+		validationReadinessProbe := probe.NewProbe()
+		validationReadinessProbe.SetAvailable(errors.New("init"))
+		validationReadinessProbe.RegisterProbe(readinessProbeController, "validationReadiness")
+
+		go func() {
+			ready := false
+			for {
+				if err := webhookHTTPSHandlerReady(vc); err != nil {
+					validationReadinessProbe.SetAvailable(errors.New("not ready"))
+					scope.Infof("https handler for validation webhook  is not ready: %v", err)
+					ready = false
+				} else {
+					validationReadinessProbe.SetAvailable(nil)
+
+					if !ready {
+						scope.Info("https handler for validation webhook is ready")
+						ready = true
+					}
+				}
+				select {
+				case <-stop:
+					validationReadinessProbe.SetAvailable(errors.New("stopped"))
+					return
+				case <-time.After(httpsHandlerReadinessFreq):
+					// check again
+				}
+			}
+		}()
+	}
 
 	go wh.Run(stop)
 	cmd.WaitSignal(stop)

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -55,6 +55,8 @@ func init() {
 
 const (
 	watchDebounceDelay = 100 * time.Millisecond
+
+	httpsHandlerReadyPath = "/ready"
 )
 
 // WebhookParameters contains the configuration for the Istio Pilot validation
@@ -240,6 +242,7 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 	h := http.NewServeMux()
 	h.HandleFunc("/admitpilot", wh.serveAdmitPilot)
 	h.HandleFunc("/admitmixer", wh.serveAdmitMixer)
+	h.HandleFunc(httpsHandlerReadyPath, wh.serveReady)
 	wh.server.Handler = h
 
 	return wh, nil
@@ -378,6 +381,10 @@ func serve(w http.ResponseWriter, r *http.Request, admit admitFunc) {
 		reportValidationHTTPError(http.StatusInternalServerError)
 		http.Error(w, fmt.Sprintf("could write response: %v", err), http.StatusInternalServerError)
 	}
+}
+
+func (wh *Webhook) serveReady(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }
 
 func (wh *Webhook) serveAdmitPilot(w http.ResponseWriter, r *http.Request) {

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -746,7 +746,7 @@ EOF`, k.KubeConfig, dummyValidationRule)
 EOF`, k.KubeConfig, dummyValidationRule)
 
 	log.Info("Creating dummy rule to check for validation webhook readiness")
-	time := time.Now().Add(validationWebhookReadinessTimeout)
+	timeout := time.Now().Add(validationWebhookReadinessTimeout)
 	for {
 		if time.Now().After(timeout) {
 			return errors.New("timeout waiting for validation webhook readiness")

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -70,6 +70,9 @@ const (
 	PrimaryCluster = "primary"
 	// RemoteCluster identifies the remote cluster
 	RemoteCluster = "remote"
+
+	validationWebhookReadinessTimeout = time.Minute
+	validationWebhookReadinessFreq    = 100 * time.Millisecond
 )
 
 var (
@@ -96,7 +99,7 @@ var (
 	imagePullPolicy     = flag.String("image_pull_policy", "", "Specifies an override for the Docker image pull policy to be used")
 	multiClusterDir     = flag.String("cluster_registry_dir", "",
 		"Directory name for the cluster registry config. When provided a multicluster test to be run across two clusters.")
-	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", false, "Use galley configuration validation webhook")
+	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", true, "Use galley configuration validation webhook")
 	installer                = flag.String("installer", "kubectl", "Istio installer, default to kubectl, or helm")
 	useMCP                   = flag.Bool("use_mcp", false, "use MCP for configuring Istio components")
 	kubeInjectCM             = flag.String("kube_inject_configmap", "",
@@ -491,7 +494,7 @@ func (k *KubeInfo) Teardown() error {
 	// confirm the namespace is deleted as it will cause future creation to fail
 	maxAttempts := 600
 	namespaceDeleted := false
-	validatingWebhookConfigurationDeleted := false
+	validatingWebhookConfigurationExists := false
 	log.Infof("Deleting namespace %v", k.Namespace)
 	for attempts := 1; attempts <= maxAttempts; attempts++ {
 		namespaceDeleted, _ = util.NamespaceDeleted(k.Namespace, k.KubeConfig)
@@ -499,9 +502,9 @@ func (k *KubeInfo) Teardown() error {
 		// be delete by kubernetes GC controller asynchronously,
 		// we need to ensure it's deleted before return.
 		// TODO: find a more general way as long term solution.
-		validatingWebhookConfigurationDeleted = util.ValidatingWebhookConfigurationDeleted("istio-galley", k.KubeConfig)
+		validatingWebhookConfigurationExists = util.ValidatingWebhookConfigurationExists("istio-galley", k.KubeConfig)
 
-		if namespaceDeleted && validatingWebhookConfigurationDeleted {
+		if namespaceDeleted && !validatingWebhookConfigurationExists {
 			break
 		}
 
@@ -513,7 +516,7 @@ func (k *KubeInfo) Teardown() error {
 		return nil
 	}
 
-	if !validatingWebhookConfigurationDeleted {
+	if validatingWebhookConfigurationExists {
 		log.Errorf("Failed to delete validatingwebhookconfiguration istio-galley after %d seconds", maxAttempts)
 		return nil
 	}
@@ -681,6 +684,10 @@ func (k *KubeInfo) deployIstio() error {
 		if !validationReady {
 			return errors.New("timeout waiting for validatingwebhookconfiguration istio-galley to be created")
 		}
+
+		if err := k.waitForValdiationWebhook(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -711,6 +718,52 @@ func (k *KubeInfo) deployTiller(yamlFileName string) error {
 	}
 	// wait till tiller reaches running
 	return util.CheckPodRunning("kube-system", "name=tiller", k.KubeConfig)
+}
+
+var (
+	dummyValidationRule = `
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: validation-readiness-dummy-rule
+spec:
+  match: request.headers["foo"] == "bar"
+  actions:
+  - handler: validation-readiness-dummy
+    instances:
+    - validation-readiness-dummy
+`
+)
+
+func (k *KubeInfo) waitForValdiationWebhook() error {
+
+	add := fmt.Sprintf(`cat << EOF | kubectl --kubeconfig=%s apply -f -
+%s
+EOF`, k.KubeConfig, dummyValidationRule)
+
+	remove := fmt.Sprintf(`cat << EOF | kubectl --kubeconfig=%s delete -f -
+%s
+EOF`, k.KubeConfig, dummyValidationRule)
+
+	log.Info("Creating dummy rule to check for validation webhook readiness")
+	time := time.Now().Add(validationWebhookReadinessTimeout)
+	for {
+		if time.Now().After(timeout) {
+			return errors.New("timeout waiting for validation webhook readiness")
+		}
+
+		out, err := util.ShellSilent(add)
+		if err == nil && !strings.Contains(out, "connection refused") {
+			break
+		}
+
+		log.Errorf("Validation webhook not ready yet: %v %v", out, err)
+		time.Sleep(validationWebhookReadinessFreq)
+
+	}
+	util.ShellSilent(remove) // nolint: errcheck
+	log.Info("Validation webhook is ready")
+	return nil
 }
 
 func (k *KubeInfo) deployIstioWithHelm() error {
@@ -783,6 +836,12 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 	if err != nil {
 		log.Errorf("Helm install istio install failed %s, setValue=%s", istioHelmInstallDir, setValue)
 		return err
+	}
+
+	if *useGalleyConfigValidator {
+		if err := k.waitForValdiationWebhook(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/tests/e2e/tests/galley/galley_test.go
+++ b/tests/e2e/tests/galley/galley_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/tests/e2e/framework"
@@ -87,6 +88,11 @@ func doGalleyConfig(configName string, do kubeDo) error {
 	}
 	return do(tc.Kube.Namespace, string(contents), tc.Kube.KubeConfig)
 }
+
+const (
+	waitForValidatingWebhookConfigTimeout   = 5 * time.Second
+	waitForValidatingWebhookConfigCheckFreq = 100 * time.Millisecond
+)
 
 func TestValidation(t *testing.T) {
 	const base = "tests/e2e/tests/galley/testdata"
@@ -192,6 +198,20 @@ func TestValidation(t *testing.T) {
 		}
 		return strings.Contains(err.Error(), "denied the request")
 	}
+
+	t.Log("Checking for istio-galley validatingwebhookconfiguration ...")
+	timeout := time.Now().Add(waitForValidatingWebhookConfigTimeout)
+	for {
+		if time.Now().After(timeout) {
+			t.Fatal("Timeout waiting for istio-galley validatingwebhookconfiguration to be created")
+		}
+		if util.ValidatingWebhookConfigurationExists("istio-galley", tc.Kube.KubeConfig) {
+			break
+		}
+		t.Log("istio-galley validatingwebhookconfiguration not ready")
+		time.Sleep(waitForValidatingWebhookConfigCheckFreq)
+	}
+	t.Log("Found istio-galley validatingwebhookconfiguration. Proceeding with test.")
 
 	for i := range cases {
 		c := cases[i]

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -135,10 +135,10 @@ func NamespaceDeleted(n string, kubeconfig string) (bool, error) {
 	return false, err
 }
 
-// ValidatingWebhookConfigurationDeleted check if a kubernetes ValidatingWebhookConfiguration is deleted
-func ValidatingWebhookConfigurationDeleted(name string, kubeconfig string) bool {
+// ValidatingWebhookConfigurationExists check if a kubernetes ValidatingWebhookConfiguration is deleted
+func ValidatingWebhookConfigurationExists(name string, kubeconfig string) bool {
 	output, _ := ShellSilent("kubectl get validatingwebhookconfiguration %s -o name --kubeconfig=%s", name, kubeconfig)
-	return strings.Contains(output, "NotFound")
+	return !strings.Contains(output, "NotFound")
 }
 
 // KubeApplyContents kubectl apply from contents


### PR DESCRIPTION
* The http handler for webhook validation was not hooked up to the
process readiness probes. This could cause premature readiness if the
https handler was slow to start relative to the configuration update
path. The http handler blocks and must therefore be run from a
goroutine. Querying the local "ready" path on the local server provides a
reliable indication of when the server is actually ready to serve
traffic.

* Verify the validationwebhookconfiguration is created before running
  the e2e galley validation test.

* Verify the kube-apiserver can reach the validation service before
  starting _any_ e2e test when validation is enabled.

* Enable validation by default in all e2e tests.

fixes https://github.com/istio/istio/issues/9863