### PR TITLE
remove chart version in pod labels.

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/_labels.tpl
+++ b/install/kubernetes/helm/istio-remote/templates/_labels.tpl
@@ -1,6 +1,0 @@
-{{- define "common_labels" }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
-    version: {{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-{{- end }}

--- a/install/kubernetes/helm/subcharts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/certmanager/templates/deployment.yaml
@@ -19,8 +19,7 @@ spec:
         app: certmanager
         chart: {{ template "certmanager.chart" . }}
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
+        release: {{ .Release.Name }}        
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}

--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -21,8 +21,7 @@ spec:
         app: {{ template "galley.name" . }}
         chart: {{ template "galley.chart" . }}
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
+        release: {{ .Release.Name }}      
         istio: galley
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/create-custom-resources-job.yaml
@@ -63,7 +63,6 @@ spec:
         chart: {{ template "grafana.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
     spec:
       serviceAccountName: istio-grafana-post-install-account
       containers:

--- a/install/kubernetes/helm/subcharts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         chart: {{ template "grafana.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         chart: {{ template "ingress.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
         istio: ingress
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/subcharts/istiocoredns/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/istiocoredns/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
         chart: {{ template "istiocoredns.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         chart: {{ template "kiali.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
@@ -17,7 +17,6 @@ spec:
         chart: {{ template "nodeagent.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
-        version: {{ .Chart.Version }}
         istio: nodeagent
     spec:
       serviceAccountName: istio-nodeagent-service-account

--- a/install/kubernetes/helm/subcharts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/pilot/templates/deployment.yaml
@@ -25,7 +25,6 @@ spec:
         chart: {{ template "pilot.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
         istio: pilot
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
@@ -21,7 +21,6 @@ spec:
         chart: {{ template "prometheus.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/cleanup-secrets.yaml
@@ -85,7 +85,6 @@ spec:
         chart: {{ template "security.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
       containers:

--- a/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/create-custom-resources-job.yaml
@@ -74,7 +74,6 @@ spec:
         chart: {{ template "security.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
     spec:
       serviceAccountName: istio-security-post-install-account
       containers:

--- a/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
@@ -23,7 +23,6 @@ spec:
         chart: {{ template "security.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
         istio: citadel
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/subcharts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/servicegraph/templates/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         chart: {{ template "servicegraph.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
         chart: {{ template "sidecar-injector.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
         istio: sidecar-injector
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/deployment-jaeger.yaml
@@ -18,7 +18,6 @@ spec:
         chart: {{ template "tracing.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
-        version: {{ .Chart.Version }}
       annotations:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""


### PR DESCRIPTION
@sdake  
`Chart.Version` should not be in pod labels, as they will break the helm chart upgrade&rollback.
Because if we add `Chart.Version` to pod labels, the pod can't be selected during upgrade&rollback, as they have different value for `Chart.Version`.

See: 
https://github.com/helm/helm/issues/2494#issuecomment-311691146
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#selector

@ymesika I know `Chart.Version` was added to fix https://github.com/istio/istio/issues/8413

Another option is that we add `matchedLabel` without `Chart.Version`.