### PR TITLE
Remove noisy metric

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -256,10 +256,6 @@ func (s *DiscoveryServer) updateClusterInc(push *model.PushContext, clusterName 
 		locEps = append(locEps, *locLbEps)
 	}
 
-	if cnt == 0 {
-		push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
-		//adsLog.Infof("EDS: no instances %s (host=%s ports=%v labels=%v)", clusterName, hostname, p, labels)
-	}
 	edsInstances.With(prometheus.Labels{"cluster": clusterName}).Set(float64(cnt))
 
 	// There is a chance multiple goroutines will update the cluster at the same time.
@@ -375,10 +371,6 @@ func (s *DiscoveryServer) updateCluster(push *model.PushContext, clusterName str
 		// TODO: k8s adapter should use EdsUpdate. This would return non-k8s stuff, needs to
 		// be merged with k8s. This returns ServiceEntries.
 		instances, err = edsCluster.discovery.Env.ServiceDiscovery.InstancesByPort(hostname, p, labels)
-		if len(instances) == 0 {
-			push.Add(model.ProxyStatusClusterNoInstances, clusterName, nil, "")
-			//adsLog.Infof("EDS: no instances %s (host=%s ports=%v labels=%v)", clusterName, hostname, p, labels)
-		}
 		edsInstances.With(prometheus.Labels{"cluster": clusterName}).Set(float64(len(instances)))
 	}
 	if err != nil {


### PR DESCRIPTION
The log message has previous been commented out and the metric increment is causing noise in prod cluster error counts. Assuming this is no longer required but please advise it that's not the case.