### PR TITLE
Add function to create kubeClient for istio CRDs by passing in a restconfig

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -748,7 +748,8 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 
 func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCache, error) {
 	kubeCfgFile := s.getKubeCfgFile(args)
-	configClient, err := crd.NewClient(kubeCfgFile, "", model.IstioConfigTypes, args.Config.ControllerOptions.DomainSuffix)
+	c, err := kubelib.BuildClientConfig(kubeCfgFile, "")
+	configClient, err := crd.NewForConfig(c, args.Config.ControllerOptions.DomainSuffix)
 	if err != nil {
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -748,8 +748,7 @@ func (s *Server) initConfigController(args *PilotArgs) error {
 
 func (s *Server) makeKubeConfigController(args *PilotArgs) (model.ConfigStoreCache, error) {
 	kubeCfgFile := s.getKubeCfgFile(args)
-	c, err := kubelib.BuildClientConfig(kubeCfgFile, "")
-	configClient, err := crd.NewForConfig(c, args.Config.ControllerOptions.DomainSuffix)
+	configClient, err := crd.NewClient(kubeCfgFile, "", model.IstioConfigTypes, args.Config.ControllerOptions.DomainSuffix)
 	if err != nil {
 		return nil, multierror.Prefix(err, "failed to open a config client.")
 	}

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -111,8 +111,8 @@ func newClientSet(descriptor model.ConfigDescriptor) (map[string]*restClient, er
 	return cs, nil
 }
 
-func (rc *restClient) init(kubeconfig string, context string) error {
-	cfg, err := rc.createRESTConfig(kubeconfig, context)
+func (rc *restClient) init(cfg *rest.Config) error {
+	cfg, err := rc.updateRESTConfig(cfg)
 	if err != nil {
 		return err
 	}
@@ -128,13 +128,8 @@ func (rc *restClient) init(kubeconfig string, context string) error {
 }
 
 // createRESTConfig for cluster API server, pass empty config file for in-cluster
-func (rc *restClient) createRESTConfig(kubeconfig string, context string) (config *rest.Config, err error) {
-	config, err = kubecfg.BuildClientConfig(kubeconfig, context)
-
-	if err != nil {
-		return nil, err
-	}
-
+func (rc *restClient) updateRESTConfig(cfg *rest.Config) (config *rest.Config, err error) {
+	config = cfg
 	config.GroupVersion = &rc.apiVersion
 	config.APIPath = "/apis"
 	config.ContentType = runtime.ContentTypeJSON
@@ -154,12 +149,9 @@ func (rc *restClient) createRESTConfig(kubeconfig string, context string) (confi
 	return
 }
 
-// NewClient creates a client to Kubernetes API using a kubeconfig file.
-// Use an empty value for `kubeconfig` to use the in-cluster config.
-// If the kubeconfig file is empty, defaults to in-cluster config as well.
-// You can also choose a config context by providing the desired context name.
-func NewClient(config string, context string, descriptor model.ConfigDescriptor, domainSuffix string) (*Client, error) {
-	cs, err := newClientSet(descriptor)
+// NewForConfig creates a client to the Kubernetes API using a rest config.
+func NewForConfig(cfg *rest.Config, domainSuffix string) (*Client, error) {
+	cs, err := newClientSet(model.IstioConfigTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -170,12 +162,25 @@ func NewClient(config string, context string, descriptor model.ConfigDescriptor,
 	}
 
 	for _, v := range out.clientset {
-		if err := v.init(config, context); err != nil {
+		if err := v.init(cfg); err != nil {
 			return nil, err
 		}
 	}
 
 	return out, nil
+}
+
+// NewClient creates a client to Kubernetes API using a kubeconfig file.
+// Use an empty value for `kubeconfig` to use the in-cluster config.
+// If the kubeconfig file is empty, defaults to in-cluster config as well.
+// You can also choose a config context by providing the desired context name.
+func NewClient(config string, context string, descriptor model.ConfigDescriptor, domainSuffix string) (*Client, error) {
+	cfg, err := kubecfg.BuildClientConfig(config, context)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfig(cfg, domainSuffix)
 }
 
 // RegisterResources sends a request to create CRDs and waits for them to initialize

--- a/pilot/pkg/config/kube/crd/client.go
+++ b/pilot/pkg/config/kube/crd/client.go
@@ -150,8 +150,8 @@ func (rc *restClient) updateRESTConfig(cfg *rest.Config) (config *rest.Config, e
 }
 
 // NewForConfig creates a client to the Kubernetes API using a rest config.
-func NewForConfig(cfg *rest.Config, domainSuffix string) (*Client, error) {
-	cs, err := newClientSet(model.IstioConfigTypes)
+func NewForConfig(cfg *rest.Config, descriptor model.ConfigDescriptor, domainSuffix string) (*Client, error) {
+	cs, err := newClientSet(descriptor)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func NewClient(config string, context string, descriptor model.ConfigDescriptor,
 		return nil, err
 	}
 
-	return NewForConfig(cfg, domainSuffix)
+	return NewForConfig(cfg, descriptor, domainSuffix)
 }
 
 // RegisterResources sends a request to create CRDs and waits for them to initialize


### PR DESCRIPTION
We are using a Istio client for a custom Kubernetes controller.

We noticed that in other projects in which there is a client for a CRD, the client can be instantiated by passing in a restConfig. This PR provides the same capability for initializing the Istio client.

In particular, we wanted this use case to be able to specify our master server address without having to set an environment variable (which is currently the case).

Ideally, to be most in line with other controllers we've seen, we would also like to remove `domainSuffix` from the `NewForConfig` function, but do not entirely understand the repercussions of doing so.

Please let us know thoughts and feedback. Thanks!

Co-authored-by: Jeff Pak <jeffrey.pak@dell.com>