### PR TITLE
Remove keepalive maximum connection age grace from command line options

### DIFF
--- a/pkg/keepalive/options.go
+++ b/pkg/keepalive/options.go
@@ -43,7 +43,7 @@ type Options struct {
 	MaxServerConnectionAge time.Duration // default value is infinity
 	// MaxServerConnectionAgeGrace is an additive period after MaxServerConnectionAge
 	// after which the connection will be forcibly closed by the server.
-	MaxServerConnectionAgeGrace time.Duration // default value is infinity
+	MaxServerConnectionAgeGrace time.Duration // default value 10s
 }
 
 // DefaultOption returns the default keepalive options.
@@ -52,7 +52,7 @@ func DefaultOption() *Options {
 		Time:                        30 * time.Second,
 		Timeout:                     10 * time.Second,
 		MaxServerConnectionAge:      Infinity,
-		MaxServerConnectionAgeGrace: Infinity,
+		MaxServerConnectionAgeGrace: 10 * time.Second,
 	}
 }
 
@@ -68,7 +68,4 @@ func (o *Options) AttachCobraFlags(cmd *cobra.Command) {
 			"and if no activity is seen even after that the connection is closed.")
 	cmd.PersistentFlags().DurationVar(&o.MaxServerConnectionAge, "keepaliveMaxServerConnectionAge",
 		o.MaxServerConnectionAge, "Maximum duration a connection will be kept open on the server before a graceful close.")
-	cmd.PersistentFlags().DurationVar(&o.MaxServerConnectionAgeGrace, "keepaliveMaxServerConnectionAgeGrace",
-		o.MaxServerConnectionAgeGrace, "Grace duration allowed before a server connection is forcibly closed "+
-			"after MaxServerConnectionAge expires.")
 }

--- a/pkg/keepalive/options_test.go
+++ b/pkg/keepalive/options_test.go
@@ -18,8 +18,6 @@ func TestAgeDefaultsToInfinite(t *testing.T) {
 
 	if ko.MaxServerConnectionAge != keepalive.Infinity {
 		t.Errorf("%s maximum connection age %v", t.Name(), ko.MaxServerConnectionAge)
-	} else if ko.MaxServerConnectionAgeGrace != keepalive.Infinity {
-		t.Errorf("%s maximum connection age grace %v", t.Name(), ko.MaxServerConnectionAgeGrace)
 	}
 }
 
@@ -34,7 +32,6 @@ func TestSetConnectionAgeCommandlineOptions(t *testing.T) {
 	sec := 1 * time.Second
 	cmd.SetArgs([]string{
 		fmt.Sprintf("--keepaliveMaxServerConnectionAge=%v", sec),
-		fmt.Sprintf("--keepaliveMaxServerConnectionAgeGrace=%v", sec),
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -42,7 +39,5 @@ func TestSetConnectionAgeCommandlineOptions(t *testing.T) {
 	}
 	if ko.MaxServerConnectionAge != sec {
 		t.Errorf("%s maximum connection age %v", t.Name(), ko.MaxServerConnectionAge)
-	} else if ko.MaxServerConnectionAgeGrace != sec {
-		t.Errorf("%s maximum connection age grace %v", t.Name(), ko.MaxServerConnectionAgeGrace)
 	}
 }


### PR DESCRIPTION
Per discussion on #7878, removed command line setting of maximum age **grace**, which is always set to 10 seconds. Only the maximum connection age is under user control.