### PR TITLE
Fix #10975. Avoid Prometheus export error by using default label core…

### DIFF
--- a/galley/pkg/source/kube/stats/stats.go
+++ b/galley/pkg/source/kube/stats/stats.go
@@ -30,6 +30,7 @@ const (
 	group      = "group"
 	kind       = "kind"
 	errorStr   = "error"
+	coreGroup  = "core"
 )
 
 var (
@@ -92,6 +93,10 @@ func RecordConverterResult(success bool, apiVersion, group, kind string) {
 		metric = sourceConversionSuccess
 	} else {
 		metric = sourceConversionFailure
+	}
+	if len(group) == 0 {
+		// For "core" resources, i.e. Pods and Nodes, group is "". Empty tags result in errors during the export to Prometheus.
+		group = coreGroup
 	}
 	key := contextKey{apiVersion, group, kind}
 	ctx, ok := ctxCache.Load(key)


### PR DESCRIPTION
… as K8s group if not set

Galley records metrics about the Kubernetes resource events that it processes and uses the apiVersion, group and kind as metric labels.
For Pods and Nodes the group is empty.
Therefore the export to Prometheus fails:
```
2019-01-15T06:52:38.260821Z     info    Failed to export to Prometheus: inconsistent label cardinality: expected 3 label values but got 2 in []string{"
v1", "Node"}                                                                                                                                          
2019-01-15T06:52:38.261000Z     info    Failed to export to Prometheus: inconsistent label cardinality: expected 3 label values but got 2 in []string{"
v1", "Pod"}                                                                                                                                            
```

This PR tries to fix this problem reported at #10975 by using the kind `core` if it is empty.

For me this made the log entries disappear.