### PR TITLE
Make code more reusable in other contexts

### DIFF
--- a/pkg/mcp/internal/size.go
+++ b/pkg/mcp/internal/size.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Provides a ProtoSize method that can be swapped for proto.Size when using Google protos.
 
 package internal

--- a/pkg/mcp/internal/size.go
+++ b/pkg/mcp/internal/size.go
@@ -1,0 +1,11 @@
+// Provides a ProtoSize method that can be swapped for proto.Size when using Google protos.
+
+package internal
+
+type hasSize interface {
+	Size() int
+}
+
+func ProtoSize(msg hasSize) int {
+	return msg.Size()
+}

--- a/pkg/mcp/sink/client_sink.go
+++ b/pkg/mcp/sink/client_sink.go
@@ -84,7 +84,7 @@ func (c *Client) Run(ctx context.Context) {
 			scope.Errorf("Failed to create a new MCP sink stream: %v", err)
 		}
 
-		err := c.processStream(c.stream)
+		err := c.ProcessStream(c.stream)
 		if err != nil && err != io.EOF {
 			c.reporter.RecordRecvError(err, status.Code(err))
 			scope.Errorf("Error receiving MCP response: %v", err)

--- a/pkg/mcp/sink/server_sink.go
+++ b/pkg/mcp/sink/server_sink.go
@@ -88,7 +88,7 @@ func (s *Server) EstablishResourceStream(stream mcp.ResourceSink_EstablishResour
 		return status.Errorf(codes.Unauthenticated, "Authentication failure: %v", err)
 	}
 
-	err := s.sink.processStream(stream)
+	err := s.sink.ProcessStream(stream)
 	code := status.Code(err)
 	if code == codes.OK || code == codes.Canceled || err == io.EOF {
 		return nil

--- a/pkg/mcp/sink/sink.go
+++ b/pkg/mcp/sink/sink.go
@@ -179,10 +179,10 @@ func (sink *Sink) createInitialRequests() []*mcp.RequestResources {
 	return initialRequests
 }
 
-// processStream implements the MCP message exchange for the resource sink. It accepts the sink
-// stream interface and returns when a send or receive error occurs. The caller is responsible for handling gRPC
-// client/server specific error handling.
-func (sink *Sink) processStream(stream Stream) error {
+// ProcessStream implements the MCP message exchange for the resource sink. It accepts the sink
+// stream interface and returns when a send or receive error occurs. The caller is responsible for
+// handling gRPC client/server specific error handling.
+func (sink *Sink) ProcessStream(stream Stream) error {
 	// send initial requests for each supported type
 	initialRequests := sink.createInitialRequests()
 	for {

--- a/pkg/mcp/sink/sink_test.go
+++ b/pkg/mcp/sink/sink_test.go
@@ -258,7 +258,7 @@ func (h *sinkHarness) openStream(t *testing.T) {
 
 	h.errgrp = errgroup.Group{}
 	h.errgrp.Go(func() error {
-		err := h.sink.processStream(h)
+		err := h.sink.ProcessStream(h)
 		return err
 	})
 }

--- a/pkg/mcp/source/client_source.go
+++ b/pkg/mcp/source/client_source.go
@@ -123,7 +123,7 @@ func (c *Client) Run(ctx context.Context) {
 			break
 		}
 
-		err := c.source.processStream(c.stream)
+		err := c.source.ProcessStream(c.stream)
 		if err != nil && err != io.EOF {
 			c.reporter.RecordRecvError(err, status.Code(err))
 			scope.Errorf("Error receiving MCP response: %v", err)

--- a/pkg/mcp/source/client_source_test.go
+++ b/pkg/mcp/source/client_source_test.go
@@ -19,10 +19,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
-	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -43,36 +40,6 @@ func (h *sourceHarness) EstablishResourceStream(ctx context.Context, opts ...grp
 // avoid ambiguity between grpc.ServerStream and test.sourceTestHarness
 func (h *sourceHarness) Context() context.Context {
 	return h.sourceTestHarness.Context()
-}
-
-func verifySentResourcesMultipleTypes(t *testing.T, h *sourceTestHarness, wantResources map[string]*mcp.Resources) map[string]*mcp.Resources {
-	t.Helper()
-
-	gotResources := make(map[string]*mcp.Resources)
-	for {
-		select {
-		case got := <-h.resourcesChan:
-			if _, ok := gotResources[got.Collection]; ok {
-				t.Fatalf("gotResources duplicate response for type %v: %v", got.Collection, got)
-			}
-			gotResources[got.Collection] = got
-
-			want, ok := wantResources[got.Collection]
-			if !ok {
-				t.Fatalf("gotResources unexpected response for type %v: %v", got.Collection, got)
-			}
-
-			if diff := cmp.Diff(*got, *want, cmpopts.IgnoreFields(mcp.Resources{}, "Nonce")); diff != "" {
-				t.Fatalf("wrong responses for %v: \n got %+v \nwant %+v \n diff %v", got.Collection, got, want, diff)
-			}
-
-			if len(gotResources) == len(wantResources) {
-				return gotResources
-			}
-		case <-time.After(time.Second):
-			t.Fatalf("timeout waiting for all responses: gotResources %v", gotResources)
-		}
-	}
 }
 
 func TestClientSource(t *testing.T) {

--- a/pkg/mcp/source/server_source.go
+++ b/pkg/mcp/source/server_source.go
@@ -84,7 +84,7 @@ func (s *Server) EstablishResourceStream(stream mcp.ResourceSource_EstablishReso
 		return status.Errorf(codes.Unauthenticated, "Authentication failure: %v", err)
 	}
 
-	err := s.src.processStream(stream)
+	err := s.src.ProcessStream(stream)
 	code := status.Code(err)
 	if code == codes.OK || code == codes.Canceled || err == io.EOF {
 		return nil

--- a/pkg/mcp/source/server_source_test.go
+++ b/pkg/mcp/source/server_source_test.go
@@ -114,7 +114,7 @@ func TestServerSource(t *testing.T) {
 		t.Fatalf("Stream exited with error: got %v", err)
 	}
 
-	// processStream error
+	// ProcessStream error
 	go func() {
 		errc <- s.EstablishResourceStream(h)
 	}()

--- a/pkg/mcp/source/source.go
+++ b/pkg/mcp/source/source.go
@@ -218,7 +218,7 @@ func (s *Source) newConnection(stream Stream) *connection {
 	return con
 }
 
-func (s *Source) processStream(stream Stream) error {
+func (s *Source) ProcessStream(stream Stream) error {
 	con := s.newConnection(stream)
 
 	defer s.closeConnection(con)
@@ -401,7 +401,7 @@ func (con *connection) close() {
 func (con *connection) processClientRequest(req *mcp.RequestResources) error {
 	collection := req.Collection
 
-	con.reporter.RecordRequestSize(collection, con.id, req.Size())
+	con.reporter.RecordRequestSize(collection, con.id, internal.ProtoSize(req))
 
 	w, ok := con.watches[collection]
 	if !ok {

--- a/pkg/mcp/source/source_test.go
+++ b/pkg/mcp/source/source_test.go
@@ -441,7 +441,7 @@ func TestConnRateLimit(t *testing.T) {
 	s := makeSourceUnderTest(h)
 	s.requestLimiter = fakeLimiter
 
-	go s.processStream(h)
+	go s.ProcessStream(h)
 
 	<-fakeLimiter.CreateCh
 	c := <-fakeLimiter.WaitCh
@@ -473,7 +473,7 @@ func TestConnRateLimitError(t *testing.T) {
 
 	errC := make(chan error)
 	go func() {
-		errC <- s.processStream(h)
+		errC <- s.ProcessStream(h)
 	}()
 
 	expectedErr := "rate limiting went wrong"
@@ -786,7 +786,7 @@ func TestSourceACKAddUpdateDelete_Incremental(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		if err := s.processStream(h); err != nil {
+		if err := s.ProcessStream(h); err != nil {
 			t.Errorf("Stream() => got %v, want no error", err)
 		}
 		wg.Done()


### PR DESCRIPTION
- Export processStream methods, they are useful when using the code
outside of Istio
- Move verifySentResourcesMultipleTypes to client_test.go