### PR TITLE
[Kiali][release-1.0] updating cluster roles necessary for the kiali v0.12.0

### DIFF
--- a/install/kubernetes/ansible/istio/tasks/install_addons.yml
+++ b/install/kubernetes/ansible/istio/tasks/install_addons.yml
@@ -2,7 +2,7 @@
   block:
 
   - set_fact:
-      kiali_version: v0.10
+      kiali_version: v0.12
 
   - name: Install Kiali on Openshift
     shell: |

--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for detail.
 name: kiali
 version: 1.0.6
-appVersion: 0.10
+appVersion: 0.12
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -9,63 +9,68 @@ rules:
 - apiGroups: ["", "apps", "autoscaling", "batch"]
   resources:
   - configmaps
+  - cronjobs
+  - deployments
+  - endpoints
+  - horizontalpodautoscalers
+  - jobs
   - namespaces
   - nodes
   - pods
   - projects
   - services
-  - endpoints
-  - deployments
-  - horizontalpodautoscalers
-  - replicasets
   - statefulsets
+  - replicasets
   - replicationcontrollers
-  - jobs
-  - cronjobs
   verbs:
   - get
   - list
   - watch
 - apiGroups: ["config.istio.io"]
   resources:
-  - rules
+  - apikeys
+  - authorizations
+  - checknothings
   - circonuses
   - deniers
   - fluentds
+  - handlers
   - kubernetesenvs
+  - kuberneteses
   - listcheckers
+  - listentries
+  - logentries
   - memquotas
+  - metrics
   - opas
   - prometheuses
+  - quotas
+  - quotaspecbindings
+  - quotaspecs
   - rbacs
+  - reportnothings
+  - rules
+  - servicecontrolreports
   - servicecontrols
   - solarwindses
   - stackdrivers
   - statsds
   - stdios
-  - apikeys
-  - authorizations
-  - checknothings
-  - kuberneteses
-  - listentries
-  - logentries
-  - metrics
-  - quotas
-  - reportnothings
-  - servicecontrolreports
-  - quotaspecs
-  - quotaspecbindings
   verbs:
+  - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups: ["networking.istio.io"]
   resources:
-  - virtualservices
   - destinationrules
-  - serviceentries
   - gateways
+  - serviceentries
+  - virtualservices
   verbs:
+  - delete
   - get
   - list
+  - patch
   - watch

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -543,7 +543,7 @@ kiali:
   enabled: false
   replicaCount: 1
   hub: docker.io/kiali
-  tag: v0.10
+  tag: v0.12
   ingress:
     enabled: false
     ## Used to create an Ingress record.


### PR DESCRIPTION
in case istio 1.0.x has another release, this PR will be needed.