### PR TITLE
quick stop server in testing

### DIFF
--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -179,6 +179,8 @@ type PilotArgs struct {
 	MCPCredentialOptions *creds.Options
 	MCPMaxMessageSize    int
 	KeepaliveOptions     *istiokeepalive.Options
+	// ForceStop is set as true when used for testing to make the server stop quickly
+	ForceStop bool
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -984,7 +986,11 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			if err != nil {
 				log.Warna(err)
 			}
-			s.grpcServer.GracefulStop()
+			if args.ForceStop {
+				s.grpcServer.Stop()
+			} else {
+				s.grpcServer.GracefulStop()
+			}
 		}()
 
 		return nil
@@ -1019,7 +1025,11 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 			}()
 			go func() {
 				<-stop
-				s.grpcServer.GracefulStop()
+				if args.ForceStop {
+					s.grpcServer.Stop()
+				} else {
+					s.grpcServer.GracefulStop()
+				}
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 				s.secureHTTPServer.Shutdown(ctx)

--- a/pkg/test/framework/runtime/components/apps/agent/pilot_agent_test.go
+++ b/pkg/test/framework/runtime/components/apps/agent/pilot_agent_test.go
@@ -254,6 +254,7 @@ func newPilot(configStore model.ConfigStoreCache, t *testing.T) (*bootstrap.Serv
 			Registries: []string{},
 		},
 		KeepaliveOptions: keepalive.DefaultOption(),
+		ForceStop:        true,
 	}
 
 	// Create the server for the discovery service.

--- a/pkg/test/framework/runtime/components/pilot/native.go
+++ b/pkg/test/framework/runtime/components/pilot/native.go
@@ -102,7 +102,8 @@ func (c *nativeComponent) Start(ctx context.Instance, scope lifecycle.Scope) (er
 			Registries: []string{},
 		},
 		// Include all of the default plugins for integration with Mixer, etc.
-		Plugins: bootstrap.DefaultPlugins,
+		Plugins:   bootstrap.DefaultPlugins,
+		ForceStop: true,
 	}
 
 	// Save the config store.

--- a/tests/local/xds_local_test.go
+++ b/tests/local/xds_local_test.go
@@ -180,6 +180,7 @@ func initLocalPilot(IstioSrc string) (*bootstrap.Server, error) {
 				string(serviceregistry.KubernetesRegistry)},
 		},
 		KeepaliveOptions: keepalive.DefaultOption(),
+		ForceStop:        true,
 	}
 	// Create the server for the discovery service.
 	discoveryServer, err := bootstrap.NewServer(serverAgrs)

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -104,6 +104,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 		},
 		MCPMaxMessageSize: bootstrap.DefaultMCPMaxMsgSize,
 		KeepaliveOptions:  keepalive.DefaultOption(),
+		ForceStop:         true,
 	}
 	// Static testdata, should include all configs we want to test.
 	args.Config.FileDir = env.IstioSrc + "/tests/testdata/config"


### PR DESCRIPTION
Pilot server stops takes time in testing. When a new test is kicked off, the original pilot discovery server is still under stopping and it will cause bad influence for the new testing, eg:
=== RUN   TestFull
2018-12-19T09:18:25.774816Z	info	mesh networks configuration not provided
2018-12-19T09:18:25.775042Z	info	ads	Starting ADS server with rateLimiter=10 burst=100
2018-12-19T09:18:25.775164Z	info	Discovery service started at http=[::]:39949 grpc=[::]:36964 secure grpc=[::]:37226
Listening HTTP/1.1 on 45551
Listening HTTP/1.1 on 39223
Listening HTTP/1.1 on 40516
Listening HTTP/1.1 on 38406
Listening GRPC on 41255
Listening GRPC on 45352
2018-12-19T09:18:25.778732Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.778781Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.778827Z	info	rpc error: code = Canceled desc = context canceled
2018-12-19T09:18:25.778889Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.778910Z	info	rpc error: code = Canceled desc = context canceled
2018-12-19T09:18:25.778934Z	info	Registry Aggregator terminated
2018-12-19T09:18:25.779020Z	info	rpc error: code = Canceled desc = grpc: the client connection is closing
2018-12-19T09:18:25.779103Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.779135Z	info	rpc error: code = Canceled desc = grpc: the client connection is closing
2018-12-19T09:18:25.779189Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.781672Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.781860Z	error	Failed to start secure grpc server open /etc/certs/cert-chain.pem: no such file or directory
2018-12-19T09:18:25.781999Z	info	ads	ADS: "127.0.0.1:34236" sidecar~127.0.0.1~b.XbO_uiHWvk~istio-system.svc.local-2 terminated rpc error: code = Canceled desc = context canceled
2018-12-19T09:18:25.796059Z	info	ads	ADS: "127.0.0.1:34228" sidecar~127.0.0.1~a.WVd2U4Rvfq~istio-system.svc.local-1 terminated rpc error: code = Canceled desc = context canceled
2018-12-19T09:18:25.796195Z	info	transport: loopyWriter.run returning. connection error: desc = "transport is closing"
2018-12-19T09:18:25.888968Z	info	parsed scheme: ""