### PR TITLE
remove deprecated 'refreshInterval' option in chart.

### DIFF
--- a/install/kubernetes/helm/istio/README.md
+++ b/install/kubernetes/helm/istio/README.md
@@ -145,7 +145,6 @@ Helm charts expose configuration options which are currently in alpha.  The curr
 | `global.controlPlaneSecurityEnabled` | Specifies whether control plane mTLS is enabled | true/false | `false` |
 | `global.mtls.enabled` | Specifies whether mTLS is enabled by default between services | true/false | `false` |
 | `global.rbacEnabled` | Specifies whether to create Istio RBAC rules or not | true/false | `true` |
-| `global.refreshInterval` | Specifies the mesh discovery refresh interval | integer followed by s | `10s` |
 | `global.arch.amd64` | Specifies the scheduling policy for `amd64` architectures | 0 = never, 1 = least preferred, 2 = no preference, 3 = most preferred | `2` |
 | `global.arch.s390x` | Specifies the scheduling policy for `s390x` architectures | 0 = never, 1 = least preferred, 2 = no preference, 3 = most preferred | `2` |
 | `global.arch.ppc64le` | Specifies the scheduling policy for `ppc64le` architectures | 0 = never, 1 = least preferred, 2 = no preference, 3 = most preferred | `2` |

--- a/install/kubernetes/helm/istio/values-istio-auth-mcp.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth-mcp.yaml
@@ -12,8 +12,6 @@ global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"
-  # Default is 10s second
-  refreshInterval: 1s
   
   useMCP: true
 

--- a/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
@@ -13,9 +13,6 @@ global:
   # imagePullSecrets:
   #   - name: "private-registry-key"
 
-  # Default is 10s second
-  refreshInterval: 1s
-
 # In a multiple cluster environment, citadel uses the same root certificate in all the clusters
 security:
   selfSigned: false

--- a/install/kubernetes/helm/istio/values-istio-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth.yaml
@@ -11,5 +11,3 @@ global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"
-  # Default is 10s second
-  refreshInterval: 1s

--- a/install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml
+++ b/install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml
@@ -6,9 +6,6 @@ global:
     # destination rules or service annotations.
     enabled: true
 
-  # Default is 10s second
-  refreshInterval: 1s
-
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"

--- a/install/kubernetes/helm/istio/values-istio-mcp.yaml
+++ b/install/kubernetes/helm/istio/values-istio-mcp.yaml
@@ -13,9 +13,6 @@ global:
   # imagePullSecrets:
   #   - name: "private-registry-key"
 
-  # Default is 10s second
-  refreshInterval: 1s
-
   useMCP: true
 
 

--- a/install/kubernetes/helm/istio/values-istio-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-multicluster.yaml
@@ -13,9 +13,6 @@ global:
   # imagePullSecrets:
   #   - name: "private-registry-key"
 
-  # Default is 10s second
-  refreshInterval: 1s
-
 # In a multiple cluster environment, citadel uses the same root certificate in all the clusters
 security:
   selfSigned: false

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-auth.yaml
@@ -12,8 +12,6 @@ global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"
-  # Default is 10s second
-  refreshInterval: 1s
 
   # Restrict the applications in one namespace the controller manages
   oneNamespace: true

--- a/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace.yaml
@@ -12,8 +12,6 @@ global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"
-  # Default is 10s second
-  refreshInterval: 1s
 
   # Restrict the applications in one namespace the controller manages
   oneNamespace: true

--- a/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-sds-auth.yaml
@@ -6,9 +6,6 @@ global:
     # destination rules or service annotations.
     enabled: true
 
-  # Default is 10s second
-  refreshInterval: 1s
-
   sds:
     enabled: true
     udsPath: "unix:/var/run/sds/uds_path"

--- a/install/kubernetes/helm/istio/values-istio.yaml
+++ b/install/kubernetes/helm/istio/values-istio.yaml
@@ -1,7 +1,7 @@
 
 # This is used to generate istio.yaml for automated CI/CD test, using v1/alpha1
 # or v2/alpha3 with 'gradual migration' (using env variable at inject time).
-global:
+# global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values-istio.yaml
+++ b/install/kubernetes/helm/istio/values-istio.yaml
@@ -5,6 +5,3 @@ global:
   ## imagePullSecrets for all ServiceAccount. Must be set for any clustser configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"
-
-  # Default is 10s second
-  refreshInterval: 1s


### PR DESCRIPTION
The option `refreshInterval` has been deprecated and removed in https://github.com/istio/istio/commit/704a275c5f3ba2af9af0d16316c218fe4731318c#diff-2c87c80803eb0c59a631cf38cbd8805e, let's cleanup it from `values-*.yaml`
