### PR TITLE
Initial implementation of Galley registers the CRDs

### DIFF
--- a/galley/pkg/kube/source/init.go
+++ b/galley/pkg/kube/source/init.go
@@ -15,17 +15,85 @@
 package source
 
 import (
+	"io/ioutil"
 	"fmt"
+	"os"
 	"time"
+	"strings"
 
+	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"istio.io/istio/galley/pkg/kube"
 	kube_meta "istio.io/istio/galley/pkg/metadata/kube"
 )
+
+func writeCRDs(cs clientset.Interface, fileName string) (error) {
+	CRDData, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		scope.Infof("Read CRD %v", err)
+		return err
+	}
+
+	// yaml.YAMLtoJSON does not appear to understand "---".
+	yamlStrings := strings.Split(string(CRDData), "---")
+	// Build a set of yaml strings and range over them.
+	for _, yamlStringCRD := range yamlStrings {
+		var yamlCRD apiextensionsv1beta1.CustomResourceDefinition
+		yaml.Unmarshal([]byte(yamlStringCRD), &yamlCRD)
+
+		_, err = cs.ApiextensionsV1beta1().CustomResourceDefinitions().Create(&yamlCRD)
+		if err != nil {
+			scope.Infof("Error writing CRDs: %v", err)
+			continue
+//			return err
+		}
+	}
+	return nil
+}
+
+func createResourceTypes(cs clientset.Interface, CRDDirectory string) (error) {
+	CRDDirectoryFile, err := os.Open(CRDDirectory)
+	if err != nil {
+		return err
+	}
+	// Read all files into a FileInfo typed array
+	fileInfo, err := CRDDirectoryFile.Readdir(0)
+	if err != nil {
+		return err
+	}
+	for _, file := range fileInfo {
+		scope.Infof("filep %s", file.Name())
+		if strings.HasSuffix(file.Name(), ".yaml") == false {
+			continue
+		}
+		scope.Infof("opened configmap %s", file.Name())
+		err = writeCRDs(cs, CRDDirectory + "/" + file.Name())
+		if err != nil {
+			scope.Infof("Error writing CRDs: %s", file.Name())
+			continue
+		}
+		scope.Infof("Wrote CRDS from configmap %s", file.Name())
+	}
+	defer CRDDirectoryFile.Close() // nolint: errcheck
+
+	return nil
+}
+
+func CreateResourceTypes(k kube.Interfaces) error {
+	cs, err := k.APIExtensionsClientset()
+	if err != nil {
+		return err
+	}
+	createResourceTypes(cs, "/etc/istio/crds")
+	if err != nil {
+		return err
+	}
+	return nil
+}
 
 // VerifyResourceTypesPresence verifies that all expected k8s resources types are
 // present in the k8s apiserver.

--- a/install/kubernetes/helm/istio/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio/files/crd-10.yaml
@@ -1,6 +1,3 @@
-# {{- if or .Values.global.crds (semverCompare ">=2.10.0-0" .Capabilities.TillerVersion.SemVer) }}
-# these CRDs only make sense when pilot is enabled
-# {{- if or .Values.pilot.enabled .Values.global.useMCP }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -143,10 +140,6 @@ spec:
   scope: Cluster
   version: v1alpha1
 ---
-# {{- end }}
-
-# these CRDs only make sense when security is enabled
-# {{- if or .Values.security.enabled .Values.global.useMCP }}
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -194,9 +187,6 @@ spec:
   scope: Cluster
   version: v1alpha1
 ---
-# {{- end }}
-
-# {{- if or .Values.mixer.policy.enabled .Values.mixer.telemetry.enabled .Values.global.useMCP }}
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -289,8 +279,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
-# Mixer CRDs
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -316,7 +304,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -342,7 +329,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -368,7 +354,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -394,7 +379,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -420,7 +404,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -446,7 +429,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -472,7 +454,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -498,7 +479,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -524,7 +504,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -550,7 +529,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -576,7 +554,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -602,7 +579,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -628,7 +604,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -651,7 +626,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -676,9 +650,7 @@ spec:
     - policy-istio-io
   scope: Namespaced
   version: v1alpha2
