### PR TITLE
use the citadel certificate given to kiali so it can be deployed behind https

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for details.
 name: kiali
 version: 1.1.0
-appVersion: 0.10
+appVersion: 0.11
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/subcharts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/configmap.yaml
@@ -18,3 +18,6 @@ data:
         url: {{ .Values.dashboard.jaegerURL }}
       grafana:
         url: {{ .Values.dashboard.grafanaURL }}
+    identity:
+      cert_file: /kiali-cert/cert-chain.pem
+      private_key_file: /kiali-cert/key.pem

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
         resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 10 }}
@@ -73,3 +75,6 @@ spec:
       - name: kiali-configuration
         configMap:
           name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: istio.kiali

--- a/install/kubernetes/helm/subcharts/kiali/templates/ingress.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
+    nginx.ingress.kubernetes.io/secure-backends: "true"
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -4,7 +4,7 @@
 enabled: false
 replicaCount: 1
 hub: docker.io/kiali
-tag: v0.10
+tag: v0.11
 contextPath: /kiali
 ingress:
   enabled: false


### PR DESCRIPTION
give citadel cert to kiali so it can be behind https.
I tested this on minikube.
This also bumps up Kiali to v0.11.

@gbaufake please review

@sdake not sure if this is what you are looking for - but this will put Kiali behind https. I only touched kiali files here - did not touch the global gw/vs stuff.