### PR TITLE
Fix Citadel Kube JWT authentication result

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -327,7 +327,7 @@ func runCA() {
 
 		// The CA API uses cert with the max workload cert TTL.
 		hostnames := append(strings.Split(opts.grpcHosts, ","), fqdn())
-		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort)
+		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort, opts.trustDomain)
 		if startErr != nil {
 			fatalf("Failed to create istio ca server: %v", startErr)
 		}

--- a/security/pkg/server/ca/authenticate/kube_jwt.go
+++ b/security/pkg/server/ca/authenticate/kube_jwt.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	// identityTemplate is the format template of identity in the CSR request.
+	// identityTemplate is the SPIFFE format template of the identity.
 	identityTemplate = "spiffe://%s/ns/%s/sa/%s"
 )
 
@@ -67,7 +67,7 @@ func (a *KubeJWTAuthenticator) Authenticate(ctx context.Context) (*Caller, error
 		return nil, fmt.Errorf("failed to validate the JWT: %v", err)
 	}
 	if len(id) != 2 {
-		return nil, fmt.Errorf("Failed to parse the JWT. Validation result length is not 2, but %d", len(id))
+		return nil, fmt.Errorf("failed to parse the JWT. Validation result length is not 2, but %d", len(id))
 	}
 	return &Caller{
 		AuthSource: AuthSourceIDToken,

--- a/security/pkg/server/ca/authenticate/kube_jwt_test.go
+++ b/security/pkg/server/ca/authenticate/kube_jwt_test.go
@@ -128,6 +128,17 @@ func TestAuthenticate(t *testing.T) {
 			client:         &mockTokenReviewClient{id: nil, err: fmt.Errorf("test error")},
 			expectedErrMsg: "failed to validate the JWT: test error",
 		},
+		"Wrong identity length": {
+			metadata: metadata.MD{
+				"random": []string{},
+				"authorization": []string{
+					"Basic callername",
+					"Bearer bearer-token",
+				},
+			},
+			client:         &mockTokenReviewClient{id: []string{"foo"}, err: nil},
+			expectedErrMsg: "failed to parse the JWT. Validation result length is not 2, but 1",
+		},
 		"Successful": {
 			metadata: metadata.MD{
 				"random": []string{},

--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -181,7 +181,7 @@ func (s *Server) Run() error {
 }
 
 // New creates a new instance of `IstioCAServiceServer`.
-func New(ca ca.CertificateAuthority, ttl time.Duration, forCA bool, hostlist []string, port int) (*Server, error) {
+func New(ca ca.CertificateAuthority, ttl time.Duration, forCA bool, hostlist []string, port int, trustDomain string) (*Server, error) {
 	if len(hostlist) == 0 {
 		return nil, fmt.Errorf("failed to create grpc server hostlist empty")
 	}
@@ -191,7 +191,7 @@ func New(ca ca.CertificateAuthority, ttl time.Duration, forCA bool, hostlist []s
 	authenticators := []authenticator{&authenticate.ClientCertAuthenticator{}}
 	log.Info("added client certificate authenticator")
 
-	authenticator, err := authenticate.NewKubeJWTAuthenticator(k8sAPIServerURL, caCertPath, jwtPath)
+	authenticator, err := authenticate.NewKubeJWTAuthenticator(k8sAPIServerURL, caCertPath, jwtPath, trustDomain)
 	if err == nil {
 		authenticators = append(authenticators, authenticator)
 		log.Info("added K8s JWT authenticator")

--- a/security/pkg/server/ca/server_test.go
+++ b/security/pkg/server/ca/server_test.go
@@ -392,7 +392,7 @@ func TestRun(t *testing.T) {
 			// K8s JWT authenticator is added in k8s env.
 			tc.expectedAuthenticatorsLen = tc.expectedAuthenticatorsLen + 1
 		}
-		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port)
+		server, err := New(tc.ca, time.Hour, false, tc.hostname, tc.port, "testdomain.com")
 		if err == nil {
 			err = server.Run()
 		}


### PR DESCRIPTION
Make the Kube JWT authentication result compliant with the SPIFFE format.