### PR TITLE
The Ingress service name is stored in a new place

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -49,7 +49,7 @@ data:
 
     {{- if .Values.ingress.enabled }}
     # This is the k8s ingress service name, update if you used a different name
-    ingressService: istio-{{ .Values.global.k8sIngressSelector }}
+    ingressService: istio-{{ .Values.global.k8sIngress.gatewayName }}
     {{- else }}
     # Let Pilot give ingresses the public IP of the Istio ingressgateway
     ingressService: istio-ingressgateway


### PR DESCRIPTION
`helm template` was generating an invalid value for `ingressService`.  It was using a value that no longer exists.

Partial resolution for https://github.com/istio/istio/issues/10500