### PR TITLE
Fix locality aware routing to be applied when proxy has empty locality config set

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -81,7 +81,7 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 	// compute the proxy's locality. See if we have a CDS cache for that locality.
 	// If not, compute one.
 	locality := proxy.Locality
-	if locality == nil {
+	if util.IsLocalityEmpty(locality) {
 		// Get the locality from the proxy's service instances.
 		// We expect all instances to have the same locality. So its enough to look at the first instance
 		if len(instances) > 0 {

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -280,6 +280,14 @@ func ConvertLocality(locality string) *core.Locality {
 	}
 }
 
+// IsLocalityEmpty checks if a locality is empty (checking region is good enough, based on how its initialized)
+func IsLocalityEmpty(locality *core.Locality) bool {
+	if locality == nil || (len(locality.GetRegion()) == 0) {
+		return true
+	}
+	return false
+}
+
 func LocalityMatch(proxyLocality *core.Locality, ruleLocality string) bool {
 	ruleRegion, ruleZone, ruleSubzone := SplitLocality(ruleLocality)
 	regionMatch := ruleRegion == "*" || proxyLocality.GetRegion() == ruleRegion

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -372,6 +372,43 @@ func TestLocalityMatch(t *testing.T) {
 	}
 }
 
+func TestIsLocalityEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		locality *core.Locality
+		want     bool
+	}{
+		{
+			"non empty locality",
+			&core.Locality{
+				Region: "region",
+			},
+			false,
+		},
+		{
+			"empty locality",
+			&core.Locality{
+				Region: "",
+			},
+			true,
+		},
+		{
+			"nil locality",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsLocalityEmpty(tt.locality)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Expected locality empty result %#v, but got %#v", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestBuildConfigInfoMetadata(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Make sure empty proxy locality will fall back to using proxy service's instance locality.