### PR TITLE
Update integration test job

### DIFF
--- a/codecov.skip
+++ b/codecov.skip
@@ -14,6 +14,7 @@ istio.io/istio/tests/codecov
 istio.io/istio/tests/e2e
 istio.io/istio/tests/integration2/examples
 istio.io/istio/tests/integration2/qualification
+istio.io/istio/tests/integration2
 istio.io/istio/tests/integration_old
 istio.io/istio/tests/local
 istio.io/istio/tests/util

--- a/codecov.threshold
+++ b/codecov.threshold
@@ -24,4 +24,12 @@ istio.io/istio/pkg/mcp/creds/watcher.go=100
 istio.io/istio/pkg/test=100
 istio.io/istio/security/proto=100
 istio.io/istio/security/pkg/nodeagent=15
+istio.io/istio/galley/pkg/testing=100
 
+# Temporary until integ tests are restored
+istio.io/istio/pilot/pkg/networking/plugin=50
+istio.io/istio/galley/pkg/runtime=30
+istio.io/istio/galley/pkg/kube/converter/legacy/legacymixer.pb.go=10
+istio.io/istio/galley/pkg/meshconfig/cache.go=100
+istio.io/istio/pkg/mcp/server/monitoring.go=50
+istio.io/istio/pilot/pkg/model/authentication.go=20

--- a/pkg/test/framework/operations.go
+++ b/pkg/test/framework/operations.go
@@ -25,8 +25,8 @@ var r = runtime.New()
 
 // Run is a helper for executing test main with appropriate resource allocation/doCleanup steps.
 // It allows us to do post-run doCleanup, and flag parsing.
-func Run(testID string, m *testing.M) {
-	_, _ = r.Run(testID, m)
+func Run(testID string, m *testing.M) (int, error) {
+	return r.Run(testID, m)
 }
 
 // GetContext resets and returns the environment. Should be called exactly once per test.

--- a/prow/istio-integ-k8s-tests.sh
+++ b/prow/istio-integ-k8s-tests.sh
@@ -72,5 +72,7 @@ make init
 
 setup_cluster
 
-time make test.integration.kube T=-v
+JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
+T="-v" \
+make test.integration.kube
 

--- a/prow/istio-integ-local-tests.sh
+++ b/prow/istio-integ-local-tests.sh
@@ -31,8 +31,6 @@ setup_and_export_git_sha
 
 cd "${ROOT}"
 
-# Unit tests are run against a local apiserver and etcd.
-# Integration/e2e tests in the other scripts are run against GKE or real clusters.
 JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
 T="-v" \
 make test.integration.local

--- a/tests/integration2/README.md
+++ b/tests/integration2/README.md
@@ -36,7 +36,7 @@ The test framework currently supports two environments:
 When running tests, only one environment can be specified:
 
 ```console
-$ go test ./... -istio.test.env local
+$ go test ./... -istio.test.env native
 $ go test ./... -istio.test.env kubernetes
 ```
 

--- a/tests/integration2/citadel/secret_creation_test.go
+++ b/tests/integration2/citadel/secret_creation_test.go
@@ -15,6 +15,7 @@
 package citadel
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -61,5 +62,6 @@ func TestSecretCreationKubernetes(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	framework.Run("citadel_test", m)
+	rt,_ := framework.Run("citadel_test", m)
+	os.Exit(rt)
 }

--- a/tests/integration2/citadel/secret_creation_test.go
+++ b/tests/integration2/citadel/secret_creation_test.go
@@ -62,6 +62,6 @@ func TestSecretCreationKubernetes(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("citadel_test", m)
+	rt, _ := framework.Run("citadel_test", m)
 	os.Exit(rt)
 }

--- a/tests/integration2/examples/basic/basic_test.go
+++ b/tests/integration2/examples/basic/basic_test.go
@@ -27,7 +27,7 @@ import (
 
 // To opt-in to the test framework, implement a TestMain, and call test.Run.
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("basic_test", m)
+	rt, _ := framework.Run("basic_test", m)
 	os.Exit(rt)
 }
 

--- a/tests/integration2/examples/basic/basic_test.go
+++ b/tests/integration2/examples/basic/basic_test.go
@@ -16,6 +16,7 @@
 package basic
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
@@ -26,7 +27,8 @@ import (
 
 // To opt-in to the test framework, implement a TestMain, and call test.Run.
 func TestMain(m *testing.M) {
-	framework.Run("basic_test", m)
+	rt,_ := framework.Run("basic_test", m)
+	os.Exit(rt)
 }
 
 func TestBasic(t *testing.T) {

--- a/tests/integration2/galley/conversion/main_test.go
+++ b/tests/integration2/galley/conversion/main_test.go
@@ -22,6 +22,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("galley_conversion_test", m)
+	rt, _ := framework.Run("galley_conversion_test", m)
 	os.Exit(rt)
 }

--- a/tests/integration2/galley/conversion/main_test.go
+++ b/tests/integration2/galley/conversion/main_test.go
@@ -15,11 +15,13 @@
 package conversion
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {
-	framework.Run("galley_conversion_test", m)
+	rt,_ := framework.Run("galley_conversion_test", m)
+	os.Exit(rt)
 }

--- a/tests/integration2/galley/validation/main_test.go
+++ b/tests/integration2/galley/validation/main_test.go
@@ -15,11 +15,13 @@
 package validation
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {
-	framework.Run("galley_validation_test", m)
+	rt,_ := framework.Run("galley_validation_test", m)
+	os.Exit(rt)
 }

--- a/tests/integration2/galley/validation/main_test.go
+++ b/tests/integration2/galley/validation/main_test.go
@@ -22,6 +22,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("galley_validation_test", m)
+	rt, _ := framework.Run("galley_validation_test", m)
 	os.Exit(rt)
 }

--- a/tests/integration2/mixer/main_test.go
+++ b/tests/integration2/mixer/main_test.go
@@ -15,11 +15,13 @@
 package mixer
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {
-	framework.Run("mixer_test", m)
+	rt,_ := framework.Run("mixer_test", m)
+	os.Exit(rt)
 }

--- a/tests/integration2/mixer/main_test.go
+++ b/tests/integration2/mixer/main_test.go
@@ -22,6 +22,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("mixer_test", m)
+	rt, _ := framework.Run("mixer_test", m)
 	os.Exit(rt)
 }

