### PR TITLE
Add retry logic to SDS grpc server at Istio gateway

### DIFF
--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -185,11 +185,13 @@ func (s *Server) initGatewaySdsService(options *Options) error {
 	}
 
 	go func() {
-		if err = s.grpcGatewayServer.Serve(s.grpcGatewayListener); err != nil {
-			log.Errorf("SDS grpc server for ingress gateway proxy failed to start: %v", err)
+		for {
+			// Retry if Serve() fails
+			log.Info("Start SDS grpc server for ingress gateway proxy")
+			if err = s.grpcGatewayServer.Serve(s.grpcGatewayListener); err != nil {
+				log.Errorf("SDS grpc server for ingress gateway proxy failed to start: %v", err)
+			}
 		}
-
-		log.Info("SDS grpc server for ingress gateway proxy started")
 	}()
 
 	return nil

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -167,6 +167,10 @@ func (s *Server) initWorkloadSdsService(options *Options) error {
 			if err = s.grpcWorkloadServer.Serve(s.grpcWorkloadListener); err != nil {
 				log.Errorf("SDS grpc server for workload proxies failed to start: %v", err)
 			}
+			s.grpcWorkloadListener, err = setUpUds(options.WorkloadUDSPath)
+			if err != nil {
+				log.Errorf("SDS grpc server for workload proxies failed to set up UDS: %v", err)
+			}
 		}
 	}()
 
@@ -190,6 +194,10 @@ func (s *Server) initGatewaySdsService(options *Options) error {
 			log.Info("Start SDS grpc server for ingress gateway proxy")
 			if err = s.grpcGatewayServer.Serve(s.grpcGatewayListener); err != nil {
 				log.Errorf("SDS grpc server for ingress gateway proxy failed to start: %v", err)
+			}
+			s.grpcGatewayListener, err = setUpUds(options.IngressGatewayUDSPath)
+			if err != nil {
+				log.Errorf("SDS grpc server for ingress gateway proxy failed to set up UDS: %v", err)
 			}
 		}
 	}()


### PR DESCRIPTION
Similar to https://github.com/istio/istio/pull/11063, the retry logic should also be added to the SDS grpc server at Istio gateway. Meanwhile, a UDS recreation logic is added just in case the UDS get corrupted.