### PR TITLE
Check key.pem instead of istio-certs directory in prom-init container

### DIFF
--- a/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/subcharts/prometheus/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       initContainers:
       - name: prom-init
         image: "busybox"
-        command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -d /etc/istio-certs ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
+        command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /etc/istio-certs/key.pem ]; then exit 0; else echo waiting for istio certs && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         volumeMounts:
           - mountPath: /etc/istio-certs


### PR DESCRIPTION
While investigating #11593 I found that just checking istio-certs directory is not enough. Even secrets are not ready, istio-certs directory will still be created. This change is to make init container check the existence of key file.

Original issue: #10528 