### PR TITLE
Make the LB weight normalizer as a filter

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -224,7 +224,8 @@ func NewDiscoveryServer(env *model.Environment, generator core.ConfigGenerator, 
 		concurrentPushLimit:     make(chan struct{}, 20), // TODO(hzxuzhonghu): support configuration
 		updateChannel:           make(chan *updateReq, 10),
 		endpointsFilterFuncs: []EndpointsFilterFunc{
-			EndpointsByNetworkFilter, // A filter to support Split Horizon EDS
+			EndpointsByNetworkFilter,     // A filter to support Split Horizon EDS
+			LoadBalancingWeightNormalize, // Normalize LoadBalancingWeight in range [1, 128]
 		},
 	}
 	env.PushContext = model.NewPushContext()

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -65,11 +65,6 @@ var (
 	connectionNumber = int64(0)
 )
 
-const (
-	// The range of LoadBalancingWeight is [1, 128]
-	maxLoadBalancingWeight = 128
-)
-
 // EdsCluster tracks eds-related info for monitored clusters. In practice it'll include
 // all clusters until we support on-demand cluster loading.
 type EdsCluster struct {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -17,7 +17,6 @@ package v2
 import (
 	"context"
 	"errors"
-	"math"
 	"reflect"
 	"strconv"
 	"sync"
@@ -659,9 +658,6 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection,
 			l = filteredCLA
 		}
 
-		// Normalize LoadBalancingWeight in range [1, 128]
-		l.Endpoints = normalizeLoadBalancingWeight(l.Endpoints)
-
 		endpoints += len(l.Endpoints)
 		if len(l.Endpoints) == 0 {
 			emptyClusters++
@@ -779,27 +775,4 @@ func (s *DiscoveryServer) FetchEndpoints(ctx context.Context, req *xdsapi.Discov
 // StreamLoadStats implements xdsapi.EndpointDiscoveryServiceServer.StreamLoadStats().
 func (s *DiscoveryServer) StreamLoadStats(xdsapi.EndpointDiscoveryService_StreamEndpointsServer) error {
 	return errors.New("unsupported streaming method")
-}
-
-// normalizeLoadBalancingWeight set LoadBalancingWeight with a valid value.
-func normalizeLoadBalancingWeight(endpoints []endpoint.LocalityLbEndpoints) []endpoint.LocalityLbEndpoints {
-	var totalLbEndpointsNum uint32
-
-	for _, localityLbEndpoint := range endpoints {
-		totalLbEndpointsNum += localityLbEndpoint.GetLoadBalancingWeight().GetValue()
-	}
-	if totalLbEndpointsNum == 0 {
-		return endpoints
-	}
-
-	out := make([]endpoint.LocalityLbEndpoints, len(endpoints))
-	for i, localityLbEndpoint := range endpoints {
-		weight := float64(localityLbEndpoint.GetLoadBalancingWeight().GetValue()*maxLoadBalancingWeight) / float64(totalLbEndpointsNum)
-		localityLbEndpoint.LoadBalancingWeight = &types.UInt32Value{
-			Value: uint32(math.Ceil(weight)),
-		}
-		out[i] = localityLbEndpoint
-	}
-
-	return out
 }

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -25,6 +25,11 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
+const (
+	// The range of LoadBalancingWeight is [1, 128]
+	maxLoadBalancingWeight = 128
+)
+
 // EndpointsFilterFunc is a function that filters data from the ClusterLoadAssignment and returns updated one
 type EndpointsFilterFunc func(endpoints []endpoint.LocalityLbEndpoints, conn *XdsConnection, env *model.Environment) []endpoint.LocalityLbEndpoints
 


### PR DESCRIPTION
Have the logic for weight normalizer as a filter that's being applied to result endpoints.