### PR TITLE
Fix TestAdsClusterUpdate/TestEds flake

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -284,7 +284,7 @@ func initLocalPilotTestEnv(t *testing.T) (*bootstrap.Server, util.TearDownFunc) 
 	server.EnvoyXdsServer.ConfigUpdate(true)
 	// TODO: channel to notify when the push is finished and to notify individual updates, for
 	// debug and for the canary.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 
 	return server, func() {
 		pilotServer = nil


### PR DESCRIPTION
Add time duration to wait for initial push finished before specific test.

200ms is not enough, add to 2s. And tested 10+ times without any flake.

fixes:  #9864