### PR TITLE
use pod-name[.namespace] to replace proxy_name in istioctl usage

### DIFF
--- a/istioctl/cmd/istioctl/proxyconfig.go
+++ b/istioctl/cmd/istioctl/proxyconfig.go
@@ -37,7 +37,7 @@ var (
 		Short: "Retrieve information about proxy configuration from Envoy [kube only]",
 		Long:  `A group of commands used to retrieve information about proxy configuration from the Envoy config dump`,
 		Example: `  # Retrieve information about proxy configuration from an Envoy instance.
-  istioctl proxy-config <clusters|listeners|routes|endpoints|bootstrap> <pod-name>`,
+  istioctl proxy-config <clusters|listeners|routes|endpoints|bootstrap> <pod-name[.namespace]>`,
 		Aliases: []string{"pc"},
 	}
 
@@ -45,17 +45,17 @@ var (
 	port                    int
 
 	clusterConfigCmd = &cobra.Command{
-		Use:   "cluster <pod-name>",
+		Use:   "cluster <pod-name[.namespace]>",
 		Short: "Retrieves cluster configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about cluster configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about cluster configuration for a given pod from Envoy.
-  istioctl proxy-config clusters <pod-name>
+  istioctl proxy-config clusters <pod-name[.namespace]>
 
   # Retrieve cluster summary for clusters with port 9080.
-  istioctl proxy-config clusters <pod-name> --port 9080
+  istioctl proxy-config clusters <pod-name[.namespace]> --port 9080
 
   # Retrieve full cluster dump for clusters that are inbound with a FQDN of details.default.svc.cluster.local.
-  istioctl proxy-config clusters <pod-name> --fqdn details.default.svc.cluster.local --direction inbound -o json
+  istioctl proxy-config clusters <pod-name[.namespace]> --fqdn details.default.svc.cluster.local --direction inbound -o json
 `,
 		Aliases: []string{"clusters", "c"},
 		Args:    cobra.ExactArgs(1),
@@ -85,17 +85,17 @@ var (
 	address, listenerType string
 
 	listenerConfigCmd = &cobra.Command{
-		Use:   "listener <pod-name>",
+		Use:   "listener <pod-name[.namespace]>",
 		Short: "Retrieves listener configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about listener configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about listener configuration for a given pod from Envoy.
-  istioctl proxy-config listeners <pod-name>
+  istioctl proxy-config listeners <pod-name[.namespace]>
 
   # Retrieve listener summary for listeners with port 9080.
-  istioctl proxy-config listeners <pod-name> --port 9080
+  istioctl proxy-config listeners <pod-name[.namespace]> --port 9080
 
   # Retrieve full listener dump for HTTP listeners with a wildcard address (0.0.0.0).
-  istioctl proxy-config listeners <pod-name> --type HTTP --address 0.0.0.0 -o json
+  istioctl proxy-config listeners <pod-name[.namespace]> --type HTTP --address 0.0.0.0 -o json
 `,
 		Aliases: []string{"listeners", "l"},
 		Args:    cobra.ExactArgs(1),
@@ -125,17 +125,17 @@ var (
 	routeName string
 
 	routeConfigCmd = &cobra.Command{
-		Use:   "route <pod-name>",
+		Use:   "route <pod-name[.namespace]>",
 		Short: "Retrieves route configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about route configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve summary about route configuration for a given pod from Envoy.
-  istioctl proxy-config routes <pod-name>
+  istioctl proxy-config routes <pod-name[.namespace]>
 
   # Retrieve route summary for route 9080.
-  istioctl proxy-config route <pod-name> --name 9080
+  istioctl proxy-config route <pod-name[.namespace]> --name 9080
 
   # Retrieve full route dump for route 9080
-  istioctl proxy-config route <pod-name> --name 9080 -o json
+  istioctl proxy-config route <pod-name[.namespace]> --name 9080 -o json
 `,
 		Aliases: []string{"routes", "r"},
 		Args:    cobra.ExactArgs(1),
@@ -160,11 +160,11 @@ var (
 	}
 
 	bootstrapConfigCmd = &cobra.Command{
-		Use:   "bootstrap <pod-name>",
+		Use:   "bootstrap <pod-name[.namespace]>",
 		Short: "Retrieves bootstrap configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about bootstrap configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full bootstrap configuration for a given pod from Envoy.
-  istioctl proxy-config bootstrap <pod-name>
+  istioctl proxy-config bootstrap <pod-name[.namespace]>
 `,
 		Aliases: []string{"b"},
 		Args:    cobra.ExactArgs(1),
@@ -180,22 +180,22 @@ var (
 
 	clusterName, status string
 	endpointConfigCmd   = &cobra.Command{
-		Use:   "endpoint <pod-name>",
+		Use:   "endpoint <pod-name[.namespace]>",
 		Short: "Retrieves endpoint configuration for the Envoy in the specified pod",
 		Long:  `Retrieve information about endpoint configuration for the Envoy instance in the specified pod.`,
 		Example: `  # Retrieve full endpoint configuration for a given pod from Envoy.
-  istioctl proxy-config endpoint <pod-name>
+  istioctl proxy-config endpoint <pod-name[.namespace]>
 
   # Retrieve endpoint summary for endpoint with port 9080.
-  istioctl proxy-config endpoint <pod-name> --port 9080
+  istioctl proxy-config endpoint <pod-name[.namespace]> --port 9080
 
   # Retrieve full endpoint with a address (172.17.0.2).
-  istioctl proxy-config endpoint <pod-name> --address 172.17.0.2 -o json
+  istioctl proxy-config endpoint <pod-name[.namespace]> --address 172.17.0.2 -o json
 
   # Retrieve full endpoint with a cluster name (outbound|9411||zipkin.istio-system.svc.cluster.local).
-  istioctl proxy-config endpoint <pod-name> --cluster "outbound|9411||zipkin.istio-system.svc.cluster.local" -o json
+  istioctl proxy-config endpoint <pod-name[.namespace]> --cluster "outbound|9411||zipkin.istio-system.svc.cluster.local" -o json
   # Retrieve full endpoint with the status (healthy).
-  istioctl proxy-config endpoint <pod-name> --status healthy -ojson
+  istioctl proxy-config endpoint <pod-name[.namespace]> --status healthy -ojson
 `,
 		Aliases: []string{"endpoints", "ep"},
 		Args:    cobra.ExactArgs(1),

--- a/istioctl/cmd/istioctl/proxystatus.go
+++ b/istioctl/cmd/istioctl/proxystatus.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	statusCmd = &cobra.Command{
-		Use:   "proxy-status [<proxy-name>]",
+		Use:   "proxy-status [<pod-name[.namespace]>]",
 		Short: "Retrieves the synchronization status of each Envoy in the mesh [kube only]",
 		Long: `
 Retrieves last sent and last acknowledged xDS sync from Pilot to each Envoy in the mesh

--- a/istioctl/cmd/istioctl/proxystatus_test.go
+++ b/istioctl/cmd/istioctl/proxystatus_test.go
@@ -24,11 +24,11 @@ func TestProxyStatus(t *testing.T) {
 	cases := []execTestCase{
 		{ // case 0
 			args:           strings.Split("proxy-status", " "),
-			expectedString: "PROXY     CDS     LDS     EDS     RDS     PILOT",
+			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
 		},
 		{ // case 1 short name "ps"
 			args:           strings.Split("ps", " "),
-			expectedString: "PROXY     CDS     LDS     EDS     RDS     PILOT",
+			expectedString: "NAME     CDS     LDS     EDS     RDS     PILOT",
 		},
 	}
 

--- a/istioctl/pkg/writer/pilot/status.go
+++ b/istioctl/pkg/writer/pilot/status.go
@@ -67,7 +67,7 @@ func (s *StatusWriter) PrintSingle(statuses map[string][]byte, proxyName string)
 
 func (s *StatusWriter) setupStatusPrint(statuses map[string][]byte) (*tabwriter.Writer, []*writerStatus, error) {
 	w := new(tabwriter.Writer).Init(s.Writer, 0, 8, 5, ' ', 0)
-	fmt.Fprintln(w, "PROXY\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
+	fmt.Fprintln(w, "NAME\tCDS\tLDS\tEDS\tRDS\tPILOT\tVERSION")
 	fullStatus := []*writerStatus{}
 	for pilot, status := range statuses {
 		ss := []*writerStatus{}

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusMultiPilot.txt
@@ -1,3 +1,3 @@
-PROXY      CDS       LDS        EDS               RDS          PILOT      VERSION
+NAME       CDS       LDS        EDS               RDS          PILOT      VERSION
 proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
 proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot2     1.0

--- a/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
+++ b/istioctl/pkg/writer/pilot/testdata/multiStatusSinglePilot.txt
@@ -1,3 +1,3 @@
-PROXY      CDS       LDS        EDS               RDS          PILOT      VERSION
+NAME       CDS       LDS        EDS               RDS          PILOT      VERSION
 proxy1     STALE     SYNCED     SYNCED (100%)     NOT SENT     pilot1     1.0
 proxy2     STALE     SYNCED     STALE (0%)        SYNCED       pilot1     1.0

--- a/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
+++ b/istioctl/pkg/writer/pilot/testdata/singleStatus.txt
@@ -1,2 +1,2 @@
-PROXY      CDS       LDS        EDS            RDS        PILOT      VERSION
+NAME       CDS       LDS        EDS            RDS        PILOT      VERSION
 proxy2     STALE     SYNCED     STALE (0%)     SYNCED     pilot2     1.0


### PR DESCRIPTION
Signed-off-by: clyang82 <clyang@cn.ibm.com>

https://github.com/istio/istio/pull/9533 is very good enhancement to have a good user experience to keep `istioctl proxy-status` and `istioctl proxy-config` consistence.

This PR is expose this enhancement in usage to let user know this enhancement.