### PR TITLE
Error message if istioctl version doesn't match data plane version

### DIFF
--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -72,7 +72,7 @@ func getMeshConfigFromConfigMap(kubeconfig string) (*meshconfig.MeshConfig, erro
 	}
 	cfg, err := model.ApplyMeshConfigDefaults(configYaml)
 	if err != nil {
-		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config.  Check Istio control plane version",
+		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config.  Install istioctl from the latest Istio release",
 			version.Info.Version), err)
 	}
 	return cfg, err

--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -70,7 +70,12 @@ func getMeshConfigFromConfigMap(kubeconfig string) (*meshconfig.MeshConfig, erro
 	if !exists {
 		return nil, fmt.Errorf("missing configuration map key %q", configMapKey)
 	}
-	return model.ApplyMeshConfigDefaults(configYaml)
+	cfg, err := model.ApplyMeshConfigDefaults(configYaml)
+	if err != nil {
+		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config.  Check Istio data plane version",
+			version.Info.Version), err)
+	}
+	return cfg, err
 }
 
 func getInjectConfigFromConfigMap(kubeconfig string) (string, error) {

--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -72,7 +72,7 @@ func getMeshConfigFromConfigMap(kubeconfig string) (*meshconfig.MeshConfig, erro
 	}
 	cfg, err := model.ApplyMeshConfigDefaults(configYaml)
 	if err != nil {
-		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config.  Check Istio data plane version",
+		err = multierr.Append(fmt.Errorf("istioctl version %s cannot parse mesh config.  Check Istio control plane version",
 			version.Info.Version), err)
 	}
 	return cfg, err


### PR DESCRIPTION
Mitigates https://github.com/istio/istio/issues/11565 and https://github.com/istio/istio/issues/5218 by providing an error message suggesting the istioctl version is not compatible with the mesh.