### PR TITLE
remove chart.version label in pod template.

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -27,7 +27,6 @@ spec:
         chart: {{ template "gateway.chart" $ }}
         heritage: {{ $.Release.Service }}
         release: {{ $.Release.Name }}
-        version: {{ $.Chart.Version }}
         {{- range $key, $val := $spec.labels }}
         {{ $key }}: {{ $val }}
         {{- end }}

--- a/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/mixer/templates/deployment.yaml
@@ -285,7 +285,6 @@ metadata:
     chart: {{ template "mixer.chart" $ }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
-    version: {{ $.Chart.Version }}
     istio: mixer
 spec:
 {{- if not $spec.autoscaleEnabled }}
@@ -305,7 +304,6 @@ spec:
       chart: {{ template "mixer.chart" $ }}
       heritage: {{ $.Release.Service }}
       release: {{ $.Release.Name }}
-      version: {{ $.Chart.Version }}
       istio: mixer
       istio-mixer-type: {{ $key }}
   template:
@@ -315,7 +313,6 @@ spec:
         chart: {{ template "mixer.chart" $ }}
         heritage: {{ $.Release.Service }}
         release: {{ $.Release.Name }}
-        version: {{ $.Chart.Version }}
         istio: mixer
         istio-mixer-type: {{ $key }}
       annotations:


### PR DESCRIPTION
As explained in: https://github.com/istio/istio/pull/10188
The `version: {{ .Chart.version }}` will make upgrade broken, let's remove the labels.