### PR TITLE
Move Sidecars CRD from 1.0 to 1.1

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -88,27 +88,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: sidecars.networking.istio.io
-  labels:
-    app: istio-pilot
-    chart: istio
-    heritage: Tiller
-    release: istio
-spec:
-  group: networking.istio.io
-  names:
-    kind: Sidecar
-    plural: sidecars
-    singular: sidecar
-    categories:
-    - istio-io
-    - networking-istio-io
-  scope: Namespaced
-  version: v1alpha3 
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot

--- a/install/kubernetes/helm/istio-init/files/crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-11.yaml
@@ -38,3 +38,24 @@ spec:
   scope: Namespaced
   version: v1alpha2
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sidecars.networking.istio.io
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
+spec:
+  group: networking.istio.io
+  names:
+    kind: Sidecar
+    plural: sidecars
+    singular: sidecar
+    categories:
+    - istio-io
+    - networking-istio-io
+  scope: Namespaced
+  version: v1alpha3
+---


### PR DESCRIPTION
All 1.1 CRDs should go in the crd-11 file to prevent breakage
during upgrade.