### PR TITLE
Update bootstrap config to use stats_matcher to filter metrics gen

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/pkg/bootstrap/testdata/auth_golden.json
+++ b/pkg/bootstrap/testdata/auth_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/pkg/bootstrap/testdata/default_golden.json
+++ b/pkg/bootstrap/testdata/default_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/pkg/bootstrap/testdata/tracing_lightstep_golden.json
+++ b/pkg/bootstrap/testdata/tracing_lightstep_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -40,7 +40,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -44,7 +44,30 @@
         "tag_name": "mongo_prefix",
         "regex": "^mongo\\.(.+?)\\.(collection|cmd|cx_|op_|delays_|decoding_)(.*?)$"
       }
-    ]
+    ],
+    "stats_matcher": {
+      "inclusion_list": {
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "listener_manager"
+          },
+          {
+            "prefix": "http_mixer_filter"
+          },
+          {
+            "prefix": "tcp_mixer_filter"
+          },
+          {
+            "prefix": "server"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          }
+        ]
+      }
+    }
   },
   "admin": {
     "access_log_path": "/dev/null",


### PR DESCRIPTION
This is the `release-1.1` version of #9972 . The priority on this fix was raised and it was asked that this work be pulled into the 1.1 release.

This PR attempts to reduce the memory and cpu burden imposed on envoy proxies deployed in an Istio mesh by filtering the set of stats that Envoy generates and maintains down to a minimal set that are in-use within Istio today.

For a rough estimate of impact, I noticed that the number of individual metrics tracked by Envoy for a quiescent basic deployment of the bookinfo app went from 5479 metrics down to 152. I saw a corresponding reduction of ~20M of memory usage by the proxy. I did not attempt to assess latency impact, etc., nor did I look at CPU reduction in Prometheus processes, etc.

A few notes:

- This PR does not provide any way to configure stats_matcher bootstrap config, even at install time. I don't know what the best way would be to provide such a feature, but I imagine that this will be desired by some Istio customers. Perhaps in a follow-on.
- I did not attempt to remove the existing `stats_tag` configuration, which may not be need at all with this configuration and could potentially further reduce resource usage.
- This list may need to be expanded to support pending health-check work. cc: @nmittler . For the time-being, I propose we start from the reduced set and build only as needed.

Related issues: #9942, #7912 