### PR TITLE
Add a newline at the end of each certificate returned by Vault

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/vault/client.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client.go
@@ -214,14 +214,14 @@ func signCsrByVault(client *api.Client, csrSigningPath string, certTTLInSec int6
 		return nil, fmt.Errorf("the certificate chain in the CSR response is of unexpected format")
 	}
 	var certChain []string
-	certChain = append(certChain, cert + "\n")
+	certChain = append(certChain, cert+"\n")
 	for idx, c := range chain {
 		_, ok := c.(string)
 		if !ok {
 			log.Errorf("the certificate in the certificate chain %v is not a string", idx)
 			return nil, fmt.Errorf("the certificate in the certificate chain %v is not a string", idx)
 		}
-		certChain = append(certChain, c.(string) + "\n")
+		certChain = append(certChain, c.(string)+"\n")
 	}
 
 	return certChain, nil

--- a/security/pkg/nodeagent/caclient/providers/vault/client.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client.go
@@ -214,14 +214,14 @@ func signCsrByVault(client *api.Client, csrSigningPath string, certTTLInSec int6
 		return nil, fmt.Errorf("the certificate chain in the CSR response is of unexpected format")
 	}
 	var certChain []string
-	certChain = append(certChain, cert)
+	certChain = append(certChain, cert + "\n")
 	for idx, c := range chain {
 		_, ok := c.(string)
 		if !ok {
 			log.Errorf("the certificate in the certificate chain %v is not a string", idx)
 			return nil, fmt.Errorf("the certificate in the certificate chain %v is not a string", idx)
 		}
-		certChain = append(certChain, c.(string))
+		certChain = append(certChain, c.(string) + "\n")
 	}
 
 	return certChain, nil

--- a/security/pkg/nodeagent/caclient/providers/vault/client_test.go
+++ b/security/pkg/nodeagent/caclient/providers/vault/client_test.go
@@ -113,7 +113,7 @@ SQYzPWVk89gu6nKV+fS2pA9C8dAnYOzVu9XXc+PGlcIhjnuS+/P74hN5D3aIGljW
 		"ONNfuN8hrIDl95vJjhUlE-O-_cx8qWtXNdqJlMje1SsiPCL4uq70OepG_I4aSzC2o8aD" +
 		"tlQ"
 
-	fakeCert        = []string{"fake-certificate", "fake-ca1", "fake-ca2"}
+	fakeCert        = []string{"fake-certificate\n", "fake-ca1\n", "fake-ca2\n"}
 	vaultNonTLSAddr = "http://35.247.15.29:8200"
 	vaultTLSAddr    = "https://35.233.249.249:8200"
 )


### PR DESCRIPTION
Envoy expects each certificate to have a newline at the end. Otherwise, Envoy will reject the certificate chain. This PR adds a newline to the end of each certificate returned by Vault. 