### PR TITLE
Use istio namespace for global destination rule to avoid overwriting mixer policy

### DIFF
--- a/install/kubernetes/helm/subcharts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/enable-mesh-mtls.yaml
@@ -23,6 +23,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}
@@ -42,6 +43,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}


### PR DESCRIPTION
This alleviate the problem described in https://github.com/istio/istio/issues/11545. 

More appropriate fix would use a special namespace that no job running, but we can do that in later when we have agreement on global namespace.