### PR TITLE
Adjust codecov threshold

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -47,6 +47,7 @@ function cleanup() {
 trap cleanup EXIT
 
 # Setup environment needed by some tests.
+make sync
 make localTestEnv
 
 # coverage test needs to run one package per command.

--- a/bin/codecov_diff.sh
+++ b/bin/codecov_diff.sh
@@ -47,6 +47,7 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
 
   go get -u istio.io/test-infra/toolbox/githubctl
   BASE_SHA=$("${GOPATH}"/bin/githubctl --token_file="${TMP_GITHUB_TOKEN}" --op=getBaseSHA --repo=istio --pr_num="${CIRCLE_PR_NUMBER}")
+  git reset HEAD --hard
   git clean -f -d
   git checkout "${BASE_SHA}"
 
@@ -56,6 +57,7 @@ if [[ -n "${CIRCLE_PR_NUMBER:-}" ]]; then
   OUT_DIR="${BASELINE_PATH}" MAXPROCS="${MAXPROCS:-}" CODECOV_SKIP="${CODECOV_SKIP:-}" ./bin/codecov.sh
 
   # Get back to the PR head
+  git reset HEAD --hard
   git clean -f -d
   git checkout "${CIRCLE_SHA1}"
 

--- a/codecov.threshold
+++ b/codecov.threshold
@@ -21,10 +21,13 @@ istio.io/istio/pilot/pkg/config/memory/monitor.go=30
 istio.io/istio/pilot/pkg/proxy/envoy/v2=10
 istio.io/istio/pilot/pkg/serviceregistry/consul/monitor.go=20
 istio.io/istio/pkg/mcp/creds/watcher.go=100
+istio.io/istio/security/pkg/nodeagent=15
+
+# Disable codecov check for testing and proto packages
+istio.io/istio/galley/pkg/testing=100	istio.io/istio/galley/pkg/testing=100
 istio.io/istio/pkg/test=100
 istio.io/istio/security/proto=100
-istio.io/istio/security/pkg/nodeagent=15
-istio.io/istio/galley/pkg/testing=100
+istio.io/istio/tests=100
 
 # Temporary until integ tests are restored
 istio.io/istio/pilot/pkg/networking/plugin=50


### PR DESCRIPTION
* Add "istio.io/istio/tests=100" to codecov.threshold to ignore test only package.

* Update bin/codecov_diff.sh to explicitly resets to HEAD before doing checkout.

* Add "make sync" to bin/codecov.sh to prepare for integration test job (they still cannot be enabled due to port conflict (see https://github.com/istio/istio/issues/11172)