### PR TITLE
make stackdriver e2e test cluster wide

### DIFF
--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -114,7 +114,7 @@ e2e_bookinfo_run: out_dir
 	go test -v -timeout 60m ./tests/e2e/tests/bookinfo -args ${E2E_ARGS} ${EXTRA_E2E_ARGS}
 
 e2e_stackdriver_run: out_dir
-	go test -v -timeout 25m ./tests/e2e/tests/stackdriver -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} --gcp_proj=${GCP_PROJ} --sa_cred=/etc/service-account/service-account.json
+	go test -v -timeout 25m ./tests/e2e/tests/stackdriver -args ${E2E_ARGS} ${EXTRA_E2E_ARGS} --cluster_wide --gcp_proj=${GCP_PROJ} --sa_cred=/etc/service-account/service-account.json
 
 e2e_all_run: out_dir
 	$(MAKE) --keep-going e2e_simple_run e2e_bookinfo_run e2e_dashboard_run


### PR DESCRIPTION
Cherry pick #11519 into release-1.1. #11652

@wenchenglu Hi, this change has already been merged into 1.1. Cherry pick it into release-1.1 to fix stackdriver e2e test: https://gubernator.k8s.io/build/istio-prow/pr-logs/pull/istio-releases_pipeline/271/release-e2e-stackdriver/86. It does not have any feature but just add a argument to make the test correctly run.