### PR TITLE
Bugfix: return an error instead of multierr.Prefix

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -839,9 +839,10 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 		case serviceregistry.MCPRegistry:
 			log.Infof("no-op: get service info from MCP ServiceEntries.")
 		default:
-			return multierror.Prefix(nil, "Service registry "+r+" is not supported.")
+			return fmt.Errorf("service registry %s is not supported", r)
 		}
 	}
+
 	serviceEntryStore := external.NewServiceDiscovery(s.configController, s.istioConfigStore)
 
 	// add service entry registry to aggregator by default


### PR DESCRIPTION
When trying to start istio-pilot with a registry that is not correct (for example `consul` vs `Consul`) istio-pilot will crash with the following error:

```
istio-pilot_1      | 2018-11-06T19:00:38.182472Z	info	CRD controller watching namespaces ""
istio-pilot_1      | 2018-11-06T19:00:38.183321Z	info	Adding consul registry adapter
istio-pilot_1      | panic: runtime error: invalid memory address or nil pointer dereference
istio-pilot_1      | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x11e6167]
istio-pilot_1      |
istio-pilot_1      | goroutine 1 [running]:
istio-pilot_1      | istio.io/istio/pilot/pkg/serviceregistry/aggregate.(*Controller).GetRegistries(0x0, 0x0, 0x0, 0x0)
istio-pilot_1      | 	/workspace/go/src/istio.io/istio/pilot/pkg/serviceregistry/aggregate/controller.go:86 +0x37
istio-pilot_1      | istio.io/istio/pilot/pkg/serviceregistry/aggregate.(*Controller).AppendServiceHandler(0x0, 0xc4200e73c0, 0x0, 0x0)
istio-pilot_1      | 	/workspace/go/src/istio.io/istio/pilot/pkg/serviceregistry/aggregate/controller.go:282 +0x43
```

This is because the default case in the initServiceController switch statement returns multierr.Prefix(nil) which actually returns a nil error to the caller.

Original PR: #9769
@ymesika suggested reopening this PR and targetting the release-1.1 branch instead of master.