### PR TITLE
Envoy Graceful Shutdown

### DIFF
--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -127,7 +127,11 @@ func (s *Server) Run(ctx context.Context) {
 			log.Errora(err)
 			// If the server errors then pilot-agent can never pass readiness or liveness probes
 			// Therefore, trigger graceful termination by sending SIGTERM to the binary pid
-			syscall.Kill(os.Getpid(), syscall.SIGTERM)
+			p, err := os.FindProcess(os.Getpid())
+			if err != nil {
+				log.Errora(err)
+			}
+			log.Errora(p.Signal(syscall.SIGTERM))
 		}
 	}()
 

--- a/pilot/cmd/pilot-agent/status/server.go
+++ b/pilot/cmd/pilot-agent/status/server.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"istio.io/istio/pilot/cmd/pilot-agent/status/ready"
@@ -124,12 +125,15 @@ func (s *Server) Run(ctx context.Context) {
 	go func() {
 		if err := http.Serve(l, nil); err != nil {
 			log.Errora(err)
-			os.Exit(-1)
+			// If the server errors then pilot-agent can never pass readiness or liveness probes
+			// Therefore, trigger graceful termination by sending SIGTERM to the binary pid
+			syscall.Kill(os.Getpid(), syscall.SIGTERM)
 		}
 	}()
 
 	// Wait for the agent to be shut down.
 	<-ctx.Done()
+	log.Info("Status server has successfully terminated")
 }
 
 func (s *Server) handleReadyProbe(w http.ResponseWriter, _ *http.Request) {

--- a/pilot/docker/Dockerfile.proxy_debug
+++ b/pilot/docker/Dockerfile.proxy_debug
@@ -29,6 +29,7 @@ ADD envoy_policy.yaml.tmpl /etc/istio/proxy/envoy_policy.yaml.tmpl
 ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
 
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \

--- a/pilot/docker/Dockerfile.proxytproxy
+++ b/pilot/docker/Dockerfile.proxytproxy
@@ -42,6 +42,7 @@ ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
 
 # Sudoers used to allow tcpdump and other debug utilities.
 RUN useradd -m --uid 1337 istio-proxy && \

--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -20,6 +20,7 @@ ADD envoy_telemetry.yaml.tmpl /etc/istio/proxy/envoy_telemetry.yaml.tmpl
 ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 
 COPY envoy_bootstrap_v2.json /var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+COPY envoy_bootstrap_drain.json /var/lib/istio/envoy/envoy_bootstrap_drain.json
 
 RUN chmod 755 /usr/local/bin/envoy /usr/local/bin/pilot-agent
 

--- a/pilot/pkg/proxy/agent.go
+++ b/pilot/pkg/proxy/agent.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"golang.org/x/time/rate"
 
 	"istio.io/istio/pkg/log"
@@ -86,14 +87,17 @@ const (
 )
 
 // NewAgent creates a new proxy agent for the proxy start-up and clean-up functions.
-func NewAgent(proxy Proxy, retry Retry) Agent {
+func NewAgent(proxy Proxy, retry Retry, parentShutdownDuration *types.Duration) Agent {
+	parentDrain, _ := types.DurationFromProto(parentShutdownDuration)
+	gtp := parentDrain + (time.Second * 10) // add 10 second buffer
 	return &agent{
-		proxy:    proxy,
-		retry:    retry,
-		epochs:   make(map[int]interface{}),
-		configCh: make(chan interface{}),
-		statusCh: make(chan exitStatus),
-		abortCh:  make(map[int]chan error),
+		proxy:                     proxy,
+		retry:                     retry,
+		epochs:                    make(map[int]interface{}),
+		configCh:                  make(chan interface{}),
+		statusCh:                  make(chan exitStatus),
+		abortCh:                   make(map[int]chan error),
+		gracefulTerminationPeriod: gtp,
 	}
 }
 
@@ -126,6 +130,9 @@ type Proxy interface {
 	Panic(interface{})
 }
 
+// DrainConfig is used to signal to the Proxy that it should start draining connections
+type DrainConfig struct{}
+
 type agent struct {
 	// proxy commands
 	proxy Proxy
@@ -150,6 +157,9 @@ type agent struct {
 
 	// channel for aborting running instances
 	abortCh map[int]chan error
+
+	// time to allow for the proxy to drain before terminating all remaining proxy processes
+	gracefulTerminationPeriod time.Duration
 }
 
 type exitStatus struct {
@@ -246,17 +256,20 @@ func (a *agent) Run(ctx context.Context) {
 		case <-reconcileTimer.C:
 			a.reconcile()
 
-		case _, more := <-ctx.Done():
-			if !more {
-				a.terminate()
-				return
-			}
+		case <-ctx.Done():
+			a.terminate()
+			log.Info("Agent has successfully terminated")
+			return
 		}
 	}
 }
 
 func (a *agent) terminate() {
-	log.Infof("Agent terminating")
+	log.Infof("Agent draining Proxy")
+	a.desiredConfig = DrainConfig{}
+	a.reconcile()
+	time.Sleep(a.gracefulTerminationPeriod)
+	log.Infof("Graceful termniation period complete, terminating remaining proxies.")
 	a.abortAll()
 }
 

--- a/pilot/pkg/proxy/agent.go
+++ b/pilot/pkg/proxy/agent.go
@@ -268,6 +268,7 @@ func (a *agent) terminate() {
 	log.Infof("Agent draining Proxy")
 	a.desiredConfig = DrainConfig{}
 	a.reconcile()
+	log.Infof("Graceful termination period is %v, starting...", a.gracefulTerminationPeriod)
 	time.Sleep(a.gracefulTerminationPeriod)
 	log.Infof("Graceful termination period complete, terminating remaining proxies.")
 	a.abortAll()

--- a/pilot/pkg/proxy/agent.go
+++ b/pilot/pkg/proxy/agent.go
@@ -269,7 +269,7 @@ func (a *agent) terminate() {
 	a.desiredConfig = DrainConfig{}
 	a.reconcile()
 	time.Sleep(a.gracefulTerminationPeriod)
-	log.Infof("Graceful termniation period complete, terminating remaining proxies.")
+	log.Infof("Graceful termination period complete, terminating remaining proxies.")
 	a.abortAll()
 }
 

--- a/pilot/pkg/proxy/agent_test.go
+++ b/pilot/pkg/proxy/agent_test.go
@@ -87,7 +87,7 @@ func TestStartDrain(t *testing.T) {
 		}
 		return nil
 	}
-	a := NewAgent(TestProxy{start, nil, nil}, testRetry, types.DurationProto(time.Duration(-10*time.Second)))
+	a := NewAgent(TestProxy{start, nil, nil}, testRetry, types.DurationProto(-10*time.Second))
 	go a.Run(ctx)
 	a.ConfigCh() <- startConfig
 	<-blockChan

--- a/pilot/pkg/proxy/agent_test.go
+++ b/pilot/pkg/proxy/agent_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gogo/protobuf/types"
 )
 
 var (
@@ -80,7 +82,7 @@ func TestStartStop(t *testing.T) {
 		}
 		cancel()
 	}
-	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry)
+	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- desired
 	<-ctx.Done()
@@ -98,7 +100,7 @@ func TestApplyTwice(t *testing.T) {
 		return nil
 	}
 	cleanup := func(epoch int) {}
-	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry)
+	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- desired
 	a.ConfigCh() <- desired
@@ -136,7 +138,7 @@ func TestApplyThrice(t *testing.T) {
 	}
 	retry := testRetry
 	retry.MaxRetries = 0
-	a = NewAgent(TestProxy{start, cleanup, nil}, retry)
+	a = NewAgent(TestProxy{start, cleanup, nil}, retry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- good
 	a.ConfigCh() <- bad
@@ -183,7 +185,7 @@ func TestAbort(t *testing.T) {
 	}
 	retry := testRetry
 	retry.InitialInterval = 10 * time.Second
-	a := NewAgent(TestProxy{start, cleanup, nil}, retry)
+	a := NewAgent(TestProxy{start, cleanup, nil}, retry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- good1
 	a.ConfigCh() <- good2
@@ -212,7 +214,7 @@ func TestStartFail(t *testing.T) {
 		return nil
 	}
 	cleanup := func(epoch int) {}
-	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry)
+	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- "test"
 	<-ctx.Done()
@@ -244,7 +246,7 @@ func TestExceedBudget(t *testing.T) {
 	}
 	retryDelay := testRetry
 	retryDelay.MaxRetries = 1
-	a := NewAgent(TestProxy{start, cleanup, func(_ interface{}) { cancel() }}, retryDelay)
+	a := NewAgent(TestProxy{start, cleanup, func(_ interface{}) { cancel() }}, retryDelay, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- "test"
 	<-ctx.Done()
@@ -297,7 +299,7 @@ func TestStartTwiceStop(t *testing.T) {
 			cancel()
 		}
 	}
-	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry)
+	a := NewAgent(TestProxy{start, cleanup, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- desired0
 	a.ConfigCh() <- desired1
@@ -321,7 +323,7 @@ func TestRecovery(t *testing.T) {
 		<-ctx.Done()
 		return nil
 	}
-	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, testRetry)
+	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- desired
 
@@ -358,7 +360,7 @@ func TestCascadingAbort(t *testing.T) {
 	}
 	retry := testRetry
 	retry.InitialInterval = 1 * time.Second
-	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, retry)
+	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, retry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- 0
 	a.ConfigCh() <- 1
