### PR TITLE
Enable Citadel to insert TLS root cert into configmap.

### DIFF
--- a/install/kubernetes/helm/subcharts/security/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/clusterrole.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create", "get", "update"]
+- apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "watch", "list", "update", "delete"]
 - apiGroups: [""]


### PR DESCRIPTION
Citadel agents need to use Citadel's root cert to establish TLS connection to Citadel. The root cert is conveyed by the Citadel to Citadel agents through the configmap.

Issue https://github.com/istio/istio/issues/10283