### PR TITLE
Alter mixer redisquota e2e tests in attempt to deflake behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -710,6 +710,8 @@ generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--set prometheus.scrapeInterval=1s \
 		--set gateways.istio-ingressgateway.autoscaleMax=1 \
+		--set mixer.policy.replicaCount=2 \
+		--set mixer.policy.autoscaleEnabled=false \
 		--values install/kubernetes/helm/istio/values.yaml \
 		install/kubernetes/helm/istio >> install/kubernetes/istio.yaml
 
@@ -721,6 +723,8 @@ generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--set global.mtls.enabled=true \
 		--set prometheus.scrapeInterval=1s \
 		--set gateways.istio-ingressgateway.autoscaleMax=1 \
+		--set mixer.policy.replicaCount=2 \
+		--set mixer.policy.autoscaleEnabled=false \
 		--set global.controlPlaneSecurityEnabled=true \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
 		--values install/kubernetes/helm/istio/values.yaml \

--- a/Makefile
+++ b/Makefile
@@ -708,6 +708,7 @@ generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--namespace=istio-system \
 		--set global.hub=${HUB} \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--set global.proxy.concurrency=1 \
 		--set prometheus.scrapeInterval=1s \
 		--set gateways.istio-ingressgateway.autoscaleMax=1 \
 		--set mixer.policy.replicaCount=2 \
@@ -727,6 +728,7 @@ generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--set mixer.policy.autoscaleEnabled=false \
 		--set global.controlPlaneSecurityEnabled=true \
 		--set global.proxy.enableCoreDump=${ENABLE_COREDUMP} \
+		--set global.proxy.concurrency=1 \
 		--values install/kubernetes/helm/istio/values.yaml \
 		install/kubernetes/helm/istio >> install/kubernetes/istio-auth.yaml
 

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -596,6 +596,7 @@ func TestTcpMetrics(t *testing.T) {
 	validateMetric(t, promAPI, query, "istio_tcp_connections_closed_total", want)
 }
 
+// nolint: unparam
 func validateMetric(t *testing.T, promAPI v1.API, query, metricName string, want float64) {
 	t.Helper()
 	t.Logf("prometheus query: %s", query)

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -1064,15 +1064,6 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 		}
 	}()
 
-	if err := util.KubeScale(tc.Kube.Namespace, "deployment/istio-policy", 2, tc.Kube.KubeConfig); err != nil {
-		fatalf(t, "Could not scale up istio-policy pod: %v", err)
-	}
-	defer func() {
-		if err := util.KubeScale(tc.Kube.Namespace, "deployment/istio-policy", 1, tc.Kube.KubeConfig); err != nil {
-			t.Fatalf("Could not scale down istio-policy pod.: %v", err)
-		}
-	}()
-
 	allowRuleSync()
 
 	// setup prometheus API
@@ -1091,8 +1082,11 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 	prior429s, prior200s, _ := fetchRequestCount(t, promAPI, "ratings")
 	// check if at least one more prior429 was reported
 	if prior429s-initPrior429s < 1 {
-		fatalf(t, "no 429 is allotted time: prior429s:%v", prior429s)
+		fatalf(t, "no 429 in allotted time: prior429s:%v", prior429s)
 	}
+
+	// print baseline metrics on istio-policy handling
+	logPolicyMetrics(t, "redisquota", "ratings")
 
 	res := sendTraffic(t, "Sending traffic...", 300)
 	allowPrometheusSync()
@@ -1109,13 +1103,15 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 	// consider only successful requests (as recorded at productpage service)
 	callsToRatings := succReqs
 
-	// the rate-limit is 0.1 rps from ratings to reviews.
-	want200s := 0.1 * actualDuration
+	want200s := 50.0
 
 	// everything in excess of 200s should be 429s (ideally)
 	want429s := callsToRatings - want200s
 
 	t.Logf("Expected Totals: 200s: %f (%f rps), 429s: %f (%f rps)", want200s, want200s/actualDuration, want429s, want429s/actualDuration)
+
+	// print metrics on istio-policy handling
+	logPolicyMetrics(t, "redisquota", "ratings")
 
 	// if we received less traffic than the expected enforced limit to ratings
 	// then there is no way to determine if the rate limit was applied at all
@@ -1163,7 +1159,7 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 
 	got = got - prior200s
 
-	t.Logf("Actual 200s: %f (%f rps), expecting ~1 rps", got, got/actualDuration)
+	t.Logf("Actual 200s: %f (%f rps), expecting ~1.666rps", got, got/actualDuration)
 
 	// establish some baseline to protect against flakiness due to randomness in routing
 	// and to allow for leniency in actual ceiling of enforcement (if 10 is the limit, but we allow slightly
@@ -1178,13 +1174,73 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 		errorf(t, "Bad metric value for successful requests (200s): got %f, want at least %f", got, want)
 	}
 	// TODO: until https://github.com/istio/istio/issues/3028 is fixed, use 25% - should be only 5% or so
-	want200s = math.Ceil(want200s * 1.5)
+	want200s = math.Ceil(want200s * 1.25)
 	if got > want200s {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 200), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 200's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
 		errorf(t, "Bad metric value for successful requests (200s): got %f, want at most %f", got, want200s)
 	}
