### PR TITLE
Fix enableNamespacesByDefault when installing istio as helm chart

### DIFF
--- a/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
+++ b/install/kubernetes/helm/subcharts/sidecarInjectorWebhook/templates/mutatingwebhook.yaml
@@ -25,6 +25,10 @@ webhooks:
     namespaceSelector:
 {{- if .Values.enableNamespacesByDefault }}
       matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - {{ .Release.Namespace }}
       - key: istio-injection
         operator: NotIn
         values:


### PR DESCRIPTION
Value `sidecarInjectorWebhook.enableNamespacesByDefault` has troubles when istio is installed via helm, because namespace where istio is installed cannot be labeld with `istio-injection=disabled`. However, since version 2.10 helm adds label `name` to created namespace (helm/helm#4231). This PR leverages that to exclude istio namespace explicitly in webhook configuration.

Fixes: #10884  