### PR TITLE
Added the env NODE_NAME to the gateways

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -125,6 +125,11 @@ spec:
 {{ toYaml $.Values.global.defaultResources | indent 12 }}
 {{- end }}
           env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
@@ -78,6 +78,11 @@ spec:
 {{ toYaml .Values.global.defaultResources | indent 12 }}
 {{- end }}
           env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.nodeName
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
We use `$(NODE_NAME)` to set up the statsd endpoint when there's an agent running as a daemonset.

For example, we have in `values.yaml`:

```
global:
  proxy:
    envoyStatsd:
      host: $(NODE_NAME)
      port: 8125
```