### PR TITLE
Add service type for kiali.

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+{{- if .Values.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.loadBalancerIP }}"
+{{- end }}
+  type: {{ .Values.type }}
   ports:
   - name: http-kiali
     protocol: TCP

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -5,6 +5,8 @@ enabled: false
 replicaCount: 1
 hub: docker.io/kiali
 tag: v0.10
+loadBalancerIP: ""
+type: ClusterIP # change to NodePort, ClusterIP or LoadBalancer if need be
 contextPath: /kiali
 ingress:
   enabled: false


### PR DESCRIPTION
Add service type for kiali. 
When using Minikube, user can set kiali's service type to NodePort.