### PR TITLE
remove 'crds' option in relevant manifests

### DIFF
--- a/install/kubernetes/helm/istio-remote/values.yaml
+++ b/install/kubernetes/helm/istio-remote/values.yaml
@@ -240,13 +240,6 @@ global:
   # for more detail.
   priorityClassName: ""
 
-  # Include the crd definition when generating the template.
-  # For 'helm template' and helm install > 2.10 it should be true.
-  # For helm < 2.9, crds must be installed ahead of time with
-  # 'kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
-  # and this options must be set off.
-  crds: true
-
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
   useMCP: true

--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -53,17 +53,6 @@ The chart deploys pods that consume minimum resources as specified in the resour
     $ kubectl create ns $NAMESPACE
     ```
 
-1. If using a Helm version prior to 2.10.0, install Istio’s [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the kube-apiserver:
-    ```
-    $ kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
-    ```
-    > If you are enabling `certmanager`, you also need to install its CRDs and wait a few seconds for the CRDs to be committed in the kube-apiserver:
-    ```
-    $ kubectl apply -f install/kubernetes/helm/istio/charts/certmanager/templates/crds.yaml
-    ```
-
-    > Helm version 2.10.0 supports a way to register CRDs via an internal feature called `crd-install`.  This feature does not exist in prior versions of Helm.
-
 1. If you are enabling `kiali`, you need to create the secret that contains the username and passphrase for `kiali` dashboard:
     ```
     $ echo -n 'admin' | base64

--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -30,6 +30,7 @@ To enable or disable each component, change the corresponding `enabled` flag.
 - Kubernetes 1.9 or newer cluster with RBAC (Role-Based Access Control) enabled is required
 - Helm 2.7.2 or newer or alternately the ability to modify RBAC rules is also required
 - If you want to enable automatic sidecar injection, Kubernetes 1.9+ with `admissionregistration` API is required, and `kube-apiserver` process must have the `admission-control` flag set with the `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers added and listed in the correct order.
+- The `istio-init` chart must be run to completion prior to install the `istio` chart.
 
 ## Resources Required
 

--- a/install/kubernetes/helm/istio/values-istio-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-gateways.yaml
@@ -1,12 +1,5 @@
 # Common settings.
 global:
-  # Include the crd definition when generating the template.
-  # For 'helm template' and helm install > 2.10 it should be true.
-  # For helm < 2.9, crds must be installed ahead of time with
-  # 'kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
-  # and this options must be set off.
-  crds: false
-
   # Omit the istio-sidecar-injector configmap when generate a
   # standalone gateway. Gateways may be created in namespaces other
   # than `istio-system` and we don't want to re-create the injector

--- a/install/kubernetes/helm/istio/values-istio-minimal.yaml
+++ b/install/kubernetes/helm/istio/values-istio-minimal.yaml
@@ -29,12 +29,6 @@ prometheus:
 
 # Common settings.
 global:
-  # Include the crd definition when generating the template.
-  # For 'helm template' and helm install > 2.10 it should be true.
-  # For helm < 2.9, crds must be installed ahead of time with
-  # 'kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
-  # and this options must be set off.
-  crds: false
 
   proxy:
     # Sets the destination Statsd in envoy (the value of the "--statsdUdpAddress" proxy argument

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -339,13 +339,6 @@ global:
   # for more detail.
   priorityClassName: ""
 
-  # Include the crd definition when generating the template.
-  # For 'helm template' and helm install > 2.10 it should be true.
-  # For helm < 2.9, crds must be installed ahead of time with
-  # 'kubectl apply -f install/kubernetes/helm/istio/templates/crds.yaml
-  # and this options must be set off.
-  crds: true
-
   # Use the Mesh Control Protocol (MCP) for configuring Mixer and
   # Pilot. Requires galley (`--set galley.enabled=true`).
   useMCP: true

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -863,9 +863,6 @@ func (k *KubeInfo) deployIstioWithHelm() error {
 		setValue += " --set istiotesting.oneNameSpace=true"
 	}
 
-	// CRDs installed ahead of time with 2.9.x
-	setValue += " --set global.crds=false"
-
 	// enable helm test for istio
 	setValue += " --set global.enableHelmTest=true"
 

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -258,8 +258,6 @@ helm/upgrade:
 	  istio-system install/kubernetes/helm/istio
 
 # Delete istio installed with helm
-# Note that for Helm 2.10, the CRDs are not cleared
 helm/delete:
 	${HELM} delete --purge istio-system
 	for i in install/kubernetes/helm/istio-init/files/crd-*; do kubectl delete -f $i; done
-	kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml


### PR DESCRIPTION
Since we have switched to `istio-init` to handle `CRDs`, we can now remove original `crds` option in relevant manifests.