### PR TITLE
Add update permissions to deployments/finalizers for galley clusterrole

### DIFF
--- a/install/kubernetes/helm/subcharts/galley/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/subcharts/galley/templates/clusterrole.yaml
@@ -33,3 +33,7 @@ rules:
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["deployments/finalizers"]
+  resourceNames: ["istio-galley"]
+  verbs: ["update"]


### PR DESCRIPTION
This PR addresses the situation described in https://github.com/istio/istio/issues/10311

After adding those permissions, Galley does not complain anymore about lack of them. If you don't allow them, then Galley is just not responding to any validation request.