### PR TITLE
remove unused MCP service registry

### DIFF
--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -204,6 +204,7 @@ function startPilot() {
   "${ISTIO_OUT}/pilot-discovery" discovery --httpAddr ":18080" \
                                          --monitoringAddr ":19093" \
                                          --log_target "${LOG_DIR}/pilot.log" \
+                                         --registries "Kubernetes" \
                                          --kubeconfig "${ISTIO_GO}/.circleci/config" &
   echo $! > "$LOG_DIR/pilot.pid"
 }

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -95,10 +95,10 @@ func hasKubeRegistry() bool {
 }
 
 func init() {
-	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Service.Registries, "registries",
-		[]string{string(serviceregistry.KubernetesRegistry)},
-		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s, %s})",
-			serviceregistry.KubernetesRegistry, serviceregistry.ConsulRegistry, serviceregistry.MCPRegistry, serviceregistry.MockRegistry))
+	discoveryCmd.PersistentFlags().StringSliceVar(&serverArgs.Service.Registries, "registries", []string{},
+		fmt.Sprintf("Comma separated list of platform service registries to read from (choose one or more from {%s, %s, %s}).  "+
+			"Choosing none will default to service registry backed by MCP ServiceEntries.",
+			serviceregistry.KubernetesRegistry, serviceregistry.ConsulRegistry, serviceregistry.MockRegistry))
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.ClusterRegistriesNamespace, "clusterRegistriesNamespace", metav1.NamespaceAll,
 		"Namespace for ConfigMap which stores clusters configs")
 	discoveryCmd.PersistentFlags().StringVar(&serverArgs.Config.KubeConfig, "kubeconfig", "",

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -925,8 +925,6 @@ func (s *Server) initServiceControllers(args *PilotArgs) error {
 			if err := s.initConsulRegistry(serviceControllers, args); err != nil {
 				return err
 			}
-		case serviceregistry.MCPRegistry:
-			log.Infof("no-op: get service info from MCP ServiceEntries.")
 		default:
 			return fmt.Errorf("service registry %s is not supported", r)
 		}

--- a/pilot/pkg/serviceregistry/platform.go
+++ b/pilot/pkg/serviceregistry/platform.go
@@ -24,6 +24,4 @@ const (
 	KubernetesRegistry ServiceRegistry = "Kubernetes"
 	// ConsulRegistry is a service registry backed by Consul
 	ConsulRegistry ServiceRegistry = "Consul"
-	// MCPRegistry is a service registry backed by MCP ServiceEntries
-	MCPRegistry ServiceRegistry = "MCP"
 )


### PR DESCRIPTION
Cloud Foundry doesn't need `serviceregistry.MCPRegistry` to exist. It's unused and can be removed. 

This change also defaults the service registry to use MCP. `--registries` is no longer required for that use case.