### PR TITLE
provide option to support always valid token to keep stream open

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -72,6 +72,20 @@ const (
 	// The environmental variable name for the flag which is used to indicate the token passed
 	// from envoy is always valid(ex, normal 8ks JWT).
 	alwaysValidTokenFlag = "VALID_TOKEN"
+
+	// The environmental variable name for secret TTL, node agent decides whether a secret
+	// is expired if time.now - secret.createtime >= secretTTL.
+	// example value format like "90m"
+	secretTTL = "SECRET_TTL"
+
+	// The environmental variable name for grace duration that secret is re-generated
+	// before it's expired time.
+	// example value format like "10m"
+	SecretRefreshGraceDuration = "SECRET_GRACE_DURATION"
+
+	// The environmental variable name for key rotation job running interval.
+	// example value format like "20m"
+	SecretRotationJobRunInterval = "SECRET_JOB_RUN_INTERVAL"
 )
 
 var (
@@ -208,14 +222,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&serverOptions.CertFile, "sdsCertFile", "", "SDS gRPC TLS server-side certificate")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.KeyFile, "sdsKeyFile", "", "SDS gRPC TLS server-side key")
 
-	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.SecretTTL, "secretTtl",
-		24*time.Hour, "Secret's TTL")
-	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.SecretRefreshGraceDuration, "secretRefreshGraceDuration",
-		time.Hour, "Secret's Refresh Grace Duration")
-	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.RotationInterval, "secretRotationInterval",
-		10*time.Minute, "Secret rotation job running interval")
-	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
-		24*time.Hour, "Secret eviction time duration")
+	setWorkloadCacheTimeParams()
+
 	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
 		alwaysValidTokenFlagEnv,
 		"If true, node agent assume token passed from envoy is always valid.")
@@ -233,6 +241,33 @@ func init() {
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)
+}
+
+func setWorkloadCacheTimeParams() {
+	secretTTLDuration := 24 * time.Hour
+	if env, err := time.ParseDuration(os.Getenv(secretTTL)); err == nil {
+		secretTTLDuration = env
+	}
+
+	secretRefreshGraceDuration := time.Hour
+	if env, err := time.ParseDuration(os.Getenv(SecretRefreshGraceDuration)); err == nil {
+		secretRefreshGraceDuration = env
+	}
+
+	secretRotationJobRunInterval := 10 * time.Minute
+	if env, err := time.ParseDuration(os.Getenv(SecretRotationJobRunInterval)); err == nil {
+		secretRotationJobRunInterval = env
+	}
+
+	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.SecretTTL, "secretTtl",
+		secretTTLDuration, "Secret's TTL")
+	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.SecretRefreshGraceDuration, "secretRefreshGraceDuration",
+		secretRefreshGraceDuration, "Secret's Refresh Grace Duration")
+	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.RotationInterval, "secretRotationInterval",
+		secretRotationJobRunInterval, "Secret rotation job running interval")
+
+	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
+		24*time.Hour, "Secret eviction time duration")
 }
 
 func main() {

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -140,7 +140,6 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 			os.Exit(1)
 		}
 		workloadSdsCacheOptions.TrustDomain = serverOptions.TrustDomain
