### PR TITLE
Remove the explicit accesslist file from Galley.

### DIFF
--- a/galley/pkg/server/configmap.go
+++ b/galley/pkg/server/configmap.go
@@ -26,8 +26,6 @@ import (
 	"istio.io/istio/pkg/mcp/server"
 )
 
-type MCPCheckMode bool
-
 type accessList struct {
 	IsBlackList bool
 	Allowed     []string

--- a/galley/pkg/server/configmap_test.go
+++ b/galley/pkg/server/configmap_test.go
@@ -44,6 +44,48 @@ allowed:
 	}
 }
 
+func TestWatchAccessList_Exists_ButRemoved(t *testing.T) {
+	removed := make(chan string, 10)
+	var fake *filewatcher.FakeWatcher
+	newFileWatcher, fake = filewatcher.NewFakeWatcher(func(path string, _ bool) { removed <- path })
+	defer func() {
+		newFileWatcher = filewatcher.NewWatcher
+		readFile = ioutil.ReadFile
+		watchEventHandledProbe = nil
+	}()
+
+	// No Pilot
+	initial := `
+allowed:
+    - spiffe://cluster.local/ns/istio-system/sa/istio-mixer-service-account
+`
+
+	file, stopCh, checker, err := setupWatchAccessList(t, initial)
+	defer close(stopCh)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if err = os.Remove(file); err != nil {
+		t.Fatalf("Unexpected error deleting file: %v", err)
+	}
+
+	// fake the watch `Write` event and wait for the event to be handled and the accesslist updated.
+	watchEventHandled := make(chan struct{})
+	watchEventHandledProbe = func() { close(watchEventHandled) }
+	fake.InjectEvent(file, fsnotify.Event{
+		Name: file,
+		Op:   fsnotify.Remove,
+	})
+	<-watchEventHandled
+
+	// Check Pilot
+	if !checker.Allowed("spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account") {
+		t.Fatal("Expected spiffe id to be allowed.")
+	}
+}
+
 func TestWatchAccessList_Initial_Unparseable(t *testing.T) {
 	initial := `
 332332
@@ -67,8 +109,71 @@ func TestWatchAccessList_Initial_NotExists(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	if _, err = watchAccessList(stopCh, file); err == nil {
-		t.Fatalf("expected error not found")
+	checker, err := watchAccessList(stopCh, file)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// We expect the request to go through.
+	if !checker.Allowed("spiffe://foo/bar/baz/goo") {
+		t.Fatal("Expected spiffe id to be allowed.")
+	}
+}
+
+func TestWatchAccessList_Initial_NotExists_ButAdded(t *testing.T) {
+	added := make(chan string, 10)
+	var fake *filewatcher.FakeWatcher
+	newFileWatcher, fake = filewatcher.NewFakeWatcher(func(path string, _ bool) { added <- path })
+	defer func() {
+		newFileWatcher = filewatcher.NewWatcher
+		readFile = ioutil.ReadFile
+		watchEventHandledProbe = nil
+	}()
+
+	folder, err := ioutil.TempDir(os.TempDir(), "testWatchAccessList")
+	file := path.Join(folder, "accesslist.yaml")
+
+	if err != nil {
+		t.Fatalf("error creating tmp folder: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	checker, err := watchAccessList(stopCh, file)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// We expect the request to go through.
+	if !checker.Allowed("spiffe://foo/bar/baz/goo") {
+		t.Fatal("Expected spiffe id to be allowed.")
+	}
+
+	updated := `
+allowed:
+    - spiffe://cluster.local/ns/istio-system/sa/istio-pilot-service-account
+`
+
+	// inject the updated file read into the watcher
+	readFile = func(filename string) ([]byte, error) {
+		if filename != file {
+			t.Fatalf("read wrong filename: got %v want %v", filename, file)
+		}
+		return []byte(updated), nil
+	}
+
+	// fake the watch `Write` event and wait for the event to be handled and the accesslist updated.
+	watchEventHandled := make(chan struct{})
+	watchEventHandledProbe = func() { close(watchEventHandled) }
+	fake.InjectEvent(file, fsnotify.Event{
+		Name: file,
+		Op:   fsnotify.Create,
+	})
+	<-watchEventHandled
+
+	// We expect the request to go through.
+	if checker.Allowed("spiffe://foo/bar/baz/goo") {
+		t.Fatal("Expected spiffe id to be not allowed.")
 	}
 }
 

--- a/install/kubernetes/helm/subcharts/galley/templates/accesslist.yaml.tpl
+++ b/install/kubernetes/helm/subcharts/galley/templates/accesslist.yaml.tpl
@@ -1,5 +1,0 @@
-{{ define "accesslist.yaml.tpl" }}
-allowed:
-    - spiffe://cluster.local/ns/{{ .Release.Namespace }}/sa/istio-mixer-service-account
-    - spiffe://cluster.local/ns/{{ .Release.Namespace }}/sa/istio-pilot-service-account
-{{- end }}

--- a/install/kubernetes/helm/subcharts/galley/templates/configmap.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/configmap.yaml
@@ -12,5 +12,3 @@ metadata:
 data:
   validatingwebhookconfiguration.yaml: |-
     {{- include "validatingwebhookconfiguration.yaml.tpl" . | indent 4}}
-  accesslist.yaml: |-
-    {{- include "accesslist.yaml.tpl" . | indent 4}}

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -110,11 +110,23 @@ func (w *fsNotifyWatcher) Add(path string) error {
 		return err
 	}
 
-	md5Sum, err := getMd5Sum(cleanedPath)
-	if err != nil {
-		watcher.Close()
-		return fmt.Errorf("failed to get md5 sum for %s: %v", path, err)
+	var md5Sum string
+
+	if _, err = os.Stat(cleanedPath); err == nil {
+		md5Sum, err = getMd5Sum(cleanedPath)
+		if err != nil {
+			watcher.Close()
+			return fmt.Errorf("failed to get md5 sum for %s: %v", path, err)
+		}
+	} else {
+		if !os.IsNotExist(err) {
+			watcher.Close()
+			return fmt.Errorf("failed to stat file: %s: %v", path, err)
+		}
+
+		// if the file doesn't exist, ignore the md5 sum.
 	}
+
 	wk := &worker{
 		watcher: watcher,
 		watchedFiles: map[string]*fileTracker{

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -190,10 +190,8 @@ func TestWatchFile(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		// Given a file being watched
-		watchFile, cleanup := newWatchFile(t)
+		watchFile, cleanup := newWatchFileThatDoesNotExist(t)
 		defer cleanup()
-		_, err := os.Stat(watchFile)
-		g.Expect(err).NotTo(HaveOccurred())
 
 		w := NewWatcher()
 		w.Add(watchFile)
@@ -209,7 +207,7 @@ func TestWatchFile(t *testing.T) {
 		}()
 
 		// Overwriting the file and waiting its event to be received.
-		err = ioutil.WriteFile(watchFile, []byte("foo: baz\n"), 0640)
+		err := ioutil.WriteFile(watchFile, []byte("foo: baz\n"), 0640)
 		g.Expect(err).NotTo(HaveOccurred())
 		wg.Wait()
 	})

--- a/pkg/filewatcher/filewatcher_test.go
+++ b/pkg/filewatcher/filewatcher_test.go
@@ -44,6 +44,21 @@ func newWatchFile(t *testing.T) (string, func()) {
 	return watchFile, cleanup
 }
 
+func newWatchFileThatDoesNotExist(t *testing.T) (string, func()) {
+	g := NewGomegaWithT(t)
+
+	watchDir, err := ioutil.TempDir("", "")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	watchFile := path.Join(watchDir, "test.conf")
+
+	cleanup := func() {
+		os.RemoveAll(watchDir)
+	}
+
+	return watchFile, cleanup
+}
+
 // newTwoWatchFile returns with two watch files that exist in the same base dir.
 func newTwoWatchFile(t *testing.T) (string, string, func()) {
 	g := NewGomegaWithT(t)
@@ -168,6 +183,34 @@ func TestWatchFile(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		// Wait its event to be received.
+		wg.Wait()
+	})
+
+	t.Run("file added later", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// Given a file being watched
+		watchFile, cleanup := newWatchFile(t)
+		defer cleanup()
+		_, err := os.Stat(watchFile)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		w := NewWatcher()
+		w.Add(watchFile)
+		events := w.Events(watchFile)
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			select {
+			case <-events:
+				wg.Done()
+			}
+		}()
+
+		// Overwriting the file and waiting its event to be received.
+		err = ioutil.WriteFile(watchFile, []byte("foo: baz\n"), 0640)
+		g.Expect(err).NotTo(HaveOccurred())
 		wg.Wait()
 	})
 }

--- a/pkg/mcp/server/listchecker.go
+++ b/pkg/mcp/server/listchecker.go
@@ -27,8 +27,14 @@ import (
 	"istio.io/istio/security/pkg/pki/util"
 )
 
+// AllowAllChecker is a simple auth checker that allows all requests.
+type AllowAllChecker struct{}
+
 // NewAllowAllChecker creates a new AllowAllChecker.
-func NewAllowAllChecker() AuthChecker { return &ListAuthChecker{mode: AuthBlackList} }
+func NewAllowAllChecker() AuthChecker { return &AllowAllChecker{} }
+
+// Check is an implementation of AuthChecker.Check that allows all check requests.
+func (*AllowAllChecker) Check(credentials.AuthInfo) error { return nil }
 
 // AuthListMode indicates the list checking mode
 type AuthListMode bool

--- a/pkg/mcp/server/listchecker.go
+++ b/pkg/mcp/server/listchecker.go
@@ -17,6 +17,7 @@ package server
 import (
 	"crypto/x509/pkix"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -26,17 +27,23 @@ import (
 	"istio.io/istio/security/pkg/pki/util"
 )
 
-// AllowAllChecker is a simple auth checker that allows all requests.
-type AllowAllChecker struct{}
-
 // NewAllowAllChecker creates a new AllowAllChecker.
-func NewAllowAllChecker() AuthChecker { return &AllowAllChecker{} }
+func NewAllowAllChecker() AuthChecker { return &ListAuthChecker{mode: AuthBlackList} }
 
-// Check is an implementation of AuthChecker.Check that allows all check requests.
-func (*AllowAllChecker) Check(credentials.AuthInfo) error { return nil }
+// AuthListMode indicates the list checking mode
+type AuthListMode bool
+
+const (
+	// AuthBlackList indicates that the list should work as a black list
+	AuthBlackList AuthListMode = false
+
+	// AuthWhiteList indicates that the list should work as a white list
+	AuthWhiteList AuthListMode = true
+)
 
 // ListAuthChecker implements AuthChecker function and is backed by a set of ids.
 type ListAuthChecker struct {
+	mode     AuthListMode
 	idsMutex sync.RWMutex
 	ids      map[string]struct{}
 
@@ -49,12 +56,13 @@ var _ AuthChecker = &ListAuthChecker{}
 // NewListAuthChecker returns a new instance of ListAuthChecker
 func NewListAuthChecker() *ListAuthChecker {
 	return &ListAuthChecker{
+		mode:         AuthWhiteList,
 		ids:          make(map[string]struct{}),
 		extractIDsFn: util.ExtractIDs,
 	}
 }
 
-// Add the provided id to the list of allowed ids.
+// Add the provided id to the list of ids.
 func (l *ListAuthChecker) Add(id string) {
 	l.idsMutex.Lock()
 	defer l.idsMutex.Unlock()
@@ -62,7 +70,7 @@ func (l *ListAuthChecker) Add(id string) {
 	l.ids[id] = struct{}{}
 }
 
-// Remove the provided id from the list of allowed ids.
+// Remove the provided id from the list of ids.
 func (l *ListAuthChecker) Remove(id string) {
 	l.idsMutex.Lock()
 	defer l.idsMutex.Unlock()
@@ -83,11 +91,30 @@ func (l *ListAuthChecker) Set(ids ...string) {
 	l.ids = newIds
 }
 
+// SetMode sets the list-checking mode for this list.
+func (l *ListAuthChecker) SetMode(mode AuthListMode) {
+	l.idsMutex.Lock()
+	defer l.idsMutex.Unlock()
+	l.mode = mode
+}
+
 // Allowed checks whether the given id is allowed.
 func (l *ListAuthChecker) Allowed(id string) bool {
 	l.idsMutex.RLock()
 	defer l.idsMutex.RUnlock()
 
+	switch l.mode {
+	case AuthWhiteList:
+		return l.contains(id)
+	case AuthBlackList:
+		return !l.contains(id)
+	default:
+		scope.Errorf("Unrecognized list auth check mode encountered: %v", l.mode)
+		return false
+	}
+}
+
+func (l *ListAuthChecker) contains(id string) bool {
 	_, found := l.ids[id]
 	return found
 }
@@ -103,8 +130,17 @@ func (l *ListAuthChecker) String() string {
 
 	sort.Strings(ids)
 
-	result := `Allowed ids:
-`
+	result := ""
+	switch l.mode {
+	case AuthWhiteList:
+		result += "Mode: whitelist\n"
+	case AuthBlackList:
+		result += "Mode: blacklist\n"
+	default:
+		result += "Mode: unknown\n"
+	}
+
+	result += "Known ids:\n"
 	result += strings.Join(ids, "\n")
 
 	return result
@@ -138,13 +174,30 @@ func (l *ListAuthChecker) Check(authInfo credentials.AuthInfo) error {
 			}
 
 			for _, id := range ids {
-				if _, ok := l.ids[id]; ok {
-					scope.Infof("Allowing access from peer with id: %s", id)
-					return nil
+				if l.contains(id) {
+					switch l.mode {
+					case AuthWhiteList:
+						scope.Infof("Allowing access from peer with id: %s", id)
+						return nil
+					case AuthBlackList:
+						scope.Infof("Blocking access from peer with id: %s", id)
+						return fmt.Errorf("id is blacklisted: %s", id)
+					default:
+						scope.Errorf("unrecognized mode in listchecker: %v", l.mode)
+						return fmt.Errorf("unrecognized mode in listchecker: %v", l.mode)
+					}
 				}
 			}
 		}
 	}
 
-	return errors.New("no allowed identity found in peer's authentication info")
+	switch l.mode {
+	case AuthWhiteList:
+		return errors.New("no allowed identity found in peer's authentication info")
+	case AuthBlackList:
+		return nil
+	default:
+		scope.Errorf("unrecognized mode in listchecker: %v", l.mode)
+		return fmt.Errorf("unrecognized mode in listchecker: %v", l.mode)
+	}
 }

--- a/pkg/mcp/server/listchecker_test.go
+++ b/pkg/mcp/server/listchecker_test.go
@@ -47,7 +47,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name:     "empty tlsinfo",
-			mode: AuthWhiteList,
+			mode:     AuthWhiteList,
 			authInfo: credentials.TLSInfo{},
 			err:      "no allowed identity found in peer's authentication info",
 		},
@@ -180,18 +180,18 @@ func (a *authInfo) AuthType() string {
 }
 
 func TestListAuthChecker_Allowed(t *testing.T) {
-	cases := []struct{
-		mode AuthListMode
-		id   string
+	cases := []struct {
+		mode   AuthListMode
+		id     string
 		testid string
 		expect bool
 	}{
-		{ mode: AuthBlackList, testid: "foo", expect: true},
-		{ mode: AuthBlackList, id: "foo", testid: "foo", expect: false},
-		{ mode: AuthBlackList, id: "foo", testid: "bar", expect: true},
-		{ mode: AuthWhiteList, testid: "foo", expect: false},
-		{ mode: AuthWhiteList, id: "foo", testid: "foo", expect: true},
-		{ mode: AuthWhiteList, id: "foo", testid: "bar", expect: false},
+		{mode: AuthBlackList, testid: "foo", expect: true},
+		{mode: AuthBlackList, id: "foo", testid: "foo", expect: false},
+		{mode: AuthBlackList, id: "foo", testid: "bar", expect: true},
+		{mode: AuthWhiteList, testid: "foo", expect: false},
+		{mode: AuthWhiteList, id: "foo", testid: "foo", expect: true},
+		{mode: AuthWhiteList, id: "foo", testid: "bar", expect: false},
 	}
 
 	for i, c := range cases {

--- a/pkg/mcp/server/listchecker_test.go
+++ b/pkg/mcp/server/listchecker_test.go
@@ -28,6 +28,7 @@ import (
 func TestListAuthChecker(t *testing.T) {
 	testCases := []struct {
 		name         string
+		mode         AuthListMode
 		authInfo     credentials.AuthInfo
 		extractIDsFn func(exts []pkix.Extension) ([]string, error)
 		err          string
@@ -46,11 +47,13 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name:     "empty tlsinfo",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{},
 			err:      "no allowed identity found in peer's authentication info",
 		},
 		{
 			name: "empty cert chain",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -59,6 +62,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "error extracting ids",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -69,6 +73,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "id mismatch",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -79,6 +84,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "success",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -88,6 +94,7 @@ func TestListAuthChecker(t *testing.T) {
 		},
 		{
 			name: "removed",
+			mode: AuthWhiteList,
 			authInfo: credentials.TLSInfo{
 				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
 			},
@@ -97,12 +104,34 @@ func TestListAuthChecker(t *testing.T) {
 			remove: true,
 			err:    "no allowed identity found in peer's authentication info",
 		},
+		{
+			name: "blacklist allow",
+			mode: AuthBlackList,
+			authInfo: credentials.TLSInfo{
+				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
+			},
+			extractIDsFn: func(exts []pkix.Extension) ([]string, error) {
+				return []string{}, nil
+			},
+		},
+		{
+			name: "blacklist block",
+			mode: AuthBlackList,
+			authInfo: credentials.TLSInfo{
+				State: tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{{}}}},
+			},
+			extractIDsFn: func(exts []pkix.Extension) ([]string, error) {
+				return []string{"foo"}, nil
+			},
+			err: "id is blacklisted: foo",
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 
 			c := NewListAuthChecker()
+			c.SetMode(testCase.mode)
 			if testCase.extractIDsFn != nil {
 				c.extractIDsFn = testCase.extractIDsFn
 			}
@@ -148,4 +177,56 @@ var _ credentials.AuthInfo = &authInfo{}
 
 func (a *authInfo) AuthType() string {
 	return ""
+}
+
+func TestListAuthChecker_Allowed(t *testing.T) {
+	cases := []struct{
+		mode AuthListMode
+		id   string
+		testid string
+		expect bool
+	}{
+		{ mode: AuthBlackList, testid: "foo", expect: true},
+		{ mode: AuthBlackList, id: "foo", testid: "foo", expect: false},
+		{ mode: AuthBlackList, id: "foo", testid: "bar", expect: true},
+		{ mode: AuthWhiteList, testid: "foo", expect: false},
+		{ mode: AuthWhiteList, id: "foo", testid: "foo", expect: true},
+		{ mode: AuthWhiteList, id: "foo", testid: "bar", expect: false},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			checker := NewListAuthChecker()
+			if c.id != "" {
+				checker.Set(c.id)
+			}
+			checker.SetMode(c.mode)
+
+			result := checker.Allowed(c.testid)
+			if result != c.expect {
+				t.Fatalf("Mismatch: Got:%v, Wanted:%v", result, c.expect)
+			}
+		})
+	}
+}
+
+func TestListAuthChecker_String(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Panic detected: %v", r)
+		}
+	}()
+
+	c := NewListAuthChecker()
+	c.SetMode(AuthBlackList)
+
+	c.Set("1", "2", "3")
+
+	// Make sure it doesn't crash
+	_ = c.String()
+
+	c.SetMode(AuthWhiteList)
+
+	// Make sure it doesn't crash
+	_ = c.String()
 }


### PR DESCRIPTION
Remove the explicit access list from Galley.

+ Change the internal logic of the access checking, so that if an access list is not supplied, the default is allow by default.
+ Update the file watcher code, so that it doesn't choke when a file that is requested to be watched does not exist initially.
+ Update the internal list-checker code to use the whitelist/blacklist approach. When a file is not supplied, it acts as an empty blacklist.