### PR TITLE
add kubeVersion to Chart.yaml

### DIFF
--- a/install/kubernetes/helm/istio-remote/Chart.yaml
+++ b/install/kubernetes/helm/istio-remote/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: istio-remote
 version: 1.1.0
 appVersion: 1.1.0
+kubeVersion: ">=1.10.0"
 tillerVersion: ">=2.7.2"
 description: Helm chart needed for remote Kubernetes clusters to join the main Istio control plane
 keywords:

--- a/install/kubernetes/helm/istio/Chart.yaml
+++ b/install/kubernetes/helm/istio/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 name: istio
 version: 1.1.0
 appVersion: 1.1.0
+kubeVersion: ">=1.10.0"
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:


### PR DESCRIPTION
Add `kubeVersion` to Istio chart to specify compatible Kubernetes versions.