### PR TITLE
Galley: Refactor runtime to support multiple processing paths

### DIFF
--- a/galley/pkg/runtime/processing/dispatcher.go
+++ b/galley/pkg/runtime/processing/dispatcher.go
@@ -39,8 +39,6 @@ func (d *Dispatcher) Handle(e resource.Event) {
 	for _, h := range handlers {
 		h.Handle(e)
 	}
-
-	return
 }
 
 // DispatcherBuilder builds Dispatchers

--- a/galley/pkg/runtime/processing/dispatcher.go
+++ b/galley/pkg/runtime/processing/dispatcher.go
@@ -1,0 +1,72 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain accumulator copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing
+
+import (
+	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/pkg/log"
+)
+
+var scope = log.RegisterScope("processing", "Galley data processing", 0)
+
+// Dispatcher is a Handler that can dispatch events to other Handlers, based on Collection.
+type Dispatcher struct {
+	handlers map[resource.Collection][]Handler
+}
+
+var _ Handler = &Dispatcher{}
+
+// Handle implements Handler
+func (d *Dispatcher) Handle(e resource.Event) {
+	handlers, found := d.handlers[e.Entry.ID.Collection]
+	if !found {
+		scope.Warnf("Unhandled resource event: %v", e)
+		return
+	}
+
+	for _, h := range handlers {
+		h.Handle(e)
+	}
+
+	return
+}
+
+// DispatcherBuilder builds Dispatchers
+type DispatcherBuilder struct {
+	handlers map[resource.Collection][]Handler
+}
+
+// NewDispatcherBuilder returns a new dispatcher dispatcher
+func NewDispatcherBuilder() *DispatcherBuilder {
+	return &DispatcherBuilder{
+		handlers: make(map[resource.Collection][]Handler),
+	}
+}
+
+// Add a new handler for the given Collection
+func (d *DispatcherBuilder) Add(t resource.Collection, h Handler) {
+	handlers := d.handlers[t]
+	handlers = append(handlers, h)
+	d.handlers[t] = handlers
+}
+
+// Build a Dispatcher
+func (d *DispatcherBuilder) Build() *Dispatcher {
+	r := &Dispatcher{
+		handlers: d.handlers,
+	}
+	d.handlers = nil
+	return r
+}

