### PR TITLE
Add readiness check for Ingress Gateway (#3063) (#11001)

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/deployment.yaml
@@ -127,6 +127,8 @@ spec:
         {{- end }}
           - --proxyAdminPort
           - "15000"
+          - --statusPort
+          - "15020"
         {{- if $.Values.global.controlPlaneSecurityEnabled }}
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
@@ -149,6 +151,16 @@ spec:
         {{- if $.Values.global.trustDomain }}
           - --trust-domain={{ $.Values.global.trustDomain }}
         {{- end }}
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
 {{- if $spec.resources }}
 {{ toYaml $spec.resources | indent 12 }}

--- a/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/ingress/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
         {{- end }}
           - --proxyAdminPort
           - "15000"
+          - --statusPort
+          - "15020"
         {{- if .Values.global.controlPlaneSecurityEnabled }}
           - --controlPlaneAuthPolicy
           - MUTUAL_TLS
@@ -77,6 +79,16 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Enabling the same readiness probe for Ingress Gateway that is being
used for sidecars.