### PR TITLE
[cherrypick]remove workaround of setting secure naming in node agent, instead set directly in pilot

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -17,7 +17,6 @@ package v1alpha3
 import (
 	"fmt"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -686,17 +685,12 @@ func applyUpstreamTLSSettings(env *model.Environment, cluster *v2.Cluster, tls *
 			cluster.TlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs = append(cluster.TlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs,
 				model.ConstructSdsSecretConfig(model.SDSDefaultResourceName, env.Mesh.SdsUdsPath, model.K8sSAJwtTokenFileName, env.Mesh.EnableSdsTokenMount))
 
-			rootResourceName := model.SDSRootResourceName
-			if len(tls.SubjectAltNames) > 0 {
-				// Pass upstream service accounts to envoy, which is eventually passed to node agent to construct CertificateValidationContext.VerifySubjectAltName
-				rootNames := []string{rootResourceName}
-				rootNames = append(rootNames, tls.SubjectAltNames...)
-				rootResourceName = strings.Join(rootNames, ",")
-			}
-
-			cluster.TlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-				ValidationContextSdsSecretConfig: model.ConstructSdsSecretConfig(
-					rootResourceName, env.Mesh.SdsUdsPath, model.K8sSAJwtTokenFileName, env.Mesh.EnableSdsTokenMount),
+			cluster.TlsContext.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
+				CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+					DefaultValidationContext: &auth.CertificateValidationContext{VerifySubjectAltName: tls.SubjectAltNames},
+					ValidationContextSdsSecretConfig: model.ConstructSdsSecretConfig(model.SDSRootResourceName,
+						env.Mesh.SdsUdsPath, model.K8sSAJwtTokenFileName, env.Mesh.EnableSdsTokenMount),
+				},
 			}
 		}
 

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -119,12 +119,15 @@ func setupFilterChains(authnPolicy *authn.Policy, sdsUdsPath string, enableSdsTo
 			},
 		}
 	} else {
-		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-			ValidationContextSdsSecretConfig: model.ConstructSdsSecretConfig(model.SDSRootResourceName, sdsUdsPath, model.K8sSAJwtTokenFileName, enableSdsTokenMount),
-		}
-
 		tls.CommonTlsContext.TlsCertificateSdsSecretConfigs = []*auth.SdsSecretConfig{
 			model.ConstructSdsSecretConfig(model.SDSDefaultResourceName, sdsUdsPath, model.K8sSAJwtTokenFileName, enableSdsTokenMount),
+		}
+
+		tls.CommonTlsContext.ValidationContextType = &auth.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
+				ValidationContextSdsSecretConfig: model.ConstructSdsSecretConfig(model.SDSRootResourceName, sdsUdsPath, model.K8sSAJwtTokenFileName, enableSdsTokenMount),
+			},
 		}
 	}
 	mtls := GetMutualTLS(authnPolicy)

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -661,8 +661,11 @@ func TestOnInboundFilterChains(t *testing.T) {
 							TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
 								constructSDSConfig(model.SDSDefaultResourceName, "/tmp/sdsuds.sock"),
 							},
-							ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-								ValidationContextSdsSecretConfig: constructSDSConfig(model.SDSRootResourceName, "/tmp/sdsuds.sock"),
+							ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+								CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+									DefaultValidationContext:         &auth.CertificateValidationContext{VerifySubjectAltName: []string{} /*subjectAltNames*/},
+									ValidationContextSdsSecretConfig: constructSDSConfig(model.SDSRootResourceName, "/tmp/sdsuds.sock"),
+								},
 							},
 							AlpnProtocols: []string{"h2", "http/1.1"},
 						},

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync"
 	"time"
 
@@ -80,11 +79,6 @@ type sdsConnection struct {
 
 	// The secret associated with the proxy.
 	secret *model.SecretItem
-
-	// Full resource Name from incoming discovery request.
-	// "default" for normal key/cert rquest.
-	// "ROOTCA,VerifySubjectAltName1,VerifySubjectAltName2.." for root cert request.
-	fullResourceName string
 }
 
 type sdsservice struct {
@@ -139,7 +133,6 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				log.Errorf("Failed to parse discovery request: %v", err)
 				continue
 			}
-			con.fullResourceName = discReq.ResourceNames[0]
 
 			// When nodeagent receives StreamSecrets request, if there is cached secret which matches
 			// request's <token, resourceName, Version>, then this request is a confirmation request.
@@ -204,7 +197,7 @@ func (s *sdsservice) FetchSecrets(ctx context.Context, discReq *xdsapi.Discovery
 		log.Errorf("Failed to get secret for proxy %q from secret cache: %v", discReq.Node.Id, err)
 		return nil, err
 	}
-	return sdsDiscoveryResponse(secret, discReq.ResourceNames[0], discReq.Node.Id)
+	return sdsDiscoveryResponse(secret, discReq.Node.Id)
 }
 
 // NotifyProxy send notification to proxy about secret update,
@@ -231,8 +224,7 @@ func parseDiscoveryRequest(discReq *xdsapi.DiscoveryRequest) (string /*resourceN
 	}
 
 	if len(discReq.ResourceNames) == 1 {
-		ss := strings.Split(discReq.ResourceNames[0], ",")
-		return ss[0], nil
+		return discReq.ResourceNames[0], nil
 	}
 
 	return "", fmt.Errorf("discovery request %+v has invalid resourceNames %+v", discReq, discReq.ResourceNames)
@@ -278,7 +270,7 @@ func removeConn(k cache.ConnKey) {
 func pushSDS(con *sdsConnection) error {
 	log.Infof("SDS: push from node agent to proxy:%q", con.proxyID)
 
-	response, err := sdsDiscoveryResponse(con.secret, con.fullResourceName, con.proxyID)
+	response, err := sdsDiscoveryResponse(con.secret, con.proxyID)
 	if err != nil {
 		log.Errorf("SDS: Failed to construct response %v", err)
 		return err
@@ -292,7 +284,7 @@ func pushSDS(con *sdsConnection) error {
 	return nil
 }
 
-func sdsDiscoveryResponse(s *model.SecretItem, fullResourceName, proxyID string) (*xdsapi.DiscoveryResponse, error) {
+func sdsDiscoveryResponse(s *model.SecretItem, proxyID string) (*xdsapi.DiscoveryResponse, error) {
 	resp := &xdsapi.DiscoveryResponse{
 		TypeUrl:     SecretType,
 		VersionInfo: s.Version,
@@ -305,15 +297,9 @@ func sdsDiscoveryResponse(s *model.SecretItem, fullResourceName, proxyID string)
 	}
 
 	secret := &authapi.Secret{
-		Name: fullResourceName,
+		Name: s.ResourceName,
 	}
 	if s.RootCert != nil {
-		ss := strings.Split(fullResourceName, ",")
-		sans := []string{}
-		if len(ss) > 1 {
-			sans = append(sans, ss[1:len(ss)]...)
-		}
-
 		secret.Type = &authapi.Secret_ValidationContext{
 			ValidationContext: &authapi.CertificateValidationContext{
 				TrustedCa: &core.DataSource{
@@ -321,7 +307,6 @@ func sdsDiscoveryResponse(s *model.SecretItem, fullResourceName, proxyID string)
 						InlineBytes: s.RootCert,
 					},
 				},
-				VerifySubjectAltName: sans,
 			},
 		}
 	} else {


### PR DESCRIPTION
cherry pick https://github.com/istio/istio/pull/10185 to release-1.1 branch

… directly in pilot (#10185)

* set secure naming in pilot instead of node agent

* lint