### PR TITLE
set podspec.securitycontext in auto-sidecar-injection webhook

### DIFF
--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -416,7 +416,10 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotation
 	patch = append(patch, addContainer(pod.Spec.Containers, sic.Containers, "/spec/containers")...)
 	patch = append(patch, addVolume(pod.Spec.Volumes, sic.Volumes, "/spec/volumes")...)
 	patch = append(patch, addImagePullSecrets(pod.Spec.ImagePullSecrets, sic.ImagePullSecrets, "/spec/imagePullSecrets")...)
-	patch = append(patch, addSecurityContext(pod.Spec.SecurityContext, "/spec/securityContext")...)
+
+	if pod.Spec.SecurityContext != nil {
+		patch = append(patch, addSecurityContext(pod.Spec.SecurityContext, "/spec/securityContext")...)
+	}
 
 	patch = append(patch, updateAnnotation(pod.Annotations, annotations)...)
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

similar to kube-inject change made in https://github.com/istio/istio/pull/10259, this PR is for auto-sidecar-injection webhook.

more context:
due to bug https://github.com/kubernetes/kubernetes/issues/57923, k8s sa trustworthy jwt token volume mount file is only accessible to root user, not istio-proxy(the user that istio proxy runs as). this PR workaround the bug using https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod, so that envoy could fetch/pass k8s sa trustworthy jwt to nodeagent, which will be eventually used for generate workload identity

