### PR TITLE
remove cached secret immediately after stream close

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache.go
+++ b/security/pkg/nodeagent/cache/secretcache.go
@@ -98,6 +98,9 @@ type SecretManager interface {
 
 	// SecretExist checks if secret already existed.
 	SecretExist(proxyID, resourceName, token, version string) bool
+
+	// DeleteSecret deletes a secret by its key from cache.
+	DeleteSecret(proxyID, resourceName string)
 }
 
 // ConnKey is the key of one SDS connection.
@@ -211,6 +214,15 @@ func (sc *SecretCache) GenerateSecret(ctx context.Context, proxyID, resourceName
 	}
 	sc.secrets.Store(key, *ns)
 	return ns, nil
+}
+
+// DeleteSecret deletes a secret by its key from cache.
+func (sc *SecretCache) DeleteSecret(proxyID, resourceName string) {
+	key := ConnKey{
+		ProxyID:      proxyID,
+		ResourceName: resourceName,
+	}
+	sc.secrets.Delete(key)
 }
 
 // DeleteK8sSecret deletes all entries that match secretName. This is called when a K8s secret

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -168,8 +168,8 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 		atomic.StoreUint32(&sc.skipTokenExpireCheck, 1)
 	}()
 
-	testProxyId := "proxy1-id"
-	_, err := sc.GenerateSecret(context.Background(), testProxyId, testResourceName, "jwtToken1")
+	testProxyID := "proxy1-id"
+	_, err := sc.GenerateSecret(context.Background(), testProxyID, testResourceName, "jwtToken1")
 	if err != nil {
 		t.Fatalf("Failed to get secrets: %v", err)
 	}
@@ -192,14 +192,14 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 	}
 
 	key := ConnKey{
-		ProxyID:      testProxyId,
+		ProxyID:      testProxyID,
 		ResourceName: testResourceName,
 	}
 	if _, ok := sc.secrets.Load(key); ok != true {
 		t.Errorf("Failed to find secret for %+v from cache", key)
 	}
 
-	sc.DeleteSecret(testProxyId, testResourceName)
+	sc.DeleteSecret(testProxyID, testResourceName)
 	if _, ok := sc.secrets.Load(key); ok != false {
 		t.Errorf("Found deleted secret for %+v from cache", key)
 	}

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -195,12 +195,12 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 		ProxyID:      testProxyID,
 		ResourceName: testResourceName,
 	}
