### PR TITLE
[WIP] Update galley to convert authentication policy to use labels.

### DIFF
--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -154,6 +154,8 @@ func GetRootCmd(args []string) *cobra.Command {
 		serverArgs.SinkAddress, "Address of MCP Resource Sink server for Galley to connect to. Ex: 'foo.com:1234'")
 	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sinkAuthMode",
 		serverArgs.SinkAuthMode, "Name of authentication plugin to use for connection to sink server.")
+	rootCmd.PersistentFlags().BoolVar(&serverArgs.ConvertAuthToUseLabelSelector, "convertAuthToUseLabelSelector", serverArgs.ConvertAuthToUseLabelSelector,
+		"Converts Istio Authentication and Authorization policy to use label selectors instead of service names in the policy.")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)
 

--- a/galley/pkg/runtime/config.go
+++ b/galley/pkg/runtime/config.go
@@ -23,4 +23,8 @@ type Config struct {
 
 	// Domain suffix to use
 	DomainSuffix string
+
+	// If true, Galley will convert the Istio Authenticaion and Authorization policy to use label
+	// selector instead of service names in the policy.
+	ConvertAuthToUseLabelSelector bool
 }

--- a/galley/pkg/runtime/conversions/auth.go
+++ b/galley/pkg/runtime/conversions/auth.go
@@ -1,0 +1,132 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package conversions
+
+import (
+	"fmt"
+	"github.com/gogo/protobuf/proto"
+	authn "istio.io/api/authentication/v1alpha1"
+	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/galley/pkg/metadata"
+	"istio.io/istio/galley/pkg/runtime/resource"
+	"strings"
+)
+
+type ServiceToSelector struct {
+	Name map[string]resource.Labels
+}
+
+type AuthConverter struct {
+	Namespace map[string]ServiceToSelector
+}
+
+// AddService adds a service name and its associated selector labels to the AuthConverter which could
+// later be retrieved by GetSelectors.
+func (ac *AuthConverter) AddService(fullName resource.FullName, selector resource.Labels) {
+	if len(selector) == 0 {
+		// Ignore empty selector for stateless service.
+		// TODO: Figure out what is the best way to handle this.
+		return
+	}
+
+	namespace, name := fullName.InterpretAsNamespaceAndName()
+
+	if ac.Namespace == nil {
+		ac.Namespace = make(map[string]ServiceToSelector)
+	}
+
+	serviceToSelector, ok := ac.Namespace[namespace]
+	if !ok {
+		ac.Namespace[namespace] = ServiceToSelector{Name: map[string]resource.Labels{name: selector}}
+		return
+	}
+
+	if serviceToSelector.Name == nil {
+		serviceToSelector.Name = make(map[string]resource.Labels)
+	}
+	serviceToSelector.Name[name] = selector
+	return
+}
+
+// GetSelectors returns a list of selectors matched with the given service name and namespace.
+// If allowPrefixSuffix is true, allows "*" to be used in the name for prefix/suffix match, otherwise
+// use exact match and the returned list contains 1 element at most.
+func (ac AuthConverter) GetSelectors(name, namespace string, allowPrefixSuffixName bool) []resource.Labels {
+	ret := make([]resource.Labels, 0)
+	serviceToSelector := ac.Namespace[namespace]
+	if len(serviceToSelector.Name) == 0 {
+		return ret
+	}
+
+	matchFn := func(selectorName string) (matched, stop bool) {
+		matched = name == selectorName
+		// Return early as we should only have 1 match if we use exact match.
+		stop = matched
+		return
+	}
+
+	if allowPrefixSuffixName {
+		if name == "*" {
+			matchFn = func(_ string) (matched, stop bool) {
+				return true, false
+			}
+		} else {
+			checkPrefix := strings.HasSuffix(name, "*")
+			checkSuffix := strings.HasPrefix(name, "*")
+
+			if checkPrefix && checkSuffix {
+				scope.Errorf("couldn't get selectors for invalid service name: %s", name)
+				return ret
+			} else if checkPrefix {
+				name = strings.TrimSuffix(name, "*")
+				matchFn = func(selectorName string) (matched, stop bool) {
+					return strings.HasPrefix(selectorName, name), false
+				}
+			} else if checkSuffix {
+				name = strings.TrimPrefix(name, "*")
+				matchFn = func(selectorName string) (matched, stop bool) {
+					return strings.HasSuffix(selectorName, name), false
+				}
+			}
+		}
+	}
+
+	for k, v := range serviceToSelector.Name {
+		matched, stop := matchFn(k)
+		if matched {
+			ret = append(ret, v)
+		}
+		if stop {
+			break
+		}
+	}
+	return ret
+}
+
+func ToAuthenticationPolicy(e *mcp.Resource) (*authn.Policy, error) {
+	p := metadata.IstioAuthenticationV1alpha1Policies.NewProtoInstance()
+	i, ok := p.(*authn.Policy)
+	if !ok {
+		// Shouldn't happen
+		return nil, fmt.Errorf("unable to convert proto to AuthenticationPolicy: %v", p)
+	}
+
+	if err := proto.Unmarshal(e.Body.Value, p); err != nil {
+		// Shouldn't happen
+		return nil, fmt.Errorf("unable to unmarshal AuthenticationPolicy: %v", err)
+	}
+
+	return i, nil
+}

