### PR TITLE
Optimize MCP Monitor

### DIFF
--- a/galley/pkg/crd/validation/monitoring.go
+++ b/galley/pkg/crd/validation/monitoring.go
@@ -94,19 +94,14 @@ var (
 		stats.UnitDimensionless)
 )
 
-var views []*view.View
-
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
-	v := &view.View{
+	return &view.View{
 		Name:        measure.Name(),
 		Description: measure.Description(),
 		Measure:     measure,
 		TagKeys:     keys,
 		Aggregation: aggregation,
 	}
-	views = append(views, v)
-
-	return v
 }
 
 func init() {
@@ -151,11 +146,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-}
-
-// UnregisterValidationMonitorViews unregisters all validation views
-func UnregisterValidationMonitorViews() {
-	view.Unregister(views...)
 }
 
 func reportValidationFailed(request *admissionv1beta1.AdmissionRequest, reason string) {

--- a/galley/pkg/kube/source/monitoring.go
+++ b/galley/pkg/kube/source/monitoring.go
@@ -111,24 +111,14 @@ func newTagKey(label string) tag.Key {
 	}
 }
 
-var views []*view.View
-
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
-	v := &view.View{
+	return &view.View{
 		Name:        measure.Name(),
 		Description: measure.Description(),
 		Measure:     measure,
 		TagKeys:     keys,
 		Aggregation: aggregation,
 	}
-	views = append(views, v)
-
-	return v
-}
-
-// UnregisterKubeSourceMonitorViews unregisters all kube/source views
-func UnregisterKubeSourceMonitorViews() {
-	view.Unregister(views...)
 }
 
 func init() {

--- a/galley/pkg/runtime/monitoring.go
+++ b/galley/pkg/runtime/monitoring.go
@@ -28,8 +28,6 @@ const collection = "collection"
 // CollectionTag holds the type URL for the context.
 var CollectionTag tag.Key
 
-var views []*view.View
-
 var (
 	strategyOnChangeTotal = stats.Int64(
 		"galley/runtime/strategy/on_change_total",
@@ -113,21 +111,13 @@ func recordStateTypeCount(collection string, count int) {
 }
 
 func newView(measure stats.Measure, keys []tag.Key, aggregation *view.Aggregation) *view.View {
-	v := &view.View{
+	return &view.View{
 		Name:        measure.Name(),
 		Description: measure.Description(),
 		Measure:     measure,
 		TagKeys:     keys,
 		Aggregation: aggregation,
 	}
-	views = append(views, v)
-
-	return v
-}
-
-// UnregisterRuntimeMonitorViews unregisters all runtime views
-func UnregisterRuntimeMonitorViews() {
-	view.Unregister(views...)
 }
 
 func init() {


### PR DESCRIPTION
1. call `view.Register` once with array instead of called one-by-one
2. remove `view.Unregister` method, because 
-  it  unregistered mcp monitor only, actually, we have more (galley-runtime/galley-kube...)
- it is unnecessary to unregister views before close the monitor server


Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>