### PR TITLE
[WIP] Update bootstrap config to use stats_matcher to filter metrics gen

### DIFF
--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -40,7 +40,30 @@
         "tag_name": "listener_address",
         "regex": "^listener\\.(((?:[_.[:digit:]]*|[_\\[\\]aAbBcCdDeEfF[:digit:]]*))\\.)"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",


### PR DESCRIPTION
This PR attempts to reduce the memory and cpu burden imposed on envoy proxies deployed in an Istio mesh by filtering the set of stats that Envoy generates and maintains down to a minimal set that are in-use within Istio today.

Full quantification of the impact is needed, especially at scale. I'm hoping to work with the perf WG on that assessment. @mandarjog has suggested this should be fairly straightforward.

For a rough estimate, I noticed that the number of individual metrics tracked by Envoy for a quiescent basic deployment of the bookinfo app went from 5479 metrics down to 152. I saw a corresponding reduction of ~20M of memory usage by the proxy. I did not attempt to assess latency impact, etc., nor did I look at CPU reduction in Prometheus processes, etc.

A few notes:
- This PR does not provide any way to configure `stats_matcher` bootstrap config, even at install time. I don't know what the best way would be to provide such a feature, but I imagine that this will be desired by some Istio customers. Perhaps in a follow-on.
- I did not attempt to remove the existing `stats_tag` configuration, which may not be need at all with this configuration and could potentially further reduce resource usage.

Marking as a WIP to investigate impact on testing and perf and to allow for more discussion of overall approach/utility.

Related issue: #9942 

/hold