### PR TITLE
add token volume mount to gateway

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -159,6 +159,10 @@ spec:
           {{- if $.Values.global.sds.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
+          {{- if $.Values.global.sds.enableTokenMount }}
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+          {{- end }}
           {{- end }}
           - name: istio-certs
             mountPath: /etc/certs
@@ -176,6 +180,15 @@ spec:
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
+      {{- if $.Values.global.sds.enableTokenMount }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: {{ $.Values.global.trustDomain }}
+      {{- end }}
       {{- end }}
       - name: istio-certs
         secret:


### PR DESCRIPTION
original PR is https://github.com/istio/istio/pull/10196, with master locked, this has go to release-1.1 branch(disable by default)

https://github.com/istio/istio/issues/9035, it will allow k8s api server mounts k8s sa jwt to ingress/egress, similar to sidecar injector change https://github.com/istio/istio/pull/9651

