### PR TITLE
Add logic to kubeenv adapter Close() to clean-up resources

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -253,20 +253,37 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 		}
 	}
 
+	// bag around the input proto that keeps track of reference attributes
+	protoBag := attribute.NewProtoBag(&req.Attributes[0], s.globalDict, s.globalWordList)
+
+	// This tracks the delta attributes encoded in the individual report entries
+	accumBag := attribute.GetMutableBag(protoBag)
+
+	// This holds the output state of preprocess operations, which ends up as a delta over the current accumBag.
+	reportBag := attribute.GetMutableBag(accumBag)
+
 	reportSpan, reportCtx := opentracing.StartSpanFromContext(ctx, "Report")
 	reporter := s.dispatcher.GetReporter(reportCtx)
 
 	var errors *multierror.Error
 	for i := 0; i < len(req.Attributes); i++ {
 		span, newctx := opentracing.StartSpanFromContext(reportCtx, fmt.Sprintf("attribute bag %d", i))
-		protoBag := attribute.NewProtoBag(&req.Attributes[i], s.globalDict, s.globalWordList)
 
-		// This holds the output state of preprocess operations
-		reportBag := attribute.GetMutableBag(protoBag)
+		// the first attribute block is handled by the protoBag as a foundation,
+		// deltas are applied to the child bag (i.e. requestBag)
+		if i > 0 {
+			if err := accumBag.UpdateBagFromProto(&req.Attributes[i], s.globalWordList); err != nil {
+				err = fmt.Errorf("request could not be processed due to invalid attributes: %v", err)
+				span.LogFields(otlog.String("error", err.Error()))
+				span.Finish()
+				errors = multierror.Append(errors, err)
+				break
+			}
+		}
 
 		lg.Debug("Dispatching Preprocess")
 
-		if err := s.dispatcher.Preprocess(newctx, protoBag, reportBag); err != nil {
+		if err := s.dispatcher.Preprocess(newctx, accumBag, reportBag); err != nil {
 			err = fmt.Errorf("preprocessing attributes failed: %v", err)
 			span.LogFields(otlog.String("error", err.Error()))
 			span.Finish()
@@ -287,9 +304,13 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 
 		span.Finish()
 
-		reportBag.Done()
-		protoBag.Done()
+		// purge the effect of the Preprocess call so that the next time through everything is clean
+		reportBag.Reset()
 	}
+
+	reportBag.Done()
+	accumBag.Done()
+	protoBag.Done()
 
 	if err := reporter.Flush(); err != nil {
 		errors = multierror.Append(errors, err)

--- a/mixer/pkg/runtime/handler/env_test.go
+++ b/mixer/pkg/runtime/handler/env_test.go
@@ -58,11 +58,17 @@ func TestEnv(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		e.ScheduleWork(func() {
+			if got, want := e.(env).hasStrayWorkers(), true; got != want {
+				t.Errorf("hasStrayWorkers() => %t; wanted %t", got, want)
+			}
 			wg.Done()
 		})
 
 		wg.Add(1)
 		e.ScheduleDaemon(func() {
+			if got, want := e.(env).hasStrayWorkers(), true; got != want {
+				t.Errorf("hasStrayWorkers() => %t; wanted %t", got, want)
+			}
 			wg.Done()
 		})
 
@@ -73,12 +79,6 @@ func TestEnv(t *testing.T) {
 		e.ScheduleDaemon(func() {
 			panic("bye!")
 		})
-
-		if got, want := e.(env).hasStrayWorkers(), true; got != want {
-			t.Errorf("hasStrayWorkers() => %t; wanted %t", got, want)
-		}
-
-		e.(env).reportStrayWorkers()
 
 		wg.Wait()
 

--- a/mixer/pkg/runtime/handler/table_test.go
+++ b/mixer/pkg/runtime/handler/table_test.go
@@ -187,7 +187,6 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 		wantWorkerStrayRoutine int64
 		wantDaemonStrayRoutine int64
 	}{
-
 		{
 			SpawnWorker:            true,
 			SpawnDaemon:            true,
@@ -227,6 +226,7 @@ func TestCleanup_WorkerNotClosed(t *testing.T) {
 			s.ID = int64(idx * 2)
 
 			oldTable := NewTable(Empty(), s, pool.NewGoroutinePool(5, false))
+			oldTable.strayWorkersRetryDuration = 5 * time.Millisecond
 
 			s = config.Empty()
 			// Every iteration of this test is working with two different config snapshot (old and new). We need to


### PR DESCRIPTION
This PR is an initial attempt to address https://github.com/istio/istio/issues/10393 (in the release-1.1 branch; it will need to be backported to 1.0, if it is accepted).

Basically, this PR builds on the changes from the multicluster PR #8536. That PR appears to have created a 1:1 relationship between builders and handlers in kubeenv. This PR makes the handler aware of the builder, so that the controllers can be deleted via `builder.deleteCacheController`.

I've tested this locally (removing/adding back kubeenv config) and it appears to work. Example logs:

```
...
2019-01-09T19:13:40.596164Z	info	Built new config.Snapshot: id='3'
2019-01-09T19:13:40.596431Z	info	adapters	getting kubeconfig from: "/usr/local/google/home/dougreid/.kube/config"	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:13:40.599171Z	info	adapters	Waiting for kubernetes cache sync...	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:13:40.699390Z	info	adapters	Cache sync successful.	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:13:40.699449Z	info	adapters	getting kubeconfig from: "/usr/local/google/home/dougreid/.kube/config"	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:13:40.704485Z	info	Setting up event handlers
2019-01-09T19:13:40.704547Z	info	Starting Secrets controller
2019-01-09T19:13:40.704611Z	info	Waiting for informer caches to sync
2019-01-09T19:13:40.708584Z	info	Cleaning up handler table, with config ID:2
2019-01-09T19:13:40.708625Z	error	adapters	adapter did not close all the scheduled daemons	{"adapter": "memquota.istio-system"}
2019-01-09T19:16:13.595788Z	info	Publishing 3 events
2019-01-09T19:16:13.603996Z	info	Built new config.Snapshot: id='4'
2019-01-09T19:16:13.605750Z	info	Cleaning up handler table, with config ID:3
2019-01-09T19:16:13.605777Z	info	adapters	deleted remote controller /usr/local/google/home/dougreid/.kube/config	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:13.605787Z	error	adapters	adapter did not close all the scheduled daemons	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:13.605795Z	error	adapters	adapter did not close all the scheduled daemons	{"adapter": "memquota.istio-system"}
2019-01-09T19:16:49.592244Z	info	Publishing 3 events
2019-01-09T19:16:49.601497Z	info	Built new config.Snapshot: id='5'
2019-01-09T19:16:49.601748Z	info	adapters	getting kubeconfig from: "/usr/local/google/home/dougreid/.kube/config"	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:49.605790Z	info	adapters	Waiting for kubernetes cache sync...	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:49.706014Z	info	adapters	Cache sync successful.	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:49.706069Z	info	adapters	getting kubeconfig from: "/usr/local/google/home/dougreid/.kube/config"	{"adapter": "kubernetesenv.istio-system"}
2019-01-09T19:16:49.715305Z	info	Setting up event handlers
2019-01-09T19:16:49.715392Z	info	Starting Secrets controller
2019-01-09T19:16:49.715447Z	info	Waiting for informer caches to sync
2019-01-09T19:16:49.718641Z	info	Cleaning up handler table, with config ID:4
2019-01-09T19:16:49.718671Z	error	adapters	adapter did not close all the scheduled daemons	{"adapter": "memquota.istio-system"}
2019-01-09T19:17:14.587753Z	info	Publishing 3 events
...
```

/cc @zhu0516123