### PR TITLE
Update istioctl authn tls-check to take into account caller proxy

### DIFF
--- a/istioctl/cmd/istioctl/authn.go
+++ b/istioctl/cmd/istioctl/authn.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"istio.io/istio/istioctl/pkg/kubernetes"
@@ -23,32 +25,35 @@ import (
 
 func tlsCheck() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tls-check [<service>]",
+		Use:   "tls-check <pod-name[.namespace]> [<service>]",
 		Short: "Check whether TLS setting are matching between authentication policy and destination rules",
 		Long: `
-Requests Pilot to check for what authentication policy and destination rule it uses for each service in
-service registry, and check if TLS settings are compatible between them.
+Check what authentication policies and destination rules pilot uses to config a proxy instance,
+and check if TLS settings are compatible between them.
 `,
 		Example: `
-# Check settings for all known services in the service registry:
-istioctl authn tls-check
+# Check settings for pod "foo-656bd7df7c-5zp4s" in namespace default:
+istioctl authn tls-check 656bd7df7c-5zp4s.default
 
-# Check settings for a specific service
-istioctl authn tls-check foo.bar.svc.cluster.local
+# Check settings for pod "foo-656bd7df7c-5zp4s" in namespace default, filtered on destintation
+service "bar" :
+istioctl authn tls-check 656bd7df7c-5zp4s.default bar
 `,
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeClient, err := kubernetes.NewClient(kubeconfig, configContext)
 			if err != nil {
 				return err
 			}
-			debug, err := kubeClient.PilotDiscoveryDo(istioNamespace, "GET", "/debug/authenticationz", nil)
+			podName, ns := inferPodInfo(args[0], handleNamespace())
+			debug, err := kubeClient.PilotDiscoveryDo(istioNamespace, "GET",
+				fmt.Sprintf("/debug/authenticationz?proxyID=%s.%s", podName, ns), nil)
 			if err != nil {
 				return err
 			}
 			tcw := pilot.TLSCheckWriter{Writer: cmd.OutOrStdout()}
-			if len(args) > 0 {
-				return tcw.PrintSingle(debug, args[0])
+			if len(args) >= 2 {
+				return tcw.PrintSingle(debug, args[1])
 			}
 			return tcw.PrintAll(debug)
 		},

--- a/pilot/pkg/proxy/envoy/v2/debug.go
+++ b/pilot/pkg/proxy/envoy/v2/debug.go
@@ -317,23 +317,35 @@ func authProtocolToString(protocol authProtocol) string {
 }
 
 // Authentication debugging
-// This handler lists what authentication policy and destination rules is used for a service, and
-// whether or not they have TLS setting conflicts (i.e authentication policy use mutual TLS, but
-// destination rule doesn't use ISTIO_MUTUAL TLS mode). If service is not provided, (via request
-// paramerter `svc`), it lists result for all services.
+// This handler lists what authentication policy is used for a service and destination rules to
+// that service that a proxy instance received.
+// Proxy ID (<pod>.<namespace> need to be provided  to correctly  determine which destination rules
+// are visible.
 func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Request) {
 	_ = req.ParseForm()
 	w.Header().Add("Content-Type", "application/json")
-	// This should be svc. However, use proxyID param for now so it can be used with
-	// `pilot-discovery debug` command
-	interestedSvc := req.Form.Get("proxyID")
 
+	proxyID := req.Form.Get("proxyID")
+	adsClientsMutex.RLock()
+	defer adsClientsMutex.RUnlock()
+
+	connections, ok := adsSidecarIDConnectionsMap[proxyID]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "\n[\n]")
+		return
+	}
+	var mostRecentProxy *model.Proxy
+	mostRecent := ""
+	for key := range connections {
+		if mostRecent == "" || key > mostRecent {
+			mostRecent = key
+		}
+	}
+	mostRecentProxy = connections[mostRecent].modelNode
 	fmt.Fprintf(w, "\n[\n")
 	svc, _ := s.Env.ServiceDiscovery.Services()
 	for _, ss := range svc {
-		if interestedSvc != "" && interestedSvc != string(ss.Hostname) {
-			continue
-		}
 		for _, p := range ss.Ports {
 			info := AuthenticationDebug{
 				Host: string(ss.Hostname),
@@ -351,7 +363,7 @@ func (s *DiscoveryServer) authenticationz(w http.ResponseWriter, req *http.Reque
 			}
 			info.ServerProtocol = authProtocolToString(serverProtocol)
 
-			destConfig := s.globalPushContext().DestinationRule(nil, ss)
+			destConfig := s.globalPushContext().DestinationRule(mostRecentProxy, ss)
 			info.DestinationRuleName = configName(destConfig)
 			if destConfig != nil {
 				rule := destConfig.Spec.(*networking.DestinationRule)


### PR DESCRIPTION
With change in #11153, (get) DestinationRule should specify a proxy instance in order to correctly resolve to the DRs that visible to its scope. This PR change the inspection tool (`istioctl authn tls-check`) to comply with the new requirement to make sure the report consistent with pilot.

After this change, proxy ID (ie. <pod>.<namespace>, though namespace is optional) must be provided. 

Examples:
```
istioctl authn tls-check client-656bd7df7c-5zp4s.default
```

This command is equivalent, assuming the pod is in `default` namespace.
```
istioctl authn tls-check client-656bd7df7c-5zp4s
```

Same as above, but filter for the `my-service.default.svc.cluster.local` service.
```
istioctl authn tls-check client-656bd7df7c-5zp4s my-service.default.svc.cluster.local
```
