### PR TITLE
Enable MCP by default in helm values and e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -863,9 +863,6 @@ workflows:
       - e2e-mixer-noauth-v1alpha3-v2:
           requires:
             - build
-      - e2e-mixer-noauth-v1alpha3-v2-non-mcp:
-          requires:
-            - build
       - e2e-galley:
           requires:
             - build
@@ -876,9 +873,6 @@ workflows:
           requires:
             - test
       - e2e-pilot-auth-v1alpha3-v2: # auth+v1alpha3+v2
-          requires:
-            - build
-      - e2e-pilot-auth-v1alpha3-v2-non-mcp: # auth+v1alpha3+v2 without MCP
           requires:
             - build
       - e2e-pilot-noauth-v1alpha3-v2: # noauth+v1alpha3+v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
-  e2e-simple-mcp:
+  e2e-simple-non-mcp:
     <<: *integrationDefaults
     environment:
             - KUBECONFIG: /go/out/minikube.conf
@@ -129,7 +129,7 @@ jobs:
             make docker.all
       - run: bin/testEnvRootMinikube.sh wait
       - run: docker images
-      - run: E2E_ARGS="--use_mcp" make test/local/auth/e2e_simple
+      - run: E2E_ARGS="--use_mcp=false" make test/local/auth/e2e_simple
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - <<: *markJobFinishesOnGCS
@@ -181,7 +181,7 @@ jobs:
       - store_artifacts:
           path: /var/lib/localkube/
 
-  e2e-dashboard-mcp:
+  e2e-dashboard-non-mcp:
     <<: *integrationDefaults
     environment:
             - KUBECONFIG: /go/out/minikube.conf
@@ -207,7 +207,7 @@ jobs:
       - run:
           command: |
             PATH=$GOPATH/bin:$PATH \
-            E2E_ARGS="--skip_cleanup -use_local_cluster --use_mcp -test.v" \
+            E2E_ARGS="--skip_cleanup -use_local_cluster --use_mcp=false -test.v" \
             set -o pipefail
             make e2e_dashboard | tee -a /go/out/tests/build-log.txt
       - <<: *recordZeroExitCodeIfTestPassed
@@ -256,7 +256,7 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
-  e2e-mixer-noauth-v1alpha3-v2-mcp:
+  e2e-mixer-noauth-v1alpha3-v2-non-mcp:
     <<: *integrationDefaults
     steps:
       - <<: *initWorkingDir
@@ -279,9 +279,9 @@ jobs:
           no_output_timeout: 20m
           # Run the test even if previous failed
           when: always
-          name: make e2e_mixer (mcp)
+          name: make e2e_mixer (non-mcp)
           command: |
-            E2E_ARGS="--use_mcp" \
+            E2E_ARGS="--use_mcp=false" \
             make test/local/noauth/e2e_mixer_envoyv2
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
@@ -395,7 +395,7 @@ jobs:
       - store_artifacts:
           path: /tmp
 
-  e2e-pilot-noauth-v1alpha3-v2-mcp:
+  e2e-pilot-noauth-v1alpha3-v2-non-mcp:
     <<: *integrationDefaults
     environment:
             - GOPATH: /go
@@ -423,7 +423,7 @@ jobs:
           # Run the test even if previous failed
           when: always
           command: |
-                E2E_ARGS="--use_mcp" \
+                E2E_ARGS="--use_mcp=false" \
                 make test/local/noauth/e2e_pilotv2
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
@@ -534,7 +534,7 @@ jobs:
       - store_test_results:
           path: /go/out/tests
 
-  e2e-pilot-auth-v1alpha3-v2-mcp:
+  e2e-pilot-auth-v1alpha3-v2-non-mcp:
     <<: *integrationDefaults
     steps:
       - <<: *initWorkingDir
@@ -558,7 +558,7 @@ jobs:
           # Run the test even if previous failed
           when: always
           command: |
-                E2E_ARGS="--use_mcp" \
+                E2E_ARGS="--use_mcp=false" \
                 make test/local/auth/e2e_pilotv2
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
@@ -815,13 +815,13 @@ workflows:
       - e2e-simple:
           requires:
             - build
-      - e2e-simple-mcp:
+      - e2e-simple-non-mcp:
           requires:
             - build
       - e2e-dashboard:
           requires:
             - build
