### PR TITLE
Adding test retry to codecov job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -603,10 +603,6 @@ jobs:
           command: |
             cd /go/src/istio.io/istio
             MAXPROCS=6 bin/codecov_diff.sh
-      - run:
-          name: Uploading code coverage to codecov.io
-          when: on_success
-          command: bash <(curl -s https://codecov.io/bash) -f /go/out/codecov/pr/coverage.cov
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - run:

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -69,5 +69,8 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
   # Merge codecov junit into the one creared by unit tests at PR head.
   go get github.com/imsky/junit-merger/...
   junit-merger "${GOPATH}"/out/codecov/pr/junit.xml "${GOPATH}"/out/codecov/junit.xml  > "${GOPATH}"/out/tests/junit.xml
+else
+  # Upload to codecov.io in post submit only for visualization
+  bash <(curl -s https://codecov.io/bash) -f /go/out/codecov/pr/coverage.cov
 fi
 

--- a/security/tools/generate_csr/main.go
+++ b/security/tools/generate_csr/main.go
@@ -35,7 +35,7 @@ var (
 )
 
 func fatalf(template string, args ...interface{}) {
-	log.Errorf(template, args)
+	log.Errorf(template, args...)
 	os.Exit(-1)
 }
 

--- a/tests/codecov/main_test.go
+++ b/tests/codecov/main_test.go
@@ -152,7 +152,7 @@ func TestCheckDeltaError(t *testing.T) {
 			// Default threshold
 			"P": 5,
 		})
-	if result {
+	if len(result) == 0 {
 		t.Error("Expecting error")
 	}
 }
@@ -184,7 +184,7 @@ func TestCheckDeltaGood(t *testing.T) {
 			// Default threshold
 			"P": 5,
 		})
-	if !result {
+	if len(result) > 0 {
 		t.Errorf("Expecting success")
 	}
 }
@@ -197,7 +197,7 @@ func TestCheckCoverage(t *testing.T) {
 	err := checkCoverage(*reportFile, *baselineFile, *thresholdFile)
 
 	if err != nil {
-		t.Errorf("Coverage test failed: %v", err)
+		t.Errorf("%v", err)
 	}
 }
 


### PR DESCRIPTION
1. Add test retry to codecov job to retry the whole package to reduce flakiness
2. Change codecov_diff to abort in case any codecov run fails 
3. Move junit xml file generation into the same test line so it is generated even if test fails.
4. Fix argument problem in security/tools/generate_csr/main.go
5. Stop uploading coverage to codecov.io in presubmit since their reports are very noisy.
