### PR TITLE
Fixing race condition in Galley Server.Close()

### DIFF
--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -50,16 +50,17 @@ var scope = log.RegisterScope("server", "Galley server debugging", 0)
 
 // Server is the main entry point into the Galley code.
 type Server struct {
-	serveWG    sync.WaitGroup
-	grpcServer *grpc.Server
-	processor  *runtime.Processor
-	mcp        *server.Server
-	mcpSource  *source.Server
-	reporter   monitoring.Reporter
-	listener   net.Listener
-	controlZ   *ctrlz.Server
-	stopCh     chan struct{}
-	callOut    *callout
+	serveWG       sync.WaitGroup
+	grpcServer    *grpc.Server
+	processor     *runtime.Processor
+	mcp           *server.Server
+	mcpSource     *source.Server
+	reporter      monitoring.Reporter
+	listenerMutex sync.Mutex
+	listener      net.Listener
+	controlZ      *ctrlz.Server
+	stopCh        chan struct{}
+	callOut       *callout
 }
 
 type patchTable struct {
@@ -237,10 +238,13 @@ func (s *Server) Run() {
 			return
 		}
 
-		// start serving
-		err = s.grpcServer.Serve(s.listener)
-		if err != nil {
-			scope.Errorf("Galley Server unexpectedly terminated: %v", err)
+		l := s.getListener()
+		if l != nil {
+			// start serving
+			err = s.grpcServer.Serve(l)
+			if err != nil {
+				scope.Errorf("Galley Server unexpectedly terminated: %v", err)
+			}
 		}
 	}()
 	if s.callOut != nil {
@@ -252,12 +256,19 @@ func (s *Server) Run() {
 	}
 }
 
+func (s *Server) getListener() net.Listener {
+	s.listenerMutex.Lock()
+	defer s.listenerMutex.Unlock()
+	return s.listener
+}
+
 // Address returns the Address of the MCP service.
 func (s *Server) Address() net.Addr {
-	if s.listener == nil {
+	l := s.getListener()
+	if l == nil {
 		return nil
 	}
-	return s.listener.Addr()
+	return l.Addr()
 }
 
 // Close cleans up resources used by the server.
@@ -279,10 +290,12 @@ func (s *Server) Close() error {
 		s.processor.Stop()
 	}
 
+	s.listenerMutex.Lock()
 	if s.listener != nil {
 		_ = s.listener.Close()
 		s.listener = nil
 	}
+	s.listenerMutex.Unlock()
 
 	if s.reporter != nil {
 		_ = s.reporter.Close()


### PR DESCRIPTION
The issue was introduced by #11285

It causes a race with the startup of the gRPC server, which leads to a segfault.  From prow logs:


=== RUN TestServer_Basic 2019-02-01T20:33:05.867746Z	info	ControlZ available at 10.44.58.28:9876 2019-02-01T20:33:05.867968Z	info ControlZ terminated 2019-02-01T20:33:05.867987Z	info	runtime Stopping processor... 2019-02-01T20:33:05.868000Z	warn	runtime Processor has already stopped 2019-02-01T20:33:05.867798Z	info runtime	Starting processor... panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x9e4bc8] goroutine 148 [running]: istio.io/istio/vendor/google.golang.org/grpc.(*Server).Serve(0xc42046d080, 0x0, 0x0, 0x0, 0x0) /home/prow/go/src/istio.io/istio/vendor/google.golang.org/grpc/server.go:522 +0x748 istio.io/istio/galley/pkg/server.(*Server).Run.func1(0xc4202d9490) /home/prow/go/src/istio.io/istio/galley/pkg/server/server.go:242 +0xfb created by istio.io/istio/galley/pkg/server.(*Server).Run /home/prow/go/src/istio.io/istio/galley/pkg/server/server.go:233 +0x5c FAIL	istio.io/istio/galley/pkg/server 0.383s
