### PR TITLE
Keep default destination rule in rootNamespace if defined

### DIFF
--- a/install/kubernetes/helm/subcharts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/enable-mesh-mtls.yaml
@@ -23,7 +23,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "default"
+  {{- if .Values.global.configRootNamespace }}
+  namespace: {{ .Values.global.configRootNamespace }}
+  {{ else }}
   namespace: {{ .Release.Namespace }}
+  {{ end }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}
@@ -43,7 +47,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: "api-server"
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "security.name" . }}
     chart: {{ template "security.chart" . }}


### PR DESCRIPTION
Keep default destination rule (for mTLS setting) in root namespace, if it is defined (e.g with `--set global.configRootNamespace=xxx`). This is to give it more accurate precedence, i.e will be used only when there is no other rule in more specific scope.

Issue: #11545, #11058