### PR TITLE
remove e2e_simple_auth

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -66,7 +66,7 @@ DEFAULT_EXTRA_E2E_ARGS += --galley_hub=${HUB}
 EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 
 e2e_simple: istioctl generate_yaml e2e_simple_run
-e2e_simple_auth: istioctl generate_yaml e2e_simple_auth_run
+
 e2e_simple_noauth: istioctl generate_yaml e2e_simple_noauth_run
 
 e2e_mixer: istioctl generate_e2e_test_yaml e2e_mixer_run
@@ -82,9 +82,8 @@ e2e_stackdriver: istioctl generate_yaml e2e_stackdriver_run
 e2e_all: istioctl generate_yaml e2e_all_run
 
 # *_run targets do not rebuild the artifacts and test with whatever is given
-e2e_simple_run: e2e_simple_auth_run
 
-e2e_simple_auth_run: out_dir
+e2e_simple_run: out_dir
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/simple -args --auth_enable=true \
 	--egress=false --ingress=false \
 	--rbac_enable=false --cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}


### PR DESCRIPTION
e2e_simple_auth is just a place holder now for e2e_simple and it will be confusing for users for the selection for the target. So let's remove it and now we will have only have below two for simple test:


e2e_simple: istioctl generate_yaml e2e_simple_run  ( auth-enabled)

e2e_simple_noauth: istioctl generate_yaml e2e_simple_noauth_run (no -auth)
