### PR TITLE
Create internal interface argument for istio-iptables script

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -40,6 +40,10 @@ data:
         - {{ "\"[[ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) ]]\"" }}
         - "-d"
         - {{ "\"[[ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` " }} {{ .Values.global.proxy.statusPort }} {{ ") (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` " }} "{{ .Values.global.proxy.excludeInboundPorts }}" {{ ") ]]\"" }}
+        {{ "[[ if (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces`) -]]" }}
+        - "-r"
+        {{ "- \"[[ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` ]]\"" }}
+        {{ "[[ end -]]" }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         resources:
           requests:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -205,6 +205,9 @@ global:
     includeIPRanges: "*"
     excludeIPRanges: ""
 
+    # pod internal interfaces
+    kubevirtInterfaces: ""
+
     # istio ingress capture whitelist
     # examples:
     #     Redirect no inbound traffic to Envoy:    --includeInboundPorts=""

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -66,6 +66,7 @@ var (
 		{"traffic.sidecar.istio.io/excludeOutboundIPRanges", ValidateExcludeIPRanges},
 		{"traffic.sidecar.istio.io/includeInboundPorts", ValidateIncludeInboundPorts},
 		{"traffic.sidecar.istio.io/excludeInboundPorts", ValidateExcludeInboundPorts},
+		{"traffic.sidecar.istio.io/kubevirtInterfaces", alwaysValidFunc},
 	}
 
 	annotationPolicy = annotationRegistry[0]
@@ -136,6 +137,7 @@ const (
 	DefaultReadinessFailureThreshold    = 30
 	DefaultIncludeIPRanges              = "*"
 	DefaultIncludeInboundPorts          = "*"
+	DefaultkubevirtInterfaces           = ""
 )
 
 const (
@@ -215,6 +217,9 @@ type Params struct {
 	// Comma separated list of inbound ports. If set, inbound traffic will not be redirected for those ports.
 	// Exclusions are only applied if configured to redirect all inbound traffic. By default, no ports are excluded.
 	ExcludeInboundPorts string `json:"excludeInboundPorts"`
+	// Comma separated list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound
+	// By default, no interfaces are configured.
+	KubevirtInterfaces string `json:"kubevirtInterfaces"`
 }
 
 // Validate validates the parameters and returns an error if there is configuration issue.
@@ -510,6 +515,7 @@ func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.O
 		"isset":               isset,
 		"excludeInboundPort":  excludeInboundPort,
 		"includeInboundPorts": includeInboundPorts,
+		"kubevirtInterfaces":  kubevirtInterfaces,
 		"applicationPorts":    applicationPorts,
 		"annotation":          annotation,
 		"valueOrDefault":      valueOrDefault,
@@ -771,6 +777,10 @@ func applicationPorts(containers []corev1.Container) string {
 func includeInboundPorts(containers []corev1.Container) string {
 	// Include the ports from all containers in the deployment.
 	return getContainerPorts(containers, func(corev1.Container) bool { return true })
+}
+
+func kubevirtInterfaces(s string) string {
+	return s
 }
 
 func toJSON(m map[string]string) string {

--- a/pilot/pkg/kube/inject/inject_test.go
+++ b/pilot/pkg/kube/inject/inject_test.go
@@ -76,6 +76,7 @@ func TestIntoResourceFile(t *testing.T) {
 		excludeIPRanges              string
 		includeInboundPorts          string
 		excludeInboundPorts          string
+		kubevirtInterfaces           string
 		statusPort                   int
 		readinessPath                string
 		readinessInitialDelaySeconds uint32
@@ -401,6 +402,7 @@ func TestIntoResourceFile(t *testing.T) {
 			want:                         "traffic-params-empty-includes.yaml.injected",
 			includeIPRanges:              "",
 			excludeIPRanges:              "",
+			kubevirtInterfaces:           "",
 			statusPort:                   DefaultStatusPort,
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
@@ -446,6 +448,7 @@ func TestIntoResourceFile(t *testing.T) {
 			want:                         "status_params.yaml.injected",
 			includeIPRanges:              DefaultIncludeIPRanges,
 			includeInboundPorts:          DefaultIncludeInboundPorts,
+			kubevirtInterfaces:           DefaultkubevirtInterfaces,
 			statusPort:                   123,
 			readinessInitialDelaySeconds: 100,
 			readinessPeriodSeconds:       200,
@@ -457,6 +460,32 @@ func TestIntoResourceFile(t *testing.T) {
 			want:                         "status_annotations.yaml.injected",
 			includeIPRanges:              DefaultIncludeIPRanges,
 			includeInboundPorts:          DefaultIncludeInboundPorts,
+			statusPort:                   DefaultStatusPort,
+			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
+			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
+			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+		},
+		{
+			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
+			in:                           "kubevirtInterfaces.yaml",
+			want:                         "kubevirtInterfaces.yaml.injected",
+			debugMode:                    true,
+			includeIPRanges:              DefaultIncludeIPRanges,
+			includeInboundPorts:          DefaultIncludeInboundPorts,
+			kubevirtInterfaces:           "net1",
+			statusPort:                   DefaultStatusPort,
+			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
+			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
+			readinessFailureThreshold:    DefaultReadinessFailureThreshold,
+		},
+		{
+			// Verifies that the kubevirtInterfaces list are applied properly from parameters..
+			in:                           "kubevirtInterfaces_list.yaml",
+			want:                         "kubevirtInterfaces_list.yaml.injected",
+			debugMode:                    true,
+			includeIPRanges:              DefaultIncludeIPRanges,
+			includeInboundPorts:          DefaultIncludeInboundPorts,
+			kubevirtInterfaces:           "net1,net2",
 			statusPort:                   DefaultStatusPort,
 			readinessInitialDelaySeconds: DefaultReadinessInitialDelaySeconds,
 			readinessPeriodSeconds:       DefaultReadinessPeriodSeconds,
@@ -496,6 +525,7 @@ func TestIntoResourceFile(t *testing.T) {
 				ExcludeIPRanges:              c.excludeIPRanges,
 				IncludeInboundPorts:          c.includeInboundPorts,
 				ExcludeInboundPorts:          c.excludeInboundPorts,
+				KubevirtInterfaces:           c.kubevirtInterfaces,
 				StatusPort:                   c.statusPort,
 				ReadinessInitialDelaySeconds: c.readinessInitialDelaySeconds,
 				ReadinessPeriodSeconds:       c.readinessPeriodSeconds,

--- a/pilot/pkg/kube/inject/mesh.go
+++ b/pilot/pkg/kube/inject/mesh.go
@@ -31,6 +31,7 @@ const (
 [[- $excludeOutboundIPRangesKey     := "traffic.sidecar.istio.io/excludeOutboundIPRanges" -]]
 [[- $includeInboundPortsKey         := "traffic.sidecar.istio.io/includeInboundPorts" -]]
 [[- $excludeInboundPortsKey         := "traffic.sidecar.istio.io/excludeInboundPorts" -]]
+[[- $kubevirtInterfacesKey          := "traffic.sidecar.istio.io/kubevirtInterfaces" -]]
 [[- $statusPortValue                := (annotation .ObjectMeta $statusPortKey {{ .StatusPort }}) -]]
 [[- $readinessInitialDelayValue     := (annotation .ObjectMeta $readinessInitialDelayKey "{{ .ReadinessInitialDelaySeconds }}") -]]
 [[- $readinessPeriodValue           := (annotation .ObjectMeta $readinessPeriodKey "{{ .ReadinessPeriodSeconds }}") ]]
@@ -55,6 +56,10 @@ initContainers:
   - "[[ annotation .ObjectMeta $includeInboundPortsKey (includeInboundPorts .Spec.Containers) ]]"
   - "-d"
   - "[[ excludeInboundPort $statusPortValue (annotation .ObjectMeta $excludeInboundPortsKey "{{ .ExcludeInboundPorts }}") ]]"
+  {{ "[[ if (isset .ObjectMeta.Annotations \"traffic.sidecar.istio.io/kubevirtInterfaces\") -]]" }}
+  - "-k"
+  - "[[ annotation .ObjectMeta $kubevirtInterfacesKey "{{ .KubevirtInterfaces }}" ]]"
+  {{ "[[ end -]]" }}
   {{ if eq .ImagePullPolicy "" -}}
   imagePullPolicy: IfNotPresent
   {{ else -}}

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  template:
+    metadata:
+      annotations:
+        traffic.sidecar.istio.io/kubevirtInterfaces: "net1"
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces.yaml.injected
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/kubevirtInterfaces: net1
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - ""
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        - --concurrency
+        - "1"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: docker.io/istio/proxy_debug:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: false
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15020"
+        - -k
+        - net1
+        image: docker.io/istio/proxy_init:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+---

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  template:
+    metadata:
+      annotations:
+        traffic.sidecar.istio.io/kubevirtInterfaces: "net1,net2"
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "fake.docker.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80

--- a/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/inject/kubevirtInterfaces_list.yaml.injected
@@ -1,0 +1,137 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/status: '{"version":"","initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-certs"],"imagePullSecrets":null}'
+        traffic.sidecar.istio.io/kubevirtInterfaces: net1,net2
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: fake.docker.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - hello.default
+        - --drainDuration
+        - 2s
+        - --parentShutdownDuration
+        - 3s
+        - --discoveryAddress
+        - istio-pilot:15007
+        - --connectTimeout
+        - 1s
+        - --statsdUdpAddress
+        - ""
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --statusPort
+        - "15020"
+        - --applicationPorts
+        - "80"
+        - --concurrency
+        - "1"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        image: docker.io/istio/proxy_debug:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+          initialDelaySeconds: 1
+          periodSeconds: 2
+        resources:
+          requests:
+            cpu: 10m
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: false
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - -p
+        - "15001"
+        - -u
+        - "1337"
+        - -m
+        - REDIRECT
+        - -i
+        - '*'
+        - -x
+        - ""
+        - -b
+        - "80"
+        - -d
+        - "15020"
+        - -k
+        - net1,net2
+        image: docker.io/istio/proxy_init:unittest
+        imagePullPolicy: IfNotPresent
+        name: istio-init
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - name: istio-certs
+        secret:
+          optional: true
+          secretName: istio.default
+status: {}
+---

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -19,7 +19,7 @@
 # Initialization script responsible for setting up port forwarding for Istio sidecar.
 
 function usage() {
-  echo "${0} -p PORT -u UID -g GID [-m mode] [-b ports] [-d ports] [-i CIDR] [-x CIDR] [-h]"
+  echo "${0} -p PORT -u UID -g GID [-m mode] [-b ports] [-d ports] [-i CIDR] [-x CIDR] [-k interfaces] [-h]"
   echo ''
   # shellcheck disable=SC2016
   echo '  -p: Specify the envoy port to which redirect all TCP traffic (default $ENVOY_PORT = 15001)'
@@ -46,6 +46,9 @@ function usage() {
   echo '  -x: Comma separated list of IP ranges in CIDR form to be excluded from redirection. Only applies when all '
   # shellcheck disable=SC2016
   echo '      outbound traffic (i.e. "*") is being redirected (default to $ISTIO_SERVICE_EXCLUDE_CIDR).'
+  echo '  -k: Comma separated list of virtual interfaces whose inbound traffic (from VM)'
+  echo '      will be treated as outbound (optional)'
+  # shellcheck disable=SC2016
   echo ''
   # shellcheck disable=SC2016
   echo 'Using environment variables in $ISTIO_SIDECAR_CONFIG (default: /var/lib/istio/envoy/sidecar.env)'
@@ -88,8 +91,9 @@ INBOUND_PORTS_INCLUDE=${ISTIO_INBOUND_PORTS-}
 INBOUND_PORTS_EXCLUDE=${ISTIO_LOCAL_EXCLUDE_PORTS-}
 OUTBOUND_IP_RANGES_INCLUDE=${ISTIO_SERVICE_CIDR-}
 OUTBOUND_IP_RANGES_EXCLUDE=${ISTIO_SERVICE_EXCLUDE_CIDR-}
+KUBEVIRT_INTERFACES=
 
-while getopts ":p:u:g:m:b:d:i:x:h" opt; do
+while getopts ":p:u:g:m:b:d:i:x:k:h" opt; do
   case ${opt} in
     p)
       PROXY_PORT=${OPTARG}
@@ -114,6 +118,9 @@ while getopts ":p:u:g:m:b:d:i:x:h" opt; do
       ;;
     x)
       OUTBOUND_IP_RANGES_EXCLUDE=${OPTARG}
+      ;;
+    k)
+      KUBEVIRT_INTERFACES=${OPTARG}
       ;;
     h)
       usage
@@ -195,6 +202,7 @@ echo "INBOUND_PORTS_INCLUDE=${INBOUND_PORTS_INCLUDE}"
 echo "INBOUND_PORTS_EXCLUDE=${INBOUND_PORTS_EXCLUDE}"
 echo "OUTBOUND_IP_RANGES_INCLUDE=${OUTBOUND_IP_RANGES_INCLUDE}"
 echo "OUTBOUND_IP_RANGES_EXCLUDE=${OUTBOUND_IP_RANGES_EXCLUDE}"
+echo "KUBEVIRT_INTERFACES=${KUBEVIRT_INTERFACES}"
 echo
 
 INBOUND_CAPTURE_PORT=${INBOUND_CAPTURE_PORT:-$PROXY_PORT}
@@ -319,13 +327,24 @@ if [ -n "${OUTBOUND_IP_RANGES_EXCLUDE}" ]; then
   done
 fi
 
+for internalInterface in ${KUBEVIRT_INTERFACES}; do
+    iptables -t nat -I PREROUTING 1 -i "${internalInterface}" -j RETURN
+done
+
 # Apply outbound IP inclusions.
 if [ "${OUTBOUND_IP_RANGES_INCLUDE}" == "*" ]; then
   # Wildcard specified. Redirect all remaining outbound traffic to Envoy.
   iptables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
+  for internalInterface in ${KUBEVIRT_INTERFACES}; do
+    iptables -t nat -I PREROUTING 1 -i "${internalInterface}" -j ISTIO_REDIRECT
+  done
+
 elif [ -n "${OUTBOUND_IP_RANGES_INCLUDE}" ]; then
   # User has specified a non-empty list of cidrs to be redirected to Envoy.
   for cidr in ${OUTBOUND_IP_RANGES_INCLUDE}; do
+    for internalInterface in ${KUBEVIRT_INTERFACES}; do
+        iptables -t nat -I PREROUTING 1 -i "${internalInterface}" -d "${cidr}" -j ISTIO_REDIRECT
+    done
     iptables -t nat -A ISTIO_OUTPUT -d "${cidr}" -j ISTIO_REDIRECT
   done
   # All other traffic is not redirected.


### PR DESCRIPTION
Related to https://github.com/istio/istio/pull/10378

traffic explain:
From k8s network to the vm.

k8s network -> prerouting rules -> ISTIO_INBOUND -> envoy process -> (localhost:port) -> PREROUTING -> KUBEVIRT_PREINBOUND -> DNAT (vm ip) -> POSTROUTING -> KUBEVIRT_POSTINBOUND -> SNAT (bridge ip) -> VM

From vm to k8s network.

VM -> PREROUTING -> ISTIO_REDIRECT -> envoy process -> PREROUTING -> POSTROUTING -> k8s network