### PR TITLE
allow envoy process to access token volume file in sidecar

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -166,6 +166,9 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          runAsGroup: 2000
+          {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}
         resources:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -195,6 +195,9 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          runAsGroup: 2000
+          {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}
         resources:

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -187,6 +187,9 @@ containers:
     [[ end -]]
     [[ if eq (annotation .ObjectMeta $interceptionModeKey .ProxyConfig.InterceptionMode) "TPROXY" -]]
     runAsUser: 1337
+    {{- if and .SDSEnabled .EnableSdsTokenMount }}
+    runAsGroup: 2000
+    {{ end -}}
     [[- end ]]
   volumeMounts:
   - mountPath: /etc/istio/proxy


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

due to bug https://github.com/kubernetes/kubernetes/issues/57923, k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as). this PR workaround the bug using https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod