### PR TITLE
Enable remote clusters to check/report to local Mixer

### DIFF
--- a/install/kubernetes/helm/subcharts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/templates/preconfigured.yaml
@@ -62,6 +62,14 @@ spec:
       name: tcp-citadel
     hosts:
     - "*"
+  - port:
+      number: 15004
+      name: tls-mixer
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
+    hosts:
+    - "*"
 ---
 {{- else }}
 apiVersion: networking.istio.io/v1alpha3
@@ -88,6 +96,14 @@ spec:
       number: 8060
       protocol: TCP
       name: tcp-citadel
+    hosts:
+    - "*"
+  - port:
+      number: 15004
+      name: tls-mixer
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
     hosts:
     - "*"
 ---

--- a/install/kubernetes/helm/subcharts/gateways/values.yaml
+++ b/install/kubernetes/helm/subcharts/gateways/values.yaml
@@ -83,6 +83,9 @@ istio-ingressgateway:
   - port: 15011
     targetPort: 15011
     name: tcp-pilot-grpc-tls
+  - port: 15004
+    targetPort: 15004
+    name: tcp-mixer-grpc-tls
   - port: 8060
     targetPort: 8060
     name: tcp-citadel-grpc-tls


### PR DESCRIPTION
Fixes #11584 

Tested on a setup with 2xClusters (1 local and 1 remote) with Split Horizon EDS.