-
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -704,7 +676,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -730,7 +701,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -756,53 +726,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: cloudwatches.config.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: mixer
-    package: cloudwatch
-    istio: mixer-adapter
-spec:
-  group: config.istio.io
-  names:
-    kind: cloudwatch
-    plural: cloudwatches
-    singular: cloudwatch
-    categories:
-    - istio-io
-    - policy-istio-io
-  scope: Namespaced
-  version: v1alpha2
----
-
-kind: CustomResourceDefinition
-apiVersion: apiextensions.k8s.io/v1beta1
-metadata:
-  name: dogstatsds.config.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: mixer
-    package: dogstatsd
-    istio: mixer-adapter
-spec:
-  group: config.istio.io
-  names:
-    kind: dogstatsd
-    plural: dogstatsds
-    singular: dogstatsd
-    categories:
-    - istio-io
-    - policy-istio-io
-  scope: Namespaced
-  version: v1alpha2
----
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -828,7 +751,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -854,7 +776,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -880,7 +801,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -906,7 +826,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -932,7 +851,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -958,7 +876,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -984,7 +901,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1010,7 +926,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1036,7 +951,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1062,7 +976,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1088,7 +1001,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1114,7 +1026,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1140,7 +1051,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1166,7 +1076,6 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1192,7 +1101,6 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1218,7 +1126,6 @@ spec:
   scope: Namespaced
   version: v1alpha1
 ---
-
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
@@ -1344,5 +1251,3 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
-# {{- end }}
-# {{- end }}

--- a/install/kubernetes/helm/istio/files/crd-11.yaml
+++ b/install/kubernetes/helm/istio/files/crd-11.yaml
@@ -1,0 +1,40 @@
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: cloudwatches.config.istio.io
+  labels:
+    app: mixer
+    package: cloudwatch
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: cloudwatch
+    plural: cloudwatches
+    singular: cloudwatch
+    categories:
+    - istio-io
+    - policy-istio-io
+  scope: Namespaced
+  version: v1alpha2
+---
+kind: CustomResourceDefinition
+apiVersion: apiextensions.k8s.io/v1beta1
+metadata:
+  name: dogstatsds.config.istio.io
+  labels:
+    app: mixer
+    package: dogstatsd
+    istio: mixer-adapter
+spec:
+  group: config.istio.io
+  names:
+    kind: dogstatsd
+    plural: dogstatsds
+    singular: dogstatsd
+    categories:
+    - istio-io
+    - policy-istio-io
+  scope: Namespaced
+  version: v1alpha2
+---

--- a/install/kubernetes/helm/istio/templates/configmap-crd-10.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap-crd-10.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-crd-10
+data:
+  crd-10.yaml: |-
+{{.Files.Get "files/crd-10.yaml" | printf "%s" | indent 4}}

--- a/install/kubernetes/helm/istio/templates/configmap-crd-11.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap-crd-11.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-crd-11
+data:
+  crd-11.yaml: |-
+{{.Files.Get "files/crd-11.yaml" | printf "%s" | indent 4}}

--- a/install/kubernetes/helm/subcharts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/clusterrole.yaml
@@ -33,3 +33,6 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create", "get", "list", "watch", "patch"]

--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -68,6 +68,14 @@ spec:
           - name: mesh-config
             mountPath: /etc/istio/mesh-config
             readOnly: true
+          - name: istio-crd-10
+            mountPath: /etc/istio/crds/crd-10.yaml
+            subPath: crd-10.yaml
+            readOnly: true
+          - name: istio-crd-11
+            mountPath: /etc/istio/crds/crd-11.yaml
+            subPath: crd-11.yaml
+            readOnly: true
           livenessProbe:
             exec:
               command:
@@ -102,5 +110,11 @@ spec:
       - name: mesh-config
         configMap:
           name: istio
+      - name: istio-crd-10
+        configMap:
+          name: istio-crd-10
+      - name: istio-crd-11
+        configMap:
+          name: istio-crd-11
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}


### PR DESCRIPTION
This PR is designed such that configmaps contain CRD information.
The CRD configmaps are mounted in a volume.  Galley consumes these
configmaps and instantiates them prior to validating the CRDs are
instantiated in kube-apiserver.  This model seems to work pretty
well.

Each version contains a separate CRD configmap file.  This is
intentional by design.

I took out the istio/templates/crd.yaml only for testing against
the gate.  This part of the change should be reverted before merge.

I have done some basic testing (with `helm template` only) and things
appear to work well there.  I will next text with `helm install` &
`helm upgrade` to ensure the various cases work properly.

The file handling could use a security review - even though the filesystem
is read only for the configmaps, better safe than sorry...
ø# Please enter the commit message for your changes. Lines starting