### PR TITLE
Move EnvoyFilters into networking core

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
@@ -15,19 +15,19 @@
 package v1alpha3
 
 import (
-	"net"
-	"strings"
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
+	"net"
+	"strings"
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pkg/log"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/log"
 )
 
 // We process EnvoyFilter CRDs after calling all plugins and building the listener with the required filter chains
@@ -241,7 +241,7 @@ func insertHTTPFilter(listenerName string, filterChain *listener.FilterChain, hc
 
 	// Rebuild the HTTP connection manager in the network filter chain
 	// Its the last filter in the filter chain
-	filterChain.Filters[len(filterChain.Filters) - 1] = listener.Filter{
+	filterChain.Filters[len(filterChain.Filters)-1] = listener.Filter{
 		Name:       xdsutil.HTTPConnectionManager,
 		ConfigType: &listener.Filter_Config{Config: util.MessageToStruct(hcm)},
 	}

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoyfilter
+package v1alpha3
 
 import (
 	"net"
 	"strings"
-
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
@@ -27,76 +27,45 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pilot/pkg/networking/util"
 )
 
-type envoyfilterplugin struct{}
-
-const (
-	// InboundDirection indicates onInboundListener callback
-	InboundDirection = "inbound"
-	// OutboundDirection indicates onOutboundListener callback
-	OutboundDirection = "outbound"
-)
-
-// NewPlugin returns an ptr to an initialized envoyfilter.Plugin.
-func NewPlugin() plugin.Plugin {
-	return envoyfilterplugin{}
-}
-
-// OnOutboundListener implements the Callbacks interface method.
-func (envoyfilterplugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
-	return insertUserSpecifiedFilters(in, mutable, OutboundDirection)
-}
-
-// OnInboundListener implements the Callbacks interface method.
-func (envoyfilterplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
-	return insertUserSpecifiedFilters(in, mutable, InboundDirection)
-}
-
-// OnOutboundCluster implements the Plugin interface method.
-func (envoyfilterplugin) OnOutboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
-	// do nothing
-}
-
-// OnInboundCluster implements the Plugin interface method.
-func (envoyfilterplugin) OnInboundCluster(in *plugin.InputParams, cluster *xdsapi.Cluster) {
-	// do nothing
-}
-
-// OnOutboundRouteConfiguration implements the Plugin interface method.
-func (envoyfilterplugin) OnOutboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
-	// do nothing
-}
-
-// OnInboundRouteConfiguration implements the Plugin interface method.
-func (envoyfilterplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConfiguration *xdsapi.RouteConfiguration) {
-	// do nothing
-}
-
-// OnInboundFilterChains is called whenever a plugin needs to setup the filter chains, including relevant filter chain configuration.
-func (envoyfilterplugin) OnInboundFilterChains(in *plugin.InputParams) []plugin.FilterChain {
-	return nil
-}
-
-func insertUserSpecifiedFilters(in *plugin.InputParams, mutable *plugin.MutableObjects, direction string) error {
-	filterCRD := getFilterForWorkload(in)
+// We process EnvoyFilter CRDs after calling all plugins and building the listener with the required filter chains
+// Having the entire filter chain is essential because users can specify one or more filters to be inserted before/after
+// a filter or remove one or more filters.
+// We use the plugin.InputParams as a convenience object to pass around parameters like proxy, proxyInstances, ports,
+// etc., instead of having a long argument list
+// NOTE: this function is called for every chain in an array of filter chains in the listener
+// A chain could be a stack of network filters, network filters+http connection manager (which has its own filters)
+// If there is a http connection manager, then the caller is expected to pass the connection manager object as well
+// If one or more filters are added to the HTTP connection manager, we will update the last filter in the listener filter chain
+// (which is the http connection manager) with the updated object.
+func insertUserFilters(in *plugin.InputParams, listener *xdsapi.Listener, httpConnectionManagers []*http_conn.HttpConnectionManager) error {
+	filterCRD := getUserFiltersForWorkload(in)
 	if filterCRD == nil {
 		return nil
 	}
 
-	listenerIPAddress := getListenerIPAddress(&mutable.Listener.Address)
+	listenerIPAddress := getListenerIPAddress(&listener.Address)
 	if listenerIPAddress == nil {
 		log.Warnf("Failed to parse IP Address from plugin listener")
 	}
 
 	for _, f := range filterCRD.Filters {
-		if !listenerMatch(in, direction, listenerIPAddress, f.ListenerMatch) {
+		if !listenerMatch(in, listenerIPAddress, f.ListenerMatch) {
 			continue
 		}
+		// 4 cases of filter insertion
+		// http listener, http filter
+		// tcp listener, tcp filter
+		// http listener, tcp filter
+		// tcp listener, http filter -- invalid
+
+		// http, http case
 		if in.ListenerProtocol == plugin.ListenerProtocolHTTP && f.FilterType == networking.EnvoyFilter_Filter_HTTP {
 			// Insert into http connection manager
-			for cnum := range mutable.FilterChains {
-				insertHTTPFilter(&mutable.FilterChains[cnum], f)
+			for cnum := range listener.FilterChains {
+				insertHTTPFilter(listener.Name, &listener.FilterChains[cnum], httpConnectionManagers[cnum], f)
 			}
 		} else {
 			// tcp listener with some opaque filter or http listener with some opaque filter
@@ -106,8 +75,8 @@ func insertUserSpecifiedFilters(in *plugin.InputParams, mutable *plugin.MutableO
 				log.Warnf("Ignoring filter %s. Cannot insert HTTP filter in network filter chain", f.FilterName)
 				continue
 			}
-			for cnum := range mutable.FilterChains {
-				insertNetworkFilter(&mutable.FilterChains[cnum], f)
+			for cnum := range listener.FilterChains {
+				insertNetworkFilter(listener.Name, &listener.FilterChains[cnum], f)
 			}
 		}
 	}
@@ -116,7 +85,7 @@ func insertUserSpecifiedFilters(in *plugin.InputParams, mutable *plugin.MutableO
 
 // NOTE: There can be only one filter for a workload. If multiple filters are defined, the behavior
 // is undefined.
-func getFilterForWorkload(in *plugin.InputParams) *networking.EnvoyFilter {
+func getUserFiltersForWorkload(in *plugin.InputParams) *networking.EnvoyFilter {
 	env := in.Env
 	// collect workload labels
 	workloadInstances := in.ProxyInstances
@@ -149,7 +118,7 @@ func getListenerIPAddress(address *core.Address) net.IP {
 	return nil
 }
 
-func listenerMatch(in *plugin.InputParams, direction string, listenerIP net.IP,
+func listenerMatch(in *plugin.InputParams, listenerIP net.IP,
 	matchCondition *networking.EnvoyFilter_ListenerMatch) bool {
 	if matchCondition == nil {
 		return true
@@ -167,21 +136,24 @@ func listenerMatch(in *plugin.InputParams, direction string, listenerIP net.IP,
 		}
 	}
 
-	// Listener type
-	switch matchCondition.ListenerType {
-	case networking.EnvoyFilter_ListenerMatch_GATEWAY:
-		if in.Node.Type != model.Router {
-			return false // We don't care about direction for gateways
-		}
-	case networking.EnvoyFilter_ListenerMatch_SIDECAR_INBOUND:
-		if in.Node.Type != model.Sidecar || direction != InboundDirection {
+	// case ANY implies do not care about proxy type or direction
+	if matchCondition.ListenerType != networking.EnvoyFilter_ListenerMatch_ANY {
+		// check if the current listener category matches with the user specified type
+		if matchCondition.ListenerType != in.ListenerCategory {
 			return false
 		}
-	case networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND:
-		if in.Node.Type != model.Sidecar || direction != OutboundDirection {
-			return false
+
+		// Check if the node's role matches properly with the listener category
+		switch matchCondition.ListenerType {
+		case networking.EnvoyFilter_ListenerMatch_GATEWAY:
+			if in.Node.Type != model.Router {
+				return false // We don't care about direction for gateways
+			}
+		case networking.EnvoyFilter_ListenerMatch_SIDECAR_INBOUND, networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND:
+			if in.Node.Type != model.Sidecar {
+				return false
+			}
 		}
-		// case ANY implies do not care about proxy type or direction
 	}
 
 	// Listener protocol
@@ -228,7 +200,7 @@ func listenerMatch(in *plugin.InputParams, direction string, listenerIP net.IP,
 	return true
 }
 
-func insertHTTPFilter(filterChain *plugin.FilterChain, envoyFilter *networking.EnvoyFilter_Filter) {
+func insertHTTPFilter(listenerName string, filterChain *listener.FilterChain, hcm *http_conn.HttpConnectionManager, envoyFilter *networking.EnvoyFilter_Filter) {
 	filter := &http_conn.HttpFilter{
 		Name:       envoyFilter.FilterName,
 		ConfigType: &http_conn.HttpFilter_Config{Config: envoyFilter.FilterConfig},
@@ -239,35 +211,44 @@ func insertHTTPFilter(filterChain *plugin.FilterChain, envoyFilter *networking.E
 		position = envoyFilter.InsertPosition.Index
 	}
 
+	oldLen := len(hcm.HttpFilters)
 	switch position {
 	case networking.EnvoyFilter_InsertPosition_FIRST, networking.EnvoyFilter_InsertPosition_BEFORE:
-		filterChain.HTTP = append([]*http_conn.HttpFilter{filter}, filterChain.HTTP...)
+		hcm.HttpFilters = append([]*http_conn.HttpFilter{filter}, hcm.HttpFilters...)
 		if position == networking.EnvoyFilter_InsertPosition_BEFORE {
 			// bubble the filter to the right position scanning from beginning
-			for i := 1; i < len(filterChain.HTTP); i++ {
-				if filterChain.HTTP[i].Name != envoyFilter.InsertPosition.RelativeTo {
-					filterChain.HTTP[i-1], filterChain.HTTP[i] = filterChain.HTTP[i], filterChain.HTTP[i-1]
+			for i := 1; i < len(hcm.HttpFilters); i++ {
+				if hcm.HttpFilters[i].Name != envoyFilter.InsertPosition.RelativeTo {
+					hcm.HttpFilters[i-1], hcm.HttpFilters[i] = hcm.HttpFilters[i], hcm.HttpFilters[i-1]
 				} else {
 					break
 				}
 			}
 		}
 	case networking.EnvoyFilter_InsertPosition_LAST, networking.EnvoyFilter_InsertPosition_AFTER:
-		filterChain.HTTP = append(filterChain.HTTP, filter)
+		hcm.HttpFilters = append(hcm.HttpFilters, filter)
 		if position == networking.EnvoyFilter_InsertPosition_AFTER {
 			// bubble the filter to the right position scanning from end
-			for i := len(filterChain.HTTP) - 2; i >= 0; i-- {
-				if filterChain.HTTP[i].Name != envoyFilter.InsertPosition.RelativeTo {
-					filterChain.HTTP[i+1], filterChain.HTTP[i] = filterChain.HTTP[i], filterChain.HTTP[i+1]
+			for i := len(hcm.HttpFilters) - 2; i >= 0; i-- {
+				if hcm.HttpFilters[i].Name != envoyFilter.InsertPosition.RelativeTo {
+					hcm.HttpFilters[i+1], hcm.HttpFilters[i] = hcm.HttpFilters[i], hcm.HttpFilters[i+1]
 				} else {
 					break
 				}
 			}
 		}
 	}
+
+	// Rebuild the HTTP connection manager in the network filter chain
+	// Its the last filter in the filter chain
+	filterChain.Filters[len(filterChain.Filters) - 1] = listener.Filter{
+		Name:       xdsutil.HTTPConnectionManager,
+		ConfigType: &listener.Filter_Config{Config: util.MessageToStruct(hcm)},
+	}
+	log.Infof("EnvoyFilters: Rebuilt HTTP Connection Manager %s (from %d filters to %d filters)", listenerName, oldLen, len(hcm.HttpFilters))
 }
 
-func insertNetworkFilter(filterChain *plugin.FilterChain, envoyFilter *networking.EnvoyFilter_Filter) {
+func insertNetworkFilter(listenerName string, filterChain *listener.FilterChain, envoyFilter *networking.EnvoyFilter_Filter) {
 	filter := &listener.Filter{
 		Name:       envoyFilter.FilterName,
 		ConfigType: &listener.Filter_Config{Config: envoyFilter.FilterConfig},
@@ -278,27 +259,30 @@ func insertNetworkFilter(filterChain *plugin.FilterChain, envoyFilter *networkin
 		position = envoyFilter.InsertPosition.Index
 	}
 
+	oldLen := len(filterChain.Filters)
 	switch position {
 	case networking.EnvoyFilter_InsertPosition_FIRST, networking.EnvoyFilter_InsertPosition_BEFORE:
-		filterChain.TCP = append([]listener.Filter{*filter}, filterChain.TCP...)
+		filterChain.Filters = append([]listener.Filter{*filter}, filterChain.Filters...)
 		if position == networking.EnvoyFilter_InsertPosition_BEFORE {
 			// bubble the filter to the right position scanning from beginning
-			for i := 1; i < len(filterChain.TCP); i++ {
-				if filterChain.TCP[i].Name != envoyFilter.InsertPosition.RelativeTo {
-					filterChain.TCP[i-1], filterChain.TCP[i] = filterChain.TCP[i], filterChain.TCP[i-1]
+			for i := 1; i < len(filterChain.Filters); i++ {
+				if filterChain.Filters[i].Name != envoyFilter.InsertPosition.RelativeTo {
+					filterChain.Filters[i-1], filterChain.Filters[i] = filterChain.Filters[i], filterChain.Filters[i-1]
+					break
 				}
 			}
 		}
 	case networking.EnvoyFilter_InsertPosition_LAST, networking.EnvoyFilter_InsertPosition_AFTER:
-		filterChain.TCP = append(filterChain.TCP, *filter)
+		filterChain.Filters = append(filterChain.Filters, *filter)
 		if position == networking.EnvoyFilter_InsertPosition_AFTER {
 			// bubble the filter to the right position scanning from end
-			for i := len(filterChain.TCP) - 2; i >= 0; i-- {
-				if filterChain.TCP[i].Name != envoyFilter.InsertPosition.RelativeTo {
-					filterChain.TCP[i+1], filterChain.TCP[i] = filterChain.TCP[i], filterChain.TCP[i+1]
+			for i := len(filterChain.Filters) - 2; i >= 0; i-- {
+				if filterChain.Filters[i].Name != envoyFilter.InsertPosition.RelativeTo {
+					filterChain.Filters[i+1], filterChain.Filters[i] = filterChain.Filters[i], filterChain.Filters[i+1]
+					break
 				}
 			}
 		}
 	}
-
+	log.Infof("EnvoyFilters: Rebuilt network filter stack for listener %s (from %d filters to %d filters)", listenerName, oldLen, len(filterChain.Filters))
 }

--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoyfilter
+package v1alpha3
 
 import (
 	"net"
@@ -39,7 +39,7 @@ func TestListenerMatch(t *testing.T) {
 		name           string
 		inputParams    *plugin.InputParams
 		listenerIP     net.IP
-		direction      string
+		direction      networking.EnvoyFilter_ListenerMatch_ListenerType
 		matchCondition *networking.EnvoyFilter_ListenerMatch
 		result         bool
 	}{
@@ -63,7 +63,7 @@ func TestListenerMatch(t *testing.T) {
 		{
 			name:           "match by listener type",
 			inputParams:    inputParams,
-			direction:      OutboundDirection,
+			direction:      networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{ListenerType: networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND},
 			result:         true,
 		},
@@ -84,7 +84,7 @@ func TestListenerMatch(t *testing.T) {
 			name:        "match outbound sidecar http listeners on 10.10.10.0/24:80, with port name prefix http-*",
 			inputParams: inputParams,
 			listenerIP:  net.ParseIP("10.10.10.10"),
-			direction:   OutboundDirection,
+			direction:   networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{
 				PortNumber:       80,
 				PortNamePrefix:   "http",
@@ -98,7 +98,7 @@ func TestListenerMatch(t *testing.T) {
 			name:        "does not match: outbound sidecar http listeners on 10.10.10.0/24:80, with port name prefix tcp-*",
 			inputParams: inputParams,
 			listenerIP:  net.ParseIP("10.10.10.10"),
-			direction:   OutboundDirection,
+			direction:   networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{
 				PortNumber:       80,
 				PortNamePrefix:   "tcp",
@@ -111,7 +111,7 @@ func TestListenerMatch(t *testing.T) {
 		{
 			name:        "does not match: inbound sidecar http listeners with port name prefix http-*",
 			inputParams: inputParams,
-			direction:   OutboundDirection,
+			direction:   networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{
 				PortNamePrefix:   "http",
 				ListenerType:     networking.EnvoyFilter_ListenerMatch_SIDECAR_INBOUND,
@@ -123,7 +123,7 @@ func TestListenerMatch(t *testing.T) {
 			name:        "does not match: outbound gateway http listeners on 10.10.10.0/24:80, with port name prefix http-*",
 			inputParams: inputParams,
 			listenerIP:  net.ParseIP("10.10.10.10"),
-			direction:   OutboundDirection,
+			direction:   networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{
 				PortNumber:       80,
 				PortNamePrefix:   "http",
@@ -137,7 +137,7 @@ func TestListenerMatch(t *testing.T) {
 			name:        "does not match: outbound sidecar listeners on 172.16.0.1/16:80, with port name prefix http-*",
 			inputParams: inputParams,
 			listenerIP:  net.ParseIP("10.10.10.10"),
-			direction:   OutboundDirection,
+			direction:   networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 			matchCondition: &networking.EnvoyFilter_ListenerMatch{
 				PortNumber:       80,
 				PortNamePrefix:   "http",
@@ -150,7 +150,8 @@ func TestListenerMatch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		ret := listenerMatch(tc.inputParams, tc.direction, tc.listenerIP, tc.matchCondition)
+		tc.inputParams.ListenerCategory = tc.direction
+		ret := listenerMatch(tc.inputParams, tc.listenerIP, tc.matchCondition)
 		if tc.result != ret {
 			t.Errorf("%s: expecting %v but got %v", tc.name, tc.result, ret)
 		}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -35,8 +35,8 @@ import (
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
-	networking "istio.io/api/networking/v1alpha3"
 	meshconfig "istio.io/api/mesh/v1alpha1"
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
@@ -270,7 +270,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 					},
 				},
 			}},
-			bindToPort: true,
+			bindToPort:      true,
 			skipUserFilters: true,
 		}
 		l := buildListener(opts)
@@ -346,7 +346,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 			ProxyInstances:   proxyInstances,
 			ServiceInstance:  instance,
 			Port:             endpoint.ServicePort,
-			Push: push,
+			Push:             push,
 		}
 		switch listenerProtocol {
 		case plugin.ListenerProtocolHTTP:
@@ -796,7 +796,7 @@ func buildSidecarInboundMgmtListeners(node *model.Proxy, env *model.Environment,
 				ListenerCategory: networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
 				Env:              env,
 				Node:             node,
-				Port: mPort,
+				Port:             mPort,
 			}
 			// TODO: should we call plugins for the admin port listeners too? We do everywhere else we construct listeners.
 			if err := buildCompleteFilterChain(pluginParams, mutable, listenerOpts); err != nil {

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -35,6 +35,7 @@ import (
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
+	networking "istio.io/api/networking/v1alpha3"
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -270,9 +271,24 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 				},
 			}},
 			bindToPort: true,
+			skipUserFilters: true,
 		}
 		l := buildListener(opts)
-		if err := marshalFilters(node, l, opts, []plugin.FilterChain{{}}); err != nil {
+		// TODO: plugins for HTTP_PROXY mode, envoyfilter needs another listener match for SIDECAR_HTTP_PROXY
+		// there is no mixer for http_proxy
+		mutable := &plugin.MutableObjects{
+			Listener:     l,
+			FilterChains: []plugin.FilterChain{{}},
+		}
+		pluginParams := &plugin.InputParams{
+			ListenerProtocol: plugin.ListenerProtocolHTTP,
+			ListenerCategory: networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
+			Env:              env,
+			Node:             node,
+			ProxyInstances:   proxyInstances,
+			Push:             push,
+		}
+		if err := buildCompleteFilterChain(pluginParams, mutable, opts); err != nil {
 			log.Warna("buildSidecarListeners ", err.Error())
 		} else {
 			listeners = append(listeners, l)
@@ -321,8 +337,18 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 		allChains := []plugin.FilterChain{}
 		var httpOpts *httpListenerOpts
 		var tcpNetworkFilters []listener.Filter
-		listenerType := plugin.ModelProtocolToListenerProtocol(protocol)
-		switch listenerType {
+		listenerProtocol := plugin.ModelProtocolToListenerProtocol(protocol)
+		pluginParams := &plugin.InputParams{
+			ListenerProtocol: listenerProtocol,
+			ListenerCategory: networking.EnvoyFilter_ListenerMatch_SIDECAR_INBOUND,
+			Env:              env,
+			Node:             node,
+			ProxyInstances:   proxyInstances,
+			ServiceInstance:  instance,
+			Port:             endpoint.ServicePort,
+			Push: push,
+		}
+		switch listenerProtocol {
 		case plugin.ListenerProtocolHTTP:
 			httpOpts = &httpListenerOpts{
 				routeConfig:      configgen.buildSidecarInboundHTTPRouteConfig(env, node, push, instance),
@@ -350,16 +376,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 			log.Warnf("Unsupported inbound protocol %v for port %#v", protocol, endpoint.ServicePort)
 			continue
 		}
+
 		for _, p := range configgen.Plugins {
-			params := &plugin.InputParams{
-				ListenerProtocol: listenerType,
-				Env:              env,
-				Node:             node,
-				ProxyInstances:   proxyInstances,
-				ServiceInstance:  instance,
-				Port:             endpoint.ServicePort,
-			}
-			chains := p.OnInboundFilterChains(params)
+			chains := p.OnInboundFilterChains(pluginParams)
 			if len(chains) == 0 {
 				continue
 			}
@@ -380,7 +399,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				networkFilters:  tcpNetworkFilters,
 				tlsContext:      chain.TLSContext,
 				match:           chain.FilterChainMatch,
-				listenerFilters: chain.RequiredListenerFilters,
+				listenerFilters: chain.ListenerFilters,
 			})
 		}
 
@@ -391,21 +410,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 			FilterChains: make([]plugin.FilterChain, len(l.FilterChains)),
 		}
 		for _, p := range configgen.Plugins {
-			params := &plugin.InputParams{
-				ListenerProtocol: listenerType,
-				Env:              env,
-				Node:             node,
-				ProxyInstances:   proxyInstances,
-				ServiceInstance:  instance,
-				Port:             endpoint.ServicePort,
-				Push:             push,
-			}
-			if err := p.OnInboundListener(params, mutable); err != nil {
+			if err := p.OnInboundListener(pluginParams, mutable); err != nil {
 				log.Warn(err.Error())
 			}
 		}
 		// Filters are serialized one time into an opaque struct once we have the complete list.
-		if err := marshalFilters(node, mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
+		if err := buildCompleteFilterChain(pluginParams, mutable, listenerOpts); err != nil {
 			log.Warna("buildSidecarInboundListeners ", err.Error())
 		} else {
 			listeners = append(listeners, mutable.Listener)
@@ -504,7 +514,17 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 				port:           servicePort.Port,
 			}
 
-			switch plugin.ModelProtocolToListenerProtocol(servicePort.Protocol) {
+			pluginParams := &plugin.InputParams{
+				ListenerProtocol: plugin.ModelProtocolToListenerProtocol(servicePort.Protocol),
+				ListenerCategory: networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
+				Env:              env,
+				Node:             node,
+				ProxyInstances:   proxyInstances,
+				Service:          service,
+				Port:             servicePort,
+				Push:             push,
+			}
+			switch pluginParams.ListenerProtocol {
 			case plugin.ListenerProtocolHTTP:
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
 				var exists bool
@@ -605,23 +625,13 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 			}
 
 			for _, p := range configgen.Plugins {
-				params := &plugin.InputParams{
-					ListenerProtocol: plugin.ModelProtocolToListenerProtocol(servicePort.Protocol),
-					Env:              env,
-					Node:             node,
-					ProxyInstances:   proxyInstances,
-					Service:          service,
-					Port:             servicePort,
-					Push:             push,
-				}
-
-				if err := p.OnOutboundListener(params, mutable); err != nil {
+				if err := p.OnOutboundListener(pluginParams, mutable); err != nil {
 					log.Warn(err.Error())
 				}
 			}
 
 			// Filters are serialized one time into an opaque struct once we have the complete list.
-			if err := marshalFilters(node, mutable.Listener, listenerOpts, mutable.FilterChains); err != nil {
+			if err := buildCompleteFilterChain(pluginParams, mutable, listenerOpts); err != nil {
 				log.Warna("buildSidecarOutboundListeners: ", err.Error())
 				continue
 			}
@@ -773,10 +783,23 @@ func buildSidecarInboundMgmtListeners(node *model.Proxy, env *model.Environment,
 				filterChainOpts: []*filterChainOpts{{
 					networkFilters: buildInboundNetworkFilters(env, node, instance),
 				}},
+				// No user filters for the management unless we introduce new listener matches
+				skipUserFilters: true,
 			}
 			l := buildListener(listenerOpts)
+			mutable := &plugin.MutableObjects{
+				Listener:     l,
+				FilterChains: []plugin.FilterChain{{}},
+			}
+			pluginParams := &plugin.InputParams{
+				ListenerProtocol: plugin.ListenerProtocolTCP,
+				ListenerCategory: networking.EnvoyFilter_ListenerMatch_SIDECAR_OUTBOUND,
+				Env:              env,
+				Node:             node,
+				Port: mPort,
+			}
 			// TODO: should we call plugins for the admin port listeners too? We do everywhere else we construct listeners.
-			if err := marshalFilters(node, l, listenerOpts, []plugin.FilterChain{{}}); err != nil {
+			if err := buildCompleteFilterChain(pluginParams, mutable, listenerOpts); err != nil {
 				log.Warna("buildSidecarInboundMgmtListeners ", err.Error())
 			} else {
 				listeners = append(listeners, l)
@@ -800,7 +823,7 @@ type httpListenerOpts struct {
 	// If set, use this as a basis
 	connectionManager *http_conn.HttpConnectionManager
 	// stat prefix for the http connection manager
-	// DO not set this field. Will be overridden by marshalFilters
+	// DO not set this field. Will be overridden by buildCompleteFilterChain
 	statPrefix string
 	// addGRPCWebFilter specifies whether the envoy.grpc_web HTTP filter
 	// should be added.
@@ -828,6 +851,7 @@ type buildListenerOpts struct {
 	port            int
 	bindToPort      bool
 	filterChainOpts []*filterChainOpts
+	skipUserFilters bool
 }
 
 func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpOpts *httpListenerOpts,
@@ -1009,39 +1033,50 @@ func buildListener(opts buildListenerOpts) *xdsapi.Listener {
 	}
 }
 
-// marshalFilters adds the provided TCP and HTTP filters to the provided Listener and serializes them.
+// buildCompleteFilterChain adds the provided TCP and HTTP filters to the provided Listener and serializes them.
 //
 // TODO: should we change this from []plugins.FilterChains to [][]listener.Filter, [][]*http_conn.HttpFilter?
 // TODO: given how tightly tied listener.FilterChains, opts.filterChainOpts, and mutable.FilterChains are to eachother
 // we should encapsulate them some way to ensure they remain consistent (mainly that in each an index refers to the same
 // chain)
-func marshalFilters(node *model.Proxy, l *xdsapi.Listener, opts buildListenerOpts, chains []plugin.FilterChain) error {
+func buildCompleteFilterChain(pluginParams *plugin.InputParams, mutable *plugin.MutableObjects, opts buildListenerOpts) error {
 	if len(opts.filterChainOpts) == 0 {
-		return fmt.Errorf("must have more than 0 chains in listener: %#v", l)
+		return fmt.Errorf("must have more than 0 chains in listener: %#v", mutable.Listener)
 	}
 
-	for i, chain := range chains {
+	httpConnectionManagers := make([]*http_conn.HttpConnectionManager, len(mutable.FilterChains))
+	for i, chain := range mutable.FilterChains {
 		opt := opts.filterChainOpts[i]
 
 		if len(chain.TCP) > 0 {
-			l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, chain.TCP...)
+			mutable.Listener.FilterChains[i].Filters = append(mutable.Listener.FilterChains[i].Filters, chain.TCP...)
 		}
 
 		if len(opt.networkFilters) > 0 {
-			l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, opt.networkFilters...)
+			mutable.Listener.FilterChains[i].Filters = append(mutable.Listener.FilterChains[i].Filters, opt.networkFilters...)
 		}
 
-		log.Debugf("attached %d network filters to listener %q filter chain %d", len(chain.TCP)+len(opt.networkFilters), l.Name, i)
+		log.Debugf("attached %d network filters to listener %q filter chain %d", len(chain.TCP)+len(opt.networkFilters), mutable.Listener.Name, i)
 
 		if opt.httpOpts != nil {
-			opt.httpOpts.statPrefix = l.Name
-			connectionManager := buildHTTPConnectionManager(node, opts.env, opt.httpOpts, chain.HTTP)
-			l.FilterChains[i].Filters = append(l.FilterChains[i].Filters, listener.Filter{
+			opt.httpOpts.statPrefix = mutable.Listener.Name
+			httpConnectionManagers[i] = buildHTTPConnectionManager(pluginParams.Node, opts.env, opt.httpOpts, chain.HTTP)
+			mutable.Listener.FilterChains[i].Filters = append(mutable.Listener.FilterChains[i].Filters, listener.Filter{
 				Name:       xdsutil.HTTPConnectionManager,
-				ConfigType: &listener.Filter_Config{Config: util.MessageToStruct(connectionManager)},
+				ConfigType: &listener.Filter_Config{Config: util.MessageToStruct(httpConnectionManagers[i])},
 			})
-			log.Debugf("attached HTTP filter with %d http_filter options to listener %q filter chain %d", len(connectionManager.HttpFilters), l.Name, i)
+			log.Debugf("attached HTTP filter with %d http_filter options to listener %q filter chain %d",
+				len(httpConnectionManagers[i].HttpFilters), mutable.Listener.Name, i)
 		}
 	}
+
+	if !opts.skipUserFilters {
+		// NOTE: we have constructed the HTTP connection manager filter above and we are passing the whole filter chain
+		// EnvoyFilter crd could choose to replace the HTTP ConnectionManager that we built or can choose to add
+		// more filters to the HTTP filter chain. In the latter case, the insertUserFilters function will
+		// overwrite the HTTP connection manager in the filter chain after inserting the new filters
+		insertUserFilters(pluginParams, mutable.Listener, httpConnectionManagers)
+	}
+
 	return nil
 }

--- a/pilot/pkg/networking/plugin/authn/authentication.go
+++ b/pilot/pkg/networking/plugin/authn/authentication.go
@@ -144,7 +144,7 @@ func setupFilterChains(authnPolicy *authn.Policy, sdsUdsPath string, enableSdsTo
 			{
 				FilterChainMatch: alpnIstioMatch,
 				TLSContext:       tls,
-				RequiredListenerFilters: []ldsv2.ListenerFilter{
+				ListenerFilters: []ldsv2.ListenerFilter{
 					{
 						Name:       EnvoyTLSInspectorFilterName,
 						ConfigType: &ldsv2.ListenerFilter_Config{Config: &types.Struct{}},

--- a/pilot/pkg/networking/plugin/authn/authentication_test.go
+++ b/pilot/pkg/networking/plugin/authn/authentication_test.go
@@ -632,7 +632,7 @@ func TestOnInboundFilterChains(t *testing.T) {
 					FilterChainMatch: &listener.FilterChainMatch{
 						ApplicationProtocols: []string{"istio"},
 					},
-					RequiredListenerFilters: []listener.ListenerFilter{
+					ListenerFilters: []listener.ListenerFilter{
 						{
 							Name:       "envoy.listener.tls_inspector",
 							ConfigType: &listener.ListenerFilter_Config{&types.Struct{}},

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	networking "istio.io/api/networking/v1alpha3"
 
 	"istio.io/istio/pilot/pkg/model"
 )
@@ -65,6 +66,9 @@ func ModelProtocolToListenerProtocol(protocol model.Protocol) ListenerProtocol {
 type InputParams struct {
 	// ListenerProtocol is the protocol/class of listener (TCP, HTTP etc.). Must be set.
 	ListenerProtocol ListenerProtocol
+	// ListenerCategory is the type of listener (sidecar_inbound, sidecar_outbound, gateway). Must be set
+	ListenerCategory networking.EnvoyFilter_ListenerMatch_ListenerType
+
 	// Env is the model environment. Must be set.
 	Env *model.Environment
 	// Node is the node the response is for.
@@ -92,9 +96,9 @@ type FilterChain struct {
 	FilterChainMatch *listener.FilterChainMatch
 	// TLSContext is the TLS settings for this filter chains.
 	TLSContext *auth.DownstreamTlsContext
-	// RequiredListenerFilters are the filters needed for the whole listener, not particular to this
+	// ListenerFilters are the filters needed for the whole listener, not particular to this
 	// filter chain.
-	RequiredListenerFilters []listener.ListenerFilter
+	ListenerFilters []listener.ListenerFilter
 	// HTTP is the set of HTTP filters for this filter chain
 	HTTP []*http_conn.HttpFilter
 	// TCP is the set of network (TCP) filters for this filter chain.

--- a/pilot/pkg/networking/plugin/plugin.go
+++ b/pilot/pkg/networking/plugin/plugin.go
@@ -19,8 +19,8 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	networking "istio.io/api/networking/v1alpha3"
 
+	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 )
 

--- a/pilot/pkg/networking/plugin/registry/registry.go
+++ b/pilot/pkg/networking/plugin/registry/registry.go
@@ -21,7 +21,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/plugin/authn"
 	"istio.io/istio/pilot/pkg/networking/plugin/authz"
-	"istio.io/istio/pilot/pkg/networking/plugin/envoyfilter"
 	"istio.io/istio/pilot/pkg/networking/plugin/health"
 	"istio.io/istio/pilot/pkg/networking/plugin/mixer"
 )
@@ -29,7 +28,6 @@ import (
 var availablePlugins = map[string]plugin.Plugin{
 	plugin.Authn:       authn.NewPlugin(),
 	plugin.Authz:       authz.NewPlugin(),
-	plugin.Envoyfilter: envoyfilter.NewPlugin(),
 	plugin.Health:      health.NewPlugin(),
 	plugin.Mixer:       mixer.NewPlugin(),
 }

--- a/pilot/pkg/networking/plugin/registry/registry.go
+++ b/pilot/pkg/networking/plugin/registry/registry.go
@@ -26,10 +26,10 @@ import (
 )
 
 var availablePlugins = map[string]plugin.Plugin{
-	plugin.Authn:       authn.NewPlugin(),
-	plugin.Authz:       authz.NewPlugin(),
-	plugin.Health:      health.NewPlugin(),
-	plugin.Mixer:       mixer.NewPlugin(),
+	plugin.Authn:  authn.NewPlugin(),
+	plugin.Authz:  authz.NewPlugin(),
+	plugin.Health: health.NewPlugin(),
+	plugin.Mixer:  mixer.NewPlugin(),
 }
 
 // NewPlugins returns a slice of default Plugins.

--- a/pilot/pkg/networking/plugin/registry/registry_test.go
+++ b/pilot/pkg/networking/plugin/registry/registry_test.go
@@ -19,14 +19,13 @@ import (
 	"testing"
 
 	"istio.io/istio/pilot/pkg/networking/plugin"
-	"istio.io/istio/pilot/pkg/networking/plugin/envoyfilter"
 	"istio.io/istio/pilot/pkg/networking/plugin/health"
 	"istio.io/istio/pilot/pkg/networking/plugin/mixer"
 	"istio.io/istio/pilot/pkg/networking/plugin/registry"
 )
 
 func TestPlugins(t *testing.T) {
-	expectedPlugins := []string{"mixer", "health", "envoyfilter"}
+	expectedPlugins := []string{"mixer", "health"}
 	plugins := registry.NewPlugins(expectedPlugins)
 	if len(plugins) != len(expectedPlugins) {
 		t.Errorf("expected length of plugins to be %d, but got %d", len(expectedPlugins), len(plugins))
@@ -40,7 +39,6 @@ func TestPlugins(t *testing.T) {
 
 	checkPluginType(0, mixer.NewPlugin)
 	checkPluginType(1, health.NewPlugin)
-	checkPluginType(2, envoyfilter.NewPlugin)
 }
 
 func TestPluginsNonValid(t *testing.T) {


### PR DESCRIPTION
EnvoyFilter CRD relies on being able to insert filters
before/after a specific filter in the filter chain. However, our plugin
model does not supply the list of filters in a filter chain to each plugin.
Instead, the filters produced by a plugin are simply added to the top of
the list, followed by core filters. 

There are two ways to solve the problem: change the plugin logic such that
we build all the core filters, and then call the plugins with the list of filters
that have been built so far. 

The other way is to fold the EnvoyFilter implementation into networking core
and process the CRD after building the filter chain.

The former approach IMO has more uncertainities as plugins can now see all 
the filters in the chain. Its unclear if that will affect the config we build
and how it will affect. So, I resorted to the latter approach, as its a break glass
configuration anyway (i.e. if someone uses EnvoyFilter, we dont guarantee that the
system will continue to work properly)

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>