### PR TITLE
add logs for citadel authenticate fail

### DIFF
--- a/security/pkg/server/ca/server.go
+++ b/security/pkg/server/ca/server.go
@@ -271,7 +271,11 @@ func (s *Server) applyServerCertificate() (*tls.Certificate, error) {
 func (s *Server) authenticate(ctx context.Context) *authenticate.Caller {
 	// TODO: apply different authenticators in specific order / according to configuration.
 	for _, authn := range s.authenticators {
-		if u, err := authn.Authenticate(ctx); u != nil && err == nil {
+		u, err := authn.Authenticate(ctx)
+		if err != nil {
+			log.Warnf("Authentication failed: %v", err)
+		}
+		if u != nil && err == nil {
 			log.Infof("Authentication successful through auth source %v", u.AuthSource)
 			return u
 		}


### PR DESCRIPTION
though sometimes it's expected to see authentication failures due to multiple authenticators are configured, add logs still help debug. 