### PR TITLE
remove old code that assumes tag were created before building

### DIFF
--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -35,14 +35,9 @@ else
   tree_status="Modified"
 fi
 
-# XXX This needs to be updated to accomodate tags added after building, rather than prior to builds
-RELEASE_TAG=$(git describe --match '[0-9]*\.[0-9]*\.[0-9]*' --exact-match 2> /dev/null || echo "")
-
 # security wanted VERSION='unknown'
 VERSION="${BUILD_GIT_REVISION}"
-if [[ -n "${RELEASE_TAG}" ]]; then
-  VERSION="${RELEASE_TAG}"
-elif [[ -n ${ISTIO_VERSION} ]]; then
+if [[ -n ${ISTIO_VERSION} ]]; then
   VERSION="${ISTIO_VERSION}"
 fi
 


### PR DESCRIPTION
remove old code that assumes tag were created before building. Old code picks up the TAG as version for istioctl, which is not what we want. We are passing it in explicitly.