### PR TITLE
Add additional output options to mcpc tool

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2200,6 +2200,7 @@
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/tools/remotecommand",
     "k8s.io/client-go/transport/spdy",
+    "k8s.io/client-go/util/jsonpath",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/helm/pkg/chartutil",
     "k8s.io/helm/pkg/engine",

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -72,6 +72,7 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 			serverArgs.CredentialOptions.KeyFile = validationArgs.KeyFile
 			serverArgs.CredentialOptions.CertificateFile = validationArgs.CertFile
 			serverArgs.LoggingOptions = loggingOptions
+
 			if livenessProbeOptions.IsValid() {
 				livenessProbeController = probe.NewFileController(&livenessProbeOptions)
 			}
@@ -81,6 +82,10 @@ func GetRootCmd(args []string, printf, fatalf shared.FormatFn) *cobra.Command {
 			}
 			if !serverArgs.EnableServer && !validationArgs.EnableValidation {
 				fatalf("Galley must be running under at least one mode: server or validation")
+			}
+
+			if err := serverArgs.Validate(); err != nil {
+				fatalf("Invalid serverArgs: %v", err)
 			}
 
 			if err := validationArgs.Validate(); err != nil {

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -135,7 +135,8 @@ func (a *Args) String() string {
 	return buf.String()
 }
 
-func (args *Args) Validate() error {
+// Validate validates the servers command line options.
+func (a *Args) Validate() error {
 	if !args.EnableServer {
 		return nil
 	}

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -137,35 +137,35 @@ func (a *Args) String() string {
 
 // Validate validates the servers command line options.
 func (a *Args) Validate() error {
-	if !args.EnableServer {
+	if !a.EnableServer {
 		return nil
 	}
 
 	var errs *multierror.Error
-	if args.APIAddress == "" {
-		addr := args.APIAddress
+	if a.APIAddress == "" {
+		addr := a.APIAddress
 		if idx := strings.Index(addr, "://"); idx < 0 {
 			addr = "tcp://" + addr
 		}
 		if _, err := url.Parse(addr); err != nil {
-			errs = multierror.Append(errs, fmt.Errorf("cannot parse %v: %v", args.APIAddress, err))
+			errs = multierror.Append(errs, fmt.Errorf("cannot parse %v: %v", a.APIAddress, err))
 		}
 	}
-	if !args.Insecure {
-		if err := args.CredentialOptions.Validate(); err != nil {
+	if !a.Insecure {
+		if err := a.CredentialOptions.Validate(); err != nil {
 			errs = multierror.Append(errs, err)
 		}
-		if args.AccessListFile == "" {
+		if a.AccessListFile == "" {
 			errs = multierror.Append(errs, errors.New("--accessListFile is not set"))
 		}
 	}
-	if err := args.LoggingOptions.Validate(); err != nil {
+	if err := a.LoggingOptions.Validate(); err != nil {
 		errs = multierror.Append(errs, err)
 	}
-	if err := args.IntrospectionOptions.Validate(); err != nil {
+	if err := a.IntrospectionOptions.Validate(); err != nil {
 		errs = multierror.Append(errs, err)
 	}
-	if args.MeshConfigFile == "" {
+	if a.MeshConfigFile == "" {
 		errs = multierror.Append(errs, errors.New("--meshConfigFile is not set"))
 	}
 	return errs.ErrorOrNil()

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -142,7 +142,7 @@ func (a *Args) Validate() error {
 	}
 
 	var errs *multierror.Error
-	if a.APIAddress == "" {
+	if a.APIAddress != "" {
 		addr := a.APIAddress
 		if idx := strings.Index(addr, "://"); idx < 0 {
 			addr = "tcp://" + addr
@@ -160,9 +160,6 @@ func (a *Args) Validate() error {
 		}
 	}
 	if err := a.LoggingOptions.Validate(); err != nil {
-		errs = multierror.Append(errs, err)
-	}
-	if err := a.IntrospectionOptions.Validate(); err != nil {
 		errs = multierror.Append(errs, err)
 	}
 	if a.MeshConfigFile == "" {

--- a/galley/pkg/server/args_test.go
+++ b/galley/pkg/server/args_test.go
@@ -50,3 +50,32 @@ func TestArgs_String(t *testing.T) {
 	// Should not crash
 	_ = a.String()
 }
+
+func TestValidate(t *testing.T) {
+	a := DefaultArgs()
+	if err := a.Validate(); err != nil {
+		t.Fatalf("DefaultArgs() is not valid: %v", err)
+	}
+
+	a = DefaultArgs()
+	a.APIAddress = "localhost:9901"
+	if err := a.Validate(); err != nil {
+		t.Fatal("APIAddress=localhost:9901 should not fail validation")
+	}
+
+	a = DefaultArgs()
+	a.CredentialOptions.KeyFile = ""
+	if err := a.Validate(); err == nil {
+		t.Fatal("Empty CredentialOptions.KeyFile  should fail validation")
+	}
+	a.Insecure = true
+	if err := a.Validate(); err != nil {
+		t.Fatalf("Empty CredentialOptions.KeyFile with Insecure should not fail validation: %v", err)
+	}
+
+	a = DefaultArgs()
+	a.MeshConfigFile = ""
+	if err := a.Validate(); err == nil {
+		t.Fatal("Empty MeshConfigFile should fail validation")
+	}
+}

--- a/galley/pkg/server/args_test.go
+++ b/galley/pkg/server/args_test.go
@@ -74,8 +74,33 @@ func TestValidate(t *testing.T) {
 	}
 
 	a = DefaultArgs()
+	a.AccessListFile = ""
+	if err := a.Validate(); err == nil {
+		t.Fatalf("Empty CredentialOptions.KeyFile with Insecure and empty accesslist should fail validation: %v", err)
+	}
+
+	a = DefaultArgs()
 	a.MeshConfigFile = ""
 	if err := a.Validate(); err == nil {
 		t.Fatal("Empty MeshConfigFile should fail validation")
+	}
+
+	a = DefaultArgs()
+	a.LoggingOptions.OutputPaths = []string{}
+	if err := a.Validate(); err == nil {
+		t.Fatal("Unset LoggingOptions.OutputPaths should fail validation")
+	}
+
+	a = DefaultArgs()
+	a.APIAddress = "http://us\ner:pass\nword@foo.com/" // invalid URL
+	if err := a.Validate(); err == nil {
+		t.Fatal("Invalid APIAddress should fail validation")
+	}
+
+	a = DefaultArgs()
+	a.EnableServer = false
+	a.CredentialOptions.KeyFile = ""
+	if err := a.Validate(); err != nil {
+		t.Fatalf("Invalid argument validation should be skipped if server is disabled: %v", err)
 	}
 }

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -88,12 +88,12 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	s := &Server{}
 	var err error
 	if err = p.logConfigure(a.LoggingOptions); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to configure logger: %v", err)
 	}
 
 	mesh, err := p.newMeshConfigCache(a.MeshConfigFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load mesh config from %v: %v", a.MeshConfigFile, err)
 	}
 	converterCfg := &converter.Config{Mesh: mesh}
 

--- a/galley/tools/mcpc/main.go
+++ b/galley/tools/mcpc/main.go
@@ -15,14 +15,21 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"text/tabwriter"
+	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/util/jsonpath"
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/pkg/mcp/client"
@@ -34,17 +41,32 @@ import (
 
 var (
 	serverAddr = flag.String("server", "127.0.0.1:9901", "The server address")
-	types      = flag.String("types", "", "The fully qualified type URLs of resources to deploy")
+	typeURLs   = flag.String("types", "", "The fully qualified type URLs of resources to deploy")
 	id         = flag.String("id", "", "The node id for the client")
+	output     = flag.String("output", "short", "output format. One of: long|short|jsonpath=<template>")
+)
+
+var (
+	shortHeader        = strings.Join([]string{"TYPE_URL", "INDEX", "KEY", "NAMESPACE", "NAME", "VERSION", "AGE"}, "\t")
+	jsonpathHeader     = strings.Join([]string{"TYPE_URL", "INDEX", "KEY", "NAMESPACE", "NAME", "VERSION", "AGE", "JSONPATH"}, "\t")
+	outputFormatWriter = tabwriter.NewWriter(os.Stdout, 4, 2, 4, ' ', 0)
 )
 
 type updater struct {
+	jp *jsonpath.JSONPath
 }
 
-// Update interface method implementation.
-func (u *updater) Apply(ch *client.Change) error {
-	fmt.Printf("Incoming change: %v\n", ch.TypeURL)
+// TODO - remove once namespace is part of MCP metadata
+func asNamespaceAndName(key string) (string, string) {
+	parts := strings.SplitN(key, "/", 2)
+	if len(parts) == 1 {
+		return "", parts[0]
+	}
+	return parts[0], parts[1]
+}
 
+func (u *updater) printLongChange(ch *client.Change) {
+	fmt.Printf("Incoming change: %v\n", ch.TypeURL)
 	for i, o := range ch.Objects {
 		fmt.Printf("%s[%d]\n", ch.TypeURL, i)
 
@@ -57,15 +79,114 @@ func (u *updater) Apply(ch *client.Change) error {
 
 		fmt.Printf("===============\n")
 	}
+}
+
+func (u *updater) printShortChange(ch *client.Change) {
+	now := time.Now()
+
+	fmt.Fprintln(outputFormatWriter, shortHeader)
+	for i, o := range ch.Objects {
+		age := ""
+		if then, err := types.TimestampFromProto(o.Metadata.CreateTime); err == nil {
+			age = now.Sub(then).Round(time.Millisecond).String()
+		}
+		namespace, name := asNamespaceAndName(o.Metadata.Name)
+
+		parts := []string{
+			o.TypeURL,
+			strconv.Itoa(i),
+			o.Metadata.Name,
+			namespace, name,
+			o.Metadata.Version,
+			age,
+		}
+
+		fmt.Fprintln(outputFormatWriter, strings.Join(parts, "\t"))
+	}
+	outputFormatWriter.Flush()
+}
+
+func (u *updater) printJsonpathChange(ch *client.Change) {
+	now := time.Now()
+
+	fmt.Fprintln(outputFormatWriter, jsonpathHeader)
+	for i, o := range ch.Objects {
+		age := ""
+		if then, err := types.TimestampFromProto(o.Metadata.CreateTime); err == nil {
+			age = now.Sub(then).Round(time.Millisecond).String()
+		}
+
+		namespace, name := asNamespaceAndName(o.Metadata.Name)
+
+		output := ""
+		m := jsonpb.Marshaler{}
+		resourceStr, err := m.MarshalToString(o.Resource)
+		if err == nil {
+			queryObj := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(resourceStr), &queryObj); err == nil {
+				var b bytes.Buffer
+				if err := u.jp.Execute(&b, queryObj); err == nil {
+					output = b.String()
+				}
+			}
+		}
+
+		parts := []string{
+			o.TypeURL,
+			strconv.Itoa(i),
+			o.Metadata.Name,
+			namespace, name,
+			o.Metadata.Version,
+			age,
+			output,
+		}
+
+		fmt.Fprintln(outputFormatWriter, strings.Join(parts, "\t"))
+	}
+	outputFormatWriter.Flush()
+}
+
+// Update interface method implementation.
+func (u *updater) Apply(ch *client.Change) error {
+	switch *output {
+	case "long":
+		u.printLongChange(ch)
+	case "short":
+		u.printShortChange(ch)
+	default: // jsonpath
+		u.printJsonpathChange(ch)
+	}
 	return nil
 }
 
 func main() {
 	flag.Parse()
 
-	typeNames := strings.Split(*types, ",")
-
 	u := &updater{}
+
+	switch *output {
+	case "long":
+	case "short":
+	default:
+		parts := strings.Split(*output, "=")
+		if len(parts) != 2 {
+			fmt.Printf("unknown output option %q:\n", *output)
+			os.Exit(-1)
+		}
+
+		if parts[0] != "jsonpath" {
+			fmt.Printf("unknown output %q:\n", *output)
+			os.Exit(-1)
+		}
+
+		u.jp = jsonpath.New("default")
+		if err := u.jp.Parse(parts[1]); err != nil {
+			fmt.Printf("Error parsing jsonpath: %v\n", err)
+			os.Exit(-1)
+		}
+	}
+
+	typeNames := strings.Split(*typeURLs, ",")
 
 	conn, err := grpc.Dial(*serverAddr, grpc.WithInsecure())
 	if err != nil {

--- a/pkg/ctrlz/options.go
+++ b/pkg/ctrlz/options.go
@@ -46,8 +46,3 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.Address, "ctrlz_address", o.Address,
 		"The IP Address to listen on for the ControlZ introspection facility. Use '*' to indicate all addresses.")
 }
-
-// Validate validates the ctrlz command line options
-func (o *Options) Validate() error {
-	return nil // no-op
-}

--- a/pkg/ctrlz/options.go
+++ b/pkg/ctrlz/options.go
@@ -46,3 +46,8 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.Address, "ctrlz_address", o.Address,
 		"The IP Address to listen on for the ControlZ introspection facility. Use '*' to indicate all addresses.")
 }
+
+// Validate validates the ctrlz command line options
+func (o *Options) Validate() error {
+	return nil // no-op
+}

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -15,9 +15,12 @@
 package log
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/spf13/cobra"
 )
@@ -119,11 +122,6 @@ type Options struct {
 	outputLevels     string
 	logCallers       string
 	stackTraceLevels string
-}
-
-// Validate validates the logger's command line options.
-func (o *Options) Validate() error {
-	return nil // no-op
 }
 
 // DefaultOptions returns a new set of options, initialized to the defaults
@@ -393,4 +391,13 @@ func (o *Options) AttachFlags(
 
 	// NOTE: we don't currently expose a command-line option to control ErrorOutputPaths since it
 	// seems too esoteric.
+}
+
+// Validate validates the logger's command line options.
+func (o *Options) Validate() error {
+	var errs *multierror.Error
+	if len(o.OutputPaths) == 0 {
+		errs = multierror.Append(errs, errors.New("--log_target is not set"))
+	}
+	return errs.ErrorOrNil()
 }

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -121,6 +121,11 @@ type Options struct {
 	stackTraceLevels string
 }
 
+// Validate validates the logger's command line options.
+func (o *Options) Validate() error {
+	return nil // no-op
+}
+
 // DefaultOptions returns a new set of options, initialized to the defaults
 func DefaultOptions() *Options {
 	return &Options{

--- a/pkg/mcp/creds/watcher_test.go
+++ b/pkg/mcp/creds/watcher_test.go
@@ -345,3 +345,28 @@ func TestAttachCobraFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate(t *testing.T) {
+	o := DefaultOptions()
+	if err := o.Validate(); err != nil {
+		t.Fatalf("DefaultOptions() should be valid: %v", err)
+	}
+
+	o = DefaultOptions()
+	o.KeyFile = ""
+	if o.Validate() == nil {
+		t.Fatal("Empty KeyFile should fail validation")
+	}
+
+	o = DefaultOptions()
+	o.CertificateFile = ""
+	if o.Validate() == nil {
+		t.Fatal("Empty CertificateFile should fail validation")
+	}
+
+	o = DefaultOptions()
+	o.CACertificateFile = ""
+	if o.Validate() == nil {
+		t.Fatal("Empty CACertificateFile should fail validation")
+	}
+}


### PR DESCRIPTION
This PR adds short and jsonpath output options to the MCP client diagnostic tool (mcpc). The short option provides a more concise summary of received changes in tabular form. The jsonpath option providers similar capabilities to kubectl's jsonpath and is useful when specific field changes are of interest. 

Example output:

```bash
$ mcpc -types type.googleapis.com/istio.networking.v1alpha3.ServiceEntry --output jsonpath='{.ports[0].number}'
2018-12-05T18:42:08.373073Z     info    parsed scheme: ""
2018-12-05T18:42:08.373100Z     info    scheme "" not registered, fallback to default scheme
2018-12-05T18:42:08.373174Z     info    ccResolverWrapper: sending new addresses to cc: [{127.0.0.1:9901 0  <nil>}]
2018-12-05T18:42:08.373186Z     info    ClientConn switching balancer to "pick_first"
2018-12-05T18:42:08.373217Z     info    pickfirstBalancer: HandleSubConnStateChange: 0xc0001f6360, CONNECTING
2018-12-05T18:42:08.373288Z     info    mcp     (re)trying to establish new MCP stream
2018-12-05T18:42:08.373434Z     info    pickfirstBalancer: HandleSubConnStateChange: 0xc0001f6360, READY
2018-12-05T18:42:08.373454Z     info    mcp     New MCP stream created
TYPE_URL                                                      INDEX    KEY                        NAMESPACE    NAME               VERSION    AGE             JSONPATH
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    0        default/baz-example-com    default      baz-example-com    3576947    42h1m30.375s    442
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    1        default/a-example-com      default      a-example-com      3576948    42h1m30.375s    442
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    2        default/b-example-com      default      b-example-com      3576949    42h1m30.375s    442
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    3        default/googleapis         default      googleapis         3570072    42h30m8.375s    443
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    4        default/foo-example-com    default      foo-example-com    4085791    42h1m30.375s    7
type.googleapis.com/istio.networking.v1alpha3.ServiceEntry    5        default/bar-example-com    default      bar-example-com    3575927    42h1m30.375s    443
```

This PR also improves some of galley's command line flag validation logic.