-      - e2e-dashboard-mcp:
+      - e2e-dashboard-non-mcp:
           requires:
             - build
       - benchcheck:
@@ -831,7 +831,7 @@ workflows:
       - e2e-mixer-noauth-v1alpha3-v2:
           requires:
             - build
-      - e2e-mixer-noauth-v1alpha3-v2-mcp:
+      - e2e-mixer-noauth-v1alpha3-v2-non-mcp:
           requires:
             - build
       - e2e-galley:
@@ -843,13 +843,13 @@ workflows:
       - e2e-pilot-noauth-v1alpha3-v2: # no auth+v1alpha3+v2
           requires:
             - build
-      - e2e-pilot-noauth-v1alpha3-v2-mcp: # no auth+v1alpha3+v2
+      - e2e-pilot-noauth-v1alpha3-v2-non-mcp: # no auth+v1alpha3+v2
           requires:
             - build
       - e2e-pilot-auth-v1alpha3-v2: # auth+v1alpha3+v2
           requires:
             - build
-      - e2e-pilot-auth-v1alpha3-v2-mcp: # auth+v1alpha3+v2 with MCP
+      - e2e-pilot-auth-v1alpha3-v2-non-mcp: # auth+v1alpha3+v2 without MCP
           requires:
             - build
 
@@ -863,7 +863,7 @@ workflows:
       - e2e-mixer-noauth-v1alpha3-v2:
           requires:
             - build
-      - e2e-mixer-noauth-v1alpha3-v2-mcp:
+      - e2e-mixer-noauth-v1alpha3-v2-non-mcp:
           requires:
             - build
       - e2e-galley:
@@ -878,7 +878,7 @@ workflows:
       - e2e-pilot-auth-v1alpha3-v2: # auth+v1alpha3+v2
           requires:
             - build
-      - e2e-pilot-auth-v1alpha3-v2-mcp: # auth+v1alpha3+v2 with MCP
+      - e2e-pilot-auth-v1alpha3-v2-non-mcp: # auth+v1alpha3+v2 without MCP
           requires:
             - build
       - e2e-pilot-noauth-v1alpha3-v2: # noauth+v1alpha3+v2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.descriptor      -diff -merge
 *.descriptor_set  linguist-generated=true
 *.descriptor_set  -diff -merge
+*.pb.html linguist-generated=true

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -249,7 +249,7 @@ global:
 
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
-  useMCP: false
+  useMCP: true
 
   # The trust domain corresponds to the trust root of a system
   # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -333,7 +333,7 @@ global:
 
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
-  useMCP: false
+  useMCP: true
 
   # The trust domain corresponds to the trust root of a system
   # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain

--- a/prow/e2e-bookInfoTests-envoyv2-v1alpha3-mcp.sh
+++ b/prow/e2e-bookInfoTests-envoyv2-v1alpha3-mcp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+################################################
+#                                              #
+#             e2e-bookInfoTests (v1alpha3)     #
+#                                              #
+################################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+echo 'Running bookinfo test with rbac, auth Tests'
+./prow/e2e-suite.sh  --use_mcp=true --single_test e2e_bookinfo_envoyv2_v1alpha3 "$@"

--- a/prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
+++ b/prow/e2e-bookInfoTests-envoyv2-v1alpha3-non-mcp.sh
@@ -29,4 +29,4 @@ set -u
 set -x
 
 echo 'Running bookinfo test with rbac, auth Tests'
-./prow/e2e-suite.sh  --use_mcp --single_test e2e_bookinfo_envoyv2_v1alpha3 "$@"
+./prow/e2e-suite.sh  --use_mcp=false --single_test e2e_bookinfo_envoyv2_v1alpha3 "$@"

--- a/prow/e2e-mixer-no_auth-mcp.sh
+++ b/prow/e2e-mixer-no_auth-mcp.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#######################################
+#                                     #
+#        mixer-e2e (v1alpha3)         #
+#             MCP variant             #
+#                                     #
+#######################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# Run tests with auth disabled
+#echo 'Running mixer e2e tests (v1alpha3, noauth)'
+./prow/e2e-suite.sh --use_mcp=true --single_test e2e_mixer

