### PR TITLE
Remove deprecated filter enabled field

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -33,7 +33,6 @@ import (
 	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/route/retry"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/proto"
 )
 
 // Headers with special meaning in Envoy
@@ -572,11 +571,9 @@ func translateCORSPolicy(in *networking.CorsPolicy) *route.CorsPolicy {
 		return nil
 	}
 
+	// CORS filter is enabled by default
 	out := route.CorsPolicy{
 		AllowOrigin: in.AllowOrigin,
-		EnabledSpecifier: &route.CorsPolicy_Enabled{
-			Enabled: proto.BoolTrue,
-		},
 	}
 	out.AllowCredentials = in.AllowCredentials
 	out.AllowHeaders = strings.Join(in.AllowHeaders, ",")


### PR DESCRIPTION
No need to set the `filter_enabled` field instead as it is [set to 100% (enabled)](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/cors_filter#runtime) by default.
