### PR TITLE
Update codecov threshold due to non-deterministism

### DIFF
--- a/codecov.threshold
+++ b/codecov.threshold
@@ -16,4 +16,4 @@
 istio.io=5
 istio.io/istio/pilot/pkg/proxy/envoy/v2=10
 istio.io/istio/pilot/pkg/config/memory/monitor.go=10
-
+istio.io/istio/mixer/adapter/solarwinds/internal/papertrail/papertrail_logger.go=10


### PR DESCRIPTION
Detail can be found diffing the following files:
https://255055-74175805-gh.circle-artifacts.com/0/go/out/codecov/baseline/coverage.html#file139
https://255055-74175805-gh.circle-artifacts.com/0/go/out/codecov/pr/coverage.html#file139