### PR TITLE
Revert "add mixerRouteConfig cache"

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
 	networking "istio.io/api/networking/v1alpha3"
@@ -82,9 +81,6 @@ type PushContext struct {
 	ServicePort2Name map[string]PortList `json:"-"`
 
 	initDone bool
-
-	// MixerPerRouteFilterConfig has mixer Router Filter config, indexed by service hostname + outbound/inbound
-	MixerPerRouteFilterConfig map[string]*types.Struct `json:"-"`
 }
 
 // XDSUpdater is used for direct updates of the xDS model and incremental push.
@@ -280,11 +276,10 @@ func NewPushContext() *PushContext {
 		publicVirtualServices:             []Config{},
 		privateVirtualServicesByNamespace: map[string][]Config{},
 
-		ServiceByHostname:         map[Hostname]*Service{},
-		ProxyStatus:               map[string]map[string]ProxyPushStatus{},
-		ServicePort2Name:          map[string]PortList{},
-		Start:                     time.Now(),
-		MixerPerRouteFilterConfig: map[string]*types.Struct{},
+		ServiceByHostname: map[Hostname]*Service{},
+		ProxyStatus:       map[string]map[string]ProxyPushStatus{},
+		ServicePort2Name:  map[string]PortList{},
+		Start:             time.Now(),
 	}
 }
 

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -50,13 +50,6 @@ const (
 	defaultConfig = "default"
 )
 
-var (
-	defaultdisableCheckPerFilterConfig = util.MessageToStruct(&mccpb.ServiceConfig{
-		DisableCheckCalls: true})
-	defaultenableCheckPerFilterConfig = util.MessageToStruct(&mccpb.ServiceConfig{
-		DisableCheckCalls: false})
-)
-
 // NewPlugin returns an ptr to an initialized mixer.Plugin.
 func NewPlugin() plugin.Plugin {
 	return mixerplugin{}
@@ -173,7 +166,7 @@ func (mixerplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConf
 			host := routeConfiguration.VirtualHosts[i]
 			for j := 0; j < len(host.Routes); j++ {
 				route := host.Routes[j]
-				route.PerFilterConfig = addServiceConfig(false, in.Push, in.ServiceInstance.Service.Hostname, in, route.PerFilterConfig)
+				route.PerFilterConfig = addServiceConfig(in.Node, route.PerFilterConfig, buildInboundRouteConfig(in.Push, in, in.ServiceInstance))
 				host.Routes[j] = route
 			}
 			routeConfiguration.VirtualHosts[i] = host
@@ -251,25 +244,29 @@ func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes) *http
 
 func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, httpRoute route.Route) route.Route {
 	// default config, to be overridden by per-weighted cluster
-	// check cache first to improve efficiency
-	if httpRoute.PerFilterConfig == nil {
-		httpRoute.PerFilterConfig = make(map[string]*types.Struct)
-	}
-	if disableClientPolicyChecks(in.Env.Mesh, in.Node) {
-		httpRoute.PerFilterConfig[mixer] = defaultdisableCheckPerFilterConfig
-	} else {
-		httpRoute.PerFilterConfig[mixer] = defaultenableCheckPerFilterConfig
-	}
+	httpRoute.PerFilterConfig = addServiceConfig(in.Node, httpRoute.PerFilterConfig, &mccpb.ServiceConfig{
+		DisableCheckCalls: disableClientPolicyChecks(in.Env.Mesh, in.Node),
+	})
 	switch action := httpRoute.Action.(type) {
 	case *route.Route_Route:
 		switch upstreams := action.Route.ClusterSpecifier.(type) {
 		case *route.RouteAction_Cluster:
 			_, _, hostname, _ := model.ParseSubsetKey(upstreams.Cluster)
-			httpRoute.PerFilterConfig = addServiceConfig(true, push, hostname, in, httpRoute.PerFilterConfig)
+			attrs := addDestinationServiceAttributes(make(attributes), push, hostname)
+			httpRoute.PerFilterConfig = addServiceConfig(in.Node, httpRoute.PerFilterConfig, &mccpb.ServiceConfig{
+				DisableCheckCalls: disableClientPolicyChecks(in.Env.Mesh, in.Node),
+				MixerAttributes:   &mpb.Attributes{Attributes: attrs},
+				ForwardAttributes: &mpb.Attributes{Attributes: attrs},
+			})
 		case *route.RouteAction_WeightedClusters:
 			for _, weighted := range upstreams.WeightedClusters.Clusters {
 				_, _, hostname, _ := model.ParseSubsetKey(weighted.Name)
-				weighted.PerFilterConfig = addServiceConfig(true, push, hostname, in, weighted.PerFilterConfig)
+				attrs := addDestinationServiceAttributes(make(attributes), push, hostname)
+				weighted.PerFilterConfig = addServiceConfig(in.Node, weighted.PerFilterConfig, &mccpb.ServiceConfig{
+					DisableCheckCalls: disableClientPolicyChecks(in.Env.Mesh, in.Node),
+					MixerAttributes:   &mpb.Attributes{Attributes: attrs},
+					ForwardAttributes: &mpb.Attributes{Attributes: attrs},
+				})
 			}
 		case *route.RouteAction_ClusterHeader:
 		default:
@@ -339,48 +336,16 @@ func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, attrs attributes) listen
 	}
 }
 
