### PR TITLE
Add back the mistakenly removed SetCurrentClientCertDetails code.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -332,7 +332,12 @@ func (configgen *ConfigGeneratorImpl) buildSidecarInboundListeners(env *model.En
 				connectionManager: &http_conn.HttpConnectionManager{
 					// Append and forward client cert to backend.
 					ForwardClientCertDetails: http_conn.APPEND_FORWARD,
-					ServerName:               EnvoyServerName,
+					SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
+						Subject: &google_protobuf.BoolValue{Value: true},
+						Uri:     true,
+						Dns:     true,
+					},
+					ServerName: EnvoyServerName,
 				},
 			}
 			// See https://github.com/grpc/grpc-web/tree/master/net/grpc/gateway/examples/helloworld#configure-the-proxy

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -145,6 +145,9 @@ func testInboundListenerConfig(t *testing.T, services ...*model.Service) {
 		t.Fatal("expected HTTP listener, found TCP")
 	}
 	verifyInboundHTTPListenerServerName(t, listeners[0])
+	if isHTTPListener(listeners[0]) {
+		verifyInboundHTTPListenerCertDetails(t, listeners[0])
+	}
 }
 
 func verifyOutboundTCPListenerHostname(t *testing.T, l *xdsapi.Listener, hostname model.Hostname) {
@@ -178,6 +181,30 @@ func verifyInboundHTTPListenerServerName(t *testing.T, l *xdsapi.Listener) {
 	serverName := f.GetConfig().Fields["server_name"].GetStringValue()
 	if serverName != expectedServerName {
 		t.Fatalf("expected listener to contain server_name %s, found %s", expectedServerName, serverName)
+	}
+}
+
+func verifyInboundHTTPListenerCertDetails(t *testing.T, l *xdsapi.Listener) {
+	t.Helper()
+	if len(l.FilterChains) != 1 {
+		t.Fatalf("expected %d filter chains, found %d", 1, len(l.FilterChains))
+	}
+	fc := l.FilterChains[0]
+	if len(fc.Filters) != 1 {
+		t.Fatalf("expected %d filters, found %d", 1, len(fc.Filters))
+	}
+	f := fc.Filters[0]
+	forwardDetails, expected := f.GetConfig().Fields["forward_client_cert_details"].GetStringValue(), "APPEND_FORWARD"
+	if forwardDetails != expected {
+		t.Fatalf("expected listener to contain forward_client_cert_details %s, found %s", expected, forwardDetails)
+	}
+	setDetails := f.GetConfig().Fields["set_current_client_cert_details"].GetStructValue()
+	subject := setDetails.Fields["subject"].GetBoolValue()
+	dns := setDetails.Fields["dns"].GetBoolValue()
+	uri := setDetails.Fields["uri"].GetBoolValue()
+	if !subject || !dns || !uri {
+		t.Fatalf("expected listener to contain set_current_client_cert_details (subject: true, dns: true, uri: true), "+
+			"found (subject: %t, dns: %t, uri %t)", subject, dns, uri)
 	}
 }
 


### PR DESCRIPTION
> The code added to the sidecar inbound listener in PR #9178 has been removed - mistakenly, I believe - by #9016. Here is the diff.

Thanks to @somcsel for catching this, I included a unit test to catch and prevent this in the future. for more background about this code, see #8263

Signed-off-by: Yangmin Zhu <ymzhu@google.com>