### PR TITLE
Galley support for MCP Source Client dial out

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2145,6 +2145,7 @@
     "google.golang.org/grpc/balancer",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/credentials",
+    "google.golang.org/grpc/credentials/oauth",
     "google.golang.org/grpc/encoding/gzip",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/keepalive",

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -150,6 +150,10 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Disable resource readiness checks. This allows Galley to start if not all resource types are supported")
 	rootCmd.PersistentFlags().StringSliceVar(&serverArgs.ExcludedResourceKinds, "excludedResourceKinds",
 		serverArgs.ExcludedResourceKinds, "Comma-separated list of resource kinds that should not generate source events")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.CalloutAddress, "callout-address",
+		serverArgs.CalloutAddress, "Address of MCP Resource Sink for Galley to connect to. Ex: 'foo.com:1234'")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.CalloutAuth, "callout-auth",
+		serverArgs.CalloutAuth, "Name of authentication plugin to use for callout")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)
 

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -150,10 +150,10 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Disable resource readiness checks. This allows Galley to start if not all resource types are supported")
 	rootCmd.PersistentFlags().StringSliceVar(&serverArgs.ExcludedResourceKinds, "excludedResourceKinds",
 		serverArgs.ExcludedResourceKinds, "Comma-separated list of resource kinds that should not generate source events")
-	rootCmd.PersistentFlags().StringVar(&serverArgs.CalloutAddress, "callout-address",
-		serverArgs.CalloutAddress, "Address of MCP Resource Sink for Galley to connect to. Ex: 'foo.com:1234'")
-	rootCmd.PersistentFlags().StringVar(&serverArgs.CalloutAuth, "callout-auth",
-		serverArgs.CalloutAuth, "Name of authentication plugin to use for callout")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAddress, "sink-address",
+		serverArgs.SinkAddress, "Address of MCP Resource Sink server for Galley to connect to. Ex: 'foo.com:1234'")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sink-auth-mode",
+		serverArgs.SinkAuthMode, "Name of authentication plugin to use for connection to sink server.")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)
 

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -150,9 +150,9 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Disable resource readiness checks. This allows Galley to start if not all resource types are supported")
 	rootCmd.PersistentFlags().StringSliceVar(&serverArgs.ExcludedResourceKinds, "excludedResourceKinds",
 		serverArgs.ExcludedResourceKinds, "Comma-separated list of resource kinds that should not generate source events")
-	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAddress, "sink-address",
+	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAddress, "sinkAddress",
 		serverArgs.SinkAddress, "Address of MCP Resource Sink server for Galley to connect to. Ex: 'foo.com:1234'")
-	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sink-auth-mode",
+	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sinkAuthMode",
 		serverArgs.SinkAuthMode, "Name of authentication plugin to use for connection to sink server.")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)

--- a/galley/pkg/authplugin/authplugin.go
+++ b/galley/pkg/authplugin/authplugin.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugin
+
+import "google.golang.org/grpc"
+
+type InfoFn func() Info
+type AuthFn func(map[string]string) ([]grpc.DialOption, error)
+
+type Info struct {
+	Name    string
+	GetAuth AuthFn
+}

--- a/galley/pkg/authplugin/authplugin.go
+++ b/galley/pkg/authplugin/authplugin.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(jeffmendoza) Longer term, consider merging with pkg/mcp/creds.
+
 package authplugin
 
 import "google.golang.org/grpc"

--- a/galley/pkg/authplugins/README.md
+++ b/galley/pkg/authplugins/README.md
@@ -7,7 +7,7 @@
 * In the returned authplugin.Info:
 
   * Set `Name` to what will be used to specify your plugin in config
-  * Set `GetAuth` to a funtion in your plugin that conforms to authplugin.AuthFn
+  * Set `GetAuth` to a function in your plugin that conforms to authplugin.AuthFn
 
 * Edit inventory.go in this directory so that your plugin's GetInfo is
   retuned in the slice that Inventory() returns.

