### PR TITLE
Fix 10971 p1 injector (#11512) (cherrypick)

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -276,7 +276,7 @@ data:
       - name: {{ "\"[[ $index ]]\"" }}
         {{ "[[ toYaml $value | indent 2 ]]" }}
         {{ "[[ end ]]" }}
-        {{ "[[ end -]]" }}
+        {{ "[[ end ]]" }}
       {{- end }}
       {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
       - name: lightstep-certs

--- a/install/kubernetes/helm/istio/values-istio-multicluster-gateways.yaml
+++ b/install/kubernetes/helm/istio/values-istio-multicluster-gateways.yaml
@@ -2,7 +2,7 @@ global:
   # Provides dns resolution for global services
   podDNSSearchNamespaces:
   - global
-  - "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"  
+  - "[[ valueOrDefault .DeploymentMeta.Namespace \"default\" ]].global"
 
   multiCluster:
     enabled: true

--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -154,6 +154,7 @@ type SidecarInjectionSpec struct {
 	InitContainers      []corev1.Container            `yaml:"initContainers"`
 	Containers          []corev1.Container            `yaml:"containers"`
 	Volumes             []corev1.Volume               `yaml:"volumes"`
+	DNSConfig           *corev1.PodDNSConfig          `yaml:"dnsConfig"`
 	ImagePullSecrets    []corev1.LocalObjectReference `yaml:"imagePullSecrets"`
 }
 
@@ -699,6 +700,8 @@ func intoObject(sidecarTemplate string, meshconfig *meshconfig.MeshConfig, in ru
 
 	podSpec.Containers = append(podSpec.Containers, spec.Containers...)
 	podSpec.Volumes = append(podSpec.Volumes, spec.Volumes...)
+
+	podSpec.DNSConfig = spec.DNSConfig
 
 	// Modify application containers' HTTP probe after appending injected containers.
 	// Because we need to extract istio-proxy's statusPort.

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -393,6 +393,15 @@ func addImagePullSecrets(target, added []corev1.LocalObjectReference, basePath s
 	return patch
 }
 
+func addPodDNSConfig(target *corev1.PodDNSConfig, basePath string) (patch []rfc6902PatchOperation) {
+	patch = append(patch, rfc6902PatchOperation{
+		Op:    "add",
+		Path:  basePath,
+		Value: target,
+	})
+	return patch
+}
+
 // escape JSON Pointer value per https://tools.ietf.org/html/rfc6901
 func escapeJSONPointerValue(in string) string {
 	step := strings.Replace(in, "~", "~0", -1)
@@ -439,6 +448,10 @@ func createPatch(pod *corev1.Pod, prevStatus *SidecarInjectionStatus, annotation
 	patch = append(patch, addContainer(pod.Spec.Containers, sic.Containers, "/spec/containers")...)
 	patch = append(patch, addVolume(pod.Spec.Volumes, sic.Volumes, "/spec/volumes")...)
 	patch = append(patch, addImagePullSecrets(pod.Spec.ImagePullSecrets, sic.ImagePullSecrets, "/spec/imagePullSecrets")...)
+
+	if sic.DNSConfig != nil {
+		patch = append(patch, addPodDNSConfig(sic.DNSConfig, "/spec/dnsConfig")...)
+	}
 
 	if pod.Spec.SecurityContext != nil {
 		patch = append(patch, addSecurityContext(pod.Spec.SecurityContext, "/spec/securityContext")...)


### PR DESCRIPTION
* Fix global DNS resolution in sidecar injector

The dnsConfig key was not honored by the sidecar injector.  This PR
ensures the dnsConfig key is honored by the sidecar injector.  This
enables the injected application can resolve DNS, but does not solve
routing via RDS.  Routing via RDS needs a followup PR.

* Fix syntax error in sidecar injector template

(cherry picked from commit 994fc424213e0fe32757b57011b5028bfa3f501c)