### PR TITLE
Fix e2e-simple test flake (#11356)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,7 +667,7 @@ isti%.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--values install/kubernetes/helm/istio/values-$@ \
 		install/kubernetes/helm/istio >> install/kubernetes/$@
 
-generate_yaml: $(HELM) $(HOME)/.helm helm-repo-add
+generate_yaml: $(HELM) $(HOME)/.helm helm-repo-add istio-init.yaml
 	$(HELM) dep update --skip-refresh install/kubernetes/helm/istio
 	./install/updateVersion.sh -a ${HUB},${TAG} >/dev/null 2>&1
 	cat install/kubernetes/namespace.yaml > install/kubernetes/istio.yaml
@@ -703,7 +703,7 @@ generate_yaml_coredump:
 # TODO(sdake) All this copy and paste needs to go.  This is easy to wrap up in
 #             isti%.yaml macro with value files per test scenario.  Will handle
 #             as a followup PR.
-generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add
+generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add istio-init.yaml
 	$(HELM) dep update --skip-refresh install/kubernetes/helm/istio
 	./install/updateVersion.sh -a ${HUB},${TAG} >/dev/null 2>&1
 	cat install/kubernetes/namespace.yaml > install/kubernetes/istio.yaml

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -39,6 +39,7 @@ import (
 const (
 	yamlSuffix                     = ".yaml"
 	istioInstallDir                = "install/kubernetes"
+	initInstallFile                = "istio-init.yaml"
 	nonAuthInstallFile             = "istio.yaml"
 	authInstallFile                = "istio-auth.yaml"
 	authSdsInstallFile             = "istio-auth-sds.yaml"
@@ -659,17 +660,35 @@ func (k *KubeInfo) deployIstio() error {
 		}
 	}
 
-	yamlDir := filepath.Join(istioInstallDir, istioYaml)
+	// Create istio-system namespace
+	if err := util.CreateNamespace(k.Namespace, k.KubeConfig); err != nil {
+		log.Errorf("Unable to create namespace %s: %s", k.Namespace, err.Error())
+		return err
+	}
+	// Apply istio-init
+	yamlDir := filepath.Join(istioInstallDir, initInstallFile)
 	baseIstioYaml := filepath.Join(k.ReleaseDir, yamlDir)
 	testIstioYaml := filepath.Join(k.TmpDir, "yaml", istioYaml)
-
 	if err := k.generateIstio(baseIstioYaml, testIstioYaml); err != nil {
-		log.Errorf("Generating yaml %s failed", testIstioYaml)
+		log.Errorf("Generating istio-init.yaml")
 		return err
 	}
 
-	if err := util.CreateNamespace(k.Namespace, k.KubeConfig); err != nil {
-		log.Errorf("Unable to create namespace %s: %s", k.Namespace, err.Error())
+	if err := util.KubeApply(k.Namespace, testIstioYaml, k.KubeConfig); err != nil {
+		log.Errorf("istio-init.yaml  %s deployment failed", testIstioYaml)
+		return err
+	}
+
+	// TODO(sdake): need a better synchronization
+	time.Sleep(20 * time.Second)
+
+	// Apply main manifest
+	yamlDir = filepath.Join(istioInstallDir, istioYaml)
+	baseIstioYaml = filepath.Join(k.ReleaseDir, yamlDir)
+	testIstioYaml = filepath.Join(k.TmpDir, "yaml", istioYaml)
+
+	if err := k.generateIstio(baseIstioYaml, testIstioYaml); err != nil {
+		log.Errorf("Generating yaml %s failed", testIstioYaml)
 		return err
 	}
 


### PR DESCRIPTION
istio-init.yaml was not being applied. Atleast on bare metal,
this caused e2e-simple to fail nearly 100% of the time in a race
between the kubeapi server applying CRD's and the applicaton of
custom resources in the manifest.

This problem is less pervasive on slower (vm) environments.
(cherry picked from commit 1caa6cedcc7b0526f94bf3f9d3941df65ae4956f)