+}
+
+func logPolicyMetrics(t *testing.T, adapter, app string) {
+	t.Helper()
+
+	promAPI, err := promAPI()
+	if err != nil {
+		fatalf(t, "Could not build prometheus API client: %v", err)
+	}
+
+	// Get check cache hit baseline.
+	envoyHits, err := getCheckCacheHits(promAPI, app)
+	if err != nil {
+		fatalf(t, "Could not retrieve valid cache hit number for app '%s': %v", app, err)
+	}
+
+	mixerCacheHits, err := mixerCheckCacheHits(promAPI)
+	if err != nil {
+		fatalf(t, "Could not retrieve cache hits for mixer: %v", err)
+	}
+
+	dispatches, err := adapterDispatches(promAPI, adapter)
+	if err != nil {
+		fatalf(t, "Could not retrieve dispatches for adapter '%s': %v", adapter, err)
+	}
+
+	requests, err := mixerRequests(promAPI, "istio-policy", app)
+	if err != nil {
+		fatalf(t, "Could not retrieve requests to istio-policy from app '%s': %v", app, err)
+	}
+
+	t.Logf("istio-policy stats (from: '%s'):  envoy checkcache hit count: %f, grpc requests: %f (total: %f) ", app, envoyHits, requests, envoyHits+requests)
+	t.Logf("istio-policy stats (all requests): mixer checkcache hits: %f, adapter '%s' dispatches: %f", mixerCacheHits, adapter, dispatches)
+}
+
+func mixerCheckCacheHits(promAPI v1.API) (float64, error) {
+	query := "sum(mixer_checkcache_cache_hits_total{job=\"istio-policy\"})"
+	return queryValue(promAPI, query)
+}
+
+func adapterDispatches(promAPI v1.API, adapter string) (float64, error) {
+	query := fmt.Sprintf("sum(mixer_runtime_dispatches_total{adapter=\"%s\"})", adapter)
+	return queryValue(promAPI, query)
+}
+
+func mixerRequests(promAPI v1.API, svcName, app string) (float64, error) {
+	query := fmt.Sprintf("sum(istio_requests_total{source_app=\"%s\", destination_service_name=\"%s\"})", app, svcName)
+	return queryValue(promAPI, query)
+}
+
+func queryValue(promAPI v1.API, query string) (float64, error) {
+	value, err := promAPI.Query(context.Background(), query, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("could not get results for query: %s: %v", query, err)
+	}
+	returnVal, err := vectorValue(value, map[string]string{})
+	if err != nil {
+		return 0, fmt.Errorf("could not get extract value from: %#v: %v", value, err)
+	}
+	return returnVal, nil
 }
 
 func TestRedisQuotaRollingWindow(t *testing.T) {

--- a/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota-fixed-window.yaml
+++ b/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota-fixed-window.yaml
@@ -7,7 +7,7 @@ spec:
   quotas:
   - name: requestcount.quota.istio-system
     maxAmount: 5000
-    validDuration: 10s
+    validDuration: 30s
     rateLimitAlgorithm: FIXED_WINDOW
     # The first matching override is applied.
     # A requestcount instance is checked against override dimensions.
@@ -17,12 +17,12 @@ spec:
     - dimensions:
         destination: ratings
         source: reviews
-      maxAmount: 1
+      maxAmount: 50
     # The following override applies to 'ratings' regardless
     # of the source.
     - dimensions:
         destination: ratings
-      maxAmount: 10
+      maxAmount: 100
   redisServerUrl: "redis-release-master.istio-system.svc.cluster.local:6379"
   connectionPoolSize: 10
 ---
@@ -45,6 +45,7 @@ metadata:
   name: quota
   namespace: istio-system
 spec:
+  match: (destination.labels["app"]|"unknown") == "ratings"
   actions:
   - handler: handler.redisquota
     instances:

--- a/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota-rolling-window.yaml
+++ b/tests/e2e/tests/mixer/testdata/mixer-rule-ratings-redis-quota-rolling-window.yaml
@@ -7,7 +7,7 @@ spec:
   quotas:
   - name: requestcount.quota.istio-system
     maxAmount: 5000
-    validDuration: 10s
+    validDuration: 30s
     bucketDuration: 9s
     rateLimitAlgorithm: ROLLING_WINDOW
     # The first matching override is applied.
@@ -18,12 +18,12 @@ spec:
     - dimensions:
         destination: ratings
         source: reviews
-      maxAmount: 1
+      maxAmount: 50
     # The following override applies to 'ratings' regardless
     # of the source.
     - dimensions:
         destination: ratings
-      maxAmount: 10
+      maxAmount: 100
   redisServerUrl: "redis-release-master.istio-system.svc.cluster.local:6379"
   connectionPoolSize: 10
 ---
@@ -46,6 +46,7 @@ metadata:
   name: quota
   namespace: istio-system
 spec:
+  match: (destination.labels["app"]|"unknown") == "ratings"
   actions:
   - handler: handler.redisquota
     instances:


### PR DESCRIPTION
This PR is an attempt to de-flake the `redisquota` e2e tests (as well as to make their behaviour a little bit more debuggable).

It does the following:
- replaces the scaling logic in the test code with install options that always create 2 `istio-policy` instances (and remove autoscaling completely). This should eliminate the possibility of anything funky happening during scale events (and remove the odd tussle between the autoscaler and the test code).
- increases the rate limits being enforced by ~10x. It appears that at sufficiently low limits, the quota enforcement mechanism functions in an inexact manner (#3028). To avoid any issues around this behaviour, this PR chooses larger limits with longer enforcement intervals.
- adds `match` clauses to the quota rules, such that we can be sure all dispatches to the `redisquota` adapter happen in instances when the rate limits should be enforced (this is for debugging).
- adds some logs around mixer caches, requests, and dispatches (this is for debugging).