@@ -401,7 +403,7 @@ func TestLockup(t *testing.T) {
 		}
 		return nil
 	}
-	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, testRetry)
+	a := NewAgent(TestProxy{start, func(_ int) {}, nil}, testRetry, types.DurationProto(0))
 	go a.Run(ctx)
 	a.ConfigCh() <- 0
 	a.ConfigCh() <- 1

--- a/pilot/pkg/proxy/envoy/proxy.go
+++ b/pilot/pkg/proxy/envoy/proxy.go
@@ -33,6 +33,9 @@ import (
 const (
 	// epochFileTemplate is a template for the root config JSON
 	epochFileTemplate = "envoy-rev%d.json"
+
+	// drainFile is the location of the bootstrap config used for draining on istio-proxy termination
+	drainFile = "/var/lib/istio/envoy/envoy_bootstrap_drain.json"
 )
 
 type envoy struct {
@@ -91,6 +94,8 @@ func (e *envoy) Run(config interface{}, epoch int, abort <-chan error) error {
 	if len(e.config.CustomConfigFile) > 0 {
 		// there is a custom configuration. Don't write our own config - but keep watching the certs.
 		fname = e.config.CustomConfigFile
+	} else if _, ok := config.(proxy.DrainConfig); ok {
+		fname = drainFile
 	} else {
 		out, err := bootstrap.WriteBootstrap(&e.config, e.node, epoch, e.pilotSAN, e.opts, os.Environ(), e.nodeIPs)
 		if err != nil {

--- a/pilot/pkg/proxy/envoy/watcher.go
+++ b/pilot/pkg/proxy/envoy/watcher.go
@@ -76,6 +76,7 @@ func (w *watcher) Run(ctx context.Context) {
 	go watchCerts(ctx, certDirs, watchFileEvents, defaultMinDelay, w.SendConfig)
 
 	<-ctx.Done()
+	log.Info("Watcher has successfully terminated")
 }
 
 func (w *watcher) SendConfig() {
@@ -83,7 +84,6 @@ func (w *watcher) SendConfig() {
 	for _, cert := range w.certs {
 		generateCertHash(h, cert.Directory, cert.Files)
 	}
-
 	w.updates <- h.Sum(nil)
 }
 
@@ -118,7 +118,7 @@ func watchFileEvents(ctx context.Context, wch <-chan *fsnotify.FileEvent, minDel
 			log.Info("watchFileEvents: notifying")
 			notifyFn()
 		case <-ctx.Done():
-			log.Info("watchFileEvents has terminated")
+			log.Info("watchFileEvents has successfully terminated")
 			return
 		}
 	}

--- a/tools/deb/envoy_bootstrap_drain.json
+++ b/tools/deb/envoy_bootstrap_drain.json
@@ -1,0 +1,11 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 15000
+      }
+    }
+  }
+}

--- a/tools/deb/istio.mk
+++ b/tools/deb/istio.mk
@@ -46,6 +46,7 @@ $(foreach DEST,$(ISTIO_DEB_DEST),\
         $(eval SIDECAR_FILES+=src/istio.io/istio/tools/deb/$(notdir $(DEST))=$(DEST)))
 
 SIDECAR_FILES+=src/istio.io/istio/tools/deb/envoy_bootstrap_v2.json=/var/lib/istio/envoy/envoy_bootstrap_tmpl.json
+SIDECAR_FILES+=src/istio.io/istio/tools/deb/envoy_bootstrap_drain.json=/var/lib/istio/envoy/envoy_bootstrap_drain.json
 
 # original name used in 0.2 - will be updated to 'istio.deb' since it now includes all istio binaries.
 ISTIO_DEB_NAME ?= istio-sidecar

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -95,6 +95,7 @@ docker.proxy_debug: BUILD_PRE=mv envoy-debug-${PROXY_REPO_SHA} envoy &&
 docker.proxy_debug: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION}
 docker.proxy_debug: pilot/docker/Dockerfile.proxy_debug
 docker.proxy_debug: tools/deb/envoy_bootstrap_v2.json
