### PR TITLE
Removed duplicated timeout arguments to test-integration-kubernetes test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,7 +523,7 @@ jobs:
           when: always
           name: make test.integration.kube
           command: |
-            make test.integration.kube T="-v -timeout=15m" | tee -a /go/out/tests/build-log.txt
+            make test.integration.kube T="-v" | tee -a /go/out/tests/build-log.txt
       - <<: *recordZeroExitCodeIfTestPassed
       - <<: *recordNonzeroExitCodeIfTestFailed
       - <<: *markJobFinishesOnGCS


### PR DESCRIPTION
The CircleCI `test-integration-kubernetes` is failing with the following message:
```sh
go test: timeout flag may be set only once
```

Examples:
https://circleci.com/gh/istio/istio/302904?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
https://circleci.com/gh/istio/istio/302960?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Removing the timeout from the circleci config in favour of the one provided by make.