### PR TITLE
Fixed incorrect event name for delete

### DIFF
--- a/pilot/pkg/config/kube/crd/controller.go
+++ b/pilot/pkg/config/kube/crd/controller.go
@@ -165,7 +165,7 @@ func (c *controller) createInformer(
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				k8sEvents.With(prometheus.Labels{"type": otype, "event": "add"}).Add(1)
+				k8sEvents.With(prometheus.Labels{"type": otype, "event": "delete"}).Add(1)
 				c.queue.Push(kube.NewTask(handler.Apply, obj, model.EventDelete))
 			},
 		})


### PR DESCRIPTION
This is in addition to a similar fix #9853 made in a different place.