### PR TITLE
Fix flakiness in redisquota tests

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -845,9 +845,9 @@ func fetchRequestCount(t *testing.T, promAPI v1.API, service, additionalLabels s
 	retryFn := func(_ context.Context, i int) error {
 		t.Helper()
 		t.Logf("Trying to find metrics via promql (attempt %d)...", i)
-		query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination", additionalLabels)
+		query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service), reporterLabel, "destination", additionalLabels)
 		t.Logf("prometheus query: %s", query)
-		totalReq, err := queryValue(promAPI,query)
+		totalReq, err := queryValue(promAPI, query)
 		if err != nil {
 			t.Logf("error getting total requests (msg: %v)", err)
 			return err
@@ -863,15 +863,17 @@ func fetchRequestCount(t *testing.T, promAPI v1.API, service, additionalLabels s
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
 
-	query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination",responseCodeLabel, "429",additionalLabels)
-	prior429s, err = queryValue(promAPI,query)
+	query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),
+		reporterLabel, "destination", responseCodeLabel, "429", additionalLabels)
+	prior429s, err = queryValue(promAPI, query)
 	if err != nil {
 		t.Logf("error getting prior 429s, using 0 as value (msg: %v)", err)
 		prior429s = 0
 	}
 
-	query = fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination",responseCodeLabel, "200", additionalLabels)
-	prior200s, err = queryValue(promAPI,query)
+	query = fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),
+		reporterLabel, "destination", responseCodeLabel, "200", additionalLabels)
+	prior200s, err = queryValue(promAPI, query)
 	if err != nil {
 		t.Logf("error getting prior 200s, using 0 as value (msg: %v)", err)
 		prior200s = 0
@@ -938,11 +940,11 @@ func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {
 
 	// establish baseline
 
-	initPrior429s, initPrior200s := fetchRequestCount(t, promAPI, "ratings", "",0)
+	initPrior429s, initPrior200s := fetchRequestCount(t, promAPI, "ratings", "", 0)
 
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	prior429s, prior200s:= fetchRequestCount(t, promAPI, "ratings", "",initPrior429s+initPrior200s+150)
+	prior429s, prior200s := fetchRequestCount(t, promAPI, "ratings", "", initPrior429s+initPrior200s+150)
 	// check if at least one more prior429 was reported
 	if prior429s-initPrior429s < 1 {
 		fatalf(t, "no 429 is allotted time: prior429s:%v", prior429s)
@@ -979,7 +981,7 @@ func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {
 		fatalf(t, "Not enough traffic generated to exercise rate limit: ratings_reqs=%f, want200s=%f", callsToRatings, want200s)
 	}
 
-	got200s, got429s := fetchRequestCount(t, promAPI, "ratings", "destination_version=\"v1\"",prior429s+prior200s+300)
+	got200s, got429s := fetchRequestCount(t, promAPI, "ratings", "destination_version=\"v1\"", prior429s+prior200s+300)
 	if got429s == 0 {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
 		errorf(t, "Could not find 429s: %v", err)
@@ -1058,11 +1060,11 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 	// establish baseline
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	initPrior429s, initPrior200s:= fetchRequestCount(t, promAPI, "ratings", "",0)
+	initPrior429s, initPrior200s := fetchRequestCount(t, promAPI, "ratings", "", 0)
 
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	prior429s, prior200s := fetchRequestCount(t, promAPI, "ratings", "",initPrior429s+initPrior200s+150-errorInRequestReportingAllowed)
+	prior429s, prior200s := fetchRequestCount(t, promAPI, "ratings", "", initPrior429s+initPrior200s+150-errorInRequestReportingAllowed)
 	// check if at least one more prior429 was reported
 	if prior429s-initPrior429s < 1 {
 		fatalf(t, "no 429 in allotted time: prior429s:%v", prior429s)
@@ -1105,7 +1107,7 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 		fatalf(t, "Not enough traffic generated to exercise rate limit: ratings_reqs=%f, want200s=%f", callsToRatings, want200s)
 	}
 
-	got429s, got200s := fetchRequestCount(t, promAPI, "ratings", "",prior429s+prior200s+300-errorInRequestReportingAllowed)
+	got429s, got200s := fetchRequestCount(t, promAPI, "ratings", "", prior429s+prior200s+300-errorInRequestReportingAllowed)
 
 	if got429s == 0 {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -833,7 +833,7 @@ func testCheckCache(t *testing.T, visit func() error, app string) {
 }
 
 // nolint: unparam
-func fetchRequestCount(t *testing.T, promAPI v1.API, service string, totalReqExpected float64) (prior429s float64, prior200s float64, value model.Value) {
+func fetchRequestCount(t *testing.T, promAPI v1.API, service, additionalLabels string, totalReqExpected float64) (prior429s float64, prior200s float64) {
 	var err error
 	t.Log("Establishing metrics baseline for test...")
 
@@ -845,13 +845,9 @@ func fetchRequestCount(t *testing.T, promAPI v1.API, service string, totalReqExp
 	retryFn := func(_ context.Context, i int) error {
 		t.Helper()
 		t.Logf("Trying to find metrics via promql (attempt %d)...", i)
-		query := fmt.Sprintf("istio_requests_total{%s=\"%s\"}", destLabel, fqdn(service))
+		query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination", additionalLabels)
 		t.Logf("prometheus query: %s", query)
-		value, err = promAPI.Query(context.Background(), query, time.Now())
-		if err != nil {
-			return err
-		}
-		totalReq, err := vectorValue(value, map[string]string{reporterLabel: "destination"})
+		totalReq, err := queryValue(promAPI,query)
 		if err != nil {
 			t.Logf("error getting total requests (msg: %v)", err)
 			return err
@@ -867,20 +863,22 @@ func fetchRequestCount(t *testing.T, promAPI v1.API, service string, totalReqExp
 		fatalf(t, "Could not get metrics from prometheus: %v", err)
 	}
 
-	prior429s, err = vectorValue(value, map[string]string{responseCodeLabel: "429", reporterLabel: "destination"})
+	query := fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination",responseCodeLabel, "429",additionalLabels)
+	prior429s, err = queryValue(promAPI,query)
 	if err != nil {
 		t.Logf("error getting prior 429s, using 0 as value (msg: %v)", err)
 		prior429s = 0
 	}
 
-	prior200s, err = vectorValue(value, map[string]string{responseCodeLabel: "200", reporterLabel: "destination"})
+	query = fmt.Sprintf("sum(istio_requests_total{%s=\"%s\",%s=\"%s\",%s=\"%s\",%s})", destLabel, fqdn(service),reporterLabel, "destination",responseCodeLabel, "200", additionalLabels)
+	prior200s, err = queryValue(promAPI,query)
 	if err != nil {
 		t.Logf("error getting prior 200s, using 0 as value (msg: %v)", err)
 		prior200s = 0
 	}
 	t.Logf("Baseline established: prior200s = %f, prior429s = %f", prior200s, prior429s)
 
-	return prior429s, prior200s, value
+	return prior429s, prior200s
 }
 
 func sendTraffic(t *testing.T, msg string, calls int64) *fhttp.HTTPRunnerResults {
@@ -940,11 +938,11 @@ func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {
 
 	// establish baseline
 
-	initPrior429s, initPrior200s, _ := fetchRequestCount(t, promAPI, "ratings", 0)
+	initPrior429s, initPrior200s := fetchRequestCount(t, promAPI, "ratings", "",0)
 
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	prior429s, prior200s, _ := fetchRequestCount(t, promAPI, "ratings", initPrior429s+initPrior200s+150)
+	prior429s, prior200s:= fetchRequestCount(t, promAPI, "ratings", "",initPrior429s+initPrior200s+150)
 	// check if at least one more prior429 was reported
 	if prior429s-initPrior429s < 1 {
 		fatalf(t, "no 429 is allotted time: prior429s:%v", prior429s)
@@ -981,55 +979,49 @@ func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {
 		fatalf(t, "Not enough traffic generated to exercise rate limit: ratings_reqs=%f, want200s=%f", callsToRatings, want200s)
 	}
 
-	_, _, value := fetchRequestCount(t, promAPI, "ratings", prior429s+prior200s+300)
-	log.Infof("promvalue := %s", value.String())
-
-	got, err := vectorValue(value, map[string]string{responseCodeLabel: "429", "destination_version": "v1"})
-	if err != nil {
+	got200s, got429s := fetchRequestCount(t, promAPI, "ratings", "destination_version=\"v1\"",prior429s+prior200s+300)
+	if got429s == 0 {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
 		errorf(t, "Could not find 429s: %v", err)
-		got = 0 // want to see 200 rate even if no 429s were recorded
 	}
 
 	// Lenient calculation TODO: tighten/simplify
-	want := math.Floor(want429s * .25)
+	want429s = math.Floor(want429s * .25)
 
-	got = got - prior429s
+	got429s = got429s - prior429s
 
-	t.Logf("Actual 429s: %f (%f rps)", got, got/actualDuration)
+	t.Logf("Actual 429s: %f (%f rps)", got429s, got429s/actualDuration)
 
 	// check resource exhausted
-	if got < want {
+	if got429s < want429s {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
-		errorf(t, "Bad metric value for rate-limited requests (429s): got %f, want at least %f", got, want)
+		errorf(t, "Bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s, want429s)
 	}
 
-	got, err = vectorValue(value, map[string]string{responseCodeLabel: "200", "destination_version": "v1"})
-	if err != nil {
+	if got200s == 0 {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
 		errorf(t, "Could not find successes value: %v", err)
-		got = 0
 	}
 
-	got = got - prior200s
+	got200s = got200s - prior200s
 
-	t.Logf("Actual 200s: %f (%f rps), expecting ~1 rps", got, got/actualDuration)
+	t.Logf("Actual 200s: %f (%f rps), expecting ~1 rps", got200s, got200s/actualDuration)
 
 	// establish some baseline to protect against flakiness due to randomness in routing
 	// and to allow for leniency in actual ceiling of enforcement (if 10 is the limit, but we allow slightly
 	// less than 10, don't fail this test).
-	want = math.Floor(want200s * .25)
+	want := math.Floor(want200s * .25)
 
 	// check successes
-	if got < want {
+	if got200s < want {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
-		errorf(t, "Bad metric value for successful requests (200s): got %f, want at least %f", got, want)
+		errorf(t, "Bad metric value for successful requests (200s): got %f, want at least %f", got200s, want)
 	}
 	// TODO: until https://github.com/istio/istio/issues/3028 is fixed, use 25% - should be only 5% or so
 	want200s = math.Ceil(want200s * 1.5)
-	if got > want200s {
+	if got200s > want {
 		t.Logf("prometheus values for istio_requests_total:\n%s", promDump(promAPI, "istio_requests_total"))
-		errorf(t, "Bad metric value for successful requests (200s): got %f, want at most %f", got, want200s)
+		errorf(t, "Bad metric value for successful requests (200s): got %f, want at most %f", got200s, want200s)
 	}
 }
 
@@ -1066,11 +1058,11 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 	// establish baseline
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	initPrior429s, initPrior200s, _ := fetchRequestCount(t, promAPI, "ratings", 0)
+	initPrior429s, initPrior200s:= fetchRequestCount(t, promAPI, "ratings", "",0)
 
 	_ = sendTraffic(t, "Warming traffic...", 150)
 	allowPrometheusSync()
-	prior429s, prior200s, _ := fetchRequestCount(t, promAPI, "ratings", initPrior429s+initPrior200s+150-errorInRequestReportingAllowed)
+	prior429s, prior200s := fetchRequestCount(t, promAPI, "ratings", "",initPrior429s+initPrior200s+150-errorInRequestReportingAllowed)
 	// check if at least one more prior429 was reported
 	if prior429s-initPrior429s < 1 {
 		fatalf(t, "no 429 in allotted time: prior429s:%v", prior429s)
@@ -1113,64 +1105,59 @@ func testRedisQuota(t *testing.T, quotaRule string) {
 		fatalf(t, "Not enough traffic generated to exercise rate limit: ratings_reqs=%f, want200s=%f", callsToRatings, want200s)
 	}
 
-	_, _, value := fetchRequestCount(t, promAPI, "ratings", prior429s+prior200s+300-errorInRequestReportingAllowed)
-	log.Infof("promvalue := %s", value.String())
+	got429s, got200s := fetchRequestCount(t, promAPI, "ratings", "",prior429s+prior200s+300-errorInRequestReportingAllowed)
 
-	got, err := vectorValue(value, map[string]string{responseCodeLabel: "429", reporterLabel: "destination"})
-	if err != nil {
+	if got429s == 0 {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 429), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 429's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
 		errorf(t, "Could not find 429s: %v", err)
-		got = 0 // want to see 200 rate even if no 429s were recorded
 	}
 
-	want := math.Floor(want429s * 0.70)
+	want429s = math.Floor(want429s * 0.70)
 
-	got = got - prior429s
+	got429s = got429s - prior429s
 
-	t.Logf("Actual 429s: %f (%f rps)", got, got/actualDuration)
+	t.Logf("Actual 429s: %f (%f rps)", got429s, got429s/actualDuration)
 
 	// check resource exhausted
-	if got < want {
+	if got429s < want429s {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 429), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 429's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
-		errorf(t, "Bad metric value for rate-limited requests (429s): got %f, want at least %f", got, want)
+		errorf(t, "Bad metric value for rate-limited requests (429s): got %f, want at least %f", got429s, want429s)
 	}
 
-	got, err = vectorValue(value, map[string]string{responseCodeLabel: "200", reporterLabel: "destination"})
-	if err != nil {
+	if got200s == 0 {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 200), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 200's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
 		errorf(t, "Could not find successes value: %v", err)
-		got = 0
 	}
 
-	got = got - prior200s
+	got200s = got200s - prior200s
 
-	t.Logf("Actual 200s: %f (%f rps), expecting ~1.666rps", got, got/actualDuration)
+	t.Logf("Actual 200s: %f (%f rps), expecting ~1.666rps", got200s, got200s/actualDuration)
 
 	// establish some baseline to protect against flakiness due to randomness in routing
 	// and to allow for leniency in actual ceiling of enforcement (if 10 is the limit, but we allow slightly
 	// less than 10, don't fail this test).
-	want = math.Floor(want200s * 0.70)
+	want := math.Floor(want200s * 0.70)
 
 	// check successes
-	if got < want {
+	if got200s < want {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 200), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 200's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
-		errorf(t, "Bad metric value for successful requests (200s): got %f, want at least %f", got, want)
+		errorf(t, "Bad metric value for successful requests (200s): got %f, want at least %f", got200s, want)
 	}
 	// TODO: until https://github.com/istio/istio/issues/3028 is fixed, use 25% - should be only 5% or so
 	want200s = math.Ceil(want200s * 1.25)
-	if got > want200s {
+	if got200s > want200s {
 		attributes := []string{fmt.Sprintf("%s=\"%s\"", destLabel, fqdn("ratings")),
 			fmt.Sprintf("%s=\"%d\"", responseCodeLabel, 200), fmt.Sprintf("%s=\"%s\"", reporterLabel, "destination")}
 		t.Logf("prometheus values for istio_requests_total for 200's:\n%s", promDumpWithAttributes(promAPI, "istio_requests_total", attributes))
-		errorf(t, "Bad metric value for successful requests (200s): got %f, want at most %f", got, want200s)
+		errorf(t, "Bad metric value for successful requests (200s): got %f, want at most %f", got200s, want200s)
 	}
 }
 


### PR DESCRIPTION
Fix flakiness in redisquota tests by adding retry for getting requests reported by prometheus

One of the things I observed in flaky tests is that total number of requests reported by prometheus was not equal to traffic sent by Fortio.
Thus adding a retry to make sure prometheus is queried till we get all requests reported.