### PR TITLE
Istio install script: manually set version when api call to get latest fails

### DIFF
--- a/release/downloadIstioCandidate.sh
+++ b/release/downloadIstioCandidate.sh
@@ -26,6 +26,11 @@ if [ "x${ISTIO_VERSION}" = "x" ] ; then
                   grep tag_name | sed "s/ *\"tag_name\": *\"\\(.*\\)\",*/\\1/")
 fi
 
+if [ "x${ISTIO_VERSION}" = "x" ] ; then
+  echo "Unable to get latest Istio version. Set ISTIO_VERSION env var and re-run. (export ISTIO_VERSION=1.0.4)"
+  exit;
+fi
+
 NAME="istio-$ISTIO_VERSION"
 URL="https://github.com/istio/istio/releases/download/${ISTIO_VERSION}/istio-${ISTIO_VERSION}-${OSEXT}.tar.gz"
 echo "Downloading $NAME from $URL ..."


### PR DESCRIPTION
The curl call to https://api.github.com/repos/istio/istio/releases/latest can fail for users and companies sometimes due to github api rate limits. When this happens, we can guide the user to set the version manually and continue. This was reported in #6383