### PR TITLE
Fixing some failures in local and k8s new framework integration test

### DIFF
--- a/pkg/test/fakes/policy/backend.go
+++ b/pkg/test/fakes/policy/backend.go
@@ -75,7 +75,7 @@ func (b *Backend) Port() int {
 
 // Start the gRPC service for the policy backend.
 func (b *Backend) Start() error {
-	scope.Infof("Starting Policy Backend at port: %d", b.port)
+	scope.Info("Starting Policy Backend")
 
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", b.port))
 	if err != nil {
@@ -91,7 +91,7 @@ func (b *Backend) Start() error {
 	RegisterControllerServiceServer(grpcServer, b)
 
 	go func() {
-		scope.Info("Starting the GRPC service")
+		scope.Infof("Starting the GRPC service at port: %d", b.port)
 		_ = grpcServer.Serve(listener)
 	}()
 
@@ -151,7 +151,8 @@ func (b *Backend) GetReports(ctx context.Context, req *GetReportsRequest) (*GetR
 func (b *Backend) Close() error {
 	scope.Info("Backend.Close")
 	b.server.Stop()
-	return b.listener.Close()
+	_ = b.listener.Close()
+	return nil
 }
 
 // Validate is an implementation InfrastructureBackendServer.Validate.

--- a/pkg/test/framework/api/descriptors/descriptors.go
+++ b/pkg/test/framework/api/descriptors/descriptors.go
@@ -92,7 +92,7 @@ var (
 	// PolicyBackend component
 	PolicyBackend = component.Descriptor{
 		ID:                ids.PolicyBackend,
-		IsSystemComponent: false,
+		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Mixer,
 			&ids.Environment,

--- a/tests/integration2/galley/conversion/conversion_test.go
+++ b/tests/integration2/galley/conversion/conversion_test.go
@@ -45,7 +45,7 @@ func TestConversion(t *testing.T) {
 
 			// TODO: Limit to Native environment until the Kubernetes environment is supported in the Galley
 			// component
-			ctx.RequireOrFail(t, lifecycle.Suite, &descriptors.NativeEnvironment)
+			ctx.RequireOrSkip(t, lifecycle.Suite, &descriptors.NativeEnvironment)
 
 			ctx.RequireOrFail(t, lifecycle.Test, &ids.Galley)
 

--- a/tests/integration2/mixer/check_test.go
+++ b/tests/integration2/mixer/check_test.go
@@ -95,12 +95,14 @@ apiVersion: "config.istio.io/v1alpha2"
 kind: checknothing
 metadata:
   name: checknothing1
+  namespace: {{.TestNamespace}}
 spec:
 ---
 apiVersion: "config.istio.io/v1alpha2"
 kind: rule
 metadata:
   name: rule1
+  namespace: {{.TestNamespace}}
 spec:
   actions:
   - handler: handler1.bypass

--- a/tests/integration2/tests.mk
+++ b/tests/integration2/tests.mk
@@ -38,7 +38,7 @@ test.integration.all: test.integration test.integration.kube
 
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube:
-	$(GO) test -p 1 ${T} ./tests/integration2/$*/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_LOGGING_FLAG} \
+	$(GO) test -p 1 ${T} ./tests/integration2/$*/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_LOGGING_FLAG} -timeout 30m \
 	--istio.test.env kubernetes \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
 	--istio.test.kube.deploy \
@@ -68,7 +68,7 @@ test.integration.local: | $(JUNIT_REPORT)
 test.integration.kube: | $(JUNIT_REPORT)
 	mkdir -p $(dir $(JUNIT_UNIT_TEST_XML))
 	set -o pipefail; \
-	$(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_LOGGING_FLAG} \
+	$(GO) test -p 1 ${T} ${TEST_PACKAGES} ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_LOGGING_FLAG} -timeout 30m \
 	--istio.test.env kubernetes \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
 	--istio.test.kube.deploy \


### PR DESCRIPTION
Fixes are as follows:
1) PolicyBackend close is failing when closing the listener in natice environment. Thus ignoring it's error and making policy backend a system component, so that it is just reset between the tests and not really closed.
2) Skipping conversion test in local environment as it requires kubernetes environment.
3) Increasing timeout of tests in kubernetes environment
4) Adding test namespace in mixer check test.