### PR TITLE
Support multiple Citadels running in one cluster.

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -148,11 +148,13 @@ func init() {
 			cmd.ListenedNamespaceKey+"} environment variable. If neither is set, Citadel listens to all namespaces.")
 	flags.StringVar(&opts.istioCaStorageNamespace, "citadel-storage-namespace", "istio-system", "Namespace where "+
 		"the Citadel pod is running. Will not be used if explicit file or other storage mechanism is specified.")
+
 	flags.StringVar(&opts.kubeConfigFile, "kube-config", "",
 		"Specifies path to kubeconfig file. This must be specified when not running inside a Kubernetes pod.")
-	flags.BoolVar(&opts.readSigningCertOnly, "readSigningCertOnly", false, "When set, Citadel only reads the self-signed signing "+
-		"key and cert without generating one. This flag avoids racing condition between multiple Citadels generating self-signed "+
-		"key and cert. Please make sure one and only one Citadel instance has this flag set to false.")
+	flags.BoolVar(&opts.readSigningCertOnly, "read-signing-cert-only", false, "When set, Citadel only reads the self-signed signing "+
+		"key and cert from Kubernetes secret without generating one (if not exist). This flag avoids racing condition between "+
+		"multiple Citadels generating self-signed key and cert. Please make sure one and only one Citadel instance has this flag set "+
+		"to false.")
 
 	// Configuration if Citadel accepts key/cert configured through arguments.
 	flags.StringVar(&opts.certChainFile, "cert-chain", "", "Path to the certificate chain file")

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -47,6 +48,7 @@ type cliOptions struct { // nolint: maligned
 	listenedNamespace       string
 	istioCaStorageNamespace string
 	kubeConfigFile          string
+	readSigningCertOnly     bool
 
 	certChainFile   string
 	signingCertFile string
@@ -66,8 +68,9 @@ type cliOptions struct { // nolint: maligned
 	// TODO(incfly): delete this field once we deprecate flag --grpc-hostname.
 	grpcHostname string
 	// Comma separated string containing all possible host name that clients may use to connect to.
-	grpcHosts string
-	grpcPort  int
+	grpcHosts  string
+	grpcPort   int
+	serverOnly bool
 
 	// Whether the CA signs certificates for other CAs.
 	signCACerts bool
@@ -145,9 +148,11 @@ func init() {
 			cmd.ListenedNamespaceKey+"} environment variable. If neither is set, Citadel listens to all namespaces.")
 	flags.StringVar(&opts.istioCaStorageNamespace, "citadel-storage-namespace", "istio-system", "Namespace where "+
 		"the Citadel pod is running. Will not be used if explicit file or other storage mechanism is specified.")
-
 	flags.StringVar(&opts.kubeConfigFile, "kube-config", "",
 		"Specifies path to kubeconfig file. This must be specified when not running inside a Kubernetes pod.")
+	flags.BoolVar(&opts.readSigningCertOnly, "readSigningCertOnly", false, "When set, Citadel only reads the self-signed signing "+
+		"key and cert without generating one. This flag avoids racing condition between multiple Citadels generating self-signed "+
+		"key and cert. Please make sure one and only one Citadel instance has this flag set to false.")
 
 	// Configuration if Citadel accepts key/cert configured through arguments.
 	flags.StringVar(&opts.certChainFile, "cert-chain", "", "Path to the certificate chain file")
@@ -163,6 +168,7 @@ func init() {
 		"The TTL of self-signed CA root certificate")
 	flags.StringVar(&opts.trustDomain, "trust-domain", "",
 		"The domain serves to identify the system with spiffe ")
+
 	// Upstream CA configuration if Citadel interacts with upstream CA.
 	flags.StringVar(&opts.cAClientConfig.CAAddress, "upstream-ca-address", "", "The IP:port address of the upstream "+
 		"CA. When set, the CA will rely on the upstream Citadel to provision its own certificate.")
@@ -187,6 +193,8 @@ func init() {
 		"The list of hostnames for istio ca server, separated by comma.")
 	flags.IntVar(&opts.grpcPort, "grpc-port", 8060, "The port number for Citadel GRPC server. "+
 		"If unspecified, Citadel will not serve GRPC requests.")
+	flags.BoolVar(&opts.serverOnly, "server-only", false, "When set, Citadel only serves as a server without writing "+
+		"the Kubernetes secrets.")
 
 	flags.StringVar(&opts.grpcHostname, "grpc-hostname", "istio-ca", "deprecated")
 	flags.MarkDeprecated("grpc-hostname", "please use --grpc-host-identities instead")
@@ -294,17 +302,24 @@ func runCA() {
 		fatalf("Could not create k8s clientset: %v", err)
 	}
 	ca := createCA(cs.CoreV1())
-	// For workloads in K8s, we apply the configured workload cert TTL.
-	sc, err := controller.NewSecretController(ca,
-		opts.workloadCertTTL,
-		opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod, opts.dualUse,
-		cs.CoreV1(), opts.signCACerts, opts.listenedNamespace, webhooks)
-	if err != nil {
-		fatalf("Failed to create secret controller: %v", err)
-	}
 
 	stopCh := make(chan struct{})
-	sc.Run(stopCh)
+	if !opts.serverOnly {
+		// For workloads in K8s, we apply the configured workload cert TTL.
+		sc, err := controller.NewSecretController(ca,
+			opts.workloadCertTTL,
+			opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod, opts.dualUse,
+			cs.CoreV1(), opts.signCACerts, opts.listenedNamespace, webhooks)
+		if err != nil {
+			fatalf("Failed to create secret controller: %v", err)
+		}
+		sc.Run(stopCh)
+	} else {
+		log.Infof("Citadel is running in server only mode, certificates will not be propagated via secret.")
+		if opts.grpcPort <= 0 {
+			fatalf("The gRPC port must be set in server-only model.")
+		}
+	}
 
 	if opts.grpcPort > 0 {
 		// start registry if gRPC server is to be started
@@ -396,9 +411,17 @@ func createCA(client corev1.CoreV1Interface) *ca.IstioCA {
 	if opts.selfSignedCA {
 		log.Info("Use self-signed certificate as the CA certificate")
 		spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(opts.trustDomain, "", len(opts.kubeConfigFile) != 0))
-		caOpts, err = ca.NewSelfSignedIstioCAOptions(opts.selfSignedCACertTTL, opts.workloadCertTTL,
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var checkInterval time.Duration
+		if opts.readSigningCertOnly {
+			checkInterval = ca.ReadSigningCertCheckInterval
+		} else {
+			checkInterval = -1
+		}
+		caOpts, err = ca.NewSelfSignedIstioCAOptions(ctx, opts.selfSignedCACertTTL, opts.workloadCertTTL,
 			opts.maxWorkloadCertTTL, spiffe.GetTrustDomain(), opts.dualUse,
-			opts.istioCaStorageNamespace, client)
+			opts.istioCaStorageNamespace, checkInterval, client)
 		if err != nil {
 			fatalf("Failed to create a self-signed Citadel (error: %v)", err)
 		}

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -317,7 +317,7 @@ func runCA() {
 		}
 		sc.Run(stopCh)
 	} else {
-		log.Infof("Citadel is running in server only mode, certificates will not be propagated via secret.")
+		log.Info("Citadel is running in server only mode, certificates will not be propagated via secret.")
 		if opts.grpcPort <= 0 {
 			fatalf("The gRPC port must be set in server-only model.")
 		}

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -107,7 +107,6 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, caCertTTL, certTTL, maxCer
 	// For subsequent restart, CA will reads key/cert from CASecret.
 	caSecret, scrtErr := client.Secrets(namespace).Get(CASecret, metav1.GetOptions{})
 	if scrtErr != nil && readCertRetryInterval > 0 {
-		// Wait to get ready.
 		log.Infof("Citadel in signing key/cert read only mode. Wait until secret %s:%s can be loaded...", namespace, CASecret)
 		ticker := time.NewTicker(readCertRetryInterval)
 		for {

--- a/security/pkg/pki/ca/ca.go
+++ b/security/pkg/pki/ca/ca.go
@@ -109,10 +109,10 @@ func NewSelfSignedIstioCAOptions(ctx context.Context, caCertTTL, certTTL, maxCer
 	if scrtErr != nil && readCertRetryInterval > 0 {
 		log.Infof("Citadel in signing key/cert read only mode. Wait until secret %s:%s can be loaded...", namespace, CASecret)
 		ticker := time.NewTicker(readCertRetryInterval)
-		for {
+		for scrtErr != nil {
 			select {
 			case <-ticker.C:
-				if caSecret, scrtErr = client.Secrets(namespace).Get(CASecret, metav1.GetOptions{}); err == nil {
+				if caSecret, scrtErr = client.Secrets(namespace).Get(CASecret, metav1.GetOptions{}); scrtErr == nil {
 					log.Infof("Citadel successfully loaded the secret.")
 					break
 				}

--- a/security/pkg/pki/ca/ca_test.go
+++ b/security/pkg/pki/ca/ca_test.go
@@ -249,8 +249,11 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 	expectedErr := "secret waiting thread is terminated"
 	ctx0, cancel0 := context.WithTimeout(context.Background(), time.Millisecond*50)
 	defer cancel0()
-	caopts, err := NewSelfSignedIstioCAOptions(ctx0, caCertTTL, certTTL, maxCertTTL,
+	_, err := NewSelfSignedIstioCAOptions(ctx0, caCertTTL, certTTL, maxCertTTL,
 		org, dualUse, caNamespace, time.Millisecond*10, client.CoreV1())
+	if err == nil {
+		t.Errorf("Expected error, but succeeded.")
+	}
 	if err.Error() != expectedErr {
 		t.Errorf("Unexpected error message: %s VS (expected) %s", err.Error(), expectedErr)
 		return
@@ -263,9 +266,9 @@ func TestCreateSelfSignedIstioCAReadSigningCertOnly(t *testing.T) {
 		t.Errorf("Failed to create secret (error: %s)", err)
 	}
 
-	ctx1, cancel1 := context.WithTimeout(context.Background(), time.Millisecond*30)
+	ctx1, cancel1 := context.WithCancel(context.Background())
 	defer cancel1()
-	caopts, err = NewSelfSignedIstioCAOptions(ctx1, caCertTTL, certTTL, maxCertTTL,
+	caopts, err := NewSelfSignedIstioCAOptions(ctx1, caCertTTL, certTTL, maxCertTTL,
 		org, dualUse, caNamespace, time.Millisecond*10, client.CoreV1())
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
1. Enable Citadel to run in server-only mode, which means it does not write workload certs to secret. This tries to avoid racing condition in writing workload key and cert.
2. Support Citadel to only read signing key and cert from secret. This tries to avoid racing condition in writing signing key and cert.

Tracking issue:
https://github.com/istio/istio/issues/11380