### PR TITLE
make stackdriver e2e test cluster wide

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -114,7 +114,7 @@ e2e_bookinfo_run: out_dir
 	go test -v -timeout 60m ./tests/e2e/tests/bookinfo -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
 e2e_stackdriver_run: out_dir
-	go test -v -timeout 25m ./tests/e2e/tests/stackdriver -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} --gcp_proj=${GCP_PROJ} --sa_cred=/etc/service-account/service-account.json
+	go test -v -timeout 25m ./tests/e2e/tests/stackdriver -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} --cluster_wide --gcp_proj=${GCP_PROJ} --sa_cred=/etc/service-account/service-account.json
 
 e2e_all_run: out_dir
 	$(MAKE) --keep-going e2e_simple_run e2e_bookinfo_run e2e_dashboard_run


### PR DESCRIPTION
SD e2e runs with daily release. Here is an example build log from a failed run: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio-releases_pipeline/281/release-e2e-stackdriver/96/build-log.txt. it is getting the following error from https://github.com/istio/istio/blob/master/tests/e2e/framework/kubernetes.go#L651:

> Failed to complete Init. Error cannot enable useGalleyConfigValidator in one namespace tests

Add cluster_wide to the test arg like other test to make the test run.