### PR TITLE
Adding istioctl and upgrade release qualification

### DIFF
--- a/prow/istioctl-tests.sh
+++ b/prow/istioctl-tests.sh
@@ -34,7 +34,7 @@ ROOT=$(dirname "$WD")
 # Expects ISTIO_REL_URL, HUB, and TAG as inputs.
 
 
-# Helper functions
+# shellcheck source=prow/lib.sh
 source "${ROOT}/prow/lib.sh"
 
 function test_istioctl_version() {
@@ -53,13 +53,13 @@ function test_helm_files() {
   local expected_hub=${2}
   local expected_tag=${3}
 
-  local hub=$(grep hub: ${istio_path}/install/kubernetes/helm/istio/values.yaml | head -n 1 | cut -c 8-)
-  local tag=$(grep tag: ${istio_path}/install/kubernetes/helm/istio/values.yaml | head -n 1 | cut -c 8-)
+  hub=$(grep hub: "${istio_path}/install/kubernetes/helm/istio/values.yaml" | head -n 1 | cut -c 8-)
+  tag=$(grep tag: "${istio_path}/install/kubernetes/helm/istio/values.yaml" | head -n 1 | cut -c 8-)
   [ "${hub}" == "${expected_hub}" ]
   [ "${tag}" == "${expected_tag}" ]
 
-  local hub=$(grep hub: ${istio_path}/install/kubernetes/helm/istio-remote/values.yaml | head -n 1 | cut -c 8-)
-  local tag=$(grep tag: ${istio_path}/install/kubernetes/helm/istio-remote/values.yaml | head -n 1 | cut -c 8-)
+  hub=$(grep hub: "${istio_path}/install/kubernetes/helm/istio-remote/values.yaml" | head -n 1 | cut -c 8-)
+  tag=$(grep tag: "${istio_path}/install/kubernetes/helm/istio-remote/values.yaml" | head -n 1 | cut -c 8-)
   [ "${hub}" == "${expected_hub}" ]
   [ "${tag}" == "${expected_tag}" ]
 }
@@ -68,6 +68,6 @@ function test_helm_files() {
 # Assert HUB and TAG are matching from all istioctl binaries.
 
 download_untar_istio_release "${ISTIO_REL_URL}" "${TAG}"
-test_istioctl_version istio-${TAG}/bin/istioctl "${HUB}" "${TAG}"
-test_helm_files istio-${TAG} "${HUB}" "${TAG}"
+test_istioctl_version "istio-${TAG}/bin/istioctl" "${HUB}" "${TAG}"
+test_helm_files "istio-${TAG}" "${HUB}" "${TAG}"
 

--- a/prow/istioctl-tests.sh
+++ b/prow/istioctl-tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# This is a script to download release artifact from monthly or daily release
+# location and test istioctl.
+#
+# This is currently triggered by https://github.com/istio-releases/daily-release
+# for release qualification.
+#
+# Expects ISTIO_REL_URL, HUB, and TAG as inputs.
+
+
+# Helper functions
+source "${ROOT}/prow/lib.sh"
+
+function test_istioctl_version() {
+  local istioctl_bin=${1}
+  local expected_hub=${2}
+  local expected_tag=${3}
+
+  hub=$(${istioctl_bin} version | grep -oP 'Hub:"\K.*?(?=")')
+  tag=$(${istioctl_bin} version | grep -oP '{Version:"\K.*?(?=")')
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+}
+
+function test_helm_files() {
+  local istio_path=${1}
+  local expected_hub=${2}
+  local expected_tag=${3}
+
+  local hub=$(grep hub: ${istio_path}/install/kubernetes/helm/istio/values.yaml | head -n 1 | cut -c 8-)
+  local tag=$(grep tag: ${istio_path}/install/kubernetes/helm/istio/values.yaml | head -n 1 | cut -c 8-)
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+
+  local hub=$(grep hub: ${istio_path}/install/kubernetes/helm/istio-remote/values.yaml | head -n 1 | cut -c 8-)
+  local tag=$(grep tag: ${istio_path}/install/kubernetes/helm/istio-remote/values.yaml | head -n 1 | cut -c 8-)
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+}
+
+
+# Assert HUB and TAG are matching from all istioctl binaries.
+
+download_untar_istio_release "${ISTIO_REL_URL}" "${TAG}"
+test_istioctl_version istio-${TAG}/bin/istioctl "${HUB}" "${TAG}"
+test_helm_files istio-${TAG} "${HUB}" "${TAG}"
+

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -14,10 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname "$0")
-WD=$(cd "$WD"; pwd)
-ROOT=$(dirname "$WD")
-
 function setup_and_export_git_sha() {
   if [[ -n "${CI:-}" ]]; then
     if [[ "${CI:-}" == 'bootstrap' ]]; then
@@ -82,6 +78,10 @@ function cleanup() {
 
 # Set up a GKE cluster for testing.
 function setup_e2e_cluster() {
+  WD=$(dirname "$0")
+  WD=$(cd "$WD" || exit; pwd)
+  ROOT=$(dirname "$WD")
+
   # shellcheck source=prow/mason_lib.sh
   source "${ROOT}/prow/mason_lib.sh"
   # shellcheck source=prow/cluster_lib.sh
@@ -90,9 +90,9 @@ function setup_e2e_cluster() {
   trap cleanup EXIT
 
   if [[ "${USE_MASON_RESOURCE}" == "True" ]]; then
-    export INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
-    export FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
-
+    INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
+    FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
+    OWNER=${OWNER:-"e2e"}
     export E2E_ARGS+=("--mason_info=${INFO_PATH}")
 
     setup_and_export_git_sha

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -30,7 +30,8 @@ function setup_and_export_git_sha() {
 
       # Set artifact dir based on checkout
       export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${GOPATH}/src/istio.io/istio/_artifacts}"
-      export E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+      E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+      export E2E_ARGS
 
     elif [[ "${CI:-}" == 'prow' ]]; then
       # Set artifact dir based on checkout
@@ -93,7 +94,7 @@ function setup_e2e_cluster() {
     INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
     FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
     OWNER=${OWNER:-"e2e"}
-    export E2E_ARGS+=("--mason_info=${INFO_PATH}")
+    E2E_ARGS+=("--mason_info=${INFO_PATH}")
 
     setup_and_export_git_sha
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
 function setup_and_export_git_sha() {
   if [[ -n "${CI:-}" ]]; then
     if [[ "${CI:-}" == 'bootstrap' ]]; then
@@ -30,6 +34,8 @@ function setup_and_export_git_sha() {
 
       # Set artifact dir based on checkout
       export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${GOPATH}/src/istio.io/istio/_artifacts}"
+      export E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+
     elif [[ "${CI:-}" == 'prow' ]]; then
       # Set artifact dir based on checkout
       export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ARTIFACTS}}"
@@ -48,3 +54,53 @@ function setup_and_export_git_sha() {
   fi
   gcloud auth configure-docker -q
 }
+
+# Download and unpack istio release artifacts.
+function download_untar_istio_release() {
+  local url_path=${1}
+  local tag=${2}
+  local dir=${3:-.}
+  # Download artifacts
+  LINUX_DIST_URL="${url_path}/istio-${tag}-linux.tar.gz"
+
+  wget  -q "${LINUX_DIST_URL}" -P "${dir}"
+  tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
+
+  export ISTIOCTL_BIN="${GOPATH}/src/istio.io/istio/istio-${TAG}/bin/istioctl"
+}
+
+# Cleanup e2e resources.
+function cleanup() {
+  if [[ "${CLEAN_CLUSTERS}" == "True" ]]; then
+    unsetup_clusters
+  fi
+  if [[ "${USE_MASON_RESOURCE}" == "True" ]]; then
+    mason_cleanup
+    cat "${FILE_LOG}"
+  fi
+}
+
+# Set up a GKE cluster for testing.
+function setup_e2e_cluster() {
+  # shellcheck source=prow/mason_lib.sh
+  source "${ROOT}/prow/mason_lib.sh"
+  # shellcheck source=prow/cluster_lib.sh
+  source "${ROOT}/prow/cluster_lib.sh"
+
+  trap cleanup EXIT
+
+  if [[ "${USE_MASON_RESOURCE}" == "True" ]]; then
+    export INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
+    export FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
+
+    export E2E_ARGS+=("--mason_info=${INFO_PATH}")
+
+    setup_and_export_git_sha
+
+    get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
+  else
+    export GIT_SHA="${GIT_SHA:-$TAG}"
+  fi
+  setup_cluster
+}
+

--- a/prow/upgrade-tests.sh
+++ b/prow/upgrade-tests.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# This is a script to download release artifacts from monthly or daily release
+# location and kick off upgrade/downgrade tests.
+#
+# This is currently triggered by https://github.com/istio-releases/daily-release
+# for release qualification.
+#
+# Expects HUB, SOURCE_VERSION, TARGET_VERSION, SOURCE_RELEASE_PATH, and TARGET_RELEASE_PATH as inputs.
+
+echo "Testing upgrade and downgrade between ${HUB}/${SOURCE_VERSION} and ${HUB}/${TARGET_VERSION}"
+
+# Download release artifacts.
+download_untar_istio_release ${SOURCE_RELEASE_PATH} ${SOURCE_VERSION}
+download_untar_istio_release ${TARGET_RELEASE_PATH} ${TARGET_VERSION}
+
+
+# Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
+# for existing resources types
+export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
+export OWNER='upgrade-tests'
+export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
+export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+setup_e2e_cluster
+
+
+# Install fortio which is needed by the upgrade test.
+go get fortio.org/fortio
+
+
+# Kick off tests
+${ROOT}/tests/upgrade/test_crossgrade.sh --from_hub=${HUB} --from_tag=${SOURCE_VERSION} --from_path=istio-${SOURCE_VERSION} --to_hub=${HUB} --to_tag=${TARGET_VERSION} --to_path=istio-${TARGET_VERSION}
+

--- a/prow/upgrade-tests.sh
+++ b/prow/upgrade-tests.sh
@@ -35,9 +35,12 @@ ROOT=$(dirname "$WD")
 
 echo "Testing upgrade and downgrade between ${HUB}/${SOURCE_VERSION} and ${HUB}/${TARGET_VERSION}"
 
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+
 # Download release artifacts.
-download_untar_istio_release ${SOURCE_RELEASE_PATH} ${SOURCE_VERSION}
-download_untar_istio_release ${TARGET_RELEASE_PATH} ${TARGET_VERSION}
+download_untar_istio_release "${SOURCE_RELEASE_PATH}" "${SOURCE_VERSION}"
+download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_VERSION}"
 
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
@@ -47,8 +50,6 @@ export OWNER='upgrade-tests'
 export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
 export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 
-# shellcheck source=prow/lib.sh
-source "${ROOT}/prow/lib.sh"
 setup_e2e_cluster
 
 
@@ -57,5 +58,5 @@ go get fortio.org/fortio
 
 
 # Kick off tests
-${ROOT}/tests/upgrade/test_crossgrade.sh --from_hub=${HUB} --from_tag=${SOURCE_VERSION} --from_path=istio-${SOURCE_VERSION} --to_hub=${HUB} --to_tag=${TARGET_VERSION} --to_path=istio-${TARGET_VERSION}
+"${ROOT}/tests/upgrade/test_crossgrade.sh" --from_hub="${HUB}" --from_tag="${SOURCE_VERSION}" --from_path="istio-${SOURCE_VERSION}" --to_hub="${HUB}" --to_tag="${TARGET_VERSION}" --to_path="istio-${TARGET_VERSION}"
 


### PR DESCRIPTION
These were moved from https://github.com/istio-releases/daily-release so they can be run and tested more easily.

Also refactored the e2e test logic in lib.sh for reusability. 