### PR TITLE
remove flag: grpc-hostname

### DIFF
--- a/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
@@ -31,7 +31,6 @@ spec:
           - --append-dns-names=true
           - --citadel-storage-namespace={ISTIO_NAMESPACE}
           - --grpc-port=8060
-          - --grpc-hostname=citadel
           - --self-signed-ca=false
           - --signing-cert=/etc/cacerts/ca-cert.pem
           - --signing-key=/etc/cacerts/ca-key.pem

--- a/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
@@ -50,7 +50,6 @@ spec:
           - --append-dns-names=true
           - --citadel-storage-namespace={ISTIO_NAMESPACE}
           - --grpc-port=8060
-          - --grpc-hostname=citadel
           - --self-signed-ca=true
           - --liveness-probe-path=/tmp/ca.liveness # path to the liveness health check status file
           - --liveness-probe-interval=60s # interval for health check file update

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
           args:
             - --append-dns-names=true
             - --grpc-port=8060
-            - --grpc-hostname=citadel
             - --citadel-storage-namespace={{ .Release.Namespace }}
             - --custom-dns-names=istio-pilot-service-account.{{ .Release.Namespace }}:istio-pilot.{{ .Release.Namespace }}
             - --monitoring-port={{ .Values.global.monitoringPort }}

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -67,8 +67,6 @@ type cliOptions struct { // nolint: maligned
 	// The minimum grace period for workload cert rotation.
 	workloadCertMinGracePeriod time.Duration
 
-	// TODO(incfly): delete this field once we deprecate flag --grpc-hostname.
-	grpcHostname string
 	// Comma separated string containing all possible host name that clients may use to connect to.
 	grpcHosts  string
 	grpcPort   int
@@ -198,9 +196,6 @@ func init() {
 		"If unspecified, Citadel will not serve GRPC requests.")
 	flags.BoolVar(&opts.serverOnly, "server-only", false, "When set, Citadel only serves as a server without writing "+
 		"the Kubernetes secrets.")
-
-	flags.StringVar(&opts.grpcHostname, "grpc-hostname", "istio-ca", "deprecated")
-	flags.MarkDeprecated("grpc-hostname", "please use --grpc-host-identities instead")
 
 	flags.BoolVar(&opts.signCACerts, "sign-ca-certs", false, "Whether Citadel signs certificates for other CAs")
 

--- a/security/docker/Dockerfile.citadel-test
+++ b/security/docker/Dockerfile.citadel-test
@@ -10,5 +10,4 @@ ENTRYPOINT [ "/usr/local/bin/istio_ca", \
 "--signing-cert", "/usr/local/bin/istio_ca.crt", \
 "--signing-key", "/usr/local/bin/istio_ca.key", \
 "--root-cert", "/usr/local/bin/istio_ca.crt", \
-"--grpc-hostname", "istio-citadel", \
 "--grpc-port", "8060" ]


### PR DESCRIPTION
`--grpc-hostname` was deprecated before and has no meaning now.