### PR TITLE
WIP: Force periodic envoy->pilot reconnections.

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -55,6 +55,15 @@ var (
 	// while debouncing. Defaults to 10 seconds. If events keep
 	// showing up with no break for this time, we'll trigger a push.
 	DebounceMax time.Duration
+
+	// MaxConnLifefime is the maximum duration of an incoming envoy
+	// connection. Connections that outlive their maximum lifetime
+	// are disconnected. This periodic disconnection enables
+	// gradual rebalancing of load between pilot instances.
+	// Note that values specified here will be jittered for each
+	// connection in order to prevent a 'thundering herd' of
+	// simultaneous reconnections.
+	MaxConnLifetime time.Duration
 )
 
 const (
@@ -75,6 +84,7 @@ const (
 func init() {
 	DebounceAfter = envDuration(pilot.DebounceAfter, 100*time.Millisecond)
 	DebounceMax = envDuration(pilot.DebounceMax, 10*time.Second)
+	MaxConnLifetime = envDuration(pilot.MaxConnLifetime, 300*time.Second)
 }
 
 func envDuration(envVal string, def time.Duration) time.Duration {

--- a/pilot/pkg/proxy/envoy/v2/discovery.go
+++ b/pilot/pkg/proxy/envoy/v2/discovery.go
@@ -56,7 +56,7 @@ var (
 	// showing up with no break for this time, we'll trigger a push.
 	DebounceMax time.Duration
 
-	// MaxConnLifefime is the maximum duration of an incoming envoy
+	// MaxConnLifetime is the maximum duration of an incoming envoy
 	// connection. Connections that outlive their maximum lifetime
 	// are disconnected. This periodic disconnection enables
 	// gradual rebalancing of load between pilot instances.

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -73,6 +73,16 @@ var (
 	// 'admin' namespaces. Using services from any other namespaces will require the new NetworkScope
 	// config. In most cases 'istio-system' should be included. Comma separated (ns1,ns2,istio-system)
 	NetworkScopes = os.Getenv("DEFAULT_NAMESPACE_DEPENDENCIES")
+
+	// MaxConnLifefime is the maximum duration of an incoming envoy
+	// connection. Connections that outlive their maximum lifetime
+	// are disconnected. This periodic disconnection enables
+	// gradual rebalancing of load between pilot instances.
+	// Note that values specified here will be jittered for each
+	// connection in order to prevent a 'thundering herd' of
+	// simultaneous reconnections.
+	// Default is 300s.
+	MaxConnLifetime = os.Getenv("PILOT_MAX_CONN_LIFETIME")
 )
 
 const (

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -74,7 +74,7 @@ var (
 	// config. In most cases 'istio-system' should be included. Comma separated (ns1,ns2,istio-system)
 	NetworkScopes = os.Getenv("DEFAULT_NAMESPACE_DEPENDENCIES")
 
-	// MaxConnLifefime is the maximum duration of an incoming envoy
+	// MaxConnLifetime is the maximum duration of an incoming envoy
 	// connection. Connections that outlive their maximum lifetime
 	// are disconnected. This periodic disconnection enables
 	// gradual rebalancing of load between pilot instances.


### PR DESCRIPTION
This attempts to avoid the pilot load hot-spotting described in #7878 by
periodically forcing envoy to reconnect, which (combined with load
balancing), should eventually smear traffic roughly evenly across the
active pilots.