### PR TITLE
Fix kubernetesenv workload attributes for multicluster with one control plane

### DIFF
--- a/mixer/adapter/kubernetesenv/cache.go
+++ b/mixer/adapter/kubernetesenv/cache.go
@@ -35,7 +35,7 @@ type (
 	cacheController interface {
 		Run(<-chan struct{})
 		Pod(string) (*v1.Pod, bool)
-		Workload(*v1.Pod) (workload, bool)
+		Workload(*v1.Pod) workload
 		HasSynced() bool
 		StopControlChannel()
 	}
@@ -132,14 +132,14 @@ func key(namespace, name string) string {
 	return namespace + "/" + name
 }
 
-func (c *controllerImpl) Workload(pod *v1.Pod) (workload, bool) {
+func (c *controllerImpl) Workload(pod *v1.Pod) workload {
 	wl := workload{name: pod.Name, namespace: pod.Namespace, selfLinkURL: pod.SelfLink}
 	if owner, found := c.rootController(&pod.ObjectMeta); found {
 		wl.name = owner.Name
 		wl.selfLinkURL = fmt.Sprintf("kubernetes://apis/%s/namespaces/%s/%ss/%s", owner.APIVersion, pod.Namespace, strings.ToLower(owner.Kind), owner.Name)
 	}
 	wl.uid = "istio://" + wl.namespace + "/workloads/" + wl.name
-	return wl, true
+	return wl
 }
 
 func (c *controllerImpl) rootController(obj *metav1.ObjectMeta) (metav1.OwnerReference, bool) {

--- a/mixer/adapter/kubernetesenv/cache_test.go
+++ b/mixer/adapter/kubernetesenv/cache_test.go
@@ -110,7 +110,7 @@ func TestClusterInfoCache_Workload_ReplicationController(t *testing.T) {
 				tt.Fatal("Failed to sync")
 			}
 			pod, _ := c.Pod(v.pod)
-			workload, _ := c.Workload(pod)
+			workload := c.Workload(pod)
 			if workload.name != v.workload {
 				tt.Errorf("GetWorkload() => (_, %s), wanted (_, %s)", workload.name, v.workload)
 			}


### PR DESCRIPTION
Currently, kubernetesenv looks for the pod across cluster controllers. This works correctly because pods are uniquely identified by their uid or their ip. We then use a similar approach to lookup the workload - iterating through the controllers again. However, `cacheController.Workload` always returns `true`, so regardless of which controller the pod was found in, we would just take the result of `cacheController.Workload` from the first controller in the `range` iteration (which is random, hence why I was seeing it inconsistently not work correctly).

This PR fixes the issue by passing the found controller along with the pod to `fillDestinationAttrs` and `fillSourceAttrs`.

FWIW - I've never written Go before, so this is just my best stab at fixing the issue. Let me know if you'd like me to add tests - I didn't add any because, honestly, this fix took <5 minutes and looking at unfamiliar tests using unfamiliar frameworks in an unfamiliar language looked like it was going to take more time than I'd like to invest right now.

Fixes https://github.com/istio/istio/issues/10915