### PR TITLE
Remove k8s integration tests from release-1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,46 +494,6 @@ jobs:
         - store_artifacts:
             path: /tmp
 
-  test-integration-kubernetes:
-    <<: *integrationDefaults
-    environment:
-      - KUBECONFIG: /go/out/minikube.conf
-      - TEST_ENV: minikube-none
-      - GOPATH: /go
-    steps:
-      - <<: *initWorkingDir
-      - checkout
-      - attach_workspace:
-          at:  /go
-      - <<: *markJobStartsOnGCS
-      - run: make sync
-      - run: bin/testEnvRootMinikube.sh start
-      - run:
-          command: |
-            if [ ! -f /go/out/linux_amd64/release/pilot-discovery ]; then
-              # Should only happen when re-running a job, and the workspace is gone
-              time make build test-bins
-            fi
-            make docker.all generate_yaml
-      - run: bin/testEnvRootMinikube.sh wait
-      - run: docker images
-      - run:
-          no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
-          name: make test.integration.kube
-          command: |
-            make test.integration.kube T="-v -timeout=15m" | tee -a /go/out/tests/build-log.txt
-      - <<: *recordZeroExitCodeIfTestPassed
-      - <<: *recordNonzeroExitCodeIfTestFailed
-      - <<: *markJobFinishesOnGCS
-      - store_artifacts:
-          path: /home/circleci/logs
-      - store_artifacts:
-          path: /tmp
-      - store_test_results:
-          path: /go/out/tests
-
   e2e-pilot-auth-v1alpha3-v2-non-mcp:
     <<: *integrationDefaults
     steps:
@@ -882,8 +842,5 @@ workflows:
           requires:
             - build
       - test-integration-local:
-          requires:
-            - build
-      - test-integration-kubernetes:
           requires:
             - build


### PR DESCRIPTION
It is flaky but it had been fixed in master. Given most test framework
developement still happens in master (including a fix for this test), we are disabling this test in
release-1.1, and leave it in master only.