### PR TITLE
Support grpc keepalive for pilot

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2127,6 +2127,7 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/encoding/gzip",
     "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/keepalive",
     "google.golang.org/grpc/metadata",
     "google.golang.org/grpc/peer",
     "google.golang.org/grpc/reflection",

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pkg/cmd"
 	"istio.io/istio/pkg/collateral"
 	"istio.io/istio/pkg/ctrlz"
+	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/version"
@@ -37,6 +38,7 @@ var (
 	serverArgs = bootstrap.PilotArgs{
 		CtrlZOptions:         ctrlz.DefaultOptions(),
 		MCPCredentialOptions: creds.DefaultOptions(),
+		KeepaliveOptions:     keepalive.DefaultOption(),
 	}
 
 	loggingOptions = log.DefaultOptions()
@@ -143,6 +145,9 @@ func init() {
 
 	// Attach the Istio Ctrlz options to the command.
 	serverArgs.CtrlZOptions.AttachCobraFlags(rootCmd)
+
+	// Attach the Istio Keepalive options to the command.
+	serverArgs.KeepaliveOptions.AttachCobraFlags(rootCmd)
 
 	cmd.AddFlags(rootCmd)
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,6 +70,7 @@ import (
 	"istio.io/istio/pkg/ctrlz"
 	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/filewatcher"
+	istiokeepalive "istio.io/istio/pkg/keepalive"
 	kubelib "istio.io/istio/pkg/kube"
 	"istio.io/istio/pkg/log"
 	mcpclient "istio.io/istio/pkg/mcp/client"
@@ -168,6 +170,7 @@ type PilotArgs struct {
 	MCPServerAddrs       []string
 	MCPCredentialOptions *creds.Options
 	MCPMaxMessageSize    int
+	KeepaliveOptions     *istiokeepalive.Options
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -575,8 +578,12 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			}
 		}
 
+		keepaliveOption := grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    args.KeepaliveOptions.Time,
+			Timeout: args.KeepaliveOptions.Timeout,
+		})
 		msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(args.MCPMaxMessageSize))
-		conn, err := grpc.DialContext(ctx, configSource.Address, securityOption, msgSizeOption)
+		conn, err := grpc.DialContext(ctx, configSource.Address, securityOption, msgSizeOption, keepaliveOption)
 		if err != nil {
 			log.Errorf("Unable to dial MCP Server %q: %v", configSource.Address, err)
 			cancel()
@@ -926,7 +933,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 	s.mux = s.discoveryService.RestContainer.ServeMux
 
 	// For now we create the gRPC server sourcing data from Pilot's older data model.
-	s.initGrpcServer()
+	s.initGrpcServer(args.KeepaliveOptions)
 
 	s.EnvoyXdsServer = envoyv2.NewDiscoveryServer(environment,
 		istio_networking.NewConfigGenerator(args.Plugins),
@@ -983,7 +990,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			}
 		}()
 
