### PR TITLE
Do not fail envoy health probe if a config was rejected (#9786)

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -71,7 +71,9 @@ func (p *Probe) checkUpdated() error {
 		return err
 	}
 
-	if s.CDSUpdates > 0 && s.LDSUpdates > 0 {
+	CDSUpdated := s.CDSUpdatesSuccess > 0 || s.CDSUpdatesRejection > 0
+	LDSUpdated := s.LDSUpdatesSuccess > 0 || s.LDSUpdatesRejection > 0
+	if CDSUpdated && LDSUpdated {
 		return nil
 	}
 

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -15,11 +15,12 @@
 package ready
 
 import (
-	. "github.com/onsi/gomega"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 var probe = Probe{AdminPort: 1234}

--- a/pilot/cmd/pilot-agent/status/ready/probe_test.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe_test.go
@@ -1,0 +1,128 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ready
+
+import (
+	. "github.com/onsi/gomega"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var probe = Probe{AdminPort: 1234}
+
+func TestEnvoyStatsCompleteAndSuccessful(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyStatsIncompleteCDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "listener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("cds updates: 0"))
+}
+
+func TestEnvoyStatsIncompleteLDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("lds updates: 0"))
+}
+
+func TestEnvoyStatsCompleteAndRejectedCDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_rejected: 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyStatsCompleteAndRejectedLDS(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: 1\nlistener_manager.lds.update_rejected: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).NotTo(HaveOccurred())
+}
+
+func TestEnvoyCheckFailsIfStatsUnparsableNoSeparator(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success; 1\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("missing separator"))
+}
+
+func TestEnvoyCheckFailsIfStatsUnparsableNoNumber(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := "cluster_manager.cds.update_success: a\nlistener_manager.lds.update_success: 1"
+
+	server := createAndStartServer(stats)
+	defer server.Close()
+
+	err := probe.Check()
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed parsing Envoy stat"))
+}
+
+func createAndStartServer(statsToReturn string) *httptest.Server {
+	// Start a local HTTP server
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		// Send response to be tested
+		rw.Write([]byte(statsToReturn))
+	}))
+	l, err := net.Listen("tcp", "127.0.0.1:1234")
+	if err != nil {
+		panic("Could not create listener for test: " + err.Error())
+	}
+	server.Listener = l
+	server.Start()
+	return server
+}

--- a/pilot/cmd/pilot-agent/status/util/stats_test.go
+++ b/pilot/cmd/pilot-agent/status/util/stats_test.go
@@ -1,0 +1,28 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStatsToString(t *testing.T) {
+	g := NewGomegaWithT(t)
+	stats := Stats{CDSUpdatesSuccess: 1, CDSUpdatesRejection: 2, LDSUpdatesSuccess: 3, LDSUpdatesRejection: 4}
+
+	g.Expect(stats.String()).To(Equal("cds updates: 1 successful, 2 rejected; lds updates: 3 successful, 4 rejected"))
+}


### PR DESCRIPTION
* Adjust so that rejection is also an allowed state of health probe for envoy.

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>

* Add unit tests for envoy health probe

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>

* Fixed linting

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>

* Fix another linting problem

Co-authored-by: Ralf Pannemans <ralf.pannemans@sap.com>

* Add new stats to String() method

* Use better wording in log message