### PR TITLE
update Makefile: use GOPATH env to print right istio path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ ${ISTIO_BIN}/have_go_$(GO_VERSION_REQUIRED):
 .PHONY: check-tree
 check-tree:
 	@if [ "$(ISTIO_GO)" != "$(GO_TOP)/src/istio.io/istio" ]; then \
-		echo Not building in expected path \'GOPATH/src/istio.io/istio\'. Make sure to clone Istio into that path. Istio root=$(ISTIO_GO), GO_TOP=$(GO_TOP) ; \
+		echo Not building in expected path \'$(GOPATH)/src/istio.io/istio\'. Make sure to clone Istio into that path. Istio root=$(ISTIO_GO), GO_TOP=$(GO_TOP) ; \
 		exit 1; fi
 
 # Downloads envoy, based on the SHA defined in the base pilot Dockerfile


### PR DESCRIPTION
 use GOPATH env to print right istio path, not print GOPATH/src/istio.io/istio