--- a/galley/pkg/authplugins/README.md
+++ b/galley/pkg/authplugins/README.md
@@ -1,0 +1,13 @@
+## How to add a new plugin:
+
+* Add a new subdirectory.
+
+* Export GetInfo() that conforms to authplugin.InfoFn
+
+* In the returned authplugin.Info:
+
+  * Set `Name` to what will be used to specify your plugin in config
+  * Set `GetAuth` to a funtion in your plugin that conforms to authplugin.AuthFn
+
+* Edit inventory.go in this directory so that your plugin's GetInfo is
+  retuned in the slice that Inventory() returns.

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package google is a Galley auth plugin that uses Google application
+// default credentials.
+package google
+
+import (
+	"context"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/oauth"
+	"istio.io/istio/galley/pkg/authplugin"
+)
+
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	ctx := context.Background()
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
+	if err != nil {
+		return nil, err
+	}
+
+	grpcOpts := []grpc.DialOption{
+		grpc.WithPerRPCCredentials(oauth.TokenSource{creds.TokenSource}),
+		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
+	}
+
+	return grpcOpts, nil
+}
+
+func GetInfo() authplugin.Info {
+	return authplugin.Info{
+		Name:    "GOOGLE",
+		GetAuth: returnAuth,
+	}
+}

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -23,10 +23,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
+
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	_ = config
 	ctx := context.Background()
 	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
 	if err != nil {
@@ -34,7 +36,7 @@ func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	}
 
 	grpcOpts := []grpc.DialOption{
-		grpc.WithPerRPCCredentials(oauth.TokenSource{creds.TokenSource}),
+		grpc.WithPerRPCCredentials(oauth.TokenSource{TokenSource: creds.TokenSource}),
 		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(nil, "")),
 	}
 

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -27,16 +27,13 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
+// To allow override in test
 type dcFn func(context.Context, ...string) (*google.Credentials, error)
 
-var findDC dcFn
+// Default value for non-test
+var findDC dcFn = google.FindDefaultCredentials
 
