### PR TITLE
move to newer urllib3

### DIFF
--- a/samples/bookinfo/src/productpage/requirements.txt
+++ b/samples/bookinfo/src/productpage/requirements.txt
@@ -17,6 +17,6 @@ opentracing==1.2.2
 opentracing-instrumentation==2.4.3
 requests==2.20.0
 simplejson==3.13.2
-urllib3==1.22
+urllib3==1.23
 visitor==0.1.3
 Werkzeug==0.13


### PR DESCRIPTION
got a security alert when view our repo.   fix security vul issue

CVE-2018-20060 More information

high severity
Vulnerable versions: < 1.23
Patched version: 1.23
urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.