### PR TITLE
Merge the new tests for isolation=none, some fixes

### DIFF
--- a/mixer/test/client/env/envoy.go
+++ b/mixer/test/client/env/envoy.go
@@ -78,6 +78,9 @@ func (s *TestSetup) NewEnvoy() (*Envoy, error) {
 	cmd := exec.Command(envoyPath, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
+	if s.Dir != "" {
+		cmd.Dir = s.Dir
+	}
 	return &Envoy{
 		cmd:    cmd,
 		ports:  s.ports,

--- a/mixer/test/client/env/setup.go
+++ b/mixer/test/client/env/setup.go
@@ -69,6 +69,9 @@ type TestSetup struct {
 
 	// expected source.uid attribute at the mixer gRPC metadata
 	mixerSourceUID string
+
+	// Dir is the working dir for envoy
+	Dir string
 }
 
 // NewTestSetup creates a new test setup

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -441,6 +441,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, proxyInstances []*ServiceIn
 	if sidecars, ok := ps.sidecarsByNamespace[proxy.ConfigNamespace]; ok {
 		// TODO: logic to merge multiple sidecar resources
 		// Currently we assume that there will be only one sidecar config for a namespace.
+		var defaultSidecar *SidecarScope
 		for _, wrapper := range sidecars {
 			if wrapper.Config != nil {
 				sidecar := wrapper.Config.Spec.(*networking.Sidecar)
@@ -452,9 +453,19 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, proxyInstances []*ServiceIn
 						continue
 					}
 					return wrapper
+				} else {
+					defaultSidecar = wrapper
+					continue
 				}
 			}
+			// Not sure when this can heppn (Config = nil ?)
+			if (defaultSidecar != nil) {
+				return defaultSidecar // still return the valid one
+			}
 			return wrapper
+		}
+		if (defaultSidecar != nil) {
+			return defaultSidecar // still return the valid one
 		}
 	}
 

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -583,10 +583,6 @@ func ValidateSidecar(name, namespace string, msg proto.Message) (errs error) {
 		}
 	}
 