-		workloadSdsCacheOptions.AlwaysValidTokenFlag = serverOptions.AlwaysValidTokenFlag
 		workloadSdsCacheOptions.Plugins = sds.NewPlugins(serverOptions.PluginNames)
 		workloadSecretCache = cache.NewSecretCache(wSecretFetcher, sds.NotifyProxy, workloadSdsCacheOptions)
 	} else {
@@ -217,8 +216,7 @@ func init() {
 		10*time.Minute, "Secret rotation job running interval")
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")
-
-	rootCmd.PersistentFlags().BoolVar(&serverOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
+	rootCmd.PersistentFlags().BoolVar(&workloadSdsCacheOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
 		alwaysValidTokenFlagEnv,
 		"If true, node agent assume token passed from envoy is always valid.")
 

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -68,6 +68,10 @@ const (
 
 	// The environmental variable name for Vault TLS root certificate.
 	vaultTLSRootCert = "VAULT_TLS_ROOT_CERT"
+
+	// The environmental variable name for the flag which is used to indicate the token passed
+	// from envoy is always valid(ex, normal 8ks JWT).
+	alwaysValidTokenFlag = "VALID_TOKEN"
 )
 
 var (
@@ -175,6 +179,12 @@ func init() {
 		enableIngressGatewaySdsEnv = env
 	}
 
+	alwaysValidTokenFlagEnv := false
+	val = os.Getenv(alwaysValidTokenFlag)
+	if env, err := strconv.ParseBool(val); err == nil {
+		alwaysValidTokenFlagEnv = env
+	}
+
 	rootCmd.PersistentFlags().BoolVar(&serverOptions.EnableWorkloadSDS, "enableWorkloadSDS",
 		enableWorkloadSdsEnv,
 		"If true, node agent works as SDS server and provisions key/certificate to workload proxies.")
@@ -206,6 +216,10 @@ func init() {
 		10*time.Minute, "Secret rotation job running interval")
 	rootCmd.PersistentFlags().DurationVar(&workloadSdsCacheOptions.EvictionDuration, "secretEvictionDuration",
 		24*time.Hour, "Secret eviction time duration")
+
+	rootCmd.PersistentFlags().BoolVar(&serverOptions.AlwaysValidTokenFlag, "alwaysValidTokenFlag",
+		alwaysValidTokenFlagEnv,
+		"If true, node agent assume token passed from envoy is always valid.")
 
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultAddress, "vaultAddress", os.Getenv(vaultAddress),
 		"Vault address")

--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -140,6 +140,7 @@ func newSecretCache(serverOptions sds.Options) (workloadSecretCache, gatewaySecr
 			os.Exit(1)
 		}
 		workloadSdsCacheOptions.TrustDomain = serverOptions.TrustDomain
+		workloadSdsCacheOptions.AlwaysValidTokenFlag = serverOptions.AlwaysValidTokenFlag
 		workloadSdsCacheOptions.Plugins = sds.NewPlugins(serverOptions.PluginNames)
 		workloadSecretCache = cache.NewSecretCache(wSecretFetcher, sds.NotifyProxy, workloadSdsCacheOptions)
 	} else {

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -150,6 +150,7 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			// request's <token, resourceName, Version>, then this request is a confirmation request.
 			// nodeagent stops sending response to envoy in this case.
 			if discReq.VersionInfo != "" && s.st.SecretExist(discReq.Node.Id, resourceName, token, discReq.VersionInfo) {
+				log.Debugf("Received SDS ACK from %q", discReq.Node.Id)
 				continue
 			}
 
@@ -175,12 +176,12 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			log.Debugf("Received push channel request for %q", con.proxyID)
 
 			if con.secret == nil {
-				// Secret is nil indicates close streaming connection to proxy, so that proxy
+				// Secret is nil indicates close streaming to proxy, so that proxy
 				// could connect again with updated token.
 				// When nodeagent stops stream by sending envoy error response, it's Ok not to remove secret
 				// from secret cache because cache has auto-evication.
-				log.Debugf("Close connection with %q", con.proxyID)
-				return fmt.Errorf("streaming connection with %q closed", con.proxyID)
+				log.Debugf("Close streaming for proxy %q", con.proxyID)
+				return fmt.Errorf("streaming for proxy %q closed", con.proxyID)
 			}
 
 			if err := pushSDS(con); err != nil {

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -76,6 +76,9 @@ type Options struct {
 
 	// The Vault TLS root certificate.
 	VaultTLSRootCert string
+
+	// AlwaysValidTokenFlag is set to true for if token used is always valid(ex, normal k8s JWT)
+	AlwaysValidTokenFlag bool
 }
 
 // Server is the gPRC server that exposes SDS through UDS.


### PR DESCRIPTION
one example of always valid token is normal k8s jwt, in this case, node agent don't send err by envoy to end the stream, instead just push the update key/cert to envoy directly

and merge https://github.com/istio/istio/pull/11101

https://github.com/istio/istio/issues/9035
