### PR TITLE
mixer: add size function to EL

### DIFF
--- a/mixer/pkg/il/builder.go
+++ b/mixer/pkg/il/builder.go
@@ -275,6 +275,11 @@ func (f *Builder) AddInteger() {
 	f.op0(AddI)
 }
 
+// SizeString appends the "size_s" instruction to the byte code.
+func (f *Builder) SizeString() {
+	f.op0(SizeS)
+}
+
 func (f *Builder) jump(op Opcode, label string) {
 	adr, exists := f.labels[label]
 	if !exists {

--- a/mixer/pkg/il/interpreter/interpreterRun.go
+++ b/mixer/pkg/il/interpreter/interpreterRun.go
@@ -868,6 +868,21 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			opstack[sp+1] = uint32(tu64 & 0xFFFFFFFF)
 			sp = sp + 2
 
+		case il.SizeS:
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			sp = sp - 1
+			if t1 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t1].(string)
+			ti64 := int64(len(tStr))
+			opstack[sp] = uint32(ti64 >> 32)
+			opstack[sp+1] = uint32(ti64 & 0xFFFFFFFF)
+			sp = sp + 2
+
 		case il.Jmp:
 			t1 = body[ip]
 			ip++

--- a/mixer/pkg/il/interpreter/interpreterRun.go
+++ b/mixer/pkg/il/interpreter/interpreterRun.go
@@ -872,13 +872,13 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			if sp < 1 {
 				goto STACK_UNDERFLOW
 			}
-			t1 = opstack[sp-1]
-			sp = sp - 1
+			sp--
+			t1 = opstack[sp]
 			if t1 >= hp {
 				goto INVALID_HEAP_ACCESS
 			}
 			tStr = heap[t1].(string)
-			ti64 := int64(len(tStr))
+			ti64 = int64(len(tStr))
 			opstack[sp] = uint32(ti64 >> 32)
 			opstack[sp+1] = uint32(ti64 & 0xFFFFFFFF)
 			sp = sp + 2

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -635,6 +635,13 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			tu64 = math.Float64bits(tf64)
 			STACK_PUSH2(uint32(tu64>>32), uint32(tu64&0xFFFFFFFF))
 
+		case il.SizeS:
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t1)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			ti64 = int64(len(tStr))
+			STACK_PUSH2(uint32(ti64>>32), uint32(ti64&0xFFFFFFFF))
+
 		case il.Jmp:
 			LOAD_OP_CODE(t1)
 			ip = t1

--- a/mixer/pkg/il/opcode.go
+++ b/mixer/pkg/il/opcode.go
@@ -310,6 +310,9 @@ const (
 	// AddS pops two string values from the stack, adds their value and pushes the result
 	// back into stack. The operation follows Go's string concatenation semantics.
 	AddS Opcode = 215
+
+	// SizeS pops a string value from the stack, and pushes its length back into stack.
+	SizeS Opcode = 216
 )
 
 const (
@@ -770,6 +773,9 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 		// The name of the attribute.
 		OpcodeArgString,
 	}},
+
+	// SizeS pops a string and pushes it length.
+	SizeS: {name: "SizeS", keyword: "size_s"},
 }
 
 var opcodesByKeyword = func() map[string]Opcode {

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -3873,6 +3873,40 @@ end
 		},
 		CompileErr: `ADD($as) arity mismatch. Got 1 arg(s), expected 2 arg(s)`,
 	},
+	{
+		E:    `size("x")`,
+		Type: descriptor.INT64,
+		R:    int64(1),
+		IL: `
+fn eval() integer
+  apush_i 1
+  ret
+end
+`,
+	},
+	{
+		E:    `size(as)`,
+		Type: descriptor.INT64,
+		I: map[string]interface{}{
+			"as": "two",
+		},
+		R: int64(3),
+		IL: `
+fn eval() integer
+  resolve_s "as"
+  size_s
+  ret
+end
+`,
+	},
+	{
+		E:          `size(1)`,
+		CompileErr: `internal compiler error -- Size for type not yet implemented: integer`,
+	},
+	{
+		E:          `size()`,
+		CompileErr: `size() arity mismatch. Got 0 arg(s), expected 1 arg(s)`,
+	},
 }
 
 // TestInfo is a structure that contains detailed test information. Depending

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -3901,7 +3901,7 @@ end
 	},
 	{
 		E:          `size(1)`,
-		CompileErr: `internal compiler error -- Size for type not yet implemented: integer`,
+		CompileErr: `size(1) arg 1 (1) typeError got INT64, expected STRING`,
 	},
 	{
 		E:          `size()`,

--- a/mixer/pkg/lang/ast/func.go
+++ b/mixer/pkg/lang/ast/func.go
@@ -81,7 +81,7 @@ func intrinsics() []FunctionMetadata {
 		{
 			Name:          "size",
 			ReturnType:    config.INT64,
-			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED},
+			ArgumentTypes: []config.ValueType{config.STRING},
 		},
 	}
 }

--- a/mixer/pkg/lang/ast/func.go
+++ b/mixer/pkg/lang/ast/func.go
@@ -78,6 +78,11 @@ func intrinsics() []FunctionMetadata {
 			ReturnType:    config.VALUE_TYPE_UNSPECIFIED,
 			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
 		},
+		{
+			Name:          "size",
+			ReturnType:    config.INT64,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED},
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/10011

Adds a polymorphic intrinsic function `size` (common with CEL). Implement it for strings.
It turns out that extending this function to stringmap is rather difficult:
- stringmap type is erased in bytecode, so it requires an extern fallback for reflection
- reference tracking for map size requires special handling in the proxy

Due to the above, I left out stringmap size implementation for nebulous future.

/assign @mandarjog 
/assign @ozevren 

Signed-off-by: Kuat Yessenov <kuat@google.com>