### PR TITLE
Remove unneeded annotations

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-11.yaml
@@ -63,8 +63,6 @@ kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
 metadata:
   name: zipkins.config.istio.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: mixer
     package: zipkin

--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-10.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: certmanager
     chart: certmanager
@@ -21,8 +19,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: certmanager
     chart: certmanager
@@ -40,8 +36,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: certmanager
     chart: certmanager


### PR DESCRIPTION
These annotations are not used, but are confusing to read.  The CRDs
are not installed directly by helm, so the annotations are ignored.  No
reason they should be present.