### PR TITLE
[WIP] remove configStore from native and use galley instead.

### DIFF
--- a/pkg/test/framework/api/descriptors/descriptors.go
+++ b/pkg/test/framework/api/descriptors/descriptors.go
@@ -39,7 +39,6 @@ var (
 		ID:                ids.Pilot,
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
-			&ids.Mixer,
 			&ids.Environment,
 			&ids.Galley,
 		},

--- a/pkg/test/framework/runtime/components/pilot/native.go
+++ b/pkg/test/framework/runtime/components/pilot/native.go
@@ -101,11 +101,11 @@ func (c *nativeComponent) Start(ctx context.Instance, scope lifecycle.Scope) (er
 	}
 
 	bootstrapArgs := bootstrap.PilotArgs{
-		Namespace:        env.Namespace,
-		DiscoveryOptions: options,
-		MeshConfig:       env.Mesh,
-		MCPServerAddrs:   []string{galley.GetGalleyAddress()},
-                MCPMaxMessageSize: 1024 * 1024 * 4,
+		Namespace:         env.Namespace,
+		DiscoveryOptions:  options,
+		MeshConfig:        env.Mesh,
+		MCPServerAddrs:    []string{galley.GetGalleyAddress()},
+		MCPMaxMessageSize: 1024 * 1024 * 4,
 		Config: bootstrap.ConfigArgs{
 			Controller: env.ServiceManager.ConfigStore,
 		},

--- a/pkg/test/framework/runtime/components/pilot/native.go
+++ b/pkg/test/framework/runtime/components/pilot/native.go
@@ -105,6 +105,7 @@ func (c *nativeComponent) Start(ctx context.Instance, scope lifecycle.Scope) (er
 		DiscoveryOptions: options,
 		MeshConfig:       env.Mesh,
 		MCPServerAddrs:   []string{galley.GetGalleyAddress()},
+                MCPMaxMessageSize: 1024 * 1024 * 4,
 		Config: bootstrap.ConfigArgs{
 			Controller: env.ServiceManager.ConfigStore,
 		},


### PR DESCRIPTION
1. remove configStore from native and use galley instead.
2. pilot -> galley, mixer -> galley