### PR TITLE
Allow Envoy listener stats to be turned off/on with a pod annotation

### DIFF
--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -52,7 +52,7 @@ const (
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
 
 	// statsPatterns gives the developer control over Envoy stats collection
-	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/v1alpha1/statsPatterns"
+	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/v1alpha1/statsInclusionPrefixes"
 )
 
 var (

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -52,7 +52,7 @@ const (
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
 
 	// statsPatterns gives the developer control over Envoy stats collection
-	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/statsPatterns"
+	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/v1alpha1/statsPatterns"
 )
 
 var (

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -50,6 +50,21 @@ const (
 	IstioMetaJSONPrefix = "ISTIO_METAJSON_"
 
 	lightstepAccessTokenBase = "lightstep_access_token.txt"
+
+	// statsPatterns gives the developer control over Envoy stats collection
+	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/statsPatterns"
+)
+
+var (
+	// default value for EnvoyStatsMatcherInclusionPatterns
+	defaultEnvoyStatsMatcherInclusionPatterns = []string{
+		"cluster_manager",
+		"listener_manager",
+		"http_mixer_filter",
+		"tcp_mixer_filter",
+		"server",
+		"cluster.xds-grpc",
+	}
 )
 
 func defaultPilotSan() []string {
@@ -232,7 +247,13 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 	// Support passing extra info from node environment as metadata
 	meta := getNodeMetaData(localEnv)
 
-	// Suppot multiple network interfaces
+	if inclusionPatterns, ok := meta[EnvoyStatsMatcherInclusionPatterns]; ok {
+		opts["inclusionPatterns"] = strings.Split(inclusionPatterns, ",")
+	} else {
+		opts["inclusionPatterns"] = defaultEnvoyStatsMatcherInclusionPatterns
+	}
+
+	// Support multiple network interfaces
 	meta["ISTIO_META_INSTANCE_IPS"] = strings.Join(nodeIPs, ",")
 
 	ba, err := json.Marshal(meta)

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -80,7 +80,7 @@ func TestGolden(t *testing.T) {
 		{
 			base: "stats_inclusion",
 			annotations: map[string]string{
-				"sidecar.istio.io/v1alpha1/statsPatterns": "cluster_manager,cluster.xds-grpc,listener.",
+				"sidecar.istio.io/v1alpha1/statsInclusionPrefixes": "cluster_manager,cluster.xds-grpc,listener.",
 			},
 		},
 	}

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -77,6 +77,12 @@ func TestGolden(t *testing.T) {
 			// Specify zipkin/statsd address, similar with the default config in v1 tests
 			base: "all",
 		},
+		{
+			base: "stats_inclusion",
+			annotations: map[string]string{
+				"sidecar.istio.io/statsPatterns": "cluster_manager,cluster.xds-grpc,listener.",
+			},
+		},
 	}
 
 	out := env.ISTIO_OUT.Value() // defined in the makefile

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -80,7 +80,7 @@ func TestGolden(t *testing.T) {
 		{
 			base: "stats_inclusion",
 			annotations: map[string]string{
-				"sidecar.istio.io/statsPatterns": "cluster_manager,cluster.xds-grpc,listener.",
+				"sidecar.istio.io/v1alpha1/statsPatterns": "cluster_manager,cluster.xds-grpc,listener.",
 			},
 		},
 	}

--- a/pkg/bootstrap/testdata/stats_inclusion.proto
+++ b/pkg/bootstrap/testdata/stats_inclusion.proto
@@ -1,0 +1,13 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+parent_shutdown_duration:  {seconds: 3}
+discovery_address:         "istio-pilot:15010"
+connect_timeout:           {seconds: 1}
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+
+#
+# This matches the default configuration hardcoded in model.DefaultProxyConfig
+# Flags may override this configuration, as specified by the injector configs.

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -1,19 +1,9 @@
 {
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
-    "locality": {
-      {{ if .region }}
-      "region": "{{ .region }}",
-      {{ end }}
-      {{ if .zone }}
-      "zone": "{{ .zone }}",
-      {{ end }}
-      {{ if .sub_zone }}
-      "sub_zone": "{{ .sub_zone }}",
-      {{ end }}
-    },
-    "metadata": {{ .meta_json_str }}
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
+    "locality": {},
+    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/statsPatterns":"cluster_manager,cluster.xds-grpc,listener."}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -53,12 +43,15 @@
     ],
     "stats_matcher": {
       "inclusion_list": {
-        "patterns": [
-          {{- range $a, $s := .inclusionPatterns }}
-            {
-              "prefix": "{{$s}}"
-            },
-          {{- end }}
+        "patterns": [{
+            "prefix": "cluster_manager"
+          },
+          {
+            "prefix": "cluster.xds-grpc"
+          },
+          {
+            "prefix": "listener."
+          }
         ]
       }
     }
@@ -68,7 +61,7 @@
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "port_value": 15000
       }
     }
   },
