### PR TITLE
"istioctl experimental gen-binding" to generate ServiceEntry for Mesh Federation

### DIFF
--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/spf13/cobra"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/istioctl/pkg/genbinding"
+)
+
+var (
+	remoteClusters []string
+	remoteSubset   string
+	genBindingCmd  = &cobra.Command{
+		Use:     "gen-binding",
+		Short:   "Generate Istio Configuration to direct traffic to another Istio mesh",
+		Long:    "Generate Istio Configuration to direct traffic to another Istio mesh.",
+		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--subset <subset>]",
+		RunE: func(c *cobra.Command, args []string) error {
+			// fmt.Fprintf(c.OutOrStdout(), "Args is %#v\n", args)                     // TODO remove
+			// fmt.Fprintf(c.OutOrStdout(), "remoteClusters is %#v\n", remoteClusters) // TODO remove
+			// fmt.Fprintf(c.OutOrStdout(), "remoteSubset is %#v\n", remoteSubset)     // TODO remove
+
+			if len(args) != 1 {
+				return fmt.Errorf("Usage: %s", c.Example)
+			}
+
+			if len(remoteClusters) == 0 {
+				return fmt.Errorf("Usage: %s", c.Example)
+			}
+
+			bindings, svcs, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset)
+			if err != nil {
+				return multierror.Prefix(err, "could not create binding:")
+			}
+			_ = svcs // TODO if we need to generate K8s services, we need to write them out.  Currently we neither gen nor write them.
+
+			configDescriptor := model.ConfigDescriptor{
+				model.VirtualService,
+				model.DestinationRule,
+			}
+			writeYAMLOutput(configDescriptor, bindings, c.OutOrStdout())
+
+			// sanity check that the outputs are valid
+			if err := validateConfigs(bindings); err != nil {
+				return multierror.Prefix(err, "output config(s) are invalid:")
+			}
+			return nil
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
+		nil, "IP:Port of remote Istio Ingress")
+	genBindingCmd.PersistentFlags().StringVarP(&remoteSubset, "subset", "",
+		"-", "Subset")
+
+	experimentalCmd.AddCommand(genBindingCmd)
+}

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -31,6 +31,7 @@ const defaultEgressGateway = "istio-egressgateway.istio-system"
 
 var (
 	remoteClusters []string
+	vip            string
 	addressLabels  string
 	useEgress      bool
 	egressGateway  string
@@ -39,7 +40,7 @@ var (
 		Use:     "gen-binding",
 		Short:   "Generate Istio traffic routing configuration to direct traffic to another Istio mesh",
 		Long:    "Generate Istio traffic routing configuration to direct traffic to another Istio mesh.",
-		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
+		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--vip <ip>] [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 		RunE: func(c *cobra.Command, args []string) error {
 
 			if len(args) != 1 {
@@ -69,7 +70,7 @@ var (
 				egressGateway = ""
 			}
 
-			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, labels, egressGateway, namespace)
+			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, vip, labels, egressGateway, namespace)
 			if err != nil {
 				return multierror.Prefix(err, "could not create binding:")
 			}
@@ -91,6 +92,8 @@ var (
 func init() {
 	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
 		nil, "IP:Port of remote Istio Ingress")
+	genBindingCmd.PersistentFlags().StringVarP(&vip, "vip", "",
+		"", "key=value pairs for the Service Entry VIP")
 	genBindingCmd.PersistentFlags().StringVarP(&addressLabels, "labels", "",
 		"", "key=value pairs for subsets")
 	genBindingCmd.PersistentFlags().BoolVarP(&useEgress, "use-egress", "",

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -37,8 +37,8 @@ var (
 
 	genBindingCmd = &cobra.Command{
 		Use:     "gen-binding",
-		Short:   "Generate Istio Configuration to direct traffic to another Istio mesh",
-		Long:    "Generate Istio Configuration to direct traffic to another Istio mesh.",
+		Short:   "Generate Istio traffic routing configuration to direct traffic to another Istio mesh",
+		Long:    "Generate Istio traffic routing configuration to direct traffic to another Istio mesh.",
 		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 		RunE: func(c *cobra.Command, args []string) error {
 
@@ -92,7 +92,7 @@ func init() {
 	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
 		nil, "IP:Port of remote Istio Ingress")
 	genBindingCmd.PersistentFlags().StringVarP(&addressLabels, "labels", "",
-		"", "Labels")
+		"", "key=value pairs for subsets")
 	genBindingCmd.PersistentFlags().BoolVarP(&useEgress, "use-egress", "",
 		false, "Use Egress Gateway")
 	genBindingCmd.PersistentFlags().StringVarP(&egressGateway, "egressgateway", "",

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -25,18 +25,27 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 )
 
+const (
+	defaultEgressGatewayHolder = "%default%"
+	defaultEgressGateway       = "istio-egressgateway.istio-system"
+)
+
 var (
 	remoteClusters []string
 	addressLabels  string
+	useEgress      bool
+	egressGateway  string
 
 	genBindingCmd = &cobra.Command{
 		Use:     "gen-binding",
 		Short:   "Generate Istio Configuration to direct traffic to another Istio mesh",
 		Long:    "Generate Istio Configuration to direct traffic to another Istio mesh.",
-		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]",
+		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]",
 		RunE: func(c *cobra.Command, args []string) error {
 			// fmt.Fprintf(c.OutOrStdout(), "Args is %#v\n", args)                     // TODO remove
 			// fmt.Fprintf(c.OutOrStdout(), "remoteClusters is %#v\n", remoteClusters) // TODO remove
+			// fmt.Fprintf(c.OutOrStdout(), "useEegress is %#v\n", useEgress)   	   // TODO remove
+			// fmt.Fprintf(c.OutOrStdout(), "egressGateway is %#v\n", egressGateway)   // TODO remove
 
 			if len(args) != 1 {
 				return fmt.Errorf("usage: %s", c.Example)
@@ -55,7 +64,15 @@ var (
 				namespace = defaultNamespace
 			}
 
-			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, labels, namespace)
+			if egressGateway == defaultEgressGatewayHolder {
+				if useEgress == false {
+					egressGateway = ""
+				} else {
+					egressGateway = defaultEgressGateway
+				}
+			}
+
+			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, labels, egressGateway, namespace)
 			if err != nil {
 				return multierror.Prefix(err, "could not create binding:")
 			}
@@ -78,7 +95,11 @@ func init() {
 	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
 		nil, "IP:Port of remote Istio Ingress")
 	genBindingCmd.PersistentFlags().StringVarP(&addressLabels, "labels", "",
-		"-", "Labels")
+		"", "Labels")
+	genBindingCmd.PersistentFlags().BoolVarP(&useEgress, "use-egress", "",
+		false, "Use Egress Gateway")
+	genBindingCmd.PersistentFlags().StringVarP(&egressGateway, "egressgateway", "",
+		defaultEgressGatewayHolder, "Egress Gateway Address")
 
 	experimentalCmd.AddCommand(genBindingCmd)
 }

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -20,8 +20,8 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/istioctl/pkg/genbinding"
+	"istio.io/istio/pilot/pkg/model"
 )
 
 var (
@@ -46,18 +46,15 @@ var (
 			}
 
 			if len(namespace) == 0 {
-			        namespace = defaultNamespace
+				namespace = defaultNamespace
 			}
 
-			bindings, svcs, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset, namespace)
+			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset, namespace)
 			if err != nil {
 				return multierror.Prefix(err, "could not create binding:")
 			}
-			_ = svcs // TODO if we need to generate K8s services, we need to write them out.  Currently we neither gen nor write them.
 
 			configDescriptor := model.ConfigDescriptor{
-				model.VirtualService,
-				model.DestinationRule,
 				model.ServiceEntry,
 			}
 			writeYAMLOutput(configDescriptor, bindings, c.OutOrStdout())

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -38,8 +38,8 @@ var (
 
 	genBindingCmd = &cobra.Command{
 		Use:     "gen-binding",
-		Short:   "Generate Istio traffic routing configuration to direct traffic to another Istio mesh",
-		Long:    "Generate Istio traffic routing configuration to direct traffic to another Istio mesh.",
+		Short:   "Generate service entries for gateway-based multicluster remote services",
+		Long:    "Generate service entries for gateway-based multicluster remote services.",
 		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--vip <ip>] [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 		RunE: func(c *cobra.Command, args []string) error {
 
@@ -93,7 +93,7 @@ func init() {
 	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
 		nil, "IP:Port of remote Istio Ingress")
 	genBindingCmd.PersistentFlags().StringVarP(&vip, "vip", "",
-		"", "key=value pairs for the Service Entry VIP")
+		"", "Service Entry unique virtual IP (e.g. 127.255.0.0)")
 	genBindingCmd.PersistentFlags().StringVarP(&addressLabels, "labels", "",
 		"", "key=value pairs for subsets")
 	genBindingCmd.PersistentFlags().BoolVarP(&useEgress, "use-egress", "",

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -26,30 +27,35 @@ import (
 
 var (
 	remoteClusters []string
-	remoteSubset   string
-	genBindingCmd  = &cobra.Command{
+	addressLabels  string
+
+	genBindingCmd = &cobra.Command{
 		Use:     "gen-binding",
 		Short:   "Generate Istio Configuration to direct traffic to another Istio mesh",
 		Long:    "Generate Istio Configuration to direct traffic to another Istio mesh.",
-		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--subset <subset>]",
+		Example: "istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]",
 		RunE: func(c *cobra.Command, args []string) error {
 			// fmt.Fprintf(c.OutOrStdout(), "Args is %#v\n", args)                     // TODO remove
 			// fmt.Fprintf(c.OutOrStdout(), "remoteClusters is %#v\n", remoteClusters) // TODO remove
-			// fmt.Fprintf(c.OutOrStdout(), "remoteSubset is %#v\n", remoteSubset)     // TODO remove
 
 			if len(args) != 1 {
-				return fmt.Errorf("Usage: %s", c.Example)
+				return fmt.Errorf("usage: %s", c.Example)
 			}
 
 			if len(remoteClusters) == 0 {
-				return fmt.Errorf("Usage: %s", c.Example)
+				return fmt.Errorf("usage: %s", c.Example)
+			}
+
+			labels, err := parseLabels(addressLabels)
+			if err != nil {
+				return multierror.Prefix(err, "could not parse --labels")
 			}
 
 			if len(namespace) == 0 {
 				namespace = defaultNamespace
 			}
 
-			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset, namespace)
+			bindings, err := genbinding.CreateBinding(args[0], remoteClusters, labels, namespace)
 			if err != nil {
 				return multierror.Prefix(err, "could not create binding:")
 			}
@@ -71,8 +77,23 @@ var (
 func init() {
 	genBindingCmd.PersistentFlags().StringSliceVarP(&remoteClusters, "cluster", "",
 		nil, "IP:Port of remote Istio Ingress")
-	genBindingCmd.PersistentFlags().StringVarP(&remoteSubset, "subset", "",
-		"-", "Subset")
+	genBindingCmd.PersistentFlags().StringVarP(&addressLabels, "labels", "",
+		"-", "Labels")
 
 	experimentalCmd.AddCommand(genBindingCmd)
+}
+
+// parseLabels() creatse a map from strings like "key1=value1,key2=value2"
+func parseLabels(s string) (map[string]string, error) {
+	retval := make(map[string]string)
+	for _, entry := range strings.Split(s, ",") {
+		if entry != "" {
+			sides := strings.Split(entry, "=")
+			if len(sides) < 2 {
+				return nil, fmt.Errorf("missing =")
+			}
+			retval[sides[0]] = strings.Join(sides[1:], "=")
+		}
+	}
+	return retval, nil
 }

--- a/istioctl/cmd/istioctl/gen_binding.go
+++ b/istioctl/cmd/istioctl/gen_binding.go
@@ -45,7 +45,11 @@ var (
 				return fmt.Errorf("Usage: %s", c.Example)
 			}
 
-			bindings, svcs, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset)
+			if len(namespace) == 0 {
+			        namespace = defaultNamespace
+			}
+
+			bindings, svcs, err := genbinding.CreateBinding(args[0], remoteClusters, remoteSubset, namespace)
 			if err != nil {
 				return multierror.Prefix(err, "could not create binding:")
 			}
@@ -54,6 +58,7 @@ var (
 			configDescriptor := model.ConfigDescriptor{
 				model.VirtualService,
 				model.DestinationRule,
+				model.ServiceEntry,
 			}
 			writeYAMLOutput(configDescriptor, bindings, c.OutOrStdout())
 
@@ -61,8 +66,6 @@ var (
 			if err := validateConfigs(bindings); err != nil {
 				return multierror.Prefix(err, "output config(s) are invalid:")
 			}
-			return nil
-
 			return nil
 		},
 	}

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -37,7 +37,7 @@ type genBindingTestCase struct {
 func TestGenBinding(t *testing.T) {
 	tt := []genBindingTestCase{
 		{args: strings.Split("experimental gen-binding", " "),
-			expectedSubstring: "Usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--subset <subset>]",
+			expectedSubstring: "Usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]",
 			wantException:     true,
 			name:              "No args"},
 
@@ -49,8 +49,12 @@ func TestGenBinding(t *testing.T) {
 			goldenFilename: "testdata/genbinding/reviews-2remotes.yaml",
 			name:           "Two remotes, no subset"},
 
-		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --subset v1", " "),
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --labels version=v1", " "),
 			goldenFilename: "testdata/genbinding/reviews-v1.yaml",
+			name:           "One remote with subset"},
+
+		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4:5 --labels version=v1,arch=i586", " "),
+			goldenFilename: "testdata/genbinding/ratings-v1-i586.yaml",
 			name:           "One remote with subset"},
 	}
 
@@ -58,7 +62,7 @@ func TestGenBinding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Clear, because we re-use
 			remoteClusters = []string{}
-			remoteSubset = ""
+			addressLabels = ""
 
 			verifyGenBindingTestOutput(t, tc)
 		})

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -37,23 +37,23 @@ type genBindingTestCase struct {
 func TestGenBinding(t *testing.T) {
 	tt := []genBindingTestCase{
 		{args: strings.Split("experimental gen-binding", " "),
-			expectedSubstring: "Usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]",
+			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]", // nolint: lll
 			wantException:     true,
 			name:              "No args"},
 
-		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5", " "),
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443", " "),
 			goldenFilename: "testdata/genbinding/reviews-1234.yaml",
 			name:           "One remote, no subset"},
 
-		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --cluster 6.7.8.9:10", " "),
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --cluster 6.7.8.9", " "),
 			goldenFilename: "testdata/genbinding/reviews-2remotes.yaml",
 			name:           "Two remotes, no subset"},
 
-		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --labels version=v1", " "),
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443 --labels version=v1", " "),
 			goldenFilename: "testdata/genbinding/reviews-v1.yaml",
 			name:           "One remote with subset"},
 
-		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4:5 --labels version=v1,arch=i586", " "),
+		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586", " "),
 			goldenFilename: "testdata/genbinding/ratings-v1-i586.yaml",
 			name:           "One remote with subset"},
 	}

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -37,13 +37,17 @@ type genBindingTestCase struct {
 func TestGenBinding(t *testing.T) {
 	tt := []genBindingTestCase{
 		{args: strings.Split("experimental gen-binding", " "),
-			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
+			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--vip <ip>] [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 			wantException:     true,
 			name:              "No args"},
 
 		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443", " "),
 			goldenFilename: "testdata/genbinding/reviews-1234.yaml",
 			name:           "One remote, no subset"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443 --vip 6.7.8.9", " "),
+			goldenFilename: "testdata/genbinding/reviews-1234-vip.yaml",
+			name:           "One remote with vip address"},
 
 		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --cluster 6.7.8.9", " "),
 			goldenFilename: "testdata/genbinding/reviews-2remotes.yaml",
@@ -88,6 +92,7 @@ func TestGenBinding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Clear, because we re-use
 			remoteClusters = []string{}
+			vip = ""
 			addressLabels = ""
 			useEgress = false
 			egressGateway = "istio-egressgateway.istio-system"

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -49,6 +49,10 @@ func TestGenBinding(t *testing.T) {
 			goldenFilename: "testdata/genbinding/reviews-1234-vip.yaml",
 			name:           "One remote with vip address"},
 
+		{args: strings.Split("experimental gen-binding reviews.ns1:9080 --cluster 1.2.3.4:15443 --vip 6.7.8.9", " "),
+			goldenFilename: "testdata/genbinding/reviews-1234-namespace.yaml",
+			name:           "Service name with namespace"},
+
 		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --cluster 6.7.8.9", " "),
 			goldenFilename: "testdata/genbinding/reviews-2remotes.yaml",
 			name:           "Two remotes, no subset"},

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -37,7 +37,7 @@ type genBindingTestCase struct {
 func TestGenBinding(t *testing.T) {
 	tt := []genBindingTestCase{
 		{args: strings.Split("experimental gen-binding", " "),
-			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]  [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
+			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2] [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 			wantException:     true,
 			name:              "No args"},
 
@@ -56,6 +56,10 @@ func TestGenBinding(t *testing.T) {
 		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586", " "),
 			goldenFilename: "testdata/genbinding/ratings-v1-i586.yaml",
 			name:           "One remote with subset"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1_2_3_4:15443", " "),
+			goldenFilename: "testdata/genbinding/bad-cluster.yaml",
+			name:           "Bad cluster hostname or IP"},
 
 		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --use-egress", " "),
 			goldenFilename: "testdata/genbinding/use-egress.yaml",
@@ -80,7 +84,7 @@ func TestGenBinding(t *testing.T) {
 			remoteClusters = []string{}
 			addressLabels = ""
 			useEgress = false
-			egressGateway = "%default%"
+			egressGateway = "istio-egressgateway.istio-system"
 
 			verifyGenBindingTestOutput(t, tc)
 		})

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -58,7 +58,7 @@ func TestGenBinding(t *testing.T) {
 			name:           "One remote with subset"},
 
 		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1_2_3_4:15443", " "),
-			expectedSubstring: "Error: could not create binding: Invalid Name or IP address",
+			expectedSubstring: "Error: could not create binding: invalid Name or IP address",
 			wantException:     true,
 			name:              "Bad cluster hostname or IP"},
 

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -1,0 +1,100 @@
+// Copyright 2017 Istio Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"istio.io/istio/pilot/test/util"
+)
+
+type genBindingTestCase struct {
+	name string
+	args []string
+
+	// Typically use one of the three
+	expectedOutput    string // Expected constant output
+	expectedSubstring string // String output is expected to contain
+	goldenFilename    string // Expected output stored in golden file
+
+	wantException bool
+}
+
+func TestGenBinding(t *testing.T) {
+	tt := []genBindingTestCase{
+		{args: strings.Split("experimental gen-binding", " "),
+			expectedSubstring: "Usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--subset <subset>]",
+			wantException:     true,
+			name:              "No args"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5", " "),
+			goldenFilename: "testdata/genbinding/reviews-1234.yaml",
+			name:           "One remote, no subset"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --cluster 6.7.8.9:10", " "),
+			goldenFilename: "testdata/genbinding/reviews-2remotes.yaml",
+			name:           "Two remotes, no subset"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4:5 --subset v1", " "),
+			goldenFilename: "testdata/genbinding/reviews-v1.yaml",
+			name:           "One remote with subset"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear, because we re-use
+			remoteClusters = []string{}
+			remoteSubset = ""
+
+			verifyGenBindingTestOutput(t, tc)
+		})
+	}
+}
+
+func verifyGenBindingTestOutput(t *testing.T, c genBindingTestCase) {
+	t.Helper()
+
+	var out bytes.Buffer
+	rootCmd.SetOutput(&out)
+	rootCmd.SetArgs(c.args)
+
+	fErr := rootCmd.Execute()
+	output := out.String()
+
+	if c.expectedOutput != "" && c.expectedOutput != output {
+		t.Fatalf("Unexpected output for 'istioctl %s'\n got: %q\nwant: %q", strings.Join(c.args, " "), output, c.expectedOutput)
+	}
+
+	if c.expectedSubstring != "" && !strings.Contains(output, c.expectedSubstring) {
+		t.Fatalf("Output didn't match for 'istioctl %s'\n got %v\nwant: %v", strings.Join(c.args, " "), output, c.expectedSubstring)
+	}
+
+	if c.goldenFilename != "" {
+		util.CompareContent([]byte(output), c.goldenFilename, t)
+	}
+
+	if c.wantException {
+		if fErr == nil {
+			t.Fatalf("Wanted an exception for 'istioctl %s', didn't get one, output was %q",
+				strings.Join(c.args, " "), output)
+		}
+	} else {
+		if fErr != nil {
+			t.Fatalf("Unwanted exception for 'istioctl %s': %v", strings.Join(c.args, " "), fErr)
+		}
+	}
+}

--- a/istioctl/cmd/istioctl/gen_binding_test.go
+++ b/istioctl/cmd/istioctl/gen_binding_test.go
@@ -37,7 +37,7 @@ type genBindingTestCase struct {
 func TestGenBinding(t *testing.T) {
 	tt := []genBindingTestCase{
 		{args: strings.Split("experimental gen-binding", " "),
-			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]", // nolint: lll
+			expectedSubstring: "Error: usage: istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]  [--use-egress] [--egressgateway <ip:port>]", // nolint: lll
 			wantException:     true,
 			name:              "No args"},
 
@@ -56,6 +56,22 @@ func TestGenBinding(t *testing.T) {
 		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586", " "),
 			goldenFilename: "testdata/genbinding/ratings-v1-i586.yaml",
 			name:           "One remote with subset"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --use-egress", " "),
+			goldenFilename: "testdata/genbinding/use-egress.yaml",
+			name:           "Use egress gateway"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --egressgateway 6.7.8.9:15443", " "),
+			goldenFilename: "testdata/genbinding/egressgateway.yaml",
+			name:           "Specify egress gateway"},
+
+		{args: strings.Split("experimental gen-binding reviews:9080 --cluster 1.2.3.4 --egressgateway 6.7.8.9", " "),
+			goldenFilename: "testdata/genbinding/egress-gateway-ip.yaml",
+			name:           "Specify egress gateway IP address only"},
+
+		{args: strings.Split("experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586 --use-egress", " "),
+			goldenFilename: "testdata/genbinding/ratings-v1-i586-egress.yaml",
+			name:           "One remote with subset with egress"},
 	}
 
 	for _, tc := range tt {
@@ -63,6 +79,8 @@ func TestGenBinding(t *testing.T) {
 			// Clear, because we re-use
 			remoteClusters = []string{}
 			addressLabels = ""
+			useEgress = false
+			egressGateway = "%default%"
 
 			verifyGenBindingTestOutput(t, tc)
 		})

--- a/istioctl/cmd/istioctl/testdata/genbinding/bad-cluster.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/bad-cluster.yaml
@@ -1,1 +1,0 @@
-Error: could not create binding: Invalid Name or IP address

--- a/istioctl/cmd/istioctl/testdata/genbinding/bad-cluster.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/bad-cluster.yaml
@@ -1,0 +1,1 @@
+Error: could not create binding: Invalid Name or IP address

--- a/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
-  addresses:
-  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  creationTimestamp: null
+  name: service-entry-reviews
+  namespace: default
+spec:
+  addresses:
+  - 127.255.214.91
+  endpoints:
+  - address: 1.2.3.4
+    labels:
+      network: external
+    ports:
+      http: 15443
+  - address: 6.7.8.9
+    ports:
+      http: 15443
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egress-gateway-ip.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   endpoints:
@@ -15,7 +15,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
-  addresses:
-  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  creationTimestamp: null
+  name: service-entry-reviews
+  namespace: default
+spec:
+  addresses:
+  - 127.255.214.91
+  endpoints:
+  - address: 1.2.3.4
+    labels:
+      network: external
+    ports:
+      http: 15443
+  - address: 6.7.8.9
+    ports:
+      http: 15443
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/egressgateway.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   endpoints:
@@ -15,7 +15,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-ratings
   namespace: default
 spec:
-  addresses:
-  - 127.255.25.103
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  creationTimestamp: null
+  name: service-entry-ratings
+  namespace: default
+spec:
+  addresses:
+  - 127.255.25.103
+  endpoints:
+  - address: 1.2.3.4
+    labels:
+      arch: i586
+      network: external
+      version: v1
+    ports:
+      http: 15443
+  - address: istio-egressgateway.istio-system
+    ports:
+      http: 15443
+  hosts:
+  - ratings
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 8080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586-egress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-ratings
+  name: service-entry-ratings.default.global
   namespace: default
 spec:
   endpoints:
@@ -17,7 +17,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - ratings
+  - ratings.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-ratings
   namespace: default
 spec:
-  addresses:
-  - 127.255.25.103
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-ratings
+  name: service-entry-ratings.default.global
   namespace: default
 spec:
   endpoints:
@@ -13,7 +13,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - ratings
+  - ratings.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
@@ -2,22 +2,23 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-ratings
   namespace: default
 spec:
   addresses:
-  - 127.255.214.91
+  - 127.255.25.103
   endpoints:
   - address: 1.2.3.4
     labels:
+      arch: i586
       version: v1
     ports:
       http: 5
   hosts:
-  - reviews
+  - ratings
   location: MESH_INTERNAL
   ports:
   - name: http
-    number: 9080
+    number: 8080
     protocol: HTTP
   resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/ratings-v1-i586.yaml
@@ -13,7 +13,7 @@ spec:
       arch: i586
       version: v1
     ports:
-      http: 5
+      http: 15443
   hosts:
   - ratings
   location: MESH_INTERNAL

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-namespace.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-namespace.yaml
@@ -2,15 +2,17 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews.default.global
+  name: service-entry-reviews.ns1.global
   namespace: default
 spec:
+  addresses:
+  - 6.7.8.9
   endpoints:
   - address: 1.2.3.4
     ports:
       http: 15443
   hosts:
-  - reviews.default.global
+  - reviews.ns1.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-vip.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-vip.yaml
@@ -5,11 +5,10 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
+  addresses:
+  - 6.7.8.9
   endpoints:
   - address: 1.2.3.4
-    ports:
-      http: 15443
-  - address: 6.7.8.9
     ports:
       http: 15443
   hosts:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-vip.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234-vip.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   addresses:
@@ -12,7 +12,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
@@ -5,6 +5,8 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
+  addresses:
+  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     ports:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  creationTimestamp: null
+  name: dest-rule-dummy
+  namespace: default
+spec:
+  host: dummy
+  trafficPolicy:
+    tls:
+      caCertificates: /etc/certs/root-cert.pem
+      clientCertificate: /etc/certs/cert-chain.pem
+      mode: MUTUAL
+      privateKey: /etc/certs/key.pem
+      sni: dummy-sni.default.svc.cluster.local

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
@@ -10,7 +10,7 @@ spec:
   endpoints:
   - address: 1.2.3.4
     ports:
-      http: 5
+      http: 15443
   hosts:
   - reviews
   location: MESH_INTERNAL

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
@@ -1,15 +1,19 @@
 apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
+kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: dest-rule-dummy
+  name: service-entry-reviews
   namespace: default
 spec:
-  host: dummy
-  trafficPolicy:
-    tls:
-      caCertificates: /etc/certs/root-cert.pem
-      clientCertificate: /etc/certs/cert-chain.pem
-      mode: MUTUAL
-      privateKey: /etc/certs/key.pem
-      sni: dummy-sni.default.svc.cluster.local
+  endpoints:
+  - address: 1.2.3.4
+    ports:
+      http: 5
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-1234.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
-  addresses:
-  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     ports:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
@@ -5,6 +5,8 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
+  addresses:
+  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     ports:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  creationTimestamp: null
+  name: dest-rule-dummy
+  namespace: default
+spec:
+  host: dummy
+  trafficPolicy:
+    tls:
+      caCertificates: /etc/certs/root-cert.pem
+      clientCertificate: /etc/certs/cert-chain.pem
+      mode: MUTUAL
+      privateKey: /etc/certs/key.pem
+      sni: dummy-sni.default.svc.cluster.local

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
@@ -1,15 +1,22 @@
 apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
+kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: dest-rule-dummy
+  name: service-entry-reviews
   namespace: default
 spec:
-  host: dummy
-  trafficPolicy:
-    tls:
-      caCertificates: /etc/certs/root-cert.pem
-      clientCertificate: /etc/certs/cert-chain.pem
-      mode: MUTUAL
-      privateKey: /etc/certs/key.pem
-      sni: dummy-sni.default.svc.cluster.local
+  endpoints:
+  - address: 1.2.3.4
+    ports:
+      http: 5
+  - address: 6.7.8.9
+    ports:
+      http: 10
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
@@ -10,10 +10,10 @@ spec:
   endpoints:
   - address: 1.2.3.4
     ports:
-      http: 5
+      http: 15443
   - address: 6.7.8.9
     ports:
-      http: 10
+      http: 15443
   hosts:
   - reviews
   location: MESH_INTERNAL

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-2remotes.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   endpoints:
@@ -13,7 +13,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -5,6 +5,8 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
+  addresses:
+  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     ports:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  creationTimestamp: null
+  name: dest-rule-dummy
+  namespace: default
+spec:
+  host: dummy
+  trafficPolicy:
+    tls:
+      caCertificates: /etc/certs/root-cert.pem
+      clientCertificate: /etc/certs/cert-chain.pem
+      mode: MUTUAL
+      privateKey: /etc/certs/key.pem
+      sni: dummy-sni.default.svc.cluster.local

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
-  addresses:
-  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   endpoints:
@@ -12,7 +12,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -1,15 +1,19 @@
 apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
+kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: dest-rule-dummy
+  name: service-entry-reviews
   namespace: default
 spec:
-  host: dummy
-  trafficPolicy:
-    tls:
-      caCertificates: /etc/certs/root-cert.pem
-      clientCertificate: /etc/certs/cert-chain.pem
-      mode: MUTUAL
-      privateKey: /etc/certs/key.pem
-      sni: dummy-sni.default.svc.cluster.local
+  endpoints:
+  - address: 1.2.3.4
+    ports:
+      http: 5
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/reviews-v1.yaml
@@ -12,7 +12,7 @@ spec:
     labels:
       version: v1
     ports:
-      http: 5
+      http: 15443
   hosts:
   - reviews
   location: MESH_INTERNAL

--- a/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
@@ -5,8 +5,6 @@ metadata:
   name: service-entry-reviews
   namespace: default
 spec:
-  addresses:
-  - 127.255.214.91
   endpoints:
   - address: 1.2.3.4
     labels:

--- a/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  creationTimestamp: null
+  name: service-entry-reviews
+  namespace: default
+spec:
+  addresses:
+  - 127.255.214.91
+  endpoints:
+  - address: 1.2.3.4
+    labels:
+      network: external
+    ports:
+      http: 15443
+  - address: istio-egressgateway.istio-system
+    ports:
+      http: 15443
+  hosts:
+  - reviews
+  location: MESH_INTERNAL
+  ports:
+  - name: http
+    number: 9080
+    protocol: HTTP
+  resolution: DNS

--- a/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
+++ b/istioctl/cmd/istioctl/testdata/genbinding/use-egress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   creationTimestamp: null
-  name: service-entry-reviews
+  name: service-entry-reviews.default.global
   namespace: default
 spec:
   endpoints:
@@ -15,7 +15,7 @@ spec:
     ports:
       http: 15443
   hosts:
-  - reviews
+  - reviews.default.global
   location: MESH_INTERNAL
   ports:
   - name: http

--- a/istioctl/pkg/genbinding/README.md
+++ b/istioctl/pkg/genbinding/README.md
@@ -1,0 +1,45 @@
+# Multi mesh support
+
+This command line utility generates the resource required for using Istio
+across multiple meshes.
+
+## Usage
+
+```
+istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]*  [--labels key1=value1,key2=value2]  [--use-egress] [--egressgateway <ip:port>]
+```
+
+## Examples:
+
+Accessing the service _reviews_ on a remote mesh by specifying the address of the ingress gateway on the remote cluster:
+
+```
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443
+```
+
+Accessing a service on multiple remote clusters:
+
+```
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4 --cluster 6.7.8.9
+```
+
+Specifying one or more labels for the service entry (used for subsets):
+
+```
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443 --labels version=v1
+
+istioctl experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586
+```
+
+Using an egress gateway on local cluster for accessing the remote cluster:
+
+```
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4 --use-egress
+
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4 --egressgateway 6.7.8.9:15443
+
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4 --egressgateway 6.7.8.9
+
+istioctl experimental gen-binding ratings:8080 --cluster 1.2.3.4 --labels version=v1,arch=i586 --use-egress
+```
+

--- a/istioctl/pkg/genbinding/README.md
+++ b/istioctl/pkg/genbinding/README.md
@@ -17,6 +17,12 @@ Accessing the service _reviews_ on a remote mesh by specifying the address of th
 istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443
 ```
 
+Accessing the service _reviews_ on a remote mesh by specifying the vip address of the service:
+
+```
+istioctl experimental gen-binding reviews:9080 --cluster 1.2.3.4:15443 --vip 5.6.7.8
+```
+
 Accessing a service on multiple remote clusters:
 
 ```

--- a/istioctl/pkg/genbinding/genbinding.go
+++ b/istioctl/pkg/genbinding/genbinding.go
@@ -83,7 +83,7 @@ func serviceToServiceEntrySniCluster(remoteService hostPort, remoteClusters []ho
 				},
 			},
 			Location:   v1alpha3.ServiceEntry_MESH_INTERNAL,
-			Resolution: v1alpha3.ServiceEntry_STATIC,
+			Resolution: v1alpha3.ServiceEntry_DNS,
 			Endpoints:  []*v1alpha3.ServiceEntry_Endpoint{},
 		},
 	}

--- a/istioctl/pkg/genbinding/genbinding.go
+++ b/istioctl/pkg/genbinding/genbinding.go
@@ -32,7 +32,7 @@ type hostPort struct {
 }
 
 const (
-        defaultMultiMeshPort  = "15443"
+	defaultMultiMeshPort  = "15443"
 	defaultHostNamespace  = "default"
 	defaultHostNameSuffix = ".global"
 )
@@ -72,12 +72,12 @@ func serviceToServiceEntrySniCluster(remoteService hostPort, remoteClusters []ho
 		}
 	}
 
