### PR TITLE
mixer: remove destination.service and source.service attributes

### DIFF
--- a/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/config.yaml
@@ -150,8 +150,6 @@ spec:
       valueType: STRING
     source.owner:
       valueType: STRING
-    source.service:  # DEPRECATED
-      valueType: STRING
     source.serviceAccount:
       valueType: STRING
     source.services:
@@ -175,8 +173,6 @@ spec:
     destination.container.name:
       valueType: STRING
     destination.namespace:
-      valueType: STRING
-    destination.service: # DEPRECATED
       valueType: STRING
     destination.service.uid:
       valueType: STRING

--- a/samples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml
+++ b/samples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml
@@ -39,7 +39,7 @@ metadata:
 spec:
   dimensions:
     source: request.headers["x-forwarded-for"] | "unknown"
-    destination: destination.labels["app"] | destination.service | "unknown"
+    destination: destination.labels["app"] | destination.service.name | "unknown"
     destinationVersion: destination.labels["version"] | "unknown"
 ---
 apiVersion: config.istio.io/v1alpha2

--- a/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
+++ b/samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml
@@ -35,7 +35,7 @@ spec:
   dimensions:
     source: source.labels["app"] | source.service | "unknown"
     sourceVersion: source.labels["version"] | "unknown"
-    destination: destination.labels["app"] | destination.service | "unknown"
+    destination: destination.labels["app"] | destination.service.name | "unknown"
     destinationVersion: destination.labels["version"] | "unknown"
 
 ---


### PR DESCRIPTION
These attributes have been deprecated and announced as such in istio 1.0 docs.
This PR removes them from the manifest.