### PR TITLE
add exponential backoff for retryable CSR error in nodeagent

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -475,7 +475,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 
 		// If reach envoy timeout, fail the request by returning err
 		if startTime.Add(time.Millisecond * envoyDefaultTimeoutInMilliSec).Before(time.Now()) {
-			log.Errorf("CSR retry timeout for for %q: %v", resourceName, err)
+			log.Errorf("CSR retry timeout for %q: %v", resourceName, err)
 			return nil, err
 		}
 

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gogo/status"
 	"google.golang.org/grpc/codes"
+
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/plugin"

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -56,8 +56,8 @@ const (
 	// For REST APIs between envoy->nodeagent, default value of 1s is be used.
 	envoyDefaultTimeoutInMilliSec = 1000
 
-	// backOffIntervalInMilliSec is the initial backoff time interval when hitting non-retryable error in CSR request.
-	backOffIntervalInMilliSec = 50
+	// initialBackOffIntervalInMilliSec is the initial backoff time interval when hitting non-retryable error in CSR request.
+	initialBackOffIntervalInMilliSec = 50
 )
 
 type k8sJwtPayload struct {
@@ -458,7 +458,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 
 	startTime := time.Now()
 	retry := 0
-	backOffInMilliSec := envoyDefaultTimeoutInMilliSec
+	backOffInMilliSec := initialBackOffIntervalInMilliSec
 	var certChainPEM []string
 	for true {
 		certChainPEM, err = sc.fetcher.CaClient.CSRSign(ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
@@ -475,7 +475,7 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 
 		retry++
 		backOffInMilliSec = retry * backOffInMilliSec
-		randomTime := rand.Intn(envoyDefaultTimeoutInMilliSec)
+		randomTime := rand.Intn(initialBackOffIntervalInMilliSec)
 		time.Sleep(time.Duration(backOffInMilliSec+randomTime) * time.Millisecond)
 		log.Warnf("Failed to sign cert for %q: %v, will retry in %d millisec", resourceName, err, backOffInMilliSec)
 	}

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -22,11 +22,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/nodeagent/model"
 	"istio.io/istio/security/pkg/nodeagent/plugin"
@@ -49,6 +52,12 @@ const (
 
 	// identityTemplate is the format template of identity in the CSR request.
 	identityTemplate = "spiffe://%s/ns/%s/sa/%s"
+
+	// For REST APIs between envoy->nodeagent, default value of 1s is be used.
+	envoyDefaultTimeoutInMilliSec = 1000
+
+	// backOffIntervalInMilliSec is the initial backoff time interval when hitting non-retryable error in CSR request.
+	backOffIntervalInMilliSec = 50
 )
 
 type k8sJwtPayload struct {
@@ -447,10 +456,27 @@ func (sc *SecretCache) generateSecret(ctx context.Context, token, resourceName s
 		return nil, err
 	}
 
-	certChainPEM, err := sc.fetcher.CaClient.CSRSign(ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
-	if err != nil {
-		log.Errorf("Failed to sign cert for %q: %v", resourceName, err)
-		return nil, err
+	startTime := time.Now()
+	retry := 0
+	backOffInMilliSec := envoyDefaultTimeoutInMilliSec
+	var certChainPEM []string
+	for true {
+		certChainPEM, err = sc.fetcher.CaClient.CSRSign(ctx, csrPEM, exchangedToken, int64(sc.configOptions.SecretTTL.Seconds()))
+		if err == nil {
+			break
+		}
+
+		// If non-retryable error or reach envoy timeout, fail the request by returning err
+		if !isRetryableErr(status.Code(err)) || startTime.Add(time.Millisecond*envoyDefaultTimeoutInMilliSec).After(time.Now()) {
+			log.Errorf("Failed to sign cert for %q: %v", resourceName, err)
+			return nil, err
+		}
+
+		retry++
+		backOffInMilliSec = retry * backOffInMilliSec
+		randomTime := rand.Intn(envoyDefaultTimeoutInMilliSec)
+		time.Sleep(time.Duration(backOffInMilliSec+randomTime) * time.Millisecond)
+		log.Warnf("Failed to sign cert for %q: %v, will retry in %d millisec", resourceName, err, backOffInMilliSec)
 	}
 
 	certChain := []byte{}
@@ -527,4 +553,12 @@ func constructCSRHostName(trustDomain, token string) (string, error) {
 	}
 
 	return fmt.Sprintf(identityTemplate, domain, ns, sa), nil
+}
+
+func isRetryableErr(c codes.Code) bool {
+	switch c {
+	case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
+		return true
+	}
+	return false
 }

--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -559,7 +559,6 @@ func constructCSRHostName(trustDomain, token string) (string, error) {
 func isRetryableErr(c codes.Code) bool {
 	switch c {
 	case codes.Canceled, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted, codes.Internal, codes.Unavailable:
-		log.Info("***retryable error")
 		return true
 	}
 	return false


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035 

to avoid traffic spike to hit CA