### PR TITLE
Fix syntax error in virtual-service-ratings-test-delay.yaml

### DIFF
--- a/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
+++ b/samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
@@ -12,8 +12,7 @@ spec:
           exact: jason
     fault:
       delay:
-        percentage:
-          value: 100.0
+        percent: 100
         fixedDelay: 7s
     route:
     - destination:


### PR DESCRIPTION
While going through the bookinfo fault injection tutorial, I noticed the following problem when attempting to apply the demonstration file `virtual-service-ratings-test-delay.yaml`.

```
$ kubectl apply -f samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml
Error from server: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"networking.istio.io/v1alpha3\",\"kind\":\"VirtualService\",\"metadata\":{\"annotations\":{},\"name\":\"ratings\",\"namespace\":\"mhite\"},\"spec\":{\"hosts\":[\"ratings\"],\"http\":[{\"fault\":{\"delay\":{\"fixedDelay\":\"7s\",\"percentage\":{\"value\":100}}},\"match\":[{\"headers\":{\"end-user\":{\"exact\":\"jason\"}}}],\"route\":[{\"destination\":{\"host\":\"ratings\",\"subset\":\"v1\"}}]},{\"route\":[{\"destination\":{\"host\":\"ratings\",\"subset\":\"v1\"}}]}]}}\n"}},"spec":{"http":[{"fault":{"delay":{"fixedDelay":"7s","percentage":{"value":100}}},"match":[{"headers":{"end-user":{"exact":"jason"}}}],"route":[{"destination":{"host":"ratings","subset":"v1"}}]},{"route":[{"destination":{"host":"ratings","subset":"v1"}}]}]}}
to:
&{0xc420274900 0xc420437500 mhite ratings samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml 0xc42000c008 4047459 false}
for: "samples/bookinfo/networking/virtual-service-ratings-test-delay.yaml": admission webhook "pilot.validation.istio.io" denied the request: error decoding configuration: YAML decoding error: hosts:
- ratings
http:
- fault:
    delay:
      fixedDelay: 7s
      percentage:
        value: 100
  match:
  - headers:
      end-user:
        exact: jason
  route:
  - destination:
      host: ratings
      subset: v1
- route:
  - destination:
      host: ratings
      subset: v1
 unknown field "percentage" in v1alpha3.HTTPFaultInjection_Delay
```

This PR fixes the demo file.