### PR TITLE
Auth plugin to be used for Galley dial out

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2143,6 +2143,7 @@
     "google.golang.org/grpc/balancer",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/credentials",
+    "google.golang.org/grpc/credentials/oauth",
     "google.golang.org/grpc/encoding/gzip",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/keepalive",

--- a/galley/pkg/authplugin/authplugin.go
+++ b/galley/pkg/authplugin/authplugin.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugin
+
+import "google.golang.org/grpc"
+
+type InfoFn func() Info
+type AuthFn func(map[string]string) ([]grpc.DialOption, error)
+
+type Info struct {
+	Name    string
+	GetAuth AuthFn
+}

--- a/galley/pkg/authplugins/README.md
+++ b/galley/pkg/authplugins/README.md
@@ -7,7 +7,7 @@
 * In the returned authplugin.Info:
 
   * Set `Name` to what will be used to specify your plugin in config
-  * Set `GetAuth` to a funtion in your plugin that conforms to authplugin.AuthFn
+  * Set `GetAuth` to a function in your plugin that conforms to authplugin.AuthFn
 
 * Edit inventory.go in this directory so that your plugin's GetInfo is
   retuned in the slice that Inventory() returns.

--- a/galley/pkg/authplugins/README.md
+++ b/galley/pkg/authplugins/README.md
@@ -1,0 +1,13 @@
+## How to add a new plugin:
+
+* Add a new subdirectory.
+
+* Export GetInfo() that conforms to authplugin.InfoFn
+
+* In the returned authplugin.Info:
+
+  * Set `Name` to what will be used to specify your plugin in config
+  * Set `GetAuth` to a funtion in your plugin that conforms to authplugin.AuthFn
+
+* Edit inventory.go in this directory so that your plugin's GetInfo is
+  retuned in the slice that Inventory() returns.

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package google is a Galley auth plugin that uses Google application
+// default credentials.
+package google
+
+import (
+	"context"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+	"istio.io/istio/galley/pkg/authplugin"
+)
+
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	ctx := context.Background()
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
+	if err != nil {
+		return nil, err
+	}
+
+	grpcOpts := []grpc.DialOption{
+		grpc.WithPerRPCCredentials(oauth.TokenSource{creds.TokenSource}),
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
+	}
+
+	return grpcOpts, nil
+}
+
+func GetInfo() authplugin.Info {
+	return authplugin.Info{
+		Name:    "GOOGLE",
+		GetAuth: returnAuth,
+	}
+}

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -23,10 +23,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
+
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	_ = config
 	ctx := context.Background()
 	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
 	if err != nil {
@@ -34,7 +36,7 @@ func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	}
 
 	grpcOpts := []grpc.DialOption{
-		grpc.WithPerRPCCredentials(oauth.TokenSource{creds.TokenSource}),
+		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: creds.TokenSource}),
 		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
 	}
 

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -30,7 +30,7 @@ import (
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	_ = config
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, err
 	}

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -27,10 +27,18 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
+type dcFn func(context.Context, ...string) (*google.Credentials, error)
+
+var findDC dcFn
+
+func init() {
+	findDC = google.FindDefaultCredentials
+}
+
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	_ = config
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	creds, err := findDC(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, err
 	}

--- a/galley/pkg/authplugins/google/google_test.go
+++ b/galley/pkg/authplugins/google/google_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	i := GetInfo()
+	if i.Name == "" {
+		t.Error("Name not valid")
+	}
+	if i.GetAuth == nil {
+		t.Error("GetAuth not valid")
+	}
+}
+
+func TestAuth(t *testing.T) {
+	opts, err := returnAuth(nil)
+	if err != nil {
+		t.Errorf("Error with auth: %v", err)
+	}
+	if opts == nil {
+		t.Error("No auth options returned")
+	}
+	if len(opts) != 2 {
+		t.Error("Should have 2 options")
+	}
+}

--- a/galley/pkg/authplugins/google/google_test.go
+++ b/galley/pkg/authplugins/google/google_test.go
@@ -15,7 +15,10 @@
 package google
 
 import (
+	"context"
 	"testing"
+
+	"golang.org/x/oauth2/google"
 )
 
 func TestInfo(t *testing.T) {
@@ -28,7 +31,12 @@ func TestInfo(t *testing.T) {
 	}
 }
 
+func mockDC(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+	return &google.Credentials{}, nil
+}
+
 func TestAuth(t *testing.T) {
+	findDC = mockDC
 	opts, err := returnAuth(nil)
 	if err != nil {
 		t.Errorf("Error with auth: %v", err)

--- a/galley/pkg/authplugins/inventory.go
+++ b/galley/pkg/authplugins/inventory.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugins
+
+import (
+	"istio.io/istio/galley/pkg/authplugin"
+
+	"istio.io/istio/galley/pkg/authplugins/google"
+	"istio.io/istio/galley/pkg/authplugins/none"
+)
+
+func Inventory() []authplugin.InfoFn {
+	return []authplugin.InfoFn{
+		google.GetInfo,
+		none.GetInfo,
+	}
+}

--- a/galley/pkg/authplugins/inventory_test.go
+++ b/galley/pkg/authplugins/inventory_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugins_test
+
+import (
+	"testing"
+
+	"istio.io/istio/galley/pkg/authplugins"
+)
+
+func TestInventory(t *testing.T) {
+	for _, v := range authplugins.Inventory() {
+		if v == nil {
+			t.Error("Invalid info function")
+		}
+	}
+}

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package none is a Galley auth plugin that returns an empty auth
+// DialOption.
+package none
+
+import (
+	"google.golang.org/grpc"
+	"istio.io/istio/galley/pkg/authplugin"
+)
+
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	return nil, nil
+}
+
+func GetInfo() authplugin.Info {
+	return authplugin.Info{
+		Name:    "NONE",
+		GetAuth: returnAuth,
+	}
+}

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -18,10 +18,11 @@ package none
 
 import (
 	"google.golang.org/grpc"
+
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
-func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) { // nolint: unparam
 	return nil, nil
 }
 

--- a/galley/pkg/authplugins/none/none_test.go
+++ b/galley/pkg/authplugins/none/none_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package none
+
+import (
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	i := GetInfo()
+	if i.Name == "" {
+		t.Error("Name not valid")
+	}
+	if i.GetAuth == nil {
+		t.Error("GetAuth not valid")
+	}
+}
+
+func TestAuth(t *testing.T) {
+	opts, err := returnAuth(nil)
+	if err != nil {
+		t.Errorf("Error with auth: %v", err)
+	}
+	if opts != nil {
+		t.Error("None auth should be nil")
+	}
+}


### PR DESCRIPTION
This interacts with #10834. A section will be added to the config file to allow specification of dial out including which type of auth to use. Auth will reference a plugin as specified in this PR. Config will include a string map to be passed to auth plugin.

Next step is to add an auth plugin that will use in-cluster mtls (if configured).