### PR TITLE
fix minProfile test failure and support multiple set values for helm installation

### DIFF
--- a/prow/e2e-simpleTests-minProfile.sh
+++ b/prow/e2e-simpleTests-minProfile.sh
@@ -29,4 +29,4 @@ set -u
 set -x
 
 echo 'Running Simple test with minimal profile and gateways, non auth test'
-./prow/e2e-suite.sh --single_test e2e_simple --installer helm --valueFile "values-istio-minimal.yaml" --values "--set gateways.enabled=true" "$@"
+./prow/e2e-suite.sh --single_test e2e_simple --installer helm --valueFile "values-istio-minimal.yaml" --helmSetValueList "gateways.enabled=true,galley.enabled=false,global.useMCP=false" "$@"

--- a/prow/e2e-simpleTests-minProfile.sh
+++ b/prow/e2e-simpleTests-minProfile.sh
@@ -29,4 +29,4 @@ set -u
 set -x
 
 echo 'Running Simple test with minimal profile and gateways, non auth test'
-./prow/e2e-suite.sh --single_test e2e_simple --installer helm --valueFile "values-istio-minimal.yaml" --helmSetValueList "gateways.enabled=true,galley.enabled=false,global.useMCP=false" "$@"
+./prow/e2e-suite.sh --single_test e2e_simple_noauth --installer helm --valueFile "values-istio-minimal.yaml" --helmSetValueList "gateways.enabled=true,galley.enabled=false,global.useMCP=false" "$@"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -124,6 +124,9 @@ func (h *helmSetValueList) Set(value string) error {
 	}
 	return nil
 }
+func init() {
+	flag.Var(&helmSetValues, "helmSetValueList", "Additional helm values parsed, eg: galley.enabled=true,global.useMCP=true")
+}
 
 type appPodsInfo struct {
 	// A map of app label values to the pods for that app
@@ -835,7 +838,6 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 	if *values != "" {
 		setValue += " --set " + *values
 	}
-	flag.Var(&helmSetValues, "helmSetValueList", "Additional helm values parsed, eg: galley.enabled=true,global.useMCP=true")
 	for _, v := range helmSetValues {
 		setValue += " --set " + v
 	}


### PR DESCRIPTION
1. Add a flag --helmSetValueList to support multi values for helm installation, eg: --helmSetValueList "gateways.enabled=true,galley.enabled=false,global.useMCP=false"
2. Modify e2e-simple to use e2e_simple_noauth since no citadel installed for minProfile