### PR TITLE
mixer: enforce type discipline for attribute values

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -28,6 +28,7 @@
           - --monitoringPort={{ .Values.global.monitoringPort }}
           - --address
           - unix:///sock/mixer.socket
+          - --numCheckCacheEntries=0
 {{- if $.Values.global.useMCP }}
     {{- if $.Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcps://istio-galley.{{ $.Release.Namespace }}.svc:9901

--- a/mixer/cmd/mixc/cmd/util_test.go
+++ b/mixer/cmd/mixc/cmd/util_test.go
@@ -72,7 +72,7 @@ func TestAttributeHandling(t *testing.T) {
 		{"p", 42 * time.Second},
 		{"q", []byte{1}},
 		{"r", []byte{0x34, 0x56}},
-		{"s", map[string]string{"k1": "v1", "k2": "v2"}},
+		{"s", attribute.NewStringMapForTesting("s", map[string]string{"k1": "v1", "k2": "v2"})},
 		{"t", "XYZ"},
 		{"u", int64(2)},
 		{"v", 3.0},
@@ -80,7 +80,7 @@ func TestAttributeHandling(t *testing.T) {
 		{"x", time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)},
 		{"y", 42 * time.Second},
 		{"z", []byte{0x98, 0x76}},
-		{"zz", map[string]string{"k3": "v3"}},
+		{"zz", attribute.NewStringMapForTesting("zz", map[string]string{"k3": "v3"})},
 	}
 
 	for _, r := range results {

--- a/mixer/pkg/attribute/bag.go
+++ b/mixer/pkg/attribute/bag.go
@@ -14,9 +14,29 @@
 
 package attribute
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+	"time"
+)
 
 // Bag is a generic mechanism to access a set of attributes.
+//
+// The type of an attribute value is guaranteed to be one of the following:
+// - int64, int
+// - string
+// - float64
+// - bool
+// - time.Time
+// - time.Duration
+// - []byte (backed by a byte array)
+// - attribute.StringMap (backed by a map[string]string)
+//
+// Attribute value types are physical representation of the semantic Mixer types.
+// For example, IP addresses are represented as []byte.
+//
+// The following types are not fully implemented at the surface level:
+// - attribute.List (backed by []interface{})
 type Bag interface {
 	fmt.Stringer
 
@@ -31,4 +51,43 @@ type Bag interface {
 
 	// Done indicates the bag can be reclaimed.
 	Done()
+}
+
+// Equal compares two attribute values.
+func Equal(this, that interface{}) bool {
+	switch x := this.(type) {
+	case int64, int, string, float64, bool:
+		return x == that
+	case time.Time:
+		if y, ok := that.(time.Time); ok {
+			return x.Equal(y)
+		}
+	case time.Duration:
+		if y, ok := that.(time.Duration); ok {
+			return x == y
+		}
+	case []byte:
+		if y, ok := that.([]byte); ok {
+			return reflect.DeepEqual(x, y)
+		}
+	case StringMap:
+		if y, ok := that.(StringMap); ok {
+			return x.Equal(y)
+		}
+	case List:
+		if y, ok := that.(List); ok {
+			return x.Equal(y)
+		}
+	}
+	return false
+}
+
+// CheckType validates that an attribute value has a supported type.
+func CheckType(value interface{}) bool {
+	switch value.(type) {
+	case int64, int, string, float64, bool, time.Time, time.Duration, []byte, StringMap, List:
+		return true
+	default:
+		return false
+	}
 }

--- a/mixer/pkg/attribute/list.go
+++ b/mixer/pkg/attribute/list.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// List wraps a list of values and optionally reference counts it
+type List struct {
+	// name of the list
+	name string
+	// entries in the list
+	entries []interface{}
+}
+
+// NewList creates a new list
+func NewList(name string) List {
+	return List{
+		name:    name,
+		entries: make([]interface{}, 0, 1),
+	}
+}
+
+// NewListForTesting should only be used for testing.
+func NewListForTesting(name string, entries []interface{}) List {
+	return List{
+		name:    name,
+		entries: entries,
+	}
+}
+
+// Append adds an element to the list
+func (l List) Append(val interface{}) List {
+	return List{
+		name:    l.name,
+		entries: append(l.entries, val),
+	}
+}
+
+// String prints the entries in the list
+func (l List) String() string {
+	return fmt.Sprintf("%v", l.entries)
+}
+
+// Equal compares the list entries
+func (l List) Equal(m List) bool {
+	return reflect.DeepEqual(l.entries, m.entries)
+}

--- a/mixer/pkg/attribute/mutableBag.go
+++ b/mixer/pkg/attribute/mutableBag.go
@@ -191,6 +191,7 @@ func (mb *MutableBag) Set(name string, value interface{}) {
 		panic(fmt.Errorf("attempt to use a bag after its Done method has been called"))
 	}
 
+	// lenient update for backwards compatibility
 	if m, ok := value.(map[string]string); ok {
 		mb.values[name] = StringMap{name: name, entries: m}
 		return
@@ -199,6 +200,7 @@ func (mb *MutableBag) Set(name string, value interface{}) {
 	if !CheckType(value) {
 		panic(fmt.Errorf("invalid type %T for %q", value, name))
 	}
+
 	mb.values[name] = value
 }
 

--- a/mixer/pkg/attribute/protoBag.go
+++ b/mixer/pkg/attribute/protoBag.go
@@ -73,29 +73,6 @@ func NewProtoBag(proto *mixerpb.CompressedAttributes, globalDict map[string]int3
 	return out
 }
 
-// StringMap wraps a map[string]string and reference counts it
-type StringMap struct {
-	// name of the stringmap  -- request.headers
-	name string
-	// entries in the stringmap
-	entries map[string]string
-	// protoBag that owns this stringmap
-	pb *ProtoBag
-}
-
-// Get returns a stringmap value and records access
-func (s StringMap) Get(key string) (string, bool) {
-	cond := mixerpb.ABSENCE
-	str, found := s.entries[key]
-
-	if found {
-		cond = mixerpb.EXACT
-	}
-	// TODO add REGEX condition
-	s.pb.trackMapReference(s.name, key, cond)
-	return str, found
-}
-
 // Get returns an attribute value.
 func (pb *ProtoBag) Get(name string) (interface{}, bool) {
 	// find the dictionary index for the given string

--- a/mixer/pkg/attribute/stringmap.go
+++ b/mixer/pkg/attribute/stringmap.go
@@ -1,0 +1,88 @@
+// Copyright 2018 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attribute
+
+import (
+	"fmt"
+	"reflect"
+
+	mixerpb "istio.io/api/mixer/v1"
+)
+
+// StringMap wraps a map[string]string and optionally reference counts it
+type StringMap struct {
+	// name of the stringmap  -- request.headers
+	name string
+	// entries in the stringmap
+	entries map[string]string
+	// protoBag that owns this stringmap
+	pb *ProtoBag
+}
+
+// NewStringMap instantiates a new string map.
+func NewStringMap(name string) StringMap {
+	return StringMap{
+		name:    name,
+		entries: make(map[string]string, 1),
+	}
+}
+
+// NewStringMapForTesting should only be used for testing.
+func NewStringMapForTesting(name string, entries map[string]string) StringMap {
+	return StringMap{
+		name:    name,
+		entries: entries,
+	}
+}
+
+// Set wraps a string map set operation.
+func (s StringMap) Set(key, val string) {
+	s.entries[key] = val
+}
+
+// Get returns a stringmap value and records access
+func (s StringMap) Get(key string) (string, bool) {
+	str, found := s.entries[key]
+
+	// the string map may be de-touched from the owning bag
+	if s.pb != nil {
+		cond := mixerpb.ABSENCE
+		if found {
+			cond = mixerpb.EXACT
+		}
+
+		// TODO add REGEX condition
+		s.pb.trackMapReference(s.name, key, cond)
+	}
+	return str, found
+}
+
+func (s StringMap) copyValue() StringMap {
+	c := make(map[string]string, len(s.entries))
+	for k2, v2 := range s.entries {
+		c[k2] = v2
+	}
+	return StringMap{name: s.name, entries: c, pb: s.pb}
+}
+
+// String prints the entries in the string map
+func (s StringMap) String() string {
+	return fmt.Sprintf("string%v", s.entries)
+}
+
+// Equal compares the string map entries
+func (s StringMap) Equal(t StringMap) bool {
+	return reflect.DeepEqual(s.entries, t.entries)
+}

--- a/mixer/pkg/checkcache/keyShape_test.go
+++ b/mixer/pkg/checkcache/keyShape_test.go
@@ -186,7 +186,6 @@ func TestKeyShape(t *testing.T) {
 				},
 
 				{
-					// TODO(kuat)
 					"ra with many exact entries, bag matching all, except map key",
 					map[string]interface{}{
 						"a": "0",

--- a/mixer/pkg/checkcache/keyShape_test.go
+++ b/mixer/pkg/checkcache/keyShape_test.go
@@ -108,7 +108,7 @@ func TestKeyShape(t *testing.T) {
 						"f":            []byte{0, 1, 2},
 						"g":            time.Now(),
 						"h":            time.Second * 10,
-						"i":            map[string]string{"j": "k"},
+						"i":            attribute.NewStringMapForTesting("i", map[string]string{"j": "k"}),
 					},
 					true,
 					true,
@@ -161,7 +161,7 @@ func TestKeyShape(t *testing.T) {
 						"f": []byte{0, 1, 2},
 						"g": time.Now(),
 						"h": time.Second * 10,
-						"i": map[string]string{"j": "j", "k": "k"},
+						"i": attribute.NewStringMapForTesting("i", map[string]string{"j": "j", "k": "k"}),
 					},
 					true,
 					true,
@@ -178,7 +178,7 @@ func TestKeyShape(t *testing.T) {
 						"f": []byte{0, 1, 2},
 						"g": time.Now(),
 						"h": 10 * time.Second,
-						"i": map[string]string{"j": "j", "k": "k", "l": "l"},
+						"i": attribute.NewStringMapForTesting("i", map[string]string{"j": "j", "k": "k", "l": "l"}),
 						"j": "k",
 					},
 					true,
@@ -186,6 +186,7 @@ func TestKeyShape(t *testing.T) {
 				},
 
 				{
+					// TODO(kuat)
 					"ra with many exact entries, bag matching all, except map key",
 					map[string]interface{}{
 						"a": "0",
@@ -196,7 +197,7 @@ func TestKeyShape(t *testing.T) {
 						"f": []byte{0, 1, 2},
 						"g": time.Now(),
 						"h": 10 * time.Second,
-						"i": map[string]string{"X": "k", "l": "m"},
+						"i": attribute.NewStringMapForTesting("i", map[string]string{"X": "k", "l": "m"}),
 					},
 					false,
 					true,
@@ -233,8 +234,8 @@ func TestKeyShape(t *testing.T) {
 					"ra with many absent entries, three unrelated entries in bag",
 					map[string]interface{}{
 						"x": "y",
-						"z": map[string]string{"Y": "Y"},
-						"i": map[string]string{"Y": "Y"},
+						"z": attribute.NewStringMapForTesting("z", map[string]string{"Y": "Y"}),
+						"i": attribute.NewStringMapForTesting("i", map[string]string{"Y": "Y"}),
 					},
 					true,
 					true,
@@ -244,7 +245,7 @@ func TestKeyShape(t *testing.T) {
 					"ra with many absent entries, two unrelated entries in bag and an absent entry present",
 					map[string]interface{}{
 						"x": "y",
-						"z": map[string]string{"Y": "Y"},
+						"z": attribute.NewStringMapForTesting("z", map[string]string{"Y": "Y"}),
 						"a": 0,
 					},
 					true,
@@ -255,8 +256,8 @@ func TestKeyShape(t *testing.T) {
 					"ra with many absent entries, absent key in string map",
 					map[string]interface{}{
 						"x": "y",
-						"z": map[string]string{"Y": "Y"},
-						"i": map[string]string{"j": "j", "k": "k"},
+						"z": attribute.NewStringMapForTesting("z", map[string]string{"Y": "Y"}),
+						"i": attribute.NewStringMapForTesting("i", map[string]string{"j": "j", "k": "k"}),
 					},
 					true,
 					false,
@@ -301,11 +302,11 @@ func TestKeyShape(t *testing.T) {
 				bag := attribute.GetMutableBagForTesting(ac.bag)
 
 				if ok := shape.checkAbsentAttrs(bag); ok != ac.checkAbsent {
-					t.Errorf("Expecting %v, got %v", ac.checkAbsent, ok)
+					t.Errorf("Expecting checkAbsent %v, got %v", ac.checkAbsent, ok)
 				}
 
 				if ok := shape.checkPresentAttrs(bag); ok != ac.checkPresent {
-					t.Errorf("Expecting %v, got %v", ac.checkPresent, ok)
+					t.Errorf("Expecting checkPresent %v, got %v", ac.checkPresent, ok)
 				}
 
 				if ok := shape.isCompatible(bag); ok != ac.checkAbsent && ac.checkPresent {

--- a/mixer/pkg/protobuf/yaml/decoder.go
+++ b/mixer/pkg/protobuf/yaml/decoder.go
@@ -90,14 +90,16 @@ type decodeVisitor struct {
 func (dv *decodeVisitor) setValue(f *descriptor.FieldDescriptorProto, val interface{}) {
 	name := dv.attrPrefix + f.GetName()
 	if f.IsRepeated() {
-		var arr []interface{}
+		var arr attribute.List
 		old, ok := dv.out.Get(name)
 		if !ok {
-			arr = make([]interface{}, 0, 1)
+			arr = attribute.NewList(name)
 		} else {
-			arr = old.([]interface{})
+			arr = old.(attribute.List)
 		}
-		dv.out.Set(name, append(arr, val))
+		// value semantics
+		arr = arr.Append(val)
+		dv.out.Set(name, arr)
 	} else {
 		dv.out.Set(name, val)
 	}
@@ -142,7 +144,7 @@ func (dv *decodeVisitor) Fixed32(n wire.Number, v uint32) {
 	case descriptor.FieldDescriptorProto_TYPE_SFIXED32:
 		val = int64(v)
 	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		val = math.Float32frombits(v)
+		val = float64(math.Float32frombits(v))
 	default:
 		dv.err = multierror.Append(dv.err, fmt.Errorf("unexpected field type %q for fixed32 encoding", f.GetType()))
 		return
@@ -218,13 +220,12 @@ func (dv *decodeVisitor) Bytes(n wire.Number, v []byte) {
 			}
 
 			// translate map<X, Y> proto3 field type to record Mixer type (map[string]string)
-			var m map[string]string
+			var m attribute.StringMap
 			val, ok := dv.out.Get(name)
 			if !ok {
-				m = make(map[string]string)
-				dv.out.Set(name, m)
+				m = attribute.NewStringMap(name)
 			} else {
-				m = val.(map[string]string)
+				m = val.(attribute.StringMap)
 			}
 
 			visitor := &mapVisitor{desc: mapType}
@@ -237,7 +238,8 @@ func (dv *decodeVisitor) Bytes(n wire.Number, v []byte) {
 				v = v[m:]
 			}
 
-			m[visitor.key] = visitor.value
+			m.Set(visitor.key, visitor.value)
+			dv.out.Set(name, m)
 			return
 		}
 

--- a/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
+++ b/mixer/pkg/protobuf/yaml/dynamic/encoder_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net"
 	"reflect"
 	"testing"
 	"time"
@@ -825,7 +824,7 @@ func testMsg(t *testing.T, input string, output string, res protoyaml.Resolver,
 		"test.i64":              int64(-123),
 		"test.i32":              int64(123),
 		"test.bool":             true,
-		"source.ip":             net.IP{8, 0, 0, 1},
+		"source.ip":             []byte{8, 0, 0, 1},
 		"response.duration":     10 * time.Second,
 		"context.timestamp":     time.Date(2018, 8, 15, 0, 0, 1, 0, time.UTC).UTC(),
 		"test.dns_name":         "google.com",

--- a/mixer/pkg/server/args.go
+++ b/mixer/pkg/server/args.go
@@ -124,7 +124,7 @@ func DefaultArgs() *Args {
 		ReadinessProbeOptions:  &probe.Options{},
 		IntrospectionOptions:   ctrlz.DefaultOptions(),
 		EnableProfiling:        true,
-		NumCheckCacheEntries:   5000 * 5 * 60, // 5000 QPS with average TTL of 5 minutes
+		NumCheckCacheEntries:   0, // prior value 5000 * 5 * 60, 5000 QPS with average TTL of 5 minutes
 		UseAdapterCRDs:         true,
 		LoadSheddingOptions:    loadshedding.DefaultOptions(),
 	}


### PR DESCRIPTION
- enforce `StringMap` use as the attribute value across the code base
- add `List`, used only by the proto decoder (otherwise, we would have to disable that code) and not surfaced to the user
- set L2 cache size to 0

