### PR TITLE
add dedicated service account to run nodeagent

### DIFF
--- a/install/kubernetes/helm/subcharts/nodeagent/templates/_helpers.tpl
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nodeagent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nodeagent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nodeagent.chart" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: istio-nodeagent-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "nodeagent.name" . }}
+    chart: {{ template "nodeagent.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/clusterrolebinding.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: istio-nodeagent-{{ .Release.Namespace }}
+  labels:
+    app: {{ template "nodeagent.name" . }}
+    chart: {{ template "nodeagent.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-nodeagent-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: istio-nodeagent-service-account
+    namespace: {{ .Release.Namespace }}

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/daemonset.yaml
@@ -1,11 +1,11 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: nodeagent
+  name: istio-nodeagent
   namespace: {{ .Release.Namespace }}
   labels:
-    app: istio-nodeagent
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "nodeagent.name" . }}
+    chart: {{ template "nodeagent.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     istio: nodeagent
@@ -13,13 +13,14 @@ spec:
   template:
     metadata:
       labels:
-        istio: nodeagent
-        app: nodeagent
-        chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app: {{ template "nodeagent.name" . }}
+        chart: {{ template "nodeagent.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
         version: {{ .Chart.Version }}
+        istio: nodeagent
     spec:
+      serviceAccountName: istio-nodeagent-service-account
       containers:
       - name: nodeagent
 {{- if contains "/" .Values.image }}

--- a/install/kubernetes/helm/subcharts/nodeagent/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/subcharts/nodeagent/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+metadata:
+  name: istio-nodeagent-service-account
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "nodeagent.name" . }}
+    chart: {{ template "nodeagent.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035, https://github.com/istio/istio/issues/10283

previous nodeagent run as default service account, which is fine; with integration with citadel, to retrieve root cert from configmap(which is written by citadel) for tls communication with citadel, nodeagent hit below error that default service account doesn't have permission of reading from configmap; this PR creates a dedicated service account for nodeagent(and grant configmap read permission). 

```
2018-12-20T22:35:27.703153Z	info	unalbe to fetch CA TLS root cert error: failed to get CA TLS root cert: configmaps "istio-security" is forbidden: User "system:serviceaccount:istio-system:default" cannot get configmaps in the namespace "istio-system", retry in 2s

```