### PR TITLE
Additional config fix, for multicluster (crashing)

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -87,7 +87,7 @@ data:
         - --parentShutdownDuration
         - {{ "[[ formatDuration .ProxyConfig.ParentShutdownDuration ]]" }}
         - --discoveryAddress
-        - {{ "[[ .ProxyConfig.DiscoveryAddress ]]" }}
+        - {{ "[[ annotation .ObjectMeta `sidecar.istio.io/discoveryAddress` .ProxyConfig.DiscoveryAddress ]]" }}
         - --discoveryRefreshDelay
         - {{ "[[ formatDuration .ProxyConfig.DiscoveryRefreshDelay ]]" }}
         - --zipkinAddress

--- a/pilot/pkg/config/clusterregistry/secretcontroller.go
+++ b/pilot/pkg/config/clusterregistry/secretcontroller.go
@@ -235,6 +235,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 				DomainSuffix:     c.domainSufix,
 				ClusterID:        clusterID,
 				XDSUpdater:       c.edsUpdater,
+				ConfigUpdater:    c.configUpdater,
 			})
 			c.cs.rc[clusterID].Controller = kubectl
 			c.serviceController.AddRegistry(


### PR DESCRIPTION
Did some manual testing for multi-cluster, it was missing a config (master doesn't have this 
problem, it was refactored/simplified).

Also backported the annotation allowing pods to specify a custom pilot address, for testing/canary.