### PR TITLE
Support define configscope for k8s service

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -35,6 +35,7 @@ import (
 
 	authn "istio.io/api/authentication/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/features/pilot"
 )
 
 // Hostname describes a (possibly wildcarded) hostname
@@ -360,12 +361,6 @@ type ServiceInstance struct {
 	ServiceAccount string          `json:"serviceaccount,omitempty"`
 }
 
-const (
-	// AZLabel indicates the region/zone of an instance. It is used if the native
-	// registry doesn't provide one.
-	AZLabel = "istio-az"
-)
-
 // GetLocality returns the availability zone from an instance.
 // - k8s: region/zone, extracted from node's failure-domain.beta.kubernetes.io/{region,zone}
 // - consul: defaults to 'instance.Datacenter'
@@ -375,7 +370,7 @@ func (si *ServiceInstance) GetLocality() string {
 	if si.Endpoint.Locality != "" {
 		return si.Endpoint.Locality
 	}
-	return si.Labels[AZLabel]
+	return si.Labels[pilot.AZLabel]
 }
 
 // IstioEndpoint has the information about a single address+port for a specific

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -27,6 +27,7 @@ import (
 
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/features/pilot"
 )
 
 const (
@@ -103,6 +104,13 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 	}
 	sort.Sort(sort.StringSlice(serviceaccounts))
 
+	configScope := networking.ConfigScope_PUBLIC
+	if svc.Labels != nil {
+		if svc.Labels[pilot.ServiceScopeLabel] == networking.ConfigScope_name[int32(networking.ConfigScope_PRIVATE)] {
+			configScope = networking.ConfigScope_PRIVATE
+		}
+	}
+
 	return &model.Service{
 		Hostname:        serviceHostname(svc.Name, svc.Namespace, domainSuffix),
 		Ports:           ports,
@@ -115,7 +123,7 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 			Name:        svc.Name,
 			Namespace:   svc.Namespace,
 			UID:         fmt.Sprintf("istio://%s/services/%s", svc.Namespace, svc.Name),
-			ConfigScope: networking.ConfigScope_PUBLIC,
+			ConfigScope: configScope,
 		},
 	}
 }

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -81,4 +81,13 @@ const (
 	// set at injection time. When set, the Endpoints returned to a note and not on same network
 	// will be replaced with the gateway defined in the settings.
 	NodeMetadataNetwork = "NETWORK"
+
+	// AZLabel indicates the region/zone of an instance. It is used if the native
+	// registry doesn't provide one.
+	AZLabel = "istio-az"
+
+	// ServiceScopeLabel configs the scope the service visible to.
+	//   "PUBLIC" which is the default, indicates it is reachable within the mesh
+	//   "PRIVATE" indicates it is reachable within its namespace
+	ServiceScopeLabel = "istio-config-scope"
 )

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -89,5 +89,5 @@ const (
 	// ServiceConfigScopeAnnotation configs the scope the service visible to.
 	//   "PUBLIC" which is the default, indicates it is reachable within the mesh
 	//   "PRIVATE" indicates it is reachable within its namespace
-	ServiceConfigScopeAnnotation = "networking.istio.io/config-scope"
+	ServiceConfigScopeAnnotation = "networking.istio.io/configScope"
 )

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -89,5 +89,5 @@ const (
 	// ServiceConfigScopeAnnotation configs the scope the service visible to.
 	//   "PUBLIC" which is the default, indicates it is reachable within the mesh
 	//   "PRIVATE" indicates it is reachable within its namespace
-	ServiceConfigScopeAnnotation = "service.istio.io/config-scope"
+	ServiceConfigScopeAnnotation = "networking.istio.io/config-scope"
 )

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -86,8 +86,8 @@ const (
 	// registry doesn't provide one.
 	AZLabel = "istio-az"
 
-	// ServiceScopeLabel configs the scope the service visible to.
+	// ServiceConfigScopeAnnotation configs the scope the service visible to.
 	//   "PUBLIC" which is the default, indicates it is reachable within the mesh
 	//   "PRIVATE" indicates it is reachable within its namespace
-	ServiceScopeLabel = "istio-config-scope"
+	ServiceConfigScopeAnnotation = "service.istio.io/config-scope"
 )


### PR DESCRIPTION
Support define Service configScope by annotation `"networking.istio.io/configScope"`