### PR TITLE
Galley: Include full Pod resource

### DIFF
--- a/galley/pkg/metadata/types.go
+++ b/galley/pkg/metadata/types.go
@@ -391,7 +391,7 @@ func init() {
 		"type.googleapis.com/k8s.io.api.core.v1.NodeSpec")
 	Pod = b.Register(
 		"k8s/core/v1/pods",
-		"type.googleapis.com/k8s.io.api.core.v1.PodSpec")
+		"type.googleapis.com/k8s.io.api.core.v1.Pod")
 	Service = b.Register(
 		"k8s/core/v1/services",
 		"type.googleapis.com/k8s.io.api.core.v1.ServiceSpec")

--- a/galley/pkg/source/kube/builtin/source_test.go
+++ b/galley/pkg/source/kube/builtin/source_test.go
@@ -251,7 +251,7 @@ func TestPods(t *testing.T) {
 		if pod, err = client.CoreV1().Pods(namespace).Create(pod); err != nil {
 			t.Fatalf("failed creating pod: %v", err)
 		}
-		expected := toEvent(resource.Added, spec, pod, &pod.Spec)
+		expected := toEvent(resource.Added, spec, pod, pod)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})
@@ -264,7 +264,7 @@ func TestPods(t *testing.T) {
 		if _, err := client.CoreV1().Pods(namespace).Update(pod); err != nil {
 			t.Fatalf("failed updating pod: %v", err)
 		}
-		expected := toEvent(resource.Updated, spec, pod, &pod.Spec)
+		expected := toEvent(resource.Updated, spec, pod, pod)
 		actual := events.Expect(t, ch)
 		g.Expect(actual).To(Equal(expected))
 	})

--- a/galley/pkg/source/kube/builtin/types.go
+++ b/galley/pkg/source/kube/builtin/types.go
@@ -102,7 +102,7 @@ var (
 			},
 			extractResource: func(o interface{}) proto.Message {
 				if obj, ok := o.(*v1.Pod); ok {
-					return &obj.Spec
+					return obj
 				}
 				return nil
 			},

--- a/galley/pkg/source/kube/builtin/types_test.go
+++ b/galley/pkg/source/kube/builtin/types_test.go
@@ -51,9 +51,9 @@ func TestParse(t *testing.T) {
 		objMeta, objResource := parse(t, input, "Pod")
 
 		// Just validate a couple of things...
-		_, ok := objResource.(*coreV1.PodSpec)
+		_, ok := objResource.(*coreV1.Pod)
 		if !ok {
-			t.Fatal("failed casting item to PodSpec")
+			t.Fatal("failed casting item to Pod")
 		}
 		g.Expect(objMeta.GetName()).To(Equal("kube-dns-548976df6c-d9kkv"))
 	})

