### PR TITLE
Fix routing when DNS is resolved

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -164,6 +164,11 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+{{- if .Values.global.podDNSSearchNamespaces }}
+        - name: ISTIO_META_DNS_DOMAINS
+{{- $local := dict "first" true }}
+          value: {{ range $k, $v := .Values.global.podDNSSearchNamespaces }}{{- if not $local.first }},{{ end }}{{- $v }}{{- $_ := set $local "first" false }}{{- end }}
+{{- end }}
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         {{- if .Values.global.network }}

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -26,35 +26,35 @@ import (
 
 func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	role.TrustDomain = ""
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.BeNil())
 }
 
 func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = "my.domain"
+	DNSDomain = "my.domain"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://my.domain/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -63,47 +63,47 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 // When pilot is started without a trust domain, the SPIFFE URI doesn't contain a host and is not valid
 func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = "my.domain"
+	DNSDomain = "my.domain"
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotDefaultDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	os.Setenv("POD_NAMESPACE", "default")
 
-	domain := getDNSDomain(role.DNSDomain)
+	domain := getDNSDomain(DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("default.svc.cluster.local"))
 	os.Unsetenv("POD_NAMESPACE")
@@ -111,42 +111,42 @@ func TestPilotDefaultDomainKubernetes(t *testing.T) {
 
 func TestPilotDefaultDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
 	registry = serviceregistry.ConsulRegistry
+	DNSDomain = ""
 
-	domain := getDNSDomain(role.DNSDomain)
+	domain := getDNSDomain(DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("service.consul"))
 }
 
 func TestPilotDefaultDomainOthers(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ""
+	DNSDomain = ""
 	registry = serviceregistry.MockRegistry
 
-	domain := getDNSDomain(role.DNSDomain)
+	domain := getDNSDomain(DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal(""))
 }
 
 func TestPilotDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = "my.domain"
+	DNSDomain = "my.domain"
 	registry = serviceregistry.MockRegistry
 
-	domain := getDNSDomain(role.DNSDomain)
+	domain := getDNSDomain(DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("my.domain"))
 }
 
 func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = ".svc.cluster.local"
+	DNSDomain = ".svc.cluster.local"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -155,12 +155,12 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 // When pilot is started without a trust domain, the SPIFFE URI doesn't contain a host and is not valid
 func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	role.DNSDomain = "service.consul"
+	DNSDomain = "service.consul"
 	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
+	pilotSAN := getPilotSAN(DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -38,7 +38,7 @@ func TestServiceNode(t *testing.T) {
 				Type:        model.Ingress,
 				ID:          "random",
 				IPAddresses: []string{"10.3.3.3"},
-				DNSDomain:   "local",
+				DNSDomains:  []string{"local"},
 			},
 			out: "ingress~10.3.3.3~random~local",
 		},
