### PR TITLE
Flag disable some debug functionality by default

### DIFF
--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -141,6 +141,8 @@ func init() {
 	// enable webhook for specific xDS config (cds/lds/etc).
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.DiscoveryOptions.WebhookEndpoint, "webhookEndpoint", "",
 		"Webhook API endpoint (supports http://sockethost, and unix:///absolute/path/to/socket")
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.Debug, "debug", false,
+		"Enable all pilot debug endpoints (registryz, ctrlz, endpointsz etc.)")
 
 	// Deprecated flags.
 	discoveryCmd.PersistentFlags().IntVar(&httpPort, "port", 8080,

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -168,6 +168,10 @@ func init() {
 		Section: "pilot-discovery CLI",
 		Manual:  "Istio Pilot Discovery",
 	}))
+
+	if os.Getenv("DEBUG_MODE") != "" {
+		serverArgs.Debug = true
+	}
 }
 
 func main() {

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -152,6 +152,7 @@ type PilotArgs struct {
 	MeshConfig       *meshconfig.MeshConfig
 	CtrlZOptions     *ctrlz.Options
 	Plugins          []string
+	Debug            bool
 }
 
 // Server contains the runtime configuration for the Pilot discovery service.
@@ -234,7 +235,7 @@ func NewServer(args PilotArgs) (*Server, error) {
 		return nil, err
 	}
 
-	if args.CtrlZOptions != nil {
+	if args.CtrlZOptions != nil && !args.Debug {
 		go ctrlz.Run(args.CtrlZOptions, nil)
 	}
 
@@ -765,6 +766,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 		s.configController,
 		environment,
 		args.DiscoveryOptions,
+		args.Debug,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create discovery service: %v", err)
@@ -794,7 +796,7 @@ func (s *Server) initDiscoveryService(args *PilotArgs) error {
 		}
 	}
 
-	s.EnvoyXdsServer.InitDebug(s.mux, s.ServiceController, discovery)
+	s.EnvoyXdsServer.InitDebug(s.mux, s.ServiceController, discovery, args.Debug)
 
 	s.EnvoyXdsServer.ConfigController = s.configController
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -235,7 +235,7 @@ func NewServer(args PilotArgs) (*Server, error) {
 		return nil, err
 	}
 
-	if args.CtrlZOptions != nil && !args.Debug {
+	if args.CtrlZOptions != nil && args.Debug {
 		go ctrlz.Run(args.CtrlZOptions, nil)
 	}
 

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -325,12 +325,13 @@ type DiscoveryServiceOptions struct {
 
 	EnableProfiling bool
 	EnableCaching   bool
+	Debug           bool
 	WebhookEndpoint string
 }
 
 // NewDiscoveryService creates an Envoy discovery service on a given port
 func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCache,
-	environment *model.Environment, o DiscoveryServiceOptions, debug bool) (*DiscoveryService, error) {
+	environment *model.Environment, o DiscoveryServiceOptions) (*DiscoveryService, error) {
 	out := &DiscoveryService{
 		Environment: environment,
 		sdsCache:    newDiscoveryCache("sds", o.EnableCaching),
@@ -338,11 +339,11 @@ func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCach
 
 	container := restful.NewContainer()
 	if o.EnableProfiling {
-		if debug {
+		if o.Debug {
 			container.ServeMux.HandleFunc("/debug/pprof/", pprof.Index)
-			container.ServeMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-			container.ServeMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		}
+		container.ServeMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		container.ServeMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		container.ServeMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		container.ServeMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	}

--- a/pilot/pkg/proxy/envoy/discovery.go
+++ b/pilot/pkg/proxy/envoy/discovery.go
@@ -330,7 +330,7 @@ type DiscoveryServiceOptions struct {
 
 // NewDiscoveryService creates an Envoy discovery service on a given port
 func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCache,
-	environment *model.Environment, o DiscoveryServiceOptions) (*DiscoveryService, error) {
+	environment *model.Environment, o DiscoveryServiceOptions, debug bool) (*DiscoveryService, error) {
 	out := &DiscoveryService{
 		Environment: environment,
 		sdsCache:    newDiscoveryCache("sds", o.EnableCaching),
@@ -338,11 +338,13 @@ func NewDiscoveryService(ctl model.Controller, configCache model.ConfigStoreCach
 
 	container := restful.NewContainer()
 	if o.EnableProfiling {
-		container.ServeMux.HandleFunc("/debug/pprof/", pprof.Index)
-		container.ServeMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		if debug {
+			container.ServeMux.HandleFunc("/debug/pprof/", pprof.Index)
+			container.ServeMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			container.ServeMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		}
 		container.ServeMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		container.ServeMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		container.ServeMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 	out.Register(container)
 

--- a/tests/util/pilot_server.go
+++ b/tests/util/pilot_server.go
@@ -153,6 +153,7 @@ func setup() error {
 			Registries: []string{
 				string(serviceregistry.MockRegistry)},
 		},
+		Debug: true,
 	}
 	// Static testdata, should include all configs we want to test.
 	args.Config.FileDir = IstioSrc + "/tests/testdata/config"


### PR DESCRIPTION
Disable ctrlz, mem registry, some of pprof, and some handler write ability by default through --debug flag.