--- a/tests/integration2/pilot/security/authn_permissive_test.go
+++ b/tests/integration2/pilot/security/authn_permissive_test.go
@@ -39,7 +39,7 @@ import (
 
 // To opt-in to the test framework, implement a TestMain, and call test.Run.
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("authn_permissive_test", m)
+	rt, _ := framework.Run("authn_permissive_test", m)
 	os.Exit(rt)
 }
 

--- a/tests/integration2/pilot/security/authn_permissive_test.go
+++ b/tests/integration2/pilot/security/authn_permissive_test.go
@@ -16,6 +16,7 @@
 package security
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -38,7 +39,8 @@ import (
 
 // To opt-in to the test framework, implement a TestMain, and call test.Run.
 func TestMain(m *testing.M) {
-	framework.Run("authn_permissive_test", m)
+	rt,_ := framework.Run("authn_permissive_test", m)
+	os.Exit(rt)
 }
 
 func verifyListener(listener *xdsapi.Listener, t *testing.T) bool {

--- a/tests/integration2/qualification/main_test.go
+++ b/tests/integration2/qualification/main_test.go
@@ -22,6 +22,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	rt,_ := framework.Run("qualification", m)
+	rt, _ := framework.Run("qualification", m)
 	os.Exit(rt)
 }

--- a/tests/integration2/qualification/main_test.go
+++ b/tests/integration2/qualification/main_test.go
@@ -15,11 +15,13 @@
 package qualification
 
 import (
+	"os"
 	"testing"
 
 	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {
-	framework.Run("qualification", m)
+	rt,_ := framework.Run("qualification", m)
+	os.Exit(rt)
 }

--- a/tests/integration2/tests.mk
+++ b/tests/integration2/tests.mk
@@ -47,7 +47,7 @@ test.integration.%.kube:
 
 # Generate integration test targets for local environment.
 test.integration.%:
-	$(GO) test -p 1 ${T} ./tests/integration2/$*/... --istio.test.env local
+	$(GO) test -p 1 ${T} ./tests/integration2/$*/... --istio.test.env native
 
 JUNIT_UNIT_TEST_XML ?= $(ISTIO_OUT)/junit_unit-tests.xml
 JUNIT_REPORT = $(shell which go-junit-report 2> /dev/null || echo "${ISTIO_BIN}/go-junit-report")

--- a/tests/integration2/tests.mk
+++ b/tests/integration2/tests.mk
@@ -60,7 +60,7 @@ TEST_PACKAGES = $(shell go list ./tests/integration2/... | grep -v /qualificatio
 test.integration.local: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
-	$(GO) test -p 1 ${T} ${TEST_PACKAGES} --istio.test.env local \
+	$(GO) test -p 1 ${T} ${TEST_PACKAGES} --istio.test.env native \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 
 # All integration tests targeting Kubernetes environment.


### PR DESCRIPTION
1. Update all env references from "local" to "native", which was changed in code for a while.
2. Fix all TestMain to return proper exit code. Otherwise, the test jobs always pass in CI even some tests have failed.
