### PR TITLE
handle special char in trustdomain (to construct sa for secure naming) 

### DIFF
--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -46,7 +46,7 @@ func GenSpiffeURI(ns, serviceAccount string) (string, error) {
 			"namespace or service account can't be empty ns=%v serviceAccount=%v", ns, serviceAccount)
 	}
 
-	// replace specifial character in spiffee
+	// replace specifial character in spiffe
 	trustDomain = strings.Replace(trustDomain, "@", ".", -1)
 	return fmt.Sprintf(Scheme+"://%s/ns/%s/sa/%s", trustDomain, ns, serviceAccount), err
 }

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -2,6 +2,7 @@ package spiffe
 
 import (
 	"fmt"
+	"strings"
 
 	"istio.io/istio/pkg/log"
 )
@@ -44,6 +45,9 @@ func GenSpiffeURI(ns, serviceAccount string) (string, error) {
 		err = fmt.Errorf(
 			"namespace or service account can't be empty ns=%v serviceAccount=%v", ns, serviceAccount)
 	}
+
+	// replace specifial character in spiffee
+	trustDomain = strings.Replace(trustDomain, "@", ".", -1)
 	return fmt.Sprintf(Scheme+"://%s/ns/%s/sa/%s", trustDomain, ns, serviceAccount), err
 }
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

our user case set trust domain as some service account like ```kube-federating-id@testproj.iam.gserviceaccount.com```, while SAN field in cert issued by google CA is ```spiffe://kube-federating-id.testproj.iam.gserviceaccount.com/ns/foo/sa/bar``` (the reason is special char ```@``` isn't allowed in spiffe I guess). 

this PR handles special char in trustdomain (to construct sa for secure naming), to align with cert issued by google CA. 
