### PR TITLE
add txt files to release archives.

### DIFF
--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -116,6 +116,7 @@ find samples install -type f \( \
   -o -name "*.conf" \
   -o -name "*.pem" \
   -o -name "*.tpl" \
+  -o -name "*.txt" \
   -o -name "kubeconfig" \
   -o -name "*.jinja*" \
   -o -name "webhook-create-signed-cert.sh" \


### PR DESCRIPTION
Add `*.txt` file in release archive because `NOTES.txt` in istio chart contains plain text that will be printed out after chart installation.
