### PR TITLE
remove 'istiotesting' parent section for 'onenamespace' values.

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
@@ -12,6 +12,8 @@ global:
   # Default is 10s second
   refreshInterval: 1s
 
+  # The trust domain corresponds to the trust root of a system
   trustDomain: test.local
 
+  # Restrict the applications in one namespace the controller manages
   oneNameSpace: true

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
@@ -16,4 +16,4 @@ global:
   trustDomain: test.local
 
   # Restrict the applications in one namespace the controller manages
-  oneNameSpace: true
+  oneNamespace: true

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
@@ -14,5 +14,4 @@ global:
 
   trustDomain: test.local
 
-istiotesting:
   oneNameSpace: true


### PR DESCRIPTION
'istiotesting' has been deprecated, remove this section in `values-istio-one-namespace-trust-domain.yaml`