### PR TITLE
Fix a crash loop when app calls itself via service VIP or endpoint

### DIFF
--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -291,19 +291,13 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
-# Redirect app calls to back itself via Envoy when using the service VIP or endpoint
-# address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
-
 for uid in ${PROXY_UID}; do
-  # Avoid infinite loops. Don't redirect Envoy traffic directly back to
-  # Envoy for non-loopback traffic.
+  # Avoid infinite loops. Don't redirect Envoy traffic directly back to Envoy.
   iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner ${uid} -j RETURN
 done
 
 for gid in ${PROXY_GID}; do
-  # Avoid infinite loops. Don't redirect Envoy traffic directly back to
-  # Envoy for non-loopback traffic.
+  # Avoid infinite loops. Don't redirect Envoy traffic directly back to Envoy.
   iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner ${gid} -j RETURN
 done
 


### PR DESCRIPTION
The line that gets removed, "iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT" would redirect traffic from Envoy back to Envoy and cause crash loop when app calls to back itself via Envoy using the service VIP or endpoint address. The expected behavior can be achieved by the rules for regular cases, no special rule needed.