### PR TITLE
Reduce racetest/test flakiness by setting mixer tests parallelism to 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,10 +450,10 @@ test: | $(JUNIT_REPORT)
 	$(MAKE) --keep-going $(TEST_OBJ) \
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_UNIT_TEST_XML))
 
-GOTEST_PARALLEL ?= '-test.parallel=2'
+GOTEST_PARALLEL ?= '-test.parallel=1'
 # This is passed to mixer and other tests to limit how many builds are used.
 # In CircleCI, set in "Project Settings" -> "Environment variables" as "-p 2" if you don't have xlarge machines
-GOTEST_P ?=
+GOTEST_P ?= '-p 1'
 GOSTATIC = -ldflags '-extldflags "-static"'
 
 TEST_APP_BINS:=${ISTIO_OUT}/pkg-test-application-echo-server ${ISTIO_OUT}/pkg-test-application-echo-client

--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ istioctl-racetest: istioctl
 .PHONY: mixer-racetest
 mixer-racetest: mixs
 	# Some tests use relative path "testdata", must be run from mixer dir
-	(cd mixer; RACE_TEST=true go test ${T} -race ${GOTEST_PARALLEL} ./...)
+	(cd mixer; RACE_TEST=true go test ${T} -race ./...)
 
 .PHONY: galley-racetest
 galley-racetest: depend

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ test: | $(JUNIT_REPORT)
 GOTEST_PARALLEL ?= '-test.parallel=1'
 # This is passed to mixer and other tests to limit how many builds are used.
 # In CircleCI, set in "Project Settings" -> "Environment variables" as "-p 2" if you don't have xlarge machines
-GOTEST_P ?= '-p 1'
+GOTEST_P ?=
 GOSTATIC = -ldflags '-extldflags "-static"'
 
 TEST_APP_BINS:=${ISTIO_OUT}/pkg-test-application-echo-server ${ISTIO_OUT}/pkg-test-application-echo-client
@@ -491,7 +491,7 @@ istioctl-test: istioctl
 MIXER_TEST_T ?= ${T} ${GOTEST_PARALLEL}
 mixer-test: mixs
 	# Some tests use relative path "testdata", must be run from mixer dir
-	(cd mixer; go test ${GOTEST_P} ${MIXER_TEST_T} ./...)
+	(cd mixer; go test -p 1 ${MIXER_TEST_T} ./...)
 
 .PHONY: galley-test
 galley-test: depend

--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,7 @@ istioctl-racetest: istioctl
 .PHONY: mixer-racetest
 mixer-racetest: mixs
 	# Some tests use relative path "testdata", must be run from mixer dir
-	(cd mixer; RACE_TEST=true go test ${T} -race ./...)
+	(cd mixer; RACE_TEST=true go test -p 1 ${T} -race ./...)
 
 .PHONY: galley-racetest
 galley-racetest: depend


### PR DESCRIPTION
Recently (past few weeks) the `racetest` is very flaky and typically fails on one of the Mixer adapters.
Examining the logs shows build errors such:
```sh
/usr/local/go/pkg/tool/linux_amd64/link: signal: killed
# istio.io/istio/mixer/adapter/bypass.test
/usr/local/go/pkg/tool/linux_amd64/link: flushing $WORK/b652/bypass.test: write $WORK/b652/bypass.test: cannot allocate memory
FAIL	istio.io/istio/mixer/adapter/bypass [build failed]
```
Which hints a lack of memory.
Trying to workaround it by setting mixer racetest parallelism to single process.

Related issue: #11122