### PR TITLE
inject sds related param in pilot/mixer deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -9,6 +9,20 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: uds-socket
         emptyDir: {}
       affinity:
@@ -132,6 +146,14 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        {{- if $.Values.global.sds.enabled }}
+        - name: sds-uds-path
+          mountPath: /var/run/sds
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - name: istio-token
+          mountPath: /var/run/secrets/tokens
+        {{- end }}
+        {{- end }}
         - name: uds-socket
           mountPath: /sock
 {{- end }}
@@ -144,6 +166,20 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: uds-socket
         emptyDir: {}
       affinity:
@@ -271,6 +307,14 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        {{- if $.Values.global.sds.enabled }}
+        - name: sds-uds-path
+          mountPath: /var/run/sds
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - name: istio-token
+          mountPath: /var/run/secrets/tokens
+        {{- end }}
+        {{- end }}
         - name: uds-socket
           mountPath: /sock
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -181,8 +181,30 @@ spec:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          {{- if $.Values.global.sds.enabled }}
+          - name: sds-uds-path
+            mountPath: /var/run/sds
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+          {{- end }}
+          {{- end }}
 {{- end }}
       volumes:
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: config-volume
         configMap:
           name: istio


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035, https://github.com/istio/istio/issues/5891

add sds related params like uds path to pilot/mixer deployment yaml file, this is required to switch from secret mount to sds at sidecar/controlplane bootstrap time, make to 1.1 asked from https://github.com/istio/istio/issues/11434

similar change to gateway was made in https://github.com/istio/istio/pull/9283, https://github.com/istio/istio/pull/10257

Related to: https://github.com/istio/istio/issues/10916