### PR TITLE
switching deployments to use apps/v1 api

### DIFF
--- a/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: certmanager

--- a/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
@@ -15,7 +15,7 @@ spec:
   maxReplicas: {{ $spec.autoscaleMax }}
   minReplicas: {{ $spec.autoscaleMin }}
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ $key }}
   metrics:

--- a/install/kubernetes/helm/istio/charts/ingress/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/ingress/templates/autoscale.yaml
@@ -13,7 +13,7 @@ spec:
   maxReplicas: {{ .Values.autoscaleMax }}
   minReplicas: {{ .Values.autoscaleMin }}
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: istio-ingress
   metrics:

--- a/install/kubernetes/helm/istio/charts/mixer/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/autoscale.yaml
@@ -15,7 +15,7 @@ spec:
     maxReplicas: {{ $spec.autoscaleMax }}
     minReplicas: {{ $spec.autoscaleMin }}
     scaleTargetRef:
-      apiVersion: apps/v1beta1
+      apiVersion: apps/v1
       kind: Deployment
       name: istio-{{ $key }}
     metrics:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/autoscale.yaml
@@ -13,7 +13,7 @@ spec:
   maxReplicas: {{ .Values.autoscaleMax }}
   minReplicas: {{ .Values.autoscaleMin }}
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: istio-pilot
   metrics:

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/statefulset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: hello

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   creationTimestamp: null

--- a/pkg/test/framework/components/apps/kube.go
+++ b/pkg/test/framework/components/apps/kube.go
@@ -87,12 +87,16 @@ spec:
   selector:
     app: {{ .service }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .deployment }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .service }}
+      version: {{ .version }}
   template:
     metadata:
       labels:

--- a/samples/httpbin/sample-client/fortio-deploy.yaml
+++ b/samples/httpbin/sample-client/fortio-deploy.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio-deploy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio
   template:
     metadata:
       labels:

--- a/samples/rawvm/k8cli.yaml.in
+++ b/samples/rawvm/k8cli.yaml.in
@@ -1,10 +1,13 @@
 # Client inside the cluster, not istio injected
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: raw-cli-deployement
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio
   template:
     metadata:
       labels:

--- a/samples/rawvm/k8services.yaml.in
+++ b/samples/rawvm/k8services.yaml.in
@@ -12,13 +12,16 @@ spec:
   selector:
     app: echosrv
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 # 2 pods for service inside the cluster, will get istio injected
 kind: Deployment
 metadata:
   name: raw-svc-deployment
 spec:
   replicas: 2 # tells deployment to run 2 pods matching the template
+  selector:
+    matchLabels:
+      app: echosrv
   template: # create pods using pod definition in this template
     metadata:
       # a unique name is generated from the deployment name
@@ -42,13 +45,16 @@ spec:
   selector:
     app: mysqlclient-istio
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 # 1 pod, will get istio injected
 kind: Deployment
 metadata:
   name: mysqlclient-istio
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mysqlclient-istio
   template:
     metadata:
       labels:

--- a/tests/e2e/tests/dashboard/fortio-rules.yaml
+++ b/tests/e2e/tests/dashboard/fortio-rules.yaml
@@ -42,12 +42,16 @@ spec:
         host: echosrv
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: echosrv
+      version: v1
   template:
     metadata:
       labels:

--- a/tests/e2e/tests/dashboard/netcat-rules.yaml
+++ b/tests/e2e/tests/dashboard/netcat-rules.yaml
@@ -9,11 +9,15 @@ spec:
   selector:
     app: netcat-srv
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: netcat-srv
 spec:
+  selector:
+    matchLabels:
+      app: netcat-srv
+      version: v1
   template:
     metadata:
       labels:
@@ -40,11 +44,15 @@ spec:
   selector:
     app: netcat-client
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: netcat-client
 spec:
+  selector:
+    matchLabels:
+      app: netcat-client
+      version: v1
   template:
     metadata:
       labels:

--- a/tests/e2e/tests/simple/testdata/v1alpha3/servicesNotInjected.yaml
+++ b/tests/e2e/tests/simple/testdata/v1alpha3/servicesNotInjected.yaml
@@ -12,12 +12,15 @@ spec:
   selector:
     app: fortio-noistio
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: raw-cli-deployement
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio-noistio
   template:
     metadata:
       labels:

--- a/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
+++ b/tests/e2e/tests/simple/testdata/v1alpha3/servicesToBeInjected.yaml
@@ -49,12 +49,18 @@ spec:
 ---
 # 2 deployments so we can change routing rules
 # 1st deployment, 1 pod for service inside the cluster, will get istio injected
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment-1
 spec:
   replicas: 1 # tells deployment to run 1 pod matching the template
+  selector:
+    matchLabels:
+      app: echosrv
+      version: v1
+      test: a
+      extrap: non # can't use "no" as that's a boolean...
   template: # create pods using pod definition in this template
     metadata:
       # a unique name is generated from the deployment name
@@ -77,12 +83,18 @@ spec:
 ---
 # 2nd deployment, 1 pod for service inside the cluster, will get istio injected
 # same as above except for the version and extra port
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment-2
 spec:
   replicas: 1 # tells deployment to run 1 pod matching the template
+  selector:
+    matchLabels:
+      app: echosrv
+      version: v2
+      test: b
+      extrap: oui # can't seem to be able to use "yes" here and in selector...
   template: # create pods using pod definition in this template
     metadata:
       # a unique name is generated from the deployment name

--- a/tests/e2e/tests/stackdriver/fortio-rules.yaml
+++ b/tests/e2e/tests/stackdriver/fortio-rules.yaml
@@ -42,12 +42,16 @@ spec:
         host: echosrv
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: echosrv
+      version: v1
   template:
     metadata:
       labels:

--- a/tests/helm/templates/etcd.yaml
+++ b/tests/helm/templates/etcd.yaml
@@ -15,7 +15,7 @@ spec:
   selector:
     component: "etcd"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "etcd"

--- a/tests/helm/templates/fortio-080.yaml
+++ b/tests/helm/templates/fortio-080.yaml
@@ -12,12 +12,16 @@ spec:
   selector:
     app: fortiov080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiov080
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortiov080
+      version: fortio080
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-10rc1.yaml
+++ b/tests/helm/templates/fortio-10rc1.yaml
@@ -12,12 +12,16 @@ spec:
   selector:
     app: fortio10rc1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio10rc1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio10rc1
+      version: fortio10rc1
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-cli.yaml
+++ b/tests/helm/templates/fortio-cli.yaml
@@ -1,12 +1,16 @@
 ## Fortio clients generating traffic on different components.
 # Generally use the ingress gateway - to capture non-istio service as well.
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-tls
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app:  cli-fortio-tls
+      version: v1-tls
   template:
     metadata:
       labels:
@@ -36,12 +40,16 @@ spec:
             cpu: 1000m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio-cli-raw
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app: fortio-cli-raw
+      version: v1
   template:
     metadata:
       labels:
@@ -71,12 +79,16 @@ spec:
             cpu: 1000m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio-cli-notls
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app: fortio-cli1
+      version: v1 
   template:
     metadata:
       labels:
@@ -107,12 +119,16 @@ spec:
             memory: "1G"
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio10rc1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio10rc1
+      version: cli-fortio10rc1
   template:
     metadata:
       labels:
@@ -143,12 +159,16 @@ spec:
             memory: "1G"
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio080
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio080
+      version: cli-fortio080
   template:
     metadata:
       labels:
@@ -178,12 +198,16 @@ spec:
             cpu: 500m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-tproxy-direct
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio-tproxy-direct
+      version: cli-fortio-tproxy-direct
   template:
     metadata:
       labels:
@@ -211,12 +235,17 @@ spec:
             cpu: 500m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-v1-direct
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: ncli-fortio-v1-direct
+      app: cli-fortio-v1-direct
+      version: cli-fortio-v1-direct
   template:
     metadata:
       labels:
@@ -245,12 +274,17 @@ spec:
             cpu: 500m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-noistio1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: cli-fortio-noistio1
+      app: acli-fortio-noistio1
+      version: cli-fortio-noistio1
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-headless.yaml
+++ b/tests/helm/templates/fortio-headless.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio-headless
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: fortio-headless
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-master.yaml
+++ b/tests/helm/templates/fortio-master.yaml
@@ -12,12 +12,16 @@ spec:
   selector:
     app: fortiomaster
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiomaster
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: fortiomaster
+      version: fortiomaster
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-noistio.yaml
+++ b/tests/helm/templates/fortio-noistio.yaml
@@ -31,12 +31,17 @@ spec:
   selector:
     name: fortionoistio
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortionoistio
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: fortionoistio
+      name: fortionoistio
+      version: fortionoistio
   template:
     metadata:
       labels:
