### PR TITLE
Add a SDS test for wrong tokens and an option to specify SDS token

### DIFF
--- a/security/cmd/node_agent_k8s/main.go
+++ b/security/cmd/node_agent_k8s/main.go
@@ -86,6 +86,9 @@ const (
 	// The environmental variable name for key rotation job running interval.
 	// example value format like "20m"
 	SecretRotationJobRunInterval = "SECRET_JOB_RUN_INTERVAL"
+
+	// The environmental variable name for the token used in StreamSecret.
+	tokenForStreamSecret = "TOKEN_FOR_STREAM_SECRET"
 )
 
 var (
@@ -238,6 +241,9 @@ func init() {
 		"Vault sign CSR path")
 	rootCmd.PersistentFlags().StringVar(&serverOptions.VaultTLSRootCert, "vaultTLSRootCert", os.Getenv(vaultTLSRootCert),
 		"Vault TLS root certificate")
+
+	rootCmd.PersistentFlags().StringVar(&serverOptions.TokenForStreamSecret, "tokenForStreamSecret", os.Getenv(tokenForStreamSecret),
+		"The token, when not empty, used as the token when streaming secrets")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -88,17 +88,20 @@ type sdsservice struct {
 	st cache.SecretManager
 	// skipToken indicates whether token is required.
 	skipToken bool
+	// tokenForStreamSecret passed from an input parameter, when not empty, is used as the token in StreamSecret().
+	tokenForStreamSecret string
 }
 
 // newSDSService creates Secret Discovery Service which implements envoy v2 SDS API.
-func newSDSService(st cache.SecretManager, skipTokenVerification bool) *sdsservice {
+func newSDSService(st cache.SecretManager, skipTokenVerification bool, tokenForStreamSecret string) *sdsservice {
 	if st == nil {
 		return nil
 	}
 
 	return &sdsservice{
-		st:        st,
-		skipToken: skipTokenVerification,
+		st:                   st,
+		skipToken:            skipTokenVerification,
+		tokenForStreamSecret: tokenForStreamSecret,
 	}
 }
 
@@ -118,6 +121,10 @@ func (s *sdsservice) StreamSecrets(stream sds.SecretDiscoveryService_StreamSecre
 			return err
 		}
 		token = t
+		if len(s.tokenForStreamSecret) > 0 {
+			log.Warn("Token passed from the input parameter is used for as the stream secret")
+			token = s.tokenForStreamSecret
+		}
 	}
 
 	var receiveError error

--- a/security/pkg/nodeagent/sds/server.go
+++ b/security/pkg/nodeagent/sds/server.go
@@ -79,6 +79,9 @@ type Options struct {
 
 	// AlwaysValidTokenFlag is set to true for if token used is always valid(ex, normal k8s JWT)
 	AlwaysValidTokenFlag bool
+
+	// TokenForStreamSecret, when not empty, is used as the token in StreamSecret().
+	TokenForStreamSecret string
 }
 
 // Server is the gPRC server that exposes SDS through UDS.
@@ -96,8 +99,8 @@ type Server struct {
 // NewServer creates and starts the Grpc server for SDS.
 func NewServer(options Options, workloadSecretCache, gatewaySecretCache cache.SecretManager) (*Server, error) {
 	s := &Server{
-		workloadSds: newSDSService(workloadSecretCache, false),
-		gatewaySds:  newSDSService(gatewaySecretCache, true),
+		workloadSds: newSDSService(workloadSecretCache, false, options.TokenForStreamSecret),
+		gatewaySds:  newSDSService(gatewaySecretCache, true, options.TokenForStreamSecret),
 	}
 	if options.EnableWorkloadSDS {
 		if err := s.initWorkloadSdsService(&options); err != nil {


### PR DESCRIPTION
- Add a test to SDS to test wrong tokens are rejected.
- Add an option to specify the token used for SDS. This option is useful when implementing various SDS test cases, e.g., specify the token for Citadel/Google CA/Vault CA.