### PR TITLE
Add bionic and deb_slim base images, optimize size for xenial

### DIFF
--- a/docker/Dockerfile.bionic_debug
+++ b/docker/Dockerfile.bionic_debug
@@ -1,0 +1,36 @@
+FROM ubuntu:bionic
+# Base image for debug builds.
+# Built manually uploaded as "istionightly/base_debug"
+
+# Do not add more stuff to this list that isn't small or critically useful.
+# If you occasionally need something on the container do
+# sudo apt-get update && apt-get whichever
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      curl \
+      iptables \
+      iproute2 \
+      iputils-ping \
+      knot-dnsutils \
+      netcat \
+      tcpdump \
+      net-tools \
+      lsof \
+      sudo && \
+      apt-get clean -y && \
+      rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
+        /var/log/* /tmp/*  /var/tmp/*
+
+# Required:
+# iptables (1.8M) (required in init, for debugging in the other cases)
+# iproute2 (1.5M) (required for init)
+
+# Debug:
+# curl (11M)
+# tcpdump (5M)
+# netcat (0.2M)
+# net-tools (0.7M): netstat
+# lsof (0.5M): for debugging open socket, file descriptors
+# knot-dnsutils (4.5M): dig/nslookup
+
+# Alternative: dnsutils(44M) for dig/nslookup

--- a/docker/Dockerfile.deb_debug
+++ b/docker/Dockerfile.deb_debug
@@ -1,0 +1,37 @@
+FROM debian:9-slim
+
+# Base image for debug builds - base is 22M
+# Built manually uploaded as "istionightly/base_debug"
+
+# Do not add more stuff to this list that isn't small or critically useful.
+# If you occasionally need something on the container do
+# sudo apt-get update && apt-get whichever
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+      curl \
+      iptables \
+      iproute2 \
+      iputils-ping \
+      knot-dnsutils \
+      netcat \
+      tcpdump \
+      net-tools \
+      lsof \
+      sudo &&  apt-get upgrade -y && \
+      apt-get clean -y && \
+      rm -rf /var/cache/debconf/* /var/lib/apt/lists/* \
+        /var/log/* /tmp/*  /var/tmp/*
+
+# Required:
+# iptables (1.8M) (required in init, for debugging in the other cases)
+# iproute2 (1.5M) (required for init)
+
+# Debug:
+# curl (11M)
+# tcpdump (5M)
+# netcat (0.2M)
+# net-tools (0.7M): netstat
+# lsof (0.5M): for debugging open socket, file descriptors
+# knot-dnsutils (4.5M): dig/nslookup
+
+# Alternative: dnsutils(44M) for dig/nslookup

--- a/docker/Dockerfile.xenial_debug
+++ b/docker/Dockerfile.xenial_debug
@@ -14,12 +14,10 @@ RUN apt-get update && \
       iptables \
       iproute2 \
       iputils-ping \
-      dnsutils \
+      knot-dnsutils \
       netcat \
       tcpdump \
       net-tools \
-      libc6-dbg gdb \
-      elvis-tiny \
       lsof \
       linux-tools-generic \
       sudo && apt-get upgrade -y && \

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -262,6 +262,18 @@ docker.push: $(DOCKER_PUSH_TARGETS)
 docker.basedebug:
 	docker build -t istionightly/base_debug -f docker/Dockerfile.xenial_debug docker/
 
+# Run this target to generate images based on Bionic Ubuntu
+# This must be run as a first step, before the 'docker' step.
+docker.basedebug_bionic:
+	docker build -t istionightly/base_debug_bionic -f docker/Dockerfile.bionic_debug docker/
+	docker tag istionightly/base_debug_bionic istionightly/base_debug
+
+# Run this target to generate images based on Debian Slim
+# This must be run as a first step, before the 'docker' step.
+docker.basedebug_deb:
+	docker build -t istionightly/base_debug_deb -f docker/Dockerfile.deb_debug docker/
+	docker tag istionightly/base_debug_deb istionightly/base_debug
+
 # Job run from the nightly cron to publish an up-to-date xenial with the debug tools.
 docker.push.basedebug: docker.basedebug
 	docker push istionightly/base_debug:latest


### PR DESCRIPTION
Old change I had on my computer - it allows building Istio with bionic or deb_slim base, and small
optimization in the size of the xenial image and a bunch of comments on different component sizes.

