### PR TITLE
Remove template dependency from istio parent chart

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -73,7 +73,9 @@ spec:
         configMap:
           name: kiali
 {{- $nodeAffinity := or (include "nodeaffinity" .) "" -}}
-{{- if ne $nodeAffinity "" }}
+{{- $nodeAffinityPreferredDuringScheduling := or (include "nodeAffinityPreferredDuringScheduling" .) "" -}}
+{{- $nodeAffinityRequiredDuringScheduling := or (include "nodeAffinityRequiredDuringScheduling" .) "" -}}
+{{- if and (ne $nodeAffinityPreferredDuringScheduling "") (ne $nodeAffinityRequiredDuringScheduling "") }}
       affinity:
       {{- printf "%s" $nodeAffinity | indent 6 }}
 {{- end }}

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -72,5 +72,7 @@ spec:
       - name: kiali-configuration
         configMap:
           name: kiali
+{{- if .Values.nodeaffinityTemplate  }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
+{{- end }}

--- a/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/deployment.yaml
@@ -72,7 +72,8 @@ spec:
       - name: kiali-configuration
         configMap:
           name: kiali
-{{- if .Values.nodeaffinityTemplate  }}
+{{- $nodeAffinity := or (include "nodeaffinity" .) "" -}}
+{{- if ne $nodeAffinity "" }}
       affinity:
-      {{- include "nodeaffinity" . | indent 6 }}
+      {{- printf "%s" $nodeAffinity | indent 6 }}
 {{- end }}


### PR DESCRIPTION
nodeaffinity template is defined on  [istio chart](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/templates/_affinity.tpl), in case you need to install this chart as a separate one will not work because of this dependency. I'm unsure if without those node affinity rules may break something for kiali, I guess this is just to be consistent with Istio deployment.