### PR TITLE
exit circleci test early if setup fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,6 +552,7 @@ jobs:
       - <<: *recordNonzeroExitCodeIfTestFailed
       - run:
           name: markJobFinishesOnGCS
+          when: always
           command: |
             bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           name: make e2e_mixer
           command: |
             make test/local/noauth/e2e_mixer_envoyv2
@@ -277,8 +275,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           name: make e2e_mixer (non-mcp)
           command: |
             E2E_ARGS="--use_mcp=false" \
@@ -318,8 +314,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           name: make e2e_galley
           command: |
             make test/local/e2e_galley
@@ -343,7 +337,6 @@ jobs:
       - run: make sync
       - run:
           no_output_timeout: 20m
-          when: always
           command: |
             export PATH=$GOPATH/bin:$PATH
             make localTestEnv
@@ -381,8 +374,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           command: |
                 make test/local/noauth/e2e_pilotv2
       - <<: *recordZeroExitCodeIfTestPassed
@@ -420,8 +411,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           command: |
                 E2E_ARGS="--use_mcp=false" \
                 make test/local/noauth/e2e_pilotv2
@@ -456,8 +445,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           command: |
                 make test/local/auth/e2e_pilotv2
       - <<: *recordZeroExitCodeIfTestPassed
@@ -515,8 +502,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           command: |
                 E2E_ARGS="--use_mcp=false" \
                 make test/local/auth/e2e_pilotv2
@@ -567,7 +552,6 @@ jobs:
       - <<: *recordNonzeroExitCodeIfTestFailed
       - run:
           name: markJobFinishesOnGCS
-          when: always
           command: |
             bin/ci2gubernator.sh --exit_code=$(cat exit_code) --junit_xml=/go/out/tests/junit.xml
       - store_artifacts:


### PR DESCRIPTION
Many of the circleci tests will attempt to run the e2e/integration
tests even after the test setup fails. This leads to misleading test
failures that suggest the problem is with the feature test and not the
test setup itself.

Example test runs where the setup failed and the test was run but
immediately errored out because a dependency was missing:

https://circleci.com/gh/istio/istio/316588
https://circleci.com/gh/istio/istio/317262
https://circleci.com/gh/istio/istio/318281
https://circleci.com/gh/istio/istio/316031
https://circleci.com/gh/istio/istio/315952
https://circleci.com/gh/istio/istio/315871
https://circleci.com/gh/istio/istio/315813

ref: https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute
```
By default, CircleCI will execute job steps one at a time, in the
order that they are defined in config.yml, until a step fails (returns
a non-zero exit code). After a command fails, no further job steps
will be executed.

Adding the when attribute to a job step allows you to override this
default behaviour, and selectively run or skip steps depending on the
status of the job.

The default value of on_success means that the step will run only if
all of the previous steps have been successful (returned exit code 0).

A value of always means that the step will run regardless of the exit
status of previous steps. This is useful if you have a task that you
want to run regardless of whether the previous steps are successful or
not. For example, you might have a job step that needs to upload logs
or code-coverage data somewhere.
```