### PR TITLE
fix unique job name generation with integer tags

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -44,7 +44,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-grafana-post-install-{{ .Values.global.tag | trunc 32 }}
+  name: istio-grafana-post-install-{{ .Values.global.tag | printf "%v" | trunc 32 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-cleanup-secrets-{{ .Values.global.tag | trunc 32 }}
+  name: istio-cleanup-secrets-{{ .Values.global.tag | printf "%v" | trunc 32 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -55,7 +55,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: istio-security-post-install-{{ .Values.global.tag | trunc 32 }}
+  name: istio-security-post-install-{{ .Values.global.tag | printf "%v" | trunc 32  }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install


### PR DESCRIPTION
helm's `trunc` function expects a string. Use `printf` to convert
integer tags (e.g. 1234) to a string before truncating when generating
unique job names.

fixes https://github.com/istio/istio/issues/10010