+docker.proxy_debug: tools/deb/envoy_bootstrap_drain.json
 docker.proxy_debug: ${ISTIO_ENVOY_DEBUG_PATH}
 docker.proxy_debug: $(ISTIO_OUT)/pilot-agent
 docker.proxy_debug: pilot/docker/Dockerfile.proxyv2
@@ -111,6 +112,7 @@ ${ISTIO_ENVOY_RELEASE_DIR}/envoy: ${ISTIO_ENVOY_RELEASE_PATH}
 # Default proxy image.
 docker.proxyv2: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION}
 docker.proxyv2: tools/deb/envoy_bootstrap_v2.json
+docker.proxyv2: tools/deb/envoy_bootstrap_drain.json
 docker.proxyv2: $(ISTIO_ENVOY_RELEASE_DIR)/envoy
 docker.proxyv2: $(ISTIO_OUT)/pilot-agent
 docker.proxyv2: pilot/docker/Dockerfile.proxyv2
@@ -123,6 +125,7 @@ docker.proxyv2: pilot/docker/envoy_telemetry.yaml.tmpl
 # Proxy using TPROXY interception - but no core dumps
 docker.proxytproxy: BUILD_ARGS=--build-arg proxy_version=istio-proxy:${PROXY_REPO_SHA} --build-arg istio_version=${VERSION}
 docker.proxytproxy: tools/deb/envoy_bootstrap_v2.json
+docker.proxytproxy: tools/deb/envoy_bootstrap_drain.json
 docker.proxytproxy: $(ISTIO_ENVOY_RELEASE_DIR)/envoy
 docker.proxytproxy: $(ISTIO_OUT)/pilot-agent
 docker.proxytproxy: pilot/docker/Dockerfile.proxytproxy


### PR DESCRIPTION
Resolves part of #7136 (doesn't allow new outbound connections when shutting down).
Supercedes #11298, #10420.

Triggers Envoy to drain all listeners on shutdown by hot restarting to an Envoy instance with no listeners. WIll start work on unit tests early next week but have manually verified the behaviour.

Behaviour:
1. Pod receives SIGTERM
2. Envoy starts rejecting any new connections, but keeps ongoing connections alive.
3. Drains connections until parent shutdown time limit is reached
4. Terminates all remaining connections by killing the remaining Envoy instances.