### PR TITLE
Increase integ test deployment timeout (#11423)

### DIFF
--- a/pkg/test/kube/accessor.go
+++ b/pkg/test/kube/accessor.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	defaultRetryTimeout = retry.Timeout(time.Minute * 3)
+	defaultRetryTimeout = retry.Timeout(time.Minute * 10)
 	defaultRetryDelay   = retry.Delay(time.Second * 10)
 )
 

--- a/tests/integration2/mixer/scenarios_test.go
+++ b/tests/integration2/mixer/scenarios_test.go
@@ -104,6 +104,7 @@ func testMetric(t *testing.T, ctx component.Repository, label string, labelValue
 
 // Port of TestTcpMetric
 func TestTcpMetric(t *testing.T) {
+	t.Skip("https://github.com/istio/istio/issues/11430")
 	ctx := framework.GetContext(t)
 	scope := lifecycle.Test
 	ctx.RequireOrSkip(t, scope, &descriptors.KubernetesEnvironment, &ids.Mixer, &ids.Prometheus, &ids.BookInfo, &ids.Ingress)


### PR DESCRIPTION
* Increase integ test deployment timeout

* Skip flaky/failing TestTcpMetric