@@ -102,7 +95,7 @@
             "socket_address": {
               "protocol": "TCP",
               "address": "127.0.0.1",
-              "port_value": {{ .config.ProxyAdminPort }}
+              "port_value": 15000
             }
           }
         ]
@@ -110,40 +103,12 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "connect_timeout": "{{ .connect_timeout }}",
+        "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        {{ if eq .config.ControlPlaneAuthPolicy 1 }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
-                }
-              }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": [
-                {{- range $a, $s := .pilot_SAN }}
-                "{{$s}}"
-                {{- end}}
-              ]
-            }
-          }
-        },
-        {{ end }}
+        
         "hosts": [
           {
-            "socket_address": {{ .pilot_grpc_address }}
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
           }
         ],
         "circuit_breakers": {
@@ -169,48 +134,7 @@
         },
         "http2_protocol_options": { }
       }
-      {{ if .zipkin }}
-      ,
-      {
-        "name": "zipkin",
-        "type": "STRICT_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .zipkin }}
-          }
-        ]
-      }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "http2_protocol_options": {},
-        {{ if .lightstepSecure }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "{{ .lightstepCacertPath }}"
-              }
-            }
-          }
-        },
-        {{ end }}
-        "type": "LOGICAL_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .lightstep }}
-          }
-        ]
-      }
-      {{ end }}
+      
     ],
     "listeners":[
       {
@@ -260,42 +184,6 @@
       }
     ]
   }
-  {{ if .zipkin }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.zipkin",
-      "config": {
-        "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
-      }
-    }
-  }
-  {{ else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.lightstep",
-      "config": {
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{ end }}
-  {{ if .statsd }}
-  ,
-  "stats_sinks": [
-    {
-      "name": "envoy.statsd",
-      "config": {
-        "address": {
-          "socket_address": {{ .statsd }}
-        }
-      }
-    }
-  ]
-  {{ end }}
+  
+  
 }

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/v1alpha1/statsPatterns":"cluster_manager,cluster.xds-grpc,listener."}
+    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/v1alpha1/statsInclusionPrefixes":"cluster_manager,cluster.xds-grpc,listener."}
   },
   "stats_config": {
     "use_all_default_tags": false,

--- a/pkg/bootstrap/testdata/stats_inclusion_golden.json
+++ b/pkg/bootstrap/testdata/stats_inclusion_golden.json
@@ -3,7 +3,7 @@
     "id": "sidecar~1.2.3.4~foo~bar",
     "cluster": "istio-proxy",
     "locality": {},
-    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/statsPatterns":"cluster_manager,cluster.xds-grpc,listener."}
+    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar","sidecar.istio.io/v1alpha1/statsPatterns":"cluster_manager,cluster.xds-grpc,listener."}
   },
   "stats_config": {
     "use_all_default_tags": false,


### PR DESCRIPTION
This PR allows Envoy to be configured to record listener stats for troubleshooting.  It is associated with https://github.com/istio/istio/issues/11322 .

With this change, the user adds

```
      annotations:
        sidecar.istio.io/statsPatterns: cluster_manager,listener.
```

to the Deployment or to the Istio Injection mutation hook.  If adding to the Deployment pods will restart with Envoy "listener." stats and "cluster_manager" stats, but not the other default stas.  If adding to the hook it should be system wide (I did not test this).  There is no ability to turn the feature on and off for running pods.

If the annotation is not specified the current default values are used.