### PR TITLE
Adding namespace declaration in Grafana PersistentVolumeClaim

### DIFF
--- a/install/kubernetes/helm/subcharts/grafana/templates/pvc.yaml
+++ b/install/kubernetes/helm/subcharts/grafana/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: istio-grafana-pvc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "grafana.name" . }}
     chart: {{ template "grafana.chart" . }}


### PR DESCRIPTION
When using the Helm chart with a user specific namespace and Grafana persistency
enabled, the generated PersistentVolumeClaim for Grafana was missing a namespace,
leading in the Grafana pod to be stuck in the Pending state.