### PR TITLE
Add 'destination.port' to mixer testdata attributes

### DIFF
--- a/mixer/testdata/config/attributes.yaml
+++ b/mixer/testdata/config/attributes.yaml
@@ -57,6 +57,8 @@ spec:
         valueType: STRING
       destination.uid:
         valueType: STRING
+      destination.port:
+        valueType: INT64
       connection.event:
         valueType: STRING
       connection.id:


### PR DESCRIPTION
This may be related to  #10267 , since I ran into the same issue when attempting to test an OOP adapter. 

It's unclear to me if the testdata file should be identical to install/kubernetes/helm/subcharts/mixer/templates/config.yaml , since there are several other attributes present in that file that are missing from here.