### PR TITLE
Add TCP sentinel metrics to dashboard e2e test

### DIFF
--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -586,8 +586,8 @@ func waitForMetricsInPrometheus(t *testing.T) error {
 		`round(sum(irate(istio_requests_total[1m])), 0.001)`,
 		`sum(irate(istio_requests_total{response_code=~"4.*"}[1m]))`,
 		`sum(irate(istio_requests_total{response_code=~"5.*"}[1m]))`,
-		`sum(rate(istio_tcp_received_bytes_total{reporter="source"}[1m])`,
-		`sum(rate(istio_tcp_sent_bytes_total{reporter="source"}[1m])`,
+		`istio_tcp_received_bytes_total{reporter="source"}`,
+		`istio_tcp_sent_bytes_total{reporter="source"}`,
 	}
 
 	for _, duration := range waitDurations {

--- a/tests/e2e/tests/dashboard/dashboard_test.go
+++ b/tests/e2e/tests/dashboard/dashboard_test.go
@@ -586,6 +586,8 @@ func waitForMetricsInPrometheus(t *testing.T) error {
 		`round(sum(irate(istio_requests_total[1m])), 0.001)`,
 		`sum(irate(istio_requests_total{response_code=~"4.*"}[1m]))`,
 		`sum(irate(istio_requests_total{response_code=~"5.*"}[1m]))`,
+		`sum(rate(istio_tcp_received_bytes_total{reporter="source"}[1m])`,
+		`sum(rate(istio_tcp_sent_bytes_total{reporter="source"}[1m])`,
 	}
 
 	for _, duration := range waitDurations {


### PR DESCRIPTION
the dashboard e2e test has recently started behaving in a flaky manner. Guess is that something about the recent switch to MCP has indirectly lead to the flakes, particularly (it appears) as related to TCP metrics. This PR adds TCP metrics to the sentinel metrics to allow for flexibility in metric generation. This should backoff the main tests until the metrics appear (or just fail completely).