### PR TITLE
Restore e2e-dashboard test to CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,6 +829,9 @@ workflows:
       - e2e-simple:
           requires:
             - build
+      - e2e-dashboard:
+          requires:
+            - build
       - racetest:
           requires:
             - test


### PR DESCRIPTION
This test should be run in all environments. It runs fast and is reliable (https://k8s-testgrid.appspot.com/istio-presubmits#circleci-e2e-dashboard). Having it on both build systems will allow earlier catching of issues where the install artifacts drift across CI systems, etc.