### PR TITLE
Disable shared span context by default

### DIFF
--- a/pkg/bootstrap/testdata/all_golden.json
+++ b/pkg/bootstrap/testdata/all_golden.json
@@ -240,7 +240,8 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit":"true"
+        "trace_id_128bit": "true",
+        "shared_span_context": "false"
       }
     }
   }

--- a/pkg/bootstrap/testdata/running_golden.json
+++ b/pkg/bootstrap/testdata/running_golden.json
@@ -240,7 +240,8 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit":"true"
+        "trace_id_128bit":"true",
+        "shared_span_context":"false"
       }
     }
   }

--- a/pkg/bootstrap/testdata/tracing_zipkin_golden.json
+++ b/pkg/bootstrap/testdata/tracing_zipkin_golden.json
@@ -214,7 +214,8 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit":"true"
+        "trace_id_128bit": "true",
+        "shared_span_context": "false"
       }
     }
   }

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -280,7 +280,8 @@
       "config": {
         "collector_cluster": "zipkin",
         "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit": "true"
+        "trace_id_128bit": "true",
+        "shared_span_context": "false"
       }
     }
   }


### PR DESCRIPTION
The envoy proxy (used by Istio proxy) creates server spans that have the same span id as the value supplied with the trace context. This can be disabled through configuration, so that all spans create their own unique id.

Usually having shared span context (i.e. where the client span in service A shares the same id as the server span from called service B) is not an issue - if the envoy proxy creating the client span only creates the one span. However there are cases where other tasks performed in the envoy proxy are also creating their own spans - which have the parent id of the client span.

In these cases, the child span can be incorrectly identified as being "caused by" the server span that had the shared id. To illustrate, this is a view of a trace instance from current master:

![jaeger-istio-bookinfo-timeline](https://user-images.githubusercontent.com/164562/51689584-e2d81400-1fee-11e9-9ac3-f1db190a5324.png)

As you will see, it is implying that the `productpage` service has called the `istio-ingressgateway`.

By disabling the shared span context feature, the individual client and server spans have the correct parent span references, e.g.

![jaeger-istio-bookinfo-timeline2](https://user-images.githubusercontent.com/164562/51689687-0e5afe80-1fef-11e9-8927-83b045cb62fe.png)

When shared span context is disabled, this has no adverse effect on the representation shown in zipkin:

![zipkin-istio-bookinfo-timeline2](https://user-images.githubusercontent.com/164562/51689741-2763af80-1fef-11e9-89bd-621b1fcb0dc0.png)


