### PR TITLE
Alter Mixer tracing to only generate spans when service tracespan exi…

### DIFF
--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -44,13 +44,6 @@ static_resources:
         path: /sock/mixer.socket
     http2_protocol_options: {}
     name: inbound_9092
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
-        address: zipkin
-        port_value: 9411
-    name: zipkin
-    type: STRICT_DNS
   - circuit_breakers:
       thresholds:
       - max_connections: 100000
@@ -171,7 +164,6 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "15004"
-          tracing: {}
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
       tls_context:
@@ -257,12 +249,5 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "9091"
-          tracing: {}
         name: envoy.http_connection_manager
     name: "9091"
-tracing:
-  http:
-    config:
-      collector_cluster: zipkin
-      collector_endpoint: /api/v1/spans
-    name: envoy.zipkin

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -44,13 +44,6 @@ static_resources:
         path: /sock/mixer.socket
     http2_protocol_options: {}
     name: inbound_9092
-  - connect_timeout: 1.000s
-    hosts:
-    - socket_address:
-        address: zipkin
-        port_value: 9411
-    name: zipkin
-    type: STRICT_DNS
   listeners:
   - address:
       socket_address:
@@ -139,7 +132,6 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "15004"
-          tracing: {}
         name: envoy.http_connection_manager
 {{- if .ControlPlaneAuth }}
       tls_context:
@@ -221,12 +213,5 @@ static_resources:
                   cluster: inbound_9092
                   timeout: 0.000s
           stat_prefix: "9091"
-          tracing: {}
         name: envoy.http_connection_manager
     name: "9091"
-tracing:
-  http:
-    config:
-      collector_cluster: zipkin
-      collector_endpoint: /api/v1/spans
-    name: envoy.zipkin

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -73,7 +73,6 @@ type holder struct {
 
 var (
 	httpTimeout = 5 * time.Second
-	sampler     = jaeger.NewConstSampler(true)
 	poolSpans   = jaeger.TracerOptions.PoolSpans(false)
 	logger      = spanLogger{}
 )
@@ -95,6 +94,11 @@ func configure(serviceName string, options *Options, nz newZipkin) (io.Closer, e
 	}
 
 	reporters := make([]jaeger.Reporter, 0, 3)
+
+	sampler, err := jaeger.NewProbabilisticSampler(options.SamplingRate)
+	if err != nil {
+		return nil, fmt.Errorf("could not build trace sampler: %v", err)
+	}
 
 	if options.ZipkinURL != "" {
 		trans, err := nz(options.ZipkinURL, zipkin.HTTPLogger(logger), zipkin.HTTPTimeout(httpTimeout))

--- a/pkg/tracing/config_test.go
+++ b/pkg/tracing/config_test.go
@@ -44,11 +44,12 @@ func TestConfigure(t *testing.T) {
 		wantLog    bool
 	}{
 		{"no options", Options{}, false, false, false},
-		{"with logging", Options{LogTraceSpans: true}, false, false, true},
-		{"with jaeger", Options{JaegerURL: jaegerServer.URL}, true, false, false},
-		{"with zipkin", Options{ZipkinURL: zipkinServer.URL}, false, true, false},
-		{"with jaeger and logging", Options{JaegerURL: jaegerServer.URL}, true, false, false},
-		{"with zipkin and logging", Options{ZipkinURL: zipkinServer.URL, LogTraceSpans: true}, false, true, true},
+		{"with logging", Options{LogTraceSpans: true, SamplingRate: 1.0}, false, false, true},
+		{"with logging and no sampling", Options{LogTraceSpans: true}, false, false, false},
+		{"with jaeger", Options{JaegerURL: jaegerServer.URL, SamplingRate: 1.0}, true, false, false},
+		{"with zipkin", Options{ZipkinURL: zipkinServer.URL, SamplingRate: 1.0}, false, true, false},
+		{"with jaeger and logging", Options{JaegerURL: jaegerServer.URL, SamplingRate: 1.0}, true, false, false},
+		{"with zipkin and logging", Options{ZipkinURL: zipkinServer.URL, LogTraceSpans: true, SamplingRate: 1.0}, false, true, true},
 	}
 
 	for _, c := range cases {

--- a/pkg/tracing/options.go
+++ b/pkg/tracing/options.go
@@ -22,14 +22,17 @@ import (
 
 // Options defines the set of options supported by Istio's component tracing package.
 type Options struct {
-	// URL of zipkin collector (example: 'http://zipkin:9411/api/v1/spans'). This enables tracing for Mixer itself.
+	// URL of zipkin collector (example: 'http://zipkin:9411/api/v1/spans').
 	ZipkinURL string
 
-	// URL of jaeger HTTP collector (example: 'http://jaeger:14268/api/traces?format=jaeger.thrift'). This enables tracing for Mixer itself.
+	// URL of jaeger HTTP collector (example: 'http://jaeger:14268/api/traces?format=jaeger.thrift').
 	JaegerURL string
 
 	// Whether or not to emit trace spans as log records.
 	LogTraceSpans bool
+
+	// SamplingRate controls the rate at which a process will decide to generate trace spans.
+	SamplingRate float64
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults
@@ -42,6 +45,10 @@ func (o *Options) Validate() error {
 	// due to a race condition in the OT libraries somewhere, we can't have both tracing outputs active at once
 	if o.JaegerURL != "" && o.ZipkinURL != "" {
 		return errors.New("can't have Jaeger and Zipkin outputs active simultaneously")
+	}
+
+	if o.SamplingRate > 1.0 || o.SamplingRate < 0.0 {
+		return errors.New("sampling rate must be in the range: [0.0, 1.0]")
 	}
 
 	return nil
@@ -66,4 +73,7 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVarP(&o.LogTraceSpans, "trace_log_spans", "", o.LogTraceSpans,
 		"Whether or not to log trace spans.")
+
+	cmd.PersistentFlags().Float64VarP(&o.SamplingRate, "trace_sampling_rate", "", o.SamplingRate,
+		"Sampling rate for generating trace data. Must be a value in the range [0.0, 1.0].")
 }

--- a/pkg/tracing/options_test.go
+++ b/pkg/tracing/options_test.go
@@ -65,8 +65,21 @@ func TestValidate(t *testing.T) {
 	o.ZipkinURL = "https://bar"
 
 	if o.Validate() == nil {
-		t.Error("Expecting failure, got success")
+		t.Error("Validate() did not produce expected failure")
 	}
+
+	o.JaegerURL = ""
+
+	o.SamplingRate = 14.45
+	if o.Validate() == nil {
+		t.Error("Validate() did not produce expected failure for invalid sampling rate")
+	}
+
+	o.SamplingRate = -1.0234
+	if o.Validate() == nil {
+		t.Error("Validate() did not produce expected failure for invalid sampling rate")
+	}
+
 }
 
 func TestTracingEnabled(t *testing.T) {


### PR DESCRIPTION
cherry pick from 1.1 #9615

* Alter Mixer tracing to only generate spans when service tracespan is already present
* Unit test cleanup