### PR TITLE
add domain parameter to proxy of istio-policy.

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -90,6 +90,10 @@
           name: http-envoy-prom
         args:
         - proxy
+{{- if $.Values.global.proxy.proxyDomain }}
+        - --domain
+        - {{ $.Values.global.proxy.proxyDomain }}
+{{- end }}
         - --serviceCluster
         - istio-policy
         - --templateFile


### PR DESCRIPTION
The fix https://github.com/istio/istio/pull/9180 to issue https://github.com/istio/istio/issues/6661 doesn't cover the `istio-proxy` container of `istio-policy` deployment.

we need to add `domain` parameter to `istio-proxy` container of `istio-policy` deployment if user specify customized cluster domain.

