### PR TITLE
Change pilot authn status report to show simple TLS and mTLS mode

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -378,7 +378,7 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 
 			if (clientProtocol & serverProtocol) == 0 {
 				if clientProtocol == authnCustomMTls && serverProtocol != authnHTTP {
-					info.TLSConflictStatus = "?"
+					info.TLSConflictStatus = "MAY CONFLICT"
 				} else {
 					info.TLSConflictStatus = "CONFLICT"
 				}

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -259,6 +259,8 @@ const (
 	authnHTTP       authProtocol = 1
 	authnMTls       authProtocol = 2
 	authnPermissive authProtocol = authnHTTP | authnMTls
+	authnCustomTLS  authProtocol = 4
+	authnCustomMTls authProtocol = 8
 )
 
 // Returns whether the given destination rule use (Istio) mutual TLS setting for given port.
@@ -269,8 +271,17 @@ func clientAuthProtocol(rule *networking.DestinationRule, port *model.Port) auth
 	}
 	_, _, _, tls := networking_core.SelectTrafficPolicyComponents(rule.TrafficPolicy, port)
 
-	if tls != nil && tls.Mode == networking.TLSSettings_ISTIO_MUTUAL {
-		return authnMTls
+	if tls != nil {
+		switch tls.Mode {
+		case networking.TLSSettings_ISTIO_MUTUAL:
+			return authnMTls
+		case networking.TLSSettings_SIMPLE:
+			return authnCustomTLS
+		case networking.TLSSettings_MUTUAL:
+			return authnCustomMTls
+		case networking.TLSSettings_DISABLE:
+			return authnHTTP
+		}
 	}
 	return authnHTTP
 }
@@ -311,6 +322,10 @@ func authProtocolToString(protocol authProtocol) string {
 		return "mTLS"
 	case authnPermissive:
 		return "HTTP/mTLS"
+	case authnCustomTLS:
+		return "TLS"
+	case authnCustomMTls:
+		return "custom mTLS"
 	default:
 		return "UNKNOWN"
 	}
@@ -362,7 +377,11 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 			info.ClientProtocol = authProtocolToString(clientProtocol)
 
 			if (clientProtocol & serverProtocol) == 0 {
-				info.TLSConflictStatus = "CONFLICT"
+				if clientProtocol == authnCustomMTls && serverProtocol != authnHTTP {
+					info.TLSConflictStatus = "?"
+				} else {
+					info.TLSConflictStatus = "CONFLICT"
+				}
 			} else {
 				info.TLSConflictStatus = "OK"
 			}


### PR DESCRIPTION
`istioctl authn tls-check` was designed for checking client & server setting consistency. It currently ignores (DestinationRule) `MUTUAL` and `SIMPLE` (TLS) mode, and displays plaintext, which may cause confusion (issue #11315)

For example, current display if authN policy is mTLS `PERMISSIVE` and destination rule is `SIMPLE`

```
HOST:PORT                                                     STATUS     SERVER        CLIENT     AUTHN POLICY     DESTINATION RULE
httpbin.default.svc.cluster.local:8000                        OK         HTTP/mTLS     HTTP       default/         default/default
```

The new status after this PR will be

```
HOST:PORT                                                     STATUS     SERVER        CLIENT     AUTHN POLICY     DESTINATION RULE
httpbin.default.svc.cluster.local:8000             CONFLICT         HTTP/mTLS     TLS       default/         default/default
```