### PR TITLE
increase control plane component replicas during upgrade test

### DIFF
--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -208,7 +208,7 @@ installIstioSystemAtVersionHelmTemplate() {
         --set prometheus.enabled=false \
         --set global.hub="${1}" \
         --set global.tag="${2}" \
-        --set global.defaultPodDisruptionBudget.enabled = true > "${ISTIO_ROOT}/istio.yaml" || die "helm template failed"
+        --set global.defaultPodDisruptionBudget.enabled=true > "${ISTIO_ROOT}/istio.yaml" || die "helm template failed"
     else
         helm template "${release_path}" "${auth_opts}" \
         --name istio --namespace "${ISTIO_NAMESPACE}" \


### PR DESCRIPTION
also enable defaultPodDisruptionBudget (only avail for 1.1 tho).