### PR TITLE
Fix citadel sync issue

### DIFF
--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -268,12 +268,7 @@ func (sc *SecretController) upsertSecret(saName, saNamespace string) {
 		time.Sleep(time.Second)
 	}
 
-	if err != nil && errors.IsAlreadyExists(err) {
-		// Do nothing for the already exist error.
-		return
-	}
-
-	if err != nil {
+	if err != nil && !errors.IsAlreadyExists(err) {
 		log.Errorf("Failed to create secret for service account \"%s\"  (error: %s), retries %v times",
 			saName, err, secretCreationRetry)
 		return

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -178,6 +178,11 @@ func NewSecretController(ca ca.CertificateAuthority, certTTL time.Duration, trus
 // Run starts the SecretController until a value is sent to stopCh.
 func (sc *SecretController) Run(stopCh chan struct{}) {
 	go sc.scrtController.Run(stopCh)
+
+	// saAdded calls upsertSecret to update and insert secret
+	// it throws error if the secret cache is not synchronized, but the secret exists in the system
+	cache.WaitForCacheSync(stopCh, sc.scrtController.HasSynced)
+
 	go sc.saController.Run(stopCh)
 }
 
@@ -255,12 +260,17 @@ func (sc *SecretController) upsertSecret(saName, saNamespace string) {
 	// We retry several times when create secret to mitigate transient network failures.
 	for i := 0; i < secretCreationRetry; i++ {
 		_, err = sc.core.Secrets(saNamespace).Create(secret)
-		if err == nil {
+		if err == nil || errors.IsAlreadyExists(err) {
 			break
 		} else {
 			log.Errorf("Failed to create secret in attempt %v/%v, (error: %s)", i+1, secretCreationRetry, err)
 		}
 		time.Sleep(time.Second)
+	}
+
+	if err != nil && errors.IsAlreadyExists(err) {
+		// Do nothing for the already exist error.
+		return
 	}
 
 	if err != nil {

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -261,6 +261,9 @@ func (sc *SecretController) upsertSecret(saName, saNamespace string) {
 	for i := 0; i < secretCreationRetry; i++ {
 		_, err = sc.core.Secrets(saNamespace).Create(secret)
 		if err == nil || errors.IsAlreadyExists(err) {
+			if errors.IsAlreadyExists(err) {
+				log.Infof("Istio secret for service account \"%s\" in namespace \"%s\" already exists", saName, saNamespace)
+			}
 			break
 		} else {
 			log.Errorf("Failed to create secret in attempt %v/%v, (error: %s)", i+1, secretCreationRetry, err)


### PR DESCRIPTION
This PR is to fix the `citadel` sync issue. sync service account depends on the secret cache, but the secret cache can be empty. Here is output of `citadel` pod:
```
2018-11-20T05:03:42.396581Z	error	Failed to create secret in attempt 1/3, (error: secrets "istio.pv-protection-controller" already exists)
2018-11-20T05:03:43.401264Z	error	Failed to create secret in attempt 2/3, (error: secrets "istio.pv-protection-controller" already exists)
2018-11-20T05:03:44.419085Z	error	Failed to create secret in attempt 3/3, (error: secrets "istio.pv-protection-controller" already exists)
2018-11-20T05:03:45.419233Z	error	Failed to create secret for service account "pv-protection-controller"  (error: secrets "istio.pv-protection-controller" already exists), retries 3 times
```
This error occurs because the secret cache is not synced.

This fix is to check secret cache is synced, then start service account  gorouter.