### PR TITLE
Corrected non privileged ports range

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -902,7 +902,7 @@ func validatePort(node *model.Proxy, i int, bindToPort bool) bool {
 	if !bindToPort {
 		return true // all good, iptables doesn't care
 	}
-	if i > 1024 {
+	if i >= 1024 {
 		return true
 	}
 	remapBase := node.Metadata[model.NodeMetadataUID]


### PR DESCRIPTION
Privileged ports are in the range of [1..1023]. 