### PR TITLE
Fix default CNI image HUB and TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ ISTIO_DOCKER_HUB ?= docker.io/istio
 export ISTIO_DOCKER_HUB
 ISTIO_GCS ?= istio-release/releases/$(VERSION)
 ISTIO_URL ?= https://storage.googleapis.com/$(ISTIO_GCS)
-ISTIO_CNI_DOCKER_HUB ?= docker.io/istio
-export ISTIO_CNI_DOCKER_HUB
-ISTIO_CNI_DOCKER_TAG ?= master-latest-daily
-export ISTIO_CNI_DOCKER_TAG
+ISTIO_CNI_HUB ?= gcr.io/istio-release
+export ISTIO_CNI_HUB
+ISTIO_CNI_TAG ?= master-latest-daily
+export ISTIO_CNI_TAG
 
 # cumulatively track the directories/files to delete after a clean
 DIRS_TO_CLEAN:=

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -68,7 +68,7 @@ EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 e2e_simple: istioctl generate_yaml e2e_simple_run
 e2e_simple_cni: istioctl
 e2e_simple_cni: export ENABLE_ISTIO_CNI=true
-e2e_simple_cni: export EXTRA_HELM_SETTINGS=--set istio-cni.excludeNamespaces={} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.tag=$(ISTIO_CNI_DOCKER_TAG) --set istio-cni.hub=$(ISTIO_CNI_DOCKER_HUB)
+e2e_simple_cni: export EXTRA_HELM_SETTINGS=--set istio-cni.excludeNamespaces={} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.tag=$(ISTIO_CNI_TAG) --set istio-cni.hub=$(ISTIO_CNI_HUB)
 e2e_simple_cni: export E2E_ARGS+=--kube_inject_configmap=istio-sidecar-injector
 e2e_simple_cni: generate_yaml e2e_simple_run
 e2e_simple_auth: istioctl generate_yaml e2e_simple_auth_run


### PR DESCRIPTION
The default hub and tag for locally run e2e tests were
pointing to docker.io,  but that is not where the nightly
CNI images are being pushed.