### PR TITLE
Use ingressgateway public IP for K8s Ingress if no legacy ingress

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -50,6 +50,9 @@ data:
     {{- if .Values.ingress.enabled }}
     # This is the k8s ingress service name, update if you used a different name
     ingressService: istio-{{ .Values.global.k8sIngressSelector }}
+    {{- else }}
+    # Let Pilot give ingresses the public IP of the Istio ingressgateway
+    ingressService: istio-ingressgateway
     {{- end }}
 
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get


### PR DESCRIPTION
@mandarjog Does this resolve your issue?

This is for issue #10500 .  Ingresses were getting the Node IP, not the public IP of the IngressGateway, when Istio 1.1 was installed without `--set ingress.enabled=true`.  This gives those Ingresses the public IP of the IngressGateway.