### PR TITLE
Fix local integ test job to run make sync before testing

### DIFF
--- a/prow/istio-integ-local-tests.sh
+++ b/prow/istio-integ-local-tests.sh
@@ -31,6 +31,8 @@ setup_and_export_git_sha
 
 cd "${ROOT}"
 
+make sync
+
 JUNIT_UNIT_TEST_XML="${ARTIFACTS_DIR}/junit_unit-tests.xml" \
 T="-v" \
 make test.integration.local


### PR DESCRIPTION
`make sync` will create $ISTIO_OUT if not exists, which causes prow integration2 tests fail. Adding this fixes the problem.