### PR TITLE
configure add-ons with https in front

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/values.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/values.yaml
@@ -47,16 +47,16 @@ istio-ingressgateway:
   ## Disable if not needed
   - port: 15029
     targetPort: 15029
-    name: http-kiali
+    name: https-kiali
   - port: 15030
     targetPort: 15030
-    name: http2-prometheus
+    name: https-prometheus
   - port: 15031
     targetPort: 15031
-    name: http2-grafana
+    name: https-grafana
   - port: 15032
     targetPort: 15032
-    name: http2-tracing
+    name: https-tracing
     # This is the port where sni routing happens
   - port: 15443
     targetPort: 15443

--- a/install/kubernetes/helm/subcharts/grafana/templates/gateway.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/gateway.yaml
@@ -15,8 +15,12 @@ spec:
   servers:
   - port:
       number: 15031
-      name: http2-grafana
-      protocol: HTTP2
+      name: https-grafana
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/certs/cert-chain.pem
+      privateKey: /etc/certs/key.pem
     hosts:
     - "*"
 ---

--- a/install/kubernetes/helm/subcharts/kiali/templates/gateway.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/gateway.yaml
@@ -15,8 +15,12 @@ spec:
   servers:
   - port:
       number: 15029
-      name: http-kiali
-      protocol: HTTP
+      name: https-kiali
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/certs/cert-chain.pem
+      privateKey: /etc/certs/key.pem
     hosts:
     - "*"
 ---

--- a/install/kubernetes/helm/subcharts/prometheus/templates/gateway.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/gateway.yaml
@@ -15,8 +15,12 @@ spec:
   servers:
   - port:
       number: 15030
-      name: http2-prometheus
-      protocol: HTTP2
+      name: https-prometheus
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/certs/cert-chain.pem
+      privateKey: /etc/certs/key.pem
     hosts:
     - "*"
 ---

--- a/install/kubernetes/helm/subcharts/tracing/templates/gateway.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/gateway.yaml
@@ -10,8 +10,12 @@ spec:
   servers:
   - port:
       number: 15032
-      name: http2-tracing
-      protocol: HTTP2
+      name: https-tracing
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/certs/cert-chain.pem
+      privateKey: /etc/certs/key.pem
     hosts:
     - "*"
 ---


### PR DESCRIPTION
This is just a quick stab at a first attempt to see if we can easily get https in front of all add-ons, without requiring the add-on apps themselves to each individually be configured with https support.

The certs used are the ones assigned to the istio-ingressgateway.

This PR is built on top of PR: https://github.com/istio/istio/pull/10349

I did a quick test and it is working. Of course, the http client/browser needs to be told to accept the unknown trusting CA authority. That is probably going to be another incremental addition we'll want to implement later - how to provide a true, valid CA authority cert.

We can always close this PR if we don't like it, but at minimum it provides an example of how it can be done. 

Here's the results. You can see that when accessing any add-on URL via http, it fails. Accessing with https succeeds:

```
#####################
# PROMETHEUS

$ echo prometheus url is https://$(minikube ip):$(kubectl -n istio-system get service istio-ingressgateway -o 'jsonpath={.spec.ports[?(@.name=="https-prometheus")].nodePort}')
prometheus url is https://192.168.99.100:30434

# This shows successful https access (http code that curl received was 200)
$ curl -ksw '%{http_code}\n' -o /dev/null https://192.168.99.100:30434/graph
200

# This shows you cannot get to it via http
$ curl -kw '%{http_code}\n' http://192.168.99.100:30434/graph
000
curl: (56) Recv failure: Connection reset by peer

#####################
# GRAFANA

$ echo grafana url is https://$(minikube ip):$(kubectl -n istio-system get service istio-ingressgateway -o 'jsonpath={.spec.ports[?(@.name=="https-grafana")].nodePort}')
grafana url is https://192.168.99.100:31132

$ curl -ksw '%{http_code}\n' -o /dev/null https://192.168.99.100:31132
200

$ curl -kw '%{http_code}\n' http://192.168.99.100:31132
000
curl: (56) Recv failure: Connection reset by peer

#####################
# JAEGER

$ echo jaeger url is https://$(minikube ip):$(kubectl -n istio-system get service istio-ingressgateway -o 'jsonpath={.spec.ports[?(@.name=="https-tracing")].nodePort}')
jaeger url is https://192.168.99.100:30640

$ curl -ksw '%{http_code}\n' -o /dev/null https://192.168.99.100:30640
200

$ curl -kw '%{http_code}\n' http://192.168.99.100:30640
000
curl: (56) Recv failure: Connection reset by peer

#####################
# KIALI

$ echo kiali url is https://$(minikube ip):$(kubectl -n istio-system get service istio-ingressgateway -o 'jsonpath={.spec.ports[?(@.name=="https-kiali")].nodePort}')
kiali url is https://192.168.99.100:31368

$ curl -ksw '%{http_code}\n' -o /dev/null https://192.168.99.100:31368/kiali/console
200

$ curl -kw '%{http_code}\n' http://192.168.99.100:31368
000
curl: (56) Recv failure: Connection reset by peer
```