### PR TITLE
Fix a crash loop with absence of server-side proxy

### DIFF
--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -291,7 +291,7 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
-if [ -z ${ISTIO_PROXY_DOES_NOT_REDIRECT_LOOPBACK_TO_LOCALHOST-} ]; then
+if [ -z "${ISTIO_PROXY_DOES_NOT_REDIRECT_LOOPBACK_TO_LOCALHOST-}" ]; then
   # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
   # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
   # If Envoy is not configured to map the endpoint to 127.0.0.1, the following rule


### PR DESCRIPTION
When apps calls back to itself via VIP or endpoint address, and Envoy is not configured to map the local endpoint address to 127.0.0.1, the rule "iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT" causes traffic out of Envoy gets redirected back to Envoy indefinitely. Deployment without server-side Envoy needs to set environment variable "ISTIO_PROXY_DOES_NOT_REDIRECT_LOOPBACK_TO_LOCALHOST" to a non-empty value to skip that rule, and also ensures that app does not run under the same user ID or group ID as Envoy.