### PR TITLE
Disable verbosity for PR head and base tests

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -62,7 +62,7 @@ function code_coverage() {
   local filename
   local count=${2:-0}
   filename="$(echo "${1}" | tr '/' '-')"
-  go test -v \
+  go test \
     -coverpkg=istio.io/istio/... \
     -coverprofile="${COVERAGEDIR}/${filename}.cov" \
     -covermode=atomic "${1}" \

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -64,11 +64,7 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
     --baseline_file="${BASELINE_PATH}/coverage.html" \
     --threshold_file="${THRESHOLD_FILE}" \
     | tee "${GOPATH}"/out/codecov/out.log \
-    | tee >(go-junit-report > "${GOPATH}"/out/codecov/junit.xml)
-
-  # Merge codecov junit into the one creared by unit tests at PR head.
-  go get github.com/imsky/junit-merger/...
-  junit-merger "${GOPATH}"/out/codecov/pr/junit.xml "${GOPATH}"/out/codecov/junit.xml  > "${GOPATH}"/out/tests/junit.xml
+    | tee >(go-junit-report > "${GOPATH}"/out/tests/junit.xml)
 else
   # Upload to codecov.io in post submit only for visualization
   bash <(curl -s https://codecov.io/bash) -f /go/out/codecov/pr/coverage.cov


### PR DESCRIPTION
This reduces noises in test output and also show only codecov related tests on testgrid.