-	if ! strings.Contains(remoteService.host, ".") {
-	     remoteService.host = remoteService.host + "." + defaultHostNamespace
+	if !strings.Contains(remoteService.host, ".") {
+		remoteService.host = remoteService.host + "." + defaultHostNamespace
 	}
-	if ! strings.HasSuffix(remoteService.host, defaultHostNameSuffix) {
-	     	  remoteService.host = remoteService.host + defaultHostNameSuffix
-	} 
+	if !strings.HasSuffix(remoteService.host, defaultHostNameSuffix) {
+		remoteService.host = remoteService.host + defaultHostNameSuffix
+	}
 
 	serviceEntry := model.Config{
 		ConfigMeta: model.ConfigMeta{

--- a/istioctl/pkg/genbinding/genbinding.go
+++ b/istioctl/pkg/genbinding/genbinding.go
@@ -31,7 +31,11 @@ type hostPort struct {
 	port int
 }
 
-const defaultMultiMeshPort = "15443"
+const (
+        defaultMultiMeshPort  = "15443"
+	defaultHostNamespace  = "default"
+	defaultHostNameSuffix = ".global"
+)
 
 var validHostnameRegex = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
 
@@ -67,6 +71,13 @@ func serviceToServiceEntrySniCluster(remoteService hostPort, remoteClusters []ho
 			return nil, errors.New("invalid VIP address specified")
 		}
 	}
+
+	if ! strings.Contains(remoteService.host, ".") {
+	     remoteService.host = remoteService.host + "." + defaultHostNamespace
+	}
+	if ! strings.HasSuffix(remoteService.host, defaultHostNameSuffix) {
+	     	  remoteService.host = remoteService.host + defaultHostNameSuffix
+	} 
 
 	serviceEntry := model.Config{
 		ConfigMeta: model.ConfigMeta{

--- a/istioctl/pkg/genbinding/genbinding.go
+++ b/istioctl/pkg/genbinding/genbinding.go
@@ -1,0 +1,53 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genbinding
+
+import (
+	kube_v1 "k8s.io/api/core/v1"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// ConvertBindingsAndExposures2 converts desired multicluster state into Kubernetes and Istio state
+func CreateBinding(service string, clusters []string, subset string) ([]model.Config, []kube_v1.Service, error) { // nolint: lll
+	istioConfig, k8sSvcs, err := dummyBinding() // TODO
+	return istioConfig, k8sSvcs, err
+}
+
+func dummyBinding() ([]model.Config, []kube_v1.Service, error) {
+	return []model.Config{
+		model.Config{
+			ConfigMeta: model.ConfigMeta{
+				Type:      model.DestinationRule.Type,
+				Group:     model.DestinationRule.Group + model.IstioAPIGroupDomain,
+				Version:   model.DestinationRule.Version,
+				Name:      "dest-rule-dummy",
+				Namespace: "default",
+			},
+			Spec: &v1alpha3.DestinationRule{
+				Host: "dummy",
+				TrafficPolicy: &v1alpha3.TrafficPolicy{
+					Tls: &v1alpha3.TLSSettings{
+						Mode:              v1alpha3.TLSSettings_MUTUAL,
+						ClientCertificate: "/etc/certs/cert-chain.pem",
+						PrivateKey:        "/etc/certs/key.pem",
+						CaCertificates:    "/etc/certs/root-cert.pem",
+						Sni:               "dummy-sni.default.svc.cluster.local",
+					},
+				},
+			},
+		}}, nil, nil
+}


### PR DESCRIPTION
Provides a quick way for user to create ServiceEntry for external services.

```
istioctl experimental gen-binding <service:port> --cluster <ip:port> [--cluster <ip:port>]* [--labels key1=value1,key2=value2]
```