### PR TITLE
WIP: Use custom tracing middleware for Mixer to avoid ID generation

### DIFF
--- a/mixer/pkg/server/interceptor.go
+++ b/mixer/pkg/server/interceptor.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	// Morally a const:
+	gRPCComponentTag = opentracing.Tag{Key: string(ext.Component), Value: "gRPC"}
+)
+
+type metadataReaderWriter struct {
+	metadata.MD
+}
+
+func (w metadataReaderWriter) Set(key, val string) {
+	// The GRPC HPACK implementation rejects any uppercase keys here.
+	//
+	// As such, since the HTTP_HEADERS format is case-insensitive anyway, we
+	// blindly lowercase the key (which is guaranteed to work in the
+	// Inject/Extract sense per the OpenTracing spec).
+	key = strings.ToLower(key)
+	w.MD[key] = append(w.MD[key], val)
+}
+
+func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range w.MD {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+type noopSpan struct{}
+type noopSpanContext struct{}
+
+var (
+	defaultNoopSpanContext = noopSpanContext{}
+	defaultNoopSpan        = noopSpan{}
+	defaultNoopTracer      = opentracing.NoopTracer{}
+)
+
+const (
+	emptyString = ""
+)
+
+// noopSpanContext:
+func (n noopSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+// noopSpan:
+func (n noopSpan) Context() opentracing.SpanContext                       { return defaultNoopSpanContext }
+func (n noopSpan) SetBaggageItem(key, val string) opentracing.Span        { return defaultNoopSpan }
+func (n noopSpan) BaggageItem(key string) string                          { return emptyString }
+func (n noopSpan) SetTag(key string, value interface{}) opentracing.Span  { return n }
+func (n noopSpan) LogFields(fields ...log.Field)                          {}
+func (n noopSpan) LogKV(keyVals ...interface{})                           {}
+func (n noopSpan) Finish()                                                {}
+func (n noopSpan) FinishWithOptions(opts opentracing.FinishOptions)       {}
+func (n noopSpan) SetOperationName(operationName string) opentracing.Span { return n }
+func (n noopSpan) Tracer() opentracing.Tracer                             { return defaultNoopTracer }
+func (n noopSpan) LogEvent(event string)                                  {}
+func (n noopSpan) LogEventWithPayload(event string, payload interface{})  {}
+func (n noopSpan) Log(data opentracing.LogData)                           {}
+
+func TracingServerInterceptor(tracer opentracing.Tracer) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp interface{}, err error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			md = metadata.New(nil)
+		}
+		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
+		if err != nil && err != opentracing.ErrSpanContextNotFound {
+			// TODO: establish some sort of error reporting mechanism here. We
+			// don't know where to put such an error and must rely on Tracer
+			// implementations to do something appropriate for the time being.
+
+			fmt.Printf("non nil error in trace extraction: %#v\n", err)
+		}
+		var serverSpan opentracing.Span
+		if err == opentracing.ErrSpanContextNotFound {
+			serverSpan = defaultNoopSpan
+			fmt.Println("using noop span")
+		} else {
+			fmt.Println("using real span with real ID")
+			serverSpan = tracer.StartSpan(
+				info.FullMethod,
+				ext.RPCServerOption(spanContext),
+				gRPCComponentTag,
+			)
+		}
+		defer serverSpan.Finish()
+
+		ctx = opentracing.ContextWithSpan(ctx, serverSpan)
+		resp, err = handler(ctx, req)
+		if err != nil {
+			otgrpc.SetSpanTags(serverSpan, err, false)
+			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
+		}
+		return resp, err
+	}
+}

--- a/mixer/pkg/server/interceptor.go
+++ b/mixer/pkg/server/interceptor.go
@@ -95,6 +95,14 @@ func TracingServerInterceptor(tracer opentracing.Tracer) grpc.UnaryServerInterce
 			}
 		}
 
