### PR TITLE
Properly report failures to delete the namespace or galley webhook

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -519,7 +519,9 @@ func (k *KubeInfo) Teardown() error {
 	}
 
 	// confirm the namespace is deleted as it will cause future creation to fail
-	maxAttempts := 600
+	// NB: Increasing maxAttempts much past 230 seconds causes the CI infrastructure
+	// to terminate the test run not reporting what actually failed in the deletion.
+	maxAttempts := 180
 	namespaceDeleted := false
 	validatingWebhookConfigurationExists := false
 	log.Infof("Deleting namespace %v", k.Namespace)


### PR DESCRIPTION
With max retries set to 600 (10 minutes), an exact error result is not
returned. Instead a vague reponse about the test case timing out is
reported, resulting in confusion for the PR authors.

The typical max I was able to run was about 230 seconds, but I trimmed
to 3 minutes so the test case bails out in all conditions and properly
reports the errors.