### PR TITLE
Fix simpletest flake in citadel testing

### DIFF
--- a/install/kubernetes/helm/subcharts/prometheus/templates/tests/test-prometheus-connection.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/tests/test-prometheus-connection.yaml
@@ -22,8 +22,7 @@ spec:
     - name: "{{ template "prometheus.fullname" . }}-test"
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['curl']
-      args: ['http://prometheus:9090/-/ready']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://prometheus:9090/-/ready && break || sleep 15; done']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}

--- a/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
@@ -22,8 +22,7 @@ spec:
     - name: "{{ template "security.fullname" . }}-test"
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['curl']
-      args: ['http://istio-citadel:8060/-/ready']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:8060/-/ready && break || sleep 15; done']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}

--- a/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
@@ -23,7 +23,7 @@ spec:
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
       command: ['curl']
-      args: ['http://istio-citadel:8060']
+      args: ['http://istio-citadel:8060/-/ready']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}


### PR DESCRIPTION
A PR was merged ~4 weeks ago which introduced built-in
testing of the Helm charts.  The readiness testing in these
Helm chart tests were defective.  This problem was masked by
a silently failing gate.

(cherry picked from commit bf9bc7bada15288cd1e4d0c8fa4b04c39e4379b5)