### PR TITLE
Add missing space in log statement

### DIFF
--- a/mixer/pkg/api/grpcServer.go
+++ b/mixer/pkg/api/grpcServer.go
@@ -83,7 +83,7 @@ func (s *grpcServer) Check(ctx context.Context, req *mixerpb.CheckRequest) (*mix
 
 	if req.GlobalWordCount > uint32(len(s.globalWordList)) {
 		err := fmt.Errorf("inconsistent global dictionary versions used: mixer knows %d words, caller knows %d", len(s.globalWordList), req.GlobalWordCount)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -136,7 +136,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 
 	if err := s.dispatcher.Preprocess(ctx, protoBag, checkBag); err != nil {
 		err = fmt.Errorf("preprocessing attributes failed: %v", err)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -151,7 +151,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 	cr, err := s.dispatcher.Check(ctx, checkBag)
 	if err != nil {
 		err = fmt.Errorf("performing check operation failed: %v", err)
-		lg.Errora("Check failed:", err.Error())
+		lg.Errora("Check failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -204,7 +204,7 @@ func (s *grpcServer) check(ctx context.Context, req *mixerpb.CheckRequest,
 			qr, err := s.dispatcher.Quota(ctx, checkBag, qma)
 			if err != nil {
 				err = fmt.Errorf("performing quota alloc failed: %v", err)
-				lg.Errora("Quota failure:", err.Error())
+				lg.Errora("Quota failure: ", err.Error())
 				// we continue the quota loop even after this error
 			} else {
 				if !status.IsOK(qr.Status) {
@@ -237,7 +237,7 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 
 	if req.GlobalWordCount > uint32(len(s.globalWordList)) {
 		err := fmt.Errorf("inconsistent global dictionary versions used: mixer knows %d words, caller knows %d", len(s.globalWordList), req.GlobalWordCount)
-		lg.Errora("Report failed:", err.Error())
+		lg.Errora("Report failed: ", err.Error())
 		return nil, grpc.Errorf(codes.Internal, err.Error())
 	}
 
@@ -323,7 +323,7 @@ func (s *grpcServer) Report(ctx context.Context, req *mixerpb.ReportRequest) (*m
 	reportSpan.Finish()
 
 	if errors != nil {
-		lg.Errora("Report failed:", errors.Error())
+		lg.Errora("Report failed: ", errors.Error())
 		return nil, grpc.Errorf(codes.Unknown, errors.Error())
 	}
 

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -50,7 +50,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env *model.Environme
 
 	gatewaysForWorkload := env.Gateways(workloadLabels)
 	if len(gatewaysForWorkload) == 0 {
-		log.Debuga("buildGatewayListeners: no gateways for router", node.ID)
+		log.Debuga("buildGatewayListeners: no gateways for router ", node.ID)
 		return []*xdsapi.Listener{}, nil
 	}
 
@@ -183,7 +183,7 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 
 	gateways := env.Gateways(workloadLabels)
 	if len(gateways) == 0 {
-		log.Debuga("buildGatewayRoutes: no gateways for router", node.ID)
+		log.Debuga("buildGatewayRoutes: no gateways for router ", node.ID)
 		return nil, nil
 	}
 

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -94,7 +94,7 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	} else {
 		out, err := bootstrap.WriteBootstrap(&e.config, e.node, epoch, e.pilotSAN, e.opts, os.Environ(), e.nodeIPs)
 		if err != nil {
-			log.Errora("Failed to generate bootstrap config", err)
+			log.Errora("Failed to generate bootstrap config: ", err)
 			os.Exit(1) // Prevent infinite loop attempting to write the file, let k8s/systemd report
 			return err
 		}

--- a/pkg/test/application/echo/handler.go
+++ b/pkg/test/application/echo/handler.go
@@ -164,7 +164,7 @@ func (h handler) WebSocketEcho(w http.ResponseWriter, r *http.Request) {
 	// First send upgrade headers
 	c, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Warna("websocket-echo upgrade failed:", err)
+		log.Warna("websocket-echo upgrade failed: ", err)
 		return
 	}
 
@@ -174,7 +174,7 @@ func (h handler) WebSocketEcho(w http.ResponseWriter, r *http.Request) {
 	// ping
 	mt, message, err := c.ReadMessage()
 	if err != nil {
-		log.Warna("websocket-echo read failed:", err)
+		log.Warna("websocket-echo read failed: ", err)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (h handler) WebSocketEcho(w http.ResponseWriter, r *http.Request) {
 	body.Write(message)
 	err = c.WriteMessage(mt, body.Bytes())
 	if err != nil {
-		log.Warna("websocket-echo write failed:", err)
+		log.Warna("websocket-echo write failed: ", err)
 		return
 	}
 }

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -58,7 +58,7 @@ type TearDownFunc func()
 func EnsureTestServer(args ...func(*bootstrap.PilotArgs)) (*bootstrap.Server, TearDownFunc) {
 	server, tearDown, err := setup(args...)
 	if err != nil {
-		log.Errora("Failed to start in-process server", err)
+		log.Errora("Failed to start in-process server: ", err)
 		panic(err)
 	}
 	return server, tearDown


### PR DESCRIPTION
Previously, the log statement was: "Failed to generate bootstrap
configopen /etc..." (note that there's no space in configopen).

This commit fixes the statement, so it reads "Failed to generate
bootstrap config: open /etc/..."