### PR TITLE
Guard weighted TCP routed with proxy version check

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -139,12 +139,13 @@ func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, config model.ConfigMeta) []listener.Filter {
 
-	if len(routes) == 1 {
+	if util.IsProxyVersionGE11(node) && len(routes) > 1 {
+		return buildOutboundNetworkFiltersWithWeightedClusters(env, node, routes, push, port, config)
+	} else {
 		service := push.ServiceByHostname[model.Hostname(routes[0].Destination.Host)]
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		return buildOutboundNetworkFiltersWithSingleDestination(env, node, clusterName, port)
 	}
-	return buildOutboundNetworkFiltersWithWeightedClusters(env, node, routes, push, port, config)
 }
 
 // buildOutboundMongoFilter builds an outbound Envoy MongoProxy filter.

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -139,13 +139,12 @@ func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy,
 	routes []*networking.RouteDestination, push *model.PushContext,
 	port *model.Port, config model.ConfigMeta) []listener.Filter {
 
-	if util.IsProxyVersionGE11(node) && len(routes) > 1 {
-		return buildOutboundNetworkFiltersWithWeightedClusters(env, node, routes, push, port, config)
-	} else {
+	if !util.IsProxyVersionGE11(node) || len(routes) == 1 {
 		service := push.ServiceByHostname[model.Hostname(routes[0].Destination.Host)]
 		clusterName := istio_route.GetDestinationCluster(routes[0].Destination, service, port.Port)
 		return buildOutboundNetworkFiltersWithSingleDestination(env, node, clusterName, port)
 	}
+	return buildOutboundNetworkFiltersWithWeightedClusters(env, node, routes, push, port, config)
 }
 
 // buildOutboundMongoFilter builds an outbound Envoy MongoProxy filter.

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -225,10 +225,7 @@ func SortVirtualHosts(hosts []route.VirtualHost) {
 // IsProxyVersionGE11 checks whether the given Proxy version is greater than or equals 1.1.
 func IsProxyVersionGE11(node *model.Proxy) bool {
 	ver, _ := node.GetProxyVersion()
-	if ver >= "1.1" {
-		return true
-	}
-	return false
+	return ver >= "1.1"
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all


### PR DESCRIPTION
This updates the TCP weighted routing setup by placing a guard i.e. to
specifically enable it when the proxy version is greater than or equal
to `1.1`.