-	if len(rule.Ingress) == 0 && len(rule.Egress) == 0 {
-		return fmt.Errorf("sidecar: missing ingress/egress listeners")
-	}
-
 	portMap := make(map[uint32]struct{})
 	udsMap := make(map[string]struct{})
 	for _, i := range rule.Ingress {

--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -16,11 +16,155 @@ package v2_test
 import (
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/adsc"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
+
+// TestLDS using isolated namespaces
+func TestLDSIsolated(t *testing.T) {
+
+	_, tearDown := initLocalPilotTestEnv(t)
+	defer tearDown()
+
+	// Sidecar in 'none' mode
+	t.Run("sidecar_none", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+				model.NodeMetadataInterceptionMode: string(model.InterceptionNone),
+			},
+			IP:        "10.11.0.1", // matches none.yaml s1tcp.none
+			Namespace: "none",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("rds", 50000*time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut + "/none")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// s1http - inbound HTTP on 7071 (forwarding to app on 30000 + 7071 - or custom port)
+		// All outbound on http proxy
+		if len(ldsr.HTTPListeners) != 2 {
+			t.Error("HTTP listeners, expecting 2 got ", len(ldsr.HTTPListeners), ldsr.HTTPListeners)
+		}
+
+		// s1tcp:2000 outbound, bind=true (to reach other instances of the service)
+		// s1:5005 outbound, bind=true
+		// :443 - https external, bind=false
+		// 10.11.0.1_7070, bind=true -> inbound|2000|s1 - on port 7070, fwd to 37070
+		// virtual
+		if len(ldsr.TCPListeners) == 0 {
+			t.Fatal("No response")
+		}
+
+		for _, s := range []string{"lds_tcp", "lds_http", "rds", "cds", "ecds"} {
+			want, err := ioutil.ReadFile(env.IstioOut + "/none_" + s + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := ioutil.ReadFile("testdata/none_" + s + ".json")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err = util.Compare(got, want); err != nil {
+				t.Error(err)
+			}
+		}
+
+		// TODO: check bind==true
+		// TODO: verify listeners for outbound are on 127.0.0.1 (not yet), port 2000, 2005, 2007
+		// TODO: verify virtual listeners for unsupported cases
+		// TODO: add and verify SNI listener on 127.0.0.1:443
+		// TODO: verify inbound service port is on 127.0.0.1, and containerPort on 0.0.0.0
+		// TODO: BUG, SE with empty endpoints is rejected - it is actually valid config (service may not have endpoints)
+	})
+
+	// Test for the examples in the ServiceEntry doc
+	t.Run("se_example", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+			},
+			IP:        "10.12.0.1", // matches none.yaml s1tcp.none
+			Namespace: "seexamples",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("rds", 50000*time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut + "/seexample")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Test for the examples in the ServiceEntry doc
+	t.Run("se_examplegw", func(t *testing.T) {
+		// TODO: add a Service with EDS resolution in the none ns.
+		// The ServiceEntry only allows STATIC - both STATIC and EDS should generated TCP listeners on :port
+		// while DNS and NONE should generate old-style bind ports.
+		// Right now 'STATIC' and 'EDS' result in ClientSideLB in the internal object, so listener test is valid.
+
+		ldsr, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
+			Meta: map[string]string{
+			},
+			IP:        "10.13.0.1",
+			Namespace: "exampleegressgw",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer ldsr.Close()
+
+		ldsr.Watch()
+
+		_, err = ldsr.Wait("rds", 50000*time.Second)
+		if err != nil {
+			t.Fatal("Failed to receive LDS", err)
+			return
+		}
+
+		err = ldsr.Save(env.IstioOut + "/seexample-eg")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+}
 
 // TestLDS is running LDSv2 tests.
 func TestLDS(t *testing.T) {
@@ -109,3 +253,10 @@ func TestLDS(t *testing.T) {
 
 	// TODO: dynamic checks ( see EDS )
 }
+
+// TODO: helper to test the http listener content
+// - file access log
+// - generate request id
+// - cors, fault, router filters
+// - tracing
+//

--- a/pilot/pkg/proxy/envoy/v2/xds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/xds_test.go
@@ -99,10 +99,14 @@ func startEnvoy(t *testing.T) {
 		t.Fatal("Can't read bootstrap template", err)
 	}
 	testEnv.EnvoyTemplate = string(tmplB)
+	testEnv.Dir = env.IstioSrc
 	nodeID := sidecarID(app3Ip, "app3")
 	testEnv.EnvoyParams = []string{"--service-cluster", "serviceCluster", "--service-node", nodeID}
 	testEnv.EnvoyConfigOpt = map[string]interface{}{
-		"NodeID": nodeID,
+		"NodeID":  nodeID,
+		"BaseDir": env.IstioSrc + "/tests/testdata/local",
+		// Same value used in the real template
+		"meta_json_str": fmt.Sprintf(`"BASE": "%s"`, env.IstioSrc+"/tests/testdata/local"),
 	}
 
 	// Mixer will push stats every 1 sec

--- a/pkg/adsc/adsc.go
+++ b/pkg/adsc/adsc.go
@@ -50,7 +50,10 @@ type Config struct {
 
 	// NodeType defaults to sidecar. "ingress" and "router" are also supported.
 	NodeType string
-	IP       string
+
+	// IP is currently the primary key used to locate inbound configs. It is sent by client,
+	// must match a known endpoint IP. Tests can use a ServiceEntry to register fake IPs.
+	IP string
 }
 
 // ADSC implements a basic client for ADS, for use in stress tests and tools
@@ -65,18 +68,36 @@ type ADSC struct {
 	// NodeID is the node identity sent to Pilot.
 	nodeID string
 
+	done chan error
+
 	certDir string
 	url     string
 
 	watchTime time.Time
 
+	// InitialLoad tracks the time to receive the initial configuration.
 	InitialLoad time.Duration
 
-	TCPListeners  map[string]*xdsapi.Listener
+	// HTTPListeners contains received listeners with a http_connection_manager filter.
 	HTTPListeners map[string]*xdsapi.Listener
-	Clusters      map[string]*xdsapi.Cluster
-	Routes        map[string]*xdsapi.RouteConfiguration
-	EDS           map[string]*xdsapi.ClusterLoadAssignment
+
+	// TCPListeners contains all listeners of type TCP (not-HTTP)
+	TCPListeners map[string]*xdsapi.Listener
+
+	// All received clusters of type EDS, keyed by name
+	EDSClusters map[string]*xdsapi.Cluster
+
+	// All received clusters of no-EDS type, keyed by name
+	Clusters map[string]*xdsapi.Cluster
+
+	// All received routes, keyed by route name
+	Routes map[string]*xdsapi.RouteConfiguration
+
+	// All received endpoints, keyed by cluster name
+	EDS map[string]*xdsapi.ClusterLoadAssignment
+
+	// DumpCfg will print all received config
+	DumpCfg bool
 
 	// Metadata has the node metadata to send to pilot.
 	// If nil, the defaults will be used.
@@ -112,6 +133,7 @@ var (
 // Dial connects to a ADS server, with optional MTLS authentication if a cert dir is specified.
 func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	adsc := &ADSC{
+		done:        make(chan error),
 		Updates:     make(chan string, 100),
 		VersionInfo: map[string]string{},
 		certDir:     certDir,
@@ -129,6 +151,7 @@ func Dial(url string, certDir string, opts *Config) (*ADSC, error) {
 	if opts.Workload == "" {
 		opts.Workload = "test-1"
 	}
+	adsc.Metadata = opts.Meta
 
 	adsc.nodeID = fmt.Sprintf("sidecar~%s~%s.%s~%s.svc.cluster.local", opts.IP,
 		opts.Workload, opts.Namespace, opts.Namespace)
@@ -322,7 +345,11 @@ func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 
 			// Getting from config is too painful..
 			port := l.Address.GetSocketAddress().GetPortValue()
-			routes = append(routes, fmt.Sprintf("%d", port))
+			if port == 15002 {
+				routes = append(routes, "http_proxy")
+			} else {
+				routes = append(routes, fmt.Sprintf("%d", port))
+			}
 			//log.Printf("HTTP: %s -> %d", l.Name, port)
 		} else if f0.Name == "envoy.mongo_proxy" {
 			// ignore for now
@@ -335,6 +362,10 @@ func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 	}
 
 	log.Println("LDS: http=", len(lh), "tcp=", len(lt), "size=", ldsSize)
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(ll, " ", " ")
+		log.Println(string(b))
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	if len(routes) > 0 {
@@ -349,19 +380,102 @@ func (a *ADSC) handleLDS(ll []*xdsapi.Listener) {
 	}
 }
 
+// compact representations, for simplified debugging/testing
+
+// TCPListener extracts the core elements from envoy Listener.
+type TCPListener struct {
+	// Address is the address, as expected by go Dial and Listen, including port
+	Address string
+
+	// LogFile is the access log address for the listener
+	LogFile string
+
+	// Target is the destination cluster.
+	Target string
+}
+
+type Target struct {
+
+	// Address is a go address, extracted from the mangled cluster name.
+	Address string
+
+	// Endpoints are the resolved endpoints from EDS or cluster static.
+	Endpoints map[string]Endpoint
+}
+
+type Endpoint struct {
+	// Weight extracted from EDS
+	Weight int
+}
+
+// Save will save the json configs to files, using the base directory
+func (a *ADSC) Save(base string) error {
+	strResponse, err := json.MarshalIndent(a.TCPListeners, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_lds_tcp.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.HTTPListeners, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_lds_http.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.Routes, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_rds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.EDSClusters, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_ecds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.Clusters, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_cds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+	strResponse, err = json.MarshalIndent(a.EDS, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(base+"_eds.json", strResponse, 0644)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
 func (a *ADSC) handleCDS(ll []*xdsapi.Cluster) {
 
 	cn := []string{}
 	cdsSize := 0
+	edscds := map[string]*xdsapi.Cluster{}
 	cds := map[string]*xdsapi.Cluster{}
 	for _, c := range ll {
 		cdsSize += c.Size()
 		if c.Type != xdsapi.Cluster_EDS {
-			// TODO: save them
+			cds[c.Name] = c
 			continue
 		}
 		cn = append(cn, c.Name)
-		cds[c.Name] = c
+		edscds[c.Name] = c
 	}
 
 	log.Println("CDS: ", len(cn), "size=", cdsSize)
@@ -369,9 +483,14 @@ func (a *ADSC) handleCDS(ll []*xdsapi.Cluster) {
 	if len(cn) > 0 {
 		a.sendRsc(endpointType, cn)
 	}
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(ll, " ", " ")
+		log.Println(string(b))
+	}
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
+	a.EDSClusters = edscds
 	a.Clusters = cds
 
 	select {
@@ -402,16 +521,27 @@ func (a *ADSC) node() *core.Node {
 	return n
 }
 
+func (a *ADSC) Send(req *xdsapi.DiscoveryRequest) error {
+	req.Node = a.node()
+	req.ResponseNonce = time.Now().String()
+	return a.stream.Send(req)
+}
+
 func (a *ADSC) handleEDS(eds []*xdsapi.ClusterLoadAssignment) {
 	la := map[string]*xdsapi.ClusterLoadAssignment{}
 	edsSize := 0
+	ep := 0
 	for _, cla := range eds {
 		edsSize += cla.Size()
 		la[cla.ClusterName] = cla
+		ep += len(cla.Endpoints)
 	}
 
-	log.Println("EDS: ", len(eds), "size=", edsSize)
-
+	log.Println("EDS: ", len(eds), "size=", edsSize, "ep=", ep)
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(eds, " ", " ")
+		log.Println(string(b))
+	}
 	if a.InitialLoad == 0 {
 		// first load - Envoy loads listeners after endpoints
 		a.stream.Send(&xdsapi.DiscoveryRequest{
@@ -446,7 +576,7 @@ func (a *ADSC) handleRDS(configurations []*xdsapi.RouteConfiguration) {
 			for _, rt := range h.Routes {
 				rcount++
 				// Example: match:<prefix:"/" > route:<cluster:"outbound|9154||load-se-154.local" ...
-				//log.Println(rt.String())
+				log.Println(h.Name, rt.Match.PathSpecifier, rt.GetRoute().GetCluster())
 				httpClusters = append(httpClusters, rt.GetRoute().GetCluster())
 			}
 		}
@@ -460,9 +590,14 @@ func (a *ADSC) handleRDS(configurations []*xdsapi.RouteConfiguration) {
 		log.Println("RDS: ", len(configurations), "size=", size, "vhosts=", vh, "routes=", rcount)
 	}
 
+	if a.DumpCfg {
+		b, _ := json.MarshalIndent(configurations, " ", " ")
+		log.Println(string(b))
+	}
+
 	a.mutex.Lock()
-	defer a.mutex.Unlock()
 	a.Routes = rds
+	a.mutex.Unlock()
 
 	select {
 	case a.Updates <- "rds":

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -74,3 +74,10 @@ var (
 	// config. In most cases 'istio-system' should be included. Comma separated (ns1,ns2,istio-system)
 	NetworkScopes = os.Getenv("DEFAULT_NAMESPACE_DEPENDENCIES")
 )
+
+var (
+	// TODO: define all other default ports here, add docs
+
+	// DefaultPortHttpProxy is used as for HTTP PROXY mode. Can be overridden by ProxyHttpPort in mesh config.
+	DefaultPortHTTPProxy = 15002
+)

--- a/tests/testdata/bootstrap_tmpl.json
+++ b/tests/testdata/bootstrap_tmpl.json
@@ -6,7 +6,7 @@
       "zone": "testzone"
     },
     "metadata": {
-      "foo": "bar"
+      {{ .EnvoyConfigOpt.meta_json_str }}
     }
   },
   "stats_config": {

--- a/tests/testdata/config/byon.yaml
+++ b/tests/testdata/config/byon.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: byon
+  namespace: testns
 spec:
    hosts:
    - byon.test.istio.io
@@ -20,6 +21,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: byon
+  namespace: testns
 spec:
   hosts:
     - mybyon.test.istio.io
@@ -34,6 +36,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: byon-docker
+  namespace: testns
 spec:
    hosts:
    - byon-docker.test.istio.io
@@ -51,6 +54,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: wikipedia-range
+  namespace: testns
 spec:
   hosts:
   - www.wikipedia.org

--- a/tests/testdata/config/destination-rule-all.yaml
+++ b/tests/testdata/config/destination-rule-all.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: destall
+  namespace: testns
 spec:
    hosts:
    - destall.default.svc.cluster.local
@@ -20,6 +21,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: destall
+  namespace: testns
 spec:
   # DNS name, prefix wildcard, short name relative to context
   # IP or CIDR only for services in gateways

--- a/tests/testdata/config/destination-rule-fqdn.yaml
+++ b/tests/testdata/config/destination-rule-fqdn.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: fqdn
+  namespace: testns
 spec:
   host: www.webinf.info
   trafficPolicy:

--- a/tests/testdata/config/destination-rule-passthrough.yaml
+++ b/tests/testdata/config/destination-rule-passthrough.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: drpassthrough
+  namespace: testns
 spec:
   host: "*.foo.com"
   trafficPolicy:

--- a/tests/testdata/config/destination-rule-ssl.yaml
+++ b/tests/testdata/config/destination-rule-ssl.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: ssl-simple
+  namespace: testns
 spec:
   host: ssl1.webinf.info
   trafficPolicy:
@@ -17,17 +18,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: drprefix
+  namespace: testns
 spec:
-  host: "ssl.webinf.info"
+  host: "random.webinf.info"
   trafficPolicy:
     loadBalancer:
       simple: RANDOM
-    tls:
-      mode: MUTUAL
-      clientCertificate: myCertFile.pem
-      privateKey: myPrivateKey.pem
-      # If omitted, no verification !!! ( can still be verified by receiver ??)
-      caCertificates: myCA.pem
-      sni: my.sni.com
-      subjectAltNames:
-      - foo.alt.name

--- a/tests/testdata/config/egressgateway.yaml
+++ b/tests/testdata/config/egressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-egressgateway
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/external_services.yaml
+++ b/tests/testdata/config/external_services.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-extsvc
+  namespace: testns
 spec:
    hosts:
    - external.extsvc.com
@@ -17,6 +18,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
  name: external-service-1
+ namespace: testns
 spec:
  host: external.extsvc.com
 # BUG: crash envoy
@@ -30,6 +32,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-ports
+  namespace: testns
 spec:
    hosts:
    - ports.extsvc.com
@@ -50,6 +53,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-dst
+  namespace: testns
 spec:
    hosts:
    - dst.extsvc.com
@@ -67,6 +71,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: external-svc-ep
+  namespace: testns
 spec:
    hosts:
    - ep.extsvc.com

--- a/tests/testdata/config/gateway-all.yaml
+++ b/tests/testdata/config/gateway-all.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: my-gateway
+  namespace: testns
 spec:
   selector:
     app: my-gateway-controller

--- a/tests/testdata/config/gateway-tcp-a.yaml
+++ b/tests/testdata/config/gateway-tcp-a.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: gateway-a
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/ingress.yaml
+++ b/tests/testdata/config/ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-ingress
+  namespace: testns
 spec:
   selector:
     istio: ingress
@@ -27,6 +28,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: ingress
+  namespace: testns
 spec:
   # K8S Ingress rules are converted on the fly to a VirtualService.
   # The local tests may run without k8s - so for ingress we test with the

--- a/tests/testdata/config/ingressgateway.yaml
+++ b/tests/testdata/config/ingressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-ingressgateway
+  namespace: testns
 spec:
   selector:
     # DO NOT CHANGE THESE LABELS

--- a/tests/testdata/config/rule-content-route.yaml
+++ b/tests/testdata/config/rule-content-route.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: headers-route
+  namespace: testns
 spec:
   hosts:
     - headers.test.istio.io

--- a/tests/testdata/config/rule-default-route-append-headers.yaml
+++ b/tests/testdata/config/rule-default-route-append-headers.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: appendh
+  namespace: testns
 spec:
    hosts:
    - appendh.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: appendh-route
+  namespace: testns
 spec:
   hosts:
     - appendh.test.istio.io

--- a/tests/testdata/config/rule-default-route-cors-policy.yaml
+++ b/tests/testdata/config/rule-default-route-cors-policy.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: cors
+  namespace: testns
 spec:
    hosts:
    - cors.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: cors
+  namespace: testns
 spec:
   hosts:
     - cors.test.istio.io

--- a/tests/testdata/config/rule-default-route.yaml
+++ b/tests/testdata/config/rule-default-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: c
+  namespace: testns
 spec:
    hosts:
    - c.foo
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default-route-1
+  namespace: testns
 spec:
   hosts:
     - c.foo
@@ -38,6 +40,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: default-route-2
+  namespace: testns
 spec:
   hosts:
     - c.foo

--- a/tests/testdata/config/rule-fault-injection.yaml
+++ b/tests/testdata/config/rule-fault-injection.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: fault
+  namespace: testns
 spec:
    hosts:
    - fault.test.istio.io
@@ -26,6 +27,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: fault
+  namespace: testns
 spec:
   host: c-weighted.extsvc.com
   subsets:
@@ -41,6 +43,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: fault
+  namespace: testns
 spec:
   hosts:
     - fault.test.istio.io

--- a/tests/testdata/config/rule-ingressgateway.yaml
+++ b/tests/testdata/config/rule-ingressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: gateway-bound-route
+  namespace: testns
 spec:
   hosts:
     - uk.bookinfo.com

--- a/tests/testdata/config/rule-redirect-injection.yaml
+++ b/tests/testdata/config/rule-redirect-injection.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: redirect
+  namespace: testns
 spec:
    hosts:
    - redirect.test.istio.io
@@ -19,6 +20,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: redirect
+  namespace: testns
 spec:
   hosts:
     - redirect.test.istio.io

--- a/tests/testdata/config/rule-regex-route.yaml
+++ b/tests/testdata/config/rule-regex-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: regex-extsvc
+  namespace: testns
 spec:
    hosts:
    - regex.extsvc.com
@@ -26,6 +27,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: regex
+  namespace: testns
 spec:
   host: regex.extsvc.com
   subsets:
@@ -40,6 +42,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: regex-route
+  namespace: testns
 spec:
   hosts:
     - regex.extsvc.com

--- a/tests/testdata/config/rule-route-via-egressgateway.yaml
+++ b/tests/testdata/config/rule-route-via-egressgateway.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: route-via-egressgateway
+  namespace: testns
 spec:
   hosts:
     - egressgateway.bookinfo.com

--- a/tests/testdata/config/rule-websocket-route.yaml
+++ b/tests/testdata/config/rule-websocket-route.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: websocket-extsvc
+  namespace: testns
 spec:
    hosts:
    - websocket.test.istio.io
@@ -22,6 +23,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: websocket
+  namespace: testns
 spec:
   host: websocket.test.istio.io
   subsets:
@@ -36,6 +38,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: websocket-route
+  namespace: testns
 spec:
   hosts:
     - websocket.test.istio.io
@@ -58,6 +61,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: websocket-route2
+  namespace: testns
 spec:
   hosts:
     - websocket2.extsvc.com

--- a/tests/testdata/config/rule-weighted-route.yaml
+++ b/tests/testdata/config/rule-weighted-route.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: weighted-extsvc
+  namespace: testns
 spec:
    hosts:
    - c-weighted.extsvc.com
@@ -28,6 +29,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: c-weighted
+  namespace: testns
 spec:
   host: c-weighted.extsvc.com
   subsets:
@@ -42,6 +44,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: c-weighted
+  namespace: testns
 spec:
   hosts:
     - c-weighted.extsvc.com

--- a/tests/testdata/config/virtual-service-all.yaml
+++ b/tests/testdata/config/virtual-service-all.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: all
+  namespace: testns
 spec:
   hosts:
   - service3.default.svc.cluster.local

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -105,6 +105,7 @@ func setup(additionalArgs ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, Tea
 		MCPMaxMessageSize: bootstrap.DefaultMCPMaxMsgSize,
 		KeepaliveOptions:  keepalive.DefaultOption(),
 		ForceStop:         true,
+		Plugins:           bootstrap.DefaultPlugins,
 	}
 	// Static testdata, should include all configs we want to test.
 	args.Config.FileDir = env.IstioSrc + "/tests/testdata/config"


### PR DESCRIPTION
- added namespace to all local test configs for xds
- added a 'none' local test, with Sidecar
- added 2 more tests with sidecar based on the examples from the api docs 
- added code to dump the generated config for tests with Sidecar
- remove the validation for 'non ingress, no egress' - it is valid to have a Sidecar and not import anything
- added a base dir to the envoy test, for better local tests with certs.