### PR TITLE
handle envoy timed drain

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -290,6 +291,9 @@ var (
 			stop := make(chan struct{})
 			cmd.WaitSignal(stop)
 			<-stop
+			http.Post(fmt.Sprintf("http://127.0.0.1:%d/healthcheck/fail", proxyAdminPort), "", nil)
+			// TODO: support global configuration
+			time.Sleep(30 * time.Second)
 			return nil
 		},
 	}


### PR DESCRIPTION
As @mattklein123  https://github.com/envoyproxy/envoy/issues/1990#issuecomment-341509716 said

```
At Lyft we just do a timed drain. Roughly our process manager does:

Get shutdown notice
/healthcheck/fail
Wait X time
Shutdown
```