### PR TITLE
Mt helm chart fixes

### DIFF
--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -95,6 +95,7 @@ spec:
       - name: certs
         secret:
           secretName: istio.istio-galley-service-account
+          optional: true
       - name: config
         configMap:
           name: istio-galley-configuration

--- a/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/deployment.yaml
@@ -54,8 +54,12 @@ spec:
 {{- if not $.Values.global.useMCP }}
           - --enable-server=false
 {{- end }}
+{{- if .Values.global.configValidation }}
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
+{{- else }}
+          - --enable-validation=false
+{{- end }}
           - --monitoringPort={{ .Values.global.monitoringPort }}
           volumeMounts:
           - name: certs


### PR DESCRIPTION
I'm trying to run Istio without Citadel. This causes there to be no volume of certs for Galley.
Pilot etc have that volume mount marked optional, and just don't do control plane mTLS when they;re not there. I've changed Galley's volume to be the same.

However, Galley also serves the validating webhook admission controller for config validation. This requires certs to run, else Galley Fatalf()'s at startup. There is a Helm chart option to turn the webhook off, but it used to only prevent registration of the hook with k8s. I've extended the chart flag to also pass the command-line option avoiding that code path completely, so Galley's main server can start.