### PR TITLE
Fix kubectl docker build on MacOS

### DIFF
--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -1,5 +1,8 @@
 FROM istionightly/base_debug
 # Image for post install jobs
 
-# This container should only contain kubectl
-ADD kubectl /usr/bin
+ARG K8S_VER=v1.10.4
+
+# Include only kubectl in the image
+RUN curl -kLo /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubectl && \
+    chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/bin/

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -155,7 +155,7 @@ docker.test_policybackend: mixer/docker/Dockerfile.test_policybackend
 docker.test_policybackend: $(ISTIO_OUT)/mixer-test-policybackend
 	$(DOCKER_RULE)
 
-docker.kubectl: docker/Dockerfile$$(suffix $$@) $(ISTIO_BIN)/kubectl
+docker.kubectl: docker/Dockerfile$$(suffix $$@)
 	$(DOCKER_RULE)
 
 # addons docker images


### PR DESCRIPTION
Currently building docker images on MacOS fails with:
```
time (mkdir -p /Users/xxxxx/go/out/linux_amd64/release/docker_build/docker.kubectl && cp -r docker/Dockerfile.kubectl /Users/xxxxx/go/bin/kubectl /Users/xxxxx/go/out/linux_amd64/release/docker_build/docker.kubectl && cd /Users/xxxxx/go/out/linux_amd64/release/docker_build/docker.kubectl &&  docker build  -t docker.io/xxxxx/kubectl:develop -f Dockerfile.kubectl .)
cp: /Users/xxxxx/go/out/linux_amd64/release/docker_build/docker.kubectl/kubectl: Permission denied

real	0m0.007s
user	0m0.002s
sys	0m0.003s
make: *** [tools/istio-docker.mk:159: docker.kubectl] Error 1
```

The `kubectl` binary added is a darwin one.

With this PR we download the desired `kubectl` binary for Linux when building the image so that it can build on non-Linux platforms too.

Might fix: https://github.com/istio/istio/issues/9908