### PR TITLE
Fix Galley Server Issues

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -90,7 +90,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	s := &Server{}
 
 	defer func() {
-		// If return with error, need to close the server.
+		// If returns with error, need to close the server.
 		if err != nil {
 			_ = s.Close()
 		}

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -191,6 +191,7 @@ func (s *Server) Run() {
 		err := s.processor.Start()
 		if err != nil {
 			scope.Fatalf("Galley Server unexpectedly terminated: %v", err)
+			return
 		}
 
 		// start serving

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"errors"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -106,7 +107,6 @@ func TestNewServer(t *testing.T) {
 	}
 
 	_ = s.Close()
-	_ = s.Wait()
 }
 
 func TestServer_Basic(t *testing.T) {
@@ -132,8 +132,14 @@ func TestServer_Basic(t *testing.T) {
 		t.Fatalf("Unexpected error creating service: %v", err)
 	}
 
-	s.Run()
+	var wg sync.WaitGroup
+	wg.Add(1)
 
+	go func() {
+		defer wg.Done()
+		s.Run()
+	}()
+
+	wg.Wait()
 	_ = s.Close()
-	_ = s.Wait()
 }

--- a/pkg/test/framework/runtime/components/galley/native.go
+++ b/pkg/test/framework/runtime/components/galley/native.go
@@ -181,7 +181,6 @@ func (c *nativeComponent) Close() (err error) {
 		if err != nil {
 			scopes.Framework.Infof("Error while Galley server close during reset: %v", err)
 		}
-		_ = c.server.Wait()
 		c.server = nil
 	}
 	return


### PR DESCRIPTION
1. the register scope should be `server` instead of `runtime`
2. move `_ = s.Close()` into defer function
3. set `s.shutdown = nil` in `Close()` method, because if set it in `Wait()` method, the `s.grpcServer.GracefulStop()` method won't be executed.


Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>