### PR TITLE
Gateway service external ips support

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -58,6 +58,7 @@ gateways:
       targetAverageUtilization: 80
     loadBalancerIP: ""
     loadBalancerSourceRanges: {}
+    externalIPs: []
     serviceAnnotations: {}
     podAnnotations: {}
     type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be

--- a/install/kubernetes/helm/subcharts/gateways/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/service.yaml
@@ -28,6 +28,10 @@ spec:
 {{- if $spec.externalTrafficPolicy }}
   externalTrafficPolicy: {{$spec.externalTrafficPolicy }}
 {{- end }}
+{{- if $spec.externalIPs }}
+  externalIPs:
+{{ toYaml $spec.externalIPs | indent 4 }}
+{{- end }}
   type: {{ .type }}
   selector:
     {{- range $key, $val := $spec.labels }}

--- a/install/kubernetes/helm/subcharts/gateways/values.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/values.yaml
@@ -26,6 +26,7 @@ istio-ingressgateway:
     targetAverageUtilization: 80
   loadBalancerIP: ""
   loadBalancerSourceRanges: []
+  externalIPs: []
   serviceAnnotations: {}
   podAnnotations: {}
   type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be


### PR DESCRIPTION
Add `externalIPs` property to gateway service in helm chart.
Document issue: https://github.com/istio/istio.io/issues/2947

## How to use
The `externalIPs` property can be edit in `istio-ingressgateway` section in `helm/istio/value.yaml `  file. 

For example:
```
istio-ingressgateway:
  enabled: true
  labels:
    app: istio-ingressgateway
    istio: ingressgateway
  replicaCount: 1
  autoscaleMin: 1
  autoscaleMax: 5
  resources: {}
    # limits:
    #  cpu: 100m
    #  memory: 128Mi
    #requests:
    #  cpu: 1800m
    #  memory: 256Mi
  cpu:
    targetAverageUtilization: 80
  loadBalancerIP: ""
  loadBalancerSourceRanges: []
  externalIPs: 
  - 10.3.0.150
  - 10.3.1.150
  serviceAnnotations: {}
  podAnnotations: {}
  type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
  #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
  ports:
    ## You can add custom gateway ports
  - port: 80
    targetPort: 80
    name: http2
    nodePort: 31380
  - port: 443
    name: https
    nodePort: 31390
  # Example of a port to add. Remove if not needed
  - port: 31400
    name: tcp
    nodePort: 31400
  ### PORTS FOR UI/metrics #####
  ## Disable if not needed
  - port: 15029
    targetPort: 15029
    name: http-kiali
  - port: 15030
    targetPort: 15030
    name: http2-prometheus
  - port: 15031
    targetPort: 15031
    name: http2-grafana
  - port: 15032
    targetPort: 15032
    name: http2-tracing
    # This is the port where sni routing happens
  - port: 15443
    targetPort: 15443
    name: tls
  #### MESH EXPANSION PORTS  ########
  # Pilot and Citadel MTLS ports are enabled in gateway - but will only redirect
  # to pilot/citadel if global.meshExpansion settings are enabled.
  # Delete these ports if mesh expansion is not enabled, to avoid
  # exposing unnecessary ports on the web.
  # You can remove these ports if you are not using mesh expansion
  meshExpansionPorts:
  - port: 15011
    targetPort: 15011
    name: tcp-pilot-grpc-tls
  - port: 8060
    targetPort: 8060
    name: tcp-citadel-grpc-tls
  - port: 853
    targetPort: 853
    name: tcp-dns-tls
  ####### end MESH EXPANSION PORTS ######  
  ##############   
  secretVolumes:
  - name: ingressgateway-certs
    secretName: istio-ingressgateway-certs
    mountPath: /etc/istio/ingressgateway-certs
  - name: ingressgateway-ca-certs
    secretName: istio-ingressgateway-ca-certs
    mountPath: /etc/istio/ingressgateway-ca-certs
  ### Advanced options ############
  env:
    # A gateway with this mode ensures that pilot generates an additional
    # set of clusters for internal services but without Istio mTLS, to
    # enable cross cluster routing.
    ISTIO_META_ROUTER_MODE: "sni-dnat"
```
## Effect
 Use this config to install istio ([helm-install](https://istio.io/docs/setup/kubernetes/helm-install/)), then check it:
```
kubectl -n istio-system get svc istio-ingressgateway
```
the result would have externalIPs 10.3.0.150 and 10.3.1.150:
```
NAME                   TYPE       CLUSTER-IP       EXTERNAL-IP             PORT(S)                                                                                                                   AGE
istio-ingressgateway   NodePort   172.30.140.196   10.3.0.150,10.3.1.150   80:31380/TCP,443:31390/TCP,31400:31400/TCP,15011:31509/TCP,8060:32592/TCP,853:31985/TCP,15030:32658/TCP,15031:31582/TCP   1d

```
 
