### PR TITLE
Allow identity domain to be configured in istio. Cherry-pick from release-1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ install/kubernetes/istio-citadel-plugin-certs.yaml
 install/kubernetes/istio-citadel-standalone.yaml
 install/kubernetes/istio-citadel-with-health-check.yaml
 install/kubernetes/istio-one-namespace-auth.yaml
+install/kubernetes/istio-one-namespace-trust-domain.yaml
 install/kubernetes/istio-one-namespace.yaml
 install/kubernetes/istio-sidecar-injector-configmap-debug.yaml
 install/kubernetes/istio-sidecar-injector-configmap-release.yaml

--- a/Makefile
+++ b/Makefile
@@ -651,7 +651,7 @@ istio-init.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--set global.hub=${HUB} \
 		install/kubernetes/helm/istio-init >> install/kubernetes/$@
 
-# creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml
+# creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml
 # Ensure that values-$filename is present in install/kubernetes/helm/istio
 isti%.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 	$(HELM) dep update --skip-refresh install/kubernetes/helm/istio
@@ -795,6 +795,7 @@ FILES_TO_CLEAN+=install/consul/istio.yaml \
                 install/kubernetes/istio-citadel-plugin-certs.yaml \
                 install/kubernetes/istio-citadel-with-health-check.yaml \
                 install/kubernetes/istio-one-namespace-auth.yaml \
+                install/kubernetes/istio-one-namespace-trust-domain.yaml \
                 install/kubernetes/istio-one-namespace.yaml \
                 install/kubernetes/istio.yaml \
                 samples/bookinfo/platform/consul/bookinfo.sidecars.yaml \

--- a/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
+++ b/install/kubernetes/helm/istio/values-istio-one-namespace-trust-domain.yaml
@@ -1,0 +1,18 @@
+# This is used to generate istio.yaml used for deprecated CI/CD testing.
+global:
+  # controlPlaneMtls enabled. Will result in delays starting the pods while secrets are
+  # propagated, not recommended for tests.
+  controlPlaneSecurityEnabled: true
+
+  mtls:
+    # Default setting for service-to-service mtls. Can be set explicitly using
+    # destination rules or service annotations.
+    enabled: true
+
+  # Default is 10s second
+  refreshInterval: 1s
+
+  trustDomain: test.local
+
+istiotesting:
+  oneNameSpace: true

--- a/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/security/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
             - --root-cert=/etc/cacerts/root-cert.pem
             - --cert-chain=/etc/cacerts/cert-chain.pem
           {{- end }}
-          {{- if .Values.trustDomain }}
-            - --trust-domain={{ .Values.trustDomain }}
+          {{- if .Values.global.trustDomain }}
+            - --trust-domain={{ .Values.global.trustDomain }}
           {{- end }}
           resources:
 {{- if .Values.resources }}

--- a/install/kubernetes/helm/subcharts/security/values.yaml
+++ b/install/kubernetes/helm/subcharts/security/values.yaml
@@ -5,5 +5,4 @@ enabled: true
 replicaCount: 1
 image: citadel
 selfSigned: true # indicate if self-signed CA is used.
-trustDomain: cluster.local # indicate the domain used in SPIFFE identity URL
 nodeSelector: {}

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -153,7 +153,7 @@ function gen_istio_files() {
             gen_file $target "${DEST_DIR}"
         done
     else
-        for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-multicluster.yaml istio-auth-multicluster.yaml istio-remote.yaml istio-mcp.yaml istio-auth-mcp.yaml;do
+        for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml istio-multicluster.yaml istio-auth-multicluster.yaml istio-remote.yaml istio-mcp.yaml istio-auth-mcp.yaml;do
             gen_file $target "${DEST_DIR}"
         done
     fi

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -134,6 +134,8 @@ var (
 				}
 			}
 
+			spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(role.TrustDomain, true))
+			role.TrustDomain = spiffe.GetTrustDomain()
 			log.Infof("Proxy role: %#v", role)
 
 			proxyConfig := model.DefaultProxyConfig()

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -62,8 +62,7 @@ var (
 				return err
 			}
 
-			spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(serverArgs.Config.ControllerOptions.TrustDomain,
-				serverArgs.Config.ControllerOptions.DomainSuffix, hasKubeRegistry()))
+			spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(serverArgs.Config.ControllerOptions.TrustDomain, hasKubeRegistry()))
 
 			// Create the stop channel for all of the servers.
 			stop := make(chan struct{})

--- a/pkg/spiffe/spiffe.go
+++ b/pkg/spiffe/spiffe.go
@@ -24,18 +24,15 @@ func GetTrustDomain() string {
 	return trustDomain
 }
 
