### PR TITLE
Allow prometheus scraper to fetch port outside of sidecar umbrella

### DIFF
--- a/install/kubernetes/helm/subcharts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/configmap.yaml
@@ -233,9 +233,10 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status]
-        action: drop
-        regex: (.+)
+      # Keep target if there's no sidecar or if prometheus.io/scheme is explicitly set to "http"
+      - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_prometheus_io_scheme]
+        action: keep
+        regex: ((;.*)|(.*;http))
       - source_labels: [__meta_kubernetes_pod_annotation_istio_mtls]
         action: drop
         regex: (true)
@@ -275,6 +276,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_annotation_sidecar_istio_io_status, __meta_kubernetes_pod_annotation_istio_mtls]
         action: keep
         regex: (([^;]+);([^;]*))|(([^;]*);(true))
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scheme]
+        action: drop
+        regex: (http)
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
         action: replace
         target_label: __metrics_path__


### PR DESCRIPTION
See issue #10487

- `kubernetes-pods` job is now keeping all targets without sidecar or with explicit `prometheus.io/scheme=http` annotation
- `kubernetes-pods-istio-secure` is now discarding targets with explicit `prometheus.io/scheme=http` annotation