### PR TITLE
Add support for metadata constraints in RBAC

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -743,9 +743,9 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 				},
 			}, nil
 		}
-	case strings.HasPrefix(key, "envoy.filters.") && isKeyBinary(key):
-		// Split key of format envoy.filters.a.b[c] to [envoy.filters.a.b, c].
-		parts := strings.SplitN(strings.TrimSuffix(key, "]"), "[", 2)
+	case strings.HasPrefix(key, "experimental.envoy.filters.") && isKeyBinary(key):
+		// Split key of format experimental.envoy.filters.a.b[c] to [envoy.filters.a.b, c].
+		parts := strings.SplitN(strings.TrimSuffix(strings.TrimPrefix(key, "experimental."), "]"), "[", 2)
 		converter = func(v string) (*policyproto.Permission, error) {
 			// If value if of format [v], create a list matcher.
 			// Else, if value is of format v, create a string matcher.

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -745,7 +745,7 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		}
 	case isKeyBinary(key) && !attributesEnforcedInPlugin(key):
 		// Split key of format a[b] to [a, b].
-		parts := strings.Split(strings.TrimSuffix(key, "]"), "[")
+		parts := strings.SplitN(strings.TrimSuffix(key, "]"), "[", 2)
 		converter = func(v string) (*policyproto.Permission, error) {
 			return &policyproto.Permission{
 				Rule: &policyproto.Permission_Metadata{

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -199,7 +199,7 @@ func generateMetadataListMatcher(filter string, keys []string, v string) *metada
 		MatchPattern: &metadata.ListMatcher_OneOf{
 			OneOf: &metadata.ValueMatcher{
 				MatchPattern: &metadata.ValueMatcher_StringMatch{
-					StringMatch: createStringMatcher(v, false /* forceRegexPattern */, false /* forTCPFilter */),
+					StringMatch: createStringMatcher(v, false /* forceRegexPattern */, false /* prependSpiffe */),
 				},
 			},
 		},
@@ -266,7 +266,7 @@ func createDynamicMetadataMatcher(k, v string, forTCPFilter bool) *metadata.Meta
 		// Proxy doesn't have attrSrcNamespace directly, but the information is encoded in attrSrcPrincipal
 		// with format: cluster.local/ns/{NAMESPACE}/sa/{SERVICE-ACCOUNT}.
 		v = fmt.Sprintf(`*/ns/%s/*`, v)
-		stringMatcher := createStringMatcher(v, true /* forceRegexPattern */, false /* forTCPFilter */)
+		stringMatcher := createStringMatcher(v, true /* forceRegexPattern */, false /* prependSpiffe */)
 		return generateMetadataStringMatcher(attrSrcPrincipal, stringMatcher, filterName)
 	} else if strings.HasPrefix(k, attrRequestClaims) {
 		claim, err := extractNameInBrackets(strings.TrimPrefix(k, attrRequestClaims))
@@ -278,7 +278,7 @@ func createDynamicMetadataMatcher(k, v string, forTCPFilter bool) *metadata.Meta
 		return generateMetadataListMatcher(authn.AuthnFilterName, []string{attrRequestClaims, claim}, v)
 	}
 
-	stringMatcher := createStringMatcher(v, false /* forceRegexPattern */, false /* forTCPFilter */)
+	stringMatcher := createStringMatcher(v, false /* forceRegexPattern */, false /* prependSpiffe */)
 	if !attributesFromAuthN(k) {
 		rbacLog.Debugf("generated dynamic metadata matcher for custom property: %s", k)
 		if forTCPFilter {
@@ -739,7 +739,7 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		converter = func(v string) (*policyproto.Permission, error) {
 			return &policyproto.Permission{
 				Rule: &policyproto.Permission_RequestedServerName{
-					RequestedServerName: createStringMatcher(v, false /* forceRegexPattern */, false /* forTCPFilter */),
+					RequestedServerName: createStringMatcher(v, false /* forceRegexPattern */, false /* prependSpiffe */),
 				},
 			}, nil
 		}
@@ -747,13 +747,13 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		// Split key of format experimental.envoy.filters.a.b[c] to [envoy.filters.a.b, c].
 		parts := strings.SplitN(strings.TrimSuffix(strings.TrimPrefix(key, "experimental."), "]"), "[", 2)
 		converter = func(v string) (*policyproto.Permission, error) {
-			// If value if of format [v], create a list matcher.
+			// If value is of format [v], create a list matcher.
 			// Else, if value is of format v, create a string matcher.
 			var metadataMatcher *metadata.MetadataMatcher
 			if strings.HasPrefix(v, "[") && strings.HasSuffix(v, "]") {
 				metadataMatcher = generateMetadataListMatcher(parts[0], parts[1:], strings.Trim(v, "[]"))
 			} else {
-				stringMatcher := createStringMatcher(v, false, false)
+				stringMatcher := createStringMatcher(v, false /* forceRegexPattern */, false /* prependSpiffe */)
 				metadataMatcher = generateMetadataStringMatcher(parts[1], stringMatcher, parts[0])
 			}
 

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -405,6 +405,19 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-7"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"mysql"},
+						Constraints: []*rbacproto.AccessRule_Constraint{
+							{Key: "envoy.filters.network.mysql_proxy[db.table]", Values: []string{"update"}},
+						},
+					},
+				},
+			},
+		},
 	}
 	bindings := []model.Config{
 		{
@@ -502,6 +515,20 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				RoleRef: &rbacproto.RoleRef{
 					Kind: "ServiceRole",
 					Name: "service-role-6",
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-binding-7"},
+			Spec: &rbacproto.ServiceRoleBinding{
+				Subjects: []*rbacproto.Subject{
+					{
+						User: "*",
+					},
+				},
+				RoleRef: &rbacproto.RoleRef{
+					Kind: "ServiceRole",
+					Name: "service-role-7",
 				},
 			},
 		},
@@ -610,13 +637,13 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 					Ids: []*policy.Principal{
 						{
 							Identifier: &policy.Principal_Metadata{
-								Metadata: generateMetadataListMatcher(
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
 									[]string{attrRequestClaims, "groups"}, "group*"),
 							},
 						},
 						{
 							Identifier: &policy.Principal_Metadata{
-								Metadata: generateMetadataListMatcher(
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
 									[]string{attrRequestClaims, "iss"}, "test-iss"),
 							},
 						},
@@ -775,6 +802,37 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		},
 	}
 
+	policy7 := &policy.Policy{
+		Permissions: []*policy.Permission{{
+			Rule: &policy.Permission_AndRules{
+				AndRules: &policy.Permission_Set{
+					Rules: []*policy.Permission{{
+						Rule: &policy.Permission_OrRules{
+							OrRules: &policy.Permission_Set{
+								Rules: []*policy.Permission{{
+									Rule: &policy.Permission_Metadata{
+										Metadata: generateMetadataListMatcher("envoy.filters.network.mysql_proxy", []string{"db.table"}, "update"),
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+		}},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{{
+						Identifier: &policy.Principal_Any{
+							Any: true,
+						},
+					}},
+				},
+			},
+		}},
+	}
+
 	expectRbac1 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
@@ -810,6 +868,12 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
 			"service-role-6": policy6,
+		},
+	}
+	expectRbac7 := &policy.RBAC{
+		Action: policy.RBAC_ALLOW,
+		Policies: map[string]*policy.Policy{
+			"service-role-7": policy7,
 		},
 	}
 
@@ -892,6 +956,14 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 			},
 			rbac:   expectRbac6,
 			option: option,
+		},
+		{
+			name: "service with metadata constraints",
+			service: &serviceMetadata{
+				name: "mysql",
+			},
+			rbac:   expectRbac7,
+			option: rbacOption{authzPolicies: authzPolicies, forTCPFilter: true},
 		},
 	}
 
@@ -1329,11 +1401,11 @@ func TestCreateDynamicMetadataMatcher(t *testing.T) {
 		},
 		{
 			k: attrRequestClaims + "[groups]", v: "group*", tcp: false,
-			expect: generateMetadataListMatcher([]string{attrRequestClaims, "groups"}, "group*"),
+			expect: generateMetadataListMatcher(authn.AuthnFilterName, []string{attrRequestClaims, "groups"}, "group*"),
 		},
 		{
 			k: attrRequestClaims + "[iss]", v: "test-iss", tcp: false,
-			expect: generateMetadataListMatcher([]string{attrRequestClaims, "iss"}, "test-iss"),
+			expect: generateMetadataListMatcher(authn.AuthnFilterName, []string{attrRequestClaims, "iss"}, "test-iss"),
 		},
 		{
 			k: attrSrcUser, v: "*test-user", tcp: false,

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -412,7 +412,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 					{
 						Services: []string{"mysql"},
 						Constraints: []*rbacproto.AccessRule_Constraint{
-							{Key: "envoy.filters.network.mysql_proxy[db.table]", Values: []string{"[update]"}},
+							{Key: "experimental.envoy.filters.network.mysql_proxy[db.table]", Values: []string{"[update]"}},
 						},
 					},
 				},
@@ -425,7 +425,7 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 					{
 						Services: []string{"dummy"},
 						Constraints: []*rbacproto.AccessRule_Constraint{
-							{Key: "envoy.filters.dummy[key]", Values: []string{"value"}},
+							{Key: "experimental.envoy.filters.dummy[key]", Values: []string{"value"}},
 						},
 					},
 				},

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -179,7 +179,7 @@ func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *po
 					Ids: []*policy.Principal{
 						{
 							Identifier: &policy.Principal_Metadata{
-								Metadata: generateMetadataListMatcher(
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
 									[]string{attrRequestClaims, "groups"}, claimName),
 							},
 						},

--- a/pilot/pkg/networking/plugin/authz/util.go
+++ b/pilot/pkg/networking/plugin/authz/util.go
@@ -136,6 +136,12 @@ func convertToHeaderMatcher(k, v string) *route.HeaderMatcher {
 	}
 }
 
