### PR TITLE
Test theory that IP Forwarding not configured on all CircleCI machines

### DIFF
--- a/bin/testEnvRootMinikube.sh
+++ b/bin/testEnvRootMinikube.sh
@@ -61,6 +61,7 @@ function startMinikubeNone() {
     export MINIKUBE_WANTREPORTERRORPROMPT=false
     export MINIKUBE_HOME=$HOME
     export CHANGE_MINIKUBE_NONE_USER=true
+	echo "IP forwarding setting: $(cat /proc/sys/net/ipv4/ip_forward)"
     sudo -E minikube start \
          --kubernetes-version=v1.9.0 \
          --vm-driver=none \


### PR DESCRIPTION
For #7863 .  CircleCI shows `docker.all generate_yaml` problems with `Temporary failure resolving 'archive.ubuntu.com'` in scripts; the message `[Warning] IPv4 forwarding is disabled. Networking will not work.` appears when processing Dockerfiles.