-func addServiceConfig(outbound bool, push *model.PushContext, hostname model.Hostname, in *plugin.InputParams,
-	filterConfigs map[string]*types.Struct) map[string]*types.Struct {
+func addServiceConfig(node *model.Proxy, filterConfigs map[string]*types.Struct, config *mccpb.ServiceConfig) map[string]*types.Struct {
 	if filterConfigs == nil {
 		filterConfigs = make(map[string]*types.Struct)
 	}
-	var key string
-	var config *mccpb.ServiceConfig
-	if outbound {
-		key = string(hostname) + "outbound"
-	} else {
-		key = string(hostname) + "inbound"
-	}
-	push.Mutex.Lock()
-	filterConfig, ok := push.MixerPerRouteFilterConfig[key]
-	push.Mutex.Unlock()
-	if ok {
-		filterConfigs[mixer] = filterConfig
-		return filterConfigs
-	}
-	if outbound {
-		attrs := addDestinationServiceAttributes(make(attributes), push, hostname)
-		config = &mccpb.ServiceConfig{
-			DisableCheckCalls: disableClientPolicyChecks(in.Env.Mesh, in.Node),
-			MixerAttributes:   &mpb.Attributes{Attributes: attrs},
-			ForwardAttributes: &mpb.Attributes{Attributes: attrs},
-		}
-	} else {
-		config = buildInboundRouteConfig(push, in, in.ServiceInstance)
-	}
 	// These settings are not backward compatible with 0.8.
 	// Proxy version is only available from 1.0 onwards.
-	if _, found := in.Node.GetProxyVersion(); !found {
+	if _, found := node.GetProxyVersion(); !found {
 		config.ForwardAttributes = nil
 	}
-	filterConfig = util.MessageToStruct(config)
-	filterConfigs[mixer] = filterConfig
-	push.Mutex.Lock()
-	if push.MixerPerRouteFilterConfig == nil {
-		push.MixerPerRouteFilterConfig = map[string]*types.Struct{}
-	}
-	push.MixerPerRouteFilterConfig[key] = filterConfig
-	push.Mutex.Unlock()
+	filterConfigs[mixer] = util.MessageToStruct(config)
 	return filterConfigs
 }
 


### PR DESCRIPTION
Sorry to revert but apart from the hacky way of adding the cache to the pushContext, there is a big perf problem here. The code is using locks and updating the cache on first compute. This is very bad as during the initial connection to Pilot, we will have 100s of proxies all blocking on the same lock (as all of them trigger the ADS computation). In other words, this is effectively serializing the entire ADS computation across all proxies..

Reverts istio/istio#10292