### PR TITLE
Fix #9658: Make Mixer trace CheckResults and QuotaResults (1.1)

### DIFF
--- a/mixer/pkg/runtime/dispatcher/tracing.go
+++ b/mixer/pkg/runtime/dispatcher/tracing.go
@@ -19,6 +19,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	tracelog "github.com/opentracing/opentracing-go/log"
 
+	"istio.io/istio/mixer/pkg/adapter"
 	"istio.io/istio/mixer/pkg/status"
 )
 
@@ -31,9 +32,19 @@ const (
 	errorStr     = "error"
 )
 
-// LogToDispatchSpan logs to the given Span in a structured manner. Span must be valid.
-func logToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, err error) {
-	st := status.OK
+func logCheckResultToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, result adapter.CheckResult, err error) {
+	logEntriesToDispatchSpan(span, template, handler, adapter, result.Status, err)
+}
+
+func logQuotaResultToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, result adapter.QuotaResult, err error) {
+	logEntriesToDispatchSpan(span, template, handler, adapter, result.Status, err)
+}
+
+func logErrorToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, err error) {
+	logEntriesToDispatchSpan(span, template, handler, adapter, status.OK, err)
+}
+
+func logEntriesToDispatchSpan(span opentracing.Span, template string, handler string, adapter string, st rpc.Status, err error) {
 	if err != nil {
 		st = status.WithError(err)
 	}

--- a/mixer/pkg/runtime/dispatcher/tracing_test.go
+++ b/mixer/pkg/runtime/dispatcher/tracing_test.go
@@ -1,0 +1,294 @@
+package dispatcher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/googleapis/google/rpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/log"
+
+	"istio.io/istio/mixer/pkg/adapter"
+	"istio.io/istio/mixer/pkg/status"
+)
+
+type testBase struct {
+	name                                   string
+	templateName, handlerName, adapterName string
+	err                                    error
+	expectedFields                         map[string]interface{}
+}
+
+var checkResultTests = []struct {
+	testBase
+	checkResult adapter.CheckResult
+}{
+	{
+		testBase: testBase{
+			name:         "Status OK and nil error",
+			templateName: "TN0",
+			handlerName:  "HN0",
+			adapterName:  "AN0",
+			err:          nil,
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN0",
+				handlerName:  "HN0",
+				adapterName:  "AN0",
+				responseCode: "OK",
+				responseMsg:  "",
+				errorStr:     false,
+			},
+		},
+	},
+	{
+		testBase: testBase{
+			name:         "Status Not Found and nil error",
+			templateName: "TN1",
+			handlerName:  "HN1",
+			adapterName:  "AN1",
+			err:          nil,
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN1",
+				handlerName:  "HN1",
+				adapterName:  "AN1",
+				responseCode: "NOT_FOUND",
+				responseMsg:  "42",
+				errorStr:     false,
+			},
+		},
+		checkResult: adapter.CheckResult{Status: status.WithMessage(rpc.NOT_FOUND, "42")},
+	},
+	{
+		testBase: testBase{
+			name:         "Status Not Found and error",
+			templateName: "TN2",
+			handlerName:  "HN2",
+			adapterName:  "AN2",
+			err:          fmt.Errorf("failed"),
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN2",
+				handlerName:  "HN2",
+				adapterName:  "AN2",
+				responseCode: "INTERNAL",
+				responseMsg:  "failed",
+				errorStr:     true,
+			},
+		},
+		checkResult: adapter.CheckResult{Status: status.WithMessage(rpc.NOT_FOUND, "42")},
+	},
+}
+
+func TestLogCheckResultToDispatchSpan(t *testing.T) {
+	for _, test := range checkResultTests {
+		t.Run(test.name, func(t *testing.T) {
+			span := &testSpan{t: t}
+			logCheckResultToDispatchSpan(span, test.templateName, test.handlerName, test.adapterName, test.checkResult, test.err)
+			for k, v := range test.expectedFields {
+				expect(t, span.fields, k, v)
+			}
+		})
+	}
+}
+
+var quotaResultTests = []struct {
+	testBase
+	quotaResult adapter.QuotaResult
+}{
+	{
+		testBase: testBase{
+			name:         "Status OK and nil error",
+			templateName: "TN0",
+			handlerName:  "HN0",
+			adapterName:  "AN0",
+			err:          nil,
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN0",
+				handlerName:  "HN0",
+				adapterName:  "AN0",
+				responseCode: "OK",
+				responseMsg:  "",
+				errorStr:     false,
+			},
+		},
+	},
+	{
+		testBase: testBase{
+			name:         "Status Cancelled and nil error",
+			templateName: "TN1",
+			handlerName:  "HN1",
+			adapterName:  "AN1",
+			err:          nil,
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN1",
+				handlerName:  "HN1",
+				adapterName:  "AN1",
+				responseCode: "CANCELLED",
+				responseMsg:  "hquota1.aquota.istio-system:cancelled details",
+				errorStr:     false,
+			},
+		},
+		quotaResult: adapter.QuotaResult{
+			Status: rpc.Status{
+				Code:    int32(rpc.CANCELLED),
+				Message: "hquota1.aquota.istio-system:cancelled details",
+			},
+		},
+	},
+	{
+		testBase: testBase{
+			name:         "Status Not Found and error",
+			templateName: "TN2",
+			handlerName:  "HN2",
+			adapterName:  "AN2",
+			err:          fmt.Errorf("failed"),
+			expectedFields: map[string]interface{}{
+				meshFunction: "TN2",
+				handlerName:  "HN2",
+				adapterName:  "AN2",
+				responseCode: "INTERNAL",
+				responseMsg:  "failed",
+				errorStr:     true,
+			},
+		},
+		quotaResult: adapter.QuotaResult{
+			Status: rpc.Status{
+				Code:    int32(rpc.CANCELLED),
+				Message: "hquota1.aquota.istio-system:cancelled details",
+			},
+		},
+	},
+}
+
+func TestLogQuotaResultToDispatchSpan(t *testing.T) {
+	for _, test := range quotaResultTests {
+		t.Run(test.name, func(t *testing.T) {
+			span := &testSpan{t: t}
+			logQuotaResultToDispatchSpan(span, test.templateName, test.handlerName, test.adapterName, test.quotaResult, test.err)
+			for k, v := range test.expectedFields {
+				expect(t, span.fields, k, v)
+			}
+		})
+	}
+}
+
+var errorTests = []testBase{
+	{
+		name:         "No error",
+		templateName: "TN0",
+		handlerName:  "HN0",
+		adapterName:  "AN0",
+		err:          nil,
+		expectedFields: map[string]interface{}{
+			meshFunction: "TN0",
+			handlerName:  "HN0",
+			adapterName:  "AN0",
+			responseCode: "OK",
+			responseMsg:  "",
+			errorStr:     false,
+		},
+	},
+	{
+		name:         "With error",
+		templateName: "TN2",
+		handlerName:  "HN2",
+		adapterName:  "AN2",
+		err:          fmt.Errorf("failed"),
+		expectedFields: map[string]interface{}{
+			meshFunction: "TN2",
+			handlerName:  "HN2",
+			adapterName:  "AN2",
+			responseCode: "INTERNAL",
+			responseMsg:  "failed",
+			errorStr:     true,
+		},
+	},
+}
+
+func TestLogErrorToDispatchSpan(t *testing.T) {
+	for _, test := range errorTests {
+		t.Run(test.name, func(t *testing.T) {
+			span := &testSpan{t: t}
+			logErrorToDispatchSpan(span, test.templateName, test.handlerName, test.adapterName, test.err)
+			for k, v := range test.expectedFields {
+				expect(t, span.fields, k, v)
+			}
+		})
+	}
+}
+
+func expect(t *testing.T, fields []log.Field, key string, value interface{}) {
+	for _, field := range fields {
+		if field.Key() == key {
+			if field.Value() != value {
+				t.Errorf("Expected logged field %v to be %v, but found %v", key, value, field.Value())
+			}
+			return
+		}
+	}
+	t.Errorf("Could not find logged field %v", key)
+}
+
+type testSpan struct {
+	t *testing.T
+
+	fields []log.Field
+}
+
+var _ opentracing.Span = &testSpan{}
+
+func (span *testSpan) Finish() {
+}
+
+func (span *testSpan) FinishWithOptions(opts opentracing.FinishOptions) {
+	span.t.Fatalf("operation not supported")
+}
+
+func (span *testSpan) Context() opentracing.SpanContext {
+	span.t.Fatalf("operation not supported")
+	return nil
+}
+
+func (span *testSpan) SetOperationName(operationName string) opentracing.Span {
+	span.t.Fatalf("operation not supported")
+	return nil
+}
+
+func (span *testSpan) SetTag(key string, value interface{}) opentracing.Span {
+	span.t.Fatalf("operation not supported")
+	return nil
+}
+
+func (span *testSpan) LogFields(fields ...log.Field) {
+	span.fields = append(span.fields, fields...)
+}
+
+func (span *testSpan) LogKV(alternatingKeyValues ...interface{}) {
+	span.t.Fatalf("operation not supported")
+}
+
+func (span *testSpan) SetBaggageItem(restrictedKey, value string) opentracing.Span {
+	span.t.Fatalf("operation not supported")
+	return nil
+}
+
+func (span *testSpan) BaggageItem(restrictedKey string) string {
+	span.t.Fatalf("operation not supported")
+	return ""
+}
+
+func (span *testSpan) Tracer() opentracing.Tracer {
+	span.t.Fatalf("operation not supported")
+	return nil
+}
+
+func (span *testSpan) LogEvent(event string) {
+	span.t.Fatalf("operation not supported")
+}
+
+func (span *testSpan) LogEventWithPayload(event string, payload interface{}) {
+	span.t.Fatalf("operation not supported")
+}
+
+func (span *testSpan) Log(data opentracing.LogData) {
+	span.t.Fatalf("operation not supported")
+}


### PR DESCRIPTION
This PR brings #9693 to the 1.1 branch.
The original description of this PR was:

As reported in #9658 Mixer currently doesn't trace failing Check- or QuotaResults.
This lets users completely in the dark why a request might have been rejected.
This PR tries to fix this by logging CheckResult.Status or QuotaResult.Status instead of status.Ok in case there was no error.
If there was an error this always takes precedence and the Check- or QuotaResult is not checked in that case.

This means that with this PR the same number of fields is traced and it doesn't consume more memory.
But it still gives better and more information about what happened.