### PR TITLE
Use 128bit traceids in envoy

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -239,7 +239,8 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans"
+        "collector_endpoint": "/api/v1/spans",
+        "trace_id_128bit":"true"
       }
     }
   }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -239,7 +239,8 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans"
+        "collector_endpoint": "/api/v1/spans",
+        "trace_id_128bit":"true"
       }
     }
   }

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -213,7 +213,8 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans"
+        "collector_endpoint": "/api/v1/spans",
+        "trace_id_128bit":"true"
       }
     }
   }

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -279,7 +279,8 @@
       "name": "envoy.zipkin",
       "config": {
         "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans"
+        "collector_endpoint": "/api/v1/spans",
+        "trace_id_128bit": "true"
       }
     }
   }


### PR DESCRIPTION
Default envoy-generated traceids are 64bit. This PR forces a switch to 128, as requested in the linked issue.

Fixes #10732 