### PR TITLE
Release 1.1 sds

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -53,7 +53,7 @@ const (
 	k8sSAJwtTokenHeaderKey = "istio_sds_credentail_header-bin"
 
 	// IngressGatewaySdsUdsPath is the UDS path for ingress gateway to get credentials via SDS.
-	IngressGatewaySdsUdsPath = "/var/run/ingress_gateway/sds"
+	IngressGatewaySdsUdsPath = "unix:/var/run/ingress_gateway/sds"
 )
 
 // JwtKeyResolver resolves JWT public key and JwksURI.

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -88,20 +88,14 @@ type sdsservice struct {
 }
 
 // newSDSService creates Secret Discovery Service which implements envoy v2 SDS API.
-func newSDSService(st cache.SecretManager, workloadSDS bool) *sdsservice {
+func newSDSService(st cache.SecretManager, skipTokenVerification bool) *sdsservice {
 	if st == nil {
 		return nil
 	}
 
-	if workloadSDS {
-		return &sdsservice{
-			st:        st,
-			skipToken: false,
-		}
-	}
 	return &sdsservice{
 		st:        st,
-		skipToken: true,
+		skipToken: skipTokenVerification,
 	}
 }
 

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -91,8 +91,8 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, options.EnableWorkloadSDS),
-		gatewaySds:  newSDSService(gatewaySecretCache, options.EnableIngressGatewaySDS),
+		workloadSds: newSDSService(workloadSecretCache, false),
+		gatewaySds:  newSDSService(gatewaySecretCache, true),
 	}
 	if options.EnableWorkloadSDS {
 		if err := s.initWorkloadSdsService(&options); err != nil {

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -44,7 +44,7 @@ const (
 	secretResyncPeriod = 15 * time.Second
 
 	// IngressSecretType the type of kubernetes secrets for ingress gateway.
-	IngressSecretType = "istio.io/ingress-k8sKey-cert"
+	IngressSecretType = "istio.io/ingress-key-cert"
 
 	// KubeConfigFile the config file name for kubernetes client.
 	// Specifies empty file name to use InClusterConfig.
@@ -53,7 +53,7 @@ const (
 	// The ID/name for the certificate chain in kubernetes secret.
 	ScrtCert = "cert"
 	// The ID/name for the k8sKey in kubernetes secret.
-	ScrtKey = "k8sKey"
+	ScrtKey = "key"
 
 	// IngressSecretNameSpace the namespace of kubernetes secrets to watch.
 	ingressSecretNameSpace = "INGRESS_GATEWAY_NAMESPACE"


### PR DESCRIPTION
Add "unix:" to sds config uri, this is needed by Envoy to use UDS.
Update ingress secret for ingress agent to watch, including key, cert, and type.