### PR TITLE
FIX #11662 Add app label to selector in galley, mixer, pilot, security and sidecarInjectorWebhook

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -19,3 +19,4 @@ spec:
     name: grpc-mcp
   selector:
     istio: galley
+    app: {{ template "galley.name" . }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -32,6 +32,7 @@ spec:
   selector:
     istio: mixer
     istio-mixer-type: {{ $key }}
+    app: {{ template "mixer.name" $ }}
 ---
 {{- end }}
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
@@ -21,3 +21,4 @@ spec:
     name: http-monitoring
   selector:
     istio: pilot
+    app: {{ template "pilot.name" . }}

--- a/install/kubernetes/helm/istio/charts/security/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/service.yaml
@@ -21,3 +21,4 @@ spec:
       port: {{ .Values.global.monitoringPort }}
   selector:
     istio: citadel
+    app: {{ template "security.name" . }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
@@ -14,3 +14,4 @@ spec:
   - port: 443
   selector:
     istio: sidecar-injector
+    app: {{ template "sidecar-injector.name" . }}


### PR DESCRIPTION
Fix https://github.com/istio/istio/issues/11662

Istio services like 
[istiocoredns](https://github.com/istio/istio/blob/master/install/kubernetes/helm/subcharts/istiocoredns/templates/service.yaml) or [servicegraph](https://github.com/istio/istio/blob/master/install/kubernetes/helm/subcharts/servicegraph/templates/service.yaml) have the app label in spec/selector  but others like pilot, security not.

