### PR TITLE
Fix a test flake.

### DIFF
--- a/mixer/adapter/list/list.go
+++ b/mixer/adapter/list/list.go
@@ -264,12 +264,13 @@ func (h *handler) purgeList() {
 	h.lock.Unlock()
 }
 
-func (h *handler) hasData() bool {
+func (h *handler) hasData() (bool, error) {
 	h.lock.Lock()
 	result := h.list != nil
+	err := h.lastFetchError
 	h.lock.Unlock()
 
-	return result
+	return result, err
 }
 
 func getCheckResult(config config.Params, code rpc.Code, msg string) adapter.CheckResult {

--- a/mixer/adapter/list/list_test.go
+++ b/mixer/adapter/list/list_test.go
@@ -503,7 +503,8 @@ func TestRefreshAndPurge(t *testing.T) {
 	// wait for the list to have been populated
 	for {
 		time.Sleep(1 * time.Millisecond)
-		if h.hasData() {
+		result, _ := h.hasData()
+		if result {
 			// list has been populated
 			break
 		}
@@ -521,8 +522,9 @@ func TestRefreshAndPurge(t *testing.T) {
 	// wait for the list to have been purged
 	for {
 		time.Sleep(1 * time.Millisecond)
-		if !h.hasData() {
-			// list has been purged
+		result, err := h.hasData()
+		if !result && err != nil {
+			// list has been purged and failed to reload
 			break
 		}
 	}


### PR DESCRIPTION
The test was inherently time-dependent. If the list was purge due to not being to be refreshed fast enough, instead of failing due to the conditions the test setup, then the test would not see the results it expected. We now wait for the right conditions explicitly before allowing things to move forward.

Fixes #11020 
