### PR TITLE
set trust domain in citadel 

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -328,7 +328,7 @@ func runCA() {
 
 		// The CA API uses cert with the max workload cert TTL.
 		hostnames := append(strings.Split(opts.grpcHosts, ","), fqdn())
-		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort, opts.trustDomain)
+		caServer, startErr := caserver.New(ca, opts.maxWorkloadCertTTL, opts.signCACerts, hostnames, opts.grpcPort, spiffe.GetTrustDomain())
 		if startErr != nil {
 			fatalf("Failed to create istio ca server: %v", startErr)
 		}


### PR DESCRIPTION
https://github.com/istio/istio/issues/10283

incorporate recent change in https://github.com/istio/istio/pull/9090, otherwise the cert domain will empty by default, which isn't correct 