@@ -91,12 +96,17 @@ spec:
   selector:
     name: fortionoistio1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortionoistio1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortionoistio1
+      name: fortionoistio1
+      version: fortionoistio1
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-tls.yaml
+++ b/tests/helm/templates/fortio-tls.yaml
@@ -47,12 +47,16 @@ spec:
   selector:
     app: fortiotls
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiotls
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: fortiotls
+      version: tls
   template:
     metadata:
       annotations:

--- a/tests/helm/templates/fortio-tproxy.yaml
+++ b/tests/helm/templates/fortio-tproxy.yaml
@@ -12,12 +12,17 @@ spec:
   selector:
     app: fortio-tproxy
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortio-tproxy
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio-tproxy
+      name: fortio-tproxy
+      version: tproxy
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-ttls-small.yaml
+++ b/tests/helm/templates/fortio-ttls-small.yaml
@@ -39,12 +39,16 @@ spec:
   selector:
     app: fortiottlssmall
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiottlssmall
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortiottlssmall
+      version: ttlssmall
   template:
     metadata:
       annotations:
@@ -74,12 +78,16 @@ spec:
             memory: "1G"
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-ttlssmall
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio-ttlssmall
+      version: v1-ttlssmall
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio-ttls.yaml
+++ b/tests/helm/templates/fortio-ttls.yaml
@@ -43,12 +43,16 @@ spec:
   selector:
     app: fortiottls
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiottls
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortiottls
+      version: ttls
   template:
     metadata:
       annotations:
@@ -93,12 +97,16 @@ spec:
         port:
           number: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-ttls-notls
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio-ttls
+      version: v1-ttls
   template:
     metadata:
       labels:
@@ -128,12 +136,16 @@ spec:
             cpu: 10m
             memory: "100M"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-ttls-tls
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio-ttls
+      version: v1-ttls 
   template:
     metadata:
       labels:
@@ -161,12 +173,16 @@ spec:
             cpu: 10m
             memory: "100M"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cli-fortio-ttls
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cli-fortio-ttls
+      version: v1-ttls
   template:
     metadata:
       labels:

--- a/tests/helm/templates/fortio.yaml
+++ b/tests/helm/templates/fortio.yaml
@@ -54,12 +54,17 @@ spec:
       labels:
         version: v2
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fortiov1
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio
+      name: fortiov1
+      version: v1
   template:
     metadata:
       labels:
@@ -83,13 +88,18 @@ spec:
             cpu: 1000m
             memory: "1G"
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 # 2 pods for service inside the cluster, will get istio injected
 kind: Deployment
 metadata:
   name: fortiov2
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: fortio
+      name: fortiov2
+      version: v2
   template:
     metadata:
       labels:

--- a/tests/upgrade/templates/fortio.yaml
+++ b/tests/upgrade/templates/fortio.yaml
@@ -28,12 +28,15 @@ spec:
           mode: ISTIO_MUTUAL
 ---
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment-v1
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app: echosrv
   minReadySeconds: 60
   strategy:
     type: RollingUpdate
@@ -55,12 +58,16 @@ spec:
           - server
 ---
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echosrv-deployment-v2
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app: echosrv
+      version: v2
   minReadySeconds: 60
   strategy:
     type: RollingUpdate

--- a/tools/perf_k8svcs.yaml
+++ b/tools/perf_k8svcs.yaml
@@ -13,12 +13,15 @@ spec:
   selector:
     app: echosrv1
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo-svc-deployment1
 spec:
   replicas: 1 # tells deployment to run 1 pods matching the template
+  selector:
+    matchLabels:
+      app: echosrv1
   template: # create pods using pod definition in this template
     metadata:
       # a unique name is generated from the deployment name
@@ -45,12 +48,15 @@ spec:
   selector:
     app: echosrv2
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: echo-svc-deployment2
 spec:
   replicas: 1 # tells deployment to run 1 pods matching the template
+  selector:
+    matchLabels:
+      app: echosrv2
   template: # create pods using pod definition in this template
     metadata:
       # a unique name is generated from the deployment name


### PR DESCRIPTION
Deployments, StatefulSets were graduated to GA in 1.8 as such apps/v1 api should be used when these objects are created. 

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>