### PR TITLE
Fix simpletest flake in citadel testing

### DIFF
--- a/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
@@ -23,7 +23,7 @@ spec:
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['curl']
-      args: ['http://istio-citadel:8060']
+      args: ['http://istio-citadel:8060/-/ready']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}


### PR DESCRIPTION
A PR was merged ~4 weeks ago which introduced built-in
testing of the Helm charts.  The readiness testing in these
Helm chart tests were defective.  This problem was masked by
a silently failing gate.