### PR TITLE
correct use_galley_config_validator default

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -93,7 +93,7 @@ E2E tests have multiple options available while running them as follows:
 * `--rbac_enabled` - Enable RBAC (default: true)
 * `--cluster_wide` - If true Pilot/Mixer will observe all namespaces rather than just the testing namespace (default: false)
 * `--use_automatic_injection` - if you want to do transparent sidecar injection  (default: false)
-* `--use_galley_config_validator` - if you want to enable automatic configuration validation (default: false)
+* `--use_galley_config_validator` - if you want to enable automatic configuration validation (default: true)
 * `--mixer_hub <hub>` - Image hub for the Mixer (default: environment $HUB)
 * `--mixer_tag <tag>` - Image tag for the Mixer (default: environment $TAG)
 * `--pilot_hub <hub>` - Image hub for the Pilot (default: environment $HUB)


### PR DESCRIPTION
The default is actually true. see here: https://github.com/istio/istio/blob/master/tests/e2e/framework/kubernetes.go#L102

Here I just fixed the docs, but IMO it's better to change the default to false, since the default for `cluster_wide` is false which will make a default e2e fail unless user explicitly set `use_galley_config_validator` to false (https://github.com/istio/istio/blob/master/tests/e2e/framework/kubernetes.go#L600)
If you agree, I'll make the change.