### PR TITLE
Set VALID_TOKEN to address SDS disconnection problem

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml
+++ b/install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml
@@ -22,6 +22,7 @@ nodeagent:
     # of a testing Vault server.
     CA_ADDR: "https://35.233.249.249:8200"
     CA_PROVIDER: "VaultCA"
+    VALID_TOKEN: true
     # https://35.233.249.249:8200 is the IP address and the port number
     # of a testing Vault server.
     VAULT_ADDR: "https://35.233.249.249:8200"


### PR DESCRIPTION
Set VALID_TOKEN to true to address a SDS disconnection problem, in which SDS server disconnects a stream to Envoy and causes certificate rotation failures.