### PR TITLE
CNI release tooling cherry pick

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ ISTIO_DOCKER_HUB ?= docker.io/istio
 export ISTIO_DOCKER_HUB
 ISTIO_GCS ?= istio-release/releases/$(VERSION)
 ISTIO_URL ?= https://storage.googleapis.com/$(ISTIO_GCS)
+ISTIO_CNI_DOCKER_HUB ?= docker.io/istio
+export ISTIO_CNI_DOCKER_HUB
+ISTIO_CNI_DOCKER_TAG ?= master-latest-daily
+export ISTIO_CNI_DOCKER_TAG
 
 # cumulatively track the directories/files to delete after a clean
 DIRS_TO_CLEAN:=

--- a/istio.deps
+++ b/istio.deps
@@ -5,5 +5,12 @@
 		"repoName": "proxy",
 		"file": "",
 		"lastStableSHA": "35381896313b5f5c5d899e3dfeeae16f05c4f972"
-	}
+	},
+	{
+                "_comment": "",
+                "name": "CNI_REPO_SHA",
+                "repoName": "cni",
+                "file": "",
+                "lastStableSHA": "9a54dd033002125d5768c64b51486628995446c1i"
+        }
 ]

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
                 "name": "CNI_REPO_SHA",
                 "repoName": "cni",
                 "file": "",
-                "lastStableSHA": "9a54dd033002125d5768c64b51486628995446c1i"
+                "lastStableSHA": "2a46a60f8f14d0e17082977f2d097462a8bf7d91"
         }
 ]

--- a/prow/e2e-simpleTests-cni.sh
+++ b/prow/e2e-simpleTests-cni.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2018 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#######################################
+#                                     #
+#         e2e-simpleTest-cni          #
+#                                     #
+#######################################
+
+# Exit immediately for non zero status
+set -e
+# Check unset variables
+set -u
+# Print commands
+set -x
+
+echo 'Running e2e_simple test with rbac, auth Tests and CNI enabled'
+export ENABLE_ISTIO_CNI=true
+# cniBinDir setting is appropriate for GKE environments
+# HUB and TAG for the cni image will be based on the defaults checked in the cni repo
+export EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.cniBinDir=/home/kubernetes/bin"
+# only gke-e2e-test-latest is enabled for Networkpolicy and Calico
+export RESOURCE_TYPE="gke-e2e-test-latest"
+# TODO - When the inline kube inject code defaults to using the configmap this setting can be removed.
+export E2E_ARGS+=" --kube_inject_configmap=istio-sidecar-injector"
+./prow/e2e-suite.sh --auth_enable --single_test e2e_simple "$@"

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -103,3 +103,12 @@ function setup_e2e_cluster() {
   setup_cluster
 }
 
+function clone_cni() {
+  # Clone the CNI repo so the CNI artifacts can be built.
+  if [[ "$PWD" == "${GOPATH}/src/istio.io/istio" ]]; then
+      TMP_DIR=$PWD
+      cd ../ || return
+      git clone -b master "https://github.com/istio/cni.git"
+      cd "${TMP_DIR}" || return
+  fi
+}

--- a/prow/release-test.sh
+++ b/prow/release-test.sh
@@ -49,5 +49,6 @@ EOF
 }
 
 create_gcb_env
+clone_cni
 
 time ./release/gcb/cloud_builder.sh

--- a/release/gcb/cloud_builder.sh
+++ b/release/gcb/cloud_builder.sh
@@ -75,6 +75,31 @@ add_license_to_tar_images "${REL_DOCKER_HUB}" "${CB_VERSION}" "${OUTPUT_PATH}"
 # log where git thinks the build might be dirty
 git status
 
+#Handle CNI artifacts.
+pushd ../cni
+CNI_OUT=$(make DEBUG=0 where-is-out)
+# CNI version strategy is to have CNI run lock step with Istio i.e. CB_VERSION
+VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB="${CB_ISTIOCTL_DOCKER_HUB}" HUB="${CB_ISTIOCTL_DOCKER_HUB}" VERSION="${ISTIO_VERSION}" TAG="${ISTIO_VERSION}" make build
+
+if [ -d "${CNI_OUT}/docker" ]; then
+    rm -r "${CNI_OUT}/docker"
+fi
+
+VERBOSE=1 DEBUG=0 ISTIO_DOCKER_HUB=${REL_DOCKER_HUB} HUB=${REL_DOCKER_HUB} VERSION="${ISTIO_VERSION}" TAG="${ISTIO_VERSION}" make docker.save
+
+mkdir "/cni_tmp"
+
+cp -r "${CNI_OUT}/docker" "/cni_tmp"
+
+go run ../istio/tools/license/get_dep_licenses.go --branch "${CB_BRANCH}" > LICENSES.txt
+add_license_to_tar_images "${REL_DOCKER_HUB}" "${ISTIO_VERSION}" "/cni_tmp"
+cp -r "/cni_tmp" "${OUTPUT_PATH}/"
+
+# log where git thinks the build might be dirty
+git status
+
+popd
+
 # preserve the source from the root of the code
 pushd "${ROOT}/../../../.."
 pwd

