### PR TITLE
Add grpc_status and grpc_message to metrics

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -374,6 +374,8 @@ spec:
     request_protocol: api.protocol | context.protocol | "unknown"
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
+    grpc_status: response.grpc_status | "2"
+    grpc_message: response.grpc_message | ""
     permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
@@ -409,6 +411,8 @@ spec:
     request_protocol: api.protocol | context.protocol | "unknown"
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
+    grpc_status: response.grpc_status | "2"
+    grpc_message: response.grpc_message | ""
     permissive_response_code: rbac.permissive.response_code | "none" 
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
@@ -444,7 +448,9 @@ spec:
     request_protocol: api.protocol | context.protocol | "unknown"
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
-    permissive_response_code: rbac.permissive.response_code | "none" 
+    grpc_status: response.grpc_status | "2"
+    grpc_message: response.grpc_message | ""
+    permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
   monitored_resource_type: '"UNSPECIFIED"'
@@ -479,6 +485,8 @@ spec:
     request_protocol: api.protocol | context.protocol | "unknown"
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
+    grpc_status: response.grpc_status | "2"
+    grpc_message: response.grpc_message | ""
     permissive_response_code: rbac.permissive.response_code | "none" 
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
@@ -583,6 +591,8 @@ spec:
       - request_protocol
       - response_code
       - response_flags
+      - grpc_status
+      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -607,6 +617,8 @@ spec:
       - request_protocol
       - response_code
       - response_flags
+      - grpc_status
+      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -634,6 +646,8 @@ spec:
       - request_protocol
       - response_code
       - response_flags
+      - grpc_status
+      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -663,6 +677,8 @@ spec:
       - request_protocol
       - response_code
       - response_flags
+      - grpc_status
+      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy

--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -375,7 +375,6 @@ spec:
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
     grpc_status: response.grpc_status | "2"
-    grpc_message: response.grpc_message | ""
     permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
@@ -412,8 +411,7 @@ spec:
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
     grpc_status: response.grpc_status | "2"
-    grpc_message: response.grpc_message | ""
-    permissive_response_code: rbac.permissive.response_code | "none" 
+    permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
   monitored_resource_type: '"UNSPECIFIED"'
@@ -449,7 +447,6 @@ spec:
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
     grpc_status: response.grpc_status | "2"
-    grpc_message: response.grpc_message | ""
     permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
@@ -486,8 +483,7 @@ spec:
     response_code: response.code | 200
     response_flags: context.proxy_error_code | "-"
     grpc_status: response.grpc_status | "2"
-    grpc_message: response.grpc_message | ""
-    permissive_response_code: rbac.permissive.response_code | "none" 
+    permissive_response_code: rbac.permissive.response_code | "none"
     permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
   monitored_resource_type: '"UNSPECIFIED"'
@@ -592,7 +588,6 @@ spec:
       - response_code
       - response_flags
       - grpc_status
-      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -618,7 +613,6 @@ spec:
       - response_code
       - response_flags
       - grpc_status
-      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -647,7 +641,6 @@ spec:
       - response_code
       - response_flags
       - grpc_status
-      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
@@ -678,7 +671,6 @@ spec:
       - response_code
       - response_flags
       - grpc_status
-      - grpc_message
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy


### PR DESCRIPTION
These two grpc values had already been added to the config, but not to
the metrics ending up in Prometheus. So I've added them to requests_total,
requests_bytes etc.