### PR TITLE
Read Vault TLS root certificate from an environmental variable

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -65,6 +65,9 @@ const (
 
 	// The environmental variable name for Vault sign CSR path.
 	vaultSignCsrPath = "VAULT_SIGN_CSR_PATH"
+
+	// The environmental variable name for Vault TLS root certificate.
+	vaultTlsRootCert = "VAULT_TLS_ROOT_CERT"
 )
 
 var (
@@ -125,7 +128,7 @@ var (
 func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecretCache *cache.SecretCache) {
 	if serverOptions.EnableWorkloadSDS {
 		wSecretFetcher, err := secretfetcher.NewSecretFetcher(false, serverOptions.CAEndpoint,
-			serverOptions.CAProviderName, true, "", "", "", "")
+			serverOptions.CAProviderName, true, []byte(serverOptions.VaultTlsRootCert), "", "", "", "")
 		if err != nil {
 			log.Errorf("failed to create secretFetcher for workload proxy: %v", err)
 			os.Exit(1)
@@ -139,7 +142,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 
 	if serverOptions.EnableIngressGatewaySDS {
 		gSecretFetcher, err := secretfetcher.NewSecretFetcher(true, "", "",
-			false, "", "", "", "")
+			false, []byte(serverOptions.VaultTlsRootCert), "", "", "", "")
 		if err != nil {
 			log.Errorf("failed to create secretFetcher for gateway proxy: %v", err)
 			os.Exit(1)
@@ -211,6 +214,8 @@ func init() {
 		"Vault auth path")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultSignCsrPath, "vaultSignCsrPath", os.Getenv(vaultSignCsrPath),
 		"Vault sign CSR path")
+	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTlsRootCert, "vaultTlsRootCert", os.Getenv(vaultTlsRootCert),
+		"Vault TLS root certificate")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -67,7 +67,7 @@ const (
 	vaultSignCsrPath = "VAULT_SIGN_CSR_PATH"
 
 	// The environmental variable name for Vault TLS root certificate.
-	vaultTlsRootCert = "VAULT_TLS_ROOT_CERT"
+	vaultTLSRootCert = "VAULT_TLS_ROOT_CERT"
 )
 
 var (
@@ -128,7 +128,7 @@ var (
 func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecretCache *cache.SecretCache) {
 	if serverOptions.EnableWorkloadSDS {
 		wSecretFetcher, err := secretfetcher.NewSecretFetcher(false, serverOptions.CAEndpoint,
-			serverOptions.CAProviderName, true, []byte(serverOptions.VaultTlsRootCert), "", "", "", "")
+			serverOptions.CAProviderName, true, []byte(serverOptions.VaultTLSRootCert), "", "", "", "")
 		if err != nil {
 			log.Errorf("failed to create secretFetcher for workload proxy: %v", err)
 			os.Exit(1)
@@ -142,7 +142,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 
 	if serverOptions.EnableIngressGatewaySDS {
 		gSecretFetcher, err := secretfetcher.NewSecretFetcher(true, "", "",
-			false, []byte(serverOptions.VaultTlsRootCert), "", "", "", "")
+			false, []byte(serverOptions.VaultTLSRootCert), "", "", "", "")
 		if err != nil {
 			log.Errorf("failed to create secretFetcher for gateway proxy: %v", err)
 			os.Exit(1)
@@ -214,7 +214,7 @@ func init() {
 		"Vault auth path")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultSignCsrPath, "vaultSignCsrPath", os.Getenv(vaultSignCsrPath),
 		"Vault sign CSR path")
-	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTlsRootCert, "vaultTlsRootCert", os.Getenv(vaultTlsRootCert),
+	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTLSRootCert, "vaultTLSRootCert", os.Getenv(vaultTLSRootCert),
 		"Vault TLS root certificate")
 
 	// Attach the Istio logging options to the command.

--- a/security/pkg/nodeagent/caclient/client.go
+++ b/security/pkg/nodeagent/caclient/client.go
@@ -46,13 +46,13 @@ type configMap interface {
 }
 
 // NewCAClient create an CA client.
-func NewCAClient(endpoint, CAProviderName string, tlsFlag bool, vaultAddr, vaultRole,
+func NewCAClient(endpoint, CAProviderName string, tlsFlag bool, tlsRootCert []byte, vaultAddr, vaultRole,
 	vaultAuthPath, vaultSignCsrPath string) (caClientInterface.Client, error) {
 	switch CAProviderName {
 	case googleCAName:
 		return gca.NewGoogleCAClient(endpoint, tlsFlag)
 	case vaultCAName:
-		return vault.NewVaultClient(tlsFlag, nil, vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath)
+		return vault.NewVaultClient(tlsFlag, tlsRootCert, vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath)
 	case citadelName:
 		cs, err := createClientSet()
 		if err != nil {

--- a/security/pkg/nodeagent/caclient/client_test.go
+++ b/security/pkg/nodeagent/caclient/client_test.go
@@ -46,7 +46,7 @@ func TestNewCAClient(t *testing.T) {
 	}
 
 	for id, tc := range testCases {
-		_, err := NewCAClient("abc:0", tc.provider, false, "", "", "", "")
+		_, err := NewCAClient("abc:0", tc.provider, false, nil, "", "", "", "")
 		if err.Error() != tc.expectedErr {
 			t.Errorf("Test case [%s]: Get error (%s) different from expected error (%s).",
 				id, err.Error(), tc.expectedErr)

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -74,6 +74,9 @@ type Options struct {
 
 	// The Vault sign CSR path.
 	VaultSignCsrPath string
+
+	// The Vault TLS root certificate.
+	VaultTlsRootCert string
 }
 
 // Server is the gPRC server that exposes SDS through UDS.

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -76,7 +76,7 @@ type Options struct {
 	VaultSignCsrPath string
 
 	// The Vault TLS root certificate.
-	VaultTlsRootCert string
+	VaultTLSRootCert string
 }
 
 // Server is the gPRC server that exposes SDS through UDS.

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -97,7 +97,7 @@ func createClientset() *kubernetes.Clientset {
 
 // NewSecretFetcher returns a pointer to a newly constructed SecretFetcher instance.
 func NewSecretFetcher(ingressGatewayAgent bool, endpoint, CAProviderName string, tlsFlag bool,
-	vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath string) (*SecretFetcher, error) {
+	tlsRootCert []byte, vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath string) (*SecretFetcher, error) {
 	ret := &SecretFetcher{}
 
 	if ingressGatewayAgent {
@@ -105,7 +105,8 @@ func NewSecretFetcher(ingressGatewayAgent bool, endpoint, CAProviderName string,
 		cs := createClientset()
 		ret.Init(cs.CoreV1())
 	} else {
-		caClient, err := ca.NewCAClient(endpoint, CAProviderName, tlsFlag, vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath)
+		caClient, err := ca.NewCAClient(endpoint, CAProviderName, tlsFlag, tlsRootCert,
+			vaultAddr, vaultRole, vaultAuthPath, vaultSignCsrPath)
 		if err != nil {
 			log.Errorf("failed to create caClient: %v", err)
 			return ret, fmt.Errorf("failed to create caClient")


### PR DESCRIPTION
Read Vault TLS root certificate from an environmental variable. 

In the current implementation, the Vault adapter reads the system default certificate pool and uses them as the TLS root certificates for Vault. This PR  allows Node Agent to read Vault TLS root certificate from an environmental variable. Thus, with this PR, the Vault TLS certificate can be provisioned either to the system certificate pool or through an environmental variable.