### PR TITLE
set meshconfig.sdsUseK8sSaJwt through sds helm value

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -194,7 +194,7 @@ data:
         {{- if .Values.global.sds.enabled }}
         - mountPath: /var/run/sds
           name: sds-uds-path
-        {{- if .Values.global.sds.enableTokenMount }}
+        {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
@@ -204,7 +204,7 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.enableTokenMount }}
+      {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
       - name: istio-token
         projected:
           sources:

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -170,7 +170,7 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.useK8sSATrustworthyJwt }}
           runAsGroup: 1337
           {{- end }}
           runAsUser: 1337

--- a/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/sidecar-injector-configmap.yaml
@@ -170,7 +170,7 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.useK8sSATrustworthyJwt }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
           runAsGroup: 1337
           {{- end }}
           runAsUser: 1337
@@ -194,7 +194,7 @@ data:
         {{- if .Values.global.sds.enabled }}
         - mountPath: /var/run/sds
           name: sds-uds-path
-        {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
+        {{- if .Values.global.sds.useTrustworthyJwt }}
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
@@ -204,7 +204,7 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
+      {{- if .Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -258,8 +258,8 @@ global:
   sds:
     enabled: false
     udsPath: ""
-    useK8sSATrustworthyJwt: false
-    useK8sSANormalJwt: false
+    useTrustworthyJwt: false
+    useNormalJwt: false
 
   # Sets an identifier for the remote network to be used for Split Horizon EDS. The network will be sent
   # to the Pilot when connected by the sidecar and will affect the results returned in EDS requests.

--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -258,7 +258,8 @@ global:
   sds:
     enabled: false
     udsPath: ""
-    enableTokenMount: false
+    useK8sSATrustworthyJwt: false
+    useK8sSANormalJwt: false
 
   # Sets an identifier for the remote network to be used for Split Horizon EDS. The network will be sent
   # to the Pilot when connected by the sidecar and will affect the results returned in EDS requests.

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -60,7 +60,7 @@ data:
     # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount 
     # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which 
     # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
-    enableSdsTokenMount: {{ .Values.global.sds.useK8sSATrustworthyJwt }}
+    enableSdsTokenMount: {{ .Values.global.sds.useTrustworthyJwt }}
 
     # This flag is used by secret discovery service(SDS). 
     # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token' 
@@ -68,7 +68,7 @@ data:
     # and pass to sds server, which will be used to request key/cert eventually. 
     # this flag is ignored if enableSdsTokenMount is set.
     # This isn't supported for non-k8s case.
-    sdsUseK8sSaJwt: {{ .Values.global.sds.useK8sSANormalJwt }}
+    sdsUseK8sSaJwt: {{ .Values.global.sds.useNormalJwt }}
 
     # The trust domain corresponds to the trust root of a system.
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -60,7 +60,15 @@ data:
     # If set to true(prerequisite: https://kubernetes.io/docs/concepts/storage/volumes/#projected), Istio will inject volumes mount 
     # for k8s service account JWT, so that K8s API server mounts k8s service account JWT to envoy container, which 
     # will be used to generate key/cert eventually. This isn't supported for non-k8s case.
-    enableSdsTokenMount: {{ .Values.global.sds.enableTokenMount }}
+    enableSdsTokenMount: {{ .Values.global.sds.useK8sSATrustworthyJwt }}
+
+    # This flag is used by secret discovery service(SDS). 
+    # If set to true, envoy will fetch normal k8s service account JWT from '/var/run/secrets/kubernetes.io/serviceaccount/token' 
+    # (https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) 
+    # and pass to sds server, which will be used to request key/cert eventually. 
+    # this flag is ignored if enableSdsTokenMount is set.
+    # This isn't supported for non-k8s case.
+    sdsUseK8sSaJwt: {{ .Values.global.sds.useK8sSANormalJwt }}
 
     # The trust domain corresponds to the trust root of a system.
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -202,7 +202,7 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.enableTokenMount }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.useK8sSATrustworthyJwt }}
           runAsGroup: 1337
           {{- end }}
           runAsUser: 1337

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -226,7 +226,7 @@ data:
         {{- if .Values.global.sds.enabled }}
         - mountPath: /var/run/sds
           name: sds-uds-path
-        {{- if .Values.global.sds.enableTokenMount }}
+        {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
@@ -241,7 +241,7 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.enableTokenMount }}
+      {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
       - name: istio-token
         projected:
           sources:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -202,7 +202,7 @@ data:
             - NET_ADMIN
           runAsGroup: 1337
           {{ "[[ else -]]" }}
-          {{ if and .Values.global.sds.enabled .Values.global.sds.useK8sSATrustworthyJwt }}
+          {{ if and .Values.global.sds.enabled .Values.global.sds.useTrustworthyJwt }}
           runAsGroup: 1337
           {{- end }}
           runAsUser: 1337
@@ -226,7 +226,7 @@ data:
         {{- if .Values.global.sds.enabled }}
         - mountPath: /var/run/sds
           name: sds-uds-path
-        {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
+        {{- if .Values.global.sds.useTrustworthyJwt }}
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
@@ -241,7 +241,7 @@ data:
       - name: sds-uds-path
         hostPath:
           path: /var/run/sds
-      {{- if .Values.global.sds.useK8sSATrustworthyJwt }}
+      {{- if .Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -348,7 +348,8 @@ global:
     # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.
     enabled: false
     udsPath: ""
-    enableTokenMount: false
+    useK8sSATrustworthyJwt: false
+    useK8sSANormalJwt: false
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   # 

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -348,8 +348,8 @@ global:
     # distributed through the SecretDiscoveryService instead of using K8S secrets to mount the certificates.
     enabled: false
     udsPath: ""
-    useK8sSATrustworthyJwt: false
-    useK8sSANormalJwt: false
+    useTrustworthyJwt: false
+    useNormalJwt: false
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   # 

--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -162,7 +162,7 @@ spec:
           {{- if $.Values.global.sds.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
-          {{- if $.Values.global.sds.useK8sSATrustworthyJwt }}
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
           {{- end }}
@@ -183,7 +183,7 @@ spec:
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
-      {{- if $.Values.global.sds.useK8sSATrustworthyJwt }}
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
       - name: istio-token
         projected:
           sources:

--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -162,7 +162,7 @@ spec:
           {{- if $.Values.global.sds.enabled }}
           - name: sdsudspath
             mountPath: /var/run/sds
-          {{- if $.Values.global.sds.enableTokenMount }}
+          {{- if $.Values.global.sds.useK8sSATrustworthyJwt }}
           - name: istio-token
             mountPath: /var/run/secrets/tokens
           {{- end }}
@@ -183,7 +183,7 @@ spec:
       - name: sdsudspath
         hostPath:
           path: /var/run/sds
-      {{- if $.Values.global.sds.enableTokenMount }}
+      {{- if $.Values.global.sds.useK8sSATrustworthyJwt }}
       - name: istio-token
         projected:
           sources:


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

if ```sds.useK8sSATrustworthyJwt``` is set, use trustworthy jwt to request key/cert, which is the preferred way but only avaiable in k8s 1.12 or later; fallback to if ```sds.useK8sSANormalJwt``` is set, use normal k8s sa jwt to request key/cert.

also do some renaming in this pr
