### PR TITLE
mixerplugin: deprecate attribute_for_mixer_proxy

### DIFF
--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -66,6 +66,9 @@ type TestSetup struct {
 
 	// AccessLogPath is the access log path for Envoy
 	AccessLogPath string
+
+	// expected source.uid attribute at the mixer gRPC metadata
+	mixerSourceUID string
 }
 
 // NewTestSetup creates a new test setup
@@ -170,6 +173,11 @@ func (s *TestSetup) SetNoBackend(no bool) {
 	s.noBackend = no
 }
 
+// SetMixerSourceUID sets the expected source.uid at the mixer server gRPC metadata
+func (s *TestSetup) SetMixerSourceUID(uid string) {
+	s.mixerSourceUID = uid
+}
+
 // SetUp setups Envoy, Mixer, and Backend server for test.
 func (s *TestSetup) SetUp() error {
 	var err error
@@ -185,7 +193,7 @@ func (s *TestSetup) SetUp() error {
 	}
 
 	if !s.noMixer {
-		s.mixer, err = NewMixerServer(s.ports.MixerPort, s.stress, s.checkDict)
+		s.mixer, err = NewMixerServer(s.ports.MixerPort, s.stress, s.checkDict, s.mixerSourceUID)
 		if err != nil {
 			log.Printf("unable to create mixer server %v", err)
 		} else {

--- a/mixer/test/client/pilotplugin/pilotplugin_test.go
+++ b/mixer/test/client/pilotplugin/pilotplugin_test.go
@@ -49,6 +49,10 @@ admin:
 node:
   id: id
   cluster: unknown
+  metadata:
+    # these two must come together and they need to be set
+    NODE_UID: pod.ns
+    NODE_NAMESPACE: ns
 dynamic_resources:
   lds_config: { ads: {} }
   ads_config:
@@ -267,6 +271,8 @@ func TestPilotPlugin(t *testing.T) {
 	}()
 	defer grpcServer.GracefulStop()
 
+	s.SetMixerSourceUID("pod.ns")
+
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
@@ -331,9 +337,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod1.ns2",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
 		Push:            &pushContext,
@@ -344,9 +347,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		Service: &svc,
 		Push:    &pushContext,

--- a/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
+++ b/mixer/test/client/pilotplugin_mtls/pilotplugin_mtls_test.go
@@ -352,9 +352,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod1.ns2",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
 		Push:            &pushContext,
@@ -365,9 +362,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		Service: &svc,
 		Push:    &pushContext,

--- a/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
+++ b/mixer/test/client/pilotplugin_tcp/pilotplugin_tcp_test.go
@@ -47,6 +47,10 @@ admin:
 node:
   id: id
   cluster: unknown
+  metadata:
+    # these two must come together and they need to be set
+    NODE_UID: pod.ns
+    NODE_NAMESPACE: ns
 dynamic_resources:
   lds_config: { ads: {} }
   ads_config:
@@ -143,6 +147,8 @@ func TestPilotPluginTCP(t *testing.T) {
 	}()
 	defer grpcServer.GracefulStop()
 
+	s.SetMixerSourceUID("pod.ns")
+
 	if err := s.SetUp(); err != nil {
 		t.Fatalf("Failed to setup test: %v", err)
 	}
@@ -208,9 +214,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod1.ns1",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		ServiceInstance: &model.ServiceInstance{Service: &svc},
 		Push:            &pushContext,
@@ -221,9 +224,6 @@ var (
 		Node: &model.Proxy{
 			ID:   "pod2.ns2",
 			Type: model.Sidecar,
-			Metadata: map[string]string{
-				"ISTIO_PROXY_VERSION": "1.1",
-			},
 		},
 		Service: &svc,
 		Push:    &pushContext,

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -114,13 +114,13 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 
 	switch in.ListenerProtocol {
 	case plugin.ListenerProtocolHTTP:
-		filter := buildInboundHTTPFilter(in.Env.Mesh, in.Node, attrs)
+		filter := buildInboundHTTPFilter(in.Env.Mesh, attrs)
 		for cnum := range mutable.FilterChains {
 			mutable.FilterChains[cnum].HTTP = append(mutable.FilterChains[cnum].HTTP, filter)
 		}
 		return nil
 	case plugin.ListenerProtocolTCP:
-		filter := buildInboundTCPFilter(in.Env.Mesh, in.Node, attrs)
+		filter := buildInboundTCPFilter(in.Env.Mesh, attrs)
 		for cnum := range mutable.FilterChains {
 			mutable.FilterChains[cnum].TCP = append(mutable.FilterChains[cnum].TCP, filter)
 		}
@@ -224,7 +224,7 @@ func buildOutboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node
 	}
 }
 
-func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, node *model.Proxy, attrs attributes) *http_conn.HttpFilter {
+func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes) *http_conn.HttpFilter {
 	return &http_conn.HttpFilter{
 		Name: mixer,
 		ConfigType: &http_conn.HttpFilter_Config{
@@ -323,7 +323,7 @@ func buildOutboundTCPFilter(mesh *meshconfig.MeshConfig, attrsIn attributes, nod
 	}
 }
 
-func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, node *model.Proxy, attrs attributes) listener.Filter {
+func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, attrs attributes) listener.Filter {
 	return listener.Filter{
 		Name: mixer,
 		ConfigType: &listener.Filter_Config{


### PR DESCRIPTION
 It turns out that attributes_for_mixer_proxy has been de-facto broken since around https://github.com/istio/proxy/pull/1961 

This PR removes it since it doesn't work, and replaces with NODE_UID and NODE_NAMESPACE per new style.

It also adds an integration test exercising the code path in envoy.

/cc @mandarjog 
/cc @douglas-reid 

Signed-off-by: Kuat Yessenov <kuat@google.com>