### PR TITLE
fix prometheus service-account name so it follows naming conventions

### DIFF
--- a/install/kubernetes/helm/subcharts/prometheus/templates/clusterrolebindings.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/clusterrolebindings.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: prometheus-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: prometheus
+  name: prometheus-service-account
   namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
-      serviceAccountName: prometheus
+      serviceAccountName: prometheus-service-account
 {{- if .Values.global.priorityClassName }}
       priorityClassName: "{{ .Values.global.priorityClassName }}"
 {{- end }}

--- a/install/kubernetes/helm/subcharts/prometheus/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: prometheus
+  name: prometheus-service-account
   namespace: {{ .Release.Namespace }}
   labels:
     app: prometheus


### PR DESCRIPTION
to follow the convention, name the service account with the suffix "-service-account" - other SA names follow this convention, thus prometheus should, too.