### PR TITLE
istioctl proxy-status should only exec into running pilot pods

### DIFF
--- a/istioctl/pkg/kubernetes/client.go
+++ b/istioctl/pkg/kubernetes/client.go
@@ -110,7 +110,10 @@ func (client *Client) PodExec(podName, podNamespace, container string, command [
 
 // AllPilotsDiscoveryDo makes an http request to each Pilot discovery instance
 func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, body []byte) (map[string][]byte, error) {
-	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{"labelSelector": "istio=pilot"})
+	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{
+		"labelSelector": "istio=pilot",
+		"fieldSelector": "status.phase=Running",
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +136,10 @@ func (client *Client) AllPilotsDiscoveryDo(pilotNamespace, method, path string, 
 
 // PilotDiscoveryDo makes an http request to a single Pilot discovery instance
 func (client *Client) PilotDiscoveryDo(pilotNamespace, method, path string, body []byte) ([]byte, error) {
-	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{"labelSelector": "istio=pilot"})
+	pilots, err := client.GetIstioPods(pilotNamespace, map[string]string{
+		"labelSelector": "istio=pilot",
+		"fieldSelector": "status.phase=Running",
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +223,10 @@ type podDetail struct {
 
 // GetIstioVersions gets the version for each Istio component
 func (client *Client) GetIstioVersions(namespace string) (*version.MeshInfo, error) {
-	pods, err := client.GetIstioPods(namespace, map[string]string{"labelSelector": "istio"})
+	pods, err := client.GetIstioPods(namespace, map[string]string{
+		"labelSelector": "istio",
+		"fieldSelector": "status.phase=Running",
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
istioctl proxy-status uses kubectl exec on pilot pods to extract debug
and diagnostic information. Use
`--field-selector=status.phase=Running` to only exec into pods that
are actually running.

fixes https://github.com/istio/istio/issues/11488

cc @therealmitchconnors