### PR TITLE
Skip prow e2e test cleanup

### DIFF
--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -48,6 +48,9 @@ source "${ROOT}/prow/lib.sh"
 setup_e2e_cluster
 
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
+# e2e tests on prow use clusters borrowed from boskos, which cleans up the
+# clusters. There is no need to cleanup in the test jobs.
+E2E_ARGS+=("--skip_cleanup")
 
 export HUB=${HUB:-"gcr.io/istio-testing"}
 export TAG="${TAG:-${GIT_SHA}}"


### PR DESCRIPTION
Since the cluster is cleaned up and returned back to the boskos pool, there is no need to clean up in the test job itself, as sometime clean up takes a long time and causes test timeout even all tests have passed. 

Example: https://k8s-gubernator.appspot.com/build/istio-prow/pr-logs/pull/istio_istio/10828/e2e-mixer-no_auth/10298