### PR TITLE
Move apply plugin below buildscript in bookinfo/reviews

### DIFF
--- a/samples/bookinfo/src/reviews/reviews-wlpcfg/build.gradle
+++ b/samples/bookinfo/src/reviews/reviews-wlpcfg/build.gradle
@@ -1,10 +1,10 @@
-apply plugin: 'eclipse'
-
 buildscript {
     repositories {
         mavenCentral()
     }
 }
+
+apply plugin: 'eclipse'
 
 task copyApplication(type: Copy) {
     from '../reviews-application/build/libs/reviews-application-1.0.war'


### PR DESCRIPTION
The Cloud Foundry open source licensing scanner has a plugin that
identifies dependencies from gradle scripts, but it requires the
buildscript and plugins block be before anything else in the file.
This change should not affect the build, but makes our lives a smidge
easier.

Co-authored-by: Teal Stannard <tstannard@pivotal.io>