### PR TITLE
Remove extra ports section

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -60,7 +60,6 @@
         - containerPort: 9091
         - containerPort: 15004
 {{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
-        ports:
         - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
           protocol: TCP
           name: http-envoy-prom
@@ -172,7 +171,6 @@
         - containerPort: 9091
         - containerPort: 15004
 {{ if ne .Values.global.proxy.stats.prometheusPort 0. }}
-        ports:
         - containerPort: {{ .Values.global.proxy.stats.prometheusPort }}
           protocol: TCP
           name: http-envoy-prom


### PR DESCRIPTION
Problem: The mixer chart gets two `ports` sections when the global `prometheusPort` is defined.

Solution: Removed the extra section.