### PR TITLE
Fix concurrent hashmap access

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -106,10 +106,18 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 			nameToServiceMap[svc.Hostname] = svc
 		} else {
 			if svcPort, exists := svc.Ports.GetByPort(listenerPort); exists {
+
+				svc.Mutex.RLock()
+				clusterVIPs := make(map[string]string, len(svc.ClusterVIPs))
+				for k, v := range svc.ClusterVIPs {
+					clusterVIPs[k] = v
+				}
+				svc.Mutex.RUnlock()
+
 				nameToServiceMap[svc.Hostname] = &model.Service{
 					Hostname:     svc.Hostname,
 					Address:      svc.Address,
-					ClusterVIPs:  svc.ClusterVIPs,
+					ClusterVIPs:  clusterVIPs,
 					MeshExternal: svc.MeshExternal,
 					Ports:        []*model.Port{svcPort},
 				}


### PR DESCRIPTION
When object is constructed in buildSidecarOutboundHTTPRouteConfig the map reference is copied, so there is no unique lock protecting access to the clusterVIP map.

fixes #9916 