### PR TITLE
mixer: disable L2 cache

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -30,6 +30,7 @@
           - --configStoreURL=k8s://
           - --configDefaultNamespace={{ $.Release.Namespace }}
           - --trace_zipkin_url=http://zipkin:9411/api/v1/spans
+          - --numCheckCacheEntries=0
         {{- if .Values.env }}
         env:
         {{- range $key, $val := .Values.env }}


### PR DESCRIPTION
Due to reports of non-deterministic L2 cache correctness violations, a workaround to disable L2 cache by default is suggested. If we can identity the root cause of this, we can enable it back by default.

Ref: https://github.com/istio/istio/issues/9596
/assign @geeknoid 
/assign @mandarjog 

Signed-off-by: Kuat Yessenov <kuat@google.com>