### PR TITLE
Add annotations for Kiali, Prometheus and Tracing

### DIFF
--- a/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
@@ -3,15 +3,30 @@ kind: Service
 metadata:
   name: kiali
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: {{ template "kiali.name" . }}
     chart: {{ template "kiali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  type: {{ .Values.service.type }}
   ports:
-  - name: http-kiali
+  - name: {{ .Values.service.name }}
     protocol: TCP
-    port: 20001
+    port: {{ .Values.service.externalPort }}
+    targetPort: 20001
   selector:
     app: kiali
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+  {{if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{range $rangeList := .Values.service.loadBalancerSourceRanges}}
+    - {{ $rangeList }}
+    {{end}}
+  {{end}}

--- a/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - name: {{ .Values.service.name }}
+  - name: http-kiali
     protocol: TCP
     port: {{ .Values.service.externalPort }}
     targetPort: 20001

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -20,6 +20,14 @@ ingress:
     # - secretName: kiali-tls
     #   hosts:
     #     - kiali.local
+service:
+  annotations: {}
+  name: http-kiali
+  type: ClusterIP
+  externalPort: 20001
+  loadBalancerIP:
+  loadBalancerSourceRanges:
+
 gateway:
   enabled: false
 dashboard:

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -22,7 +22,6 @@ ingress:
     #     - kiali.local
 service:
   annotations: {}
-  name: http-kiali
   type: ClusterIP
   externalPort: 20001
   loadBalancerIP:

--- a/install/kubernetes/helm/subcharts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/service.yaml
@@ -29,6 +29,10 @@ kind: Service
 metadata:
   name: prometheus-nodeport
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.service.nodePort.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   labels:
     app: prometheus
     chart: {{ template "prometheus.chart" . }}

--- a/install/kubernetes/helm/subcharts/prometheus/values.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/values.yaml
@@ -30,6 +30,7 @@ ingress:
 service:
   annotations: {}
   nodePort:
+    annotations: {}
     enabled: false
     port: 32090
 

--- a/install/kubernetes/helm/subcharts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/templates/service.yaml
@@ -43,6 +43,7 @@ items:
       heritage: {{ .Release.Service }}
       release: {{ .Release.Name }}
   spec:
+    type: {{ .Values.service.type }}
     ports:
       - name: http-query
         port: 80
@@ -54,3 +55,12 @@ items:
 {{ end}}
     selector:
       app: {{ .Values.provider }}
+{{- if .Values.service.loadBalancerIP }}
+    loadBalancerIP: "{{ .Values.service.loadBalancerIP }}"
+{{- end }}
+  {{if .Values.service.loadBalancerSourceRanges}}
+    loadBalancerSourceRanges:
+    {{range $rangeList := .Values.service.loadBalancerSourceRanges}}
+      - {{ $rangeList }}
+    {{end}}
+  {{end}}

--- a/install/kubernetes/helm/subcharts/tracing/values.yaml
+++ b/install/kubernetes/helm/subcharts/tracing/values.yaml
@@ -38,6 +38,8 @@ service:
   name: http
   type: ClusterIP
   externalPort: 9411
+  loadBalancerIP:
+  loadBalancerSourceRanges:
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Proposed change

Currently only the following Helm sub-charts support defining custom annotations to Service resources:

- Grafana
- Service Graph

This PR adds service annotation support to the following Helm sub-charts:

- Kiali
- Prometheus (exposed over `NodePort`)
- Tracing

It also adds support for Kiali and Tracing to be directly exposed through a L4 load balancer with source IP address white listing defined on the service level at `loadBalancerSourceRanges`. This model is already supported on some sub-charts, like Grafana. It is especially useful for internal demo deployments where TLS is not necessarily worth setting up.

Default behaviour of the Istio Helm chart remains as is. This PR only extends it.

## Details

In general, service annotations allow customizing LBs such as Google L7 HTTP(S) LB. With it, users can define a single load balancer to securely forward traffic to Istio "management" components (Grafana, Tracing, Prometheus, ...) which are run on the `istio-system` namespace. Even with a non-functioning mesh network these components would still be reachable. Since many of these components don't provide authentication out-of-the-box, some sort of source IP address white listing is encouraged. For an L7 ingress Google allows to do this by defining a Cloud Armor policy. As a bonus, users can define pre-existing TLS certificates to be used by the ingress.

## Example

Here's an example of a deployment model with Istio on GKE:

- Deploy custom Google Cloud Armor policy `allow-certain-source-ips-only` to allow source IP address whitelisting.
- Deploy Istio with Helm by defining this Cloud Armor policy to each service backend [as shown on GKE documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/backendconfig). In the Istio Helm values file this would look like this (for each service):

```
kiali:
  enabled: true
  service:
    type: NodePort
    annotations:
      beta.cloud.google.com/backend-config: '{"ports": {"20001":"allow-certain-source-ips-only"}}'

prometheus:
  service:
    nodePort:
      enabled: true
      annotations:
        beta.cloud.google.com/backend-config: '{"ports": {"9090":"allow-certain-source-ips-only"}}'
```

Then to actually expose these over an Ingress:

- Reserve a global compute address for Google HTTP(S) LB
- Create a custom Ingress resource which uses this reserved compute address
- In the Ingress resource, route only certain services through based on request hostname, for example Grafana and Tracing.


