### PR TITLE
Fix sed command in bin/init.sh for MacOS and Linux compatibility

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -164,7 +164,7 @@ fi
 ISTIO_PROXY_DEPS_URL="https://raw.githubusercontent.com/istio/proxy/${PROXY_REPO_SHA}/istio.deps"
 ISTIO_PROXY_DEPS_FILE="${ISTIO_OUT}/istio_proxy.deps"
 echo "Downloading istio.deps from ${ISTIO_PROXY_DEPS_URL} to ${ISTIO_PROXY_DEPS_FILE}"
-${DOWNLOAD_COMMAND} "${ISTIO_PROXY_DEPS_URL}" | sed -n '/name/,/lastStableSHA/{//p}' \
+${DOWNLOAD_COMMAND} "${ISTIO_PROXY_DEPS_URL}" | sed -n '/name/,/lastStableSHA/{ //p; }' \
     | cut -d: -f2 | sed 'N;s/\n/ /' | sed 's/[" ]//g' | sed 's/,/=/' > "${ISTIO_PROXY_DEPS_FILE}"
 ISTIO_PROXY_ISTIO_API_SHA_LABEL=$(grep ISTIO_API "${ISTIO_PROXY_DEPS_FILE}" | cut -d= -f2)
 export ISTIO_PROXY_ISTIO_API_SHA_LABEL


### PR DESCRIPTION
Following issue reported for #11524, fix sed syntax for MacOS (verified on Linux too...).

FYI: @ricochet