### PR TITLE
Fix a crash loop caused by redirection on Envoy's outbound traffic.

### DIFF
--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -291,19 +291,13 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
-# Redirect app calls to back itself via Envoy when using the service VIP or endpoint
-# address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
-
 for uid in ${PROXY_UID}; do
-  # Avoid infinite loops. Don't redirect Envoy traffic directly back to
-  # Envoy for non-loopback traffic.
+  # Avoid infinite loops. Don't redirect Envoy traffic directly back to Envoy.
   iptables -t nat -A ISTIO_OUTPUT -m owner --uid-owner ${uid} -j RETURN
 done
 
 for gid in ${PROXY_GID}; do
-  # Avoid infinite loops. Don't redirect Envoy traffic directly back to
-  # Envoy for non-loopback traffic.
+  # Avoid infinite loops. Don't redirect Envoy traffic directly back to Envoy.
   iptables -t nat -A ISTIO_OUTPUT -m owner --gid-owner ${gid} -j RETURN
 done
 


### PR DESCRIPTION
The rule that gets removed, "iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT" would redirect traffic out from Envoy back to Envoy. No special rule needed when app calls itself via Envoy using the service VIP or endpoint address, it's covered by rules for normal cases.