--- a/galley/pkg/runtime/processing/dispatcher_test.go
+++ b/galley/pkg/runtime/processing/dispatcher_test.go
@@ -1,0 +1,77 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing_test
+
+import (
+	"testing"
+
+	"istio.io/istio/galley/pkg/runtime/processing"
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
+
+func TestDispatcher_Handle(t *testing.T) {
+	b := processing.NewDispatcherBuilder()
+
+	fh1 := &fakeHandler{}
+	fh2 := &fakeHandler{}
+	fh3 := &fakeHandler{}
+	b.Add(emptyInfo.Collection, fh1)
+	b.Add(emptyInfo.Collection, fh2)
+	b.Add(structInfo.Collection, fh3)
+	d := b.Build()
+
+	d.Handle(addRes1V1())
+	d.Handle(addRes2V1())
+	if len(fh1.evts) != 2 {
+		t.Fatalf("unexpected events: %v", fh1.evts)
+	}
+	if len(fh2.evts) != 2 {
+		t.Fatalf("unexpected events: %v", fh2.evts)
+	}
+
+	if len(fh3.evts) != 0 {
+		t.Fatalf("unexpected events: %v", fh3.evts)
+	}
+
+	d.Handle(addRes3V1())
+	if len(fh1.evts) != 2 {
+		t.Fatalf("unexpected events: %v", fh1.evts)
+	}
+	if len(fh2.evts) != 2 {
+		t.Fatalf("unexpected events: %v", fh2.evts)
+	}
+
+	if len(fh3.evts) != 1 {
+		t.Fatalf("unexpected events: %v", fh3.evts)
+	}
+}
+
+func TestDispatcher_UnhandledEvent(t *testing.T) {
+	b := processing.NewDispatcherBuilder()
+	d := b.Build()
+
+	d.Handle(addRes1V1())
+	// no panic
+}
+
+type fakeHandler struct {
+	evts []resource.Event
+}
+
+var _ processing.Handler = &fakeHandler{}
+
+func (f *fakeHandler) Handle(e resource.Event) {
+	f.evts = append(f.evts, e)
+}

--- a/galley/pkg/runtime/processing/handler.go
+++ b/galley/pkg/runtime/processing/handler.go
@@ -1,0 +1,41 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain accumulator copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing
+
+import (
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
+
+// Handler handles an incoming resource event.
+type Handler interface {
+	Handle(e resource.Event)
+}
+
+// HandlerFromFn returns a new Handler, based on the Handler function.
+func HandlerFromFn(fn func(e resource.Event)) Handler {
+	return &fnHandler{
+		fn: fn,
+	}
+}
+
+var _ Handler = &fnHandler{}
+
+type fnHandler struct {
+	fn func(e resource.Event)
+}
+
+func (h *fnHandler) Handle(e resource.Event) {
+	h.fn(e)
+}

--- a/galley/pkg/runtime/processing/handler_test.go
+++ b/galley/pkg/runtime/processing/handler_test.go
@@ -1,0 +1,38 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing_test
+
+import (
+	"reflect"
+	"testing"
+
+	"istio.io/istio/galley/pkg/runtime/processing"
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
+
+func TestHandlerFromFn(t *testing.T) {
+	var received resource.Event
+	h := processing.HandlerFromFn(func(e resource.Event) {
+		received = e
+	})
+
+	sent := updateRes1V2()
+
+	h.Handle(sent)
+
+	if !reflect.DeepEqual(received, sent) {
+		t.Fatalf("Mismatch: got:%v, expected:%v", received, sent)
+	}
+}

--- a/galley/pkg/runtime/processing/testdata_test.go
+++ b/galley/pkg/runtime/processing/testdata_test.go
@@ -1,0 +1,121 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing_test
+
+import (
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	"istio.io/istio/galley/pkg/runtime/resource"
+)
+
+var emptyInfo resource.Info
+var structInfo resource.Info
+
+func init() {
+	b := resource.NewSchemaBuilder()
+	emptyInfo = b.Register("empty", "type.googleapis.com/google.protobuf.Empty")
+	structInfo = b.Register("struct", "type.googleapis.com/google.protobuf.Struct")
+	_ = b.Build()
+}
+
+func res1V1() resource.Entry {
+	return resource.Entry{
+		ID: resource.VersionedKey{
+			Version: "v1",
+			Key: resource.Key{
+				Collection: emptyInfo.Collection,
+				FullName:   resource.FullNameFromNamespaceAndName("ns1", "res1"),
+			},
+		},
+		Metadata: resource.Metadata{
+			CreateTime: time.Unix(1, 1),
+		},
+		Item: &types.Empty{},
+	}
+}
+
+func res2V1() resource.Entry {
+	return resource.Entry{
+		ID: resource.VersionedKey{
+			Version: "v1",
+			Key: resource.Key{
+				Collection: emptyInfo.Collection,
+				FullName:   resource.FullNameFromNamespaceAndName("ns1", "res2"),
+			},
+		},
+		Metadata: resource.Metadata{
+			CreateTime: time.Unix(2, 1),
+		},
+		Item: &types.Empty{},
+	}
+}
+
+func res3V1() resource.Entry {
+	return resource.Entry{
+		ID: resource.VersionedKey{
+			Version: "v1",
+			Key: resource.Key{
+				Collection: structInfo.Collection,
+				FullName:   resource.FullNameFromNamespaceAndName("ns2", "res1"),
+			},
+		},
+		Metadata: resource.Metadata{
+			CreateTime: time.Unix(3, 1),
+		},
+		Item: &types.Empty{},
+	}
+}
+
+func addRes1V1() resource.Event {
+	return resource.Event{
+		Kind:  resource.Added,
+		Entry: res1V1(),
+	}
+}
+
+func addRes2V1() resource.Event {
+	return resource.Event{
+		Kind:  resource.Added,
+		Entry: res2V1(),
+	}
+}
+
+func addRes3V1() resource.Event {
+	return resource.Event{
+		Kind:  resource.Added,
+		Entry: res3V1(),
+	}
+}
+
+func updateRes1V2() resource.Event {
+	return resource.Event{
+		Kind: resource.Updated,
+		Entry: resource.Entry{
+			ID: resource.VersionedKey{
+				Version: "v2",
+				Key: resource.Key{
+					Collection: emptyInfo.Collection,
+					FullName:   resource.FullNameFromNamespaceAndName("ns1", "res1"),
+				},
+			},
+			Metadata: resource.Metadata{
+				CreateTime: time.Unix(1, 2),
+			},
+			Item: &types.Empty{},
+		},
+	}
+}

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -15,14 +15,15 @@
 package runtime
 
 import (
-	"github.com/pkg/errors"
-
 	"time"
 
+	"github.com/pkg/errors"
+
 	"istio.io/istio/galley/pkg/metadata"
+	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/mcp/snapshot"
+	sn "istio.io/istio/pkg/mcp/snapshot"
 )
 
 var scope = log.RegisterScope("runtime", "Galley runtime", 0)
@@ -33,25 +34,14 @@ type Processor struct {
 	// source interface for retrieving the events from.
 	source Source
 
-	// distributor interface for publishing config snapshots to.
-	distributor Distributor
-
-	// configuration for the processor
-	config *Config
-
-	// The heuristic publishing strategy
-	strategy *publishingStrategy
-
-	schema *resource.Schema
-
 	// events channel that was obtained from source
 	events chan resource.Event
 
+	// handler for events.
+	handler processing.Handler
+
 	// channel that gets closed during Shutdown.
 	done chan struct{}
-
-	// indicates that the State is built-up enough to warrant distribution.
-	distribute bool
 
 	// channel that signals the background process as being stopped.
 	stopped chan struct{}
@@ -62,42 +52,32 @@ type Processor struct {
 	// hook that gets called after each event processing. Useful for testing.
 	postProcessHook postProcessHookFn
 
-	// pendingEvents counts the number of events awaiting publishing.
-	pendingEvents int64
-
 	// lastEventTime records the last time an event was received.
 	lastEventTime time.Time
-
-	// lastSnapshotTime records the last time a snapshot was published.
-	lastSnapshotTime time.Time
 }
 
 type postProcessHookFn func()
 
 // NewProcessor returns a new instance of a Processor
 func NewProcessor(src Source, distributor Distributor, cfg *Config) *Processor {
-	return newProcessor(src, distributor, cfg, newPublishingStrategyWithDefaults(), metadata.Types, nil)
+	state := newState(sn.DefaultGroup, metadata.Types, cfg, newPublishingStrategyWithDefaults(), distributor)
+	return newProcessor(state, src, nil)
 }
 
 func newProcessor(
+	state *State,
 	src Source,
-	distributor Distributor,
-	cfg *Config,
-	strategy *publishingStrategy,
-	schema *resource.Schema,
 	postProcessHook postProcessHookFn) *Processor {
 
+	now := time.Now()
 	return &Processor{
-		source:           src,
-		distributor:      distributor,
-		config:           cfg,
-		strategy:         strategy,
-		schema:           schema,
-		postProcessHook:  postProcessHook,
-		done:             make(chan struct{}),
-		stopped:          make(chan struct{}),
-		lastEventTime:    time.Now(),
-		lastSnapshotTime: time.Now(),
+		handler:         buildDispatcher(state),
+		state:           state,
+		source:          src,
+		postProcessHook: postProcessHook,
+		done:            make(chan struct{}),
+		stopped:         make(chan struct{}),
+		lastEventTime:   now,
 	}
 }
 
@@ -111,8 +91,6 @@ func (p *Processor) Start() error {
 		return errors.New("already started")
 	}
 
-	p.distribute = false
-
 	events := make(chan resource.Event, 1024)
 	err := p.source.Start(func(e resource.Event) {
 		events <- e
@@ -123,7 +101,6 @@ func (p *Processor) Start() error {
 	}
 
 	p.events = events
-	p.state = newState(p.schema, p.config)
 
 	go p.process()
 
@@ -147,8 +124,6 @@ func (p *Processor) Stop() {
 
 	p.events = nil
 	p.done = nil
-	p.state = nil
-	p.distribute = false
 }
 
 func (p *Processor) process() {
@@ -160,15 +135,11 @@ loop:
 
 		// Incoming events are received through p.events
 		case e := <-p.events:
-			scope.Debugf("Processor.process: event: %v", e)
-			if p.processEvent(e) {
-				scope.Debugf("Processor.process: event: %v, signaling onChange", e)
-				p.strategy.onChange()
-			}
+			p.processEvent(e)
 
-		case <-p.strategy.publish:
+		case <-p.state.strategy.publish:
 			scope.Debug("Processor.process: publish")
-			p.publish()
+			p.state.publish()
 
 		// p.done signals the graceful Shutdown of the processor.
 		case <-p.done:
@@ -181,33 +152,36 @@ loop:
 		}
 	}
 
-	p.strategy.reset()
+	p.state.close()
 	close(p.stopped)
 	scope.Debugf("Process.process: Exiting process loop")
 }
 
-func (p *Processor) processEvent(e resource.Event) bool {
+func (p *Processor) processEvent(e resource.Event) {
 	scope.Debugf("Incoming source event: %v", e)
-	now := time.Now()
-	recordProcessorEventProcessed(now.Sub(p.lastEventTime))
-	p.lastEventTime = now
-	p.pendingEvents++
+	p.recordEvent()
 
 	if e.Kind == resource.FullSync {
 		scope.Infof("Synchronization is complete, starting distribution.")
-		p.distribute = true
-		return true
+		p.state.onFullSync()
+		return
 	}
 
-	return p.state.apply(e) && p.distribute
+	p.handler.Handle(e)
 }
 
-func (p *Processor) publish() {
+func (p *Processor) recordEvent() {
 	now := time.Now()
-	recordProcessorSnapshotPublished(p.pendingEvents, now.Sub(p.lastSnapshotTime))
-	p.lastSnapshotTime = now
-	sn := p.state.buildSnapshot()
+	recordProcessorEventProcessed(now.Sub(p.lastEventTime))
+	p.lastEventTime = now
+}
 
-	p.distributor.SetSnapshot(snapshot.DefaultGroup, sn)
-	p.pendingEvents = 0
+func buildDispatcher(states ...*State) *processing.Dispatcher {
+	b := processing.NewDispatcherBuilder()
+	for _, state := range states {
+		for _, spec := range state.schema.All() {
+			b.Add(spec.Collection, state)
+		}
+	}
+	return b.Build()
 }

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -81,7 +81,7 @@ func TestProcessor_Stop(t *testing.T) {
 	strategy := newPublishingStrategyWithDefaults()
 	cfg := &Config{Mesh: meshconfig.NewInMemory()}
 
-	p := newProcessor(src, distributor, cfg, strategy, testSchema, nil)
+	p := newProcessor(newState(snapshot.DefaultGroup, testSchema, cfg, strategy, distributor), src, nil)
 
 	err := p.Start()
 	if err != nil {
@@ -101,7 +101,7 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 	strategy := newPublishingStrategy(time.Hour, time.Hour, time.Millisecond)
 	cfg := &Config{Mesh: meshconfig.NewInMemory()}
 
-	p := newProcessor(src, distributor, cfg, strategy, testSchema, nil)
+	p := newProcessor(newState(snapshot.DefaultGroup, testSchema, cfg, strategy, distributor), src, nil)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -127,7 +127,7 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 	strategy := newPublishingStrategy(time.Hour, time.Hour, time.Millisecond)
 	cfg := &Config{Mesh: meshconfig.NewInMemory()}
 
-	p := newProcessor(src, distributor, cfg, strategy, testSchema, nil)
+	p := newProcessor(newState(snapshot.DefaultGroup, testSchema, cfg, strategy, distributor), src, nil)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -158,7 +158,7 @@ func TestProcessor_Publishing(t *testing.T) {
 	}
 	processCallCount.Add(3) // 1 for add, 1 for sync, 1 for publish trigger
 
-	p := newProcessor(src, distributor, cfg, strategy, testSchema, hookFn)
+	p := newProcessor(newState(snapshot.DefaultGroup, testSchema, cfg, strategy, distributor), src, hookFn)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
This PR is just transferring a few things from processor into state, in anticipation of supporting multiple processing paths. The next step will be to have a second state specifically for generating synthetic ServieEntry resources.

Supporting work for #10589 and #10497