### PR TITLE
Ensure xenial base image present before building proxy_init

### DIFF
--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -78,6 +78,10 @@ $(foreach FILE,$(DOCKER_FILES_FROM_ISTIO_BIN), \
 
 docker.proxy_init: pilot/docker/Dockerfile.proxy_init
 docker.proxy_init: $(ISTIO_DOCKER)/istio-iptables.sh
+	# Ensure ubuntu:xenial, the base image for proxy_init, is present so build doesn't fail on network hiccup
+	if [[ "$(docker images -q ubuntu:xenial 2> /dev/null)" == "" ]]; then \
+		docker pull ubuntu:xenial || (sleep 15 ; docker pull ubuntu:xenial) || (sleep 45 ; docker pull ubuntu:xenial) \
+	fi
 	$(DOCKER_RULE)
 
 docker.sidecar_injector: pilot/docker/Dockerfile.sidecar_injector


### PR DESCRIPTION
This attempts to mitigate builds that were failing because CircleCI machines were having intermittent trouble contacting docker.io.  It addresses https://github.com/istio/istio/issues/11029 .

The idea is to pull ubuntu/xenial before builds if it isn't already present on the CircleCI machine.  If there is trouble it will try up to three times over the course of one minute before giving up.