### PR TITLE
Added 'intercept=none' mode and fix isolation.

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -324,8 +324,14 @@ func (ps *PushContext) UpdateMetrics() {
 
 // Services returns the list of services that are visible to a Proxy in a given config namespace
 func (ps *PushContext) Services(proxy *Proxy) []*Service {
-	out := []*Service{}
+	if proxy.Isolated() {
+		// Isolation enabled - only return visible nodes
+		proxy.mutex.RLock()
+		defer proxy.mutex.RUnlock()
+		return proxy.serviceDependencies
+	}
 
+	out := []*Service{}
 	// First add private services
 	if proxy == nil {
 		for _, privateServices := range ps.privateServicesByNamespace {
@@ -349,10 +355,12 @@ func (ps *PushContext) Services(proxy *Proxy) []*Service {
 func (ps *PushContext) UpdateNodeIsolation(proxy *Proxy) {
 	// For now Router (Gateway) is not using the isolation - the Gateway already has explicit
 	// bindings.
-	if pilot.NetworkScopes != "" && proxy.Type == Sidecar {
+	scopes := pilot.NetworkScopes
+
+	if proxy.Isolated() {
 		// Add global namespaces. This may be loaded from mesh config ( after the API is stable and
 		// reviewed ), or from an env variable.
-		adminNs := strings.Split(pilot.NetworkScopes, ",")
+		adminNs := strings.Split(scopes, ",")
 		globalDeps := map[string]bool{}
 		for _, ns := range adminNs {
 			globalDeps[ns] = true

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -34,6 +34,7 @@ import (
 	xdsutil "github.com/envoyproxy/go-control-plane/pkg/util"
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
+	"istio.io/istio/pkg/features/pilot"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
@@ -181,6 +182,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		return nil, err
 	}
 
+	noneMode := node.Metadata[pilot.InterceptionMode] == pilot.InterceptionModeNone
+
 	services := push.Services(node)
 
 	listeners := make([]*xdsapi.Listener, 0)
@@ -192,27 +195,29 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		listeners = append(listeners, inbound...)
 		listeners = append(listeners, outbound...)
 
-		// Let ServiceDiscovery decide which IP and Port are used for management if
-		// there are multiple IPs
-		mgmtListeners := make([]*xdsapi.Listener, 0)
-		for _, ip := range node.IPAddresses {
-			managementPorts := env.ManagementPorts(ip)
-			management := buildSidecarInboundMgmtListeners(node, env, managementPorts, ip)
-			mgmtListeners = append(mgmtListeners, management...)
-		}
-
-		// If management listener port and service port are same, bad things happen
-		// when running in kubernetes, as the probes stop responding. So, append
-		// non overlapping listeners only.
-		for i := range mgmtListeners {
-			m := mgmtListeners[i]
-			l := util.GetByAddress(listeners, m.Address.String())
-			if l != nil {
-				log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener %s (%s)",
-					m.Name, m.Address.String(), l.Name, l.Address.String())
-				continue
+		if !noneMode {
+			// Let ServiceDiscovery decide which IP and Port are used for management if
+			// there are multiple IPs
+			mgmtListeners := make([]*xdsapi.Listener, 0)
+			for _, ip := range node.IPAddresses {
+				managementPorts := env.ManagementPorts(ip)
+				management := buildSidecarInboundMgmtListeners(node, env, managementPorts, ip)
+				mgmtListeners = append(mgmtListeners, management...)
 			}
-			listeners = append(listeners, m)
+
+			// If management listener port and service port are same, bad things happen
+			// when running in kubernetes, as the probes stop responding. So, append
+			// non overlapping listeners only.
+			for i := range mgmtListeners {
+				m := mgmtListeners[i]
+				l := util.GetByAddress(listeners, m.Address.String())
+				if l != nil {
+					log.Warnf("Omitting listener for management address %s (%s) due to collision with service listener %s (%s)",
+						m.Name, m.Address.String(), l.Name, l.Address.String())
+					continue
+				}
+				listeners = append(listeners, m)
+			}
 		}
 
 		// We need a passthrough filter to fill in the filter stack for orig_dst listener
@@ -222,7 +227,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		}
 
 		var transparent *google_protobuf.BoolValue
-		if mode := node.Metadata["INTERCEPTION_MODE"]; mode == "TPROXY" {
+		if mode := node.Metadata[pilot.InterceptionMode]; mode == pilot.InterceptionModeTproxy {
 			transparent = proto.BoolTrue
 		}
 
@@ -248,7 +253,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 	}
 
 	// enable HTTP PROXY port if necessary; this will add an RDS route for this port
-	if mesh.ProxyHttpPort > 0 {
+	httpProxyPort := mesh.ProxyHttpPort
+	if httpProxyPort == 0 && noneMode {
+		httpProxyPort = pilot.DefaultPortHttpProxy
+	}
+	if httpProxyPort > 0 {
 		useRemoteAddress := false
 		traceOperation := http_conn.EGRESS
 		listenAddress := LocalhostAddress
@@ -504,6 +513,8 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 	meshGateway := map[string]bool{model.IstioMeshGateway: true}
 	configs := push.VirtualServices(node, meshGateway)
 
+	noneMode := node.Metadata[pilot.InterceptionMode] == pilot.InterceptionModeNone
+
 	var tcpListeners, httpListeners []*xdsapi.Listener
 	// For conflict resolution
 	listenerMap := make(map[string]*listenerEntry)
@@ -533,6 +544,11 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 			}
 			switch pluginParams.ListenerProtocol {
 			case plugin.ListenerProtocolHTTP:
+				if noneMode {
+					// TODO: in future we may use the Sidecar config to still bind http ports. This will require DNS interception
+					// or /etc/hosts, to resolve the http requests to 127.0.0.1
+					continue // will use HTTP PROXY
+				}
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
 				var exists bool
 				// Check if this HTTP listener conflicts with an existing wildcard TCP listener
@@ -585,6 +601,15 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundListeners(env *model.E
 						destinationIPAddress = svcListenAddress
 					}
 				}
+
+				if noneMode &&
+						service.Resolution == model.ClientSideLB { // TODO: more conditions
+					listenerOpts.bindToPort = true
+					listenAddress = "127.0.0.1" // model.UnspecifiedIP // 0.0.0.0
+					svcListenAddress = "127.0.0.1"
+				}
+
+				// TODO: for DNS resolution and type TLS, we can generate bind=true, with client DNS overrides.
 
 				listenerMapKey = fmt.Sprintf("%s:%d", listenAddress, servicePort.Port)
 				var exists bool

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -16,11 +16,143 @@ package v2_test
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/adsc"
+	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
+
+
+// TestLDS using isolated namespaces
+func TestLDSIsolated(t *testing.T) {
+
+	_, tearDown := initLocalPilotTestEnv(t)
+	defer tearDown()
+
+	// Sidecar in 'none' mode
+	t.Run("sidecar_none", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+				pilot.InterceptionMode: pilot.InterceptionModeNone,
+			},
+			IP: "10.11.0.1", // matches none.yaml s1tcp.none
+			Namespace: "none",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("lds", 50000 * time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut+"/none")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// s1http - inbound HTTP on 7071 (forwarding to app on 30000 + 7071 - or custom port)
+		// All outbound on http proxy
+		if len(ldsr.HTTPListeners) != 2 {
+			t.Error("HTTP listeners, expecting 2 got ", len(ldsr.HTTPListeners), ldsr.HTTPListeners)
+		}
+
+		// s1tcp:2000 outbound, bind=true (to reach other instances of the service)
+		// s1:5005 outbound, bind=true
+		// :443 - https external, bind=false
+		// 10.11.0.1_7070, bind=true -> inbound|2000|s1 - on port 7070, fwd to 37070
+		// virtual
+		if len(ldsr.TCPListeners) == 0 {
+			t.Fatal("No response")
+		}
+		// TODO: check bind==true
+		// TODO: verify listeners for outbound are on 127.0.0.1 (not yet), port 2000, 2005, 2007
+		// TODO: verify virtual listeners for unsupported cases
+		// TODO: add and verify SNI listener on 127.0.0.1:443
+		// TODO: verify inbound service port is on 127.0.0.1, and containerPort on 0.0.0.0
+		// TODO: BUG, SE with empty endpoints is rejected - it is actually valid config (service may not have endpoints)
+	})
+
+	// Test for the examples in the ServiceEntry doc
+	t.Run("se_example", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+				pilot.Isolation: "1",
+			},
+			IP: "10.12.0.1", // matches none.yaml s1tcp.none
+			Namespace: "seexamples",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("rds", 50000 * time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut+"/seexample")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test for the examples in the ServiceEntry doc
+	t.Run("se_examplegw", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+				pilot.Isolation: "1",
+			},
+			IP: "10.13.0.1",
+			Namespace: "exampleegressgw",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("rds", 50000 * time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut+"/seexample-eg")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+}
 
 // TestLDS is running LDSv2 tests.
 func TestLDS(t *testing.T) {
@@ -109,3 +241,10 @@ func TestLDS(t *testing.T) {
 
 	// TODO: dynamic checks ( see EDS )
 }
+
+// TODO: helper to test the http listener content
+// - file access log
+// - generate request id
+// - cors, fault, router filters
+// - tracing
+//

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -50,6 +50,9 @@ type Config struct {
 
 	// NodeType defaults to sidecar. "ingress" and "router" are also supported.
 	NodeType string
+
+	// IP is currently the primary key used to locate inbound configs. It is sent by client,
+	// must match a known endpoint IP. Tests can use a ServiceEntry to register fake IPs.
 	IP       string
 }
 
@@ -65,22 +68,40 @@ type ADSC struct {
 	// NodeID is the node identity sent to Pilot.
 	nodeID string
 
+	done chan error
+
 	certDir string
 	url     string
 
 	watchTime time.Time
 
+	// InitialLoad tracks the time to receive the initial configuration.
 	InitialLoad time.Duration
 
-	TCPListeners  map[string]*xdsapi.Listener
+	// HTTPListeners contains received listeners with a http_connection_manager filter.
 	HTTPListeners map[string]*xdsapi.Listener
+
+	// TCPListeners contains all listeners of type TCP (not-HTTP)
+	TCPListeners  map[string]*xdsapi.Listener
+
+	// All received clusters, keyed by name
 	Clusters      map[string]*xdsapi.Cluster
+
+	// All received routes, keyed by route name
 	Routes        map[string]*xdsapi.RouteConfiguration
+
+	// All recieved endpoints, keyed by cluster name
 	EDS           map[string]*xdsapi.ClusterLoadAssignment
+
+	// DumpCfg will print all received config
+	DumpCfg 	bool
 
 	// Metadata has the node metadata to send to pilot.
 	// If nil, the defaults will be used.
 	Metadata map[string]string
+
+	rdsNames     []string
+	clusterNames []string
 
 	// Updates includes the type of the last update received from the server.
 	Updates     chan string
@@ -112,6 +133,7 @@ var (
 // Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
 func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	adsc := &ADSC{
+		done:        make(chan error),
 		Updates:     make(chan string, 100),
 		VersionInfo: map[string]string{},
 		certDir:     certDir,
@@ -129,6 +151,7 @@ func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	if opts.Workload == "" {
 		opts.Workload = "test-1"
 	}
+	adsc.Metadata = opts.Meta
 
 	adsc.nodeID = fmt.Sprintf("sidecar~%s~%s.%s~%s.svc.cluster.local", opts.IP,
 		opts.Workload, opts.Namespace, opts.Namespace)
@@ -298,6 +321,8 @@ func (a *ADSC) handleRecv() {
 
 }
 
+
+
 func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 	lh := map[string]*xdsapi.Listener{}
 	lt := map[string]*xdsapi.Listener{}
@@ -335,6 +360,10 @@ func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 	}
 
 	log.Println("LDS: http=", len(lh), "tcp=", len(lt), "size=", ldsSize)
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(ll, " ", " ")
+		log.Println(string(b))
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	if len(routes) > 0 {
@@ -347,6 +376,80 @@ func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 	case a.Updates <- "lds":
 	default:
 	}
+}
+
+// compact representations, for simplified debugging/testing
+
+// TCPListener extracts the core elements from envoy Listener.
+type TCPListener struct {
+	// Address is the address, as expected by go Dial and Listen, including port
+	Address string
+
+	// LogFile is the access log address for the listener
+	LogFile string
+
+	// Target is the destination cluster.
+	Target string
+}
+
+type Target struct {
+
+	// Address is a go address, extracted from the mangled cluster name.
+	Address string
+
+	// Endpoints are the resolved endpoints from EDS or cluster static.
+	Endpoints map[string]Endpoint
+}
+
+type Endpoint struct {
+	// Weight extracted from EDS
+	Weight int
+}
+
+// Save will save the json configs to files, using the base directory
+func (a *ADSC) Save(base string) error {
+	strResponse, err := json.MarshalIndent(a.TCPListeners, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base + "_lds_tcp.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.HTTPListeners, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base +"_lds_http.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.Routes, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base +"_rds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.Clusters, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base + "_cds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.EDS, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base + "_eds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+
+	return err
 }
 
 func (a *ADSC) handleCDS(ll []*xdsapi.Cluster) {
@@ -368,6 +471,10 @@ func (a *ADSC) handleCDS(ll []*xdsapi.Cluster) {
 
 	if len(cn) > 0 {
 		a.sendRsc(endpointType, cn)
+	}
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(ll, " ", " ")
+		log.Println(string(b))
 	}
 
 	a.mutex.Lock()
@@ -402,16 +509,27 @@ func (a *ADSC) node() *core.Node {
 	return n
 }
 
+func (a *ADSC) Send(req *xdsapi.DiscoveryRequest) error {
+	req.Node = a.node()
+	req.ResponseNonce = time.Now().String()
+	return a.stream.Send(req)
+}
+
 func (a *ADSC) handleEDS(eds []*xdsapi.ClusterLoadAssignment) {
 	la := map[string]*xdsapi.ClusterLoadAssignment{}
 	edsSize := 0
+	ep := 0
 	for _, cla := range eds {
 		edsSize += cla.Size()
 		la[cla.ClusterName] = cla
+		ep += len(cla.Endpoints)
 	}
 
-	log.Println("EDS: ", len(eds), "size=", edsSize)
-
+	log.Println("EDS: ", len(eds), "size=", edsSize, "ep=", ep)
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(eds, " ", " ")
+		log.Println(string(b))
+	}
 	if a.InitialLoad == 0 {
 		// first load - Envoy loads listeners after endpoints
 		a.stream.Send(&xdsapi.DiscoveryRequest{
@@ -446,7 +564,7 @@ func (a *ADSC) handleRDS(configurations []*xdsapi.RouteConfiguration) {
 			for _, rt := range h.Routes {
 				rcount++
 				// Example: match:<prefix:"/" > route:<cluster:"outbound|9154||load-se-154.local" ...
-				//log.Println(rt.String())
+				log.Println(h.Name, rt.Match.PathSpecifier, rt.GetRoute().GetCluster())
 				httpClusters = append(httpClusters, rt.GetRoute().GetCluster())
 			}
 		}
@@ -460,9 +578,14 @@ func (a *ADSC) handleRDS(configurations []*xdsapi.RouteConfiguration) {
 		log.Println("RDS: ", len(configurations), "size=", size, "vhosts=", vh, "routes=", rcount)
 	}
 
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(configurations, " ", " ")
+		log.Println(string(b))
+	}
+
 	a.mutex.Lock()
-	defer a.mutex.Unlock()
 	a.Routes = rds
+	a.mutex.Unlock()
 
 	select {
 	case a.Updates <- "rds":

--- a/tests/testdata/config/byon.yaml
+++ b/tests/testdata/config/byon.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: byon
+  namespace: testns
 spec:
    hosts:
    - byon.test.istio.io
@@ -20,6 +21,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: byon
+  namespace: testns
 spec:
   hosts:
     - mybyon.test.istio.io
@@ -34,6 +36,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: byon-docker
+  namespace: testns
 spec:
    hosts:
    - byon-docker.test.istio.io
@@ -51,6 +54,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: wikipedia-range
+  namespace: testns
 spec:
   hosts:
   - www.wikipedia.org

--- a/tests/testdata/config/destination-rule-all.yaml
+++ b/tests/testdata/config/destination-rule-all.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: destall
+  namespace: testns
 spec:
    hosts:
    - destall.default.svc.cluster.local
@@ -20,6 +21,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: destall
+  namespace: testns
 spec:
   # DNS name, prefix wildcard, short name relative to context
   # IP or CIDR only for services in gateways

--- a/tests/testdata/config/destination-rule-fqdn.yaml
+++ b/tests/testdata/config/destination-rule-fqdn.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: fqdn
+  namespace: testns
 spec:
   host: www.webinf.info
   trafficPolicy:

--- a/tests/testdata/config/destination-rule-passthrough.yaml
+++ b/tests/testdata/config/destination-rule-passthrough.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: drpassthrough
+  namespace: testns
 spec:
   host: "*.foo.com"
   trafficPolicy:

--- a/tests/testdata/config/egressgateway.yaml
+++ b/tests/testdata/config/egressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-egressgateway
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/external_services.yaml
+++ b/tests/testdata/config/external_services.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-extsvc
+  namespace: testns
 spec:
    hosts:
    - external.extsvc.com
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
  name: external-service-1
+ namespace: testns
 spec:
  host: external.extsvc.com
 # BUG: crash envoy
@@ -30,6 +32,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-ports
+  namespace: testns
 spec:
    hosts:
    - ports.extsvc.com
@@ -50,6 +53,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-dst
+  namespace: testns
 spec:
    hosts:
    - dst.extsvc.com
@@ -67,6 +71,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-ep
+  namespace: testns
 spec:
    hosts:
    - ep.extsvc.com

--- a/tests/testdata/config/gateway-all.yaml
+++ b/tests/testdata/config/gateway-all.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: my-gateway
+  namespace: testns
 spec:
   selector:
     app: my-gateway-controller

--- a/tests/testdata/config/gateway-tcp-a.yaml
+++ b/tests/testdata/config/gateway-tcp-a.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: gateway-a
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/ingress.yaml
+++ b/tests/testdata/config/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-ingress
+  namespace: testns
 spec:
   selector:
     istio: ingress
@@ -27,6 +28,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: ingress
+  namespace: testns
 spec:
   # K8S Ingress rules are converted on the fly to a VirtualService.
   # The local tests may run without k8s - so for ingress we test with the

--- a/tests/testdata/config/ingressgateway.yaml
+++ b/tests/testdata/config/ingressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-ingressgateway
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/none.yaml
+++ b/tests/testdata/config/none.yaml
@@ -1,0 +1,233 @@
+# All configs for 'none' namespace, used to test interception without iptables.
+# In this mode the namespace isolation is required - the tests will also verify isolation
+# It is important to update the tests in ../envoy/v2 which verify the number of generated listeners.
+
+# This is the first test using the new isolated model, you can use it as a template to create more
+# isolated tests. It should be possible to also apply it to real k8s.
+
+# TODO: the IP addresses are not namespaced yet, so must be unique on the mesh (flat namespace) including in
+# ServiceEntry tests. Removing deps on ip in progress.
+
+---
+# "None" mode depends on unique ports for each defined service or service entry.
+# Not supported/require iptables:
+# - TCP with 'addresses' field - needs iptables
+# - resolution:NONE - 'original DST' - external services (for example https, ServiceEntry+address), stateful sets
+# - TCP with resolution:DNS - same issue
+# -
+
+# Local ServiceEntry (meshex, test) - the tests will use the IPs defined in the service when connecting.
+# This works on local mode where K8S Service controller doesn't exist, and can be used for testing in k8s by a test
+# pretending to have this address.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: s1tcp
+  namespace: none
+spec:
+   hosts:
+   - s1tcp.none
+
+   ports:
+   - number: 2000
+     name: tcplocal
+     protocol: TCP
+
+   location: MESH_INTERNAL
+   resolution: STATIC
+
+   endpoints:
+    - address: 10.11.0.1
+      ports:
+        tcplocal: 7070
+
+---
+# Another inbound service, http type. Should generate a http listener on :7071
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: s1http
+  namespace: none
+spec:
+  hosts:
+  - s1http.none
+
+  ports:
+  - number: 2001
+    name: httplocal
+    protocol: HTTP
+
+  location: MESH_INTERNAL
+  resolution: STATIC
+
+  endpoints:
+  - address: 10.11.0.1
+    ports:
+      httplocal: 7071
+
+---
+
+# Regular TCP outbound cluster (Default MeshExternal = true, Resolution ClientSideLB)
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: s2
+  namespace: none
+spec:
+  hosts:
+  - s2.external.test.istio.io
+
+  ports:
+  - number: 2005
+    name: http-remote # To verify port name doesn't confuse pilot - protocol is TCP
+    protocol: TCP
+  resolution: STATIC
+  endpoints:
+  - address: 10.11.0.2
+    ports:
+      http-remote: 7071
+  - address: 10.11.0.3
+    ports:
+      http-remote: 7072
+
+---
+# Another TCP outbound cluster, resolution DNS (Default MeshExternal = true)
+# Not supported, bind=false
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: s2dns
+  namespace: none
+spec:
+  hosts:
+  - s2dns.external.test.istio.io
+
+  ports:
+  - number: 2006
+    protocol: TCP
+    name: tcp1 # TODO: is it optional ? Why not ?
+  resolution: DNS
+
+---
+# Outbound TCP cluster, resolution DNS - for a '.svc' (in cluster) service.
+# As an optimization, this can be converted to EDS
+# The new Sidecar is the recommended way to declare deps to mesh services - however
+# DNS resolution is supposed to continue to work.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: tcpmeshdns
+  namespace: none
+spec:
+  hosts:
+  - tcpmeshdns.seexamples.svc
+  ports:
+  - number: 2007
+    protocol: TCP
+    name: tcp1
+  resolution: DNS
+
+
+---
+
+# Outbound TCP cluster, resolution STATIC - for a '.svc' (in cluster) service.
+# This binds on each endpoint address !
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: tcpmeshstatic
+  namespace: none
+spec:
+  hosts:
+  - tcpmeshstatic.seexamples.svc
+  ports:
+  - number: 2008
+    protocol: TCP
+    name: tcp1
+  resolution: STATIC
+  endpoints:
+  - address: 10.11.0.8
+    ports:
+      tcp1: 7070
+---
+# Outbound TCP cluster, resolution STATIC - for a '.svc' (in cluster) service.
+# This generates EDS
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: tcpmeshstaticint
+  namespace: none
+spec:
+  hosts:
+  - tcpmeshstaticint.seexamples.svc
+  ports:
+  - number: 2009
+    protocol: TCP
+    name: tcp1
+  location: MESH_INTERNAL
+  resolution: STATIC
+  endpoints:
+  # NEEDED FOR VALIDATION - LIKELY BUG
+  - address: 10.11.0.9
+    ports:
+      tcp1: 7070
+---
+
+# TODO: in progres, should bind to 127.0.0.1
+# will resolve using SNI
+# DNS or etc/hosts or code must override the address, but pass proper SNI
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: https
+  namespace: none
+spec:
+  hosts:
+  - api.dropboxapi.com
+  - www.googleapis.com
+  - api.facebook.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: TLS
+  resolution: DNS
+---
+# TODO: this should be auto-generated from ServiceEntry/protocol=TLS, it's just boilerplate
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tls-routing
+  namespace: seexamples
+spec:
+  hosts:
+  - api.dropboxapi.com
+  - www.googleapis.com
+  - api.facebook.com
+  tls:
+  - match:
+    - port: 443
+      sniHosts:
+      - api.dropboxapi.com
+    route:
+    - destination:
+        host: api.dropboxapi.com
+  - match:
+    - port: 443
+      sniHosts:
+      - www.googleapis.com
+    route:
+    - destination:
+        host: www.googleapis.com
+  - match:
+    - port: 443
+      sniHosts:
+      - api.facebook.com
+    route:
+    - destination:
+        host: api.facebook.com
+---
+# DestinationRules attach to services, have no impact on 'none' interception
+
+# VirtualService for HTTP affect routes, no impact on none interception
+

--- a/tests/testdata/config/rule-content-route.yaml
+++ b/tests/testdata/config/rule-content-route.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: headers-route
+  namespace: testns
 spec:
   hosts:
     - headers.test.istio.io

--- a/tests/testdata/config/rule-default-route-append-headers.yaml
+++ b/tests/testdata/config/rule-default-route-append-headers.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: appendh
+  namespace: testns
 spec:
    hosts:
    - appendh.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: appendh-route
+  namespace: testns
 spec:
   hosts:
     - appendh.test.istio.io

--- a/tests/testdata/config/rule-default-route-cors-policy.yaml
+++ b/tests/testdata/config/rule-default-route-cors-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: cors
+  namespace: testns
 spec:
    hosts:
    - cors.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: cors
+  namespace: testns
 spec:
   hosts:
     - cors.test.istio.io

--- a/tests/testdata/config/rule-default-route.yaml
+++ b/tests/testdata/config/rule-default-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: c
+  namespace: testns
 spec:
    hosts:
    - c.foo
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default-route-1
+  namespace: testns
 spec:
   hosts:
     - c.foo
@@ -38,6 +40,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default-route-2
+  namespace: testns
 spec:
   hosts:
     - c.foo

--- a/tests/testdata/config/rule-fault-injection.yaml
+++ b/tests/testdata/config/rule-fault-injection.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: fault
+  namespace: testns
 spec:
    hosts:
    - fault.test.istio.io
@@ -26,6 +27,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: fault
+  namespace: testns
 spec:
   host: c-weighted.extsvc.com
   subsets:
@@ -41,6 +43,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: fault
+  namespace: testns
 spec:
   hosts:
     - fault.test.istio.io

--- a/tests/testdata/config/rule-ingressgateway.yaml
+++ b/tests/testdata/config/rule-ingressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: gateway-bound-route
+  namespace: testns
 spec:
   hosts:
     - uk.bookinfo.com

--- a/tests/testdata/config/rule-redirect-injection.yaml
+++ b/tests/testdata/config/rule-redirect-injection.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: redirect
+  namespace: testns
 spec:
    hosts:
    - redirect.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: redirect
+  namespace: testns
 spec:
   hosts:
     - redirect.test.istio.io

--- a/tests/testdata/config/rule-regex-route.yaml
+++ b/tests/testdata/config/rule-regex-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: regex-extsvc
+  namespace: testns
 spec:
    hosts:
    - regex.extsvc.com
@@ -26,6 +27,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: regex
+  namespace: testns
 spec:
   host: regex.extsvc.com
   subsets:
@@ -40,6 +42,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: regex-route
+  namespace: testns
 spec:
   hosts:
     - regex.extsvc.com

--- a/tests/testdata/config/rule-route-via-egressgateway.yaml
+++ b/tests/testdata/config/rule-route-via-egressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: route-via-egressgateway
+  namespace: testns
 spec:
   hosts:
     - egressgateway.bookinfo.com

--- a/tests/testdata/config/rule-websocket-route.yaml
+++ b/tests/testdata/config/rule-websocket-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: websocket-extsvc
+  namespace: testns
 spec:
    hosts:
    - websocket.test.istio.io
@@ -22,6 +23,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: websocket
+  namespace: testns
 spec:
   host: websocket.test.istio.io
   subsets:
@@ -36,6 +38,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: websocket-route
+  namespace: testns
 spec:
   hosts:
     - websocket.test.istio.io
@@ -58,6 +61,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: websocket-route2
+  namespace: testns
 spec:
   hosts:
     - websocket2.extsvc.com

--- a/tests/testdata/config/rule-weighted-route.yaml
+++ b/tests/testdata/config/rule-weighted-route.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: weighted-extsvc
+  namespace: testns
 spec:
    hosts:
    - c-weighted.extsvc.com
@@ -28,6 +29,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: c-weighted
+  namespace: testns
 spec:
   host: c-weighted.extsvc.com
   subsets:
@@ -42,6 +44,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: c-weighted
+  namespace: testns
 spec:
   hosts:
     - c-weighted.extsvc.com

--- a/tests/testdata/config/se-example-gw.yaml
+++ b/tests/testdata/config/se-example-gw.yaml
@@ -1,0 +1,89 @@
+#The following example demonstrates the use of a dedicated egress gateway
+#through which all external service traffic is forwarded.
+
+# Test workload entry
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: workload
+  namespace: exampleegressgw
+spec:
+  hosts:
+  - test.exampleegressgw
+
+  ports:
+  - number: 1300
+    name: tcplocal
+    protocol: TCP
+
+  location: MESH_INTERNAL
+  resolution: STATIC
+
+  endpoints:
+  - address: 10.13.0.1
+    ports:
+      tcplocal: 31200
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-httpbin
+  namespace: exampleegressgw
+spec:
+  hosts:
+  - httpbin.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: DNS
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+ name: istio-egressgateway
+ namespace: exampleegressgw
+spec:
+ selector:
+   istio: egressgateway
+ servers:
+ - port:
+     number: 80
+     name: http
+     protocol: HTTP
+   hosts:
+   - "*"
+---
+#And the associated VirtualService to route from the sidecar to the
+#gateway service (istio-egressgateway.istio-system.svc.cluster.local), as
+#well as route from the gateway to the external service.
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: gateway-routing
+  namespace: exampleegressgw
+spec:
+  hosts:
+  - httpbin.com
+  gateways:
+  - mesh
+  - istio-egressgateway
+  http:
+  - match:
+    - port: 80
+      gateways:
+      - mesh
+    route:
+    - destination:
+        host: istio-egressgateway.istio-system.svc.cluster.local
+  - match:
+    - port: 80
+      gateways:
+      - istio-egressgateway
+    route:
+    - destination:
+        host: httpbin.com
+---

--- a/tests/testdata/config/se-example.yaml
+++ b/tests/testdata/config/se-example.yaml
@@ -1,0 +1,213 @@
+# Examples from the doc and site, in namespace examples
+# The 'egress' example conflicts, it's in separate namespace
+#
+# Ports:
+# - 27018 (mongo) - with VIP
+# - 443 - SNI routing
+# - 80 - *.bar.com resolution:NONE example
+#
+# - 8000 - virtual entry backed by multiple DNS-based services
+# - 8001 - unix domain socket
+#
+# - 1200 - the inbound service and
+# - 21200 - the inbound container
+#
+# Test workload entry
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: workload
+  namespace: seexamples
+spec:
+  hosts:
+  - test.seexamples
+
+  ports:
+  - number: 1200
+    name: tcplocal
+    protocol: TCP
+
+  location: MESH_INTERNAL
+  resolution: STATIC
+
+  endpoints:
+  - address: 10.12.0.1
+    ports:
+      tcplocal: 21200
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+   name: external-svc-mongocluster
+   namespace: seexamples
+spec:
+  hosts:
+  - mymongodb.somedomain # not used
+ 
+  addresses:
+  - 192.192.192.192/24 # VIPs
+ 
+  ports:
+  - number: 27018
+    name: mongodb
+    protocol: MONGO
+  location: MESH_INTERNAL
+  resolution: STATIC
+  endpoints:
+  - address: 2.2.2.2
+  - address: 3.3.3.3
+    
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: mtls-mongocluster
+  namespace: seexamples
+spec:
+  host: mymongodb.somedomain
+  trafficPolicy:
+    tls:
+      mode: MUTUAL
+      clientCertificate: /etc/certs/myclientcert.pem
+      privateKey: /etc/certs/client_private_key.pem
+      caCertificates: /etc/certs/rootcacerts.pem
+---
+#The following example uses a combination of service entry and TLS
+#routing in virtual service to demonstrate the use of SNI routing to
+#forward unterminated TLS traffic from the application to external
+#services via the sidecar. The sidecar inspects the SNI value in the
+#ClientHello message to route to the appropriate external service.
+
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-https
+  namespace: seexamples
+spec:
+  hosts:
+  - api.dropboxapi.com
+  - www.googleapis.com
+  - api.facebook.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 443
+    name: https
+    protocol: TLS
+  resolution: DNS
+  
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tls-routing
+  namespace: seexamples
+spec:
+  hosts:
+  - api.dropboxapi.com
+  - www.googleapis.com
+  - api.facebook.com
+  tls:
+  - match:
+    - port: 443
+      sniHosts:
+      - api.dropboxapi.com
+    route:
+    - destination:
+        host: api.dropboxapi.com
+  - match:
+    - port: 443
+      sniHosts:
+      - www.googleapis.com
+    route:
+    - destination:
+        host: www.googleapis.com
+  - match:
+    - port: 443
+      sniHosts:
+      - api.facebook.com
+    route:
+    - destination:
+        host: api.facebook.com
+---
+#The following example demonstrates the use of wildcards in the hosts for
+#external services. If the connection has to be routed to the IP address
+#requested by the application (i.e. application resolves DNS and attempts
+#to connect to a specific IP), the discovery mode must be set to `NONE`.
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-wildcard-example
+  namespace: seexamples
+spec:
+  hosts:
+  - "*.bar.com"
+  location: MESH_EXTERNAL
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  resolution: NONE
+
+---
+# The following example demonstrates a service that is available via a
+# Unix Domain Socket on the host of the client. The resolution must be
+# set to STATIC to use unix address endpoints.
+
+# Modified to use port 8001
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: unix-domain-socket-example
+  namespace: seexamples
+spec:
+  hosts:
+  - "example.unix.local"
+  location: MESH_EXTERNAL
+  ports:
+  - number: 8001
+    name: http
+    protocol: HTTP
+  resolution: STATIC
+  endpoints:
+  - address: unix:///var/run/example/socket
+
+---
+
+# For HTTP based services, it is possible to create a VirtualService
+# backed by multiple DNS addressable endpoints. In such a scenario, the
+# application can use the HTTP_PROXY environment variable to transparently
+# reroute API calls for the VirtualService to a chosen backend. For
+# example, the following configuration creates a non-existent external
+# service called foo.bar.com backed by three domains: us.foo.bar.com:8080,
+# uk.foo.bar.com:9080, and in.foo.bar.com:7080
+
+# Modified to use port 8000
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc-dns
+  namespace: seexamples
+spec:
+  hosts:
+  - foo.bar.com
+  location: MESH_EXTERNAL
+  ports:
+  - number: 8000
+    name: http
+    protocol: HTTP
+  resolution: DNS
+  endpoints:
+  - address: us.foo.bar.com
+    ports:
+      # TODO: example uses 'https', which is rejected currently
+      http: 8080
+  - address: uk.foo.bar.com
+    ports:
+      http: 9080
+  - address: in.foo.bar.com
+    ports:
+      http: 7080
+
+---

--- a/tests/testdata/config/virtual-service-all.yaml
+++ b/tests/testdata/config/virtual-service-all.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: all
+  namespace: testns
 spec:
   hosts:
   - service3.default.svc.cluster.local


### PR DESCRIPTION
Extend the node metadata that controls REDIRECT/TPROXY interception with NONE mode,
where iptables are not used ( except where we can't avoid them for now - like stateful sets )

Listeners will use bind=true and localhost. Apps will need to be modified or use /etc/hosts or DNS
to connect to localhost. HTTP will use the PROXY mode, apps will need to setup the env or config.

This mode is also useful for developer or cases where 'root' access is not available. 

- added tests for isolation and 'none' mode
- added a test for the API doc examples ( the last one in ServiceEntry was not validating )

Initial PR is focused on outbound listeners - inbound ports will be setup using the new Sidecar API,
will need a way to configure the 'local' app port. 

3 ports will be used for each inbound - the service port will be used for outbound connections to 
other instances of the service, the container port will be bound by Envoy, and accept incoming
traffic, and an extra port will be bound by the app on localhost and accept envoy traffic.
It is not possible to have containerPort == service port without losing ability to call other instances of the
service.