--- a/galley/pkg/testing/testdata/dataset.gen.go
+++ b/galley/pkg/testing/testdata/dataset.gen.go
@@ -1464,7 +1464,7 @@ func datasetV1PodYaml() (*asset, error) {
 var _datasetV1Pod_expectedJson = []byte(`{
   "k8s/core/v1/pods": [
     {
-      "TypeURL": "type.googleapis.com/k8s.io.api.core.v1.PodSpec",
+      "TypeURL": "type.googleapis.com/k8s.io.api.core.v1.Pod",
       "Metadata": {
         "name": "kube-dns-548976df6c-d9kkv",
         "annotations": {
@@ -1477,286 +1477,405 @@ var _datasetV1Pod_expectedJson = []byte(`{
         }
       },
       "Body": {
-        "containers": [
-          {
-            "args": [
-              "--domain=cluster.local.",
-              "--dns-port=10053",
-              "--config-dir=/kube-dns-config",
-              "--v=2"
-            ],
-            "env": [
-              {
-                "name": "PROMETHEUS_PORT",
-                "value": "10055"
-              }
-            ],
-            "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/healthcheck/kubedns",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "kubedns",
-            "ports": [
-              {
-                "containerPort": 10053,
-                "name": "dns-local",
-                "protocol": "UDP"
-              },
-              {
-                "containerPort": 10053,
-                "name": "dns-tcp-local",
-                "protocol": "TCP"
-              },
-              {
-                "containerPort": 10055,
-                "name": "metrics",
-                "protocol": "TCP"
-              }
-            ],
-            "readinessProbe": {
-              "failureThreshold": 3,
-              "httpGet": {
-                "path": "/readiness",
-                "port": 8081,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 3,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "resources": {
-              "limits": {
-                "memory": "170Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "70Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/kube-dns-config",
-                "name": "kube-dns-config"
-              },
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
+        "metadata": {
+          "annotations": {
+            "scheduler.alpha.kubernetes.io/critical-pod": "",
+            "seccomp.security.alpha.kubernetes.io/pod": "docker/default"
           },
-          {
-            "args": [
-              "-v=2",
-              "-logtostderr",
-              "-configDir=/etc/k8s/dns/dnsmasq-nanny",
-              "-restartDnsmasq=true",
-              "--",
-              "-k",
-              "--cache-size=1000",
-              "--no-negcache",
-              "--log-facility=-",
-              "--server=/cluster.local/127.0.0.1#10053",
-              "--server=/in-addr.arpa/127.0.0.1#10053",
-              "--server=/ip6.arpa/127.0.0.1#10053"
-            ],
-            "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/healthcheck/dnsmasq",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "dnsmasq",
-            "ports": [
-              {
-                "containerPort": 53,
-                "name": "dns",
-                "protocol": "UDP"
-              },
-              {
-                "containerPort": 53,
-                "name": "dns-tcp",
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {
-              "requests": {
-                "cpu": "150m",
-                "memory": "20Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/etc/k8s/dns/dnsmasq-nanny",
-                "name": "kube-dns-config"
-              },
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
+          "creationTimestamp": "2018-12-03T16:59:57Z",
+          "generateName": "kube-dns-548976df6c-",
+          "labels": {
+            "k8s-app": "kube-dns",
+            "pod-template-hash": "1045328927"
           },
-          {
-            "args": [
-              "--v=2",
-              "--logtostderr",
-              "--probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV",
-              "--probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV"
-            ],
-            "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/metrics",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "sidecar",
-            "ports": [
-              {
-                "containerPort": 10054,
-                "name": "metrics",
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {
-              "requests": {
-                "cpu": "10m",
-                "memory": "20Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
-          },
-          {
-            "command": [
-              "/monitor",
-              "--component=kubedns",
-              "--target-port=10054",
-              "--stackdriver-prefix=container.googleapis.com/internal/addons",
-              "--api-override=https://monitoring.googleapis.com/",
-              "--whitelisted-metrics=probe_kubedns_latency_ms,probe_kubedns_errors,dnsmasq_misses,dnsmasq_hits",
-              "--pod-id=$(POD_NAME)",
-              "--namespace-id=$(POD_NAMESPACE)",
-              "--v=2"
-            ],
-            "env": [
-              {
-                "name": "POD_NAME",
-                "valueFrom": {
-                  "fieldRef": {
-                    "apiVersion": "v1",
-                    "fieldPath": "metadata.name"
-                  }
-                }
-              },
-              {
-                "name": "POD_NAMESPACE",
-                "valueFrom": {
-                  "fieldRef": {
-                    "apiVersion": "v1",
-                    "fieldPath": "metadata.namespace"
-                  }
-                }
-              }
-            ],
-            "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
-            "imagePullPolicy": "IfNotPresent",
-            "name": "prometheus-to-sd",
-            "resources": {},
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
-          }
-        ],
-        "dnsPolicy": "Default",
-        "nodeName": "gke-istio-test-default-pool-866a0405-ftch",
-        "priority": 2000000000,
-        "priorityClassName": "system-cluster-critical",
-        "restartPolicy": "Always",
-        "schedulerName": "default-scheduler",
-        "securityContext": {},
-        "serviceAccount": "kube-dns",
-        "serviceAccountName": "kube-dns",
-        "terminationGracePeriodSeconds": 30,
-        "tolerations": [
-          {
-            "key": "CriticalAddonsOnly",
-            "operator": "Exists"
-          },
-          {
-            "effect": "NoExecute",
-            "key": "node.kubernetes.io/not-ready",
-            "operator": "Exists",
-            "tolerationSeconds": 300
-          },
-          {
-            "effect": "NoExecute",
-            "key": "node.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "tolerationSeconds": 300
-          }
-        ],
-        "volumes": [
-          {
-            "configMap": {
-              "defaultMode": 420,
-              "name": "kube-dns",
-              "optional": true
-            },
-            "name": "kube-dns-config"
-          },
-          {
-            "name": "kube-dns-token-lwn8l",
-            "secret": {
-              "defaultMode": 420,
-              "secretName": "kube-dns-token-lwn8l"
+          "name": "kube-dns-548976df6c-d9kkv",
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "ReplicaSet",
+              "name": "kube-dns-548976df6c",
+              "uid": "b589a851-f71b-11e8-af4f-42010a800072"
             }
-          }
-        ]
+          ],
+          "resourceVersion": "50572715",
+          "selfLink": "/api/v1/namespaces/kube-system/pods/kube-dns-548976df6c-d9kkv",
+          "uid": "dd4bbbd4-f71c-11e8-af4f-42010a800072"
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--domain=cluster.local.",
+                "--dns-port=10053",
+                "--config-dir=/kube-dns-config",
+                "--v=2"
+              ],
+              "env": [
+                {
+                  "name": "PROMETHEUS_PORT",
+                  "value": "10055"
+                }
+              ],
+              "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/healthcheck/kubedns",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "kubedns",
+              "ports": [
+                {
+                  "containerPort": 10053,
+                  "name": "dns-local",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 10053,
+                  "name": "dns-tcp-local",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 10055,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/readiness",
+                  "port": 8081,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 3,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "resources": {
+                "limits": {
+                  "memory": "170Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "70Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/kube-dns-config",
+                  "name": "kube-dns-config"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "-v=2",
+                "-logtostderr",
+                "-configDir=/etc/k8s/dns/dnsmasq-nanny",
+                "-restartDnsmasq=true",
+                "--",
+                "-k",
+                "--cache-size=1000",
+                "--no-negcache",
+                "--log-facility=-",
+                "--server=/cluster.local/127.0.0.1#10053",
+                "--server=/in-addr.arpa/127.0.0.1#10053",
+                "--server=/ip6.arpa/127.0.0.1#10053"
+              ],
+              "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/healthcheck/dnsmasq",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "dnsmasq",
+              "ports": [
+                {
+                  "containerPort": 53,
+                  "name": "dns",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 53,
+                  "name": "dns-tcp",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "150m",
+                  "memory": "20Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/etc/k8s/dns/dnsmasq-nanny",
+                  "name": "kube-dns-config"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "--v=2",
+                "--logtostderr",
+                "--probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV",
+                "--probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV"
+              ],
+              "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/metrics",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "sidecar",
+              "ports": [
+                {
+                  "containerPort": 10054,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "20Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "command": [
+                "/monitor",
+                "--component=kubedns",
+                "--target-port=10054",
+                "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                "--api-override=https://monitoring.googleapis.com/",
+                "--whitelisted-metrics=probe_kubedns_latency_ms,probe_kubedns_errors,dnsmasq_misses,dnsmasq_hits",
+                "--pod-id=$(POD_NAME)",
+                "--namespace-id=$(POD_NAMESPACE)",
+                "--v=2"
+              ],
+              "env": [
+                {
+                  "name": "POD_NAME",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "apiVersion": "v1",
+                      "fieldPath": "metadata.name"
+                    }
+                  }
+                },
+                {
+                  "name": "POD_NAMESPACE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "apiVersion": "v1",
+                      "fieldPath": "metadata.namespace"
+                    }
+                  }
+                }
+              ],
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "prometheus-to-sd",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "Default",
+          "nodeName": "gke-istio-test-default-pool-866a0405-ftch",
+          "priority": 2000000000,
+          "priorityClassName": "system-cluster-critical",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "kube-dns",
+          "serviceAccountName": "kube-dns",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+            {
+              "key": "CriticalAddonsOnly",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            }
+          ],
+          "volumes": [
+            {
+              "configMap": {
+                "defaultMode": 420,
+                "name": "kube-dns",
+                "optional": true
+              },
+              "name": "kube-dns-config"
+            },
+            {
+              "name": "kube-dns-token-lwn8l",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "kube-dns-token-lwn8l"
+              }
+            }
+          ]
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T17:00:00Z",
+              "status": "True",
+              "type": "Initialized"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T17:00:20Z",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": null,
+              "status": "True",
+              "type": "ContainersReady"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T16:59:57Z",
+              "status": "True",
+              "type": "PodScheduled"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "containerID": "docker://676f6c98bfa136315c4ccf0fe40e7a56cbf9ac85128e94310eae82f191246b3e",
+              "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:45df3e8e0c551bd0c79cdba48ae6677f817971dcbd1eeed7fd1f9a35118410e4",
+              "lastState": {},
+              "name": "dnsmasq",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:14Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://93fd0664e150982dad0481c5260183308a7035a2f938ec50509d586ed586a107",
+              "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
+              "lastState": {},
+              "name": "kubedns",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:10Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://e823b79a0a48af75f2eebb1c89ba4c31e8c1ee67ee0d917ac7b4891b67d2cd0f",
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
+              "imageID": "docker-pullable://gcr.io/google-containers/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2",
+              "lastState": {},
+              "name": "prometheus-to-sd",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:18Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://74223c401a8dac04b8bd29cdfedcb216881791b4e84bb80a15714991dd18735e",
+              "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-sidecar-amd64@sha256:cedc8fe2098dffc26d17f64061296b7aa54258a31513b6c52df271a98bb522b3",
+              "lastState": {},
+              "name": "sidecar",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:16Z"
+                }
+              }
+            }
+          ],
+          "hostIP": "10.128.0.5",
+          "phase": "Running",
+          "podIP": "10.40.1.4",
+          "qosClass": "Burstable",
+          "startTime": "2018-12-03T17:00:00Z"
+        }
       }
     }
   ]

--- a/galley/pkg/testing/testdata/dataset/v1/pod_expected.json
+++ b/galley/pkg/testing/testdata/dataset/v1/pod_expected.json
@@ -1,7 +1,7 @@
 {
   "k8s/core/v1/pods": [
     {
-      "TypeURL": "type.googleapis.com/k8s.io.api.core.v1.PodSpec",
+      "TypeURL": "type.googleapis.com/k8s.io.api.core.v1.Pod",
       "Metadata": {
         "name": "kube-dns-548976df6c-d9kkv",
         "annotations": {
@@ -14,286 +14,405 @@
         }
       },
       "Body": {
-        "containers": [
-          {
-            "args": [
-              "--domain=cluster.local.",
-              "--dns-port=10053",
-              "--config-dir=/kube-dns-config",
-              "--v=2"
-            ],
-            "env": [
-              {
-                "name": "PROMETHEUS_PORT",
-                "value": "10055"
-              }
-            ],
-            "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/healthcheck/kubedns",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "kubedns",
-            "ports": [
-              {
-                "containerPort": 10053,
-                "name": "dns-local",
-                "protocol": "UDP"
-              },
-              {
-                "containerPort": 10053,
-                "name": "dns-tcp-local",
-                "protocol": "TCP"
-              },
-              {
-                "containerPort": 10055,
-                "name": "metrics",
-                "protocol": "TCP"
-              }
-            ],
-            "readinessProbe": {
-              "failureThreshold": 3,
-              "httpGet": {
-                "path": "/readiness",
-                "port": 8081,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 3,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "resources": {
-              "limits": {
-                "memory": "170Mi"
-              },
-              "requests": {
-                "cpu": "100m",
-                "memory": "70Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/kube-dns-config",
-                "name": "kube-dns-config"
-              },
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
+        "metadata": {
+          "annotations": {
+            "scheduler.alpha.kubernetes.io/critical-pod": "",
+            "seccomp.security.alpha.kubernetes.io/pod": "docker/default"
           },
-          {
-            "args": [
-              "-v=2",
-              "-logtostderr",
-              "-configDir=/etc/k8s/dns/dnsmasq-nanny",
-              "-restartDnsmasq=true",
-              "--",
-              "-k",
-              "--cache-size=1000",
-              "--no-negcache",
-              "--log-facility=-",
-              "--server=/cluster.local/127.0.0.1#10053",
-              "--server=/in-addr.arpa/127.0.0.1#10053",
-              "--server=/ip6.arpa/127.0.0.1#10053"
-            ],
-            "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/healthcheck/dnsmasq",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "dnsmasq",
-            "ports": [
-              {
-                "containerPort": 53,
-                "name": "dns",
-                "protocol": "UDP"
-              },
-              {
-                "containerPort": 53,
-                "name": "dns-tcp",
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {
-              "requests": {
-                "cpu": "150m",
-                "memory": "20Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/etc/k8s/dns/dnsmasq-nanny",
-                "name": "kube-dns-config"
-              },
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
+          "creationTimestamp": "2018-12-03T16:59:57Z",
+          "generateName": "kube-dns-548976df6c-",
+          "labels": {
+            "k8s-app": "kube-dns",
+            "pod-template-hash": "1045328927"
           },
-          {
-            "args": [
-              "--v=2",
-              "--logtostderr",
-              "--probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV",
-              "--probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV"
-            ],
-            "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
-            "imagePullPolicy": "IfNotPresent",
-            "livenessProbe": {
-              "failureThreshold": 5,
-              "httpGet": {
-                "path": "/metrics",
-                "port": 10054,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "timeoutSeconds": 5
-            },
-            "name": "sidecar",
-            "ports": [
-              {
-                "containerPort": 10054,
-                "name": "metrics",
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {
-              "requests": {
-                "cpu": "10m",
-                "memory": "20Mi"
-              }
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
-          },
-          {
-            "command": [
-              "/monitor",
-              "--component=kubedns",
-              "--target-port=10054",
-              "--stackdriver-prefix=container.googleapis.com/internal/addons",
-              "--api-override=https://monitoring.googleapis.com/",
-              "--whitelisted-metrics=probe_kubedns_latency_ms,probe_kubedns_errors,dnsmasq_misses,dnsmasq_hits",
-              "--pod-id=$(POD_NAME)",
-              "--namespace-id=$(POD_NAMESPACE)",
-              "--v=2"
-            ],
-            "env": [
-              {
-                "name": "POD_NAME",
-                "valueFrom": {
-                  "fieldRef": {
-                    "apiVersion": "v1",
-                    "fieldPath": "metadata.name"
-                  }
-                }
-              },
-              {
-                "name": "POD_NAMESPACE",
-                "valueFrom": {
-                  "fieldRef": {
-                    "apiVersion": "v1",
-                    "fieldPath": "metadata.namespace"
-                  }
-                }
-              }
-            ],
-            "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
-            "imagePullPolicy": "IfNotPresent",
-            "name": "prometheus-to-sd",
-            "resources": {},
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "volumeMounts": [
-              {
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-                "name": "kube-dns-token-lwn8l",
-                "readOnly": true
-              }
-            ]
-          }
-        ],
-        "dnsPolicy": "Default",
-        "nodeName": "gke-istio-test-default-pool-866a0405-ftch",
-        "priority": 2000000000,
-        "priorityClassName": "system-cluster-critical",
-        "restartPolicy": "Always",
-        "schedulerName": "default-scheduler",
-        "securityContext": {},
-        "serviceAccount": "kube-dns",
-        "serviceAccountName": "kube-dns",
-        "terminationGracePeriodSeconds": 30,
-        "tolerations": [
-          {
-            "key": "CriticalAddonsOnly",
-            "operator": "Exists"
-          },
-          {
-            "effect": "NoExecute",
-            "key": "node.kubernetes.io/not-ready",
-            "operator": "Exists",
-            "tolerationSeconds": 300
-          },
-          {
-            "effect": "NoExecute",
-            "key": "node.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "tolerationSeconds": 300
-          }
-        ],
-        "volumes": [
-          {
-            "configMap": {
-              "defaultMode": 420,
-              "name": "kube-dns",
-              "optional": true
-            },
-            "name": "kube-dns-config"
-          },
-          {
-            "name": "kube-dns-token-lwn8l",
-            "secret": {
-              "defaultMode": 420,
-              "secretName": "kube-dns-token-lwn8l"
+          "name": "kube-dns-548976df6c-d9kkv",
+          "ownerReferences": [
+            {
+              "apiVersion": "apps/v1",
+              "blockOwnerDeletion": true,
+              "controller": true,
+              "kind": "ReplicaSet",
+              "name": "kube-dns-548976df6c",
+              "uid": "b589a851-f71b-11e8-af4f-42010a800072"
             }
-          }
-        ]
+          ],
+          "resourceVersion": "50572715",
+          "selfLink": "/api/v1/namespaces/kube-system/pods/kube-dns-548976df6c-d9kkv",
+          "uid": "dd4bbbd4-f71c-11e8-af4f-42010a800072"
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--domain=cluster.local.",
+                "--dns-port=10053",
+                "--config-dir=/kube-dns-config",
+                "--v=2"
+              ],
+              "env": [
+                {
+                  "name": "PROMETHEUS_PORT",
+                  "value": "10055"
+                }
+              ],
+              "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/healthcheck/kubedns",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "kubedns",
+              "ports": [
+                {
+                  "containerPort": 10053,
+                  "name": "dns-local",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 10053,
+                  "name": "dns-tcp-local",
+                  "protocol": "TCP"
+                },
+                {
+                  "containerPort": 10055,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "failureThreshold": 3,
+                "httpGet": {
+                  "path": "/readiness",
+                  "port": 8081,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 3,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "resources": {
+                "limits": {
+                  "memory": "170Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "70Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/kube-dns-config",
+                  "name": "kube-dns-config"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "-v=2",
+                "-logtostderr",
+                "-configDir=/etc/k8s/dns/dnsmasq-nanny",
+                "-restartDnsmasq=true",
+                "--",
+                "-k",
+                "--cache-size=1000",
+                "--no-negcache",
+                "--log-facility=-",
+                "--server=/cluster.local/127.0.0.1#10053",
+                "--server=/in-addr.arpa/127.0.0.1#10053",
+                "--server=/ip6.arpa/127.0.0.1#10053"
+              ],
+              "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/healthcheck/dnsmasq",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "dnsmasq",
+              "ports": [
+                {
+                  "containerPort": 53,
+                  "name": "dns",
+                  "protocol": "UDP"
+                },
+                {
+                  "containerPort": 53,
+                  "name": "dns-tcp",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "150m",
+                  "memory": "20Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/etc/k8s/dns/dnsmasq-nanny",
+                  "name": "kube-dns-config"
+                },
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "args": [
+                "--v=2",
+                "--logtostderr",
+                "--probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,SRV",
+                "--probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,SRV"
+              ],
+              "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
+              "imagePullPolicy": "IfNotPresent",
+              "livenessProbe": {
+                "failureThreshold": 5,
+                "httpGet": {
+                  "path": "/metrics",
+                  "port": 10054,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 60,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 5
+              },
+              "name": "sidecar",
+              "ports": [
+                {
+                  "containerPort": 10054,
+                  "name": "metrics",
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "20Mi"
+                }
+              },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            },
+            {
+              "command": [
+                "/monitor",
+                "--component=kubedns",
+                "--target-port=10054",
+                "--stackdriver-prefix=container.googleapis.com/internal/addons",
+                "--api-override=https://monitoring.googleapis.com/",
+                "--whitelisted-metrics=probe_kubedns_latency_ms,probe_kubedns_errors,dnsmasq_misses,dnsmasq_hits",
+                "--pod-id=$(POD_NAME)",
+                "--namespace-id=$(POD_NAMESPACE)",
+                "--v=2"
+              ],
+              "env": [
+                {
+                  "name": "POD_NAME",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "apiVersion": "v1",
+                      "fieldPath": "metadata.name"
+                    }
+                  }
+                },
+                {
+                  "name": "POD_NAMESPACE",
+                  "valueFrom": {
+                    "fieldRef": {
+                      "apiVersion": "v1",
+                      "fieldPath": "metadata.namespace"
+                    }
+                  }
+                }
+              ],
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
+              "imagePullPolicy": "IfNotPresent",
+              "name": "prometheus-to-sd",
+              "resources": {},
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File",
+              "volumeMounts": [
+                {
+                  "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                  "name": "kube-dns-token-lwn8l",
+                  "readOnly": true
+                }
+              ]
+            }
+          ],
+          "dnsPolicy": "Default",
+          "nodeName": "gke-istio-test-default-pool-866a0405-ftch",
+          "priority": 2000000000,
+          "priorityClassName": "system-cluster-critical",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "serviceAccount": "kube-dns",
+          "serviceAccountName": "kube-dns",
+          "terminationGracePeriodSeconds": 30,
+          "tolerations": [
+            {
+              "key": "CriticalAddonsOnly",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 300
+            }
+          ],
+          "volumes": [
+            {
+              "configMap": {
+                "defaultMode": 420,
+                "name": "kube-dns",
+                "optional": true
+              },
+              "name": "kube-dns-config"
+            },
+            {
+              "name": "kube-dns-token-lwn8l",
+              "secret": {
+                "defaultMode": 420,
+                "secretName": "kube-dns-token-lwn8l"
+              }
+            }
+          ]
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T17:00:00Z",
+              "status": "True",
+              "type": "Initialized"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T17:00:20Z",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": null,
+              "status": "True",
+              "type": "ContainersReady"
+            },
+            {
+              "lastProbeTime": null,
+              "lastTransitionTime": "2018-12-03T16:59:57Z",
+              "status": "True",
+              "type": "PodScheduled"
+            }
+          ],
+          "containerStatuses": [
+            {
+              "containerID": "docker://676f6c98bfa136315c4ccf0fe40e7a56cbf9ac85128e94310eae82f191246b3e",
+              "image": "k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64@sha256:45df3e8e0c551bd0c79cdba48ae6677f817971dcbd1eeed7fd1f9a35118410e4",
+              "lastState": {},
+              "name": "dnsmasq",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:14Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://93fd0664e150982dad0481c5260183308a7035a2f938ec50509d586ed586a107",
+              "image": "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
+              "lastState": {},
+              "name": "kubedns",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:10Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://e823b79a0a48af75f2eebb1c89ba4c31e8c1ee67ee0d917ac7b4891b67d2cd0f",
+              "image": "gcr.io/google-containers/prometheus-to-sd:v0.2.3",
+              "imageID": "docker-pullable://gcr.io/google-containers/prometheus-to-sd@sha256:be220ec4a66275442f11d420033c106bb3502a3217a99c806eef3cf9858788a2",
+              "lastState": {},
+              "name": "prometheus-to-sd",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:18Z"
+                }
+              }
+            },
+            {
+              "containerID": "docker://74223c401a8dac04b8bd29cdfedcb216881791b4e84bb80a15714991dd18735e",
+              "image": "k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13",
+              "imageID": "docker-pullable://k8s.gcr.io/k8s-dns-sidecar-amd64@sha256:cedc8fe2098dffc26d17f64061296b7aa54258a31513b6c52df271a98bb522b3",
+              "lastState": {},
+              "name": "sidecar",
+              "ready": true,
+              "restartCount": 0,
+              "state": {
+                "running": {
+                  "startedAt": "2018-12-03T17:00:16Z"
+                }
+              }
+            }
+          ],
+          "hostIP": "10.128.0.5",
+          "phase": "Running",
+          "podIP": "10.40.1.4",
+          "qosClass": "Burstable",
+          "startTime": "2018-12-03T17:00:00Z"
+        }
       }
     }
   ]

--- a/galley/tools/gen-meta/metadata.yaml
+++ b/galley/tools/gen-meta/metadata.yaml
@@ -33,7 +33,7 @@ resources:
     singular:    "pod"
     plural:      "pods"
     version:     "v1"
-    proto:       "k8s.io.api.core.v1.PodSpec"
+    proto:       "k8s.io.api.core.v1.Pod"
     protoPackage: "k8s.io/api/core/v1"
     collection:   "k8s/core/v1/pods"
 


### PR DESCRIPTION
The ServiceEntry transformation requires the Pod status, which is
not included in the PodSpec. We need to pass through the entire
Pod proto, so that it's available for the conversion.