### PR TITLE
Fix a flaky e2e_simpleTests

### DIFF
--- a/install/kubernetes/helm/subcharts/prometheus/templates/tests/test-prometheus-connection.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/tests/test-prometheus-connection.yaml
@@ -22,8 +22,7 @@ spec:
     - name: "{{ template "prometheus.fullname" . }}-test"
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['curl']
-      args: ['--retry', '3', '--retry-connrefused', '--retry-delay', '30', 'http://prometheus:9090/-/ready']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://prometheus:9090/-/ready && break || sleep 15; done']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}

--- a/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/tests/test-citadel-connection.yaml
@@ -22,8 +22,7 @@ spec:
     - name: "{{ template "security.fullname" . }}-test"
       image: {{ .Values.global.hub }}/{{ .Values.global.proxy.image }}:{{ .Values.global.tag }}
       imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
-      command: ['curl']
-      args: ['http://istio-citadel:8060/-/ready']
+      command: ['sh', '-c', 'for i in 1 2 3; do curl http://istio-citadel:8060/-/ready && break || sleep 15; done']
   restartPolicy: Never
   affinity:
     {{- include "nodeaffinity" . | indent 4 }}


### PR DESCRIPTION
As can be seen [here](https://k8s-gubernator.appspot.com/build/istio-prow/pr-logs/pull/istio_istio/11227/e2e-simpleTests/16741) the `e2e_simpleTests` usually fails just because the `istio-prometheus-test` fails.

The reason is that there is a little race between test the connection and prometheus being ready.
This PR adds retries with delays between them before giving up on trying to connect and reporting a failure.