### PR TITLE
Allow choosing only mixer policy enabled

### DIFF
--- a/docker/Dockerfile.kubectl
+++ b/docker/Dockerfile.kubectl
@@ -1,5 +1,8 @@
 FROM istionightly/base_debug
 # Image for post install jobs
 
-# This container should only contain kubectl
-ADD kubectl /usr/bin
+ARG K8S_VER=v1.10.4
+
+# Include only kubectl in the image
+RUN curl -kLo /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VER}/bin/linux/amd64/kubectl && \
+    chmod +x /tmp/kubectl && sudo mv /tmp/kubectl /usr/bin/

--- a/install/kubernetes/helm/istio/requirements.yaml
+++ b/install/kubernetes/helm/istio/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: file://../subcharts/gateways
   - name: mixer
     version: 1.1.0
-    condition: mixer.policy.enabled,mixer.telemetry.enabled
+    condition: or mixer.policy.enabled mixer.telemetry.enabled
     repository: file://../subcharts/mixer
   - name: nodeagent
     version: 1.1.0

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -155,7 +155,7 @@ docker.test_policybackend: mixer/docker/Dockerfile.test_policybackend
 docker.test_policybackend: $(ISTIO_OUT)/mixer-test-policybackend
 	$(DOCKER_RULE)
 
-docker.kubectl: docker/Dockerfile$$(suffix $$@) $(ISTIO_BIN)/kubectl
+docker.kubectl: docker/Dockerfile$$(suffix $$@)
 	$(DOCKER_RULE)
 
 # addons docker images


### PR DESCRIPTION
This or between the two works for me with Helm v2.11.0.
Can someone with the minimum required version for v1.1 (do we have such?) can give it a try?

Tested:
* Both disabled
* Both enabled
* Only Policy
* Only Telemetry

Fixes #10138

/cc @gyliu513 @morvencao @linsun 