### PR TITLE
mixer: reconcile nondet bug fix between 1.0 and 1.1

### DIFF
--- a/mixer/pkg/protobuf/yaml/encoder.go
+++ b/mixer/pkg/protobuf/yaml/encoder.go
@@ -56,7 +56,7 @@ func (e *Encoder) EncodeBytes(data map[string]interface{}, msgName string, skipU
 	return result, nil
 }
 
-// encodeBytes updates a proto.Buffer from a yaml representation of a proto.
+// encodeBytes updates a proto.Buffer from a yaml representation of a proto and outputs into a buffer.
 func (e *Encoder) encodeBytes(data map[string]interface{}, msgName string, skipUnknown bool, dest *proto.Buffer) error {
 	buf := GetBuffer()
 	defer func() { PutBuffer(buf) }()
@@ -626,6 +626,7 @@ func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDe
 			for i, iface := range v {
 				c, ok := ToInt64(iface)
 				if !ok {
+					PutBuffer(tmpBuffer)
 					return badTypeError(fmt.Sprintf("%s[%d]", name, i), "int", iface)
 				}
 				_ = tmpBuffer.EncodeZigzag32(uint64(c))
@@ -710,6 +711,7 @@ func (e *Encoder) visit(name string, data interface{}, field *descriptor.FieldDe
 			for i, iface := range v {
 				c, ok := ToInt64(iface)
 				if !ok {
+					PutBuffer(tmpBuffer)
 					return badTypeError(fmt.Sprintf("%s[%d]", name, i), "int", iface)
 				}
 				_ = tmpBuffer.EncodeZigzag64(uint64(c))

--- a/mixer/pkg/runtime/config/ephemeral_test.go
+++ b/mixer/pkg/runtime/config/ephemeral_test.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"istio.io/istio/mixer/adapter/list/config"
+	"istio.io/istio/mixer/pkg/runtime/testing/data"
+)
+
+func TestDynamicHandlerCorruption(t *testing.T) {
+	adapters := data.BuildAdapters(nil)
+	templates := data.BuildTemplates(nil)
+
+	// need an adapter with config
+	listbackend, err := ioutil.ReadFile("../../../test/listbackend/nosession.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := string(listbackend)
+
+	listentry, err := ioutil.ReadFile("../../../template/listentry/template.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg = cfg + "\n---\n" + string(listentry)
+
+	cfg = cfg + `
+---
+apiVersion: config.istio.io/v1alpha2
+kind: handler
+metadata:
+  name: h1
+  namespace: istio-system
+spec:
+  adapter: listbackend-nosession
+  connection:
+    address: 127.0.0.1:8080
+  params:
+    provider_url: google.com
+    overrides:
+    - a
+    - b
+    caching_interval: 5s
+---
+apiVersion: config.istio.io/v1alpha2
+kind: handler
+metadata:
+  name: h2
+  namespace: istio-system
+spec:
+  adapter: listbackend-nosession
+  connection:
+    address: 127.0.0.1:8080
+  params:
+    refresh_interval: 5s
+    caching_use_count: 50
+---
+apiVersion: config.istio.io/v1alpha2
+kind: handler
+metadata:
+  name: h3
+  namespace: istio-system
+spec:
+  adapter: listbackend-nosession
+  connection:
+    address: 127.0.0.1:8080
+  params:
+    blacklist: true
+---
+`
+	s, err := GetSnapshotForTest(templates, adapters, data.ServiceConfig, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handlers := s.HandlersDynamic
+	if len(handlers) != 3 {
+		t.Errorf("got %d, want 3 handlers", len(handlers))
+	}
+
+	for _, handler := range handlers {
+		bytes := handler.AdapterConfig.Value
+		params := config.Params{}
+		if err = params.Unmarshal(bytes); err != nil {
+			t.Errorf("got corrupt handler %#v", bytes)
+		}
+	}
+}


### PR DESCRIPTION
Copies the test from 1.0 to 1.1 fix, and adds buffer leak fix.
/assign @geeknoid 

Signed-off-by: Kuat Yessenov <kuat@google.com>