--- a/galley/pkg/runtime/conversions/auth_test.go
+++ b/galley/pkg/runtime/conversions/auth_test.go
@@ -1,0 +1,132 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package conversions
+
+import (
+	"istio.io/istio/galley/pkg/runtime/resource"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestAuthConverter(t *testing.T) {
+	ac := AuthConverter{}
+
+	services := []struct {
+		Name      string
+		Namespace string
+		Selector  resource.Labels
+	}{
+		{Name: "svc1", Namespace: "ns1", Selector: resource.Labels{"version": "1"}},
+		{Name: "svc2", Namespace: "ns1", Selector: resource.Labels{"version": "2"}},
+		{Name: "headless", Namespace: "ns1"},
+		{Name: "svc4", Namespace: "ns2", Selector: resource.Labels{"version": "4"}},
+		{Name: "svc5", Namespace: "ns2", Selector: resource.Labels{"version": "5"}},
+		{Name: "foo.svc", Namespace: "ns3", Selector: resource.Labels{"version": "6"}},
+		{Name: "bar.svc", Namespace: "ns3", Selector: resource.Labels{"version": "7"}},
+		{Name: "svc.foo", Namespace: "ns3", Selector: resource.Labels{"version": "8"}},
+		{Name: "svc.bar", Namespace: "ns3", Selector: resource.Labels{"version": "9"}},
+	}
+
+	for _, svc := range services {
+		ac.AddService(resource.FullNameFromNamespaceAndName(svc.Namespace, svc.Name), svc.Selector)
+	}
+
+	testCases := []struct {
+		Name                  string
+		Namespace             string
+		AllowPrefixSuffixName bool
+		ExpectSelectors       []resource.Labels
+	}{
+		{
+			Name:                  "non-exist-svc",
+			Namespace:             "ns1",
+			AllowPrefixSuffixName: false,
+			ExpectSelectors:       make([]resource.Labels, 0),
+		},
+		{
+			Name:                  "svc1",
+			Namespace:             "non-exist-namespace",
+			AllowPrefixSuffixName: false,
+			ExpectSelectors:       make([]resource.Labels, 0),
+		},
+		{
+			Name:                  "svc1",
+			Namespace:             "ns1",
+			AllowPrefixSuffixName: false,
+			ExpectSelectors:       []resource.Labels{{"version": "1"}},
+		},
+		{
+			Name:                  "svc2",
+			Namespace:             "ns1",
+			AllowPrefixSuffixName: false,
+			ExpectSelectors:       []resource.Labels{{"version": "2"}},
+		},
+		{
+			Name:                  "headless",
+			Namespace:             "ns1",
+			AllowPrefixSuffixName: false,
+			ExpectSelectors:       make([]resource.Labels, 0),
+		},
+		{
+			Name:                  "svc4",
+			Namespace:             "ns2",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors:       []resource.Labels{{"version": "4"}},
+		},
+		{
+			Name:                  "svc5",
+			Namespace:             "ns2",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors:       []resource.Labels{{"version": "5"}},
+		},
+		{
+			Name:                  "*",
+			Namespace:             "ns3",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors: []resource.Labels{{"version": "6"}, {"version": "7"},
+				{"version": "8"}, {"version": "9"}},
+		},
+		{
+			Name:                  "*.svc",
+			Namespace:             "ns3",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors:       []resource.Labels{{"version": "6"}, {"version": "7"}},
+		},
+		{
+			Name:                  "svc.*",
+			Namespace:             "ns3",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors:       []resource.Labels{{"version": "8"}, {"version": "9"}},
+		},
+		{
+			Name:                  "*.*",
+			Namespace:             "ns3",
+			AllowPrefixSuffixName: true,
+			ExpectSelectors:       make([]resource.Labels, 0),
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := ac.GetSelectors(tc.Name, tc.Namespace, tc.AllowPrefixSuffixName)
+		// Sort the result to make the test stable.
+		sort.Slice(actual, func(i, j int) bool {
+			return actual[i]["version"] < actual[j]["version"]
+		})
+		if !reflect.DeepEqual(actual, tc.ExpectSelectors) {
+			t.Errorf("failed for %v, expect: %v but got %v", tc, tc.ExpectSelectors, actual)
+		}
+	}
+}

--- a/galley/pkg/runtime/state.go
+++ b/galley/pkg/runtime/state.go
@@ -16,12 +16,14 @@ package runtime
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 
 	mcp "istio.io/api/mcp/v1alpha1"
@@ -194,11 +196,77 @@ func (s *State) buildSnapshot() snapshot.Snapshot {
 	// Build entities that are derived from existing ones.
 	s.buildProjections(b)
 
+	if s.config.ConvertAuthToUseLabelSelector {
+		// Update AuthenticationPolicy to use labels in its target selector.
+		s.updateAuthenticationPolicy(b)
+	}
+
 	return b.Build()
 }
 
 func (s *State) buildProjections(b *snapshot.InMemoryBuilder) {
 	s.buildIngressProjectionResources(b)
+}
+
+func (s *State) createAuthConverter() *conversions.AuthConverter {
+	serviceState := s.entries[metadata.K8sCoreV1Services.Collection]
+	if serviceState == nil {
+		return nil
+	}
+
+	authConverter := conversions.AuthConverter{}
+	for name, entry := range serviceState.entries {
+		selector := make(resource.Labels)
+		// The entry actually includes the Istio ServiceEntry, not the k8s Service resource due to the
+		// the kubeServiceResource() in galley/pkg/source/kube/dynamic/converter/converter.go. We have to
+		// look into the custom annotation to get the selectors for a given service name.
+		data := entry.Metadata.Annotations["_service_spec_selector_"]
+		if err := json.Unmarshal([]byte(data), &selector); err != nil {
+			scope.Errorf("failed to unmarshal service %s: %v", name, err)
+			continue
+		}
+		authConverter.AddService(name, selector)
+	}
+
+	scope.Debugf("created auth converter: %+v", authConverter)
+	return &authConverter
+}
+
+func (s *State) updateAuthenticationPolicy(b *snapshot.InMemoryBuilder) {
+	authConverter := s.createAuthConverter()
+	if authConverter == nil {
+		return
+	}
+
+	state := s.entries[metadata.IstioAuthenticationV1alpha1Policies.Collection]
+	if state == nil {
+		return
+	}
+
+	for name, entry := range state.entries {
+		policy, err := conversions.ToAuthenticationPolicy(entry)
+		if err != nil {
+			scope.Errorf("error updating authentication policy: %s", err)
+			return
+		}
+
+		namespace, _ := name.InterpretAsNamespaceAndName()
+		for _, target := range policy.Targets {
+			selectors := authConverter.GetSelectors(target.Name, namespace, false)
+			if len(selectors) != 1 {
+				scope.Debugf("no services for authentication policy %s/%s", namespace, target.Name)
+				continue
+			}
+			scope.Debugf("matched authentication policy %s with selectors: %v", target.Name, selectors)
+			target.Labels = selectors[0]
+		}
+
+		if entry.Body.Value, err = proto.Marshal(policy); err != nil {
+			scope.Errorf("failed to marshal updated authentication policy: %s", err)
+			continue
+		}
+		scope.Debugf("updated authentication policy: %v", entry)
+	}
 }
 
 func (s *State) buildIngressProjectionResources(b *snapshot.InMemoryBuilder) {

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -92,24 +92,30 @@ type Args struct {
 	// SinkAuthMode should be set to a name of an authentication plugin,
 	// see the istio.io/istio/galley/pkg/autplugins package.
 	SinkAuthMode string
+
+	// If true, Galley will convert the Istio Authenticaion and Authorization policy to use label
+	// selector instead of service names in the policy.
+	ConvertAuthToUseLabelSelector bool
+
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
 func DefaultArgs() *Args {
 	return &Args{
-		APIAddress:                "tcp://0.0.0.0:9901",
-		MaxReceivedMessageSize:    1024 * 1024,
-		MaxConcurrentStreams:      1024,
-		IntrospectionOptions:      ctrlz.DefaultOptions(),
-		Insecure:                  false,
-		AccessListFile:            defaultAccessListFile,
-		MeshConfigFile:            defaultMeshConfigFile,
-		EnableServer:              true,
-		CredentialOptions:         creds.DefaultOptions(),
-		ConfigPath:                "",
-		DomainSuffix:              defaultDomainSuffix,
-		DisableResourceReadyCheck: false,
-		ExcludedResourceKinds:     defaultExcludedResourceKinds(),
+		APIAddress:                    "tcp://0.0.0.0:9901",
+		MaxReceivedMessageSize:        1024 * 1024,
+		MaxConcurrentStreams:          1024,
+		IntrospectionOptions:          ctrlz.DefaultOptions(),
+		Insecure:                      false,
+		AccessListFile:                defaultAccessListFile,
+		MeshConfigFile:                defaultMeshConfigFile,
+		EnableServer:                  true,
+		CredentialOptions:             creds.DefaultOptions(),
+		ConfigPath:                    "",
+		DomainSuffix:                  defaultDomainSuffix,
+		DisableResourceReadyCheck:     false,
+		ExcludedResourceKinds:         defaultExcludedResourceKinds(),
+		ConvertAuthToUseLabelSelector: false,
 	}
 }
 
@@ -145,6 +151,7 @@ func (a *Args) String() string {
 	_, _ = fmt.Fprintf(buf, "ExcludedResourceKinds: %v\n", a.ExcludedResourceKinds)
 	_, _ = fmt.Fprintf(buf, "SinkAddress: %v\n", a.SinkAddress)
 	_, _ = fmt.Fprintf(buf, "SinkAuthMode: %v\n", a.SinkAuthMode)
+	_, _ = fmt.Fprintf(buf, "ConvertAuthToUseLabelSelector: %v\n", a.ConvertAuthToUseLabelSelector)
 
 	return buf.String()
 }

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -138,6 +138,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	processorCfg := runtime.Config{
 		DomainSuffix: a.DomainSuffix,
 		Mesh:         mesh,
+		ConvertAuthToUseLabelSelector: a.ConvertAuthToUseLabelSelector,
 	}
 	distributor := snapshot.New(groups.IndexFunction)
 	s.processor = runtime.NewProcessor(src, distributor, &processorCfg)

--- a/galley/pkg/source/kube/dynamic/converter/converter_test.go
+++ b/galley/pkg/source/kube/dynamic/converter/converter_test.go
@@ -597,6 +597,9 @@ func TestKubeServiceResource(t *testing.T) {
 				},
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "10.39.241.161",
+					Selector: map[string]string{
+						"a": "1", "b": "2",
+					},
 					Ports: []corev1.ServicePort{
 						{
 							Name:       "http",
@@ -623,8 +626,9 @@ func TestKubeServiceResource(t *testing.T) {
 				Key: resource.FullNameFromNamespaceAndName("default", "reviews"),
 				Metadata: resource.Metadata{
 					Annotations: map[string]string{
-						"a1_key": "a1_value",
-						"a2_key": "a2_value",
+						"a1_key":                  "a1_value",
+						"a2_key":                  "a2_value",
+						"_service_spec_selector_": `{"a":"1","b":"2"}`,
 					},
 					Labels: map[string]string{
 						"l1_key": "l1_value",


### PR DESCRIPTION
As discussed we will update the Auth policy to use labels instead of service name in galley, please take a look at this POC PR and let me know if this is the right direction we should go. This PR only includes change for Authentication policy, for RBAC the change is similar.

Please treat TODOs as questions, I will update the code based on feedback.

Signed-off-by: Yangmin Zhu <ymzhu@google.com>