### PR TITLE
WIP: Align certs folder for MCP.

### DIFF
--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -42,10 +42,7 @@ spec:
           - containerPort: 9901
           command:
           - /usr/local/bin/galley
-          - --meshConfigFile=/etc/istio/mesh-config/mesh
-          - --caCertFile=/etc/istio/certs/root-cert.pem
-          - --tlsCertFile=/etc/istio/certs/cert-chain.pem
-          - --tlsKeyFile=/etc/istio/certs/key.pem
+          - --meshConfigFile=/etc/mesh-config/mesh
           - --livenessProbeInterval=1s
           - --livenessProbePath=/healthliveness
           - --readinessProbePath=/healthready
@@ -56,17 +53,17 @@ spec:
           - --insecure=true
 {{- end }}
           - --validation-webhook-config-file
-          - /etc/istio/config/validatingwebhookconfiguration.yaml
+          - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}
           volumeMounts:
           - name: certs
-            mountPath: /etc/istio/certs
+            mountPath: /etc/certs
             readOnly: true
           - name: config
-            mountPath: /etc/istio/config
+            mountPath: /etc/config
             readOnly: true
           - name: mesh-config
-            mountPath: /etc/istio/mesh-config
+            mountPath: /etc/mesh-config
             readOnly: true
           livenessProbe:
             exec:

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -31,9 +31,6 @@
 {{- if $.Values.global.useMCP }}
     {{- if $.Values.global.controlPlaneSecurityEnabled}}
           - --configStoreURL=mcps://istio-galley.{{ $.Release.Namespace }}.svc:9901
-          - --certFile=/etc/certs/cert-chain.pem
-          - --keyFile=/etc/certs/key.pem
-          - --caCertFile=/etc/certs/root-cert.pem
     {{- else }}
           - --configStoreURL=mcp://istio-galley.{{ $.Release.Namespace }}.svc:9901
     {{- end }}

--- a/install/kubernetes/helm/subcharts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/pilot/templates/deployment.yaml
@@ -61,9 +61,6 @@ spec:
 {{- if $.Values.global.useMCP }}
     {{- if $.Values.global.controlPlaneSecurityEnabled}}
           - --mcpServerAddrs=mcps://istio-galley.{{ $.Release.Namespace }}.svc:9901
-          - --certFile=/etc/certs/cert-chain.pem
-          - --keyFile=/etc/certs/key.pem
-          - --caCertFile=/etc/certs/root-cert.pem
     {{- else }}
           - --mcpServerAddrs=mcp://istio-galley.{{ $.Release.Namespace }}.svc:9901
     {{- end }}

--- a/pkg/mcp/creds/watcher.go
+++ b/pkg/mcp/creds/watcher.go
@@ -43,7 +43,7 @@ var scope = log.RegisterScope("mcp", "mcp debugging", 0)
 
 const (
 	// defaultCertDir is the default directory in which MCP options reside.
-	defaultCertDir = "/etc/istio/certs/"
+	defaultCertDir = "/etc/certs/"
 	// defaultCertificateFile is the default name to use for the certificate file.
 	defaultCertificateFile = "cert-chain.pem"
 	// defaultKeyFile is the default name to use for the key file.


### PR DESCRIPTION
+ Remove all MCP client command line flags from templates, and make it depend on defaults.
+ Update MCP client command-line flags to point to /etc/certs, instead of /etc/istio/certs.