### PR TITLE
Increase the test-integration-kubernetes test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,7 +523,7 @@ jobs:
           when: always
           name: make test.integration.kube
           command: |
-            make test.integration.kube T=-v | tee -a /go/out/tests/build-log.txt
+            make test.integration.kube T="-v -timeout=15m" | tee -a /go/out/tests/build-log.txt
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - <<: *markJobFinishesOnGCS


### PR DESCRIPTION
In recent runs it always fails due to timeout (after 10m).
Increasing the timeout to 15m.

Failed examples:
https://circleci.com/gh/istio/istio/253552
https://circleci.com/gh/istio/istio/253414