### PR TITLE
Add <, <=, >= and > operators for string, ints and floats to Mixer EL (1.1)

### DIFF
--- a/mixer/pkg/il/builder.go
+++ b/mixer/pkg/il/builder.go
@@ -150,6 +150,134 @@ func (f *Builder) AEQString(v string) {
 	f.op1(AEqS, f.id(v))
 }
 
+// LTString appends the "lt_s" instruction to the byte code.
+func (f *Builder) LTString() {
+	f.op0(LtS)
+}
+
+// LTInteger appends the "lt_i" instruction to the byte code.
+func (f *Builder) LTInteger() {
+	f.op0(LtI)
+}
+
+// LTDouble appends the "lt_d" instruction to the byte code.
+func (f *Builder) LTDouble() {
+	f.op0(LtD)
+}
+
+// ALTString appends the "alt_s" instruction to the byte code.
+func (f *Builder) ALTString(v string) {
+	f.op1(ALtS, f.id(v))
+}
+
+// ALTInteger appends the "alt_i" instruction to the byte code.
+func (f *Builder) ALTInteger(v int64) {
+	a1, a2 := IntegerToByteCode(v)
+	f.op2(ALtI, a1, a2)
+}
+
+// ALTDouble appends the "alt_d" instruction to the byte code.
+func (f *Builder) ALTDouble(v float64) {
+	a1, a2 := DoubleToByteCode(v)
+	f.op2(ALtD, a1, a2)
+}
+
+// LEString appends the "le_s" instruction to the byte code.
+func (f *Builder) LEString() {
+	f.op0(LeS)
+}
+
+// LEInteger appends the "le_i" instruction to the byte code.
+func (f *Builder) LEInteger() {
+	f.op0(LeI)
+}
+
+// LEDouble appends the "le_d" instruction to the byte code.
+func (f *Builder) LEDouble() {
+	f.op0(LeD)
+}
+
+// ALEString appends the "ale_s" instruction to the byte code.
+func (f *Builder) ALEString(v string) {
+	f.op1(ALeS, f.id(v))
+}
+
+// ALEInteger appends the "ale_i" instruction to the byte code.
+func (f *Builder) ALEInteger(v int64) {
+	a1, a2 := IntegerToByteCode(v)
+	f.op2(ALeI, a1, a2)
+}
+
+// ALEDouble appends the "ale_d" instruction to the byte code.
+func (f *Builder) ALEDouble(v float64) {
+	a1, a2 := DoubleToByteCode(v)
+	f.op2(ALeD, a1, a2)
+}
+
+// GTString appends the "gt_s" instruction to the byte code.
+func (f *Builder) GTString() {
+	f.op0(GtS)
+}
+
+// GTInteger appends the "gt_i" instruction to the byte code.
+func (f *Builder) GTInteger() {
+	f.op0(GtI)
+}
+
+// GTDouble appends the "gt_d" instruction to the byte code.
+func (f *Builder) GTDouble() {
+	f.op0(GtD)
+}
+
+// AGTString appends the "agt_s" instruction to the byte code.
+func (f *Builder) AGTString(v string) {
+	f.op1(AGtS, f.id(v))
+}
+
+// AGTInteger appends the "agt_i" instruction to the byte code.
+func (f *Builder) AGTInteger(v int64) {
+	a1, a2 := IntegerToByteCode(v)
+	f.op2(AGtI, a1, a2)
+}
+
+// AGTDouble appends the "agt_d" instruction to the byte code.
+func (f *Builder) AGTDouble(v float64) {
+	a1, a2 := DoubleToByteCode(v)
+	f.op2(AGtD, a1, a2)
+}
+
+// GEString appends the "ge_s" instruction to the byte code.
+func (f *Builder) GEString() {
+	f.op0(GeS)
+}
+
+// GEInteger appends the "ge_i" instruction to the byte code.
+func (f *Builder) GEInteger() {
+	f.op0(GeI)
+}
+
+// GEDouble appends the "ge_d" instruction to the byte code.
+func (f *Builder) GEDouble() {
+	f.op0(GeD)
+}
+
+// AGEString appends the "age_s" instruction to the byte code.
+func (f *Builder) AGEString(v string) {
+	f.op1(AGeS, f.id(v))
+}
+
+// AGEInteger appends the "age_d" instruction to the byte code.
+func (f *Builder) AGEInteger(v int64) {
+	a1, a2 := IntegerToByteCode(v)
+	f.op2(AGeI, a1, a2)
+}
+
+// AGEDouble appends the "age_i" instruction to the byte code.
+func (f *Builder) AGEDouble(v float64) {
+	a1, a2 := DoubleToByteCode(v)
+	f.op2(AGeD, a1, a2)
+}
+
 // EQBool appends the "eq_b" instruction to the byte code.
 func (f *Builder) EQBool() {
 	f.op0(EqB)

--- a/mixer/pkg/il/interpreter/bench.baseline
+++ b/mixer/pkg/il/interpreter/bench.baseline
@@ -26,3 +26,10 @@ BenchmarkInterpreter/false_&&_false-8           	20000000	        95.4 ns/op	   
 # BenchmarkInterpreter/ASTBenchmark/[a=2,_host="abc]"-8          	10000000	       158 ns/op	       0 B/op	       0 allocs/op
 # BenchmarkInterpreter/ASTBenchmark/[a=20,_host="abcd]"-8        	10000000	       165 ns/op	       0 B/op	       0 allocs/op
 
+#  11/27/2018
+# BenchmarkInterpreter/ExprBench/ok_1st-8                 10000000               167 ns/op               0 B/op          0 allocs/op
+# BenchmarkInterpreter/ExprBench/ok_2nd-8                  2000000               634 ns/op              56 B/op          4 allocs/op
+# BenchmarkInterpreter/ExprBench/not_found-8               2000000               647 ns/op              56 B/op          4 allocs/op
+# BenchmarkInterpreter/true_&&_false-8                    20000000               111 ns/op               0 B/op          0 allocs/op
+# BenchmarkInterpreter/true_&&_true-8                     20000000               113 ns/op               0 B/op          0 allocs/op
+# BenchmarkInterpreter/false_&&_false-8                   20000000               110 ns/op               0 B/op          0 allocs/op

--- a/mixer/pkg/il/interpreter/interpreterRun.go
+++ b/mixer/pkg/il/interpreter/interpreterRun.go
@@ -1163,6 +1163,447 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			opstack[sp] = t3
 			sp++
 
+		case il.LtS:
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			t2 = opstack[sp-2]
+			sp = sp - 2
+			if t1 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t1].(string)
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr2 = heap[t2].(string)
+
+			if tStr > tStr2 {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.LtI:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(opstack[sp-3])+int64(opstack[sp-4])<<32 < ti64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.LtD:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3])+uint64(opstack[sp-4])<<32) < tf64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALtS:
+			t1 = body[ip]
+			ip++
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			sp--
+			t2 = opstack[sp]
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t2].(string)
+			if strings.GetString(t1) > tStr {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALtI:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1)+int64(t2)<<32 > ti64 {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALtD:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+
+			if tf64 < math.Float64frombits(uint64(t1)+uint64(t2)<<32) {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.LeS:
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			t2 = opstack[sp-2]
+			sp = sp - 2
+			if t1 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t1].(string)
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr2 = heap[t2].(string)
+
+			if tStr >= tStr2 {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.LeI:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) <= ti64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.LeD:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3])+uint64(opstack[sp-4])<<32) <= tf64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALeS:
+			t1 = body[ip]
+			ip++
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			sp--
+			t2 = opstack[sp]
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t2].(string)
+			if strings.GetString(t1) >= tStr {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALeI:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1)+int64(t2)<<32 >= ti64 {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.ALeD:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 <= math.Float64frombits(uint64(t1)+uint64(t2)<<32) {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GtS:
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			t2 = opstack[sp-2]
+			sp = sp - 2
+			if t1 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t1].(string)
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr2 = heap[t2].(string)
+
+			if tStr < tStr2 {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GtI:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) > ti64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GtD:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3])+uint64(opstack[sp-4])<<32) > tf64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGtS:
+			t1 = body[ip]
+			ip++
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			sp--
+			t2 = opstack[sp]
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t2].(string)
+			if strings.GetString(t1) < tStr {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGtI:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1)+int64(t2)<<32 < ti64 {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGtD:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 > math.Float64frombits(uint64(t1)+uint64(t2)<<32) {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GeS:
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			t1 = opstack[sp-1]
+			t2 = opstack[sp-2]
+			sp = sp - 2
+			if t1 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t1].(string)
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr2 = heap[t2].(string)
+
+			if tStr <= tStr2 {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GeI:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) >= ti64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.GeD:
+			if sp < 4 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3])+uint64(opstack[sp-4])<<32) >= tf64 {
+				sp -= 4
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp -= 4
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGeS:
+			t1 = body[ip]
+			ip++
+			if sp < 1 {
+				goto STACK_UNDERFLOW
+			}
+			sp--
+			t2 = opstack[sp]
+			if t2 >= hp {
+				goto INVALID_HEAP_ACCESS
+			}
+			tStr = heap[t2].(string)
+			if strings.GetString(t1) <= tStr {
+				opstack[sp] = 1
+				sp++
+			} else {
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGeI:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(t1) + int64(t2)<<32) <= ti64 {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
+		case il.AGeD:
+			t1 = body[ip]
+			t2 = body[ip+1]
+			ip = ip + 2
+			if sp < 2 {
+				goto STACK_UNDERFLOW
+			}
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 >= math.Float64frombits(uint64(t1)+uint64(t2)<<32) {
+				sp = sp - 2
+				opstack[sp] = 1
+				sp++
+			} else {
+				sp = sp - 2
+				opstack[sp] = 0
+				sp++
+			}
+
 		default:
 			tErr = fmt.Errorf("invalid opcode: '%v'", il.Opcode(code))
 			goto RETURN_ERR

--- a/mixer/pkg/il/interpreter/interpreterRun.got
+++ b/mixer/pkg/il/interpreter/interpreterRun.got
@@ -773,7 +773,7 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			GET_HEAP_VALUE(t2, tVal)
 			tStr, tFound = il.MapGet(tVal, tStr)
 			if !tFound {
-    			GET_HEAP_VALUE_STRING(t1, tStr)
+				GET_HEAP_VALUE_STRING(t1, tStr)
 				ERRF("member lookup failed: '%v'", tStr)
 			}
 			NEW_HEAP_VALUE(tStr, t3)
@@ -816,6 +816,283 @@ func (in *Interpreter) run(fn *il.Function, bag attribute.Bag, step bool) (Resul
 			}
 			NEW_HEAP_VALUE(tStr, t3)
 			STACK_PUSH(t3)
+
+		case il.LtS:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr2)
+
+			if tStr > tStr2 {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.LtI:
+			STACK_UNDERFLOW_GUARD(4)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(opstack[sp-3]) + int64(opstack[sp-4])<<32 < ti64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.LtD:
+			STACK_UNDERFLOW_GUARD(4)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3]) + uint64(opstack[sp-4])<<32) < tf64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.ALtS:
+			LOAD_OP_CODE(t1)
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t2)
+			GET_HEAP_VALUE_STRING(t2, tStr)
+			if strings.GetString(t1) > tStr {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.ALtI:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1) + int64(t2)<<32 > ti64 {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.ALtD:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+
+			if tf64 < math.Float64frombits(uint64(t1) + uint64(t2)<<32) {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.LeS:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr2)
+
+			if tStr >= tStr2 {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.LeI:
+			STACK_UNDERFLOW_GUARD(4)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) <= ti64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.LeD:
+			STACK_UNDERFLOW_GUARD(4)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3]) + uint64(opstack[sp-4])<<32) <= tf64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.ALeS:
+			LOAD_OP_CODE(t1)
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t2)
+			GET_HEAP_VALUE_STRING(t2, tStr)
+			if strings.GetString(t1) >= tStr {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.ALeI:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1) + int64(t2)<<32 >= ti64 {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.ALeD:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 <= math.Float64frombits(uint64(t1) + uint64(t2)<<32) {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.GtS:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr2)
+
+			if tStr < tStr2 {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.GtI:
+			STACK_UNDERFLOW_GUARD(4)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) > ti64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.GtD:
+			STACK_UNDERFLOW_GUARD(4)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3]) + uint64(opstack[sp-4])<<32) > tf64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.AGtS:
+			LOAD_OP_CODE(t1)
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t2)
+			GET_HEAP_VALUE_STRING(t2, tStr)
+			if strings.GetString(t1) < tStr {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.AGtI:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if int64(t1) + int64(t2)<<32 < ti64 {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.AGtD:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 > math.Float64frombits(uint64(t1) + uint64(t2)<<32) {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.GeS:
+			STACK_UNDERFLOW_GUARD(2)
+			STACK_POP2(t1, t2)
+			GET_HEAP_VALUE_STRING(t1, tStr)
+			GET_HEAP_VALUE_STRING(t2, tStr2)
+
+			if tStr <= tStr2 {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.GeI:
+			STACK_UNDERFLOW_GUARD(4)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(opstack[sp-3]) + int64(opstack[sp-4])<<32) >= ti64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.GeD:
+			STACK_UNDERFLOW_GUARD(4)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if math.Float64frombits(uint64(opstack[sp-3]) + uint64(opstack[sp-4])<<32) >= tf64 {
+				sp -= 4
+				STACK_PUSH(1)
+			} else {
+				sp -= 4
+				STACK_PUSH(0)
+			}
+
+		case il.AGeS:
+			LOAD_OP_CODE(t1)
+			STACK_UNDERFLOW_GUARD(1)
+			STACK_POP(t2)
+			GET_HEAP_VALUE_STRING(t2, tStr)
+			if strings.GetString(t1) <= tStr {
+				STACK_PUSH(1)
+			} else {
+				STACK_PUSH(0)
+			}
+
+		case il.AGeI:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			ti64 = int64(opstack[sp-1]) + int64(opstack[sp-2])<<32
+			if (int64(t1) + int64(t2)<<32) <= ti64 {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
+
+		case il.AGeD:
+			LOAD_OP_CODE2(t1, t2)
+			STACK_UNDERFLOW_GUARD(2)
+			tf64 = math.Float64frombits(uint64(opstack[sp-1]) + uint64(opstack[sp-2])<<32)
+			if tf64 >= math.Float64frombits(uint64(t1) + uint64(t2)<<32) {
+				STACK_REMOVE2()
+				STACK_PUSH(1)
+			} else {
+				STACK_REMOVE2()
+				STACK_PUSH(0)
+			}
 
 		default:
 			ERRF("invalid opcode: '%v'", il.Opcode(code))

--- a/mixer/pkg/il/interpreter/interpreter_test.go
+++ b/mixer/pkg/il/interpreter/interpreter_test.go
@@ -2216,6 +2216,78 @@ L0:
 		"anlookup": {
 			code: `anlookup "a"`,
 		},
+		"alt_s": {
+			code: `alt_s "a"`,
+		},
+		"alt_i": {
+			code: `alt_i 232`,
+		},
+		"alt_d": {
+			code: `alt_d 12.34`,
+		},
+		"lt_s": {
+			code: `lt_s`,
+		},
+		"lt_i": {
+			code: `lt_i`,
+		},
+		"lt_d": {
+			code: `lt_d`,
+		},
+		"ale_s": {
+			code: `ale_s "a"`,
+		},
+		"ale_i": {
+			code: `ale_i 232`,
+		},
+		"ale_d": {
+			code: `ale_d 12.34`,
+		},
+		"le_s": {
+			code: `le_s`,
+		},
+		"le_i": {
+			code: `le_i`,
+		},
+		"le_d": {
+			code: `le_d`,
+		},
+		"age_s": {
+			code: `age_s "a"`,
+		},
+		"age_i": {
+			code: `age_i 232`,
+		},
+		"age_d": {
+			code: `age_d 12.34`,
+		},
+		"ge_s": {
+			code: `ge_s`,
+		},
+		"ge_i": {
+			code: `ge_i`,
+		},
+		"ge_d": {
+			code: `ge_d`,
+		},
+		"agt_s": {
+			code: `agt_s "a"`,
+		},
+		"agt_i": {
+			code: `agt_i 232`,
+		},
+		"agt_d": {
+			code: `agt_d 12.34`,
+		},
+		"gt_s": {
+			code: `gt_s`,
+		},
+		"gt_i": {
+			code: `gt_i`,
+		},
+		"gt_d": {
+			code: `gt_d`,
+		},
 	}
 
 	template := `

--- a/mixer/pkg/il/opcode.go
+++ b/mixer/pkg/il/opcode.go
@@ -313,6 +313,102 @@ const (
 
 	// SizeS pops a string value from the stack, and pushes its length back into stack.
 	SizeS Opcode = 216
+
+	// LtS pops two string values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtS Opcode = 217
+
+	// LtI pops two integer values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtI Opcode = 218
+
+	// LtD pops two float values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtD Opcode = 219
+
+	// ALtS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtS Opcode = 220
+
+	// ALtI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtI Opcode = 221
+
+	// ALtD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtD Opcode = 222
+
+	// LeS pops two string values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeS Opcode = 223
+
+	// LeI pops two integer values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeI Opcode = 224
+
+	// LeD pops two float values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeD Opcode = 225
+
+	// ALeS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeS Opcode = 226
+
+	// ALeI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeI Opcode = 227
+
+	// ALeD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeD Opcode = 228
+
+	// GtS pops two string values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtS Opcode = 229
+
+	// GtI pops two integer values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtI Opcode = 230
+
+	// GtD pops two float values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtD Opcode = 231
+
+	// AGtS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtS Opcode = 232
+
+	// AGtI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtI Opcode = 233
+
+	// AGtD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtD Opcode = 234
+
+	// GeS pops two string values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeS Opcode = 235
+
+	// GeI pops two integer values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeI Opcode = 236
+
+	// GeD pops two float values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeD Opcode = 237
+
+	// AGeS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeS Opcode = 238
+
+	// AGeI pops an integer value from the stack and compare it against its argument for equality.
+	// If greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeI Opcode = 239
+
+	// AGeD pops a float value from the stack and compare it against its argument for equality.
+	// If greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeD Opcode = 240
 )
 
 const (
@@ -776,6 +872,138 @@ var opCodeInfos = map[Opcode]opcodeInfo{
 
 	// SizeS pops a string and pushes it length.
 	SizeS: {name: "SizeS", keyword: "size_s"},
+
+	// LtS pops two string values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtS: {name: "LtS", keyword: "lt_s"},
+
+	// LtI pops two integer values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtI: {name: "LtI", keyword: "lt_i"},
+
+	// LtD pops two float values from the stack and compare for order.
+	// If less then it pushes 1 into the stack, otherwise it pushes 0.
+	LtD: {name: "LtD", keyword: "lt_d"},
+
+	// ALtS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtS: {name: "ALtS", keyword: "alt_s", args: []OpcodeArg{
+		// The string value for comparison.
+		OpcodeArgString,
+	}},
+
+	// ALtI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtI: {name: "ALtI", keyword: "alt_i", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgInt,
+	}},
+
+	// ALtD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is less, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALtD: {name: "ALtD", keyword: "alt_d", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgDouble,
+	}},
+
+	// LeS pops two string values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeS: {name: "LeS", keyword: "le_s"},
+
+	// LeI pops two integer values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeI: {name: "LeI", keyword: "le_i"},
+
+	// LeD pops two float values from the stack and compare for order.
+	// If less or equals then it pushes 1 into the stack, otherwise it pushes 0.
+	LeD: {name: "LeD", keyword: "le_d"},
+
+	// ALeS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeS: {name: "ALeS", keyword: "ale_s", args: []OpcodeArg{
+		// The string value for comparison.
+		OpcodeArgString,
+	}},
+
+	// ALeI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeI: {name: "ALeI", keyword: "ale_i", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgInt,
+	}},
+
+	// ALeD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is less or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	ALeD: {name: "ALeD", keyword: "ale_d", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgDouble,
+	}},
+
+	// GtS pops two string values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtS: {name: "GtS", keyword: "gt_s"},
+
+	// GtI pops two integer values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtI: {name: "GtI", keyword: "gt_i"},
+
+	// GtD pops two float values from the stack and compare for order.
+	// If greater then it pushes 1 into the stack, otherwise it pushes 0.
+	GtD: {name: "GtD", keyword: "gt_d"},
+
+	// AGtS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtS: {name: "AGtS", keyword: "agt_s", args: []OpcodeArg{
+		// The string value for comparison.
+		OpcodeArgString,
+	}},
+
+	// AGtI pops an integer value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtI: {name: "AGtI", keyword: "agt_i", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgInt,
+	}},
+
+	// AGtD pops a float value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGtD: {name: "AGtD", keyword: "agt_d", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgDouble,
+	}},
+
+	// GeS pops two string values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeS: {name: "GeS", keyword: "ge_s"},
+
+	// GeI pops two integer values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeI: {name: "GeI", keyword: "ge_i"},
+
+	// GeD pops two float values from the stack and compare for order.
+	// If greater or equal then it pushes 1 into the stack, otherwise it pushes 0.
+	GeD: {name: "GeD", keyword: "ge_d"},
+
+	// AGeS pops a string value from the stack and compare it against its argument for order.
+	// If the value on the stack is greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeS: {name: "AGeS", keyword: "age_s", args: []OpcodeArg{
+		// The string value for comparison.
+		OpcodeArgString,
+	}},
+
+	// AGeI pops an integer value from the stack and compare it against its argument for equality.
+	// If greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeI: {name: "AGeI", keyword: "age_i", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgInt,
+	}},
+
+	// AGeD pops a float value from the stack and compare it against its argument for equality.
+	// If greater or equal, then it pushes 1 into the stack, otherwise it pushes 0.
+	AGeD: {name: "AGeD", keyword: "age_d", args: []OpcodeArg{
+		// The integer value for comparison.
+		OpcodeArgDouble,
+	}},
 }
 
 var opcodesByKeyword = func() map[string]Opcode {

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -2611,12 +2611,100 @@ end`,
 end`,
 	},
 	{
-		E:    `timestamp("2015-01-02T15:04:35Z")`,
-		Type: descriptor.TIMESTAMP,
-		R:    t,
-		IL: `fn eval() interface
+		E:    `timestamp("2015-01-02T15:04:35Z") < timestamp("2015-01-02T15:04:36Z")`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
   apush_s "2015-01-02T15:04:35Z"
   call timestamp
+  apush_s "2015-01-02T15:04:36Z"
+  call timestamp
+  call timestamp_lt
+  ret
+end`,
+	},
+	{
+		E:    `t1 < timestamp("2015-01-02T15:04:36Z")`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"t1": t,
+		},
+		IL: `fn eval() bool
+  resolve_f "t1"
+  apush_s "2015-01-02T15:04:36Z"
+  call timestamp
+  call timestamp_lt
+  ret
+end`,
+	},
+	{
+		E:    `t1 <= t2`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+			"t2": t2,
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t2"
+  call timestamp_le
+  ret
+end`,
+	},
+	{
+		E:    `t2 <= t1`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+			"t2": t2,
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_f "t2"
+  resolve_f "t1"
+  call timestamp_le
+  ret
+end`,
+	},
+	{
+		E:          `t1 <= 42`,
+		CompileErr: "LEQ($t1, 42) arg 2 (42) typeError got INT64, expected TIMESTAMP",
+	},
+	{
+		E:          `t1 < 42`,
+		CompileErr: "LT($t1, 42) arg 2 (42) typeError got INT64, expected TIMESTAMP",
+	},
+	{
+		E:          `42 <= t1`,
+		CompileErr: "LEQ(42, $t1) arg 2 ($t1) typeError got TIMESTAMP, expected INT64",
+	},
+	{
+		E:    `t1 <= t1`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t1"
+  call timestamp_le
+  ret
+end`,
+	},
+	{
+		E:    `t1 < t1`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t1"
+  call timestamp_lt
   ret
 end`,
 	},
@@ -2632,6 +2720,64 @@ end`,
   resolve_f "t1"
   resolve_f "t2"
   call timestamp_equal
+  ret
+end`,
+	},
+	{
+		E:    `t1 > t2`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+			"t2": t2,
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t2"
+  call timestamp_gt
+  ret
+end`,
+	},
+	{
+		E:    `t1 >= t2`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+			"t2": t2,
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t2"
+  call timestamp_ge
+  ret
+end`,
+	},
+	{
+		E:    `t1 > t1`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t1"
+  call timestamp_gt
+  ret
+end`,
+	},
+	{
+		E:    `t1 >= t1`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"t1": t,
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_f "t1"
+  resolve_f "t1"
+  call timestamp_ge
   ret
 end`,
 	},
@@ -3090,6 +3236,1028 @@ end
 				return string(runes)
 			},
 		},
+	},
+
+	{
+		E:    `1.0 < 2.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  alt_d 2.000000
+  ret
+end`,
+	},
+	{
+		E:          `1 < "a"`,
+		Type:       descriptor.BOOL,
+		CompileErr: `LT(1, "a") arg 2 ("a") typeError got STRING, expected INT64`,
+	},
+	{
+		E:          `"a" < 1`,
+		Type:       descriptor.BOOL,
+		CompileErr: `LT("a", 1) arg 2 (1) typeError got INT64, expected STRING`,
+	},
+	{
+		E:    `1.0 < 1.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  alt_d 1.000000
+  ret
+end`,
+	},
+	{
+		E:    `2.0 < 1.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 2.000000
+  alt_d 1.000000
+  ret
+end`,
+	},
+
+	{
+		E:    `1.0 <= 2.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  ale_d 2.000000
+  ret
+end`,
+	},
+	{
+		E:    `1.0 <= 1.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  ale_d 1.000000
+  ret
+end`,
+	},
+	{
+		E:    `2.0 <= 1.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 2.000000
+  ale_d 1.000000
+  ret
+end`,
+	},
+
+	{
+		E:    `1.0 > 2.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  agt_d 2.000000
+  ret
+end`,
+	},
+	{
+		E:    `1.0 > 1.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  agt_d 1.000000
+  ret
+end`,
+	},
+	{
+		E:    `2.0 > 1.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 2.000000
+  agt_d 1.000000
+  ret
+end`,
+	},
+
+	{
+		E:    `1.0 >= 2.0`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  age_d 2.000000
+  ret
+end`,
+	},
+	{
+		E:    `1.0 >= 1.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 1.000000
+  age_d 1.000000
+  ret
+end`,
+	},
+	{
+		E:    `2.0 >= 1.0`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_d 2.000000
+  age_d 1.000000
+  ret
+end`,
+	},
+
+	{
+		E:    `ad < bd`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "bd"
+  lt_d
+  ret
+end`,
+	},
+	{
+		E:    `bd < ad`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "bd"
+  resolve_d "ad"
+  lt_d
+  ret
+end`,
+	},
+	{
+		E:    `ad < ad`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "ad"
+  lt_d
+  ret
+end`,
+	},
+
+	{
+		E:    `ad <= bd`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "bd"
+  le_d
+  ret
+end`,
+	},
+	{
+		E:    `bd <= ad`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "bd"
+  resolve_d "ad"
+  le_d
+  ret
+end`,
+	},
+	{
+		E:    `ad <= ad`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "ad"
+  le_d
+  ret
+end`,
+	},
+
+	{
+		E:    `ad > bd`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "bd"
+  gt_d
+  ret
+end`,
+	},
+	{
+		E:    `bd > ad`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "bd"
+  resolve_d "ad"
+  gt_d
+  ret
+end`,
+	},
+	{
+		E:    `ad > ad`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "ad"
+  gt_d
+  ret
+end`,
+	},
+
+	{
+		E:    `ad >= bd`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "bd"
+  ge_d
+  ret
+end`,
+	},
+	{
+		E:    `bd >= ad`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+			"bd": float64(2.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "bd"
+  resolve_d "ad"
+  ge_d
+  ret
+end`,
+	},
+	{
+		E:    `ad >= ad`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ad": float64(1.0),
+		},
+		IL: `fn eval() bool
+  resolve_d "ad"
+  resolve_d "ad"
+  ge_d
+  ret
+end`,
+	},
+
+	{
+		E:    `1 > 2`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 1
+  agt_i 2
+  ret
+end`,
+	},
+
+	{
+		E:    `2 > 1`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 2
+  agt_i 1
+  ret
+end`,
+	},
+
+	{
+		E:    `1 > 1`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 1
+  agt_i 1
+  ret
+end`,
+	},
+
+	{
+		E:    `1 >= 2`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 1
+  age_i 2
+  ret
+end`,
+	},
+
+	{
+		E:    `2 >= 1`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 2
+  age_i 1
+  ret
+end`,
+	},
+
+	{
+		E:    `1 >= 1`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 1
+  age_i 1
+  ret
+end`,
+	},
+
+	{
+		E:    `1 < 2`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 1
+  alt_i 2
+  ret
+end`,
+	},
+	{
+		E:    `1 < 1`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 1
+  alt_i 1
+  ret
+end`,
+	},
+	{
+		E:    `2 < 1`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 2
+  alt_i 1
+  ret
+end`,
+	},
+	{
+		E:    `1 <= 2`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 1
+  ale_i 2
+  ret
+end`,
+	},
+	{
+		E:    `1 <= 1`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_i 1
+  ale_i 1
+  ret
+end`,
+	},
+	{
+		E:    `2 <= 1`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_i 2
+  ale_i 1
+  ret
+end`,
+	},
+	{
+		E:    `ai < bi`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "bi"
+  lt_i
+  ret
+end`,
+	},
+	{
+		E:    `bi < ai`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "bi"
+  resolve_i "ai"
+  lt_i
+  ret
+end`,
+	},
+	{
+		E:    `ai < ai`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "ai"
+  lt_i
+  ret
+end`,
+	},
+
+	{
+		E:    `ai > bi`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "bi"
+  gt_i
+  ret
+end`,
+	},
+	{
+		E:    `bi > ai`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "bi"
+  resolve_i "ai"
+  gt_i
+  ret
+end`,
+	},
+	{
+		E:    `ai > ai`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "ai"
+  gt_i
+  ret
+end`,
+	},
+
+	{
+		E:    `ai >= bi`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "bi"
+  ge_i
+  ret
+end`,
+	},
+	{
+		E:    `bi >= ai`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "bi"
+  resolve_i "ai"
+  ge_i
+  ret
+end`,
+	},
+	{
+		E:    `ai >= ai`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "ai"
+  ge_i
+  ret
+end`,
+	},
+
+	{
+		E:    `ai <= bi`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "bi"
+  le_i
+  ret
+end`,
+	},
+	{
+		E:    `bi <= ai`,
+		Type: descriptor.BOOL,
+		R:    false,
+		I: map[string]interface{}{
+			"ai": int64(1),
+			"bi": int64(2),
+		},
+		IL: `fn eval() bool
+  resolve_i "bi"
+  resolve_i "ai"
+  le_i
+  ret
+end`,
+	},
+	{
+		E:    `ai <= ai`,
+		Type: descriptor.BOOL,
+		R:    true,
+		I: map[string]interface{}{
+			"ai": int64(1),
+		},
+		IL: `fn eval() bool
+  resolve_i "ai"
+  resolve_i "ai"
+  le_i
+  ret
+end`,
+	},
+
+	{
+		E:    `"a" < "b"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  alt_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" < "a"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "b"
+  alt_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `"a" < "a"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "a"
+  alt_s "a"
+  ret
+end`,
+	},
+
+	{
+		E:    `"a" <= "b"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  ale_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" <= "a"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "b"
+  ale_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `"a" <= "a"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  ale_s "a"
+  ret
+end`,
+	},
+
+	{
+		E:    `"a" > "b"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "a"
+  agt_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" > "a"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "b"
+  agt_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `"a" > "a"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "a"
+  agt_s "a"
+  ret
+end`,
+	},
+
+	{
+		E:    `"a" >= "b"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "a"
+  age_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" >= "a"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "b"
+  age_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `"a" >= "a"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  age_s "a"
+  ret
+end`,
+	},
+
+	{
+		E:    `as < "b"`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  alt_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" < as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: false,
+		IL: `fn eval() bool
+  apush_s "b"
+  resolve_s "as"
+  lt_s
+  ret
+end`,
+	},
+	{
+		E:    `as < bs`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "bs"
+  lt_s
+  ret
+end`,
+	},
+	{
+		E:    `bs < as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "bs"
+  resolve_s "as"
+  lt_s
+  ret
+end`,
+	},
+	{
+		E:    `as < as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "as"
+  lt_s
+  ret
+end`,
+	},
+	{
+		E:    `as <= bs`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "bs"
+  le_s
+  ret
+end`,
+	},
+	{
+		E:    `bs <= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "bs"
+  resolve_s "as"
+  le_s
+  ret
+end`,
+	},
+	{
+		E:    `as <= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "as"
+  le_s
+  ret
+end`,
+	},
+	{
+		E:    `as > bs`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "bs"
+  gt_s
+  ret
+end`,
+	},
+	{
+		E:    `bs > as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "bs"
+  resolve_s "as"
+  gt_s
+  ret
+end`,
+	},
+	{
+		E:    `as > as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "as"
+  gt_s
+  ret
+end`,
+	},
+	{
+		E:    `as >= bs`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "bs"
+  ge_s
+  ret
+end`,
+	},
+	{
+		E:    `bs >= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "bs"
+  resolve_s "as"
+  ge_s
+  ret
+end`,
+	},
+	{
+		E:    `as >= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "as"
+  ge_s
+  ret
+end`,
+	},
+	{
+		E:    `"a" <= "b"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  ale_s "b"
+  ret
+end`,
+	},
+	{
+		E:    `"b" <= "a"`,
+		Type: descriptor.BOOL,
+		R:    false,
+		IL: `fn eval() bool
+  apush_s "b"
+  ale_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `"a" <= "a"`,
+		Type: descriptor.BOOL,
+		R:    true,
+		IL: `fn eval() bool
+  apush_s "a"
+  ale_s "a"
+  ret
+end`,
+	},
+	{
+		E:    `as <= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "as"
+  le_s
+  ret
+end`,
+	},
+	{
+		E:    `as <= bs`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: true,
+		IL: `fn eval() bool
+  resolve_s "as"
+  resolve_s "bs"
+  le_s
+  ret
+end`,
+	},
+	{
+		E:    `bs <= as`,
+		Type: descriptor.BOOL,
+		I: map[string]interface{}{
+			"as": "a",
+			"bs": "b",
+		},
+		R: false,
+		IL: `fn eval() bool
+  resolve_s "bs"
+  resolve_s "as"
+  le_s
+  ret
+end`,
 	},
 
 	{

--- a/mixer/pkg/lang/ast/func.go
+++ b/mixer/pkg/lang/ast/func.go
@@ -49,6 +49,26 @@ func intrinsics() []FunctionMetadata {
 			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
 		},
 		{
+			Name:          "LT",
+			ReturnType:    config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:          "LEQ",
+			ReturnType:    config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:          "GT",
+			ReturnType:    config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
+			Name:          "GEQ",
+			ReturnType:    config.BOOL,
+			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},
+		},
+		{
 			Name:          "OR",
 			ReturnType:    config.VALUE_TYPE_UNSPECIFIED,
 			ArgumentTypes: []config.ValueType{config.VALUE_TYPE_UNSPECIFIED, config.VALUE_TYPE_UNSPECIFIED},

--- a/mixer/pkg/lang/compiler/compiler.go
+++ b/mixer/pkg/lang/compiler/compiler.go
@@ -270,6 +270,14 @@ func (g *generator) generateFunction(f *ast.Function, depth int, mode nilMode, v
 		g.generateEq(f, depth)
 	case "NEQ":
 		g.generateNeq(f, depth)
+	case "LT":
+		g.generateLt(f, depth)
+	case "LEQ":
+		g.generateLe(f, depth)
+	case "GT":
+		g.generateGt(f, depth)
+	case "GEQ":
+		g.generateGe(f, depth)
 	case "LOR":
 		g.generateLor(f, depth)
 	case "LAND":
@@ -367,6 +375,187 @@ func (g *generator) generateEq(f *ast.Function, depth int) {
 
 	default:
 		g.internalError("equality for type not yet implemented: %v", exprType)
+	}
+}
+
+func (g *generator) generateLt(f *ast.Function, depth int) {
+	exprType := g.evalType(f.Args[0])
+	g.generate(f.Args[0], depth+1, nmNone, "")
+
+	var constArg1 interface{}
+	if f.Args[1].Const != nil {
+		constArg1 = f.Args[1].Const.Value
+	} else {
+		g.generate(f.Args[1], depth+1, nmNone, "")
+	}
+
+	switch exprType {
+
+	case il.String:
+		if constArg1 != nil {
+			g.builder.ALTString(constArg1.(string))
+		} else {
+			g.builder.LTString()
+		}
+
+	case il.Integer:
+		if constArg1 != nil {
+			g.builder.ALTInteger(constArg1.(int64))
+		} else {
+			g.builder.LTInteger()
+		}
+
+	case il.Double:
+		if constArg1 != nil {
+			g.builder.ALTDouble(constArg1.(float64))
+		} else {
+			g.builder.LTDouble()
+		}
+
+	case il.Interface:
+		dvt, _ := f.Args[0].EvalType(g.finder, g.functions)
+		switch dvt {
+		case descriptor.TIMESTAMP:
+			g.builder.Call("timestamp_lt")
+		default:
+			g.internalError("less than for type not yet implemented: %v", exprType)
+		}
+
+	default:
+		g.internalError("less than for type not yet implemented: %v", exprType)
+	}
+}
+
+func (g *generator) generateGt(f *ast.Function, depth int) {
+	exprType := g.evalType(f.Args[0])
+	g.generate(f.Args[0], depth+1, nmNone, "")
+
+	var constArg1 interface{}
+	if f.Args[1].Const != nil {
+		constArg1 = f.Args[1].Const.Value
+	} else {
+		g.generate(f.Args[1], depth+1, nmNone, "")
+	}
+
+	switch exprType {
+
+	case il.String:
+		if constArg1 != nil {
+			g.builder.AGTString(constArg1.(string))
+		} else {
+			g.builder.GTString()
+		}
+	case il.Integer:
+		if constArg1 != nil {
+			g.builder.AGTInteger(constArg1.(int64))
+		} else {
+			g.builder.GTInteger()
+		}
+	case il.Double:
+		if constArg1 != nil {
+			g.builder.AGTDouble(constArg1.(float64))
+		} else {
+			g.builder.GTDouble()
+		}
+	case il.Interface:
+		dvt, _ := f.Args[0].EvalType(g.finder, g.functions)
+		switch dvt {
+		case descriptor.TIMESTAMP:
+			g.builder.Call("timestamp_gt")
+		default:
+			g.internalError("greater than for type not yet implemented: %v", exprType)
+		}
+	default:
+		g.internalError("greater than for type not yet implemented: %v", exprType)
+	}
+}
+
+func (g *generator) generateGe(f *ast.Function, depth int) {
+	exprType := g.evalType(f.Args[0])
+	g.generate(f.Args[0], depth+1, nmNone, "")
+
+	var constArg1 interface{}
+	if f.Args[1].Const != nil {
+		constArg1 = f.Args[1].Const.Value
+	} else {
+		g.generate(f.Args[1], depth+1, nmNone, "")
+	}
+
+	switch exprType {
+
+	case il.String:
+		if constArg1 != nil {
+			g.builder.AGEString(constArg1.(string))
+		} else {
+			g.builder.GEString()
+		}
+	case il.Integer:
+		if constArg1 != nil {
+			g.builder.AGEInteger(constArg1.(int64))
+		} else {
+			g.builder.GEInteger()
+		}
+	case il.Double:
+		if constArg1 != nil {
+			g.builder.AGEDouble(constArg1.(float64))
+		} else {
+			g.builder.GEDouble()
+		}
+	case il.Interface:
+		dvt, _ := f.Args[0].EvalType(g.finder, g.functions)
+		switch dvt {
+		case descriptor.TIMESTAMP:
+			g.builder.Call("timestamp_ge")
+		default:
+			g.internalError("greater or equal for type not yet implemented: %v", exprType)
+		}
+	default:
+		g.internalError("greater or equal for type not yet implemented: %v", exprType)
+	}
+}
+
+func (g *generator) generateLe(f *ast.Function, depth int) {
+	exprType := g.evalType(f.Args[0])
+	g.generate(f.Args[0], depth+1, nmNone, "")
+
+	var constArg1 interface{}
+	if f.Args[1].Const != nil {
+		constArg1 = f.Args[1].Const.Value
+	} else {
+		g.generate(f.Args[1], depth+1, nmNone, "")
+	}
+
+	switch exprType {
+
+	case il.String:
+		if constArg1 != nil {
+			g.builder.ALEString(constArg1.(string))
+		} else {
+			g.builder.LEString()
+		}
+	case il.Integer:
+		if constArg1 != nil {
+			g.builder.ALEInteger(constArg1.(int64))
+		} else {
+			g.builder.LEInteger()
+		}
+	case il.Double:
+		if constArg1 != nil {
+			g.builder.ALEDouble(constArg1.(float64))
+		} else {
+			g.builder.LEDouble()
+		}
+	case il.Interface:
+		dvt, _ := f.Args[0].EvalType(g.finder, g.functions)
+		switch dvt {
+		case descriptor.TIMESTAMP:
+			g.builder.Call("timestamp_le")
+		default:
+			g.internalError("less or equal for type not yet implemented: %v", exprType)
+		}
+
+	default:
+		g.internalError("less or equal for type not yet implemented: %v", exprType)
 	}
 }
 

--- a/mixer/pkg/lang/externs.go
+++ b/mixer/pkg/lang/externs.go
@@ -38,6 +38,10 @@ var Externs = map[string]interpreter.Extern{
 	"ip_equal":          interpreter.ExternFromFn("ip_equal", externIPEqual),
 	"timestamp":         interpreter.ExternFromFn("timestamp", externTimestamp),
 	"timestamp_equal":   interpreter.ExternFromFn("timestamp_equal", externTimestampEqual),
+	"timestamp_lt":      interpreter.ExternFromFn("timestamp_lt", externTimestampLt),
+	"timestamp_le":      interpreter.ExternFromFn("timestamp_le", externTimestampLe),
+	"timestamp_gt":      interpreter.ExternFromFn("timestamp_gt", externTimestampGt),
+	"timestamp_ge":      interpreter.ExternFromFn("timestamp_ge", externTimestampGe),
 	"dnsName":           interpreter.ExternFromFn("dnsName", externDNSName),
 	"dnsName_equal":     interpreter.ExternFromFn("dnsName_equal", externDNSNameEqual),
 	"email":             interpreter.ExternFromFn("email", externEmail),
@@ -148,6 +152,22 @@ func externTimestamp(in string) (time.Time, error) {
 
 func externTimestampEqual(t1 time.Time, t2 time.Time) bool {
 	return t1.Equal(t2)
+}
+
+func externTimestampLt(t1 time.Time, t2 time.Time) bool {
+	return t1.Before(t2)
+}
+
+func externTimestampLe(t1 time.Time, t2 time.Time) bool {
+	return t1 == t2 || t1.Before(t2)
+}
+
+func externTimestampGt(t1 time.Time, t2 time.Time) bool {
+	return t2.Before(t1)
+}
+
+func externTimestampGe(t1 time.Time, t2 time.Time) bool {
+	return t1 == t2 || t2.Before(t1)
 }
 
 // This IDNA profile is for performing validations, but does not otherwise modify the string.


### PR DESCRIPTION
This PR is a cherry-pick of #10086 on top of the release-1.1 branch. 

That means it tries to fix #10012 by adding support for operators <, > etc to the Mixer EL.