-func DetermineTrustDomain(commandLineTrustDomain string, domain string, isKubernetes bool) string {
+func DetermineTrustDomain(commandLineTrustDomain string, isKubernetes bool) string {
 
 	if len(commandLineTrustDomain) != 0 {
 		return commandLineTrustDomain
 	}
-	if len(domain) != 0 {
-		return domain
-	}
 	if isKubernetes {
 		return defaultTrustDomain
 	}
-	return domain
+	return ""
 }
 
 // GenSpiffeURI returns the formatted uri(SPIFFEE format for now) for the certificate.

--- a/prow/e2e-bookInfoTests-trustdomain.sh
+++ b/prow/e2e-bookInfoTests-trustdomain.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+echo 'Running bookinfo test with a different trust domain'
+./prow/e2e-suite.sh --single_test e2e_bookinfo_trustdomain "$@"

--- a/release/create_release_archives.sh
+++ b/release/create_release_archives.sh
@@ -142,6 +142,7 @@ popd
 for unwanted_manifest in \
     istio-one-namespace.yaml \
     istio-one-namespace-auth.yaml \
+    istio-one-namespace-trust-domain.yaml \
     istio-multicluster.yaml \
     istio-auth-multicluster.yaml \
     istio.yaml \

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -395,7 +395,7 @@ func createCA(client corev1.CoreV1Interface) *ca.IstioCA {
 
 	if opts.selfSignedCA {
 		log.Info("Use self-signed certificate as the CA certificate")
-		spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(opts.trustDomain, "", len(opts.kubeConfigFile) != 0))
+		spiffe.SetTrustDomain(spiffe.DetermineTrustDomain(opts.trustDomain, true))
 		caOpts, err = ca.NewSelfSignedIstioCAOptions(opts.selfSignedCACertTTL, opts.workloadCertTTL,
 			opts.maxWorkloadCertTTL, spiffe.GetTrustDomain(), opts.dualUse,
 			opts.istioCaStorageNamespace, client)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -47,6 +47,7 @@ const (
 	authWithoutMCPInstallFile      = "istio-auth-mcp.yaml"
 	nonAuthInstallFileNamespace    = "istio-one-namespace.yaml"
 	authInstallFileNamespace       = "istio-one-namespace-auth.yaml"
+	trustDomainFileNamespace       = "istio-one-namespace-trust-domain.yaml"
 	mcNonAuthInstallFileNamespace  = "istio-multicluster.yaml"
 	mcAuthInstallFileNamespace     = "istio-auth-multicluster.yaml"
 	mcRemoteInstallFile            = "istio-remote.yaml"
@@ -96,6 +97,7 @@ var (
 	galleyTag          = flag.String("galley_tag", os.Getenv("TAG"), "Galley tag")
 	sidecarInjectorHub = flag.String("sidecar_injector_hub", os.Getenv("HUB"), "Sidecar injector hub")
 	sidecarInjectorTag = flag.String("sidecar_injector_tag", os.Getenv("TAG"), "Sidecar injector tag")
+	trustDomainEnable  = flag.Bool("trust_domain_enable", false, "Enable different trust domains (e.g. test.local)")
 	authEnable         = flag.Bool("auth_enable", false, "Enable auth")
 	authSdsEnable      = flag.Bool("auth_sds_enable", false, "Enable auth using key/cert distributed through SDS")
 	rbacEnable         = flag.Bool("rbac_enable", true, "Enable rbac")
@@ -201,6 +203,9 @@ func getClusterWideInstallFile() string {
 		} else {
 			istioYaml = nonAuthWithoutMCPInstallFile
 		}
+	}
+	if *trustDomainEnable {
+		istioYaml = trustDomainFileNamespace
 	}
 	return istioYaml
 }
@@ -646,6 +651,9 @@ func (k *KubeInfo) deployIstio() error {
 			if *multiClusterDir != "" {
 				istioYaml = mcAuthInstallFileNamespace
 			}
+		}
+		if *trustDomainEnable {
+			istioYaml = trustDomainFileNamespace
 		}
 		if *useGalleyConfigValidator {
 			return errors.New("cannot enable useGalleyConfigValidator in one namespace tests")

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -139,6 +139,8 @@ e2e_pilotv2_v1alpha3: | istioctl test/local/noauth/e2e_pilotv2
 
 e2e_bookinfo_envoyv2_v1alpha3: | istioctl test/local/auth/e2e_bookinfo_envoyv2
 
+e2e_bookinfo_trustdomain: | istioctl test/local/auth/e2e_bookinfo_trustdomain
+
 e2e_pilotv2_auth_sds: | istioctl test/local/auth/e2e_sds_pilotv2
 
 # This is used to keep a record of the test results.
@@ -208,6 +210,11 @@ test/local/cloudfoundry/e2e_pilotv2: out_dir
 test/local/auth/e2e_bookinfo_envoyv2: out_dir generate_yaml
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/bookinfo \
 		--auth_enable=true --egress=true --ingress=false --rbac_enable=false \
+		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
+
+test/local/auth/e2e_bookinfo_trustdomain: out_dir generate_yaml
+	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/bookinfo \
+		--auth_enable=true --trust_domain_enable --egress=true --ingress=false --rbac_enable=false \
 		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 test/local/noauth/e2e_mixer_envoyv2: out_dir generate_e2e_test_yaml


### PR DESCRIPTION
… working with different identity domain (#9226)

* Refactor identity domain handling and adapt unit tests

Co-authored-by: Ulrich Kramer <u.kramer@sap.com>

* Fix goimports error

*  set role.TrustDomain in pilot main

Co-authored-by: Holger Oehm <holger.oehm@sap.com>

* Add end to end test e2e_bookinfo_trustdomain

Co-authored-by: Holger Oehm <holger.oehm@sap.com>

* Use .Values.global.trustDomain as trustDomain for citadel

Co-authored-by: Holger Oehm <holger.oehm@sap.com>

* Removed commented out code

Co-authored-by: Jakob Schmid <jakob.schmid@sap.com>

* Remove fallback to domain for trust domain

This became necessary due to #11050, which always set the domain
command line flag for executables. But we didn't expect this flag to
have two different meanings (dns-domain and domain-suffix).

Co-authored-by: Ulrich Kramer <u.kramer@sap.com>