### PR TITLE
Add adapter tuning install options to helm

### DIFF
--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -17,7 +17,6 @@ dependencies:
     repository: file://../subcharts/gateways
   - name: mixer
     version: 1.1.0
-    condition: mixer.policy.enabled,mixer.telemetry.enabled
     repository: file://../subcharts/mixer
   - name: nodeagent
     version: 1.1.0

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -17,6 +17,7 @@ dependencies:
     repository: file://../subcharts/gateways
   - name: mixer
     version: 1.1.0
+    condition: or mixer.policy.enabled mixer.telemetry.enabled
     repository: file://../subcharts/mixer
   - name: nodeagent
     version: 1.1.0

--- a/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -23,3 +24,4 @@ rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
   verbs: ["get", "list", "watch"]
+{{ end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
+{{- if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -24,4 +24,4 @@ rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
   verbs: ["get", "list", "watch"]
-{{ end }}
+{{- end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
+{{- if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -16,4 +16,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-mixer-service-account
     namespace: {{ .Release.Namespace }}
-{{ end }}
+{{- end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -15,3 +16,4 @@ subjects:
   - kind: ServiceAccount
     name: istio-mixer-service-account
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
+{{- if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
 metadata:
@@ -195,7 +195,7 @@ spec:
     destination.workload.namespace:
       valueType: STRING
 ---
-{{ if and .Values.adapters.stdio.enabled .Values.telemetry.enabled }}
+{{- if and .Values.adapters.stdio.enabled .Values.telemetry.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -341,9 +341,9 @@ spec:
   - handler: stdio
     instances:
     - tcpaccesslog.logentry
-{{ end }}
+{{- end }}
 ---
-{{ if and .Values.adapters.prometheus.enabled .Values.telemetry.enabled }}
+{{- if and .Values.adapters.prometheus.enabled .Values.telemetry.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
 metadata:
@@ -737,9 +737,9 @@ spec:
     instances:
     - tcpbytesent.metric
     - tcpbytereceived.metric
-{{ end }}
+{{- end }}
 ---
-{{ if and .Values.adapters.kubernetesenv.enabled (or .Values.policy.enabled .Values.telemetry.enabled) }}
+{{- if and .Values.adapters.kubernetesenv.enabled (or .Values.policy.enabled .Values.telemetry.enabled) }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -834,9 +834,9 @@ spec:
     destination.workload.uid: $out.destination_workload_uid | "unknown"
     destination.workload.name: $out.destination_workload_name | "unknown"
     destination.workload.namespace: $out.destination_workload_namespace | "unknown"
-{{ end }}
+{{- end }}
 ---
-{{ if .Values.policy.enabled }}
+{{- if .Values.policy.enabled }}
 # Configuration needed by Mixer.
 # Mixer cluster is delivered via CDS
 # Specify mixer cluster settings
@@ -864,9 +864,9 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
-{{ end }}
+{{- end }}
 ---
-{{ if .Values.telemetry.enabled }}
+{{- if .Values.telemetry.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -891,6 +891,6 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
-{{ end }}
+{{- end }}
 ---
-{{ end }}
+{{- end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -1,3 +1,4 @@
+{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: attributemanifest
 metadata:
@@ -194,6 +195,7 @@ spec:
     destination.workload.namespace:
       valueType: STRING
 ---
+{{ if and .Values.adapters.stdio.enabled .Values.telemetry.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -207,7 +209,7 @@ metadata:
 spec:
   compiledAdapter: stdio
   params:
-    outputAsJson: true
+    outputAsJson: {{ .Values.adapters.stdio.outputAsJson }}
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: logentry
@@ -339,7 +341,9 @@ spec:
   - handler: stdio
     instances:
     - tcpaccesslog.logentry
+{{ end }}
 ---
+{{ if and .Values.adapters.prometheus.enabled .Values.telemetry.enabled }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: metric
 metadata:
@@ -733,8 +737,9 @@ spec:
     instances:
     - tcpbytesent.metric
     - tcpbytereceived.metric
+{{ end }}
 ---
-
+{{ if and .Values.adapters.kubernetesenv.enabled (or .Values.policy.enabled .Values.telemetry.enabled) }}
 apiVersion: "config.istio.io/v1alpha2"
 kind: handler
 metadata:
@@ -829,8 +834,9 @@ spec:
     destination.workload.uid: $out.destination_workload_uid | "unknown"
     destination.workload.name: $out.destination_workload_name | "unknown"
     destination.workload.namespace: $out.destination_workload_namespace | "unknown"
-
+{{ end }}
 ---
+{{ if .Values.policy.enabled }}
 # Configuration needed by Mixer.
 # Mixer cluster is delivered via CDS
 # Specify mixer cluster settings
@@ -858,7 +864,9 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
+{{ end }}
 ---
+{{ if .Values.telemetry.enabled }}
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
@@ -883,4 +891,6 @@ spec:
       http:
         http2MaxRequests: 10000
         maxRequestsPerConnection: 10000
+{{ end }}
 ---
+{{ end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -14,4 +15,4 @@ metadata:
     chart: {{ template "mixer.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-
+{{ end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
+{{- if or (.Values.policy.enabled) (.Values.telemetry.enabled) }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
@@ -15,4 +15,4 @@ metadata:
     chart: {{ template "mixer.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
-{{ end }}
+{{- end }}

--- a/install/kubernetes/helm/subcharts/mixer/values.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/values.yaml
@@ -6,7 +6,7 @@ image: mixer
 env:
   GODEBUG: gctrace=2
 
-istio-policy:
+policy:
   enabled: true
   replicaCount: 1
   autoscaleEnabled: true
@@ -15,7 +15,7 @@ istio-policy:
   cpu:
     targetAverageUtilization: 80
 
-istio-telemetry:
+telemetry:
   enabled: true
   replicaCount: 1
   autoscaleEnabled: true
@@ -27,5 +27,11 @@ istio-telemetry:
 podAnnotations: {}
 
 adapters:
+  kubernetesenv:
+    enabled: true
+  stdio:
+    enabled: true
+    outputAsJson: true
   prometheus:
+    enabled: true
     metricsExpiryDuration: 10m


### PR DESCRIPTION
This PR attempts to do the following:
1. Fix the problematic condition in `requirements.yaml` on the mixer charts
1. Make it possible to select default adapters for install via helm
1. Only install precisely what is selected for install by an operator