### PR TITLE
galley ingest mcp

### DIFF
--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -70,6 +70,17 @@ func GetRootCmd(args []string) *cobra.Command {
 			serverArgs.CredentialOptions.CACertificateFile = validationArgs.CACertFile
 			serverArgs.CredentialOptions.KeyFile = validationArgs.KeyFile
 			serverArgs.CredentialOptions.CertificateFile = validationArgs.CertFile
+			// Default MCPClient credentials to MCP Server if not supplied
+			if serverArgs.MCPClientCredOpts.CertificateFile == "" {
+				serverArgs.MCPClientCredOpts.CertificateFile = validationArgs.CertFile
+			}
+			if serverArgs.MCPClientCredOpts.KeyFile == "" {
+				serverArgs.MCPClientCredOpts.KeyFile = validationArgs.KeyFile
+			}
+			if serverArgs.MCPClientCredOpts.CACertificateFile == "" {
+				serverArgs.MCPClientCredOpts.CACertificateFile = validationArgs.CACertFile
+			}
+
 			if livenessProbeOptions.IsValid() {
 				livenessProbeController = probe.NewFileController(&livenessProbeOptions)
 			}
@@ -169,6 +180,17 @@ func GetRootCmd(args []string) *cobra.Command {
 		"Name of the validation service running in the same namespace as the deployment")
 	rootCmd.PersistentFlags().StringVar(&validationArgs.WebhookName, "webhook-name", "istio-galley",
 		"Name of the k8s validatingwebhookconfiguration")
+
+	// MCP client flags
+	rootCmd.PersistentFlags().StringVar(&serverArgs.SourceMCPServerAddress, "sourceMCPServerAddress", "",
+		" MCP server addresses with "+"mcp:// (insecure) or mcps:// (secure) schema, e.g. mcps://istio-galley.istio-system.svc:9901")
+	// MCP Client defaults to MCP server certs to connect to MCP Source server
+	rootCmd.PersistentFlags().StringVar(&serverArgs.MCPClientCredOpts.CertificateFile, "mcpClientTLSCertFile", "",
+		"File containing the x509 Certificate for mTLS to connect to source MCP Server")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.MCPClientCredOpts.KeyFile, "mcpClientTLSKeyFile", "",
+		"File containing the x509 private key matching --mcpClientTLSCertFile")
+	rootCmd.PersistentFlags().StringVar(&serverArgs.MCPClientCredOpts.CACertificateFile, "mcpClientCACertFile", "",
+		"File containing the caBundle that signed the cert/key specified by --mcpClientTLSCertFile and --mcpClientTLSKeyFile.")
 
 	rootCmd.AddCommand(probeCmd())
 	rootCmd.AddCommand(version.CobraCommand())

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -70,6 +70,12 @@ type Args struct {
 	// ConfigPath is the path for Galley specific config files
 	ConfigPath string
 
+	// SourceMCPServerAddress is the mcpserver address galley will connect to source config
+	SourceMCPServerAddress string
+
+	// MCPClientCredOpts is the credentials galley will use to connect to source mcpserver
+	MCPClientCredOpts *creds.Options
+
 	// ExcludedResourceKinds is a list of resource kinds for which no source events will be triggered.
 	ExcludedResourceKinds []string
 
@@ -98,6 +104,7 @@ func DefaultArgs() *Args {
 		EnableServer:              true,
 		CredentialOptions:         creds.DefaultOptions(),
 		ConfigPath:                "",
+		MCPClientCredOpts:         creds.DefaultOptions(),
 		DomainSuffix:              defaultDomainSuffix,
 		DisableResourceReadyCheck: false,
 		ExcludedResourceKinds:     defaultExcludedResourceKinds(),
@@ -130,6 +137,10 @@ func (a *Args) String() string {
 	_, _ = fmt.Fprintf(buf, "CertificateFile: %s\n", a.CredentialOptions.CertificateFile)
 	_, _ = fmt.Fprintf(buf, "CACertificateFile: %s\n", a.CredentialOptions.CACertificateFile)
 	_, _ = fmt.Fprintf(buf, "ConfigFilePath: %s\n", a.ConfigPath)
+	_, _ = fmt.Fprintf(buf, "SourceMCPServerAddress: %s\n", a.SourceMCPServerAddress)
+	_, _ = fmt.Fprintf(buf, "MCPClientKeyFile: %s\n", a.MCPClientCredOpts.KeyFile)
+	_, _ = fmt.Fprintf(buf, "MCPClientCertificateFile: %s\n", a.MCPClientCredOpts.CertificateFile)
+	_, _ = fmt.Fprintf(buf, "MCPClientCACertificateFile: %s\n", a.MCPClientCredOpts.CACertificateFile)
 	_, _ = fmt.Fprintf(buf, "MeshConfigFile: %s\n", a.MeshConfigFile)
 	_, _ = fmt.Fprintf(buf, "DomainSuffix: %s\n", a.DomainSuffix)
 	_, _ = fmt.Fprintf(buf, "DisableResourceReadyCheck: %v\n", a.DisableResourceReadyCheck)

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net"
 	"sync"
@@ -28,6 +29,7 @@ import (
 	"istio.io/istio/galley/pkg/source/kube/dynamic/converter"
 	"istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/testing/mock"
+	"istio.io/istio/pkg/mcp/creds"
 	"istio.io/istio/pkg/mcp/monitoring"
 	mcptestmon "istio.io/istio/pkg/mcp/testing/monitoring"
 )
@@ -68,6 +70,11 @@ loop:
 		case 3:
 			p.newMeshConfigCache = func(path string) (meshconfig.Cache, error) { return nil, e }
 		case 4:
+			args.SourceMCPServerAddress = "mcp"
+			p.mcpSrcNew = func(ctx context.Context, copts *creds.Options, mcpAddress, nodeID string) (runtime.Source, error) {
+				return nil, e
+			}
+		case 5:
 			args.ConfigPath = "aaa"
 			p.fsNew = func(string, *schema.Instance, *converter.Config) (runtime.Source, error) { return nil, e }
 		default:

--- a/galley/pkg/source/mcp/source.go
+++ b/galley/pkg/source/mcp/source.go
@@ -1,0 +1,275 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	multierror "github.com/hashicorp/go-multierror"
+	"google.golang.org/grpc"
+
+	mcpapi "istio.io/api/mcp/v1alpha1"
+	"istio.io/istio/galley/pkg/metadata"
+	"istio.io/istio/galley/pkg/runtime"
+	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/pilot/pkg/bootstrap"
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/mcp/client"
+	"istio.io/istio/pkg/mcp/creds"
+	"istio.io/istio/pkg/mcp/monitoring"
+	"istio.io/istio/pkg/mcp/sink"
+)
+
+var (
+	scope = log.RegisterScope("mcp", "mcp debugging", 0)
+)
+
+// This should line up with the MCP client's batch size so we can enqueue every event in a batch without blocking.
+const defaultChanSize = 1000
+
+type source struct {
+	nodeID             string
+	address            string
+	ctx                context.Context
+	dial               func(ctx context.Context, address string) (mcpapi.AggregatedMeshConfigServiceClient, error)
+	handler            resource.EventHandler
+	stop               func()
+	cashCollectionLock map[string]*sync.Mutex
+	lCache             map[string]map[string]*cache
+}
+
+type cache struct {
+	version string
+	prevVer string
+	ek      resource.EventKind
+	entry   *resource.Entry
+}
+
+var _ runtime.Source = &source{}
+var _ sink.Updater = &source{}
+
+// New returns nil error. error is added to be consistent with other source's New functions
+func New(ctx context.Context, copts *creds.Options, mcpAddress, nodeID string) (runtime.Source, error) {
+	s := &source{
+		nodeID:             nodeID,
+		address:            mcpAddress,
+		ctx:                ctx,
+		cashCollectionLock: make(map[string]*sync.Mutex),
+		lCache:             make(map[string]map[string]*cache),
+		dial: func(ctx context.Context, address string) (mcpapi.AggregatedMeshConfigServiceClient, error) {
+
+			// Copied from pilot/pkg/bootstrap/server.go
+			requiredMCPCertCheckFreq := 500 * time.Millisecond
+			u, err := url.Parse(mcpAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			securityOption := grpc.WithInsecure()
+			if u.Scheme == "mcps" {
+				// TODO - Check for presence of cert files - this code could be extracted into function
+				// and shared with pilot/pkg/bootstrap/server.go- initMCPConfigController
+				// https://github.com/istio/istio/blob/master/pilot/pkg/bootstrap/server.go#L574-L591
+
+				requiredFiles := []string{
+					copts.CertificateFile,
+					copts.KeyFile,
+					copts.CACertificateFile,
+				}
+				scope.Infof("Secure MCP Client configured. Waiting for required certificate files to become available: %v",
+					requiredFiles)
+				retry := 20 //10s
+				for len(requiredFiles) > 0 {
+					if _, err := os.Stat(requiredFiles[0]); os.IsNotExist(err) {
+						log.Infof("%v not found. Checking again in %v", requiredFiles[0], requiredMCPCertCheckFreq)
+						select {
+						case <-ctx.Done():
+							return nil, nil
+						case <-time.After(requiredMCPCertCheckFreq):
+							if retry <= 0 {
+								return nil, fmt.Errorf("required file %s not found", requiredFiles[0])
+							}
+							retry--
+						}
+						continue
+					}
+					log.Infof("%v found", requiredFiles[0])
+					requiredFiles = requiredFiles[1:]
+					retry = 20
+				}
+
+				watcher, err := creds.WatchFiles(ctx.Done(), copts)
+				if err != nil {
+					return nil, err
+				}
+				credentials := creds.CreateForClient(u.Hostname(), watcher)
+				securityOption = grpc.WithTransportCredentials(credentials)
+			}
+
+			msgSizeOption := grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(bootstrap.DefaultMCPMaxMsgSize))
+			conn, err := grpc.DialContext(ctx, u.Hostname()+":"+u.Port(), securityOption, msgSizeOption)
+			if err != nil {
+				scope.Errorf("Unable to dial MCP Server %q: %v", address, err)
+				return nil, err
+			}
+			return mcpapi.NewAggregatedMeshConfigServiceClient(conn), nil
+		},
+	}
+	return s, nil
+}
+
+func (s *source) Start(handler resource.EventHandler) error {
+	//Assign the channel for the Apply function to use
+	s.handler = handler
+	ctx, cancel := context.WithCancel(s.ctx)
+	s.stop = cancel
+	cl, err := s.dial(ctx, s.address)
+	if err != nil {
+		scope.Debugf("failed to dial %q", s.address)
+		return err
+	}
+
+	options := &sink.Options{
+		CollectionOptions: sink.CollectionOptionsFromSlice(metadata.Types.Collections()),
+		Updater:           s,
+		ID:                s.nodeID,
+		Metadata:          map[string]string{},
+		Reporter:          monitoring.NewStatsContext("galley-mcp-client"),
+	}
+	mcpClient := client.New(cl, options)
+	scope.Debugf("starting MCP client in its own goroutine")
+	go mcpClient.Run(ctx)
+	return nil
+}
+
+func (s *source) Stop() {
+	s.stop()
+}
+
+func (s *source) Apply(c *sink.Change) error {
+	cInfo, found := metadata.Types.Lookup(c.Collection)
+	if !found {
+		return fmt.Errorf("invalid type: %v", c.Collection)
+	}
+	scope.Debugf("received object %+v and length %d", c, len(c.Objects))
+
+	if _, ok := s.lCache[c.Collection]; !ok {
+		s.lCache[c.Collection] = make(map[string]*cache)
+		s.cashCollectionLock[c.Collection] = &sync.Mutex{}
+	}
+	s.cashCollectionLock[c.Collection].Lock()
+	defer s.cashCollectionLock[c.Collection].Unlock()
+
+	// By default mark all the elements of local cache deleted, if present
+	for _, c := range s.lCache[c.Collection] {
+		c.ek = resource.Deleted
+	}
+
+	var errs error
+	for _, o := range c.Objects {
+		if o.TypeURL != cInfo.TypeURL.String() {
+			errs = multierror.Append(errs,
+				fmt.Errorf("type %v mismatch in received object: %v", cInfo.TypeURL.String(), o.TypeURL))
+			continue
+		}
+		e, err := toEntry(o, cInfo)
+		if err != nil {
+			errs = multierror.Append(errs, err)
+			continue
+		}
+		// If there is an error, ignore the entire batch.
+		// but keep appending errs[] for the batch
+		if errs == nil {
+			lc, ok := s.lCache[c.Collection][o.Metadata.Name]
+			if ok {
+				if lc.version == o.Metadata.Version {
+					lc.ek = resource.None
+				} else {
+					lc.prevVer = lc.version
+					lc.version = o.Metadata.Version
+					lc.ek = resource.Updated
+				}
+				lc.entry = &e
+
+			} else {
+				s.lCache[c.Collection][o.Metadata.Name] = &cache{
+					version: o.Metadata.Version,
+					ek:      resource.Added,
+					entry:   &e,
+				}
+			}
+		}
+	}
+
+	// If there is an error, the entire batch will be ignored
+	// Hence remove any new adds from the local cache
+	// And restore prev version if there were updates
+	if errs != nil {
+		for key, lc := range s.lCache[c.Collection] {
+			if lc.ek == resource.Added {
+				// this is safe because anything with state `Added` was new in this batch
+				delete(s.lCache[c.Collection], key)
+			} else if lc.ek == resource.Updated {
+				lc.version = lc.prevVer // We are not worried about the entry as it will be overwritten
+			}
+		}
+		return errs
+	}
+
+	// At this point we have all resources for that TypeURL
+	//loop through the local cache and generate the appropriate events
+	fsync := false
+	for key, lc := range s.lCache[c.Collection] {
+		if lc.ek == resource.None {
+			continue
+		}
+		fsync = true
+		scope.Debugf("pushed an event %+v", lc.ek)
+		s.handler(resource.Event{
+			Kind:  lc.ek,
+			Entry: *lc.entry,
+		})
+		// If its a Deleted event, remove it from local cache
+		if lc.ek == resource.Deleted {
+			delete(s.lCache[c.Collection], key)
+		}
+	}
+	if fsync {
+		// Do a FullSynch after all events for a publish
+		s.handler(resource.Event{Kind: resource.FullSync})
+	}
+
+	return nil
+}
+
+// toEntry converts the object into a resource.Entry.
+func toEntry(o *sink.Object, info resource.Info) (resource.Entry, error) {
+
+	t := time.Now()
+	if o.Metadata.CreateTime != nil {
+		var err error
+		if t, err = types.TimestampFromProto(o.Metadata.CreateTime); err != nil {
+			return resource.Entry{}, err
+		}
+	}
+	// Verified in the caller that o is of kind info
+	return resource.Entry{
+		ID: resource.VersionedKey{
+			Key: resource.Key{
+				Collection: info.Collection,
+				FullName:   resource.FullNameFromNamespaceAndName("", o.Metadata.Name),
+			},
+			Version: resource.Version(o.Metadata.Version),
+		},
+		Metadata: resource.Metadata{
+			CreateTime:  t,
+			Annotations: o.Metadata.Annotations,
+			Labels:      o.Metadata.Labels,
+		},
+		Item: o.Body,
+	}, nil
+}

--- a/galley/pkg/source/mcp/source_test.go
+++ b/galley/pkg/source/mcp/source_test.go
@@ -1,0 +1,494 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+
+	mcp "istio.io/api/mcp/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/galley/pkg/metadata"
+	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/pkg/mcp/creds"
+	"istio.io/istio/pkg/mcp/sink"
+	"istio.io/istio/pkg/mcp/snapshot"
+	mcpsource "istio.io/istio/pkg/mcp/source"
+	mcptest "istio.io/istio/pkg/mcp/testing"
+)
+
+type testData struct {
+	info    resource.Info
+	entry   proto.Message
+	name    string
+	version string
+}
+
+func allConfigsSnapshot(infos []testData, version string) snapshot.Snapshot {
+	//createTime := time.Now()
+	var createTime time.Time
+	b := snapshot.NewInMemoryBuilder()
+	// snapshot is supposed to be immutable. This is for testing
+	for _, i := range infos {
+		b.SetEntry(i.info.Collection.String(), i.name, i.version, createTime, map[string]string{}, map[string]string{}, i.entry)
+		b.SetVersion(i.info.Collection.String(), version)
+	}
+
+	return b.Build()
+}
+
+func Test(t *testing.T) {
+	data := []testData{
+		{
+			info:    metadata.Types.Get("istio/networking/v1alpha3/virtualservices"),
+			name:    "test.vservice1",
+			version: "1",
+			entry: &v1alpha3.VirtualService{
+				Hosts: []string{"localhost"},
+			},
+		},
+		{
+			info:    metadata.Types.Get("istio/networking/v1alpha3/virtualservices"),
+			name:    "test.vservice2",
+			version: "1",
+			entry: &v1alpha3.VirtualService{
+				Hosts:       []string{"somehost"},
+				Gateways:    []string{"test"},
+				Http:        nil,
+				Tls:         nil,
+				Tcp:         nil,
+				ConfigScope: 0,
+			},
+		},
+		{
+			info:    metadata.Types.Get("istio/networking/v1alpha3/gateways"),
+			name:    "test.gw1",
+			version: "1",
+			entry: &v1alpha3.Gateway{
+				Servers:  nil,
+				Selector: map[string]string{"istio": "ingressgateway"},
+			},
+		},
+	}
+
+	// start test mcp server
+	server, err := mcptest.NewServer(0, mcpsource.CollectionOptionsFromSlice(metadata.Types.Collections()))
+	if err != nil {
+		t.Fatalf("failed to start MCP test server: %v", err)
+	}
+
+	// run galley Start for galley mcp client to connect to mcp server
+	url := schemeURL(server.URL, false)
+	fmt.Printf("connecting to: %q\n", url)
+	underTest, _ := New(context.Background(), &creds.Options{}, url, "")
+	events := make(chan resource.Event, defaultChanSize)
+	if err := underTest.Start(func(e resource.Event) {
+		events <- e
+	}); err != nil {
+		t.Fatalf("failed to start test server with: %v", err)
+	}
+
+	// Test Add
+	// We should receive 2 Add events and a FullSync for Virtual Service
+	// 1 Add and a FullSync for Gateway
+	server.Cache.SetSnapshot(snapshot.DefaultGroup, allConfigsSnapshot(data, "1"))
+	testAdd(t, events)
+
+	//Test Update
+	// We should see one update event in the channel
+	data[0].version = "2"
+	server.Cache.SetSnapshot(snapshot.DefaultGroup, allConfigsSnapshot(data, "2"))
+	testUpdate(t, events)
+
+	//Test AddAndUpdate
+	// We should see one Update and one Add event in the channel
+	data[1].version = "2"
+	a := testData{
+		info:    metadata.Types.Get("istio/networking/v1alpha3/gateways"),
+		name:    "test.gw2",
+		version: "1",
+		entry: &v1alpha3.Gateway{
+			Servers:  nil,
+			Selector: map[string]string{"istio": "ingressgateway"},
+		},
+	}
+	data = append(data, a)
+	server.Cache.SetSnapshot(snapshot.DefaultGroup, allConfigsSnapshot(data, "3"))
+	testAddAndUpdate(t, events)
+
+	//Test Delete
+	//We should see two Delete events in the channel
+	data = append(data[:1], data[2])
+	server.Cache.SetSnapshot(snapshot.DefaultGroup, allConfigsSnapshot(data, "4"))
+	testDelete(t, events)
+
+	//Test NoUpdate
+	// We should not see any events in the channel
+	server.Cache.SetSnapshot(snapshot.DefaultGroup, allConfigsSnapshot(data, "5"))
+	testNoChange(t, events)
+
+	// Mismatch in TypeURL
+	testTypeURLMismatch(t, data)
+
+	underTest.Stop()
+}
+
+func testTypeURLMismatch(t *testing.T, data []testData) {
+	// Mismatch in TypeURL
+	events := make(chan resource.Event, defaultChanSize)
+	src := &source{
+		lCache:             make(map[string]map[string]*cache),
+		cashCollectionLock: make(map[string]*sync.Mutex),
+		handler:            func(e resource.Event) { events <- e },
+	}
+
+	// Create object in local cache
+	// There should be an event for Added and Fullsync
+	c := &sink.Change{
+		Collection: data[0].info.Collection.String(),
+		Objects: []*sink.Object{
+			{TypeURL: data[0].info.TypeURL.String(),
+				Metadata: &mcp.Metadata{Name: data[0].name, Version: data[0].version},
+				Body:     data[0].entry,
+			},
+		},
+	}
+	if err := src.Apply(c); err != nil {
+		t.Fatalf("Apply returned error when not expected %v:", err)
+	}
+	results := make(chan resource.Event)
+	tot := 0
+	go func() {
+		for {
+			if tot == 2 {
+				break
+			}
+			e := <-events
+			switch e.Kind {
+			case resource.Added:
+				tot++
+			case resource.FullSync:
+				tot++
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+		results <- resource.Event{}
+	}()
+	wait := time.NewTimer(1 * time.Minute).C
+	select {
+	case <-wait:
+		t.Fatalf("timed out waiting for all events")
+	case r := <-results:
+		if tot != 2 {
+			t.Fatalf("too few results: %v", r)
+		}
+	}
+
+	// Send an update to the object and another object with invalid typeurl
+	c = &sink.Change{
+		Collection: data[0].info.Collection.String(),
+		Objects: []*sink.Object{
+			{TypeURL: data[0].info.TypeURL.String(),
+				Metadata: &mcp.Metadata{Name: data[0].name, Version: "9"},
+				Body:     data[0].entry,
+			},
+			{TypeURL: "InvalidTypeURL",
+				Metadata: &mcp.Metadata{Name: "testresource", Version: data[0].version},
+				Body:     data[0].entry,
+			},
+		},
+	}
+	if err := src.Apply(c); err == nil {
+		t.Fatalf("Apply expected to return error but returned nil")
+	}
+
+	// Send a new object and another object with invalid typeURL
+	c = &sink.Change{
+		Collection: data[0].info.Collection.String(),
+		Objects: []*sink.Object{
+			{TypeURL: data[0].info.TypeURL.String(),
+				Metadata: &mcp.Metadata{Name: "testresource", Version: data[0].version},
+				Body:     data[0].entry,
+			},
+			{TypeURL: "InvalidTypeURL",
+				Metadata: &mcp.Metadata{Name: "some", Version: data[0].version},
+				Body:     data[0].entry,
+			},
+		},
+	}
+	if err := src.Apply(c); err == nil {
+		t.Fatalf("Apply expected to return error but returned nil")
+	}
+
+	// Invalid TypeURL at the response level
+	// We should not see any events in the channel
+	c = &sink.Change{Collection: "test",
+		Objects: []*sink.Object{{TypeURL: "something"}},
+	}
+	if err := src.Apply(c); err == nil {
+		t.Fatalf("Apply expected to return error but returned nil")
+	}
+	// All the Apply call above shouldn't have resulted in any event
+	testNoChange(t, events)
+
+	fmt.Println("event testypeURLMismatch pass")
+}
+
+func schemeURL(u *url.URL, secure bool) string {
+	if secure {
+		return fmt.Sprintf("mcps://%s:%s", u.Hostname(), u.Port())
+	}
+	return fmt.Sprintf("mcp://%s:%s", u.Hostname(), u.Port())
+}
+
+func testAdd(t *testing.T, events chan resource.Event) {
+	results := make(chan resource.Event)
+	vs := 0
+	gw := 0
+	tot := 0
+	go func() {
+		for {
+			if tot == 5 {
+				break
+			}
+			e := <-events
+			fmt.Println("received event ", e)
+			switch e.Kind {
+			case resource.Added:
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/virtualservices" {
+					vs++
+				}
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/gateways" {
+					gw++
+				}
+				tot++
+			case resource.FullSync:
+				tot++
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+		if gw != 1 || vs != 2 {
+			t.Fatalf("Didn't receive all the Add events")
+		}
+		results <- resource.Event{}
+	}()
+
+	wait := time.NewTimer(1 * time.Minute).C
+	select {
+	case <-wait:
+		t.Fatalf("timed out waiting for all events")
+	case r := <-results:
+		if tot != 5 {
+			t.Fatalf("too few results: %v", r)
+		}
+	}
+	fmt.Println("event testAdd pass")
+
+}
+
+func testUpdate(t *testing.T, events chan resource.Event) {
+	results := make(chan resource.Event)
+	vs := 0
+	tot := 0
+	go func() {
+		for {
+			if tot == 2 {
+				break
+			}
+			e := <-events
+			fmt.Println("received event ", e)
+			switch e.Kind {
+			case resource.Updated:
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/virtualservices" {
+					vs++
+				}
+				tot++
+			case resource.FullSync:
+				tot++
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+		if vs != 1 {
+			t.Fatalf("Didn't receive all the Update events")
+		}
+		results <- resource.Event{}
+	}()
+
+	wait := time.NewTimer(1 * time.Minute).C
+	select {
+	case <-wait:
+		t.Fatalf("timed out waiting for all events")
+	case r := <-results:
+		if tot != 2 {
+			t.Fatalf("too few results: %v", r)
+		}
+	}
+	fmt.Println("event testUpdate pass")
+
+}
+
+func testAddAndUpdate(t *testing.T, events chan resource.Event) {
+	results := make(chan resource.Event)
+	vs := 0
+	gw := 0
+	tot := 0
+	go func() {
+		for {
+			if tot == 4 {
+				break
+			}
+			e := <-events
+			fmt.Println("received event ", e)
+			switch e.Kind {
+			case resource.Added:
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/gateways" {
+					gw++
+					tot++
+				} else {
+					t.Fatalf("Unexpected event received")
+				}
+			case resource.Updated:
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/virtualservices" {
+					vs++
+					tot++
+				} else {
+					t.Fatalf("Unexpected event received")
+				}
+			case resource.FullSync:
+				tot++
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+		if gw != 1 || vs != 1 {
+			t.Fatalf("Didn't receive all the expected events")
+		}
+		results <- resource.Event{}
+	}()
+
+	wait := time.NewTimer(1 * time.Minute).C
+	select {
+	case <-wait:
+		t.Fatalf("timed out waiting for all events")
+	case r := <-results:
+		if tot != 4 {
+			t.Fatalf("too few results: %v", r)
+		}
+	}
+	fmt.Println("event testAddAndUpdate pass")
+
+}
+
+func testDelete(t *testing.T, events chan resource.Event) {
+	results := make(chan resource.Event)
+	vs := 0
+	gw := 0
+	tot := 0
+	go func() {
+		for {
+			if tot == 4 {
+				break
+			}
+			e := <-events
+			fmt.Println("received event ", e)
+			switch e.Kind {
+			case resource.Deleted:
+				if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/virtualservices" {
+					vs++
+				} else if e.Entry.ID.Collection.String() == "istio/networking/v1alpha3/gateways" {
+					gw++
+				} else {
+					t.Fatalf("Unexpected event received")
+				}
+				tot++
+			case resource.FullSync:
+				tot++
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+		if vs != 1 || gw != 1 {
+			t.Fatalf("Didn't receive all the Deleted events")
+		}
+		results <- resource.Event{}
+	}()
+
+	wait := time.NewTimer(1 * time.Minute).C
+	select {
+	case <-wait:
+		t.Fatalf("timed out waiting for all events")
+	case r := <-results:
+		if tot != 4 {
+			t.Fatalf("too few results: %v", r)
+		}
+	}
+	fmt.Println("event testDeleted pass")
+
+}
+
+func testNoChange(t *testing.T, events chan resource.Event) {
+	go func() {
+		for {
+			e := <-events
+			fmt.Println("received event ", e)
+			switch e.Kind {
+			default:
+				t.Fatalf("Unexpected event received")
+			}
+		}
+	}()
+
+	wait := time.NewTimer(30 * time.Second).C
+	<-wait
+	fmt.Println("event testNoChange pass")
+}
+
+func TestCreds(t *testing.T) {
+	// start test mcp server
+	server, err := mcptest.NewServer(0, mcpsource.CollectionOptionsFromSlice(metadata.Types.Collections()))
+	if err != nil {
+		t.Fatalf("failed to start MCP test server: %v", err)
+	}
+
+	// run galley Start for galley mcp client to connect to mcp server
+	url := schemeURL(server.URL, true)
+	events := make(chan resource.Event, defaultChanSize)
+
+	fmt.Printf("connecting to: %q\n", url)
+	//Try with cred dummy dirs
+	copts := &creds.Options{
+		CertificateFile:   "/etc",
+		KeyFile:           "/etc",
+		CACertificateFile: "/etc",
+	}
+	underTest, _ := New(context.Background(), copts, url, "")
+	if err := underTest.Start(func(e resource.Event) {
+		events <- e
+	}); err == nil {
+		t.Fatalf("Expecting failed to dial but instead it was successful")
+	}
+
+	fmt.Printf("connecting to: %q\n", url)
+	//Try with nonexistent cred file
+	copts = &creds.Options{
+		CertificateFile:   "/etc",
+		KeyFile:           "/etc/certs",
+		CACertificateFile: "/etc/certs/nonexistent",
+	}
+	underTest, _ = New(context.Background(), copts, url, "")
+	if err := underTest.Start(func(e resource.Event) {
+		events <- e
+	}); err == nil {
+		t.Fatalf("Expecting failed to dial but instead it was successful")
+	}
+
+	//Test with a valid cred file
+
+}


### PR DESCRIPTION
Galley to accept MCP Server as a source for config (Galley as an mcp client)
Added command line flags for Galley as an MCP Client
secure mode - very similar to pilot as an mcp client