### PR TITLE
Remove sidecar injection in istio-init jobs

### DIFF
--- a/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-10.yaml
@@ -5,6 +5,9 @@ metadata:
   name: istio-init-crd-10
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-init-service-account
       containers:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-11.yaml
@@ -5,6 +5,9 @@ metadata:
   name: istio-init-crd-11
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-init-service-account
       containers:

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-10.yaml
@@ -5,6 +5,9 @@ metadata:
   name: istio-init-crd-certmanager-10
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: istio-init-service-account
       containers:


### PR DESCRIPTION
This PR aims to solve a problem where the injector is running
but a new job is added in an upgrade scenario.  In this condition
the job is injected, which can result in errors contacting the
injector.