### PR TITLE
Completely disable endpoints networks filtering if not set

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -313,6 +313,7 @@ global:
 
 
     # Configure the mesh networks to be used by the Split Horizon EDS.
+    # Please notice that it is an Alpha level feature.
     # 
     # The following example defines two networks with different endpoints
     # association methods. For `network1` all endpoints that their IP belongs

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -647,16 +647,19 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection,
 			l = loadAssignment(c)
 		}
 
-		// Apply registered endpoints filter functions and create a new
-		// ClusterLoadAssignment to be pushed with filtered endpoints
-		if len(s.endpointsFilterFuncs) > 0 {
+		// If networks are set (by default they aren't) apply the Split Horizon
+		// EDS filter on the endpoints
+		if s.Env.MeshNetworks != nil && len(s.Env.MeshNetworks.Networks) > 0 {
 			filteredCLA := &xdsapi.ClusterLoadAssignment{
 				ClusterName: l.ClusterName,
-				Endpoints:   s.applyEndpointsFilterFuncs(l.Endpoints, con),
+				Endpoints:   EndpointsByNetworkFilter(l.Endpoints, con, s.Env),
 				Policy:      l.Policy,
 			}
 			l = filteredCLA
 		}
+
+		// Normalize LoadBalancingWeight in range [1, 128]
+		l.Endpoints = LoadBalancingWeightNormalize(l.Endpoints, con, s.Env)
 
 		endpoints += len(l.Endpoints)
 		if len(l.Endpoints) == 0 {

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -802,7 +802,7 @@ func (n namedRangerEntry) Network() net.IPNet {
 // InitNetworkLookup will read the mesh networks configuration from the environment
 // and initialize CIDR rangers for an efficient network lookup when needed
 func (c *Controller) InitNetworkLookup(meshNetworks *meshconfig.MeshNetworks) {
-	if meshNetworks == nil {
+	if meshNetworks == nil || len(meshNetworks.Networks) == 0 {
 		return
 	}
 


### PR DESCRIPTION
With PR the logic of Split Horizon EDS won't get executed and affect EDS if users haven't specifically enabled it by settings the networks config.

Fixes #10029