### PR TITLE
feat: additional volumes for sidecar injection configuration

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -237,6 +237,12 @@ data:
           name: lightstep-certs
           readOnly: true
         {{- end }}
+          {{ "[[- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount` ]]" }}
+          {{ "[[ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolumeMount`) ]]" }}
+        - name: {{ "\"[[ $index ]]\"" }}
+          {{ "[[ toYaml $value | indent 4 ]]" }}
+          {{ "[[ end ]]" }}
+          {{ "[[- end ]]" }}
       volumes:
       {{- if .Values.global.sds.enabled }}
       - name: sds-uds-path
@@ -269,6 +275,12 @@ data:
           {{ "[[ else -]]" }}
           secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
           {{ "[[ end -]]" }}
+        {{ "[[- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` ]]" }}
+        {{ "[[ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) ]]" }}
+      - name: {{ "\"[[ $index ]]\"" }}
+        {{ "[[ toYaml $value | indent 2 ]]" }}
+        {{ "[[ end ]]" }}
+        {{ "[[ end -]]" }}
 {{- end }}
 {{- if .Values.global.podDNSSearchNamespaces }}
       dnsConfig:

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -511,6 +511,9 @@ func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.O
 		"annotation":          annotation,
 		"valueOrDefault":      valueOrDefault,
 		"toJSON":              toJSON,
+		"fromJSON":            fromJSON,
+		"toYaml":              toYaml,
+		"indent":              indent,
 		"directory":           directory,
 	}
 
@@ -769,6 +772,38 @@ func toJSON(m map[string]string) string {
 	}
 
 	return string(ba)
+}
+
+func fromJSON(j string) interface{} {
+	var m interface{}
+	err := json.Unmarshal([]byte(j), &m)
+	if err != nil {
+		log.Warnf("Unable to unmarshal %s", j)
+		return "{}"
+	}
+
+	log.Warnf("%v", m)
+	return m
+}
+
+func indent(spaces int, source string) string {
+	res := strings.Split(source, "\n")
+	for i, line := range res {
+		if i > 0 {
+			res[i] = fmt.Sprintf(fmt.Sprintf("%% %ds%%s", spaces), "", line)
+		}
+	}
+	return strings.Join(res, "\n")
+}
+
+func toYaml(value interface{}) string {
+	y, err := yaml.Marshal(value)
+	if err != nil {
+		log.Warnf("Unable to marshal %v", value)
+		return ""
+	}
+
+	return string(y)
 }
 
 func annotation(meta metav1.ObjectMeta, name string, defaultValue interface{}) string {

--- a/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/deployment-user-volume.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: user-volume
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/userMount: '[{"name": "proto", "mountPath": "/etc/proto/description.proto", "readonly": true}]'
+        sidecar.istio.io/userVolume: '[{"name": "proto", "persistentVolumeClaim": [{"claimName": "some-claim-name"}]}]'
+      labels:
+        app: user-volume
+    spec:
+      containers:
+        - name: user-volume
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80
+

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: user-volume
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: user-volume
+        tier: backend
+        track: stable
+      annotations:
+        sidecar.istio.io/userVolumeMount: '{"user-volume-1":{"mountPath":"/mnt/volume-1","readOnly":true},"user-volume-2":{"mountPath":"/mnt/volume-2"}}'
+        sidecar.istio.io/userVolume: '{"user-volume-1":{"persistentVolumeClaim":{"claimName":"pvc-claim"}},"user-volume-2":{"configMap":{"name":"configmap-volume","items":[{"key":"some-key","path":"/some-path"}]}}}'
+    spec:
+      containers:
+        - name: user-volume
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80
+

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: ISTIO_META_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: ISTIO_META_INTERCEPTION_MODE
           value: REDIRECT
         image: gcr.io/istio-release/proxyv2:master-latest-daily
@@ -150,4 +154,3 @@ spec:
           - key: some-key
             path: /some-path
 status: {}
-

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -1,0 +1,153 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: user-volume
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"unit-test-fake-version","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        sidecar.istio.io/userVolumeMount: '{"user-volume-1":{"mountPath":"/mnt/volume-1","readOnly":true},"user-volume-2":{"mountPath":"/mnt/volume-2"}}'
+        sidecar.istio.io/userVolume: '{"user-volume-1":{"persistentVolumeClaim":{"claimName":"pvc-claim"}},"user-volume-2":{"configMap":{"name":"configmap-volume","items":[{"key":"some-key","path":"/some-path"}]}}}'
+      creationTimestamp: null
+      labels:
+        app: user-volume
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: user-volume
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - user-volume.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --zipkinAddress
+        - ""
+        - --connectTimeout
+        - 1s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: gcr.io/istio-release/proxyv2:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+        - name: user-volume-1
+          mountPath: /mnt/volume-1
+          readOnly: true
+        - name: user-volume-2
+          mountPath: /mnt/volume-2
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15020"
+        image: gcr.io/istio-release/proxy_init:master-latest-daily
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources:
+          limits:
+            cpu: 10m
+            memory: 10Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+      - name: user-volume-1
+        persistentVolumeClaim:
+          claimName: pvc-claim
+      - name: user-volume-2
+        configMap:
+          name: configmap-volume
+          items:
+          - key: some-key
+            path: /some-path
+status: {}
+

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -716,6 +716,10 @@ func TestHelmInject(t *testing.T) {
 			inputFile: "resource_annotations.yaml",
 			wantFile:  "resource_annotations.yaml.injected",
 		},
+		{
+	    inputFile: "user-volume.yaml",
+		  wantFile:  "user-volume.yaml.injected",
+		},
 	}
 
 	for ci, c := range cases {

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -717,8 +717,8 @@ func TestHelmInject(t *testing.T) {
 			wantFile:  "resource_annotations.yaml.injected",
 		},
 		{
-	    inputFile: "user-volume.yaml",
-		  wantFile:  "user-volume.yaml.injected",
+			inputFile: "user-volume.yaml",
+			wantFile:  "user-volume.yaml.injected",
 		},
 	}
 


### PR DESCRIPTION
---
name: Additional volumes to sidecar configuration
---

**Describe the feature request**
It's a two annotation parameter for configuration additional volume for a proxy container. For example in JSON <-> GRPC transcoding in envoy you should generate the additional file and use it with envoy configuration.

**Describe alternatives you've considered**
We can reconfigure it right now after installation and use this functionality

**Additional context**
example envoy filter configuration:
```
...
- name: envoy.grpc_json_transcoder
  config:
    proto_descriptor: "/etc/custom-config/proto.pb" # <-- here use file from volume
    services: ["micro.srv.subscription.Subscription"]
    print_options:
      add_whitespace: true
      always_print_primitive_fields: true
      always_print_enums_as_ints: false
      preserve_proto_field_names: true
```

**Possible Usage**
```
kind: Pod
apiVersion: v1
metadata:
  name: mypod
  annotations:
    sidecar.istio.io/userVolumeMount: /etc/custom-config/
    sidecar.istio.io/userVolumeClaim: myVolumeClaim
spec:
```