### PR TITLE
Fix MCP Legacy Mixer config conversion logic. (#9862)

### DIFF
--- a/galley/pkg/kube/converter/converter_test.go
+++ b/galley/pkg/kube/converter/converter_test.go
@@ -26,11 +26,13 @@ import (
 	"istio.io/istio/galley/pkg/meshconfig"
 	"istio.io/istio/pilot/pkg/model"
 	"k8s.io/api/extensions/v1beta1"
+	extensions "k8s.io/api/extensions/v1beta1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	authn "istio.io/api/authentication/v1alpha1"
+	mcfg "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/galley/pkg/kube/converter/legacy"
 	"istio.io/istio/galley/pkg/runtime/resource"
 )
@@ -55,7 +57,7 @@ func TestGet_Panic(t *testing.T) {
 var fakeCreateTime, _ = time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 
 func TestNilConverter(t *testing.T) {
-	e, err := nilConverter(nil, resource.Info{}, resource.FullName{}, nil)
+	e, err := nilConverter(nil, resource.Info{}, resource.FullName{}, "", nil)
 
 	if e != nil {
 		t.Fatalf("Unexpected entries: %v", e)
@@ -86,7 +88,7 @@ func TestIdentity(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	entries, err := identity(nil, info, key, u)
+	entries, err := identity(nil, info, key, "", u)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -142,9 +144,32 @@ func TestIdentity_Error(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	_, err := identity(nil, info, key, u)
+	_, err := identity(nil, info, key, "", u)
 	if err == nil {
 		t.Fatal("Expected error not found")
+	}
+}
+
+func TestIdentity_NilResource(t *testing.T) {
+	b := resource.NewSchemaBuilder()
+	b.Register("type.googleapis.com/google.protobuf.Struct")
+	s := b.Build()
+
+	info := s.Get("type.googleapis.com/google.protobuf.Struct")
+
+	key := resource.FullNameFromNamespaceAndName("foo", "Key")
+
+	entries, err := identity(nil, info, key, "knd", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected one entry: %v", entries)
+	}
+
+	if key != entries[0].Key {
+		t.Fatalf("Keys mismatch. Wanted=%s, Got=%s", key, entries[0].Key)
 	}
 }
 
@@ -169,7 +194,7 @@ func TestLegacyMixerResource(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	entries, err := legacyMixerResource(nil, info, key, u)
+	entries, err := legacyMixerResource(nil, info, key, "k1", u)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -212,6 +237,30 @@ func TestLegacyMixerResource(t *testing.T) {
 	}
 }
 
+func TestLegacyMixerResource_NilResource(t *testing.T) {
+	b := resource.NewSchemaBuilder()
+	b.Register("type.googleapis.com/google.protobuf.Struct")
+	s := b.Build()
+
+	info := s.Get("type.googleapis.com/google.protobuf.Struct")
+
+	key := resource.FullNameFromNamespaceAndName("ns1", "Key")
+
+	entries, err := legacyMixerResource(nil, info, key, "k1", nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("Expected one entry: %v", entries)
+	}
+
+	expectedKey := "k1/" + key.String()
+	if entries[0].Key.String() != expectedKey {
+		t.Fatalf("Keys mismatch. Wanted=%s, Got=%s", expectedKey, entries[0].Key)
+	}
+}
+
 func TestLegacyMixerResource_Error(t *testing.T) {
 	b := resource.NewSchemaBuilder()
 	b.Register("type.googleapis.com/google.protobuf.Any")
@@ -228,7 +277,7 @@ func TestLegacyMixerResource_Error(t *testing.T) {
 
 	key := resource.FullNameFromNamespaceAndName("", "Key")
 
-	_, err := legacyMixerResource(nil, info, key, u)
+	_, err := legacyMixerResource(nil, info, key, "", u)
 	if err == nil {
 		t.Fatalf("expected error not found")
 	}
@@ -313,12 +362,20 @@ func TestAuthPolicyResource(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name:      "nil resource",
+			in:        nil,
+			wantProto: nil,
+		},
 	}
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(tt *testing.T) {
-			wantKey := resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
-			entries, err := authPolicyResource(nil, info, wantKey, c.in)
+			wantKey := resource.FullNameFromNamespaceAndName("ns1", "res1")
+			if c.in != nil {
+				wantKey = resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
+			}
+			entries, err := authPolicyResource(nil, info, wantKey, "kind", c.in)
 			if err != nil {
 				tt.Fatalf("Unexpected error: %v", err)
 			}
@@ -335,6 +392,10 @@ func TestAuthPolicyResource(t *testing.T) {
 				tt.Fatalf("Keys mismatch. got=%s, want=%s", gotKey, wantKey)
 			}
 
+			if c.in == nil {
+				return
+			}
+
 			if !createTime.Equal(fakeCreateTime) {
 				tt.Fatalf("createTime mismatch: got %q want %q",
 					createTime, fakeCreateTime)
@@ -343,6 +404,151 @@ func TestAuthPolicyResource(t *testing.T) {
 			gotProto, ok := pb.(*authn.Policy)
 			if !ok {
 				tt.Fatalf("Unable to convert to authn.Policy: %v", pb)
+			}
+
+			if !reflect.DeepEqual(gotProto, c.wantProto) {
+				tt.Fatalf("Mismatch:\nGot:\n%v\nWanted:\n%v\n", gotProto, c.wantProto)
+			}
+		})
+	}
+}
+
+func TestKubeIngressResource(t *testing.T) {
+	typeURL := fmt.Sprintf("type.googleapis.com/" + proto.MessageName((*extensions.IngressSpec)(nil)))
+	b := resource.NewSchemaBuilder()
+	b.Register(typeURL)
+	s := b.Build()
+
+	info := s.Get(typeURL)
+
+	meshCfgOff := meshconfig.NewInMemory()
+	meshCfgStrict := meshconfig.NewInMemory()
+	meshCfgStrict.Set(mcfg.MeshConfig{
+		IngressClass:          "cls",
+		IngressControllerMode: mcfg.MeshConfig_STRICT,
+	})
+	meshCfgDefault := meshconfig.NewInMemory()
+	meshCfgDefault.Set(mcfg.MeshConfig{
+		IngressClass:          "cls",
+		IngressControllerMode: mcfg.MeshConfig_DEFAULT,
+	})
+
+	cases := []struct {
+		name      string
+		in        *unstructured.Unstructured
+		wantProto *extensions.IngressSpec
+		cfg       *Config
+	}{
+		{
+			name: "no-conversion",
+			in: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Ingress",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": fakeCreateTime.Format(time.RFC3339),
+						"name":              "foo",
+						"namespace":         "default",
+					},
+					"spec": map[string]interface{}{
+						"backend": map[string]interface{}{
+							"serviceName": "testsvc",
+							"servicePort": "80",
+						},
+					},
+				},
+			},
+			cfg: &Config{
+				Mesh: meshCfgOff,
+			},
+
+			wantProto: nil,
+		},
+		{
+			name: "strict",
+			in: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind": "Ingress",
+					"metadata": map[string]interface{}{
+						"creationTimestamp": fakeCreateTime.Format(time.RFC3339),
+						"name":              "foo",
+						"namespace":         "default",
+						"annotations": map[string]interface{}{
+							"kubernetes.io/ingress.class": "cls",
+						},
+					},
+					"spec": map[string]interface{}{
+						"backend": map[string]interface{}{
+							"serviceName": "testsvc",
+							"servicePort": "80",
+						},
+					},
+				},
+			},
+			cfg: &Config{
+				Mesh: meshCfgStrict,
+			},
+
+			wantProto: &extensions.IngressSpec{
+				Backend: &extensions.IngressBackend{
+					ServiceName: "testsvc",
+					ServicePort: intstr.IntOrString{Type: intstr.String, StrVal: "80"},
+				},
+			},
+		},
+		{
+			name: "nil",
+			in:   nil,
+			cfg: &Config{
+				Mesh: meshCfgDefault,
+			},
+
+			wantProto: &extensions.IngressSpec{},
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("[%d] %s", i, c.name), func(tt *testing.T) {
+			wantKey := resource.FullNameFromNamespaceAndName("ns1", "res1")
+			if c.in != nil {
+				wantKey = resource.FullNameFromNamespaceAndName(c.in.GetNamespace(), c.in.GetName())
+			}
+			entries, err := kubeIngressResource(c.cfg, info, wantKey, "kind", c.in)
+			if err != nil {
+				tt.Fatalf("Unexpected error: %v", err)
+			}
+
+			if c.wantProto == nil {
+
+				if len(entries) != 0 {
+					tt.Fatalf("Expected zero entries: %v", entries)
+				}
+				return
+			}
+
+			if len(entries) != 1 {
+				tt.Fatalf("Expected one entry: %v", entries)
+			}
+
+			gotKey := entries[0].Key
+			createTime := entries[0].CreationTime
+			pb := entries[0].Resource
+
+			if entries[0].Key != wantKey {
+				tt.Fatalf("Keys mismatch. got=%s, want=%s", gotKey, wantKey)
+			}
+
+			if c.in == nil {
+				return
+			}
+
+			if !createTime.Equal(fakeCreateTime) {
+				tt.Fatalf("createTime mismatch: got %q want %q",
+					createTime, fakeCreateTime)
+			}
+
+			gotProto, ok := pb.(*extensions.IngressSpec)
+			if !ok {
+				tt.Fatalf("Unable to convert to ingress spec: %v", pb)
 			}
 
 			if !reflect.DeepEqual(gotProto, c.wantProto) {

--- a/galley/pkg/kube/source/source_test.go
+++ b/galley/pkg/kube/source/source_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -246,7 +247,7 @@ func TestSource_ProtoConversionError(t *testing.T) {
 			Singular: "foo",
 			Plural:   "foos",
 			Target:   emptyInfo,
-			Converter: func(_ *converter.Config, info resource.Info, name resource.FullName, u *unstructured.Unstructured) ([]converter.Entry, error) {
+			Converter: func(_ *converter.Config, info resource.Info, name resource.FullName, kind string, u *unstructured.Unstructured) ([]converter.Entry, error) {
 				return nil, fmt.Errorf("cant convert")
 			},
 		},
@@ -273,6 +274,77 @@ func TestSource_ProtoConversionError(t *testing.T) {
 	log := logChannelOutput(ch, 1)
 	expected := strings.TrimSpace(`
 [Event](FullSync)
+`)
+	if log != expected {
+		t.Fatalf("Event mismatch:\nActual:\n%s\nExpected:\n%s\n", log, expected)
+	}
+
+	s.Stop()
+}
+
+func TestSource_MangledNames(t *testing.T) {
+	k := &mock.Kube{}
+	cl := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	k.AddResponse(cl, nil)
+
+	i1 := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":            "f1",
+				"namespace":       "ns",
+				"resourceVersion": "rv1",
+			},
+			"spec": map[string]interface{}{
+				"zoo": "zar",
+			},
+		},
+	}
+
+	cl.PrependReactor("*", "foos", func(action dtesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &unstructured.UnstructuredList{Items: []unstructured.Unstructured{i1}}, nil
+	})
+	cl.PrependWatchReactor("foos", func(action dtesting.Action) (handled bool, ret watch.Interface, err error) {
+		return true, mock.NewWatch(), nil
+	})
+
+	entries := []kube.ResourceSpec{
+		{
+			Kind:     "foo",
+			Singular: "foo",
+			Plural:   "foos",
+			Target:   emptyInfo,
+			Converter: func(_ *converter.Config, info resource.Info, name resource.FullName, kind string, u *unstructured.Unstructured) ([]converter.Entry, error) {
+				e := converter.Entry{
+					Key:      resource.FullNameFromNamespaceAndName("foo", name.String()),
+					Resource: &types.Struct{},
+				}
+
+				return []converter.Entry{e}, nil
+			},
+		},
+	}
+
+	cfg := converter.Config{
+		Mesh: meshconfig.NewInMemory(),
+	}
+	s, err := newSource(k, 0, &cfg, entries)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if s == nil {
+		t.Fatal("Expected non nil source")
+	}
+
+	ch, err := s.Start()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// The mangled name foo/ns/f1 should appear.
+	log := logChannelOutput(ch, 1)
+	expected := strings.TrimSpace(`
+[Event](Added: [VKey](type.googleapis.com/google.protobuf.Empty:foo/ns/f1 @rv1))
 `)
 	if log != expected {
 		t.Fatalf("Event mismatch:\nActual:\n%s\nExpected:\n%s\n", log, expected)


### PR DESCRIPTION
* Fix MCP Legacy Mixer config conversion logic.

+ During the fixing of https://github.com/istio/istio/pull/9652, a bug
was introduced that caused legacy Mixer resources to overwrite each other
due to a bug in name mangling. This PR fixes the issue.
+ In addition, it is hardening the conversion code against cases where
we get tombstone entries instead of full entities during delete events.

(cherry picked from commit 92f8e4a406947896fedb89d4bb8105e5f6662398)