### PR TITLE
add node selector for istio chart.

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio-remote/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}

--- a/install/kubernetes/helm/istio/templates/_affinity.tpl
+++ b/install/kubernetes/helm/istio/templates/_affinity.tpl
@@ -19,6 +19,13 @@
           - {{ $key }}
           {{- end }}
         {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val }}
+        {{- end }}
 {{- end }}
 
 {{- define "nodeAffinityPreferredDuringScheduling" }}

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -271,6 +271,12 @@ global:
     s390x: 2
     ppc64le: 2
 
+  # Default node selector to be applied to all deployments so that all pos can be 
+  # constrained to run a particular nodes. Each component can overwrite these default 
+  # values by adding its node selector block in the relevant section below and setting 
+  # the desired values.
+  defaultNodeSelector: {}
+
   # Whether to restrict the applications namespace the controller manages;
   # If not set, controller watches all namespaces
   oneNamespace: false

--- a/install/kubernetes/helm/subcharts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/certmanager/templates/deployment.yaml
@@ -52,22 +52,12 @@ spec:
               fieldPath: metadata.namespace
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- if .Values.podDnsPolicy }}
+      {{- if .Values.podDnsPolicy }}
       dnsPolicy: {{ .Values.podDnsPolicy }}
-{{- end }}
-{{- if .Values.podDnsConfig }}
+      {{- end }}
+      {{- if .Values.podDnsConfig }}
       dnsConfig:
-{{ toYaml .Values.podDnsConfig | indent 8 }}
-{{- end }}
+      {{ toYaml .Values.podDnsConfig | indent 8 }}
+      {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/subcharts/certmanager/values.yaml
+++ b/install/kubernetes/helm/subcharts/certmanager/values.yaml
@@ -7,3 +7,4 @@ enabled: false
 hub: quay.io/jetstack
 tag: v0.5.0
 resources: {}
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/galley/values.yaml
+++ b/install/kubernetes/helm/subcharts/galley/values.yaml
@@ -4,3 +4,4 @@
 enabled: true
 replicaCount: 1
 image: galley
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/gateways/templates/autoscale.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if and $spec.enabled $spec.autoscaleMin }}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/install/kubernetes/helm/subcharts/gateways/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if $spec.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/install/kubernetes/helm/subcharts/gateways/templates/clusterrolebindings.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/clusterrolebindings.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if $spec.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if $spec.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/install/kubernetes/helm/subcharts/gateways/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if $spec.enabled }}
 apiVersion: v1
 kind: Service

--- a/install/kubernetes/helm/subcharts/gateways/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $spec := .Values }}
-{{- if ne $key "enabled" }}
+{{- if and (ne $key "enabled") (ne $key "nodeSelector") }}
 {{- if $spec.enabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/install/kubernetes/helm/subcharts/gateways/values.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/values.yaml
@@ -6,6 +6,7 @@
 # Disable specifc gateway by setting the `enabled` to false.
 #
 enabled: true
+nodeSelector: {}
 
 istio-ingressgateway:
   enabled: true

--- a/install/kubernetes/helm/subcharts/grafana/values.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/values.yaml
@@ -14,6 +14,7 @@ security:
   secretName: grafana
   usernameKey: username
   passphraseKey: passphrase
+nodeSelector: {}
 service:
   annotations: {}
   name: http

--- a/install/kubernetes/helm/subcharts/ingress/values.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/values.yaml
@@ -5,6 +5,7 @@ enabled: false
 replicaCount: 1
 autoscaleMin: 1
 autoscaleMax: 5
+nodeSelector: {}
 service:
   annotations: {}
   loadBalancerIP: ""

--- a/install/kubernetes/helm/subcharts/istiocoredns/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/istiocoredns/templates/deployment.yaml
@@ -83,3 +83,5 @@ spec:
           items:
           - key: Corefile
             path: Corefile
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/subcharts/istiocoredns/values.yaml
+++ b/install/kubernetes/helm/subcharts/istiocoredns/values.yaml
@@ -8,3 +8,4 @@ coreDNSImage: coredns/coredns:1.1.2
 # https://github.com/istio-ecosystem/istio-coredns-plugin
 # The plugin listens for DNS requests from coredns server at 127.0.0.1:8053
 coreDNSPluginImage: istio/coredns-plugin:0.1-istio-1.1
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -73,3 +73,5 @@ spec:
       - name: kiali-configuration
         configMap:
           name: kiali
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 hub: docker.io/kiali
 tag: v0.10
 contextPath: /kiali
+nodeSelector: {}
 ingress:
   enabled: false
   ## Used to create an Ingress record.

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -139,10 +139,8 @@
           optional: true
       - name: uds-socket
         emptyDir: {}
-    {{- if $.Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml $.Values.nodeSelector | indent 8 }}
-    {{- end }}
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
       containers:
       - name: mixer
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/subcharts/mixer/values.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/values.yaml
@@ -25,6 +25,7 @@ telemetry:
     targetAverageUtilization: 80
 
 podAnnotations: {}
+nodeSelector: {}
 
 adapters:
   kubernetesenv:

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
@@ -44,3 +44,5 @@ spec:
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/subcharts/nodeagent/values.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/values.yaml
@@ -10,3 +10,4 @@ env:
   CA_ADDR: ""  
   # names of authentication provider's plugins.
   Plugins: ""
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/pilot/values.yaml
+++ b/install/kubernetes/helm/subcharts/pilot/values.yaml
@@ -18,3 +18,4 @@ env:
   GODEBUG: gctrace=2
 cpu:
   targetAverageUtilization: 80
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/prometheus/values.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 hub: docker.io/prom
 tag: v2.3.1
 retention: 6h
+nodeSelector: {}
 
 # Controls the frequency of prometheus scraping
 scrapeInterval: 15s

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -102,3 +102,5 @@ spec:
                 kubectl delete secret $name -n $ns;
               done
       restartPolicy: OnFailure
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -90,4 +90,6 @@ spec:
           configMap:
             name: istio-security-custom-resources
       restartPolicy: OnFailure
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
 {{- end }}

--- a/install/kubernetes/helm/subcharts/security/values.yaml
+++ b/install/kubernetes/helm/subcharts/security/values.yaml
@@ -6,4 +6,4 @@ replicaCount: 1
 image: citadel
 selfSigned: true # indicate if self-signed CA is used.
 trustDomain: cluster.local # indicate the domain used in SPIFFE identity URL
-
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/servicegraph/values.yaml
+++ b/install/kubernetes/helm/subcharts/servicegraph/values.yaml
@@ -4,6 +4,7 @@
 enabled: false
 replicaCount: 1
 image: servicegraph
+nodeSelector: {}
 service:
   annotations: {}
   name: http

--- a/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/values.yaml
+++ b/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/values.yaml
@@ -5,3 +5,4 @@ enabled: true
 replicaCount: 1
 image: sidecar_injector
 enableNamespacesByDefault: false
+nodeSelector: {}

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -4,6 +4,7 @@
 enabled: false
 
 provider: jaeger
+nodeSelector: {}
 
 jaeger:
   hub: docker.io/jaegertracing


### PR DESCRIPTION
Add `nodeSelector` to Istio deployments to constrain pods to only be able to run on particular nodes.

`defaultNodeSelector` in global area can be used for all Istio components,  each component can overwrite these default values by adding its `nodeSelector` block in the relevant section below and setting.

