### PR TITLE
Do not include common name in subject alternative name for Vault

### DIFF
--- a/mixer/pkg/runtime/dispatcher/tracing_test.go
+++ b/mixer/pkg/runtime/dispatcher/tracing_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/gogo/googleapis/google/rpc"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 
 	"istio.io/istio/mixer/pkg/adapter"

--- a/security/pkg/nodeagent/caclient/providers/vault/client.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client.go
@@ -177,6 +177,7 @@ func signCsrByVault(client *api.Client, csrSigningPath string, certTTLInSec int6
 		"format": "pem",
 		"csr":    string(csr[:]),
 		"ttl":    strconv.FormatInt(certTTLInSec, 10) + "s",
+		"exclude_cn_from_sans": true,
 	}
 	res, err := client.Logical().Write(csrSigningPath, m)
 	if err != nil {

--- a/security/pkg/nodeagent/caclient/providers/vault/client.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client.go
@@ -174,9 +174,9 @@ func loginVaultK8sAuthMethod(client *api.Client, loginPath, role, sa string) (st
 // csr: the CSR to be signed, in pem format
 func signCsrByVault(client *api.Client, csrSigningPath string, certTTLInSec int64, csr []byte) ([]string, error) {
 	m := map[string]interface{}{
-		"format": "pem",
-		"csr":    string(csr[:]),
-		"ttl":    strconv.FormatInt(certTTLInSec, 10) + "s",
+		"format":               "pem",
+		"csr":                  string(csr[:]),
+		"ttl":                  strconv.FormatInt(certTTLInSec, 10) + "s",
 		"exclude_cn_from_sans": true,
 	}
 	res, err := client.Logical().Write(csrSigningPath, m)


### PR DESCRIPTION
When Vault signs a CSR, it may add DNS:common name to the Subject Alternative Name section as follows. This PR fix this problem such that DNS:common name is not added to the SAN section. 
        X509v3 Subject Alternative Name:                                                         
                DNS:common name, URI:spiffe://cluster.local/ns/default/sa/default