### PR TITLE
Disable galley server if useMCP is false

### DIFF
--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
 {{- else }}
           - --insecure=true
 {{- end }}
+{{- if not $.Values.global.useMCP }}
+          - --enable-server=false
+{{- end }}
           - --validation-webhook-config-file
           - /etc/istio/config/validatingwebhookconfiguration.yaml
           - --monitoringPort={{ .Values.global.monitoringPort }}


### PR DESCRIPTION
use Galley Config Validator only when install istio with `--set galley.enabled=true --set global.useMCP=false`. we should disable Galley server for this case.

Signed-off-by: clyang82 <clyang@cn.ibm.com>