### PR TITLE
Support gateway agent to read TLS secret.

### DIFF
--- a/security/pkg/nodeagent/cache/secretcache_test.go
+++ b/security/pkg/nodeagent/cache/secretcache_test.go
@@ -45,8 +45,8 @@ var (
 	k8sSecretName = "test-scrt"
 	k8sTestSecret = &v1.Secret{
 		Data: map[string][]byte{
-			secretfetcher.ScrtCert: k8sCertChain,
-			secretfetcher.ScrtKey:  k8sKey,
+			secretfetcher.GenericScrtCert: k8sCertChain,
+			secretfetcher.GenericScrtKey:  k8sKey,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sSecretName,

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher.go
@@ -39,17 +39,15 @@ import (
 const (
 	secretResyncPeriod = 15 * time.Second
 
-	// IngressSecretType the type of kubernetes secrets for ingress gateway.
-	IngressSecretType = "istio.io/ingress-key-cert"
+	// The ID/name for the certificate chain in kubernetes generic secret.
+	GenericScrtCert = "cert"
+	// The ID/name for the k8sKey in kubernetes generic secret.
+	GenericScrtKey = "key"
 
-	// KubeConfigFile the config file name for kubernetes client.
-	// Specifies empty file name to use InClusterConfig.
-	KubeConfigFile = ""
-
-	// The ID/name for the certificate chain in kubernetes secret.
-	ScrtCert = "cert"
-	// The ID/name for the k8sKey in kubernetes secret.
-	ScrtKey = "key"
+	// The ID/name for the certificate chain in kubernetes tls secret.
+	TlsScrtCert = "tls.crt"
+	// The ID/name for the k8sKey in kubernetes tls secret.
+	TlsScrtKey = "tls.key"
 
 	// IngressSecretNameSpace the namespace of kubernetes secrets to watch.
 	ingressSecretNameSpace = "INGRESS_GATEWAY_NAMESPACE"
@@ -118,7 +116,7 @@ func (sf *SecretFetcher) Run(ch chan struct{}) {
 // Init initializes SecretFetcher to watch kubernetes secrets.
 func (sf *SecretFetcher) Init(core corev1.CoreV1Interface) { // nolint:interfacer
 	namespace := os.Getenv(ingressSecretNameSpace)
-	istioSecretSelector := fields.SelectorFromSet(map[string]string{"type": IngressSecretType}).String()
+	istioSecretSelector := fields.SelectorFromSet(nil).String()
 	scrtLW := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = istioSecretSelector
@@ -137,6 +135,17 @@ func (sf *SecretFetcher) Init(core corev1.CoreV1Interface) { // nolint:interface
 		})
 }
 
+func extractCertAndKey(scrt *v1.Secret) (cert, key []byte) {
+	if len(scrt.Data[GenericScrtCert]) > 0 {
+		cert = scrt.Data[GenericScrtCert]
+		key = scrt.Data[GenericScrtKey]
+	} else {
+		cert = scrt.Data[TlsScrtCert]
+		key = scrt.Data[TlsScrtKey]
+	}
+	return cert, key
+}
+
 func (sf *SecretFetcher) scrtAdded(obj interface{}) {
 	scrt, ok := obj.(*v1.Secret)
 	if !ok {
@@ -146,12 +155,13 @@ func (sf *SecretFetcher) scrtAdded(obj interface{}) {
 
 	t := time.Now()
 	resourceName := scrt.GetName()
+	newCert, newKey := extractCertAndKey(scrt)
 	// If there is secret with the same resource name, delete that secret now.
 	sf.secrets.Delete(resourceName)
 	ns := &model.SecretItem{
 		ResourceName:     resourceName,
-		CertificateChain: scrt.Data[ScrtCert],
-		PrivateKey:       scrt.Data[ScrtKey],
+		CertificateChain: newCert,
+		PrivateKey:       newKey,
 		CreatedTime:      t,
 		Version:          t.String(),
 	}
@@ -187,30 +197,32 @@ func (sf *SecretFetcher) scrtUpdated(oldObj, newObj interface{}) {
 		return
 	}
 
-	okey := oscrt.GetName()
-	nkey := nscrt.GetName()
-	if okey != nkey {
-		log.Warnf("Failed to update secret: name does not match (%s vs %s).", okey, nkey)
+	oldScrtName := oscrt.GetName()
+	newScrtName := nscrt.GetName()
+	if oldScrtName != newScrtName {
+		log.Warnf("Failed to update secret: name does not match (%s vs %s).", oldScrtName, newScrtName)
 		return
 	}
-	if bytes.Equal(oscrt.Data[ScrtCert], nscrt.Data[ScrtCert]) && bytes.Equal(oscrt.Data[ScrtKey], nscrt.Data[ScrtKey]) {
-		log.Debugf("secret %s does not change, skip update", okey)
+	oldCert, oldKey := extractCertAndKey(oscrt)
+	newCert, newKey := extractCertAndKey(nscrt)
+	if bytes.Equal(oldCert, newCert) && bytes.Equal(oldKey, newKey) {
+		log.Debugf("secret %s does not change, skip update", oldScrtName)
 		return
 	}
-	sf.secrets.Delete(okey)
+	sf.secrets.Delete(oldScrtName)
 
 	t := time.Now()
 	ns := &model.SecretItem{
-		ResourceName:     nkey,
-		CertificateChain: nscrt.Data[ScrtCert],
-		PrivateKey:       nscrt.Data[ScrtKey],
+		ResourceName:     newScrtName,
+		CertificateChain: newCert,
+		PrivateKey:       newKey,
 		CreatedTime:      t,
 		Version:          t.String(),
 	}
-	sf.secrets.Store(nkey, *ns)
+	sf.secrets.Store(newScrtName, *ns)
 	log.Debugf("secret %s is updated", nscrt.GetName())
 	if sf.UpdateCache != nil {
-		sf.UpdateCache(nkey, *ns)
+		sf.UpdateCache(newScrtName, *ns)
 	}
 }
 

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
@@ -185,7 +185,7 @@ func TestSecretFetcherTlsSecretFormat(t *testing.T) {
 	expectedSecret := &model.SecretItem{
 		ResourceName:     k8sSecretNameC,
 		CertificateChain: k8sCertChainC,
-		PrivateKey:       k8sKeyD,
+		PrivateKey:       k8sKeyC,
 	}
 	testAddSecret(t, gSecretFetcher, k8sTestTlsSecretC, expectedSecret, &secretVersion)
 

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
@@ -55,9 +55,9 @@ var (
 		Type: "test-secret",
 	}
 
-	k8sKeyC               = []byte("fake private k8sKeyC")
-	k8sCertChainC         = []byte("fake cert chain C")
-	k8sSecretNameC        = "test-scrtC"
+	k8sKeyC           = []byte("fake private k8sKeyC")
+	k8sCertChainC     = []byte("fake cert chain C")
+	k8sSecretNameC    = "test-scrtC"
 	k8sTestTlsSecretC = &v1.Secret{
 		Data: map[string][]byte{
 			TlsScrtCert: k8sCertChainC,
@@ -70,9 +70,9 @@ var (
 		Type: "test-tls-secret",
 	}
 
-	k8sKeyD               = []byte("fake private k8sKeyD")
-	k8sCertChainD         = []byte("fake cert chain D")
-	k8sSecretNameD        = "test-scrtD"
+	k8sKeyD           = []byte("fake private k8sKeyD")
+	k8sCertChainD     = []byte("fake cert chain D")
+	k8sSecretNameD    = "test-scrtD"
 	k8sTestTlsSecretD = &v1.Secret{
 		Data: map[string][]byte{
 			TlsScrtCert: k8sCertChainD,

--- a/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
+++ b/security/pkg/nodeagent/secretfetcher/secretfetcher_test.go
@@ -26,33 +26,63 @@ import (
 )
 
 var (
-	k8sKeyA        = []byte("fake private k8sKeyA")
-	k8sCertChainA  = []byte("fake cert chain A")
-	k8sSecretNameA = "test-scrtA"
-	k8sTestSecretA = &v1.Secret{
+	k8sKeyA               = []byte("fake private k8sKeyA")
+	k8sCertChainA         = []byte("fake cert chain A")
+	k8sSecretNameA        = "test-scrtA"
+	k8sTestGenericSecretA = &v1.Secret{
 		Data: map[string][]byte{
-			ScrtCert: k8sCertChainA,
-			ScrtKey:  k8sKeyA,
+			GenericScrtCert: k8sCertChainA,
+			GenericScrtKey:  k8sKeyA,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sSecretNameA,
 			Namespace: "test-namespace",
 		},
-		Type: IngressSecretType,
+		Type: "test-secret",
 	}
 
-	k8sKeyB        = []byte("k8sKeyB private fake")
-	k8sCertChainB  = []byte("B chain cert fake")
-	k8sTestSecretB = &v1.Secret{
+	k8sKeyB               = []byte("k8sKeyB private fake")
+	k8sCertChainB         = []byte("B chain cert fake")
+	k8sTestGenericSecretB = &v1.Secret{
 		Data: map[string][]byte{
-			ScrtCert: k8sCertChainB,
-			ScrtKey:  k8sKeyB,
+			GenericScrtCert: k8sCertChainB,
+			GenericScrtKey:  k8sKeyB,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k8sSecretNameA,
 			Namespace: "test-namespace",
 		},
-		Type: IngressSecretType,
+		Type: "test-secret",
+	}
+
+	k8sKeyC               = []byte("fake private k8sKeyC")
+	k8sCertChainC         = []byte("fake cert chain C")
+	k8sSecretNameC        = "test-scrtC"
+	k8sTestTlsSecretC = &v1.Secret{
+		Data: map[string][]byte{
+			TlsScrtCert: k8sCertChainC,
+			TlsScrtKey:  k8sKeyC,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sSecretNameC,
+			Namespace: "test-namespace",
+		},
+		Type: "test-tls-secret",
+	}
+
+	k8sKeyD               = []byte("fake private k8sKeyD")
+	k8sCertChainD         = []byte("fake cert chain D")
+	k8sSecretNameD        = "test-scrtD"
+	k8sTestTlsSecretD = &v1.Secret{
+		Data: map[string][]byte{
+			TlsScrtCert: k8sCertChainD,
+			TlsScrtKey:  k8sKeyD,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sSecretNameC,
+			Namespace: "test-namespace",
+		},
+		Type: "test-tls-secret",
 	}
 )
 
@@ -83,13 +113,13 @@ func TestSecretFetcher(t *testing.T) {
 		PrivateKey:       k8sKeyA,
 	}
 	var secretVersionOne string
-	testAddSecret(t, gSecretFetcher, k8sTestSecretA, expectedAddedSecret, &secretVersionOne)
+	testAddSecret(t, gSecretFetcher, k8sTestGenericSecretA, expectedAddedSecret, &secretVersionOne)
 
 	// Delete test secret and verify that key/cert pair in secret is removed from local store.
 	expectedDeletedSecret := &model.SecretItem{
 		ResourceName: k8sSecretNameA,
 	}
-	testDeleteSecret(t, gSecretFetcher, k8sTestSecretA, expectedDeletedSecret)
+	testDeleteSecret(t, gSecretFetcher, k8sTestGenericSecretA, expectedDeletedSecret)
 
 	// Add test secret again and verify that key/cert pair is stored and version number is different.
 	expectedSecret := &model.SecretItem{
@@ -98,7 +128,7 @@ func TestSecretFetcher(t *testing.T) {
 		PrivateKey:       k8sKeyA,
 	}
 	var secretVersionTwo string
-	testAddSecret(t, gSecretFetcher, k8sTestSecretA, expectedSecret, &secretVersionTwo)
+	testAddSecret(t, gSecretFetcher, k8sTestGenericSecretA, expectedSecret, &secretVersionTwo)
 	if secretVersionTwo == secretVersionOne {
 		t.Errorf("added secret should have different version")
 	}
@@ -110,8 +140,64 @@ func TestSecretFetcher(t *testing.T) {
 		PrivateKey:       k8sKeyB,
 	}
 	var secretVersionThree string
-	testUpdateSecret(t, gSecretFetcher, k8sTestSecretA, k8sTestSecretB, expectedUpdateSecret, &secretVersionThree)
+	testUpdateSecret(t, gSecretFetcher, k8sTestGenericSecretA, k8sTestGenericSecretB, expectedUpdateSecret, &secretVersionThree)
 	if secretVersionThree == secretVersionTwo || secretVersionThree == secretVersionOne {
+		t.Errorf("updated secret should have different version")
+	}
+}
+
+// TestSecretFetcherTlsSecretFormat verifies that secret fetcher is able to extract key/cert
+// from TLS secret format.
+func TestSecretFetcherTlsSecretFormat(t *testing.T) {
+	gSecretFetcher := &SecretFetcher{
+		UseCaClient: false,
+		DeleteCache: func(secretName string) {},
+		UpdateCache: func(secretName string, ns model.SecretItem) {},
+	}
+	gSecretFetcher.Init(fake.NewSimpleClientset().CoreV1())
+	if gSecretFetcher.UseCaClient {
+		t.Error("secretFetcher should not use ca client")
+	}
+	ch := make(chan struct{})
+	gSecretFetcher.Run(ch)
+
+	// Searching a non-existing secret should return false.
+	if _, ok := gSecretFetcher.FindIngressGatewaySecret("non-existing-secret"); ok {
+		t.Error("secretFetcher returns a secret non-existing-secret that should not exist")
+	}
+
+	// Add test secret and verify that key/cert pair is stored.
+	expectedAddedSecret := &model.SecretItem{
+		ResourceName:     k8sSecretNameC,
+		CertificateChain: k8sCertChainC,
+		PrivateKey:       k8sKeyC,
+	}
+	var secretVersion string
+	testAddSecret(t, gSecretFetcher, k8sTestTlsSecretC, expectedAddedSecret, &secretVersion)
+
+	// Delete test secret and verify that key/cert pair in secret is removed from local store.
+	expectedDeletedSecret := &model.SecretItem{
+		ResourceName: k8sSecretNameC,
+	}
+	testDeleteSecret(t, gSecretFetcher, k8sTestTlsSecretC, expectedDeletedSecret)
+
+	// Add test secret again and verify that key/cert pair is stored and version number is different.
+	expectedSecret := &model.SecretItem{
+		ResourceName:     k8sSecretNameC,
+		CertificateChain: k8sCertChainC,
+		PrivateKey:       k8sKeyD,
+	}
+	testAddSecret(t, gSecretFetcher, k8sTestTlsSecretC, expectedSecret, &secretVersion)
+
+	// Update test secret and verify that key/cert pair is changed and version number is different.
+	expectedUpdateSecret := &model.SecretItem{
+		ResourceName:     k8sSecretNameC,
+		CertificateChain: k8sCertChainD,
+		PrivateKey:       k8sKeyD,
+	}
+	var newSecretVersion string
+	testUpdateSecret(t, gSecretFetcher, k8sTestTlsSecretC, k8sTestTlsSecretD, expectedUpdateSecret, &newSecretVersion)
+	if secretVersion == newSecretVersion {
 		t.Errorf("updated secret should have different version")
 	}
 }


### PR DESCRIPTION
If user create secret with
$kubectl create -n istio-system secret generic --from-file=key=key.pem --from-file=cert=cert.pem
key/cert are stored in "key:" and "cert:" sections.
If user create secret with
$kubectl create -n istio-system secret tls --key key.pem --cert cert.pem
key/cert are stored in "tls.key:" and "tls.crt:" sections.
Support Gateway agent to extract key/cert from both formats.