### PR TITLE
Fix flaky test by reducing poll interval.

### DIFF
--- a/pkg/mcp/creds/pollingWatcher.go
+++ b/pkg/mcp/creds/pollingWatcher.go
@@ -61,12 +61,16 @@ func (p *pollingWatcher) certPool() *x509.CertPool {
 //
 // Internally PollFolder will call PollFiles.
 func PollFolder(stop <-chan struct{}, folder string) (CertificateWatcher, error) {
+	return pollFolder(stop, folder, time.Minute)
+}
+
+func pollFolder(stop <-chan struct{}, folder string, interval time.Duration) (CertificateWatcher, error) {
 	cred := &Options{
 		CertificateFile:   path.Join(folder, defaultCertificateFile),
 		KeyFile:           path.Join(folder, defaultKeyFile),
 		CACertificateFile: path.Join(folder, defaultCACertificateFile),
 	}
-	return PollFiles(stop, cred)
+	return pollFiles(stop, cred, interval)
 }
 
 // PollFiles loads certificate & key files from the file system. The method will start a background

--- a/pkg/mcp/creds/pollingWatcher_test.go
+++ b/pkg/mcp/creds/pollingWatcher_test.go
@@ -368,16 +368,14 @@ func newFixture(t *testing.T) *watcherFixture {
 
 func (f *watcherFixture) newWatcher() (err error) {
 	ch := make(chan struct{})
-	w, err := PollFolder(ch, f.folder)
+	// Reduce poll time for quick turnaround of events
+	w, err := pollFolder(ch, f.folder, time.Millisecond)
 	if err != nil {
 		return err
 	}
 
 	f.ch = ch
 	f.w = w
-
-	// Reduce poll time for quick turnaround of events
-	f.w.(*pollingWatcher).pollInterval = time.Millisecond
 
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/10851

I couldn't repro this locally, but noticed an issue with the test setup, where the shortening of the poll interval was not being taken into account. This can cause the retry logic to timeout (which it does) when the polling takes longer than the check/retry loop in the test.