### PR TITLE
add Bearer prefix for jwt token sent to citadel

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/citadel/client.go
+++ b/security/pkg/nodeagent/caclient/providers/citadel/client.go
@@ -30,7 +30,10 @@ import (
 	pb "istio.io/istio/security/proto"
 )
 
-const caServerName = "istio-citadel"
+const (
+	caServerName      = "istio-citadel"
+	bearerTokenPrefix = "Bearer "
+)
 
 type citadelClient struct {
 	caEndpoint    string
@@ -76,6 +79,8 @@ func (c *citadelClient) CSRSign(ctx context.Context, csrPEM []byte, token string
 		ValidityDuration: certValidTTLInSec,
 	}
 
+	// add Bearer prefix, which is required by Citadel.
+	token = bearerTokenPrefix + token
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", token))
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {


### PR DESCRIPTION
jwt token sent from nodeagent to cidetal for request cert should be has Bearer prefix, which is required by citadel
(https://github.com/istio/istio/blob/release-1.1/security/pkg/server/ca/authenticate/kube_jwt.go#L53)