### PR TITLE
[pilot] Export virtual service and destination rule metadata

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -178,7 +178,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 				defaultSni := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, port.Port)
 				applyTrafficPolicy(env, defaultCluster, destinationRule.TrafficPolicy, port, serviceAccounts,
 					defaultSni, DefaultClusterMode, model.TrafficDirectionOutbound)
-
+				defaultCluster.Metadata = util.BuildConfigInfoMetadata(config.ConfigMeta)
 				for _, subset := range destinationRule.Subsets {
 					inputParams.Subset = subset.Name
 					subsetClusterName := model.BuildSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
@@ -196,6 +196,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundClusters(env *model.Environme
 						DefaultClusterMode, model.TrafficDirectionOutbound)
 					applyTrafficPolicy(env, subsetCluster, subset.TrafficPolicy, port, serviceAccounts, defaultSni,
 						DefaultClusterMode, model.TrafficDirectionOutbound)
+					subsetCluster.Metadata = util.BuildConfigInfoMetadata(config.ConfigMeta)
 					// call plugins
 					for _, p := range configgen.Plugins {
 						p.OnOutboundCluster(inputParams, subsetCluster)
@@ -241,6 +242,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(env *model.En
 				destinationRule := config.Spec.(*networking.DestinationRule)
 				applyTrafficPolicy(env, defaultCluster, destinationRule.TrafficPolicy, port, nil, "",
 					SniDnatClusterMode, model.TrafficDirectionOutbound)
+				defaultCluster.Metadata = util.BuildConfigInfoMetadata(config.ConfigMeta)
 
 				for _, subset := range destinationRule.Subsets {
 					subsetClusterName := model.BuildDNSSrvSubsetKey(model.TrafficDirectionOutbound, subset.Name, service.Hostname, port.Port)
@@ -256,6 +258,7 @@ func (configgen *ConfigGeneratorImpl) buildOutboundSniDnatClusters(env *model.En
 						SniDnatClusterMode, model.TrafficDirectionOutbound)
 					applyTrafficPolicy(env, subsetCluster, subset.TrafficPolicy, port, nil, "",
 						SniDnatClusterMode, model.TrafficDirectionOutbound)
+					subsetCluster.Metadata = util.BuildConfigInfoMetadata(config.ConfigMeta)
 					clusters = append(clusters, subsetCluster)
 				}
 			}
@@ -519,6 +522,7 @@ func (configgen *ConfigGeneratorImpl) buildInboundClusterForPortOrUDS(pluginPara
 			// upstream TLS settings/outlier detection/load balancer don't apply here.
 			applyConnectionPool(pluginParams.Env, localCluster, destinationRule.TrafficPolicy.ConnectionPool,
 				model.TrafficDirectionInbound)
+			localCluster.Metadata = util.BuildConfigInfoMetadata(config.ConfigMeta)
 		}
 	}
 	return localCluster

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -430,9 +430,9 @@ func TestClusterMetadata(t *testing.T) {
 			md := cluster.Metadata
 			g.Expect(md.FilterMetadata["istio"]).NotTo(BeNil())
 			istio := md.FilterMetadata["istio"]
-			g.Expect(istio.Fields["destination-rule"]).NotTo(BeNil())
-			dr := istio.Fields["destination-rule"]
-			g.Expect(dr.GetStringValue()).To(Equal("acme.."))
+			g.Expect(istio.Fields["config"]).NotTo(BeNil())
+			dr := istio.Fields["config"]
+			g.Expect(dr.GetStringValue()).To(Equal("/apis//v1alpha3/namespaces//destination-rule/acme"))
 		} else {
 			g.Expect(cluster.Metadata).To(BeNil())
 		}
@@ -449,9 +449,9 @@ func TestClusterMetadata(t *testing.T) {
 			md := cluster.Metadata
 			g.Expect(md.FilterMetadata["istio"]).NotTo(BeNil())
 			istio := md.FilterMetadata["istio"]
-			g.Expect(istio.Fields["destination-rule"]).NotTo(BeNil())
-			dr := istio.Fields["destination-rule"]
-			g.Expect(dr.GetStringValue()).To(Equal("acme.."))
+			g.Expect(istio.Fields["config"]).NotTo(BeNil())
+			dr := istio.Fields["config"]
+			g.Expect(dr.GetStringValue()).To(Equal("/apis//v1alpha3/namespaces//destination-rule/acme"))
 		} else {
 			g.Expect(cluster.Metadata).To(BeNil())
 		}

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -16,6 +16,7 @@ package v1alpha3_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -424,7 +425,7 @@ func TestClusterMetadata(t *testing.T) {
 
 	for _, cluster := range clusters {
 		if strings.HasPrefix(cluster.Name, "outbound") || strings.HasPrefix(cluster.Name, "inbound") {
-			clustersWithMetadata
+			clustersWithMetadata++
 			g.Expect(cluster.Metadata).NotTo(BeNil())
 			md := cluster.Metadata
 			g.Expect(md.FilterMetadata["istio"]).NotTo(BeNil())
@@ -437,7 +438,7 @@ func TestClusterMetadata(t *testing.T) {
 		}
 	}
 
-	g.Expect(clustersWithMetadata).To(Equal(len(destRule.Subsets)  2)) // outbound  outbound subsets  inbound
+	g.Expect(clustersWithMetadata).To(Equal(len(destRule.Subsets) + 2)) // outbound  outbound subsets  inbound
 
 	sniClusters, err := buildSniDnatTestClusters("test-sni")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -456,4 +457,3 @@ func TestClusterMetadata(t *testing.T) {
 		}
 	}
 }
-

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1315,6 +1315,7 @@ type httpListenerOpts struct {
 type filterChainOpts struct {
 	sniHosts         []string
 	destinationCIDRs []string
+	metadata         *core.Metadata
 	tlsContext       *auth.DownstreamTlsContext
 	httpOpts         *httpListenerOpts
 	match            *listener.FilterChainMatch
@@ -1540,6 +1541,7 @@ func buildCompleteFilterChain(pluginParams *plugin.InputParams, mutable *plugin.
 			mutable.Listener.FilterChains[i].Filters = append(mutable.Listener.FilterChains[i].Filters, opt.networkFilters...)
 		}
 
+		mutable.Listener.FilterChains[i].Metadata = opt.metadata
 		log.Debugf("attached %d network filters to listener %q filter chain %d", len(chain.TCP)+len(opt.networkFilters), mutable.Listener.Name, i)
 
 		if opt.httpOpts != nil {

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -247,19 +247,17 @@ func BuildHTTPRoutesForVirtualService(
 		return nil, fmt.Errorf("in not a virtual service: %#v", virtualService)
 	}
 
-	vsName := virtualService.ConfigMeta.Name
-
 	out := make([]route.Route, 0, len(vs.Http))
 allroutes:
 	for _, http := range vs.Http {
 		if len(http.Match) == 0 {
-			if r := translateRoute(push, node, http, nil, listenPort, vsName, serviceRegistry, proxyLabels, gatewayNames); r != nil {
+			if r := translateRoute(push, node, http, nil, listenPort, virtualService, serviceRegistry, proxyLabels, gatewayNames); r != nil {
 				out = append(out, *r)
 			}
 			break allroutes // we have a rule with catch all match prefix: /. Other rules are of no use
 		} else {
 			for _, match := range http.Match {
-				if r := translateRoute(push, node, http, match, listenPort, vsName, serviceRegistry, proxyLabels, gatewayNames); r != nil {
+				if r := translateRoute(push, node, http, match, listenPort, virtualService, serviceRegistry, proxyLabels, gatewayNames); r != nil {
 					out = append(out, *r)
 					rType, _ := getEnvoyRouteTypeAndVal(r)
 					if rType == envoyCatchAll {
@@ -301,7 +299,7 @@ func sourceMatchHTTP(match *networking.HTTPMatchRequest, proxyLabels model.Label
 // translateRoute translates HTTP routes
 func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.HTTPRoute,
 	match *networking.HTTPMatchRequest, port int,
-	vsName string,
+	virtualService model.Config,
 	serviceRegistry map[model.Hostname]*model.Service,
 	proxyLabels model.LabelsCollection,
 	gatewayNames map[string]bool) *route.Route {
@@ -322,6 +320,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 	out := &route.Route{
 		Match:           translateRouteMatch(match),
 		PerFilterConfig: make(map[string]*types.Struct),
+		Metadata:        util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
 	}
 
 	if redirect := in.Redirect; redirect != nil {
@@ -451,7 +450,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 	}
 
 	out.Decorator = &route.Decorator{
-		Operation: getRouteOperation(out, vsName, port),
+		Operation: getRouteOperation(out, virtualService.Name, port),
 	}
 	if fault := in.Fault; fault != nil {
 		out.PerFilterConfig[xdsutil.Fault] = util.MessageToStruct(translateFault(node, in.Fault))

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -318,8 +318,8 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 	}
 
 	out := &route.Route{
-		Match:           translateRouteMatch(match),
-		Metadata:        util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
+		Match:    translateRouteMatch(match),
+		Metadata: util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
 	}
 
 	if util.IsProxyVersionGE11(node) {

--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -137,6 +137,7 @@ func buildSidecarOutboundTLSFilterChainOpts(env *model.Environment, node *model.
 					matchHash := hashRuntimeTLSMatchPredicates(match)
 					if !matchHasBeenHandled[matchHash] {
 						out = append(out, &filterChainOpts{
+							metadata:         util.BuildConfigInfoMetadata(config.ConfigMeta),
 							sniHosts:         match.SniHosts,
 							destinationCIDRs: destinationCIDRs,
 							networkFilters:   buildOutboundNetworkFilters(env, node, tls.Route, push, listenPort, config.ConfigMeta),
@@ -193,6 +194,7 @@ TcpLoop:
 			if len(tcp.Match) == 0 {
 				// implicit match
 				out = append(out, &filterChainOpts{
+					metadata:         util.BuildConfigInfoMetadata(config.ConfigMeta),
 					destinationCIDRs: destinationCIDRs,
 					networkFilters:   buildOutboundNetworkFilters(env, node, tcp.Route, push, listenPort, config.ConfigMeta),
 				})
@@ -216,6 +218,7 @@ TcpLoop:
 					// (this is similar to virtual hosts in http) and create filter chain match accordingly.
 					if len(match.DestinationSubnets) == 0 || listenPort.Port == 0 {
 						out = append(out, &filterChainOpts{
+							metadata:         util.BuildConfigInfoMetadata(config.ConfigMeta),
 							destinationCIDRs: destinationCIDRs,
 							networkFilters:   buildOutboundNetworkFilters(env, node, tcp.Route, push, listenPort, config.ConfigMeta),
 						})

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -286,10 +286,9 @@ func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
 		FilterMetadata: map[string]*types.Struct{
 			IstioMetadataKey: {
 				Fields: map[string]*types.Value{
-					config.Type: {
+					"config": {
 						Kind: &types.Value_StringValue{
-							StringValue: config.Name + "." + config.Namespace + "." + config.Domain,
-							//							StringValue: fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s", config.Group, config.Version, config.Namespace, config.Type, config.Name),
+							StringValue: fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s", config.Group, config.Version, config.Namespace, config.Type, config.Name),
 						},
 					},
 				},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -46,7 +46,7 @@ const (
 	SniClusterFilter = "envoy.filters.network.sni_cluster"
 	// IstioMetadataKey is the key under which metadata is added to a route or cluster
 	// regarding the virtual service or destination rule used for each
-	istioMetadataKey = "istio"
+	IstioMetadataKey = "istio"
 	// The range of LoadBalancingWeight is [1, 128]
 	maxLoadBalancingWeight = 128
 )
@@ -284,11 +284,12 @@ func ConvertLocality(locality string) *core.Locality {
 func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
 	return &core.Metadata{
 		FilterMetadata: map[string]*types.Struct{
-			istioMetadataKey: {
+			IstioMetadataKey: {
 				Fields: map[string]*types.Value{
 					config.Type: {
 						Kind: &types.Value_StringValue{
 							StringValue: config.Name + "." + config.Namespace + "." + config.Domain,
+							//							StringValue: fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s", config.Group, config.Version, config.Namespace, config.Type, config.Name),
 						},
 					},
 				},

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -44,7 +44,9 @@ const (
 	PassthroughCluster = "PassthroughCluster"
 	// SniClusterFilter is the name of the sni_cluster envoy filter
 	SniClusterFilter = "envoy.filters.network.sni_cluster"
-
+	// IstioMetadataKey is the key under which metadata is added to a route or cluster
+	// regarding the virtual service or destination rule used for each
+	istioMetadataKey = "istio"
 	// The range of LoadBalancingWeight is [1, 128]
 	maxLoadBalancingWeight = 128
 )
@@ -273,5 +275,24 @@ func ConvertLocality(locality string) *core.Locality {
 			Zone:    items[1],
 			SubZone: items[2],
 		}
+	}
+}
+
+// BuildConfigInfoMetadata builds core.Metadata struct containing the
+// name.namespace of the config, the type, etc. Used by Mixer client
+// to generate attributes for policy and telemetry.
+func BuildConfigInfoMetadata(config model.ConfigMeta) *core.Metadata {
+	return &core.Metadata{
+		FilterMetadata: map[string]*types.Struct{
+			istioMetadataKey: {
+				Fields: map[string]*types.Value{
+					config.Type: {
+						Kind: &types.Value_StringValue{
+							StringValue: config.Name + "." + config.Namespace + "." + config.Domain,
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -280,66 +280,22 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 		want *core.Metadata
 	}{
 		{
-			"route-rule",
-			model.ConfigMeta{Name: "svcA", Namespace: "default", Domain: "svc.cluster.local", Type: "route-rule"},
-			&core.Metadata{
-				FilterMetadata: map[string]*types.Struct{
-					IstioMetadataKey: {
-						Fields: map[string]*types.Value{
-							"route-rule": {
-								Kind: &types.Value_StringValue{
-									StringValue: "svcA.default.svc.cluster.local",
-								},
-							},
-						},
-					},
-				},
+			"destination-rule",
+			model.ConfigMeta{
+				Group:     "networking.istio.io",
+				Version:   "v1alpha3",
+				Name:      "svcA",
+				Namespace: "default",
+				Domain:    "svc.cluster.local",
+				Type:      "destination-rule",
 			},
-		},
-		{
-			"missing namespace",
-			model.ConfigMeta{Name: "svcA", Domain: "svc.cluster.local", Type: "route-rule"},
 			&core.Metadata{
 				FilterMetadata: map[string]*types.Struct{
 					IstioMetadataKey: {
 						Fields: map[string]*types.Value{
-							"route-rule": {
+							"config": {
 								Kind: &types.Value_StringValue{
-									StringValue: "svcA..svc.cluster.local",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			"missing domain",
-			model.ConfigMeta{Name: "svcA", Namespace: "istio-system", Type: "unknown-type"},
-			&core.Metadata{
-				FilterMetadata: map[string]*types.Struct{
-					IstioMetadataKey: {
-						Fields: map[string]*types.Value{
-							"unknown-type": {
-								Kind: &types.Value_StringValue{
-									StringValue: "svcA.istio-system.", // is this OK?
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			"no-type",
-			model.ConfigMeta{Name: "svcA", Namespace: "istio-system", Domain: "istio.io"},
-			&core.Metadata{
-				FilterMetadata: map[string]*types.Struct{
-					IstioMetadataKey: {
-						Fields: map[string]*types.Value{
-							"": { // is this OK?
-								Kind: &types.Value_StringValue{
-									StringValue: "svcA.istio-system.istio.io",
+									StringValue: "/apis/networking.istio.io/v1alpha3/namespaces/default/destination-rule/svcA",
 								},
 							},
 						},

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -18,12 +18,8 @@ import (
 	"reflect"
 	"testing"
 
-<<<<<<< HEAD
-=======
 	"gopkg.in/d4l3k/messagediff.v1"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
->>>>>>> [pilot] Export virtual service and destination rule metadata
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 
@@ -358,7 +354,7 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 		t.Run(v.name, func(tt *testing.T) {
 			got := BuildConfigInfoMetadata(v.in)
 			if diff, equal := messagediff.PrettyDiff(got, v.want); !equal {
-				t.Errorf("BuildConfigInfoMetadata(%v) produced incorrect result:\ngot: %v\nwant: %v\nDiff: %s", v.in, got, v.want, diff)
+				tt.Errorf("BuildConfigInfoMetadata(%v) produced incorrect result:\ngot: %v\nwant: %v\nDiff: %s", v.in, got, v.want, diff)
 			}
 		})
 	}

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -18,10 +18,9 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/d4l3k/messagediff.v1"
-
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
+	"gopkg.in/d4l3k/messagediff.v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
@@ -285,7 +284,7 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 			model.ConfigMeta{Name: "svcA", Namespace: "default", Domain: "svc.cluster.local", Type: "route-rule"},
 			&core.Metadata{
 				FilterMetadata: map[string]*types.Struct{
-					istioMetadataKey: {
+					IstioMetadataKey: {
 						Fields: map[string]*types.Value{
 							"route-rule": {
 								Kind: &types.Value_StringValue{
@@ -302,7 +301,7 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 			model.ConfigMeta{Name: "svcA", Domain: "svc.cluster.local", Type: "route-rule"},
 			&core.Metadata{
 				FilterMetadata: map[string]*types.Struct{
-					istioMetadataKey: {
+					IstioMetadataKey: {
 						Fields: map[string]*types.Value{
 							"route-rule": {
 								Kind: &types.Value_StringValue{
@@ -319,7 +318,7 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 			model.ConfigMeta{Name: "svcA", Namespace: "istio-system", Type: "unknown-type"},
 			&core.Metadata{
 				FilterMetadata: map[string]*types.Struct{
-					istioMetadataKey: {
+					IstioMetadataKey: {
 						Fields: map[string]*types.Value{
 							"unknown-type": {
 								Kind: &types.Value_StringValue{
@@ -336,7 +335,7 @@ func TestBuildConfigInfoMetadata(t *testing.T) {
 			model.ConfigMeta{Name: "svcA", Namespace: "istio-system", Domain: "istio.io"},
 			&core.Metadata{
 				FilterMetadata: map[string]*types.Struct{
-					istioMetadataKey: {
+					IstioMetadataKey: {
 						Fields: map[string]*types.Value{
 							"": { // is this OK?
 								Kind: &types.Value_StringValue{

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
-	"gopkg.in/d4l3k/messagediff.v1"
+	messagediff "gopkg.in/d4l3k/messagediff.v1"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -157,7 +157,7 @@ func endpointMetadata(UID string, network string) *core.Metadata {
 
 	metadata := &core.Metadata{
 		FilterMetadata: map[string]*types.Struct{
-			"istio": {
+			util.IstioMetadataKey: {
 				Fields: map[string]*types.Value{},
 			},
 		},


### PR DESCRIPTION
Added some unit test coverage to #11060 (big thanks to @rshriram for doing the hard work).

This PR adds virtual service and destination rule metadata to generated Envoy config. This should enable mixer client to retrieve this information and use it to create appropriate attributes.

This is targeted at `release-1.1` as the original PR was as well.  The diff can easily be applied to `master` if that is more appropriate.

Manually verified with bookinfo in example cluster (snippets):

```json
{
     "cluster": {
      "name": "outbound|9080|details-abort-dr-subset-v1|details.default.svc.cluster.local",
      },
      "metadata": {
       "filter_metadata": {
        "istio": {
         "destination-rule": "details-abort-dr.default.cluster.local"
        }
       }
      },
},

{
      "route_config": {
          "metadata": {
           "filter_metadata": {
            "istio": {
             "virtual-service": "details-abort-vs.default.cluster.local"
            }
           }
     },
}
```

