### PR TITLE
Enhance Galley Validation Debugging

### DIFF
--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -94,6 +94,7 @@ func webhookHTTPSHandlerReady(client httpClient, vc *WebhookParameters) error {
 //RunValidation start running Galley validation mode
 func RunValidation(vc *WebhookParameters, printf, faltaf shared.FormatFn, kubeConfig string,
 	livenessProbeController, readinessProbeController probe.Controller) {
+	printf("Galley validation started with\n%s", vc)
 	mixerValidator := createMixerValidator()
 	clientset, err := kube.CreateClientset(kubeConfig, "")
 	if err != nil {
@@ -158,21 +159,6 @@ func RunValidation(vc *WebhookParameters, printf, faltaf shared.FormatFn, kubeCo
 
 	go wh.Run(stop)
 	cmd.WaitSignal(stop)
-}
-
-// DefaultArgs allocates an WebhookParameters struct initialized with Webhook's default configuration.
-func DefaultArgs() *WebhookParameters {
-	return &WebhookParameters{
-		Port:                          443,
-		CertFile:                      "/etc/certs/cert-chain.pem",
-		KeyFile:                       "/etc/certs/key.pem",
-		CACertFile:                    "/etc/certs/root-cert.pem",
-		DeploymentAndServiceNamespace: "istio-system",
-		DeploymentName:                "istio-galley",
-		ServiceName:                   "istio-galley",
-		WebhookName:                   "istio-galley",
-		EnableValidation:              true,
-	}
 }
 
 // isDNS1123Label tests for a string that conforms to the definition of a label in

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -15,6 +15,7 @@
 package validation
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -132,6 +133,40 @@ var (
 			fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", name)))
 	}
 )
+
+// String produces a stringified version of the arguments for debugging.
+func (p *WebhookParameters) String() string {
+	buf := &bytes.Buffer{}
+
+	fmt.Fprintf(buf, "DomainSuffix: %s\n", p.DomainSuffix)
+	fmt.Fprintf(buf, "Port: %d\n", p.Port)
+	fmt.Fprintf(buf, "CertFile: %s\n", p.CertFile)
+	fmt.Fprintf(buf, "KeyFile: %s\n", p.KeyFile)
+	fmt.Fprintf(buf, "WebhookConfigFile: %s\n", p.WebhookConfigFile)
+	fmt.Fprintf(buf, "CACertFile: %s\n", p.CACertFile)
+	fmt.Fprintf(buf, "DeploymentAndServiceNamespace: %s\n", p.DeploymentAndServiceNamespace)
+	fmt.Fprintf(buf, "WebhookName: %s\n", p.WebhookName)
+	fmt.Fprintf(buf, "DeploymentName: %s\n", p.DeploymentName)
+	fmt.Fprintf(buf, "ServiceName: %s\n", p.ServiceName)
+	fmt.Fprintf(buf, "EnableValidation: %v\n", p.EnableValidation)
+
+	return buf.String()
+}
+
+// DefaultArgs allocates an WebhookParameters struct initialized with Webhook's default configuration.
+func DefaultArgs() *WebhookParameters {
+	return &WebhookParameters{
+		Port:                          443,
+		CertFile:                      "/etc/certs/cert-chain.pem",
+		KeyFile:                       "/etc/certs/key.pem",
+		CACertFile:                    "/etc/certs/root-cert.pem",
+		DeploymentAndServiceNamespace: "istio-system",
+		DeploymentName:                "istio-galley",
+		ServiceName:                   "istio-galley",
+		WebhookName:                   "istio-galley",
+		EnableValidation:              true,
+	}
+}
 
 // Webhook implements the validating admission webhook for validating Istio configuration.
 type Webhook struct {

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -122,6 +122,12 @@ var (
 	}
 )
 
+func TestArgs_String(t *testing.T) {
+	p := DefaultArgs()
+	// Should not crash
+	_ = p.String()
+}
+
 func createTestWebhook(
 	t testing.TB,
 	cl clientset.Interface,

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -115,7 +115,7 @@ func (a *Args) String() string {
 	fmt.Fprintf(buf, "MaxReceivedMessageSize: %d\n", a.MaxReceivedMessageSize)
 	fmt.Fprintf(buf, "MaxConcurrentStreams: %d\n", a.MaxConcurrentStreams)
 	fmt.Fprintf(buf, "LoggingOptions: %#v\n", *a.LoggingOptions)
-	fmt.Fprintf(buf, "IntrospectionOptions: %#v\n", *a.IntrospectionOptions)
+	fmt.Fprintf(buf, "IntrospectionOptions: %+v\n", *a.IntrospectionOptions)
 	fmt.Fprintf(buf, "Insecure: %v\n", a.Insecure)
 	fmt.Fprintf(buf, "AccessListFile: %s\n", a.AccessListFile)
 	fmt.Fprintf(buf, "EnableServer: %v\n", a.EnableServer)


### PR DESCRIPTION
1. Print galley validation webhook parameters for debugging
2. `DefaultArgs()` should belong to `webhook`
3. Print friendly `port` content instead of `ctrlz.Options{Port:0x2694`

Signed-off-by: clyang82 <clyang@cn.ibm.com>