### PR TITLE
Extend istio-reader role permission

### DIFF
--- a/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio-remote/templates/clusterrole.yaml
@@ -4,5 +4,11 @@ metadata:
   name: istio-reader
 rules:
   - apiGroups: ['']
-    resources: ['nodes', 'pods', 'services', 'endpoints']
+    resources: ['nodes', 'pods', 'services', 'endpoints', "replicationcontrollers"]
     verbs: ['get', 'watch', 'list']
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
In multi cluster deployment, mixer k8s env adapter does not work for remote workload because of permission issue: 

> Failed to list *v1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:istio-system:istio-multi" cannot list replicasets.apps at the cluster scope

This is to extend istio-reader rule to make mixer be able to derive k8s attributes for workloads in remote cluster.