### PR TITLE
Resolve helm upgrade failure

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/validatingwehookconfiguration.yaml.tpl
+++ b/install/kubernetes/helm/istio/charts/galley/templates/validatingwehookconfiguration.yaml.tpl
@@ -94,8 +94,6 @@ webhooks:
         - servicecontrols
         - solarwindses
         - stackdrivers
-        - cloudwatches
-        - dogstatsds
         - statsds
         - stdios
         - apikeys

--- a/install/kubernetes/helm/istio/templates/crds.yaml
+++ b/install/kubernetes/helm/istio/templates/crds.yaml
@@ -637,52 +637,6 @@ spec:
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
-  name: cloudwatches.config.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: mixer
-    package: cloudwatch
-    istio: mixer-adapter
-spec:
-  group: config.istio.io
-  names:
-    kind: cloudwatch
-    plural: cloudwatches
-    singular: cloudwatch
-    categories:
-    - istio-io
-    - policy-istio-io
-  scope: Namespaced
-  version: v1alpha2
----
-
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: dogstatsds.config.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: mixer
-    package: dogstatsd
-    istio: mixer-adapter
-spec:
-  group: config.istio.io
-  names:
-    kind: dogstatsd
-    plural: dogstatsds
-    singular: dogstatsd
-    categories:
-    - istio-io
-    - policy-istio-io
-  scope: Namespaced
-  version: v1alpha2
----
-
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
   name: statsds.config.istio.io
   annotations:
     "helm.sh/hook": crd-install


### PR DESCRIPTION
The `crd-install` install hook via helm is defective.  Most importantly
it does not permit the addition of new CRDs.  If new CRDs are added, several
serious problems occur.  Remove these CRDs from 1.0.  They can be reintroduced
in 1.1 with a μ-operator which serves to install CRDs from a configmap.

This is to unblock 1.0.4 so it can be released.