### PR TITLE
add Bearer prefix in oauth token that passed to GoogleCA

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -33,7 +34,10 @@ import (
 
 var usePodDefaultFlag = false
 
-const podIdentityFlag = "POD_IDENTITY"
+const (
+	podIdentityFlag   = "POD_IDENTITY"
+	bearerTokenPrefix = "Bearer "
+)
 
 type googleCAClient struct {
 	caEndpoint     string
@@ -81,6 +85,11 @@ func (cl *googleCAClient) CSRSign(ctx context.Context, csrPEM []byte, token stri
 	req := &gcapb.IstioCertificateRequest{
 		Csr:              string(csrPEM),
 		ValidityDuration: certValidTTLInSec,
+	}
+
+	// If the token doesn't have "Bearer " prefix, add it.
+	if !strings.HasSuffix(token, bearerTokenPrefix) {
+		token = bearerTokenPrefix + token
 	}
 
 	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", token))


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

enforce this otherwise backend throw error
```
 rpc error: code = Unauthenticated desc = Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.
```