@@ -47,7 +47,7 @@ func TestServiceNode(t *testing.T) {
 				Type:        model.SidecarProxy,
 				ID:          "random",
 				IPAddresses: []string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"},
-				DNSDomain:   "local",
+				DNSDomains:  []string{"local"},
 				Metadata: map[string]string{
 					"INSTANCE_IPS": "10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
 				},
@@ -68,6 +68,28 @@ func TestServiceNode(t *testing.T) {
 		}
 		if !reflect.DeepEqual(in, node.in) {
 			t.Errorf("ParseServiceNode(%q) => Got %#v, want %#v", node.out, in, node.in)
+		}
+	}
+}
+
+func TestGetUniqueSuffixes(t *testing.T) {
+	data := []struct {
+		in  []string
+		out []string
+	}{
+		{
+			in:  []string{"part1.part2.com", "part2.com", "default.svc.local", "kube.default.svc.local"},
+			out: []string{"part1.part2.com", "kube.default.svc.local"},
+		},
+		{
+			in:  []string{"global", "istio-system.global", "global"},
+			out: []string{"istio-system.global"},
+		},
+	}
+	for _, datum := range data {
+		out := model.GetUniqueSuffixes(datum.in)
+		if !reflect.DeepEqual(datum.out, out) {
+			t.Errorf("GetSuperString() =>\n Got %s\nwant %s", out, datum.out)
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -169,7 +169,7 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, nodeType model.N
 			ClusterID:   "some-cluster-id",
 			Type:        model.SidecarProxy,
 			IPAddresses: []string{"6.6.6.6"},
-			DNSDomain:   "com",
+			DNSDomains:  []string{"com"},
 			Metadata:    meta,
 		}
 	case model.Router:
@@ -177,7 +177,7 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, nodeType model.N
 			ClusterID:   "some-cluster-id",
 			Type:        model.Router,
 			IPAddresses: []string{"6.6.6.6"},
-			DNSDomain:   "default.example.org",
+			DNSDomains:  []string{"default.example.org"},
 			Metadata:    meta,
 		}
 	default:

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -220,7 +220,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) []string {
 	domains := []string{string(service.Hostname), fmt.Sprintf("%s:%d", service.Hostname, port)}
-	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
+	for _, domain := range node.DNSDomains {
+		domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, domain)...)
+	}
 
 	if len(service.Address) > 0 && service.Address != model.UnspecifiedIP {
 		svcAddr := service.GetServiceAddressForProxy(node)

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -41,7 +41,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomain: "local.campus.net",
+				DNSDomains: []string{"local.campus.net"},
 			},
 			want: []string{"foo", "foo.local", "foo.local.campus", "foo.local.campus.net",
 				"foo:80", "foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
@@ -54,7 +54,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomain: "remote.campus.net",
+				DNSDomains: []string{"remote.campus.net"},
 			},
 			want: []string{"foo.local", "foo.local.campus", "foo.local.campus.net",
 				"foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
@@ -67,7 +67,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomain: "example.com",
+				DNSDomains: []string{"example.com"},
 			},
 			want: []string{"foo.local.campus.net", "foo.local.campus.net:80"},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -39,7 +39,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1"},
 		ID:          "v0.default",
-		DNSDomain:   "default.example.org",
+		DNSDomains:  []string{"default.example.org"},
 		Metadata: map[string]string{
 			model.NodeMetadataConfigNamespace: "not-default",
 			"ISTIO_PROXY_VERSION":             "1.1",

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -47,7 +47,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1"},
 		ID:          "someID",
-		DNSDomain:   "foo.com",
+		DNSDomains:  []string{"foo.com"},
 		Metadata:    map[string]string{"ISTIO_PROXY_VERSION": "1.1"},
 	}
 	gatewayNames := map[string]bool{"some-gateway": true}

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -451,7 +451,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	svcNode.Type = model.Ingress
 	svcNode.IPAddresses = []string{"128.0.0.1"}
 	svcNode.ID = "pod1.nsa"
-	svcNode.DNSDomain = "nsa.svc.cluster.local"
+	svcNode.DNSDomains = []string{"nsa.svc.cluster.local"}
 	services, err := controller.GetProxyServiceInstances(&svcNode)
 	if err != nil {
 		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)

--- a/pilot/pkg/serviceregistry/memory/discovery_mock.go
+++ b/pilot/pkg/serviceregistry/memory/discovery_mock.go
@@ -46,7 +46,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{HelloInstanceV0},
 		ID:          "v0.default",
-		DNSDomain:   "default.svc.cluster.local",
+		DNSDomains:  []string{"default.svc.cluster.local"},
 	}
 
 	// HelloProxyV1 is a mock proxy v1 of HelloService
@@ -54,7 +54,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{HelloInstanceV1},
 		ID:          "v1.default",
-		DNSDomain:   "default.svc.cluster.local",
+		DNSDomains:  []string{"default.svc.cluster.local"},
 	}
 
 	// Ingress is a mock proxy to IP 10.3.3.3
@@ -62,7 +62,7 @@ var (
 		Type:        model.Ingress,
 		IPAddresses: []string{"10.3.3.3"},
 		ID:          "ingress.default",
-		DNSDomain:   "default.svc.cluster.local",
+		DNSDomains:  []string{"default.svc.cluster.local"},
 	}
 
 	// MockDiscovery is an in-memory ServiceDiscover with mock services


### PR DESCRIPTION
Fix routing when DNS is resolved
    
The DNSDomain variable needs to be enhanced to include more then one DNS entry.  Change DNSDomain to DNSDomains as a meta and add the dnsConfig in the meta.  As now DNSDomain is a slice of strings instead of a string, the variable needs consolidation.

Depends-On: https://github.com/istio/istio/pull/11512