### PR TITLE
Filter Nodes/Pods in Galley temporarily until custom sources land.

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -117,7 +117,9 @@ func newServer(a *Args, p patchTable, convertK8SService bool) (*Server, error) {
 	if !convertK8SService {
 		var filtered []kube.ResourceSpec
 		for _, t := range specs {
-			if t.Kind != "Service" {
+			// TODO(nmittler): Temporarily filter Node and Pod until custom sources land.
+			// Pod yaml cannot be parsed currently. See: https://github.com/istio/istio/issues/10891
+			if t.Kind != "Service" && t.Kind != "Node" && t.Kind != "Pod" {
 				filtered = append(filtered, t)
 			}
 		}


### PR DESCRIPTION
This is due to the fact that Pod yaml cannot currently be parsed into
unstructured types.  See: #10891.