### PR TITLE
Attempt to fix flaky test: TestIngressGateway503DuringRuleChange

### DIFF
--- a/tests/e2e/tests/pilot/ingressgateway_test.go
+++ b/tests/e2e/tests/pilot/ingressgateway_test.go
@@ -229,7 +229,7 @@ func TestIngressGateway503DuringRuleChange(t *testing.T) {
 		fatalError = true
 		goto cleanup
 	}
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	log.Infof("routing to v3,v4")
 	if err = routeToNewSubsets.Setup(); err != nil {
 		fatalError = true


### PR DESCRIPTION
Increase sleep value to account for Galley default waiting of 1 sec to aggregate MCP resources.

Attempt to fix flakiness in #11594 
Flaky test: TestIngressGateway503DuringRuleChange