### PR TITLE
Set the full external client TLS cert in the XFCC header

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -318,6 +318,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 					ForwardClientCertDetails: http_conn.SANITIZE_SET,
 					SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 						Subject: proto.BoolTrue,
+						Cert:    true,
 						Uri:     true,
 						Dns:     true,
 					},
@@ -346,6 +347,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 						ForwardClientCertDetails: http_conn.SANITIZE_SET,
 						SetCurrentClientCertDetails: &http_conn.HttpConnectionManager_SetCurrentClientCertDetails{
 							Subject: proto.BoolTrue,
+							Cert:    true,
 							Uri:     true,
 							Dns:     true,
 						},


### PR DESCRIPTION
Configure the Ingress Gateway's Envoy proxy to include the full client
TLS certificate data inside the X-Forwarded-Client-Cert HTTP header.

Fixes #10395 