--- a/prow/e2e-mixer-no_auth-non-mcp.sh
+++ b/prow/e2e-mixer-no_auth-non-mcp.sh
@@ -30,4 +30,4 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running mixer e2e tests (v1alpha3, noauth)'
-./prow/e2e-suite.sh --use_mcp --single_test e2e_mixer
+./prow/e2e-suite.sh --use_mcp=false --single_test e2e_mixer

--- a/prow/e2e-simpleTests-mcp.sh
+++ b/prow/e2e-simpleTests-mcp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#######################################
+#                                     #
+#             e2e-suite               #
+#                                     #
+#######################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+echo 'Running Simple test with rbac, auth Tests'
+./prow/e2e-suite.sh --auth_enable --use_mcp=true --single_test e2e_simple --installer helm "$@"

--- a/prow/e2e-simpleTests-non-mcp.sh
+++ b/prow/e2e-simpleTests-non-mcp.sh
@@ -29,4 +29,4 @@ set -u
 set -x
 
 echo 'Running Simple test with rbac, auth Tests'
-./prow/e2e-suite.sh --auth_enable --use_mcp --single_test e2e_simple --installer helm "$@"
+./prow/e2e-suite.sh --auth_enable --use_mcp=false --single_test e2e_simple --installer helm "$@"

--- a/prow/istio-pilot-e2e-envoyv2-v1alpha3-mcp.sh
+++ b/prow/istio-pilot-e2e-envoyv2-v1alpha3-mcp.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2017 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#######################################
+#                                     #
+#        pilot-e2e (v1alpha3)         #
+#                                     #
+#######################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+# Run tests with auth disabled
+#echo 'Running pilot e2e tests (v1alpha3, noauth)'
+./prow/e2e-suite.sh --use_mcp=true --single_test e2e_pilotv2_v1alpha3
+
+# Run tests with auth enabled
+#echo 'Running pilot e2e tests (v1alpha3, auth)'
+#./prow/e2e-suite.sh --auth_enable=true --v1alpha1=false --single_test e2e_pilot "$@"

--- a/prow/istio-pilot-e2e-envoyv2-v1alpha3-non-mcp.sh
+++ b/prow/istio-pilot-e2e-envoyv2-v1alpha3-non-mcp.sh
@@ -29,7 +29,7 @@ set -x
 
 # Run tests with auth disabled
 #echo 'Running pilot e2e tests (v1alpha3, noauth)'
-./prow/e2e-suite.sh --use_mcp --single_test e2e_pilotv2_v1alpha3
+./prow/e2e-suite.sh --use_mcp=false --single_test e2e_pilotv2_v1alpha3
 
 # Run tests with auth enabled
 #echo 'Running pilot e2e tests (v1alpha3, auth)'

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -101,7 +101,7 @@ var (
 		"Directory name for the cluster registry config. When provided a multicluster test to be run across two clusters.")
 	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", true, "Use galley configuration validation webhook")
 	installer                = flag.String("installer", "kubectl", "Istio installer, default to kubectl, or helm")
-	useMCP                   = flag.Bool("use_mcp", false, "use MCP for configuring Istio components")
+	useMCP                   = flag.Bool("use_mcp", true, "use MCP for configuring Istio components")
 	kubeInjectCM             = flag.String("kube_inject_configmap", "",
 		"Configmap to use by the istioctl kube-inject command.")
 	valueFile = flag.String("valueFile", "", "Istio value yaml file when helm is used")
@@ -792,11 +792,15 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 	if *useAutomaticInjection {
 		setValue += " --set sidecarInjectorWebhook.enabled=true"
 	}
+
 	if *useMCP {
 		setValue += " --set galley.enabled=true --set global.useMCP=true"
 	} else if *useGalleyConfigValidator {
-		setValue += " --set galley.enabled=true"
+		setValue += " --set galley.enabled=true --set global.useMCP=false"
+	} else {
+		setValue += " --set galley.enabled=false --set global.useMCP=false"
 	}
+
 	// hubs and tags replacement.
 	// Helm chart assumes hub and tag are the same among multiple istio components.
 	if *pilotHub != "" && *pilotTag != "" {


### PR DESCRIPTION
This PR inverts the default helm options so that MCP is enabled by default. For the time being users can still disable MCP to compare performance and functional behavior with MCP. 

The MCP and non-MCP e2e tests have also been inverted so that the full test suite now runs with MCP enabled. A subset of e2e tests are run w/o MCP as a reference for flakiness.