### PR TITLE
Skip spybackend test when in racetest

### DIFF
--- a/mixer/test/spybackend/nosession_integration_test.go
+++ b/mixer/test/spybackend/nosession_integration_test.go
@@ -256,7 +256,7 @@ func TestNoSessionBackend(t *testing.T) {
 
 	// We skip this test if it is being run as part of the racetest because
 	// it is intensive on memory and will cause the test to fail with no error
-	if len(os.Getenv("RACE_TEST"))>0 {
+	if len(os.Getenv("RACE_TEST")) > 0 {
 		t.Skip()
 	}
 

--- a/mixer/test/spybackend/nosession_integration_test.go
+++ b/mixer/test/spybackend/nosession_integration_test.go
@@ -17,6 +17,7 @@ package spybackend
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -252,6 +253,12 @@ spec:
 )
 
 func TestNoSessionBackend(t *testing.T) {
+
+	// We skip this test if it is being run as part of the racetest because
+	// it is intensive on memory and will cause the test to fail with no error
+	if len(os.Getenv("RACE_TEST"))>0 {
+		t.Skip()
+	}
 
 	testdata := []struct {
 		name   string


### PR DESCRIPTION
The `racetest` is steadily failing since #11197 has been merged.

Deeper analysis shows that it fails on `spybackend` with no error message and memory profiling hints that it's because the test is very intensive on memory when running in race mode. Running the test locally on a machine with higher memory will succeed.