### PR TITLE
[test-framework] Fixing system deploy and undeploy

### DIFF
--- a/pkg/test/deployment/helm.go
+++ b/pkg/test/deployment/helm.go
@@ -94,9 +94,8 @@ func NewHelmDeployment(c HelmConfig) (*Instance, error) {
 
 // HelmTemplate calls "helm template".
 func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile string, values map[string]string) (string, error) {
-	valuesString := ""
-
 	// Apply the overrides for the values file.
+	valuesString := ""
 	if values != nil {
 		for k, v := range values {
 			valuesString += fmt.Sprintf(" --set %s=%s", k, v)
@@ -105,7 +104,7 @@ func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile strin
 
 	valuesFileString := ""
 	if valuesFile != "" {
-		valuesFileString = fmt.Sprintf(" --values %s", valuesFile)
+		valuesFileString = fmt.Sprintf("--values %s", valuesFile)
 	}
 
 	helmRepoDir := filepath.Join(workDir, "helmrepo")
@@ -132,11 +131,12 @@ func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile strin
 	if _, err := exec(fmt.Sprintf("helm --home %s package -u %s -d %s", helmRepoDir, chartDir, chartBuildDir)); err != nil {
 		return "", err
 	}
-	return exec(fmt.Sprintf("helm --home %s template %s --name %s --namespace %s%s%s",
+	return exec(fmt.Sprintf("helm --home %s template %s --name %s --namespace %s %s %s",
 		helmRepoDir, chartDir, deploymentName, namespace, valuesFileString, valuesString))
 }
 
 func exec(cmd string) (string, error) {
+	scopes.CI.Infof("executing: %s", cmd)
 	str, err := shell.Execute(cmd)
 	if err != nil {
 		scopes.CI.Errorf("failed executing command (%s): %v: %s", cmd, err, str)

--- a/pkg/test/docker/registry/cmd/main.go
+++ b/pkg/test/docker/registry/cmd/main.go
@@ -103,7 +103,7 @@ func inClusterRegistry(_ []string, fatalf shared.FormatFn, cr *closerRegister) *
 		Use:   "in_cluster_registry",
 		Short: "sets up a in-cluster registry in your Kubernetes cluster",
 		Run: func(cmd *cobra.Command, args []string) {
-			accessor, err := testKube.NewAccessor(sa.kubeconfig)
+			accessor, err := testKube.NewAccessor(sa.kubeconfig, "")
 			if err != nil {
 				fatalf("failed to create accessor. %v", err)
 			}

--- a/pkg/test/framework/components/apps/kube/deployment.go
+++ b/pkg/test/framework/components/apps/kube/deployment.go
@@ -194,7 +194,14 @@ func (d *deployment) waitForPod(e *kubernetes.Implementation) (kubeApiCore.Pod, 
 		return kubeApiCore.Pod{}, err
 	}
 
-	if err = e.Accessor.WaitUntilPodIsRunning(n, pod.Name); err != nil {
+	fetchFn := func() ([]kubeApiCore.Pod, error) {
+		pod, err := e.Accessor.GetPod(n, pod.Name)
+		if err != nil {
+			return nil, err
+		}
+		return []kubeApiCore.Pod{*pod}, nil
+	}
+	if err = e.Accessor.WaitUntilPodsAreReady(fetchFn); err != nil {
 		return kubeApiCore.Pod{}, err
 	}
 	return pod, nil

--- a/pkg/test/framework/components/policybackend/kube.go
+++ b/pkg/test/framework/components/policybackend/kube.go
@@ -17,7 +17,7 @@ package policybackend
 import (
 	"fmt"
 
-	v12 "k8s.io/api/core/v1"
+	kubeApiCore "k8s.io/api/core/v1"
 
 	"istio.io/istio/pkg/test/fakes/policy"
 	"istio.io/istio/pkg/test/framework/dependency"
@@ -136,19 +136,27 @@ func (c *kubeComponent) Init(ctx environment.ComponentContext, deps map[dependen
 		return
 	}
 
-	var pod v12.Pod
+	var pod kubeApiCore.Pod
 	pod, err = e.Accessor.WaitForPodBySelectors(s.DependencyNamespace, "app=policy-backend", "version=test")
 	if err != nil {
 		scopes.CI.Infof("Error waiting for PolicyBackend pod: %v", err)
 		return
 	}
 
-	if err = e.Accessor.WaitUntilPodIsRunning(s.DependencyNamespace, pod.Name); err != nil {
+	fetchFn := func() ([]kubeApiCore.Pod, error) {
+		pod, err := e.Accessor.GetPod(pod.Namespace, pod.Name)
+		if err != nil {
+			return nil, err
+		}
+		return []kubeApiCore.Pod{*pod}, nil
+	}
+
+	if err = e.Accessor.WaitUntilPodsAreReady(fetchFn); err != nil {
 		scopes.CI.Infof("Error waiting for PolicyBackend pod to become running: %v", err)
 		return
 	}
 
-	var svc *v12.Service
+	var svc *kubeApiCore.Service
 	svc, err = e.Accessor.GetService(s.DependencyNamespace, "policy-backend")
 	if err != nil {
 		scopes.CI.Infof("Error waiting for PolicyBackend service to be available: %v", err)

--- a/pkg/test/framework/environments/kubernetes/implementation.go
+++ b/pkg/test/framework/environments/kubernetes/implementation.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,13 +35,18 @@ import (
 	"istio.io/istio/pkg/test/kube"
 )
 
+const (
+	validatingWebhookName = "istio-galley"
+)
+
 // Implementation is the implementation of a kubernetes environment. It implements environment.Implementation,
 // and also hosts publicly accessible methods that are specific to cluster environment.
 type Implementation struct {
 	kube *Settings
 	ctx  environment.ComponentContext
 
-	Accessor *kube.Accessor
+	Accessor   *kube.Accessor
+	deployment *deployment.Instance
 
 	// Both rest.Config and kube config path is used by different parts of the code.
 	config *rest.Config
@@ -48,8 +54,6 @@ type Implementation struct {
 	systemNamespace     *namespace
 	dependencyNamespace *namespace
 	testNamespace       *namespace
-
-	deployment *deployment.Instance
 }
 
 var _ internal.EnvironmentController = &Implementation{}
@@ -88,7 +92,7 @@ func (e *Implementation) Initialize(ctx *internal.TestContext) error {
 
 	scopes.CI.Infof("Test Framework Kubernetes environment settings:\n%s", e.kube)
 
-	if e.Accessor, err = kube.NewAccessor(e.kube.KubeConfig); err != nil {
+	if e.Accessor, err = kube.NewAccessor(e.kube.KubeConfig, ctx.Settings().WorkDir); err != nil {
 		return err
 	}
 
@@ -135,6 +139,7 @@ func (e *Implementation) deployIstio() (err error) {
 	defer func() {
 		if err != nil {
 			scopes.CI.Infof("=== FAILED: Deploy Istio ===")
+			scopes.CI.Infoa(err)
 		} else {
 			scopes.CI.Infof("=== SUCCEEDED: Deploy Istio ===")
 		}
@@ -233,13 +238,13 @@ func (e *Implementation) DumpState(context string) {
 func (e *Implementation) Close() error {
 	var err error
 
-	// Delete any namespaces that were allocated.
+	// Delete test and dependency namespaces if allocated.
 	waitFuncs := make([]func() error, 0)
-	for _, ns := range []*namespace{e.testNamespace, e.dependencyNamespace, e.systemNamespace} {
+	for _, ns := range []*namespace{e.testNamespace, e.dependencyNamespace} {
 		if ns.created {
-			waitFunc, e := ns.Close()
-			if e != nil {
-				err = multierror.Append(err, e)
+			waitFunc, tempErr := ns.Close()
+			if tempErr != nil {
+				err = multierror.Append(err, tempErr)
 			} else {
 				waitFuncs = append(waitFuncs, waitFunc)
 			}
@@ -248,20 +253,38 @@ func (e *Implementation) Close() error {
 
 	// Wait for any allocated namespaces to be deleted.
 	for _, waitFunc := range waitFuncs {
-		e := waitFunc()
-		if e != nil {
-			err = multierror.Append(e)
-		}
+		err = multierror.Append(err, waitFunc()).ErrorOrNil()
 	}
 
-	if e.deployment != nil {
-		// TODO: Deleting the deployment is extremely noisy. It is outputting a whole slew of errors
-		// Disabling the collection of errors from Delete for the time being.
-		_ = e.deployment.Delete(e.Accessor, true)
-		//if err2 := e.deployment.Delete(); err2 != nil {
-		//	err = multierror.Append(err, err2)
-		//}
-		e.deployment = nil
+	if e.KubeSettings().DeployIstio {
+		// Delete the deployment yaml file.
+		err = multierror.Append(e.deployment.Delete(e.Accessor, true))
+
+		// Deleting the deployment should have removed everything, but just in case...
+
+		// Make sure the system namespace is deleted.
+		err = multierror.Append(err, e.systemNamespace.CloseAndWait()).ErrorOrNil()
+
+		// Make sure the validating webhook is deleted.
+		if e.Accessor.ValidatingWebhookConfigurationExists(validatingWebhookName) {
+			scopes.CI.Info("Deleting ValidatingWebhook")
+			err = multierror.Append(err, e.Accessor.DeleteValidatingWebhook(validatingWebhookName)).ErrorOrNil()
+			err = multierror.Append(err, e.Accessor.WaitForValidatingWebhookDeletion(validatingWebhookName)).ErrorOrNil()
+		}
+
+		// Make sure all Istio CRDs are deleted.
+		crds, tempErr := e.Accessor.GetCustomResourceDefinitions()
+		if tempErr != nil {
+			err = multierror.Append(err, tempErr)
+		}
+		if len(crds) > 0 {
+			scopes.CI.Info("Deleting Istio CRDs")
+			for _, crd := range crds {
+				if strings.HasSuffix(crd.Name, ".istio.io") {
+					err = multierror.Append(err, e.Accessor.DeleteCustomResourceDefinitions(crd.Name)).ErrorOrNil()
+				}
+			}
+		}
 	}
 
 	return err
@@ -300,7 +323,8 @@ func (n *namespace) allocate() error {
 
 // Close implements io.Closer interface.
 func (n *namespace) Close() (func() error, error) {
-	if n.created {
+	if n.created && n.accessor.NamespaceExists(n.allocatedName) {
+		scopes.CI.Infof("Deleting Namespace %s", n.allocatedName)
 		defer func() {
 			n.allocatedName = ""
 			n.created = false

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -451,7 +451,7 @@ func (p *promProxy) portForward(labelSelector string, localPort uint16, remotePo
 		PodNamespace:  p.namespace,
 		LabelSelector: labelSelector,
 	}
-	accessor, err := kube.NewAccessor(tc.Kube.KubeConfig)
+	accessor, err := kube.NewAccessor(tc.Kube.KubeConfig, "")
 	if err != nil {
 		log.Errorf("Error creating accessor: %v", err)
 		return err
@@ -546,7 +546,7 @@ func waitForMixerProxyReadiness() error {
 				PodName:      pod,
 			}
 
-			accessor, err := kube.NewAccessor(tc.Kube.KubeConfig)
+			accessor, err := kube.NewAccessor(tc.Kube.KubeConfig, "")
 			if err != nil {
 				log.Errorf("Error creating accessor: %v", err)
 				return err

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -360,7 +360,7 @@ func (p *promProxy) portForward(labelSelector string, localPort, remotePort uint
 		PodNamespace:  p.namespace,
 		LabelSelector: labelSelector,
 	}
-	accessor, err := kube.NewAccessor(tc.Kube.KubeConfig)
+	accessor, err := kube.NewAccessor(tc.Kube.KubeConfig, "")
 	if err != nil {
 		log.Errorf("Error creating accessor: %v", err)
 		return err


### PR DESCRIPTION
Deploying the Istio system yaml file (generated by Helm template)
would occasionally fail. It appears that this is due to the order that
resources in the yaml are created. By installing namespaces/CRDs first,
the deployment issues seem to be resolved.

Deleting the deployment also had problems because we were manually
deleting the system namespace before deleting the deployment. Switching
to deleting the deployment first (in proper tear-down order: resources,
then namespaces/CRDs) seems to have resolved the issue.

Also fixed the logic for waiting for pod startup.