### PR TITLE
remove localkube refs from e2e minikube script

### DIFF
--- a/tests/e2e/local/minikube/setup_host.sh
+++ b/tests/e2e/local/minikube/setup_host.sh
@@ -31,8 +31,6 @@ if [[ "${VM_DRIVER}" == "none" ]]; then
 fi
 
 $SUDO_PREFIX minikube start \
-    --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
-    --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
     --extra-config=apiserver.admission-control="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota" \
     --kubernetes-version=v1.10.0 \
     --insecure-registry="localhost:5000" \


### PR DESCRIPTION
in place of https://github.com/istio/istio/pull/10195

the `setup_host.sh` script will fail with recent versions of minikube since `localkube` was removed from minikube: https://github.com/kubernetes/minikube/pull/2911
The default ca path in `/var/lib/minikube/certs` works fine