### PR TITLE
Added an istio-remote Helm flag to create the services and endpoints for the mixer

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -126,7 +126,7 @@ data:
       controlPlaneAuthPolicy: MUTUAL_TLS
       #
       # Address where istio Pilot service is running
-      {{- if .Values.global.remotePilotCreateSvcEndpoint }}
+      {{- if or .Values.global.remotePilotCreateSvcEndpoint .Values.global.createRemoteSvcEndpoints }}
       discoveryAddress: {{ $defPilotHostname }}:15011
       {{- else }}
       discoveryAddress: {{ $pilotAddress }}:15011
@@ -137,7 +137,7 @@ data:
       controlPlaneAuthPolicy: NONE
       #
       # Address where istio Pilot service is running
-      {{- if .Values.global.remotePilotCreateSvcEndpoint }}
+      {{- if or .Values.global.remotePilotCreateSvcEndpoint .Values.global.createRemoteSvcEndpoints }}
       discoveryAddress: {{ $defPilotHostname }}:15010
       {{- else }}
       discoveryAddress: {{ $pilotAddress }}:15010

--- a/install/kubernetes/helm/istio-remote/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/configmap.yaml
@@ -33,11 +33,19 @@ data:
     # To disable the mixer completely (including metrics), comment out
     # the following lines
   {{- if .Values.global.remotePolicyAddress }}
+  {{- if .Values.global.createRemoteSvcEndpoints }}
+    mixerCheckServer: istio-policy.{{ .Release.Namespace }}:15004
+  {{- else }}
     mixerCheckServer: {{ .Values.global.remotePolicyAddress }}:15004
+  {{- end }}
   {{- end }}
 
   {{- if .Values.global.remoteTelemetryAddress }}
+  {{- if .Values.global.createRemoteSvcEndpoints }}
+    mixerReportServer: istio-telemetry.{{ .Release.Namespace }}:15004
+  {{- else }}
     mixerReportServer: {{ .Values.global.remoteTelemetryAddress }}:15004
+  {{- end }}
   {{- end }}
 
     defaultConfig:

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.remotePilotCreateSvcEndpoint }}
+{{- if or .Values.global.remotePilotCreateSvcEndpoint .Values.global.createRemoteSvcEndpoints }}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -22,4 +22,42 @@ subsets:
     name: http-legacy-discovery # direct
   - port: 9093
     name: http-monitoring
+{{- end }}
+{{- if and .Values.global.remotePolicyAddress .Values.global.createRemoteSvcEndpoints }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: istio-policy
+  namespace: {{ .Release.Namespace }}
+subsets:
+- addresses:
+  - ip: {{ .Values.global.remotePolicyAddress }}
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+{{- end }}
+{{- if and .Values.global.remoteTelemetryAddress .Values.global.createRemoteSvcEndpoints }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-telemetry
+  namespace: istio-system
+subsets:
+- addresses:
+  - ip: {{ .Values.global.remoteTelemetryAddress }}
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  - name: prometheus
+    port: 42422
 {{- end }}

--- a/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/endpoints.yaml
@@ -44,7 +44,7 @@ subsets:
 {{- if and .Values.global.remoteTelemetryAddress .Values.global.createRemoteSvcEndpoints }}
 ---
 apiVersion: v1
-kind: Service
+kind: Endpoints
 metadata:
   name: istio-telemetry
   namespace: istio-system

--- a/install/kubernetes/helm/istio-remote/templates/service.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.remotePilotCreateSvcEndpoint }}
+{{- if or .Values.global.remotePilotCreateSvcEndpoint .Values.global.createRemoteSvcEndpoints }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,5 +20,41 @@ spec:
     name: http-legacy-discovery # direct
   - port: 9093
     name: http-monitoring
+  clusterIP: None
+{{- end }}
+{{- if and .Values.global.remotePolicyAddress .Values.global.createRemoteSvcEndpoints }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  clusterIP: None
+{{- end }}
+{{- if and .Values.global.remoteTelemetryAddress .Values.global.createRemoteSvcEndpoints }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-telemetry
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: grpc-mixer
+    port: 9091
+  - name: grpc-mixer-mtls
+    port: 15004
+  - name: http-monitoring
+    port: 9093
+  - name: prometheus
+    port: 42422
   clusterIP: None
 {{- end }}


### PR DESCRIPTION
When creating the istio-remote deployment yaml user can now specify a `global.createRemoteSvcEndpoints=true` value to create Services with no selector and Endpoints pointing to the remote Mixer components.
Those will only be created if the Mixer addresses have been specified.

I left the `global.remotePilotCreateSvcEndpoint` flag for backward compatibility.