### PR TITLE
Add pprof for galley

### DIFF
--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -52,6 +52,7 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 		livenessProbeController  probe.Controller
 		readinessProbeController probe.Controller
 		monitoringPort           uint
+		enableProfiling          bool
 	)
 
 	rootCmd := &cobra.Command{
@@ -94,7 +95,7 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 				go validation.RunValidation(validationArgs, printf, fatalf, flags.kubeConfig, livenessProbeController, readinessProbeController)
 			}
 			galleyStop := make(chan struct{})
-			go server.StartSelfMonitoring(galleyStop, monitoringPort)
+			go server.StartSelfMonitoring(galleyStop, monitoringPort, enableProfiling)
 			go server.StartProbeCheck(livenessProbeController, readinessProbeController, galleyStop)
 			istiocmd.WaitSignal(galleyStop)
 
@@ -123,6 +124,8 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 		"Interval of updating file for the Galley readiness probe.")
 	rootCmd.PersistentFlags().UintVar(&monitoringPort, "monitoringPort", 9093,
 		"Port to use for exposing self-monitoring information")
+	rootCmd.PersistentFlags().BoolVar(&enableProfiling, "enableProfiling", true,
+		"Enable pprof for Galley")
 
 	//server config
 	rootCmd.PersistentFlags().StringVarP(&serverArgs.APIAddress, "server-address", "", serverArgs.APIAddress,

--- a/galley/pkg/server/monitoring.go
+++ b/galley/pkg/server/monitoring.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus"
 	ocprom "go.opencensus.io/exporter/prometheus"
@@ -33,7 +32,7 @@ const (
 )
 
 //StartSelfMonitoring start the self monitoring for Galley
-func StartSelfMonitoring(stop <-chan struct{}, port uint, enableProfiling bool) {
+func StartSelfMonitoring(stop <-chan struct{}, port uint) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
 	if err != nil {
 		scope.Errorf("Unable to listen on monitoring port %v: %v", port, err)
@@ -57,14 +56,6 @@ func StartSelfMonitoring(stop <-chan struct{}, port uint, enableProfiling bool) 
 	})
 
 	version.Info.RecordComponentBuildTag("galley")
-
-	if enableProfiling {
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	}
 
 	server := &http.Server{
 		Handler: mux,

--- a/galley/pkg/server/profiling.go
+++ b/galley/pkg/server/profiling.go
@@ -1,0 +1,58 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+)
+
+//StartProfiling start the profiling for Galley
+func StartProfiling(stop <-chan struct{}, port uint) {
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", port))
+	if err != nil {
+		scope.Errorf("Unable to listen on profiling port %v: %v", port, err)
+		return
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		//Redirect ROOT to /debug/pprof/ for convenience
+		http.Redirect(w, r, "/debug/pprof/", http.StatusSeeOther)
+	})
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	server := &http.Server{
+		Handler: mux,
+	}
+
+	go func() {
+		if err := server.Serve(lis); err != nil {
+			scope.Errorf("Profiling http server failed: %v", err)
+			return
+		}
+	}()
+
+	<-stop
+	err = server.Close()
+	scope.Debugf("Profiling http server terminated: %v", err)
+}


### PR DESCRIPTION
Enable pprof for `galley` only. the pprof will be started in `9094` by default.

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>