### PR TITLE
use image tag in post-install job name

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -44,7 +44,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-grafana-post-install-{{ .Values.global.tag }}
+  name: istio-grafana-post-install-{{ .Values.global.tag | trunc 32 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -44,7 +44,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-grafana-post-install-v1.1.0
+  name: istio-grafana-post-install-{{ .Values.global.tag }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-cleanup-secrets-{{ .Values.global.tag }}
+  name: istio-cleanup-secrets-{{ .Values.global.tag | trunc 32 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-cleanup-secrets-v1.1.0
+  name: istio-cleanup-secrets-{{ .Values.global.tag }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -55,7 +55,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-security-post-install-{{ .Values.global.tag }}
+  name: istio-security-post-install-{{ .Values.global.tag | trunc 32 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -55,7 +55,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-security-post-install-v1.1.0
+  name: istio-security-post-install-{{ .Values.global.tag }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install


### PR DESCRIPTION
Our post-install jobs use images whose tag changes with each build /
release. This breaks install as job specs are immutable w.r.t image.

upside: we don't need to manually rename jobs for every build/release
downside: users need to manually delete completed jobs (e.g. kubectl -n istio-system delete job --all) after everything is installed.