+// Check if the key is of format a[b].
+func isKeyBinary(key string) bool {
+	open := strings.Index(key, "[")
+	return strings.HasSuffix(key, "]") && open > 0 && open < len(key)-2
+}
+
 func extractNameInBrackets(s string) (string, error) {
 	if !strings.HasPrefix(s, "[") || !strings.HasSuffix(s, "]") {
 		return "", fmt.Errorf("expecting format [<NAME>], but found %s", s)

--- a/pilot/pkg/networking/plugin/authz/util_test.go
+++ b/pilot/pkg/networking/plugin/authz/util_test.go
@@ -209,6 +209,31 @@ func TestConvertToHeaderMatcher(t *testing.T) {
 	}
 }
 
+func TestIsKeyBinary(t *testing.T) {
+	cases := []struct {
+		s      string
+		expect bool
+	}{
+		{s: "a[b]", expect: true},
+		{s: "a", expect: false},
+		{s: "a.b", expect: false},
+		{s: "a.b[c]", expect: true},
+		{s: "a.b[c.d]", expect: true},
+		{s: "[a]", expect: false},
+		{s: "[a", expect: false},
+		{s: "a]", expect: false},
+		{s: "a[]", expect: false},
+		{s: "a.b[c.d]e", expect: false},
+		{s: "a.b[[c.d]]", expect: true},
+	}
+
+	for _, c := range cases {
+		if isKeyBinary(c.s) != c.expect {
+			t.Errorf("isKeyBinary returned incorrect result for key: %s", c.s)
+		}
+	}
+}
+
 func TestExtractNameInBrackets(t *testing.T) {
 	cases := []struct {
 		s      string


### PR DESCRIPTION
This adds support for mapping RBAC constraints with keys in the `a[b]` format to Envoy's filter metadata matcher.