### PR TITLE
Logging fatal errors should exit the process

### DIFF
--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -16,17 +16,22 @@ package log
 
 import (
 	"fmt"
+	"os"
 
 	"go.uber.org/zap/zapcore"
 )
 
 var defaultScope = RegisterScope(DefaultScopeName, "Unscoped logging messages.", 0)
 
+// use os.Exit via a function pointer so we can temporarily disable for unit tests
+var osExit = os.Exit
+
 // Fatal outputs a message at fatal level.
 func Fatal(msg string, fields ...zapcore.Field) {
 	if defaultScope.GetOutputLevel() >= FatalLevel {
 		defaultScope.emit(zapcore.FatalLevel, defaultScope.GetStackTraceLevel() >= FatalLevel, msg, fields)
 	}
+	osExit(255)
 }
 
 // Fatala uses fmt.Sprint to construct and log a message at fatal level.
@@ -34,6 +39,7 @@ func Fatala(args ...interface{}) {
 	if defaultScope.GetOutputLevel() >= FatalLevel {
 		defaultScope.emit(zapcore.FatalLevel, defaultScope.GetStackTraceLevel() >= FatalLevel, fmt.Sprint(args...), nil)
 	}
+	osExit(255)
 }
 
 // Fatalf uses fmt.Sprintf to construct and log a message at fatal level.
@@ -45,6 +51,7 @@ func Fatalf(template string, args ...interface{}) {
 		}
 		defaultScope.emit(zapcore.FatalLevel, defaultScope.GetStackTraceLevel() >= FatalLevel, msg, nil)
 	}
+	osExit(255)
 }
 
 // FatalEnabled returns whether output of messages using this scope is currently enabled for fatal-level output.

--- a/pkg/log/default_test.go
+++ b/pkg/log/default_test.go
@@ -15,12 +15,16 @@
 package log
 
 import (
+	"os"
 	"regexp"
 	"strconv"
 	"testing"
 )
 
 func TestDefault(t *testing.T) {
+	osExit = func(int) {}
+	defer func() { osExit = os.Exit }()
+
 	cases := []struct {
 		f          func()
 		pat        string


### PR DESCRIPTION
Popular logging packages such as glog, logrus, pkg/log, etc. exit the
process on fatal errors. Our custom logger should do the same. Many
locations in Istio's code already assume this behavior.

fixes https://github.com/istio/istio/issues/11345