### PR TITLE
Fix data race during pilot shutdown

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -203,13 +203,14 @@ type Server struct {
 	httpServer       *http.Server
 	grpcServer       *grpc.Server
 	secureHTTPServer *http.Server
+	secureHTTPMutex  sync.RWMutex
 	secureGRPCServer *grpc.Server
+	secureGrpcMutex  sync.RWMutex
 	discoveryService *envoy.DiscoveryService
 	istioConfigStore model.IstioConfigStore
 	mux              *http.ServeMux
 	kubeRegistry     *kube.Controller
 	fileWatcher      filewatcher.FileWatcher
-	secureGrpcMutex  sync.RWMutex
 }
 
 // NewServer creates a new Server instance based on the provided arguments.
@@ -1020,7 +1021,9 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			if s.secureGRPCServer != nil {
 				ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 				defer cancel()
+				s.secureHTTPMutex.RLock()
 				s.secureHTTPServer.Shutdown(ctx)
+				s.secureHTTPMutex.RUnlock()
 				s.secureGrpcMutex.RLock()
 				s.secureGRPCServer.Stop()
 				s.secureGrpcMutex.RUnlock()
@@ -1107,6 +1110,7 @@ func (s *Server) secureGrpcStart(listener net.Listener, options *istiokeepalive.
 
 	log.Infof("Starting GRPC secure on %v with certs in %s", listener.Addr(), certDir)
 
+	s.secureHTTPMutex.Lock()
 	s.secureHTTPServer = &http.Server{
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{certificate},
@@ -1128,6 +1132,7 @@ func (s *Server) secureGrpcStart(listener net.Listener, options *istiokeepalive.
 			}
 		}),
 	}
+	s.secureHTTPMutex.Unlock()
 
 	// This seems the only way to call setupHTTP2 - it may also be possible to set NextProto
 	// on a listener


### PR DESCRIPTION
There seem to be a race when shutting down pilot server. For more context, the data race is revealed more when shutting down an [in-memory pilot](https://github.com/istio/istio/blob/913b459130045fc4846a36c46c05a48da88776bb/tests/e2e/tests/pilot/mcp_test.go#L180) during tests. The following [data race](https://gist.github.com/Nino-K/3a93ad89419bb4d5beabd414f4358c52) indicates that the `secureHTTPServer` object is being read and written to simultaneously [here](https://github.com/istio/istio/blob/913b459130045fc4846a36c46c05a48da88776bb/pilot/pkg/bootstrap/server.go#L1002) and [here](https://github.com/istio/istio/blob/913b459130045fc4846a36c46c05a48da88776bb/pilot/pkg/bootstrap/server.go#L1089).