### PR TITLE
Add delay for mcp client request if response or request is error

### DIFF
--- a/pkg/mcp/client/client_test.go
+++ b/pkg/mcp/client/client_test.go
@@ -64,7 +64,7 @@ func (ts *testStream) wantRequest(want *mcp.MeshConfigRequest) error {
 	case got := <-ts.requestC:
 		got = proto.Clone(got).(*mcp.MeshConfigRequest)
 		return checkRequest(got, want)
-	case <-time.After(time.Second):
+	case <-time.After(2 * time.Second):
 		return fmt.Errorf("no request received")
 	}
 }
@@ -212,7 +212,6 @@ func mustMarshalAny(pb proto.Message) *types.Any {
 func init() {
 	proto.RegisterType((*fakeType0)(nil), fakeType0MessageName)
 	proto.RegisterType((*fakeType1)(nil), fakeType1MessageName)
-	proto.RegisterType((*fakeType2)(nil), fakeType2MessageName)
 	proto.RegisterType((*fakeType2)(nil), fakeType2MessageName)
 	proto.RegisterType((*unmarshalErrorType)(nil), unmarshalErrorMessageName)
 


### PR DESCRIPTION
Add delay for mcp client request if response or request is error. 
send a wrong typeurl, it leads high CPU usage
`mcpc -types type.googleapis.com/istio.networking.v1alpha3.ServiceEntry1`

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>