### PR TITLE
Remove a flag never used in updateVersion.sh

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -18,7 +18,6 @@ The [updateVersion.sh](updateVersion.sh) script is used to update image versions
 * `-n <namespace>` namespace in which to install Istio control plane components (defaults to istio-system)
 * `-P` URL to download pilot debian packages
 * `-d <dir>` directory to store updated/generated files (optional, defaults to source code tree)
-* `-D` enable debug for proxy (optional, default is false)
 
 Default values for the `-p`, `-x`, `-c`, `-o`, and `-a` options are as specified in `istio.VERSION`
 (i.e., they are left unchanged).

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -42,7 +42,6 @@ usage: ${BASH_SOURCE[0]} [options ...]
     -n ... <namespace> namespace in which to install Istio control plane components
     -P ... URL to download pilot debian packages
     -d ... directory to store file (optional, defaults to source code tree)
-    -D ... enable debug for proxy (optional, false or true, default is false)
 EOF
   exit 2
 }
@@ -57,7 +56,6 @@ while getopts :n:p:x:c:a:h:o:P:d:D: arg; do
     o) PROXY_HUB_TAG="${OPTARG}";;     # Format: "<hub>,<tag>"
     P) PILOT_DEBIAN_URL="${OPTARG}";;
     d) DEST_DIR="${OPTARG}";;
-    D) PROXY_DEBUG="${OPTARG}";;
     *) usage;;
   esac
 done
@@ -120,7 +118,6 @@ export PILOT_HUB="${PILOT_HUB}"
 export PILOT_TAG="${PILOT_TAG}"
 export PROXY_HUB="${PROXY_HUB}"
 export PROXY_TAG="${PROXY_TAG}"
-export PROXY_DEBUG="${PROXY_DEBUG}"
 export ISTIO_NAMESPACE="${ISTIO_NAMESPACE}"
 export PILOT_DEBIAN_URL="${PILOT_DEBIAN_URL}"
 export FORTIO_HUB="${FORTIO_HUB}"

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -46,7 +46,7 @@ EOF
   exit 2
 }
 
-while getopts :n:p:x:c:a:h:o:P:d:D: arg; do
+while getopts :n:p:x:c:a:h:o:P:d: arg; do
   case ${arg} in
     n) ISTIO_NAMESPACE="${OPTARG}";;
     p) PILOT_HUB_TAG="${OPTARG}";;     # Format: "<hub>,<tag>"


### PR DESCRIPTION
The value of `-D` is never being used and the flag is never provided upon calling the script.
Therefore removing it.