### PR TITLE
Run LoadBalancingWeightNormalize when creating CLA instead of in pushEDS

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -151,6 +151,6 @@ func createLocalityLbEndpoints(base *endpoint.LocalityLbEndpoints, lbEndpoints [
 }
 
 // LoadBalancingWeightNormalize set LoadBalancingWeight with a valid value.
-func LoadBalancingWeightNormalize(endpoints []endpoint.LocalityLbEndpoints, conn *XdsConnection, env *model.Environment) []endpoint.LocalityLbEndpoints {
+func LoadBalancingWeightNormalize(endpoints []endpoint.LocalityLbEndpoints) []endpoint.LocalityLbEndpoints {
 	return util.LocalityLbWeightNormalize(endpoints)
 }


### PR DESCRIPTION
Improve EDS performance by running the LB weight normalizer when creating the ClusterLoadAssignment instead of for every EDS push.

It also solves a data race reading/writing endpoints.