### PR TITLE
Remove istio-init jobs if completed successfully

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: istio-init-crd-10
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: istio-init-crd-11
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
@@ -3,6 +3,9 @@ kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: istio-init-crd-certmanager-10
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:


### PR DESCRIPTION
Currently installing `istio-init` leaves behind the completed jobs/pods:

```sh
istio-init-crd-10-xns9t               0/1     Completed   0          13s
istio-init-crd-11-f77lb               0/1     Completed   0          13s
istio-init-crd-certmanager-10-knxwb   0/1     Completed   0          13s
```

This will delete the jobs if they were completed successfully.