### PR TITLE
Fix #10694. Improve error message for wildcard ServiceEntry host

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2093,7 +2093,7 @@ func ValidateServiceEntry(name, namespace string, config proto.Message) (errs er
 	for _, host := range serviceEntry.Hosts {
 		// Full wildcard is not allowed in the service entry.
 		if host == "*" {
-			errs = appendErrors(errs, fmt.Errorf("invalid host %s", host))
+			errs = appendErrors(errs, fmt.Errorf("wildcard host %s not allowed in ServiceEntry", host))
 		} else {
 			errs = appendErrors(errs, ValidateWildcardDomain(host))
 		}


### PR DESCRIPTION
Error message for ServiceEntries with a wildcard host was unclear
about why an error was generated. Example:

    "admission webhook "pilot.validation.istio.io" denied the request:
    configuration is invalid: invalid host metadata"

Improved error message to report why the metadata was not valid. Ex:

    Error from server: error when creating "../../testServiceEntry.yaml":
    admission webhook "pilot.validation.istio.io" denied the request:
    configuration is invalid: wildcard host * not allowed in ServiceEntry