### PR TITLE
Add zipkin deployment option to helm

### DIFF
--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
@@ -71,8 +71,8 @@ spec:
               path: /
               port: 16686
           resources:
-{{- if .Values.resources }}
-{{ toYaml .Values.resources | indent 12 }}
+{{- if .Values.jaeger.resources }}
+{{ toYaml .Values.jaeger.resources | indent 12 }}
 {{- else }}
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
@@ -11,7 +11,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
@@ -1,3 +1,5 @@
+{{ if eq .Values.provider "jaeger" }}
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -76,3 +78,5 @@ spec:
 {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
+
+{{ end }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.zipkin.hub }}:{{ .Values.zipkin.tag }}"
+          image: "{{ .Values.zipkin.hub }}/zipkin:{{ .Values.zipkin.tag }}"
           ports:
             - containerPort: {{ .Values.zipkin.queryPort }}
           livenessProbe:
@@ -31,12 +31,11 @@ spec:
               path: /health
               port: {{ .Values.zipkin.queryPort }}
           resources:
-            limits:
-              cpu: "{{ .Values.zipkin.resources.cpuLimit }}"
-              memory: "{{ .Values.zipkin.resources.ramMb }}Mi" # TODO fix this, this field is mi but the value is mb. There will be slight wastage
-            requests:
-              cpu: "{{ .Values.zipkin.resources.cpuRequest }}"
-              memory: "{{ .Values.zipkin.resources.ramMb }}Mi" # TODO fix this, this field is mi but the value is mb. There will be slight wastage
+{{- if .Values.zipkin.resources }}
+{{ toYaml .Values.zipkin.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -46,7 +45,7 @@ spec:
             - name: QUERY_PORT
               value: "{{ .Values.zipkin.queryPort }}"
             - name: JAVA_OPTS
-              value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.resources.javaOptsHeap }}M -Xmx{{ .Values.zipkin.resources.javaOptsHeap }}M -XX:+UseG1GC -server"
+              value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.javaOptsHeap }}M -Xmx{{ .Values.zipkin.javaOptsHeap }}M -XX:+UseG1GC -server"
             - name: COLLECTOR_SAMPLE_RATE
               value: "{{ .Values.zipkin.sampleRate }}"
             - name: QUERY_ENABLED

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
@@ -4,6 +4,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-zipkin
+  namespace: {{ .Release.Namespace }}
   labels:
     app: zipkin
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
@@ -1,0 +1,57 @@
+{{ if eq .Values.provider "zipkin" }}
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-zipkin
+  labels:
+    app: zipkin
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: zipkin
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.zipkin.hub }}:{{ .Values.zipkin.tag }}"
+          ports:
+            - containerPort: {{ .Values.zipkin.queryPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
+            tcpSocket:
+              port: {{ .Values.zipkin.queryPort }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.zipkin.probeStartupDelay }}
+            httpGet:
+              path: /health
+              port: {{ .Values.zipkin.queryPort }}
+          resources:
+            limits:
+              cpu: "{{ .Values.zipkin.resources.cpuLimit }}"
+              memory: "{{ .Values.zipkin.resources.ramMb }}Mi" # TODO fix this, this field is mi but the value is mb. There will be slight wastage
+            requests:
+              cpu: "{{ .Values.zipkin.resources.cpuRequest }}"
+              memory: "{{ .Values.zipkin.resources.ramMb }}Mi" # TODO fix this, this field is mi but the value is mb. There will be slight wastage
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: QUERY_PORT
+              value: "{{ .Values.zipkin.queryPort }}"
+            - name: JAVA_OPTS
+              value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.resources.javaOptsHeap }}M -Xmx{{ .Values.zipkin.resources.javaOptsHeap }}M -XX:+UseG1GC -server"
+            - name: COLLECTOR_SAMPLE_RATE
+              value: "{{ .Values.zipkin.sampleRate }}"
+            - name: QUERY_ENABLED
+              value: "true"
+            - name: STORAGE_METHOD
+              value: "mem"
+
+{{ end }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-zipkin.yaml
@@ -46,11 +46,9 @@ spec:
               value: "{{ .Values.zipkin.queryPort }}"
             - name: JAVA_OPTS
               value: "-XX:ConcGCThreads={{ .Values.zipkin.node.cpus }} -XX:ParallelGCThreads={{ .Values.zipkin.node.cpus }} -Djava.util.concurrent.ForkJoinPool.common.parallelism={{ .Values.zipkin.node.cpus }} -Xms{{ .Values.zipkin.javaOptsHeap }}M -Xmx{{ .Values.zipkin.javaOptsHeap }}M -XX:+UseG1GC -server"
-            - name: COLLECTOR_SAMPLE_RATE
-              value: "{{ .Values.zipkin.sampleRate }}"
-            - name: QUERY_ENABLED
-              value: "true"
             - name: STORAGE_METHOD
               value: "mem"
+            - name: ZIPKIN_STORAGE_MEM_MAXSPANS
+              value: "{{ .Values.zipkin.maxSpans }}"
 
 {{ end }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ template "tracing.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
+    app: {{ .Values.provider }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/install/kubernetes/helm/subcharts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tracing-services
   namespace: {{ .Release.Namespace }}
   labels:
-    app: jaeger
+    app: {{ .Values.provider }}
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -15,7 +15,7 @@ items:
     name: zipkin
     namespace: {{ .Release.Namespace }}
     labels:
-      app: jaeger
+      app: {{ .Values.provider }}
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
@@ -27,7 +27,7 @@ items:
         protocol: TCP
         name: {{ .Values.service.name }}
     selector:
-      app: jaeger
+      app: {{ .Values.provider }}
 - apiVersion: v1
   kind: Service
   metadata:
@@ -38,7 +38,7 @@ items:
       {{ $key }}: {{ $val | quote }}
       {{- end }}
     labels:
-      app: jaeger
+      app: {{ .Values.provider }}
       chart: {{ template "tracing.chart" . }}
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
@@ -47,6 +47,10 @@ items:
       - name: http-query
         port: 80
         protocol: TCP
+{{ if eq .Values.provider "jaeger" }}
         targetPort: 16686
+{{ else }}
+        targetPort: 9411
+{{ end}}
     selector:
-      app: jaeger
+      app: {{ .Values.provider }}

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -28,7 +28,6 @@ jaeger:
 zipkin:
   hub: docker.io/openzipkin
   tag: 2
-  sampleRate: 1.0
   probeStartupDelay: 200
   queryPort: 9411
   resources:
@@ -39,6 +38,11 @@ zipkin:
       cpu: 150m
       memory: 900Mi
   javaOptsHeap: 700
+  # From: https://github.com/openzipkin/zipkin/blob/master/zipkin-server/src/main/resources/zipkin-server-shared.yml#L51
+  # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.
+  # A safe estimate is 1K of memory per span (each span with 2 annotations + 1 binary annotation), plus
+  # 100 MB for a safety buffer.  You'll need to verify in your own environment.
+  maxSpans: 500000
   node:
     cpus: 2
 

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -2,7 +2,9 @@
 # addon jeager tracing configuration
 #
 enabled: false
+
 provider: jaeger
+
 jaeger:
   hub: docker.io/jaegertracing
   tag: 1.7
@@ -22,24 +24,30 @@ jaeger:
       # - secretName: jaeger-tls
       #   hosts:
       #     - jaeger.local
+
 zipkin:
-  hub: docker.io/openzipkin/zipkin
+  hub: docker.io/openzipkin
   tag: 2
   sampleRate: 1.0
   probeStartupDelay: 200
   queryPort: 9411
   resources:
-    ramMb: 900
-    javaOptsHeap: 700
-    cpuRequest: 150m
-    cpuLimit: 300m
+    limits:
+      cpu: 300m
+      memory: 900Mi
+    requests:
+      cpu: 150m
+      memory: 900Mi
+  javaOptsHeap: 700
   node:
     cpus: 2
+
 service:
   annotations: {}
   name: http
   type: ClusterIP
   externalPort: 9411
+
 ingress:
   enabled: false
   # Used to create an Ingress record.

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -22,7 +22,19 @@ jaeger:
       # - secretName: jaeger-tls
       #   hosts:
       #     - jaeger.local
-replicaCount: 1
+zipkin:
+  hub: docker.io/openzipkin/zipkin
+  tag: 2
+  sampleRate: 1.0
+  probeStartupDelay: 200
+  queryPort: 9411
+  resources:
+    ramMb: 900
+    javaOptsHeap: 700
+    cpuRequest: 150m
+    cpuLimit: 300m
+  node:
+    cpus: 2
 service:
   annotations: {}
   name: http


### PR DESCRIPTION
This PR restores the option to use [zipkin](https://zipkin.io/) proper to implement the `zipkin` service in Istio deployments.

No attempt is made to incorporate significant productionization options for Zipkin at this time. It uses a single in-memory store + UI backend for now.

I looked at using the helm templates in https://github.com/Financial-Times/zipkin-helm, however there were some environmental assumptions (aws), etc., in those templates that made their use non-ideal out-of-the-box. Hopefully, as this moves forward, we can find a fully-configurable option (or operator) to use as a replacement.

cc: @adriancole, @costinm 

Example in action:
![zipkin](https://user-images.githubusercontent.com/21148125/48373413-97ac9700-e676-11e8-8969-75d019d9f9d0.png)
