### PR TITLE
Quick fixes for interception and debugging

### DIFF
--- a/galley/docker/Dockerfile.galley
+++ b/galley/docker/Dockerfile.galley
@@ -1,3 +1,3 @@
-FROM scratch
+FROM istionightly/base_debug
 ADD galley /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/galley"]

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -301,6 +301,7 @@ func validateInterceptionMode(mode string) error {
 	switch mode {
 	case meshconfig.ProxyConfig_REDIRECT.String():
 	case meshconfig.ProxyConfig_TPROXY.String():
+	case "NONE": // not a global mesh config - must be enabled for each sidecar
 	default:
 		return fmt.Errorf("interceptionMode invalid: %v", mode)
 	}

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gogo/protobuf/types"
 	multierror "github.com/hashicorp/go-multierror"
+	"istio.io/istio/pilot/pkg/model"
 	"k8s.io/api/batch/v2alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -301,7 +302,7 @@ func validateInterceptionMode(mode string) error {
 	switch mode {
 	case meshconfig.ProxyConfig_REDIRECT.String():
 	case meshconfig.ProxyConfig_TPROXY.String():
-	case "NONE": // not a global mesh config - must be enabled for each sidecar
+	case string(model.InterceptionNone): // not a global mesh config - must be enabled for each sidecar
 	default:
 		return fmt.Errorf("interceptionMode invalid: %v", mode)
 	}


### PR DESCRIPTION
- add none to inject validation
- use same base as Pilot for Galley - can be switched back to scratch after we make sure it's stable and 
prod ready, but for now we seem to need debugging tools ( see the crash loop bug)