### PR TITLE
Allow passing command line options to Node Agent

### DIFF
--- a/security/docker/Dockerfile.node-agent-k8s
+++ b/security/docker/Dockerfile.node-agent-k8s
@@ -2,4 +2,4 @@ FROM ubuntu:16.04
 ADD node_agent_k8s /
 RUN apt-get update && apt-get install -y ca-certificates
 RUN chmod 755 /node_agent_k8s
-CMD ["/node_agent_k8s"]
+ENTRYPOINT ["/node_agent_k8s"]


### PR DESCRIPTION
Allow passing command line options to Node Agent, so that an user can set logging level for Node Agent.

With this PR, Node Agent's logging level can be passed through as a command line option for Node Agent. A yaml example to set the logging level of Node Agent to "debug" is as follows:

    - name: node-agent
        image: gcr.io/istio-releases/node-agent-k8s
        imagePullPolicy: Always
        args:
        - --log_output_level
        - "default:debug"
        env:
        - name: CA_ADDR 