### PR TITLE
Remove nodePort from the gateways

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -68,13 +68,10 @@ gateways:
     - port: 80
       targetPort: 80
       name: http2
-      # nodePort: 31380
     - port: 443
       name: https
-      # nodePort: 31390
     - port: 31400
       name: tcp
-      # nodePort: 31400
     # Pilot and Citadel MTLS ports are enabled in gateway - but will only redirect
     # to pilot/citadel if global.meshExpansion settings are enabled.
     - port: 15011

--- a/install/kubernetes/helm/subcharts/gateways/values.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/values.yaml
@@ -48,14 +48,11 @@ istio-ingressgateway:
   - port: 80
     targetPort: 80
     name: http2
-    nodePort: 31380
   - port: 443
     name: https
-    nodePort: 31390
   # Example of a port to add. Remove if not needed
   - port: 31400
     name: tcp
-    nodePort: 31400
   ### PORTS FOR UI/metrics #####
   ## Disable if not needed
   - port: 15029


### PR DESCRIPTION
By default the gateways  are of type `LoadBalancer` and the `nodePort` isn't needed and may already be used.

Fixes #10795 