+		// allow for compressed header too
+		for _, val := range md.Get("b3") {
+			if strings.EqualFold(strings.ToLower(val), "0") {
+				sampled = false
+				break
+			}
+		}
+
 		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
 			// TODO: establish some sort of error reporting mechanism here. We

--- a/mixer/pkg/server/server.go
+++ b/mixer/pkg/server/server.go
@@ -24,7 +24,6 @@ import (
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	ot "github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -136,7 +135,7 @@ func newServer(a *Args, p *patchTable) (*Server, error) {
 			_ = s.Close()
 			return nil, fmt.Errorf("unable to setup tracing")
 		}
-		interceptors = append(interceptors, otgrpc.OpenTracingServerInterceptor(ot.GlobalTracer()))
+		interceptors = append(interceptors, TracingServerInterceptor(ot.GlobalTracer()))
 	}
 
 	// setup server prometheus monitoring (as final interceptor in chain)


### PR DESCRIPTION
/hold

Exploratory PR, based on conversations in #10258. The code here is a quick cut/paste from various repos (with small mods) to provide a PoC for testing.

Idea here is to duplicate the bits of the opentracing middleware lib that Mixer uses to create a gRPC interceptor that handles the span creation bits, but to return a `noopSpan` instead of a root span when the tracing headers do not exist in the originating call.

I've tested this locally, as follows:

```
$ mixc check ...  --trace_log_spans=true --trace_sampling_rate=1.0
...
2018-12-19T05:52:47.313661Z	info	Reporting span	{"operation": "/istio.mixer.v1.Mixer/Check", "span": "56823ce319507225:3e07932d2a1b843b:56823ce319507225:1"}
Check RPC completed successfully. Check status was PERMISSION_DENIED (denyall.denier.istio-system:Not allowed)
  Valid use count: 1000, valid duration: 5s
...
2018-12-19T05:52:47.313758Z	info	Reporting span	{"operation": "mixc Check", "span": "56823ce319507225:56823ce319507225:0:1"}

---

$ KUBECONFIG=~/.kube/config mixs server --configStoreURL=fs://$(pwd)/mixer/testdata/config --trace_log_spans
...
using real span with real ID
2018-12-19T05:52:47.312550Z	info	Reporting span	{"operation": "kubernetes:handler.kubernetesenv.istio-system(kubernetesenv)", "span": "56823ce319507225:18d7c4f6c4c221ad:19494fff456a61da:1"}
2018-12-19T05:52:47.312664Z	info	Reporting span	{"operation": "checknothing:denyall.denier.istio-system(denier)", "span": "56823ce319507225:439bd7b4ca9c6fa6:19494fff456a61da:1"}
2018-12-19T05:52:47.312967Z	info	Reporting span	{"operation": "/istio.mixer.v1.Mixer/Check", "span": "56823ce319507225:19494fff456a61da:3e07932d2a1b843b:1"}
2018-12-19T05:52:47.314420Z	info	transport: loopyWriter.run returning. Err: connection error: desc = "transport is closing"
```

And (without trace context from client):

```
$ mixc check ...
...
Check RPC completed successfully. Check status was PERMISSION_DENIED (denyall.denier.istio-system:Not allowed)
  Valid use count: 1000, valid duration: 5s
...

---

$ KUBECONFIG=~/.kube/config mixs server --configStoreURL=fs://$(pwd)/mixer/testdata/config --trace_log_spans
...
using noop span
2018-12-19T05:52:49.458051Z	info	transport: loopyWriter.run returning. Err: connection error: desc = "transport is closing"
...
```

This seems to indicate that this at least doesn't crash Mixer and that when trace headers *are* present, we do the right thing.

NOTE: The code here was borrowed from https://github.com/grpc-ecosystem/grpc-opentracing/go and https://github.com/opentracing/opentracing-go/. It will need to be cleaned up and properly attributed if this looks like a viable path forward.

/cc @mandarjog @objectiser 
