### PR TITLE
Clean up the Helm readiness checking in test cases

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -754,11 +754,12 @@ func (k *KubeInfo) deployTiller(yamlFileName string) error {
 
 	// deploy tiller, helm cli is already available
 	if err := util.HelmInit("tiller"); err != nil {
-		log.Errorf("Failed to init helm tiller ")
+		log.Errorf("Failed to init helm tiller")
 		return err
 	}
-	// wait till tiller reaches running
-	return util.CheckPodRunning("kube-system", "name=tiller", k.KubeConfig)
+
+	// Wait until Helm's Tiller is running
+	return util.HelmTillerRunning()
 }
 
 var (

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -396,20 +396,9 @@ type redisDeployment struct {
 }
 
 func (r *redisDeployment) Setup() error {
-	// Deploy Tiller if it not does not already exist. Otherwise, wait to see if it is running for 3m before
-	// trying to deploy.
-	if _, err := util.GetPodName("kube-system", "name=tiller", tc.Kube.KubeConfig); err == nil {
-		// if the pod exists, check to see if it is running...
-		if err := util.CheckPodRunning("kube-system", "name=tiller", tc.Kube.KubeConfig); err != nil {
-			if errDeployTiller := tc.Kube.DeployTiller(); errDeployTiller != nil {
-				return fmt.Errorf("failed to deploy helm tiller: %v", errDeployTiller)
-			}
-		}
-	} else {
-		// no sense in retrying if the pod was not deployed before... deploy it now...
-		if errDeployTiller := tc.Kube.DeployTiller(); errDeployTiller != nil {
-			return fmt.Errorf("failed to deploy helm tiller: %v", errDeployTiller)
-		}
+	// Deploy Tiller if not already deployed
+	if errDeployTiller := tc.Kube.DeployTiller(); errDeployTiller != nil {
+		return fmt.Errorf("failed to deploy helm tiller: %v", errDeployTiller)
 	}
 
 	setValue := "--set usePassword=false,persistence.enabled=false"

--- a/tests/util/helm_utils.go
+++ b/tests/util/helm_utils.go
@@ -14,6 +14,13 @@
 
 package util
 
+import (
+	"context"
+	"time"
+
+	"istio.io/istio/pkg/log"
+)
+
 // HelmInit init helm with a service account
 func HelmInit(serviceAccount string) error {
 	_, err := Shell("helm init --upgrade --service-account %s", serviceAccount)
@@ -73,4 +80,32 @@ func HelmParams(chartDir, chartName, valueFile, namespace, setValue string) stri
 	}
 
 	return helmCmd
+}
+
+// Obtain the version of Helm client and server with a timeout of 10s or return an error
+func helmVersion() (string, error) {
+	version, err := Shell("helm version --tiller-connection-timeout=10")
+	return version, err
+}
+
+// HelmTillerRunning will block for up to 120 seconds waiting for Tiller readiness
+func HelmTillerRunning() error {
+	retry := Retrier{
+		BaseDelay: 10 * time.Second,
+		MaxDelay:  10 * time.Second,
+		Retries:   12,
+	}
+
+	retryFn := func(_ context.Context, i int) error {
+		_, err := helmVersion()
+		return err
+	}
+	ctx := context.Background()
+	_, err := retry.Retry(ctx, retryFn)
+	if err != nil {
+		log.Errorf("Tiller failed to start")
+		return err
+	}
+	log.Infof("Tiller is running")
+	return nil
 }

--- a/tests/util/helm_utils.go
+++ b/tests/util/helm_utils.go
@@ -84,7 +84,7 @@ func HelmParams(chartDir, chartName, valueFile, namespace, setValue string) stri
 
 // Obtain the version of Helm client and server with a timeout of 10s or return an error
 func helmVersion() (string, error) {
-	version, err := Shell("helm version --tiller-connection-timeout=10")
+	version, err := Shell("helm version")
 	return version, err
 }
 


### PR DESCRIPTION
The e2e test cases are often flakey because of the logic
of Helm readiness checking in the test cases.  Instead of
checking of the Pod is in the "RUNNING" state, check that
Tiller is able to provide service via the `helm version`
operation.  If the server is not ready, this will return 1,
otherwise 0 will be returned.