-		go s.secureGrpcStart(secureGrpcListener)
+		go s.secureGrpcStart(secureGrpcListener, args.KeepaliveOptions)
 
 		go func() {
 			<-stop
@@ -1030,13 +1037,13 @@ func (s *Server) initConsulRegistry(serviceControllers *aggregate.Controller, ar
 	return nil
 }
 
-func (s *Server) initGrpcServer() {
-	grpcOptions := s.grpcServerOptions()
+func (s *Server) initGrpcServer(options *istiokeepalive.Options) {
+	grpcOptions := s.grpcServerOptions(options)
 	s.grpcServer = grpc.NewServer(grpcOptions...)
 }
 
 // The secure grpc will start when the credentials are found.
-func (s *Server) secureGrpcStart(listener net.Listener) {
+func (s *Server) secureGrpcStart(listener net.Listener, options *istiokeepalive.Options) {
 	certDir := pilot.CertDir
 	if certDir == "" {
 		certDir = PilotCertDir
@@ -1078,7 +1085,7 @@ func (s *Server) secureGrpcStart(listener net.Listener) {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
 
-	opts := s.grpcServerOptions()
+	opts := s.grpcServerOptions(options)
 	opts = append(opts, grpc.Creds(creds))
 	s.secureGRPCServer = grpc.NewServer(opts...)
 
@@ -1114,7 +1121,7 @@ func (s *Server) secureGrpcStart(listener net.Listener) {
 	log.Infof("Stoppped listening on %s", listener.Addr().String())
 }
 
-func (s *Server) grpcServerOptions() []grpc.ServerOption {
+func (s *Server) grpcServerOptions(options *istiokeepalive.Options) []grpc.ServerOption {
 	interceptors := []grpc.UnaryServerInterceptor{
 		// setup server prometheus monitoring (as final interceptor in chain)
 		prometheus.UnaryServerInterceptor,
@@ -1134,6 +1141,10 @@ func (s *Server) grpcServerOptions() []grpc.ServerOption {
 	grpcOptions := []grpc.ServerOption{
 		grpc.UnaryInterceptor(middleware.ChainUnaryServer(interceptors...)),
 		grpc.MaxConcurrentStreams(uint32(maxStreams)),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    options.Time,
+			Timeout: options.Timeout,
+		}),
 	}
 
 	return grpcOptions

--- a/pkg/keepalive/options.go
+++ b/pkg/keepalive/options.go
@@ -19,6 +19,7 @@ import (
 	"time"
 )
 
+// Options defines the set of options used for grpc keepalive.
 type Options struct {
 	// After a duration of this time if the server/client doesn't see any activity it pings the peer to see if the transport is still alive.
 	Time time.Duration
@@ -27,6 +28,7 @@ type Options struct {
 	Timeout time.Duration
 }
 
+// DefaultOption returns the default keepalive options.
 func DefaultOption() *Options {
 	return &Options{
 		Time:    30 * time.Second,

--- a/pkg/keepalive/options.go
+++ b/pkg/keepalive/options.go
@@ -1,0 +1,47 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"github.com/spf13/cobra"
+	"time"
+)
+
+type Options struct {
+	// After a duration of this time if the server/client doesn't see any activity it pings the peer to see if the transport is still alive.
+	Time time.Duration
+	// After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that
+	// the connection is closed.
+	Timeout time.Duration
+}
+
+func DefaultOption() *Options {
+	return &Options{
+		Time:    30 * time.Second,
+		Timeout: 10 * time.Second,
+	}
+}
+
+// AttachCobraFlags attaches a set of Cobra flags to the given Cobra command.
+//
+// Cobra is the command-line processor that Istio uses. This command attaches
+// the necessary set of flags to configure the grpc keepalive options.
+func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().DurationVar(&o.Time, "keepaliveInterval", o.Time,
+		"The time interval if no activity on the connection it pings the peer to see if the transport is alive")
+	cmd.PersistentFlags().DurationVar(&o.Timeout, "keepaliveTimeout", o.Timeout,
+		"After having pinged for keepalive check, the client/server waits for a duration of keepaliveTimeout "+
+			"and if no activity is seen even after that the connection is closed.")
+}

--- a/pkg/test/framework/components/apps/local/agent/pilot_agent_test.go
+++ b/pkg/test/framework/components/apps/local/agent/pilot_agent_test.go
@@ -23,16 +23,15 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/test/framework/environments/local/service"
-
-	"istio.io/istio/pkg/test/application"
-
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	proxyEnvoy "istio.io/istio/pilot/pkg/proxy/envoy"
+	"istio.io/istio/pkg/keepalive"
+	"istio.io/istio/pkg/test/application"
 	"istio.io/istio/pkg/test/application/echo"
 	"istio.io/istio/pkg/test/application/echo/proto"
 	"istio.io/istio/pkg/test/envoy"
+	"istio.io/istio/pkg/test/framework/environments/local/service"
 )
 
 const (
@@ -247,6 +246,7 @@ func newPilot(configStore model.ConfigStoreCache, t *testing.T) (*bootstrap.Serv
 			// A ServiceEntry registry is added by default, which is what we want. Don't include any other registries.
 			Registries: []string{},
 		},
+		KeepaliveOptions: keepalive.DefaultOption(),
 	}
 
 	// Create the server for the discovery service.

--- a/pkg/test/framework/components/pilot/local.go
+++ b/pkg/test/framework/components/pilot/local.go
@@ -18,18 +18,17 @@ import (
 	"fmt"
 	"net"
 
-	"istio.io/istio/pkg/test/framework/scopes"
-
-	meshConfig "istio.io/api/mesh/v1alpha1"
-
 	"github.com/hashicorp/go-multierror"
 
+	meshConfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
+	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/test/framework/dependency"
 	"istio.io/istio/pkg/test/framework/environment"
 	"istio.io/istio/pkg/test/framework/environments/local"
+	"istio.io/istio/pkg/test/framework/scopes"
 )
 
 var (
@@ -71,7 +70,8 @@ func NewLocalPilot(namespace string, mesh *meshConfig.MeshConfig, configStore mo
 			Registries: []string{},
 		},
 		// Include all of the default plugins for integration with Mixer, etc.
-		Plugins: bootstrap.DefaultPlugins,
+		Plugins:          bootstrap.DefaultPlugins,
+		KeepaliveOptions: keepalive.DefaultOption(),
 	}
 
 	// Create the server for the discovery service.

--- a/tests/local/xds_local_test.go
+++ b/tests/local/xds_local_test.go
@@ -29,6 +29,7 @@ import (
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/keepalive"
 )
 
 func buildLocalClient(apiServerURL string) (*kubernetes.Clientset, error) {
@@ -178,6 +179,7 @@ func initLocalPilot(IstioSrc string) (*bootstrap.Server, error) {
 			Registries: []string{
 				string(serviceregistry.KubernetesRegistry)},
 		},
+		KeepaliveOptions: keepalive.DefaultOption(),
 	}
 	// Create the server for the discovery service.
 	discoveryServer, err := bootstrap.NewServer(serverAgrs)

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
+	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/test/env"
 )
@@ -102,6 +103,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 				string(serviceregistry.MockRegistry)},
 		},
 		MCPMaxMessageSize: bootstrap.DefaultMCPMaxMsgSize,
+		KeepaliveOptions:  keepalive.DefaultOption(),
 	}
 	// Static testdata, should include all configs we want to test.
 	args.Config.FileDir = env.IstioSrc + "/tests/testdata/config"

--- a/tools/hyperistio/hyperistio.go
+++ b/tools/hyperistio/hyperistio.go
@@ -32,6 +32,7 @@ import (
 	"istio.io/istio/pilot/pkg/proxy/envoy"
 	"istio.io/istio/pilot/pkg/serviceregistry"
 	agent "istio.io/istio/pkg/bootstrap"
+	"istio.io/istio/pkg/keepalive"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
@@ -173,7 +174,8 @@ func startPilot() error {
 			Registries: []string{
 				string(serviceregistry.MockRegistry)},
 		},
-		MeshConfig: &mcfg,
+		MeshConfig:       &mcfg,
+		KeepaliveOptions: keepalive.DefaultOption(),
 	}
 	bootstrap.PilotCertDir = env.IstioSrc + "/tests/testdata/certs/pilot"
 


### PR DESCRIPTION

Todo: other components also need keepalive for reliable communication between server and client. 