### PR TITLE
Filter flaky query from galley dashboard test

### DIFF
--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -340,6 +340,10 @@ func galleyQueryFilterFn(queries []string) []string {
 		if strings.Contains(query, "request_acks_total") {
 			continue
 		}
+		// This is a frequent source of flakes in e2e-dashboard test. Remove from checked queries for now.
+		if strings.Contains(query, "runtime_strategy_timer_quiesce_reached_total") {
+			continue
+		}
 		filtered = append(filtered, query)
 	}
 	return filtered


### PR DESCRIPTION
In some test runs, the following query seems to lead to failures ([example](https://k8s-gubernator.appspot.com/build/istio-prow/pr-logs/pull/istio_istio/10171/e2e-dashboard/8495)):

`sum(rate(galley_runtime_strategy_timer_quiesce_reached_total[1m])) * 60`

This PR filters that query out from consideration during the e2e test, with the goal of improved testing stability.