### PR TITLE
Add cli option to Galley to allow metadata on outgoing sink connections.

### DIFF
--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -154,6 +154,8 @@ func GetRootCmd(args []string) *cobra.Command {
 		serverArgs.SinkAddress, "Address of MCP Resource Sink server for Galley to connect to. Ex: 'foo.com:1234'")
 	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sinkAuthMode",
 		serverArgs.SinkAuthMode, "Name of authentication plugin to use for connection to sink server.")
+	rootCmd.PersistentFlags().StringSliceVar(&serverArgs.SinkMeta, "sinkMeta",
+		serverArgs.SinkMeta, "Comma-separated list of key values to attach as metadata to outgoing sink connections. Ex: 'key,value,key2,value2'")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)
 

--- a/galley/cmd/galley/cmd/root.go
+++ b/galley/cmd/galley/cmd/root.go
@@ -155,7 +155,7 @@ func GetRootCmd(args []string) *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&serverArgs.SinkAuthMode, "sinkAuthMode",
 		serverArgs.SinkAuthMode, "Name of authentication plugin to use for connection to sink server.")
 	rootCmd.PersistentFlags().StringSliceVar(&serverArgs.SinkMeta, "sinkMeta",
-		serverArgs.SinkMeta, "Comma-separated list of key values to attach as metadata to outgoing sink connections. Ex: 'key,value,key2,value2'")
+		serverArgs.SinkMeta, "Comma-separated list of key=values to attach as metadata to outgoing sink connections. Ex: 'key=value,key2=value2'")
 
 	serverArgs.IntrospectionOptions.AttachCobraFlags(rootCmd)
 

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -92,6 +92,10 @@ type Args struct {
 	// SinkAuthMode should be set to a name of an authentication plugin,
 	// see the istio.io/istio/galley/pkg/autplugins package.
 	SinkAuthMode string
+
+	// SinkMeta list of key values to attach as gRPC stream metadata to
+	// outgoing Sink connections. Must be even length
+	SinkMeta []string
 }
 
 // DefaultArgs allocates an Args struct initialized with Mixer's default configuration.
@@ -110,6 +114,7 @@ func DefaultArgs() *Args {
 		DomainSuffix:              defaultDomainSuffix,
 		DisableResourceReadyCheck: false,
 		ExcludedResourceKinds:     defaultExcludedResourceKinds(),
+		SinkMeta:                  make([]string, 0),
 	}
 }
 

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -93,8 +93,8 @@ type Args struct {
 	// see the istio.io/istio/galley/pkg/autplugins package.
 	SinkAuthMode string
 
-	// SinkMeta list of key values to attach as gRPC stream metadata to
-	// outgoing Sink connections. Must be even length
+	// SinkMeta list of key=values to attach as gRPC stream metadata to
+	// outgoing Sink connections.
 	SinkMeta []string
 }
 
@@ -150,6 +150,7 @@ func (a *Args) String() string {
 	_, _ = fmt.Fprintf(buf, "ExcludedResourceKinds: %v\n", a.ExcludedResourceKinds)
 	_, _ = fmt.Fprintf(buf, "SinkAddress: %v\n", a.SinkAddress)
 	_, _ = fmt.Fprintf(buf, "SinkAuthMode: %v\n", a.SinkAuthMode)
+	_, _ = fmt.Fprintf(buf, "SinkMeta: %v\n", a.SinkMeta)
 
 	return buf.String()
 }

--- a/galley/pkg/server/callout.go
+++ b/galley/pkg/server/callout.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -77,9 +78,15 @@ func newCalloutPT(address, auth string, meta []string, so *source.Options,
 		return nil, err
 	}
 
-	if len(meta)%2 != 0 {
-		return nil, fmt.Errorf("sinkMeta length must be even, "+
-			"in key value pairs, len: %v", len(meta))
+	m := make([]string, 0)
+
+	for _, v := range meta {
+		kv := strings.Split(v, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf(
+				"sinkMeta not in key=value format: %v", v)
+		}
+		m = append(m, kv[0], kv[1])
 	}
 
 	return &callout{
@@ -87,7 +94,7 @@ func newCalloutPT(address, auth string, meta []string, so *source.Options,
 		so:      so,
 		do:      opts,
 		pt:      pt,
-		meta:    meta,
+		meta:    m,
 	}, nil
 }
 

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -33,12 +33,24 @@ func TestCallout(t *testing.T) {
 	if co.address != "foo" {
 		t.Error("Callout address not set")
 	}
-	if len(co.meta) != 2 || co.meta[0] != "foo" || co.meta[1] != "bar" {
-		t.Errorf("Callout meta not set: %v", co.meta)
+	if len(co.metadata) != 2 || co.metadata[0] != "foo" || co.metadata[1] != "bar" {
+		t.Errorf("Callout meta not set: %v", co.metadata)
 	}
 	co, err = newCallout("foo", "NONE", []string{"foo"}, &source.Options{})
 	if err == nil {
-		t.Error("did not error with malformed metadata")
+		t.Error("did not error with malformed metadata, no =")
+	}
+	co, err = newCallout("foo", "NONE", []string{"foo="}, &source.Options{})
+	if err == nil {
+		t.Error("did not error with malformed metadata, no value")
+	}
+	co, err = newCallout("foo", "NONE", []string{"=foo"}, &source.Options{})
+	if err == nil {
+		t.Error("did not error with malformed metadata, no key")
+	}
+	co, err = newCallout("foo", "NONE", []string{"="}, &source.Options{})
+	if err == nil {
+		t.Error("did not error with malformed metadata, no key or value")
 	}
 }
 
@@ -72,7 +84,7 @@ func TestCalloutRun(t *testing.T) {
 			sourceNewClient: sourceNewClient,
 			connClose:       connClose,
 		},
-		meta: make([]string, 2),
+		metadata: make([]string, 2),
 	}
 	co.Run()
 

--- a/galley/pkg/server/callout_test.go
+++ b/galley/pkg/server/callout_test.go
@@ -26,16 +26,19 @@ import (
 )
 
 func TestCallout(t *testing.T) {
-	co, err := newCallout("foo", "NONE", make([]string, 0), &source.Options{})
+	co, err := newCallout("foo", "NONE", []string{"foo=bar"}, &source.Options{})
 	if err != nil {
 		t.Errorf("Callout creation failed: %v", err)
 	}
 	if co.address != "foo" {
 		t.Error("Callout address not set")
 	}
-	co, err = newCallout("foo", "NONE", make([]string, 1), &source.Options{})
+	if len(co.meta) != 2 || co.meta[0] != "foo" || co.meta[1] != "bar" {
+		t.Errorf("Callout meta not set: %v", co.meta)
+	}
+	co, err = newCallout("foo", "NONE", []string{"foo"}, &source.Options{})
 	if err == nil {
-		t.Error("did not error with odd length metadata")
+		t.Error("did not error with malformed metadata")
 	}
 }
 

--- a/galley/pkg/server/server.go
+++ b/galley/pkg/server/server.go
@@ -174,7 +174,7 @@ func newServer(a *Args, p patchTable) (*Server, error) {
 	}
 
 	if a.SinkAddress != "" {
-		s.callOut, err = newCallout(a.SinkAddress, a.SinkAuthMode, options)
+		s.callOut, err = newCallout(a.SinkAddress, a.SinkAuthMode, a.SinkMeta, options)
 		if err != nil {
 			s.callOut = nil
 			scope.Fatalf("Callout could not be initialized: %v", err)


### PR DESCRIPTION
For use with sinkAddress, outgoing connections to MCP sink servers
will have gRPC stream metadata attached as defined by sinkMeta.