### PR TITLE
Avoid generating 'email' with null value in ClusterIssuer resource

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -55,6 +55,12 @@ ingress:
   enabled: false
 
 #
+# certmanager configuration
+#
+certmanager:
+  enabled: false
+
+#
 # addon grafana configuration
 #
 grafana:

--- a/install/kubernetes/helm/subcharts/certmanager/templates/issuer.yaml
+++ b/install/kubernetes/helm/subcharts/certmanager/templates/issuer.yaml
@@ -12,7 +12,9 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
+{{- if .Values.email }}
     email: {{ .Values.email }}
+{{- end }}
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt-staging
@@ -31,7 +33,9 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
+{{- if .Values.email }}
     email: {{ .Values.email }}
+{{- end }}
     privateKeySecretRef:
       name: letsencrypt
     http01: {}


### PR DESCRIPTION
Pull request changes `certmanager` sub-chart template so it does not generate `certmanager.k8s.io/v1alpha1/ClusterIssue` with email field set to `null`.

The cert manager controller immediately drops `null` email from ClusterIssue CRD. As a result `kubectl apply` (and any automation tool on top of it ) would consider it as a difference try to apply 'null' value instead.