### PR TITLE
Dumps the logs from the remote cluster

### DIFF
--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -200,7 +200,15 @@ func (c *CommonConfig) saveLogs(r int) error {
 		log.Errorf("Could not create status file. Error %s", err)
 		return err
 	}
-	return c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.KubeConfig)
+	if err := c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.KubeConfig); err != nil {
+		return err
+	}
+	if c.Kube.RemoteKubeConfig  != "" {
+		if err := c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.RemoteKubeConfig); err != nil {
+			return err
+		}
+	}
+        return nil
 }
 
 // RunTest sets up all registered cleanables in FIFO order

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -203,12 +203,12 @@ func (c *CommonConfig) saveLogs(r int) error {
 	if err := c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.KubeConfig); err != nil {
 		return err
 	}
-	if c.Kube.RemoteKubeConfig  != "" {
+	if c.Kube.RemoteKubeConfig != "" {
 		if err := c.Info.FetchAndSaveClusterLogs(c.Kube.Namespace, c.Kube.RemoteKubeConfig); err != nil {
 			return err
 		}
 	}
-        return nil
+	return nil
 }
 
 // RunTest sets up all registered cleanables in FIFO order


### PR DESCRIPTION
This change will dump the logs from the remote cluster
if multicluster is enabled and the logs from the primary
cluster are being dumped.