--- a/release/gcb/generate_manifest.sh
+++ b/release/gcb/generate_manifest.sh
@@ -45,22 +45,25 @@ function checkout_code() {
 function create_manifest_check_consistency() {
   local MANIFEST_FILE=$1
 
- pushd istio
+  pushd istio
   local ISTIO_REPO_SHA
   local PROXY_REPO_SHA
+  local CNI_REPO_SHA
   local API_REPO_SHA
   ISTIO_REPO_SHA=$(git rev-parse HEAD)
+  CNI_REPO_SHA=$(grep CNI_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
   PROXY_REPO_SHA=$(grep PROXY_REPO_SHA istio.deps  -A 4 | grep lastStableSHA | cut -f 4 -d '"')
   API_REPO_SHA=$(grep istio.io.api -A 100 < Gopkg.lock | grep revision -m 1 | cut -f 2 -d '"')
 
-  if [ -z "${ISTIO_REPO_SHA}" ] || [ -z "${API_REPO_SHA}" ] || [ -z "${PROXY_REPO_SHA}" ]; then
-    echo "ISTIO_REPO_SHA:$ISTIO_REPO_SHA API_REPO_SHA:$API_REPO_SHA PROXY_REPO_SHA:$PROXY_REPO_SHA some shas not found"
+  if [ -z "${ISTIO_REPO_SHA}" ] || [ -z "${API_REPO_SHA}" ] || [ -z "${PROXY_REPO_SHA}" ] || [ -z "${CNI_REPO_SHA}" ] ; then
+    echo "ISTIO_REPO_SHA:$ISTIO_REPO_SHA API_REPO_SHA:$API_REPO_SHA PROXY_REPO_SHA:$PROXY_REPO_SHA CNI_REPO_SHA:$CNI_REPO_SHA some shas not found"
     exit 8
   fi
 cat << EOF > "${MANIFEST_FILE}"
 istio ${ISTIO_REPO_SHA}
 proxy ${PROXY_REPO_SHA}
 api ${API_REPO_SHA}
+cni ${CNI_REPO_SHA}
 EOF
 
  popd

--- a/release/gcb/github_tag_release.sh
+++ b/release/gcb/github_tag_release.sh
@@ -123,7 +123,7 @@ EOF
 gsutil cp "gs://$CB_GCS_RELEASE_TOOLS_PATH/manifest.txt" "/workspace/manifest.txt"
 
 echo "Beginning tag of github"
-ORG_REPOS=(api istio proxy)
+ORG_REPOS=(api istio proxy cni)
 
 for GITREPO in "${ORG_REPOS[@]}"; do
   SHA=$(grep "$GITREPO" "/workspace/manifest.txt"  | cut -f 2 -d " ")

--- a/release/gcb/istio_checkout_code.sh
+++ b/release/gcb/istio_checkout_code.sh
@@ -46,7 +46,9 @@ function istio_code_init_manifest() {
 
   API_SHA=$(  grep "api"   "$MANIFEST_FILE" | cut -f 2 -d " ")
   PROXY_SHA=$(grep "proxy" "$MANIFEST_FILE" | cut -f 2 -d " ")
+  CNI_SHA=$(  grep "cni"   "$MANIFEST_FILE" | cut -f 2 -d " ")
 
+  checkout_code "cni" "${CNI_SHA}" "/workspace/go/src/istio.io"
   checkout_code "proxy" "${PROXY_SHA}" "/workspace/src"
   checkout_code "api"     "${API_SHA}" "/workspace/go/src/istio.io"
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -67,6 +67,12 @@ EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 
 e2e_simple: istioctl generate_yaml e2e_simple_run
 
+e2e_simple_cni: istioctl
+e2e_simple_cni: export ENABLE_ISTIO_CNI=true
+e2e_simple_cni: export EXTRA_HELM_SETTINGS=--set istio-cni.excludeNamespaces={} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.tag=$(ISTIO_CNI_DOCKER_TAG) --set istio-cni.hub=$(ISTIO_CNI_DOCKER_HUB)
+e2e_simple_cni: export E2E_ARGS+=--kube_inject_configmap=istio-sidecar-injector
+e2e_simple_cni: generate_yaml e2e_simple_run
+
 e2e_simple_noauth: istioctl generate_yaml e2e_simple_noauth_run
 
 e2e_mixer: istioctl generate_e2e_test_yaml e2e_mixer_run


### PR DESCRIPTION
Cherry picks 3 commits on master back to 1.1 to enable the
building, testing and pushing of CNI images on release
1.1