### PR TITLE
allow envoy process to access token volume file in sidecar

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -170,6 +170,9 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          runAsGroup: 2000
+          {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}
         resources:

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -171,7 +171,7 @@ data:
           runAsGroup: 1337
           {{ "[[ else -]]" }}
           {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
-          runAsGroup: 2000
+          runAsGroup: 1337
           {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -200,7 +200,7 @@ data:
           runAsGroup: 1337
           {{ "[[ else -]]" }}
           {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
-          runAsGroup: 2000
+          runAsGroup: 1337
           {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -199,6 +199,9 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          runAsGroup: 2000
+          {{- end }}
           runAsUser: 1337
           {{ "[[- end ]]" }}
         resources:

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -697,7 +697,7 @@ func intoObject(sidecarTemplate string, meshconfig *meshconfig.MeshConfig, in ru
 	// k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as).
 	// workaround by https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 	if meshconfig.EnableSdsTokenMount && meshconfig.SdsUdsPath != "" {
-		var grp = int64(2000)
+		var grp = int64(1337)
 		podSpec.SecurityContext = &corev1.PodSecurityContext{
 			FSGroup: &grp,
 		}

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -693,6 +693,16 @@ func intoObject(sidecarTemplate string, meshconfig *meshconfig.MeshConfig, in ru
 	// Because we need to extract istio-proxy's statusPort.
 	rewriteAppHTTPProbe(spec, podSpec)
 
+	// due to bug https://github.com/kubernetes/kubernetes/issues/57923,
+	// k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as).
+	// workaround by https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+	if meshconfig.EnableSdsTokenMount && meshconfig.SdsUdsPath != "" {
+		var grp = int64(2000)
+		podSpec.SecurityContext = &corev1.PodSecurityContext{
+			FSGroup: &grp,
+		}
+	}
+
 	if metadata.Annotations == nil {
 		metadata.Annotations = make(map[string]string)
 	}

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -188,7 +188,7 @@ containers:
     [[ if eq (annotation .ObjectMeta $interceptionModeKey .ProxyConfig.InterceptionMode) "TPROXY" -]]
     runAsUser: 1337
     {{- if and .SDSEnabled .EnableSdsTokenMount }}
-    runAsGroup: 2000
+    runAsGroup: 1337
     {{ end -}}
     [[- end ]]
   volumeMounts:

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -187,6 +187,9 @@ containers:
     [[ end -]]
     [[ if eq (annotation .ObjectMeta $interceptionModeKey .ProxyConfig.InterceptionMode) "TPROXY" -]]
     runAsUser: 1337
+    {{- if and .SDSEnabled .EnableSdsTokenMount }}
+    runAsGroup: 2000
+    {{ end -}}
     [[- end ]]
   volumeMounts:
   - mountPath: /etc/istio/proxy


### PR DESCRIPTION
original PR is https://github.com/istio/istio/pull/10199,  with master locked, this has go to release-1.1 branch(disable by default)

https://github.com/istio/istio/issues/9035, due to bug https://github.com/kubernetes/kubernetes/issues/57923, k8s sa jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as). this PR workaround the bug using https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod