### PR TITLE
Quote accessLogFormat in configmap template in helm chart

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
     # If AccessLogEncoding is JSON, value will be parsed as map[string]string
     # example: '{"start_time": "%START_TIME%", "req_method": "%REQ(:METHOD)%"}'
     # Leave empty to use default log format
-    accessLogFormat: '{{ .Values.global.proxy.accessLogFormat }}'
+    accessLogFormat: {{ .Values.global.proxy.accessLogFormat | quote }}
 
     # Set accessLogEncoding to JSON or TEXT to configure sidecar access log
     accessLogEncoding: '{{ .Values.global.proxy.accessLogEncoding }}'


### PR DESCRIPTION
According to https://github.com/envoyproxy/envoy/issues/5193, the access log formatter cannot work without a `\n`. 

If I set the [accessLogFormat](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/values.yaml#L152) with `"[%START_TIME%] %REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\n"`, the [accessLogFormat](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/templates/configmap.yaml#L29) in ConfigMap template cannot be rendered correctly.

Signed-off-by: mathspanda mathspanda826@gmail.com