### PR TITLE
typo: insert whitespace into log.Errora

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -73,7 +73,7 @@ func (s *grpcServer) Check(ctx context.Context, req *mixerpb.CheckRequest) (*mix
 
 	if req.GlobalWordCount > uint32(len(s.globalWordList)) {
 		err := fmt.Errorf("inconsistent global dictionary versions used: mixer knows %d words, caller knows %d", len(s.globalWordList), req.GlobalWordCount)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -126,7 +126,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 
 	if err := s.dispatcher.Preprocess(ctx, protoBag, checkBag); err != nil {
 		err = fmt.Errorf("preprocessing attributes failed: %v", err)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -141,7 +141,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 	cr, err := s.dispatcher.Check(ctx, checkBag)
 	if err != nil {
 		err = fmt.Errorf("performing check operation failed: %v", err)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -194,7 +194,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 			qr, err := s.dispatcher.Quota(ctx, checkBag, qma)
 			if err != nil {
 				err = fmt.Errorf("performing quota alloc failed: %v", err)
-				lg.Errora("Quota failure:", err.Error())
+				lg.Errora("Quota failure: ", err.Error())
 				// we continue the quota loop even after this error
 			} else {
 				if !status.IsOK(qr.Status) {
@@ -222,7 +222,7 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 
 	if req.GlobalWordCount > uint32(len(s.globalWordList)) {
 		err := fmt.Errorf("inconsistent global dictionary versions used: mixer knows %d words, caller knows %d", len(s.globalWordList), req.GlobalWordCount)
-		lg.Errora("Report failed:", err.Error())
+		lg.Errora("Report failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -308,7 +308,7 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 	reportSpan.Finish()
 
 	if errors != nil {
-		lg.Errora("Report failed:", errors.Error())
+		lg.Errora("Report failed: ", errors.Error())
 		return nil, grpc.Errorf(codes.Unknown, errors.Error())
 	}
 

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -92,7 +92,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	} else {
 		out, err := bootstrap.WriteBootstrap(&e.config, e.node, epoch, e.pilotSAN, e.opts, os.Environ())
 		if err != nil {
-			log.Errora("Failed to generate bootstrap config", err)
+			log.Errora("Failed to generate bootstrap config ", err)
 			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
 			return err
 		}

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -65,7 +65,7 @@ type TearDownFunc func()
 func EnsureTestServer(args ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, TearDownFunc) {
 	tearDown, err := setup(args...)
 	if err != nil {
-		log.Errora("Failed to start in-process server", err)
+		log.Errora("Failed to start in-process server ", err)
 		panic(err)
 	}
 	return MockTestServer, tearDown


### PR DESCRIPTION
Signed-off-by: detailyang <detailyang@gmail.com>

Minor patch and wow many debug log forget to keep the whitespace like the following:

```go
log.Errora("Failed to generate bootstrap config", err)
```

It will output `2018-11-26T11:40:39.811012Z	error	Failed to generate bootstrap configopen /var/lib/istio/envoy/envoy_bootstrap_tmpl.json: no such file or directory`