### PR TITLE
[WIP] Enable Mixer policy enforcement for websockets upgrade events

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -100,6 +100,8 @@ spec:
       valueType: STRING
     context.reporter.uid:
       valueType: STRING
+    context.upgrade:
+      valueType: STRING
     api.service:
       valueType: STRING
     api.version:

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -86,6 +86,14 @@ func (mixerplugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.Mu
 	return fmt.Errorf("unknown listener type %v in mixer.OnOutboundListener", in.ListenerProtocol)
 }
 
+func AddUpgradeAttribute(filter *http_conn.HttpFilter_Config) *http_conn.HttpFilter_Config {
+	out := &mccpb.HttpClientConfig{}
+	util.StructToMessage(filter.Config, out)
+	out.MixerAttributes.Attributes["context.upgrade"] = attrStringValue("websocket")
+	filter.Config = util.MessageToStruct(out)
+	return filter
+}
+
 // OnInboundListener implements the Callbacks interface method.
 func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	if in.Env.Mesh.MixerCheckServer == "" && in.Env.Mesh.MixerReportServer == "" {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -188,6 +188,12 @@ func MessageToStruct(msg proto.Message) *types.Struct {
 	return s
 }
 
+func StructToMessage(in *types.Struct, out proto.Message) {
+	if err := util.StructToMessage(in, out); err != nil {
+		log.Error(err.Error())
+	}
+}
+
 // GogoDurationToDuration converts from gogo proto duration to time.duration
 func GogoDurationToDuration(d *types.Duration) time.Duration {
 	if d == nil {

--- a/samples/websockets/app.yaml
+++ b/samples/websockets/app.yaml
@@ -19,6 +19,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        readiness.status.sidecar.istio.io/applicationPorts: ""
       labels:
         app: tornado
         version: v1


### PR DESCRIPTION
Partially address #7544 (Enable Mixer rules for websocket upgrade).

Reviewers: This PR is currently only in a *Proof-of-Concept* state. I'm hoping to solicit feedback on a number of areas, with the hopes towards moving forward to a reasonable design state.

For pilot:
- Is there a better way to structure the websockets modification to filters created by plugins? Is it worth adding new interfaces?
- How much of a concern is it to duplicate filter configs inside the websockets upgrade config? Since that config is generated non-conditionally now (the virtual service config doesn't seem to matter), this duplication could be quite large.
- Is there a better way to handle deserialization and reserialization ?

For mixer:
- Is `context.upgrade` a reasonable attribute?  I wanted to preserve the `context.protocol` attribute and provide a flexible way to specify what the nature of the upgrade is.
- Are there other attribute modifications that would be desired?
- We probably want to add some metrics around upgrades, etc., to better track this behavior.

FWIW, I've tested the following with 1.1 by using the Tornado sample app. I used the following deny rule in conjunction with these code changes to observe a "closed" status for the websocket when the rule takes effect.

```yaml
apiVersion: "config.istio.io/v1alpha2"
kind: handler
metadata:
  name: denyall
  namespace: istio-system
spec:
  compiledAdapter: denier
  adapter: denier
  params:
    status:
      code: 7
      message: Not allowed
---
apiVersion: "config.istio.io/v1alpha2"
kind: checknothing
metadata:
  name: denyrequest
  namespace: istio-system
spec:
 
---
apiVersion: "config.istio.io/v1alpha2"
kind: rule
metadata:
  name: mixerdenysome
  namespace: istio-system
spec:
  match: context.upgrade == "websocket" && destination.workload.name == "tornado"
  actions:
  # handler and instance names default to the rule's namespace.
  - handler: denyall
    instances:
    - denyrequest.checknothing

```