-	if _, found := sc.secrets.Load(key); found != true {
+	if _, found := sc.secrets.Load(key); !found {
 		t.Errorf("Failed to find secret for %+v from cache", key)
 	}
 
 	sc.DeleteSecret(testProxyID, testResourceName)
-	if _, found := sc.secrets.Load(key); found != false {
+	if _, found := sc.secrets.Load(key); found {
 		t.Errorf("Found deleted secret for %+v from cache", key)
 	}
 }

--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -195,12 +195,12 @@ func TestWorkloadAgentRefreshSecret(t *testing.T) {
 		ProxyID:      testProxyID,
 		ResourceName: testResourceName,
 	}
-	if _, ok := sc.secrets.Load(key); ok != true {
+	if _, found := sc.secrets.Load(key); found != true {
 		t.Errorf("Failed to find secret for %+v from cache", key)
 	}
 
 	sc.DeleteSecret(testProxyID, testResourceName)
-	if _, ok := sc.secrets.Load(key); ok != false {
+	if _, found := sc.secrets.Load(key); found != false {
 		t.Errorf("Found deleted secret for %+v from cache", key)
 	}
 }

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -71,7 +71,7 @@ type sdsConnection struct {
 	// The ID of proxy from which the connection comes from.
 	proxyID string
 
-	// The ResourceName of SDS request.
+	// The ResourceName of the SDS request.
 	ResourceName string
 
 	// Sending on this channel results in  push.
@@ -172,7 +172,8 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			addConn(key, con)
 			defer func() {
 				removeConn(key)
-				// Remove the secret from cache.
+				// Remove the secret from cache, otherwise refresh job will process this item(if envoy fails to reconnect)
+				// and cause some confusing logs like 'fails to notify because connection isn't found'.
 				s.st.DeleteSecret(con.proxyID, con.ResourceName)
 			}()
 

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -71,6 +71,9 @@ type sdsConnection struct {
 	// The ID of proxy from which the connection comes from.
 	proxyID string
 
+	// The ResourceName of SDS request.
+	ResourceName string
+
 	// Sending on this channel results in  push.
 	pushChannel chan *sdsEvent
 
@@ -139,12 +142,13 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 
 			log.Debugf("Received discovery request from %q", discReq.Node.Id)
 
-			con.proxyID = discReq.Node.Id
 			resourceName, err := parseDiscoveryRequest(discReq)
 			if err != nil {
 				log.Errorf("Failed to parse discovery request: %v", err)
 				return err
 			}
+			con.proxyID = discReq.Node.Id
+			con.ResourceName = resourceName
 
 			// When nodeagent receives StreamSecrets request, if there is cached secret which matches
 			// request's <token, resourceName, Version>, then this request is a confirmation request.
@@ -166,7 +170,11 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 				ResourceName: resourceName,
 			}
 			addConn(key, con)
-			defer removeConn(key)
+			defer func() {
+				removeConn(key)
+				// Remove the secret from cache.
+				s.st.DeleteSecret(con.proxyID, con.ResourceName)
+			}()
 
 			if err := pushSDS(con); err != nil {
 				log.Errorf("SDS failed to push key/cert to proxy %q: %v", con.proxyID, err)

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -296,8 +296,8 @@ func TestStreamSecretsPush(t *testing.T) {
 		ProxyID:      proxyID,
 		ResourceName: req.ResourceNames[0],
 	}
-	if _, found := st.secrets.Load(key); found != true {
-		t.Errorf("failed to find cached secret")
+	if _, found := st.secrets.Load(key); !found {
+		t.Errorf("Failed to find cached secret")
 	}
 
 	// Test push nil secret(indicates close the streaming connection) to proxy.
@@ -311,8 +311,8 @@ func TestStreamSecretsPush(t *testing.T) {
 	if len(sdsClients) != 0 {
 		t.Errorf("sdsClients, got %d, expected 0", len(sdsClients))
 	}
-	if _, found := st.secrets.Load(key); found != false {
-		t.Errorf("found cached secret after stream close, expected the secret to not exist")
+	if _, found := st.secrets.Load(key); found {
+		t.Errorf("Found cached secret after stream close, expected the secret to not exist")
 	}
 }
 

--- a/security/pkg/nodeagent/sds/sdsservice_test.go
+++ b/security/pkg/nodeagent/sds/sdsservice_test.go
@@ -296,7 +296,7 @@ func TestStreamSecretsPush(t *testing.T) {
 		ProxyID:      proxyID,
 		ResourceName: req.ResourceNames[0],
 	}
-	if _, ok := st.secrets.Load(key); ok != true {
+	if _, found := st.secrets.Load(key); found != true {
 		t.Errorf("failed to find cached secret")
 	}
 
@@ -311,8 +311,8 @@ func TestStreamSecretsPush(t *testing.T) {
 	if len(sdsClients) != 0 {
 		t.Errorf("sdsClients, got %d, expected 0", len(sdsClients))
 	}
-	if _, ok := st.secrets.Load(key); ok != false {
-		t.Errorf("found cached secret after stream close, expected non-exist")
+	if _, found := st.secrets.Load(key); found != false {
+		t.Errorf("found cached secret after stream close, expected the secret to not exist")
 	}
 }
 


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035

remove cached item immediately rather than wait the auto-eviction to happen, otherwise periodical refresh job will process this item and cause some confusing logs  