### PR TITLE
Adding istioctl and upgrade release qualification (#9947)

### DIFF
--- a/prow/cluster_lib.sh
+++ b/prow/cluster_lib.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Copyright 2017 Istio Authors
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#       http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 #######################################
@@ -20,23 +20,142 @@
 #             e2e-suite               #
 #                                     #
 #######################################
-KUBE_USER="istio-prow-test-job@istio-testing.iam.gserviceaccount.com"
+
+KUBE_USER="${KUBE_USER:-istio-prow-test-job@istio-testing.iam.gserviceaccount.com}"
+SETUP_CLUSTERREG="${SETUP_CLUSTERREG:-False}"
+USE_GKE="${USE_GKE:-True}"
+CLUSTER_NAME=
+SA_NAMESPACE="istio-system-multi"
+
+
+function gen_kubeconf_from_sa () {
+    local service_account=$1
+    local filename=$2
+
+    NAMESPACE="${SA_NAMESPACE:-istio-system}"
+
+    SERVER=$(kubectl config view --minify=true -o "jsonpath={.clusters[].cluster.server}")
+    SECRET_NAME=$(kubectl get sa "${service_account}" -n ${NAMESPACE} -o jsonpath='{.secrets[].name}')
+    CA_DATA=$(kubectl get secret "${SECRET_NAME}" -n ${NAMESPACE} -o "jsonpath={.data['ca\\.crt']}")
+    TOKEN=$(kubectl get secret "${SECRET_NAME}" -n ${NAMESPACE} -o "jsonpath={.data['token']}" | base64 --decode)
+
+    cat <<EOF > "${filename}"
+      apiVersion: v1
+      clusters:
+         - cluster:
+             certificate-authority-data: ${CA_DATA}
+             server: ${SERVER}
+           name: ${CLUSTER_NAME}
+      contexts:
+         - context:
+             cluster: ${CLUSTER_NAME}
+             user: ${CLUSTER_NAME}
+           name: ${CLUSTER_NAME}
+      current-context: ${CLUSTER_NAME}
+      kind: Config
+      preferences: {}
+      users:
+         - name: ${CLUSTER_NAME}
+           user:
+             token: ${TOKEN}
+EOF
+
+}
+
+function setup_clusterreg () {
+    # setup cluster-registries dir setup by mason
+    CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
+
+    SERVICE_ACCOUNT="istio-multi-test"
+
+    # mason dumps all the kubeconfigs into the same file but we need to use per cluster
+    # files for the clusterregsitry config.  Create the separate files.
+    #  -- if PILOT_CLUSTER not set, assume pilot install to be in the first cluster
+    PILOT_CLUSTER="${PILOT_CLUSTER:-$(kubectl config current-context)}"
+    unset IFS
+    k_contexts=$(kubectl config get-contexts -o name)
+    for context in ${k_contexts}; do
+        if [[ "${PILOT_CLUSTER}" != "${context}" ]]; then
+            kubectl config use-context "${context}"
+
+            kubectl create ns ${SA_NAMESPACE}
+            kubectl create sa ${SERVICE_ACCOUNT} -n ${SA_NAMESPACE}
+            kubectl create clusterrolebinding istio-multi-test --clusterrole=cluster-admin --serviceaccount=${SA_NAMESPACE}:${SERVICE_ACCOUNT}
+            CLUSTER_NAME=$(kubectl config view --minify=true -o "jsonpath={.clusters[].name}")
+            if [[ "${CLUSTER_NAME}" =~ .*"_".* ]]; then
+                # if clustername has '_' set value to stuff after the last '_' due to k8s secret data name limitation
+                CLUSTER_NAME="${CLUSTER_NAME##*_}"
+            fi
+            KUBECFG_FILE="${CLUSTERREG_DIR}/${CLUSTER_NAME}"
+            gen_kubeconf_from_sa ${SERVICE_ACCOUNT} "${KUBECFG_FILE}"
+        fi
+    done
+    kubectl config use-context "${PILOT_CLUSTER}"
+}
+
+function join_by { local IFS="$1"; shift; echo "$*"; }
+
+function join_lines_by_comma() {
+  # Turn each line into an element in an array.
+  mapfile -t array <<< "$1"
+  list=$(join_by , "${array[@]}")
+  echo "${list}"
+}
 
 function setup_cluster() {
-  kubectl create clusterrolebinding prow-cluster-admin-binding\
-    --clusterrole=cluster-admin\
-    --user="${KUBE_USER}"
+  # use current-context if pilot_cluster not set
+  PILOT_CLUSTER="${PILOT_CLUSTER:-$(kubectl config current-context)}"
+
+  unset IFS
+  k_contexts=$(kubectl config get-contexts -o name)
+  for context in ${k_contexts}; do
+     kubectl config use-context "${context}"
+
+     kubectl create clusterrolebinding prow-cluster-admin-binding\
+       --clusterrole=cluster-admin\
+       --user="${KUBE_USER}"
+  done
+  if [[ "${SETUP_CLUSTERREG}" == "True" ]]; then
+      setup_clusterreg
+  fi
+  kubectl config use-context "${PILOT_CLUSTER}"
+
+  if [[ "${USE_GKE}" == "True" && "${SETUP_CLUSTERREG}" == "True" ]]; then
+    ALL_CLUSTER_CIDRS_LINES=$(gcloud container clusters list --format='value(clusterIpv4Cidr)' | sort | uniq)
+    ALL_CLUSTER_CIDRS=$(join_lines_by_comma "${ALL_CLUSTER_CIDRS_LINES}")
+
+    ALL_CLUSTER_NETTAGS_LINES=$(gcloud compute instances list --format='value(tags.items.[0])' | sort | uniq)
+    ALL_CLUSTER_NETTAGS=$(join_lines_by_comma "${ALL_CLUSTER_NETTAGS_LINES}")
+
+    gcloud compute firewall-rules create istio-multicluster-test-pods \
+	    --allow=tcp,udp,icmp,esp,ah,sctp \
+	    --direction=INGRESS \
+	    --priority=900 \
+	    --source-ranges="${ALL_CLUSTER_CIDRS}" \
+	    --target-tags="${ALL_CLUSTER_NETTAGS}" --quiet
+  fi
 }
 
-function check_cluster() {
-  for i in {1..10}
-  do
-    status=$(kubectl get namespace || echo "Unreachable")
-    [[ ${status} == 'Unreachable' ]] || break
-    if [ ${i} -eq 10 ]; then
-      echo "Cannot connect to the new cluster"; exit 1
-    fi
-    sleep 5
+function unsetup_clusters() {
+  # use current-context if pilot_cluster not set
+  PILOT_CLUSTER="${PILOT_CLUSTER:-$(kubectl config current-context)}"
+
+  unset IFS
+  k_contexts=$(kubectl config get-contexts -o name)
+  for context in ${k_contexts}; do
+     kubectl config use-context "${context}"
+
+     kubectl delete clusterrolebinding prow-cluster-admin-binding 2>/dev/null
+     if [[ "${SETUP_CLUSTERREG}" == "True" && "${PILOT_CLUSTER}" != "$context" ]]; then
+        kubectl delete clusterrolebinding istio-multi-test 2>/dev/null
+        kubectl delete ns ${SA_NAMESPACE} 2>/dev/null
+     fi
   done
+  kubectl config use-context "${PILOT_CLUSTER}"
+  if [[ "${USE_GKE}" == "True" && "${SETUP_CLUSTERREG}" == "True" ]]; then
+     gcloud compute firewall-rules delete istio-multicluster-test-pods --quiet
+  fi
 }
+
+
 

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -44,29 +44,14 @@ SINGLE_MODE=false
 
 # Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
 # for existing resources types
-RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
-OWNER='e2e-suite'
-INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
-FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
-
-E2E_ARGS=(--mason_info="${INFO_PATH}")
+export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
+export OWNER="${OWNER:-e2e-suite}"
+export PILOT_CLUSTER="${PILOT_CLUSTER:-}"
+export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
+export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 
 source "${ROOT}/prow/lib.sh"
-source "${ROOT}/prow/mason_lib.sh"
-source "${ROOT}/prow/cluster_lib.sh"
-
-function cleanup() {
-  mason_cleanup
-  cat "${FILE_LOG}"
-}
-
-setup_and_export_git_sha
-
-if [ "${CI:-}" == 'bootstrap' ]; then
-  # bootsrap upload all artifacts in _artifacts to the log bucket.
-  ARTIFACTS_DIR=${ARTIFACTS_DIR:-"${GOPATH}/src/istio.io/istio/_artifacts"}
-  E2E_ARGS+=(--test_logs_path="${ARTIFACTS_DIR}")
-fi
+setup_e2e_cluster
 
 ISTIO_GO=$(cd $(dirname $0)/..; pwd)
 
@@ -74,11 +59,6 @@ export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${TAG:-${GIT_SHA}}"
 
 make init
-
-trap cleanup EXIT
-get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
-check_cluster
-setup_cluster
 
 # getopts only handles single character flags
 for ((i=1; i<=$#; i++)); do

--- a/prow/istioctl-tests.sh
+++ b/prow/istioctl-tests.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# This is a script to download release artifact from monthly or daily release
+# location and test istioctl.
+#
+# This is currently triggered by https://github.com/istio-releases/daily-release
+# for release qualification.
+#
+# Expects ISTIO_REL_URL, HUB, and TAG as inputs.
+
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+
+function test_istioctl_version() {
+  local istioctl_bin=${1}
+  local expected_hub=${2}
+  local expected_tag=${3}
+
+  local hub=$(${istioctl_bin} version | grep Hub: | head -n 1 | cut -c 6-)
+  local tag=$(${istioctl_bin} version | grep Version: | head -n 1 | cut -c 10-)
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+}
+
+function test_helm_files() {
+  local istio_path=${1}
+  local expected_hub=${2}
+  local expected_tag=${3}
+
+  hub=$(grep hub: "${istio_path}/install/kubernetes/helm/istio/values.yaml" | head -n 1 | cut -c 8-)
+  tag=$(grep tag: "${istio_path}/install/kubernetes/helm/istio/values.yaml" | head -n 1 | cut -c 8-)
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+
+  hub=$(grep hub: "${istio_path}/install/kubernetes/helm/istio-remote/values.yaml" | head -n 1 | cut -c 8-)
+  tag=$(grep tag: "${istio_path}/install/kubernetes/helm/istio-remote/values.yaml" | head -n 1 | cut -c 8-)
+  [ "${hub}" == "${expected_hub}" ]
+  [ "${tag}" == "${expected_tag}" ]
+}
+
+
+# Assert HUB and TAG are matching from all istioctl binaries.
+
+download_untar_istio_release "${ISTIO_REL_URL}" "${TAG}"
+test_istioctl_version "istio-${TAG}/bin/istioctl" "${HUB}" "${TAG}"
+test_helm_files "istio-${TAG}" "${HUB}" "${TAG}"
+

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -15,17 +15,27 @@
 # limitations under the License.
 
 function setup_and_export_git_sha() {
-  if [ "${CI:-}" == 'bootstrap' ]; then
-    # Handle prow environment and checkout
-    export USER=Prow
+  if [[ -n "${CI:-}" ]]; then
+    if [[ "${CI:-}" == 'bootstrap' ]]; then
+      # TODO: Remove after update to pod-utils
 
-    # Make sure we are in the right directory
-    # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
-    # but we depend on being at path $GOPATH/src/istio.io/istio for imports
-    if [[ ! $PWD = ${GOPATH}/src/istio.io/istio ]]; then
-      mv ${GOPATH}/src/github.com/${REPO_OWNER:-istio} ${GOPATH}/src/istio.io
-      export ROOT=${GOPATH}/src/istio.io/istio
-      cd ${GOPATH}/src/istio.io/istio
+      # Make sure we are in the right directory
+      # Test harness will checkout code to directory $GOPATH/src/github.com/istio/istio
+      # but we depend on being at path $GOPATH/src/istio.io/istio for imports
+      if [[ ! $PWD = ${GOPATH}/src/istio.io/istio ]]; then
+        mv "${GOPATH}/src/github.com/${REPO_OWNER:-istio}" "${GOPATH}/src/istio.io"
+        export ROOT=${GOPATH}/src/istio.io/istio
+        cd "${GOPATH}/src/istio.io/istio" || return
+      fi
+
+      # Set artifact dir based on checkout
+      export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${GOPATH}/src/istio.io/istio/_artifacts}"
+      E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+      export E2E_ARGS
+
+    elif [[ "${CI:-}" == 'prow' ]]; then
+      # Set artifact dir based on checkout
+      export ARTIFACTS_DIR="${ARTIFACTS_DIR:-${ARTIFACTS}}"
     fi
 
     if [ -z "${PULL_PULL_SHA:-}" ]; then
@@ -34,11 +44,64 @@ function setup_and_export_git_sha() {
       export GIT_SHA="${PULL_PULL_SHA}"
     fi
 
-    # Set artifact dir based on checkout
-    export ARTIFACTS_DIR="${GOPATH}/src/istio.io/istio/_artifacts"
   else
     # Use the current commit.
-    export GIT_SHA="$(git rev-parse --verify HEAD)"
+    GIT_SHA="$(git rev-parse --verify HEAD)"
+    export GIT_SHA
   fi
   gcloud auth configure-docker -q
 }
+
+# Download and unpack istio release artifacts.
+function download_untar_istio_release() {
+  local url_path=${1}
+  local tag=${2}
+  local dir=${3:-.}
+  # Download artifacts
+  LINUX_DIST_URL="${url_path}/istio-${tag}-linux.tar.gz"
+
+  wget  -q "${LINUX_DIST_URL}" -P "${dir}"
+  tar -xzf "${dir}/istio-${tag}-linux.tar.gz" -C "${dir}"
+
+  export ISTIOCTL_BIN="${GOPATH}/src/istio.io/istio/istio-${TAG}/bin/istioctl"
+}
+
+# Cleanup e2e resources.
+function cleanup() {
+  if [[ "${CLEAN_CLUSTERS}" == "True" ]]; then
+    unsetup_clusters
+  fi
+  if [[ "${USE_MASON_RESOURCE}" == "True" ]]; then
+    mason_cleanup
+    cat "${FILE_LOG}"
+  fi
+}
+
+# Set up a GKE cluster for testing.
+function setup_e2e_cluster() {
+  WD=$(dirname "$0")
+  WD=$(cd "$WD" || exit; pwd)
+  ROOT=$(dirname "$WD")
+
+  # shellcheck source=prow/mason_lib.sh
+  source "${ROOT}/prow/mason_lib.sh"
+  # shellcheck source=prow/cluster_lib.sh
+  source "${ROOT}/prow/cluster_lib.sh"
+
+  trap cleanup EXIT
+
+  if [[ "${USE_MASON_RESOURCE}" == "True" ]]; then
+    INFO_PATH="$(mktemp /tmp/XXXXX.boskos.info)"
+    FILE_LOG="$(mktemp /tmp/XXXXX.boskos.log)"
+    OWNER=${OWNER:-"e2e"}
+    E2E_ARGS+=("--mason_info=${INFO_PATH}")
+
+    setup_and_export_git_sha
+
+    get_resource "${RESOURCE_TYPE}" "${OWNER}" "${INFO_PATH}" "${FILE_LOG}"
+  else
+    export GIT_SHA="${GIT_SHA:-$TAG}"
+  fi
+  setup_cluster
+}
+

--- a/prow/mason_lib.sh
+++ b/prow/mason_lib.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Copyright 2017 Istio Authors
-
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
-
-#       http://www.apache.org/licenses/LICENSE-2.0
-
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 MASON_CLIENT_PID=-1
 
@@ -37,17 +37,20 @@ function get_resource() {
     --boskos-url='http://boskos.boskos.svc.cluster.local' \
     --owner="${owner}" \
     --info-save "${info_path}" \
-    --kubeconfig-save ${HOME}/.kube/config > ${file_log} 2>&1 &
+    --kubeconfig-save "${HOME}/.kube/config" > "${file_log}" 2>&1 &
   MASON_CLIENT_PID=$!
 
   local ready
   local exited
 
   # Wait up to 10 mn by increment of 10 seconds unit ready or failure
-  for i in {1..60}; do
-    grep -q READY ${file_log} && ready=true || ready=false
+  for _ in {1..60}; do
+    grep -q READY "${file_log}" && ready=true || ready=false
     if [[ ${ready} == true ]]; then
       cat "${info_path}"
+      local project
+      project="$(head -n 1 "${info_path}" | tr -d ':')"
+      gcloud config set project "${project}"
       return 0
     fi
     kill -s 0 ${MASON_CLIENT_PID} && exited=false || exited=true

--- a/prow/upgrade-tests.sh
+++ b/prow/upgrade-tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
+ROOT=$(dirname "$WD")
+
+# This is a script to download release artifacts from monthly or daily release
+# location and kick off upgrade/downgrade tests.
+#
+# This is currently triggered by https://github.com/istio-releases/daily-release
+# for release qualification.
+#
+# Expects HUB, SOURCE_VERSION, TARGET_VERSION, SOURCE_RELEASE_PATH, and TARGET_RELEASE_PATH as inputs.
+
+echo "Testing upgrade and downgrade between ${HUB}/${SOURCE_VERSION} and ${HUB}/${TARGET_VERSION}"
+
+# shellcheck source=prow/lib.sh
+source "${ROOT}/prow/lib.sh"
+
+# Download release artifacts.
+download_untar_istio_release "${SOURCE_RELEASE_PATH}" "${SOURCE_VERSION}"
+download_untar_istio_release "${TARGET_RELEASE_PATH}" "${TARGET_VERSION}"
+
+
+# Check https://github.com/istio/test-infra/blob/master/boskos/configs.yaml
+# for existing resources types
+export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
+export OWNER='upgrade-tests'
+export USE_MASON_RESOURCE="${USE_MASON_RESOURCE:-True}"
+export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
+
+setup_e2e_cluster
+
+
+# Install fortio which is needed by the upgrade test.
+go get fortio.org/fortio
+
+
+# Kick off tests
+"${ROOT}/tests/upgrade/test_crossgrade.sh" --from_hub="${HUB}" --from_tag="${SOURCE_VERSION}" --from_path="istio-${SOURCE_VERSION}" --to_hub="${HUB}" --to_tag="${TARGET_VERSION}" --to_path="istio-${TARGET_VERSION}"
+


### PR DESCRIPTION
Adding istioctl and upgrade release qualification

These were moved from https://github.com/istio-releases/daily-release so
they can be run and tested more easily.

Also refactored the e2e test logic in lib.sh for re-usability.

Cherry-pick from #9947. No impact to production code.