### PR TITLE
Remove redundant "Summary:" from bookinfo product description

### DIFF
--- a/samples/bookinfo/src/productpage/templates/productpage.html
+++ b/samples/bookinfo/src/productpage/templates/productpage.html
@@ -96,7 +96,7 @@ $('#login-modal').on('shown.bs.modal', function () {
     <div class="col-md-12">
       <h3 class="text-center text-primary">{{ product.title }}</h3>
       {% autoescape false %}
-        <p>Summary: {{ product.descriptionHtml }}</p>
+        <p>{{ product.descriptionHtml }}</p>
       {% endautoescape %}
     </div>
   </div>


### PR DESCRIPTION
The productpage html has an extra "Summary:" in front of the description:
![image](https://user-images.githubusercontent.com/2752495/51279427-653b5500-19ab-11e9-9da2-4f465d4ddbdf.png)
