### PR TITLE
Fix to use HasPrefix() if token doesn't have "Bearer " prefix.

### DIFF
--- a/security/pkg/nodeagent/caclient/providers/google/client.go
+++ b/security/pkg/nodeagent/caclient/providers/google/client.go
@@ -88,7 +88,7 @@ func (cl *googleCAClient) CSRSign(ctx context.Context, csrPEM []byte, token stri
 	}
 
 	// If the token doesn't have "Bearer " prefix, add it.
-	if !strings.HasSuffix(token, bearerTokenPrefix) {
+	if !strings.HasPrefix(token, bearerTokenPrefix) {
 		token = bearerTokenPrefix + token
 	}
 


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>