### PR TITLE
Adding --controlPlaneBootstrap pilot-agent flag

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -241,7 +241,8 @@ var (
 			}
 
 			log.Infof("Monitored certs: %#v", certs)
-
+			
+			// TODO: change Mixer and Pilot to use standard template and deprecate this custom bootstrap parser
 			if controlPlaneBootstrap {
 				if templateFile != "" && proxyConfig.CustomConfigFile == "" {
 					opts := make(map[string]string)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -54,6 +54,7 @@ var (
 
 	// proxy config flags (named identically)
 	configPath               string
+	controlPlaneBootstrap    bool
 	binaryPath               string
 	serviceCluster           string
 	drainDuration            time.Duration
@@ -241,37 +242,41 @@ var (
 
 			log.Infof("Monitored certs: %#v", certs)
 
-			if templateFile != "" && proxyConfig.CustomConfigFile == "" {
-				opts := make(map[string]string)
-				opts["PodName"] = os.Getenv("POD_NAME")
-				opts["PodNamespace"] = os.Getenv("POD_NAMESPACE")
-				opts["MixerSubjectAltName"] = envoy.GetMixerSAN(opts["PodNamespace"])
+			if controlPlaneBootstrap {
+				if templateFile != "" && proxyConfig.CustomConfigFile == "" {
+					opts := make(map[string]string)
+					opts["PodName"] = os.Getenv("POD_NAME")
+					opts["PodNamespace"] = os.Getenv("POD_NAMESPACE")
+					opts["MixerSubjectAltName"] = envoy.GetMixerSAN(opts["PodNamespace"])
 
-				// protobuf encoding of IP_ADDRESS type
-				opts["PodIP"] = base64.StdEncoding.EncodeToString(net.ParseIP(os.Getenv("INSTANCE_IP")))
+					// protobuf encoding of IP_ADDRESS type
+					opts["PodIP"] = base64.StdEncoding.EncodeToString(net.ParseIP(os.Getenv("INSTANCE_IP")))
 
-				if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
-					opts["ControlPlaneAuth"] = "enable"
+					if proxyConfig.ControlPlaneAuthPolicy == meshconfig.AuthenticationPolicy_MUTUAL_TLS {
+						opts["ControlPlaneAuth"] = "enable"
+					}
+					if disableInternalTelemetry {
+						opts["DisableReportCalls"] = "true"
+					}
+					tmpl, err := template.ParseFiles(templateFile)
+					if err != nil {
+						return err
+					}
+					var buffer bytes.Buffer
+					err = tmpl.Execute(&buffer, opts)
+					if err != nil {
+						return err
+					}
+					content := buffer.Bytes()
+					log.Infof("Static config:\n%s", string(content))
+					proxyConfig.CustomConfigFile = proxyConfig.ConfigPath + "/envoy.yaml"
+					err = ioutil.WriteFile(proxyConfig.CustomConfigFile, content, 0644)
+					if err != nil {
+						return err
+					}
 				}
-				if disableInternalTelemetry {
-					opts["DisableReportCalls"] = "true"
-				}
-				tmpl, err := template.ParseFiles(templateFile)
-				if err != nil {
-					return err
-				}
-				var buffer bytes.Buffer
-				err = tmpl.Execute(&buffer, opts)
-				if err != nil {
-					return err
-				}
-				content := buffer.Bytes()
-				log.Infof("Static config:\n%s", string(content))
-				proxyConfig.CustomConfigFile = proxyConfig.ConfigPath + "/envoy.yaml"
-				err = ioutil.WriteFile(proxyConfig.CustomConfigFile, content, 0644)
-				if err != nil {
-					return err
-				}
+			} else if templateFile != "" && proxyConfig.CustomConfigFile == "" {
+				proxyConfig.ProxyBootstrapTemplatePath = templateFile
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -441,6 +446,8 @@ func init() {
 		"Go template bootstrap config")
 	proxyCmd.PersistentFlags().BoolVar(&disableInternalTelemetry, "disableInternalTelemetry", false,
 		"Disable internal telemetry")
+	proxyCmd.PersistentFlags().BoolVar(&controlPlaneBootstrap, "controlPlaneBootstrap", true,
+		"Process bootstrap provided via templateFile to be used by control plane components.")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -241,7 +241,7 @@ var (
 			}
 
 			log.Infof("Monitored certs: %#v", certs)
-			
+
 			// TODO: change Mixer and Pilot to use standard template and deprecate this custom bootstrap parser
 			if controlPlaneBootstrap {
 				if templateFile != "" && proxyConfig.CustomConfigFile == "" {


### PR DESCRIPTION
Adding --controlPlaneBootstrap pilot-agent flag to explicitly enable
generation of Envoy bootstrap for Istio control plane components. Only
effective when --templateFile is provided as well.

If --templateFile is provided, but --controlPlaneBootstrap=false, then
template file will be passed through regular bootstrap config
processing, replacing default bootstrap config template.

Default flag value is "true" to be backward-compatible with existing
behavior, so that no other changes are required by other components that
rely on pilot-agent for control plane bootstrap config generation.

Fixes --templateFile behavior inconsistency raised in #11198