### PR TITLE
tracing: Provide default configuration when no host specified for k8s…

### DIFF
--- a/install/kubernetes/helm/subcharts/tracing/templates/ingress.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
-{{- $serviceName := "zipkin" -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $serviceName := "tracing" -}}
+{{- $servicePort := 80 -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -17,6 +17,7 @@ metadata:
     {{- end }}
 spec:
   rules:
+{{- if .Values.ingress.hosts }}
     {{- range $host := .Values.ingress.hosts }}
     - host: {{ $host }}
       http:
@@ -25,8 +26,17 @@ spec:
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}
+
     {{- end -}}
-  {{- if .Values.ingress.tls }}
+{{- else }}
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+{{- end }}
+   {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
   {{- end -}}

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -32,7 +32,7 @@ ingress:
   enabled: false
   # Used to create an Ingress record.
   hosts:
-    - tracing.local
+    # - tracing.local
   annotations:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
… ingress - and direct to tracing service

Updates the main tracing k8s ingress definition to be similar to the one recently updated in the ingress-jaeger.yaml definition - which can work without a host being specified.

The ingress is used to provide access to the UI - but in this case was being directed to the zipkin collector service/port. So also updated the service/port to `tracing:80`.