### PR TITLE
set VALID_TOKEN for nodeagent->citadel

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
@@ -20,3 +20,4 @@ nodeagent:
   env:
     CA_PROVIDER: "Citadel"
     CA_ADDR: "istio-citadel:8060"
+    VALID_TOKEN: true


### PR DESCRIPTION
since citadel today use normal k8s sa jwt which is always valid, set this flag to simplify the flow. 