### PR TITLE
Allow pulling images from private repository

### DIFF
--- a/install/gcp/deployment_manager/istio-cluster.jinja
+++ b/install/gcp/deployment_manager/istio-cluster.jinja
@@ -16,6 +16,7 @@ resources:
         oauthScopes:
         - https://www.googleapis.com/auth/logging.write
         - https://www.googleapis.com/auth/monitoring
+        - https://www.googleapis.com/auth/devstorage.read_only
 
 - type: runtimeconfig.v1beta1.config
   name: {{ CLUSTER_NAME }}-config


### PR DESCRIPTION
Without this scope, GKE will not be able to pull images from the projects private repository on gcr.io like you can do on a normal default cluster. 

This probably causes new beginners testing the bookinfo solution to work but when they begin to try test their own apps it will not work 😅