### PR TITLE
use correct namespace for retrieving rootcert for nodeagent->citadel TLS communication

### DIFF
--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -33,6 +33,7 @@ import (
 const (
 	googleCAName = "GoogleCA"
 	citadelName  = "Citadel"
+	ns           = "istio-system"
 
 	retryInterval = time.Second * 2
 	maxRetries    = 100
@@ -52,7 +53,7 @@ func NewCAClient(endpoint, CAProviderName string, tlsFlag bool) (caClientInterfa
 		if err != nil {
 			return nil, err
 		}
-		controller := configmap.NewController("", cs.CoreV1())
+		controller := configmap.NewController(ns, cs.CoreV1())
 		rootCert, err := getCATLSRootCertFromConfigMap(controller, retryInterval, maxRetries)
 		if err != nil {
 			return nil, err
@@ -74,7 +75,7 @@ func getCATLSRootCertFromConfigMap(controller configMap, interval time.Duration,
 			break
 		}
 		time.Sleep(retryInterval)
-		log.Infof("unalbe to fetch CA TLS root cert, retry in %v", interval)
+		log.Infof("unalbe to fetch CA TLS root cert: %v, retry in %v", err, interval)
 	}
 	if cert == "" {
 		return nil, fmt.Errorf("exhausted all the retries (%d) to fetch the CA TLS root cert", max)


### PR DESCRIPTION
https://github.com/istio/istio/issues/10283

fix below error
```
2018-12-20T22:22:39.904475Z	info	unalbe to fetch CA TLS root cert error: failed to get CA TLS root cert: an empty namespace may not be set when a resource name is provided, retry in 2s
```