### PR TITLE
tools/dump_kubernetes.sh bugfix

### DIFF
--- a/tools/dump_kubernetes.sh
+++ b/tools/dump_kubernetes.sh
@@ -115,7 +115,7 @@ mv_unless_max_exceeded() {
   local dst_file="${2}"
 
   file_size=$(wc -c "${src_file}" | awk '{print $1}')
-  local nsb=$(("${stored_log_bytes}" + "${file_size}"))
+  local nsb=$((stored_log_bytes + file_size))
 
   if (("${nsb}" > "${MAX_LOG_BYTES}")); then
     log "Not storing ${log_file} because appending its ${file_size} bytes would exceed max logged bytes ${MAX_LOG_BYTES}"


### PR DESCRIPTION
Remove quotes from variables as per [SC2004](https://github.com/koalaman/shellcheck/wiki/SC2004) since they break the script for macOS supplied BASH:

```
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
Copyright (C) 2007 Free Software Foundation, Inc.
```

This was the only thing preventing the script from passing `shellcheck`