### PR TITLE
Revert "Permit port to domain validation."

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -268,19 +268,7 @@ func checkDNS1123Preconditions(name string) error {
 
 func validateDNS1123Labels(domain string) error {
 	parts := strings.Split(domain, ".")
-	lastPart := parts[len(parts)-1]
-	lastPartArray := strings.SplitN(lastPart, ":", 2)
-
-	// Allow port in domain name
-	if len(lastPartArray) > 1 {
-		port, err := strconv.Atoi(lastPartArray[1])
-		if err != nil {
-			return fmt.Errorf("port (%s) is not a number: %v", lastPartArray[1], err)
-		}
-		return ValidatePort(int(port))
-	}
-
-	topLevelDomain := lastPartArray[0]
+	topLevelDomain := parts[len(parts)-1]
 	if _, err := strconv.Atoi(topLevelDomain); err == nil {
 		return fmt.Errorf("domain name %q invalid (top level domain %q cannot be all-numeric)", domain, topLevelDomain)
 	}


### PR DESCRIPTION
This will impact multiple configs. We need a different way of allowing ports in virtualservice configs, which was the original intent.
Reverts istio/istio#9656