### PR TITLE
Run the first checkAndUpdate also asynchronously

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -94,7 +94,6 @@ const (
 	// URL types supported by the config store
 	// example fs:///tmp/configroot
 	fsScheme = "fs"
-	mcpScheme = "mcp"
 )
 
 var (
@@ -548,10 +547,6 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			}
 			configStores = append(configStores, configController)
 			continue
-		}
-
-		if url.Scheme == mcpScheme{
-			configSource.Address = url.Host
 		}
 
 		securityOption := grpc.WithInsecure()

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -94,6 +94,7 @@ const (
 	// URL types supported by the config store
 	// example fs:///tmp/configroot
 	fsScheme = "fs"
+	mcpScheme = "mcp"
 )
 
 var (
@@ -547,6 +548,10 @@ func (s *Server) initMCPConfigController(args *PilotArgs) error {
 			}
 			configStores = append(configStores, configController)
 			continue
+		}
+
+		if url.Scheme == mcpScheme{
+			configSource.Address = url.Host
 		}
 
 		securityOption := grpc.WithInsecure()

--- a/pilot/pkg/config/monitor/monitor.go
+++ b/pilot/pkg/config/monitor/monitor.go
@@ -52,7 +52,7 @@ func NewMonitor(name string, delegateStore model.ConfigStore, checkInterval time
 // and updates the controller. It then kicks off an asynchronous event loop that
 // periodically polls the getSnapshotFunc for changes until a close event is sent.
 func (m *Monitor) Start(stop <-chan struct{}) {
-	m.checkAndUpdate()
+	go m.checkAndUpdate()
 	tick := time.NewTicker(m.checkDuration)
 
 	// Run the close loop asynchronously.


### PR DESCRIPTION
When there are more than BufferSize (100) resources in the
file system, the first call will fill up the event channel
and block. Thus the server won't start properly.

Co-authored-by: Holger Oehm <holger.oehm@sap.com>