### PR TITLE
Disable MCP when installing Istio minimal

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-minimal.yaml
+++ b/install/kubernetes/helm/istio/values-istio-minimal.yaml
@@ -40,5 +40,7 @@ global:
       enabled: false
       host: # example: statsd-svc
       port: # example: 9125
+  
+  useMCP: false
 
 


### PR DESCRIPTION
Added a flag that disables the MCP flag when installing with the Istio minimal values.