### PR TITLE
webhook inject k8s service account volume mount to istio-proxy container

### DIFF
--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -299,9 +299,27 @@ func removeImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference, remo
 }
 
 func addContainer(target, added []corev1.Container, basePath string) (patch []rfc6902PatchOperation) {
+	name := ""
+	var mt corev1.VolumeMount
+	// find service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
+	// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) from app container
+	for _, add := range target {
+		for _, vmount := range add.VolumeMounts {
+			if vmount.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" {
+				name = vmount.Name
+				mt = vmount
+			}
+		}
+	}
 	first := len(target) == 0
 	var value interface{}
 	for _, add := range added {
+		if add.Name == "istio-proxy" && name != "" {
+			// add service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
+			// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) to istio-proxy container,
+			// so that envoy could fetch/pass k8s sa jwt and pass to sds server, which will be used to request workload identity for the pod.
+			add.VolumeMounts = append(add.VolumeMounts, mt)
+		}
 		value = add
 		path := basePath
 		if first {

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -299,26 +299,26 @@ func removeImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference, remo
 }
 
 func addContainer(target, added []corev1.Container, basePath string) (patch []rfc6902PatchOperation) {
-	name := ""
-	var mt corev1.VolumeMount
+	saJwtSecretMountName := ""
+	var saJwtSecretMount corev1.VolumeMount
 	// find service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
 	// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) from app container
 	for _, add := range target {
 		for _, vmount := range add.VolumeMounts {
 			if vmount.MountPath == "/var/run/secrets/kubernetes.io/serviceaccount" {
-				name = vmount.Name
-				mt = vmount
+				saJwtSecretMountName = vmount.Name
+				saJwtSecretMount = vmount
 			}
 		}
 	}
 	first := len(target) == 0
 	var value interface{}
 	for _, add := range added {
-		if add.Name == "istio-proxy" && name != "" {
+		if add.Name == "istio-proxy" && saJwtSecretMountName != "" {
 			// add service account secret volume mount(/var/run/secrets/kubernetes.io/serviceaccount,
 			// https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-automation) to istio-proxy container,
 			// so that envoy could fetch/pass k8s sa jwt and pass to sds server, which will be used to request workload identity for the pod.
-			add.VolumeMounts = append(add.VolumeMounts, mt)
+			add.VolumeMounts = append(add.VolumeMounts, saJwtSecretMount)
 		}
 		value = add
 		path := basePath


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

app deployed by sidecar auto injection webhook doesn't have k8s normal jwt in ```/var/run/secrets/kubernetes.io/serviceaccount```(manually injection works fine), this jwt is used to request workload identity through SDS if trustworthy jwt isn't available.  

By looking into pod yaml file generated by webhook, it already has pod.volume whose mountPath == "/var/run/secrets/kubernetes.io/serviceaccount", and volume mount is already added to app container, this PR inject same volume mount to sidecar container. 