-func init() {
-	findDC = google.FindDefaultCredentials
-}
-
-func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
-	_ = config
+func returnAuth(map[string]string) ([]grpc.DialOption, error) {
 	ctx := context.Background()
 	creds, err := findDC(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -30,7 +30,7 @@ import (
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	_ = config
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/<SCOPE>")
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, err
 	}

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -27,10 +27,18 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
+type dcFn func(context.Context, ...string) (*google.Credentials, error)
+
+var findDC dcFn
+
+func init() {
+	findDC = google.FindDefaultCredentials
+}
+
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
 	_ = config
 	ctx := context.Background()
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	creds, err := findDC(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, err
 	}

--- a/galley/pkg/authplugins/google/google.go
+++ b/galley/pkg/authplugins/google/google.go
@@ -27,11 +27,8 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
-// To allow override in test
-type dcFn func(context.Context, ...string) (*google.Credentials, error)
-
 // Default value for non-test
-var findDC dcFn = google.FindDefaultCredentials
+var findDC = google.FindDefaultCredentials
 
 func returnAuth(map[string]string) ([]grpc.DialOption, error) {
 	ctx := context.Background()

--- a/galley/pkg/authplugins/google/google_test.go
+++ b/galley/pkg/authplugins/google/google_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	i := GetInfo()
+	if i.Name == "" {
+		t.Error("Name not valid")
+	}
+	if i.GetAuth == nil {
+		t.Error("GetAuth not valid")
+	}
+}
+
+func TestAuth(t *testing.T) {
+	opts, err := returnAuth(nil)
+	if err != nil {
+		t.Errorf("Error with auth: %v", err)
+	}
+	if opts == nil {
+		t.Error("No auth options returned")
+	}
+	if len(opts) != 2 {
+		t.Error("Should have 2 options")
+	}
+}

--- a/galley/pkg/authplugins/google/google_test.go
+++ b/galley/pkg/authplugins/google/google_test.go
@@ -15,7 +15,10 @@
 package google
 
 import (
+	"context"
 	"testing"
+
+	"golang.org/x/oauth2/google"
 )
 
 func TestInfo(t *testing.T) {
@@ -28,7 +31,12 @@ func TestInfo(t *testing.T) {
 	}
 }
 
+func mockDC(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+	return &google.Credentials{}, nil
+}
+
 func TestAuth(t *testing.T) {
+	findDC = mockDC
 	opts, err := returnAuth(nil)
 	if err != nil {
 		t.Errorf("Error with auth: %v", err)

--- a/galley/pkg/authplugins/inventory.go
+++ b/galley/pkg/authplugins/inventory.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugins
+
+import (
+	"istio.io/istio/galley/pkg/authplugin"
+
+	"istio.io/istio/galley/pkg/authplugins/google"
+	"istio.io/istio/galley/pkg/authplugins/none"
+)
+
+func Inventory() []authplugin.InfoFn {
+	return []authplugin.InfoFn{
+		google.GetInfo,
+		none.GetInfo,
+	}
+}

--- a/galley/pkg/authplugins/inventory.go
+++ b/galley/pkg/authplugins/inventory.go
@@ -27,3 +27,12 @@ func Inventory() []authplugin.InfoFn {
 		none.GetInfo,
 	}
 }
+
+func AuthMap() map[string]authplugin.AuthFn {
+	m := make(map[string]authplugin.AuthFn)
+	for _, g := range Inventory() {
+		i := g()
+		m[i.Name] = i.GetAuth
+	}
+	return m
+}

--- a/galley/pkg/authplugins/inventory.go
+++ b/galley/pkg/authplugins/inventory.go
@@ -21,6 +21,8 @@ import (
 	"istio.io/istio/galley/pkg/authplugins/none"
 )
 
+// Inventory returns a slice of all supported plugins. For new plugins
+// add them here.
 func Inventory() []authplugin.InfoFn {
 	return []authplugin.InfoFn{
 		google.GetInfo,
@@ -28,6 +30,8 @@ func Inventory() []authplugin.InfoFn {
 	}
 }
 
+// AuthMap goes ahead and runs each GetInfo function and produces a
+// map of plugin names to GetAuth functions.
 func AuthMap() map[string]authplugin.AuthFn {
 	m := make(map[string]authplugin.AuthFn)
 	for _, g := range Inventory() {

--- a/galley/pkg/authplugins/inventory_test.go
+++ b/galley/pkg/authplugins/inventory_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authplugins_test
+
+import (
+	"testing"
+
+	"istio.io/istio/galley/pkg/authplugins"
+)
+
+func TestInventory(t *testing.T) {
+	for _, v := range authplugins.Inventory() {
+		if v == nil {
+			t.Error("Invalid info function")
+		}
+	}
+}

--- a/galley/pkg/authplugins/inventory_test.go
+++ b/galley/pkg/authplugins/inventory_test.go
@@ -23,7 +23,18 @@ import (
 func TestInventory(t *testing.T) {
 	for _, v := range authplugins.Inventory() {
 		if v == nil {
-			t.Error("Invalid info function")
+			t.Error("Invalid GetInfo function")
+		}
+	}
+}
+
+func TestAuthMap(t *testing.T) {
+	for k, v := range authplugins.AuthMap() {
+		if k == "" {
+			t.Error("Empty plugin name")
+		}
+		if v == nil {
+			t.Error("Invalid GetAuth function")
 		}
 	}
 }

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package none is a Galley auth plugin that returns an empty auth
+// DialOption.
+package none
+
+import (
+	"google.golang.org/grpc"
+	"istio.io/istio/galley/pkg/authplugin"
+)
+
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+	return nil, nil
+}
+
+func GetInfo() authplugin.Info {
+	return authplugin.Info{
+		Name:    "NONE",
+		GetAuth: returnAuth,
+	}
+}

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -23,7 +23,7 @@ import (
 )
 
 func returnAuth(config map[string]string) ([]grpc.DialOption, error) { // nolint: unparam
-	return nil, nil
+	return []grpc.DialOption{grpc.WithInsecure()}, nil
 }
 
 func GetInfo() authplugin.Info {

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -18,10 +18,11 @@ package none
 
 import (
 	"google.golang.org/grpc"
+
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
-func returnAuth(config map[string]string) ([]grpc.DialOption, error) {
+func returnAuth(config map[string]string) ([]grpc.DialOption, error) { // nolint: unparam
 	return nil, nil
 }
 

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
-func returnAuth(map[string]string) ([]grpc.DialOption, error) {
+func returnAuth(map[string]string) ([]grpc.DialOption, error) { // nolint: unparam
 	return []grpc.DialOption{grpc.WithInsecure()}, nil
 }
 

--- a/galley/pkg/authplugins/none/none.go
+++ b/galley/pkg/authplugins/none/none.go
@@ -22,7 +22,7 @@ import (
 	"istio.io/istio/galley/pkg/authplugin"
 )
 
-func returnAuth(config map[string]string) ([]grpc.DialOption, error) { // nolint: unparam
+func returnAuth(map[string]string) ([]grpc.DialOption, error) {
 	return []grpc.DialOption{grpc.WithInsecure()}, nil
 }
 

--- a/galley/pkg/authplugins/none/none_test.go
+++ b/galley/pkg/authplugins/none/none_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package none
+
+import (
+	"testing"
+)
+
+func TestInfo(t *testing.T) {
+	i := GetInfo()
+	if i.Name == "" {
+		t.Error("Name not valid")
+	}
+	if i.GetAuth == nil {
+		t.Error("GetAuth not valid")
+	}
+}
+
+func TestAuth(t *testing.T) {
+	opts, err := returnAuth(nil)
+	if err != nil {
+		t.Errorf("Error with auth: %v", err)
+	}
+	if opts != nil {
+		t.Error("None auth should be nil")
+	}
+}

--- a/galley/pkg/authplugins/none/none_test.go
+++ b/galley/pkg/authplugins/none/none_test.go
@@ -33,7 +33,10 @@ func TestAuth(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error with auth: %v", err)
 	}
-	if opts != nil {
-		t.Error("None auth should be nil")
+	if opts == nil {
+		t.Error("No auth options returned")
+	}
+	if len(opts) != 1 {
+		t.Error("Should have 1 options")
 	}
 }

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -84,14 +84,14 @@ type Args struct {
 	// registered with the kube-apiserver.
 	DisableResourceReadyCheck bool
 
-	// CalloutAddress should be set to the address of a MCP Resource
+	// SinkAddress should be set to the address of a MCP Resource
 	// Sink service that Galley will dial out to. Leaving empty disables
-	// callout.
-	CalloutAddress string
+	// sink.
+	SinkAddress string
 
-	// CalloutAuth should be set to a name of an authentication plugin,
+	// SinkAuthMode should be set to a name of an authentication plugin,
 	// see the istio.io/istio/galley/pkg/autplugins package.
-	CalloutAuth string
+	SinkAuthMode string
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
@@ -143,8 +143,8 @@ func (a *Args) String() string {
 	_, _ = fmt.Fprintf(buf, "DomainSuffix: %s\n", a.DomainSuffix)
 	_, _ = fmt.Fprintf(buf, "DisableResourceReadyCheck: %v\n", a.DisableResourceReadyCheck)
 	_, _ = fmt.Fprintf(buf, "ExcludedResourceKinds: %v\n", a.ExcludedResourceKinds)
-	_, _ = fmt.Fprintf(buf, "CalloutAddress: %v\n", a.CalloutAddress)
-	_, _ = fmt.Fprintf(buf, "CalloutAuth: %v\n", a.CalloutAuth)
+	_, _ = fmt.Fprintf(buf, "SinkAddress: %v\n", a.SinkAddress)
+	_, _ = fmt.Fprintf(buf, "SinkAuthMode: %v\n", a.SinkAuthMode)
 
 	return buf.String()
 }

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -83,6 +83,15 @@ type Args struct {
 	// allows Galley to start when not all supported CRD are
 	// registered with the kube-apiserver.
 	DisableResourceReadyCheck bool
+
+	// CalloutAddress should be set to the address of a MCP Resource
+	// Sink service that Galley will dial out to. Leaving empty disables
+	// callout.
+	CalloutAddress string
+
+	// CalloutAuth should be set to a name of an authentication plugin,
+	// see the istio.io/istio/galley/pkg/autplugins package.
+	CalloutAuth string
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
@@ -134,6 +143,8 @@ func (a *Args) String() string {
 	_, _ = fmt.Fprintf(buf, "DomainSuffix: %s\n", a.DomainSuffix)
 	_, _ = fmt.Fprintf(buf, "DisableResourceReadyCheck: %v\n", a.DisableResourceReadyCheck)
 	_, _ = fmt.Fprintf(buf, "ExcludedResourceKinds: %v\n", a.ExcludedResourceKinds)
+	_, _ = fmt.Fprintf(buf, "CalloutAddress: %v\n", a.CalloutAddress)
+	_, _ = fmt.Fprintf(buf, "CalloutAuth: %v\n", a.CalloutAuth)
 
 	return buf.String()
 }

--- a/galley/pkg/server/callout.go
+++ b/galley/pkg/server/callout.go
@@ -87,7 +87,7 @@ func (c *callout) Run() {
 
 	conn, err := c.pt.grpcDial(c.address, c.do...)
 	if err != nil {
-		scope.Fatalf("Failed to connect to server: %v", err)
+		scope.Errorf("Failed to connect to server: %v", err)
 		return
 	}
 	defer c.pt.connClose(conn)

--- a/galley/pkg/server/callout.go
+++ b/galley/pkg/server/callout.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/galley/pkg/authplugin"
+	"istio.io/istio/galley/pkg/authplugins"
+	"istio.io/istio/pkg/mcp/source"
+)
+
+type callout struct {
+	address string
+	so      *source.Options
+	do      []grpc.DialOption
+	cancel  context.CancelFunc
+}
+
+// Test override types
+type dialFn func(string, ...grpc.DialOption) (*grpc.ClientConn, error)
+type mcpClient interface {
+	Run(context.Context)
+}
+type newClientFn func(mcp.ResourceSinkClient, *source.Options) mcpClient
+type closeFn func(*grpc.ClientConn)
+
+// Test override variables
+var (
+	connClose       closeFn
+	grpcDial        dialFn
+	sourceNewClient newClientFn
+)
+
+func init() {
+	// Setup non-test defaults
+	grpcDial = grpc.Dial
+	sourceNewClient = func(c mcp.ResourceSinkClient, o *source.Options) mcpClient { return source.NewClient(c, o) }
+	connClose = func(c *grpc.ClientConn) { c.Close() }
+}
+
+func newCallout(sa *Args, so *source.Options) (*callout, error) {
+	auths := getAuth()
+
+	f, ok := auths[sa.CalloutAuth]
+	if !ok {
+		return nil, fmt.Errorf("auth plugin %v not found", sa.CalloutAuth)
+	}
+
+	opts, err := f(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &callout{
+		address: sa.CalloutAddress,
+		so:      so,
+		do:      opts,
+	}, nil
+}
+
+func (c *callout) Run() {
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+
+	conn, err := grpcDial(c.address, c.do...)
+	if err != nil {
+		scope.Fatalf("Failed to connect to server: %v", err)
+		return
+	}
+	defer connClose(conn)
+
+	client := mcp.NewResourceSinkClient(conn)
+
+	mcpClient := sourceNewClient(client, c.so)
+	scope.Infof("Starting MCP Source Client connection to: %v", c.address)
+	mcpClient.Run(ctx)
+}
+
+func (c *callout) Close() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+}
+
+func getAuth() map[string]authplugin.AuthFn {
+	m := make(map[string]authplugin.AuthFn)
+	for _, g := range authplugins.Inventory() {
+		i := g()
+		m[i.Name] = i.GetAuth
+	}
+	return m
+}

--- a/galley/pkg/server/callout.go
+++ b/galley/pkg/server/callout.go
@@ -30,7 +30,7 @@ type callout struct {
 	so      *source.Options
 	do      []grpc.DialOption
 	cancel  context.CancelFunc
-	pt      calloutPT
+	pt      calloutPatchTable
 }
 
 // Test override types
@@ -41,15 +41,15 @@ type mcpClient interface {
 type newClientFn func(mcp.ResourceSinkClient, *source.Options) mcpClient
 type closeFn func(*grpc.ClientConn)
 
-type calloutPT struct {
+type calloutPatchTable struct {
 	connClose       closeFn
 	grpcDial        dialFn
 	sourceNewClient newClientFn
 }
 
-func defaultCalloutPT() calloutPT {
+func defaultCalloutPT() calloutPatchTable {
 	// non-test defaults
-	return calloutPT{
+	return calloutPatchTable{
 		grpcDial:        grpc.Dial,
 		sourceNewClient: func(c mcp.ResourceSinkClient, o *source.Options) mcpClient { return source.NewClient(c, o) },
 		connClose:       func(c *grpc.ClientConn) { c.Close() },
@@ -60,7 +60,7 @@ func newCallout(address, auth string, so *source.Options) (*callout, error) {
 	return newCalloutPT(address, auth, so, defaultCalloutPT())
 }
 
-func newCalloutPT(address, auth string, so *source.Options, pt calloutPT) (*callout, error) {
+func newCalloutPT(address, auth string, so *source.Options, pt calloutPatchTable) (*callout, error) {
 	auths := authplugins.AuthMap()
 
 	f, ok := auths[auth]

--- a/galley/pkg/server/callout.go
+++ b/galley/pkg/server/callout.go
@@ -64,9 +64,9 @@ func newCallout(sa *Args, so *source.Options) (*callout, error) {
 func newCalloutPT(sa *Args, so *source.Options, pt calloutPT) (*callout, error) {
 	auths := authplugins.AuthMap()
 
-	f, ok := auths[sa.CalloutAuth]
+	f, ok := auths[sa.SinkAuthMode]
 	if !ok {
-		return nil, fmt.Errorf("auth plugin %v not found", sa.CalloutAuth)
+		return nil, fmt.Errorf("auth plugin %v not found", sa.SinkAuthMode)
 	}
 
 	opts, err := f(nil)
@@ -75,7 +75,7 @@ func newCalloutPT(sa *Args, so *source.Options, pt calloutPT) (*callout, error) 
 	}
 
 	return &callout{
-		address: sa.CalloutAddress,
+		address: sa.SinkAddress,
 		so:      so,
 		do:      opts,
 		pt:      pt,

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -27,8 +27,8 @@ import (
 
 func TestCallout(t *testing.T) {
 	sa := &Args{
-		CalloutAuth:    "NONE",
-		CalloutAddress: "foo",
+		SinkAuthMode: "NONE",
+		SinkAddress:  "foo",
 	}
 	co, err := newCallout(sa, &source.Options{})
 	if err != nil {

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -16,7 +16,6 @@ package server
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -26,11 +25,7 @@ import (
 )
 
 func TestCallout(t *testing.T) {
-	sa := &Args{
-		SinkAuthMode: "NONE",
-		SinkAddress:  "foo",
-	}
-	co, err := newCallout(sa, &source.Options{})
+	co, err := newCallout("foo", "NONE", &source.Options{})
 	if err != nil {
 		t.Errorf("Callout creation failed: %v", err)
 	}
@@ -68,9 +63,7 @@ func TestCalloutRun(t *testing.T) {
 			connClose:       connClose,
 		},
 	}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	co.Run(&wg)
+	co.Run()
 
 	if dialAddr != "foo" {
 		t.Error("Callout run did not dial address")

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/pkg/mcp/source"
+)
+
+func TestCallout(t *testing.T) {
+	sa := &Args{
+		CalloutAuth:    "NONE",
+		CalloutAddress: "foo",
+	}
+	co, err := newCallout(sa, &source.Options{})
+	if err != nil {
+		t.Errorf("Callout creation failed: %v", err)
+	}
+	if co.address != "foo" {
+		t.Error("Callout address not set")
+	}
+}
+
+type mockMcpClient struct {
+	RunCalled bool
+}
+
+func (m *mockMcpClient) Run(ctx context.Context) {
+	m.RunCalled = true
+}
+
+func TestCalloutRun(t *testing.T) {
+	dialAddr := ""
+	grpcDial = func(addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+		dialAddr = addr
+		return &grpc.ClientConn{}, nil
+	}
+
+	m := &mockMcpClient{RunCalled: false}
+	sourceNewClient = func(c mcp.ResourceSinkClient, o *source.Options) mcpClient { return m }
+
+	connClosed := false
+	connClose = func(c *grpc.ClientConn) { connClosed = true }
+
+	co := &callout{
+		address: "foo",
+	}
+	co.Run()
+	if dialAddr != "foo" {
+		t.Error("Callout run did not dial address")
+	}
+	if m.RunCalled == false {
+		t.Error("Did not run the mcp client")
+	}
+	if connClosed == false {
+		t.Error("Did not close connection")
+	}
+}

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -57,7 +57,7 @@ func TestCalloutRun(t *testing.T) {
 
 	co := &callout{
 		address: "foo",
-		pt: calloutPT{
+		pt: calloutPatchTable{
 			grpcDial:        grpcDial,
 			sourceNewClient: sourceNewClient,
 			connClose:       connClose,

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -62,7 +63,10 @@ func TestCalloutRun(t *testing.T) {
 	co := &callout{
 		address: "foo",
 	}
-	co.Run()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	co.Run(&wg)
+
 	if dialAddr != "foo" {
 		t.Error("Callout run did not dial address")
 	}

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -49,19 +49,24 @@ func (m *mockMcpClient) Run(ctx context.Context) {
 
 func TestCalloutRun(t *testing.T) {
 	dialAddr := ""
-	grpcDial = func(addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	grpcDial := func(addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 		dialAddr = addr
 		return &grpc.ClientConn{}, nil
 	}
 
 	m := &mockMcpClient{RunCalled: false}
-	sourceNewClient = func(c mcp.ResourceSinkClient, o *source.Options) mcpClient { return m }
+	sourceNewClient := func(c mcp.ResourceSinkClient, o *source.Options) mcpClient { return m }
 
 	connClosed := false
-	connClose = func(c *grpc.ClientConn) { connClosed = true }
+	connClose := func(c *grpc.ClientConn) { connClosed = true }
 
 	co := &callout{
 		address: "foo",
+		pt: calloutPT{
+			grpcDial:        grpcDial,
+			sourceNewClient: sourceNewClient,
+			connClose:       connClose,
+		},
 	}
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -239,7 +239,8 @@ func (s *Server) Run() {
 		}
 	}()
 	if s.callOut != nil {
-		go s.callOut.Run()
+		s.serveWG.Add(1)
+		go s.callOut.Run(&s.serveWG)
 	}
 }
 

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -170,7 +170,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 		CollectionsOptions: source.CollectionOptionsFromSlice(metadata.Types.Collections()),
 	}
 
-	if a.CalloutAddress != "" {
+	if a.SinkAddress != "" {
 		s.callOut, err = newCallout(a, options)
 		if err != nil {
 			s.callOut = nil

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -171,7 +171,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	}
 
 	if a.SinkAddress != "" {
-		s.callOut, err = newCallout(a, options)
+		s.callOut, err = newCallout(a.SinkAddress, a.SinkAuthMode, options)
 		if err != nil {
 			s.callOut = nil
 			scope.Fatalf("Callout could not be initialized: %v", err)
@@ -240,7 +240,10 @@ func (s *Server) Run() {
 	}()
 	if s.callOut != nil {
 		s.serveWG.Add(1)
-		go s.callOut.Run(&s.serveWG)
+		go func() {
+			defer s.serveWG.Done()
+			s.callOut.Run()
+		}()
 	}
 }
 

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -256,7 +256,6 @@ func (s *Server) Close() error {
 
 	if s.grpcServer != nil {
 		s.grpcServer.GracefulStop()
-		s.serveWG.Wait()
 	}
 
 	if s.controlZ != nil {
@@ -277,6 +276,10 @@ func (s *Server) Close() error {
 
 	if s.callOut != nil {
 		s.callOut.Close()
+	}
+
+	if s.grpcServer != nil || s.callOut != nil {
+		s.serveWG.Wait()
 	}
 
 	// final attempt to purge buffered logs

--- a/pkg/mcp/source/client_source.go
+++ b/pkg/mcp/source/client_source.go
@@ -99,12 +99,12 @@ func (c *Client) Run(ctx context.Context) {
 			// slow subsequent reconnection attempts down
 			retryDelay = reestablishStreamDelay
 
-			scope.Info("(re)trying to establish new MCP source stream")
-			stream, err := c.client.EstablishResourceStream(ctx)
-
 			if reconnectTestProbe != nil {
 				reconnectTestProbe()
 			}
+
+			scope.Info("(re)trying to establish new MCP source stream")
+			stream, err := c.client.EstablishResourceStream(ctx)
 
 			if err != nil {
 				scope.Errorf("Failed to create a new MCP source stream: %v", err)

--- a/pkg/mcp/source/client_source.go
+++ b/pkg/mcp/source/client_source.go
@@ -63,12 +63,13 @@ func (c *Client) sendTriggerResponse(stream Stream) error {
 	}
 
 	if err := stream.Send(trigger); err != nil {
-		return fmt.Errorf("could not send trigger request %v", err)
+		return status.Errorf(status.Code(err), "could not send trigger request %v", err)
 	}
 
 	msg, err := stream.Recv()
 	if err != nil {
-		return fmt.Errorf("could not receive expected nack response: %v", err)
+		return status.Errorf(status.Code(err),
+			"could not receive expected nack response: %v", err)
 	}
 
 	if msg.ErrorDetail == nil {

--- a/pkg/mcp/source/client_source_test.go
+++ b/pkg/mcp/source/client_source_test.go
@@ -79,6 +79,7 @@ func TestClientSource(t *testing.T) {
 	h := &sourceHarness{
 		sourceTestHarness: newSourceTestHarness(t),
 	}
+	h.client = true
 
 	options := &Options{
 		Watcher:            h,
@@ -115,6 +116,7 @@ func TestClientSource(t *testing.T) {
 		Resources:  []*mcp.Resource{test.Type2A[0].Resource},
 	})
 
+	h.requestsChan <- test.MakeRequest("", "", codes.Unimplemented)
 	h.requestsChan <- test.MakeRequest(test.FakeType0Collection, "", codes.OK)
 	h.requestsChan <- test.MakeRequest(test.FakeType1Collection, "", codes.OK)
 	h.requestsChan <- test.MakeRequest(test.FakeType2Collection, "", codes.OK)

--- a/pkg/mcp/source/source_test.go
+++ b/pkg/mcp/source/source_test.go
@@ -63,6 +63,7 @@ type sourceTestHarness struct {
 	watchResponses    map[string]*WatchResponse
 	pushResponseFuncs map[string][]PushResponseFunc
 	watchCreated      map[string]int
+	client            bool
 }
 
 func newSourceTestHarness(t *testing.T) *sourceTestHarness {
@@ -89,6 +90,11 @@ func (h *sourceTestHarness) resetStream() {
 }
 
 func (h *sourceTestHarness) Send(resources *mcp.Resources) error {
+	if h.client == true {
+		// Swallow trigger send for source client
+		h.client = false
+		return nil
+	}
 	// check that nonce is monotonically incrementing
 	h.nonce++
 	if resources.Nonce != fmt.Sprintf("%d", h.nonce) {


### PR DESCRIPTION
By setting the new "callout-address" Galley cli option, this code will execute and initiate a MCP Source connection to an MCP Sink server.

This includes the Auth plugin code from #11068