### PR TITLE
Adding support for named components and configuration to test framework.

### DIFF
--- a/pkg/test/framework/api/component/configuration.go
+++ b/pkg/test/framework/api/component/configuration.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Istio Authors
+//  Copyright 2019 Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,20 +12,9 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package key
+package component
 
-import "istio.io/istio/pkg/test/framework/api/component"
+import "fmt"
 
-// Instance of a key for component descriptors.
-type Instance struct {
-	ID      component.ID
-	Variant component.Variant
-}
-
-// For creates a key for the given descriptor.
-func For(d component.Descriptor) Instance {
-	return Instance{
-		ID:      d.ID,
-		Variant: d.Variant,
-	}
-}
+// Configuration is a marker interface for configuration objects that components take.
+type Configuration fmt.Stringer

--- a/pkg/test/framework/api/component/descriptor.go
+++ b/pkg/test/framework/api/component/descriptor.go
@@ -18,33 +18,45 @@ import "fmt"
 
 var _ Requirement = &Descriptor{}
 
-// Variant allows an environment to support multiple components with the same ID. For example, an environment might
-// support to Widget components: "fake widget" and "real widget".
+// Variant supports multiple components with the same ID. For example, a test may use two Widget
+// components: "fake widget" and "real widget".
 type Variant string
+
+// NewDescriptor creates a descriptor with the given ID and variant. Variants of a component type
+// will override the properties of the default Descriptor for that component type if set. For example
+// setting a new Configuration or Requires value will override the default Configuration or Requires
+// values. This can be used to create multiple instances of a component type with different
+// configuration and requirements.
+func NewDescriptor(id ID, variant Variant) *Descriptor {
+	return &Descriptor{Key: Key{ID: id, Variant: variant}}
+}
 
 // Descriptor describes a component of the testing framework.
 type Descriptor struct {
-	ID
+	Key               Key
 	IsSystemComponent bool
-	Variant           Variant
+	Configuration     Configuration
 	Requires          []Requirement
+}
+
+// GetKey returns the key for this Descriptor, which includes the ID and Variant.
+func (d Descriptor) GetKey() Key {
+	return d.Key
 }
 
 // FriendlyName provides a brief one-liner containing ID and Variant. Useful for error messages.
 func (d Descriptor) FriendlyName() string {
-	if d.Variant != "" {
-		return fmt.Sprintf("%s(%s)", d.ID, d.Variant)
-	}
-	return string(d.ID)
+	return d.Key.String()
 }
 
-func (d *Descriptor) String() string {
-	result := ""
+func (d Descriptor) String() string {
+	result := "Descriptor{\n"
 
-	result += fmt.Sprintf("ID:                 %v\n", d.ID)
+	result += fmt.Sprintf("Key:                %v\n", d.Key)
 	result += fmt.Sprintf("IsSystemComponent:  %t\n", d.IsSystemComponent)
-	result += fmt.Sprintf("Variant:            %s\n", d.Variant)
+	result += fmt.Sprintf("Configuration:      %s\n", d.Configuration)
 	result += fmt.Sprintf("Requires:           %v\n", d.Requires)
+	result += "}"
 
 	return result
 }

--- a/pkg/test/framework/api/component/factory.go
+++ b/pkg/test/framework/api/component/factory.go
@@ -22,6 +22,9 @@ import (
 
 // Factory for new component instances
 type Factory interface {
+	// Creates a new component with the given descriptor and scope.
 	NewComponent(d Descriptor, scope lifecycle.Scope) (Instance, error)
+
+	// Creates a new component with the given descriptor and scope, failing if the component cannot be created.
 	NewComponentOrFail(d Descriptor, scope lifecycle.Scope, t testing.TB) Instance
 }

--- a/pkg/test/framework/api/component/key.go
+++ b/pkg/test/framework/api/component/key.go
@@ -14,15 +14,18 @@
 
 package component
 
-var _ Requirement = ID("")
+import "fmt"
 
-// ID for a component of the testing framework
-type ID string
-
-func (i ID) GetKey() Key {
-	return Key{ID: i}
+// Instance of a key for identifying component variants.
+type Key struct {
+	ID
+	Variant Variant
 }
 
-func (i ID) String() string {
-	return string(i)
+// String provides a brief one-liner containing ID and Variant. Useful for error messages.
+func (k Key) String() string {
+	if k.Variant != "" {
+		return fmt.Sprintf("%s(%s)", k.ID, k.Variant)
+	}
+	return string(k.ID)
 }

--- a/pkg/test/framework/api/component/repository.go
+++ b/pkg/test/framework/api/component/repository.go
@@ -18,13 +18,9 @@ import "testing"
 
 // Repository of components.
 type Repository interface {
-	// Gets the component with the given ID, or null if not found.
-	GetComponent(id ID) Instance
-	GetComponentOrFail(id ID, t testing.TB) Instance
-
-	// Gets the component matching the given descriptor, or null if not found.
-	GetComponentForDescriptor(d Descriptor) Instance
-	GetComponentForDescriptorOrFail(d Descriptor, t testing.TB) Instance
+	// Gets the component for the given Requirement, or null if not found.
+	GetComponent(req Requirement) Instance
+	GetComponentOrFail(req Requirement, t testing.TB) Instance
 
 	// Gets all components currently active in the system.
 	GetAllComponents() []Instance

--- a/pkg/test/framework/api/component/requirement.go
+++ b/pkg/test/framework/api/component/requirement.go
@@ -17,4 +17,9 @@ package component
 import "fmt"
 
 // Requirement is a marker interface for an element that can be required of the testing framework.
-type Requirement fmt.Stringer
+type Requirement interface {
+	fmt.Stringer
+
+	// GetKey returns the key representing this requirement.
+	GetKey() Key
+}

--- a/pkg/test/framework/api/components/echo.go
+++ b/pkg/test/framework/api/components/echo.go
@@ -1,0 +1,101 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package components
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/application/echo"
+	"istio.io/istio/pkg/test/framework/api/component"
+)
+
+var _ component.Configuration = &EchoConfig{}
+
+// EchoProtocol enumerates the protocol options for calling an EchoEndpoint endpoint.
+type EchoProtocol string
+
+const (
+	// EchoProtocolHTTP calls echo with HTTP
+	EchoProtocolHTTP = "http"
+	// EchoProtocolGRPC calls echo with GRPC
+	EchoProtocolGRPC = "grpc"
+	// EchoProtocolWebSocket calls echo with WebSocket
+	EchoProtocolWebSocket = "ws"
+)
+
+// Echo is a component that provides access to the deployed echo service.
+type Echo interface {
+	component.Instance
+
+	// Config returns the configuration of the Echo instance.
+	Config() EchoConfig
+
+	// Endpoints returns the endpoints that are available for calling the Echo instance.
+	Endpoints() []EchoEndpoint
+
+	// EndpointsForProtocol return the endpoints filtered for a specific protocol (e.g. GRPC)
+	EndpointsForProtocol(protocol model.Protocol) []EchoEndpoint
+
+	// Call makes a call from this Echo instance to an EchoEndpoint from another instance.
+	Call(e EchoEndpoint, opts EchoCallOptions) ([]*echo.ParsedResponse, error)
+	CallOrFail(e EchoEndpoint, opts EchoCallOptions, t testing.TB) []*echo.ParsedResponse
+}
+
+// EchoConfig defines the options for creating an Echo component.
+type EchoConfig struct {
+	// Service indicates the service name of the Echo application.
+	Service string
+
+	// Version indicates the version path for calls to the Echo application.
+	Version string
+}
+
+// String implements the Configuration interface (which implements fmt.Stringer)
+func (ec EchoConfig) String() string {
+	return fmt.Sprint("{service: ", ec.Service, ", version: ", ec.Version, "}")
+}
+
+// EchoCallOptions defines options for calling a EchoEndpoint.
+type EchoCallOptions struct {
+	// Secure indicates whether a secure connection should be established to the endpoint.
+	Secure bool
+
+	// Protocol indicates the protocol to be used.
+	Protocol EchoProtocol
+
+	// UseShortHostname indicates whether shortened hostnames should be used. This may be ignored by the environment.
+	UseShortHostname bool
+
+	// Count indicates the number of exchanges that should be made with the service endpoint. If not set (i.e. 0), defaults to 1.
+	Count int
+
+	// Headers indicates headers that should be sent in the request. Ingnored for WebSocket calls.
+	Headers http.Header
+}
+
+// EchoEndpoint represents a single endpoint in an Echo instance.
+type EchoEndpoint interface {
+	Name() string
+	Owner() Echo
+	Protocol() model.Protocol
+}
+
+// Get an echo instance from the repository.
+func GetEcho(req component.Requirement, e component.Repository, t testing.TB) Echo {
+	return e.GetComponentOrFail(req, t).(Echo)
+}

--- a/pkg/test/framework/api/descriptors/descriptors.go
+++ b/pkg/test/framework/api/descriptors/descriptors.go
@@ -22,21 +22,19 @@ import (
 var (
 	// NativeEnvironment component
 	NativeEnvironment = component.Descriptor{
-		ID:                ids.Environment,
+		Key:               component.Key{ID: ids.Environment, Variant: "native"},
 		IsSystemComponent: true,
-		Variant:           "native",
 	}
 
 	// KubernetesEnvironment component
 	KubernetesEnvironment = component.Descriptor{
-		ID:                ids.Environment,
+		Key:               component.Key{ID: ids.Environment, Variant: "kubernetes"},
 		IsSystemComponent: true,
-		Variant:           "kubernetes",
 	}
 
 	// Pilot component
 	Pilot = component.Descriptor{
-		ID:                ids.Pilot,
+		Key:               ids.Pilot.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Mixer,
@@ -46,7 +44,7 @@ var (
 
 	// Mixer component
 	Mixer = component.Descriptor{
-		ID:                ids.Mixer,
+		Key:               ids.Mixer.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Environment,
@@ -55,7 +53,7 @@ var (
 
 	// Galley component
 	Galley = component.Descriptor{
-		ID:                ids.Galley,
+		Key:               ids.Galley.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Environment,
@@ -64,7 +62,7 @@ var (
 
 	// Citadel component
 	Citadel = component.Descriptor{
-		ID:                ids.Citadel,
+		Key:               ids.Citadel.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Environment,
@@ -73,7 +71,7 @@ var (
 
 	// Ingress component
 	Ingress = component.Descriptor{
-		ID:                ids.Ingress,
+		Key:               ids.Ingress.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Environment,
@@ -82,7 +80,7 @@ var (
 
 	// Prometheus component
 	Prometheus = component.Descriptor{
-		ID:                ids.Prometheus,
+		Key:               ids.Prometheus.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Environment,
@@ -91,7 +89,7 @@ var (
 
 	// PolicyBackend component
 	PolicyBackend = component.Descriptor{
-		ID:                ids.PolicyBackend,
+		Key:               ids.PolicyBackend.GetKey(),
 		IsSystemComponent: true,
 		Requires: []component.Requirement{
 			&ids.Mixer,
@@ -99,9 +97,18 @@ var (
 		},
 	}
 
+	// Echo component. Multiple of these may be created.
+	Echo = component.Descriptor{
+		Key:               ids.Echo.GetKey(),
+		IsSystemComponent: false,
+		Requires: []component.Requirement{
+			&ids.Environment,
+		},
+	}
+
 	// Apps component
 	Apps = component.Descriptor{
-		ID:                ids.Apps,
+		Key:               ids.Apps.GetKey(),
 		IsSystemComponent: false,
 		Requires: []component.Requirement{
 			&ids.Pilot,
@@ -111,7 +118,7 @@ var (
 
 	// BookInfo component
 	BookInfo = component.Descriptor{
-		ID:                ids.BookInfo,
+		Key:               ids.BookInfo.GetKey(),
 		IsSystemComponent: false,
 		Requires: []component.Requirement{
 			&ids.Pilot,

--- a/pkg/test/framework/api/ids/ids.go
+++ b/pkg/test/framework/api/ids/ids.go
@@ -31,6 +31,9 @@ var (
 	// Citadel component
 	Citadel = component.ID("citadel")
 
+	// Echo component
+	Echo = component.ID("echo")
+
 	// Ingress component
 	Ingress = component.ID("ingress")
 

--- a/pkg/test/framework/runtime/api/configurable.go
+++ b/pkg/test/framework/runtime/api/configurable.go
@@ -1,4 +1,4 @@
-//  Copyright 2018 Istio Authors
+//  Copyright 2019 Istio Authors
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -12,17 +12,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package component
+package api
 
-var _ Requirement = ID("")
+import "istio.io/istio/pkg/test/framework/api/component"
 
-// ID for a component of the testing framework
-type ID string
-
-func (i ID) GetKey() Key {
-	return Key{ID: i}
-}
-
-func (i ID) String() string {
-	return string(i)
+// Configurable interface is implemented by Components that accept Configuration.
+type Configurable interface {
+	// Configure is called by the test framework to configure a component. It should not be called directly by test code.
+	// To configure a component, pass the configuration when requiring the component.
+	Configure(config component.Configuration) error
 }

--- a/pkg/test/framework/runtime/components/echo/native.go
+++ b/pkg/test/framework/runtime/components/echo/native.go
@@ -1,0 +1,300 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package echo
+
+import (
+	gocontext "context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"google.golang.org/grpc"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/application"
+	"istio.io/istio/pkg/test/application/echo"
+	"istio.io/istio/pkg/test/application/echo/proto"
+	"istio.io/istio/pkg/test/framework/api/component"
+	"istio.io/istio/pkg/test/framework/api/components"
+	"istio.io/istio/pkg/test/framework/api/context"
+	"istio.io/istio/pkg/test/framework/api/descriptors"
+	"istio.io/istio/pkg/test/framework/api/lifecycle"
+	"istio.io/istio/pkg/test/framework/runtime/api"
+)
+
+var (
+	_ components.Echo  = &nativeComponent{}
+	_ api.Component    = &nativeComponent{}
+	_ io.Closer        = &nativeComponent{}
+	_ api.Configurable = &nativeComponent{}
+
+	ports = model.PortList{
+		{
+			Name:     "http",
+			Protocol: model.ProtocolHTTP,
+		},
+		{
+			Name:     "http-two",
+			Protocol: model.ProtocolHTTP,
+		},
+		{
+			Name:     "tcp",
+			Protocol: model.ProtocolTCP,
+		},
+		{
+			Name:     "https",
+			Protocol: model.ProtocolHTTPS,
+		},
+		{
+			Name:     "http2-example",
+			Protocol: model.ProtocolHTTP2,
+		},
+		{
+			Name:     "grpc",
+			Protocol: model.ProtocolGRPC,
+		},
+	}
+)
+
+// NewNativeComponent factory function for the component
+func NewNativeComponent() (api.Component, error) {
+	return &nativeComponent{}, nil
+}
+
+type nativeComponent struct {
+	scope     lifecycle.Scope
+	endpoints []components.EchoEndpoint
+	client    *echo.Client
+	config    components.EchoConfig
+}
+
+func (c *nativeComponent) Descriptor() component.Descriptor {
+	return descriptors.Echo
+}
+
+func (c *nativeComponent) Scope() lifecycle.Scope {
+	return c.scope
+}
+
+func (c *nativeComponent) Configure(config component.Configuration) error {
+	echoConfig, ok := config.(components.EchoConfig)
+	if !ok {
+		return fmt.Errorf("supplied configuration was not an EchoConfig, got %T (%v)", config, config)
+	}
+	c.config = echoConfig
+	return nil
+}
+
+// Start implements the api.Component interface
+func (c *nativeComponent) Start(ctx context.Instance, scope lifecycle.Scope) (err error) {
+	c.scope = scope
+
+	// Setup a close function to close the echo instance on an error.
+	defer func() {
+		if err != nil {
+			_ = c.Close()
+		}
+	}()
+
+	// Setup defaults for config values if not provided.
+	if c.config.Service == "" {
+		c.config.Service = "echo"
+	}
+	if c.config.Version == "" {
+		c.config.Version = "v1"
+	}
+
+	echoFactory := (&echo.Factory{
+		Ports:   ports,
+		Version: c.config.Version,
+	}).NewApplication
+
+	dialer := application.Dialer{
+		GRPC:      c.dialGRPC,
+		Websocket: c.dialWebsocket,
+		HTTP:      c.doHTTP,
+	}
+	app, err := echoFactory(dialer)
+
+	// Create the endpoints for the app.
+	var grpcEndpoint *nativeEndpoint
+	ports := app.GetPorts()
+	endpoints := make([]components.EchoEndpoint, len(ports))
+	for i, port := range ports {
+		ep := &nativeEndpoint{
+			owner: c,
+			port:  port,
+		}
+		endpoints[i] = ep
+
+		if ep.Protocol() == model.ProtocolGRPC {
+			grpcEndpoint = ep
+		}
+	}
+	c.endpoints = endpoints
+
+	// Create the client for sending forward requests.
+	if grpcEndpoint == nil {
+		return errors.New("unable to find grpc port for application")
+	}
+	c.client, err = echo.NewClient(fmt.Sprintf("127.0.0.1:%d", grpcEndpoint.port.Port))
+	if err != nil {
+		return err
+	}
+	return
+}
+
+// function for establishing GRPC connections from the application.
+func (c *nativeComponent) dialGRPC(ctx gocontext.Context, address string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return grpc.DialContext(ctx, address, opts...)
+}
+
+// function for establishing Websocket connections from the application.
+func (c *nativeComponent) dialWebsocket(dialer *websocket.Dialer, urlStr string, requestHeader http.Header) (*websocket.Conn, *http.Response, error) {
+	return dialer.Dial(urlStr, requestHeader)
+}
+
+// function for making outbound HTTP requests from the application.
+func (c *nativeComponent) doHTTP(client *http.Client, req *http.Request) (*http.Response, error) {
+	return client.Do(req)
+}
+
+// Close implements io.Closer
+func (c *nativeComponent) Close() (err error) {
+	if c.client != nil {
+		err = c.client.Close()
+	}
+	return
+}
+
+func (c *nativeComponent) Config() components.EchoConfig {
+	return c.config
+}
+
+func (c *nativeComponent) Endpoints() []components.EchoEndpoint {
+	return c.endpoints
+}
+
+func (c *nativeComponent) EndpointsForProtocol(protocol model.Protocol) []components.EchoEndpoint {
+	eps := make([]components.EchoEndpoint, 0, len(c.endpoints))
+	for _, ep := range c.endpoints {
+		if ep.Protocol() == protocol {
+			eps = append(eps, ep)
+		}
+	}
+	return eps
+}
+
+func (c *nativeComponent) Call(ee components.EchoEndpoint, opts components.EchoCallOptions) ([]*echo.ParsedResponse, error) {
+	dst, ok := ee.(*nativeEndpoint)
+	if !ok {
+		return nil, fmt.Errorf("supplied endpoint was not created by this environment")
+	}
+
+	// Normalize the count.
+	if opts.Count <= 0 {
+		opts.Count = 1
+	}
+
+	// Forward a request from 'this' service to the destination service.
+	dstURL := dst.makeURL(opts)
+	dstService := dst.owner.Config().Service
+
+	var headers []*proto.Header
+	headers = append(headers, &proto.Header{Key: "Host", Value: dstService})
+	for key, values := range opts.Headers {
+		for _, value := range values {
+			headers = append(headers, &proto.Header{Key: key, Value: value})
+		}
+	}
+	request := &proto.ForwardEchoRequest{
+		Url:     dstURL.String(),
+		Count:   int32(opts.Count),
+		Headers: headers,
+	}
+
+	resp, err := c.client.ForwardEcho(request)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp) != 1 {
+		return nil, fmt.Errorf("unexpected number of responses: %d", len(resp))
+	}
+	if !resp[0].IsOK() {
+		return nil, fmt.Errorf("unexpected response status code: %s", resp[0].Code)
+	}
+	if resp[0].Host != dstService {
+		return nil, fmt.Errorf("unexpected host: %s (expected %s)", resp[0].Host, dstService)
+	}
+	if resp[0].Port != strconv.Itoa(dst.port.Port) {
+		return nil, fmt.Errorf("unexpected port: %s (expected %s)", resp[0].Port, strconv.Itoa(dst.port.Port))
+	}
+
+	return resp, nil
+}
+
+func (c *nativeComponent) CallOrFail(ee components.EchoEndpoint, opts components.EchoCallOptions, t testing.TB) []*echo.ParsedResponse {
+	r, err := c.Call(ee, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+type nativeEndpoint struct {
+	owner *nativeComponent
+	port  *model.Port
+}
+
+func (e *nativeEndpoint) Name() string {
+	return e.port.Name
+}
+
+func (e *nativeEndpoint) Owner() components.Echo {
+	return e.owner
+}
+
+func (e *nativeEndpoint) Protocol() model.Protocol {
+	return e.port.Protocol
+}
+
+func (e *nativeEndpoint) makeURL(opts components.EchoCallOptions) *url.URL {
+	protocol := string(opts.Protocol)
+	switch protocol {
+	case components.AppProtocolHTTP:
+	case components.AppProtocolGRPC:
+	case components.AppProtocolWebSocket:
+	default:
+		protocol = string(components.AppProtocolHTTP)
+	}
+
+	if opts.Secure {
+		protocol += "s"
+	}
+
+	host := "127.0.0.1"
+	port := e.port.Port
+	return &url.URL{
+		Scheme: protocol,
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+	}
+}

--- a/pkg/test/framework/runtime/components/environment/kube/environment.go
+++ b/pkg/test/framework/runtime/components/environment/kube/environment.go
@@ -76,7 +76,7 @@ func GetEnvironment(r component.Repository) (*Environment, error) {
 
 	ne, ok := e.(*Environment)
 	if !ok {
-		return nil, fmt.Errorf("unsupported environment: %q", e.Descriptor().Variant)
+		return nil, fmt.Errorf("unsupported environment: %q", e.Descriptor().Key)
 	}
 	return ne, nil
 }

--- a/pkg/test/framework/runtime/components/environment/native/environment.go
+++ b/pkg/test/framework/runtime/components/environment/native/environment.go
@@ -67,7 +67,7 @@ func GetEnvironment(r component.Repository) (*Environment, error) {
 
 	ne, ok := e.(*Environment)
 	if !ok {
-		return nil, fmt.Errorf("unsupported environment: %q", e.Descriptor().Variant)
+		return nil, fmt.Errorf("unsupported environment: %q", e.Descriptor().Key)
 	}
 	return ne, nil
 }

--- a/pkg/test/framework/runtime/components/prometheus/kube.go
+++ b/pkg/test/framework/runtime/components/prometheus/kube.go
@@ -288,15 +288,15 @@ func areEqual(v1, v2 model.Value) bool {
 		for i := 0; i < len(vec1); i++ {
 			if !vec1[i].Metric.Equal(vec2[i].Metric) {
 				scopes.Framework.Debugf(
-					"Prometheus.areEqual vector metric mismatch (at:%d): %d != %d",
+					"Prometheus.areEqual vector metric mismatch (at:%d): \n%v\n != \n%v\n",
 					i, vec1[i].Metric, vec2[i].Metric)
 				return false
 			}
 
 			if vec1[i].Value != vec2[i].Value {
 				scopes.Framework.Debugf(
-					"Prometheus.areEqual vector  value mismatch (at:%d): \n%v\n!=\n%v\n",
-					i, vec1[i].Metric, vec2[i].Metric)
+					"Prometheus.areEqual vector value mismatch (at:%d): %f != %f",
+					i, vec1[i].Value, vec2[i].Value)
 				return false
 			}
 		}

--- a/pkg/test/framework/runtime/dependency/manager_test.go
+++ b/pkg/test/framework/runtime/dependency/manager_test.go
@@ -16,7 +16,6 @@ package dependency_test
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"istio.io/istio/pkg/log"
@@ -54,6 +53,7 @@ func TestRequireIDs(t *testing.T) {
 
 	// Creating component a should create b and c.
 	scope := lifecycle.Suite
+
 	m.RequireOrFail(t, scope, &aID, &bID, &cID)
 
 	m.assertCount(3)
@@ -121,7 +121,7 @@ func TestOverrideDefault(t *testing.T) {
 	bOverride := m.registerVariant(bID, "b-variant", &cID)
 	c := m.registerDefault(cID)
 
-	// Creating component a should create b and c.
+	// Creating component a should create b-variant and c.
 	scope := lifecycle.Suite
 	m.RequireOrFail(t, scope, &aID, &bOverride, &cID)
 
@@ -171,24 +171,6 @@ func TestRequireExistingComponentSucceeds(t *testing.T) {
 	m.RequireOrFail(t, scope, &a)
 	m.assertCount(2)
 	m.assertDescriptor(a, scope)
-}
-
-func TestRequireConflictingExistingComponentFails(t *testing.T) {
-	m := newManager(t)
-
-	// Creating component a should create b and c.
-	scope := lifecycle.Suite
-
-	v1 := m.registerVariant(aID, "v1")
-	v2 := m.registerVariant(aID, "v2")
-
-	// First create v1
-	m.RequireOrFail(t, scope, &v1)
-	m.assertCount(1)
-	m.assertDescriptor(v1, scope)
-
-	// Now create v2
-	expect(t).resolutionError(m.Require(scope, &v2))
 }
 
 func TestRequireGreaterScopeThanExistingComponentFails(t *testing.T) {
@@ -281,13 +263,73 @@ func TestDependencyWithLesserScopeFails(t *testing.T) {
 	expect(t).resolutionError(m.Require(lifecycle.Suite, &a))
 }
 
+func TestVariantsCreateMultipleComponents(t *testing.T) {
+	m := newManager(t)
+
+	_ = m.registerDefault(aID)
+	req1 := component.NewDescriptor(aID, "one")
+	req2 := component.NewDescriptor(aID, "two")
+
+	m.RequireOrFail(t, lifecycle.Test, req1, req2)
+	m.assertCount(2)
+	m.assertDescriptor(*req1, lifecycle.Test)
+	m.assertDescriptor(*req2, lifecycle.Test)
+}
+
+type testConfig struct {
+	content string
+}
+
+func (c testConfig) String() string {
+	return c.content
+}
+
+func TestMismatchedConfiguration(t *testing.T) {
+	m := newManager(t)
+
+	_ = m.registerDefault(aID)
+
+	req1 := component.NewDescriptor(aID, "")
+	req1.Configuration = testConfig{"one"}
+
+	req2 := component.NewDescriptor(aID, "")
+	req2.Configuration = testConfig{"two"}
+
+	expect(t).resolutionError(m.Require(lifecycle.Test, req1, req2))
+}
+
+func TestConfigOverride(t *testing.T) {
+	m := newManager(t)
+
+	a := m.registerDefault(aID)
+
+	req := component.NewDescriptor(aID, "")
+	req.Configuration = testConfig{"one"}
+
+	m.RequireOrFail(t, lifecycle.Test, &a, req)
+	m.assertCount(1)
+	m.assertDescriptor(a, lifecycle.Test)
+	m.assertConfiguration(a, req.Configuration)
+}
+
 func assertDescriptor(c component.Instance, desc component.Descriptor, scope lifecycle.Scope, t *testing.T) {
 	t.Helper()
 	if c.Scope() != scope {
 		t.Fatalf("expected %v, found %v", scope, c.Scope())
 	}
-	if !reflect.DeepEqual(c.Descriptor(), desc) {
-		t.Fatalf("expected %v, found %v", desc, c.Descriptor())
+	if c.Descriptor().Key.ID != desc.Key.ID {
+		t.Fatalf("expected %v, found %v", desc.Key.ID, c.Descriptor().Key.ID)
+	}
+}
+
+func assertConfiguration(c component.Instance, config component.Configuration, t *testing.T) {
+	t.Helper()
+	if co, ok := c.(*comp); ok {
+		if co.config != config {
+			t.Fatalf("expected %v, found %v", config, co.config)
+		}
+	} else {
+		t.Fatalf("Unable to cast component %v (%T) to local comp type.", c, c)
 	}
 }
 
@@ -328,16 +370,26 @@ func (m *manager) assertCount(expected int) {
 }
 
 func (m *manager) assertDescriptor(desc component.Descriptor, scope lifecycle.Scope) {
-	c := m.GetComponentForDescriptor(desc)
+	c := m.GetComponent(&desc)
 	if c == nil {
 		m.t.Fatalf("component not found for descriptor: %v", desc)
 	}
 	assertDescriptor(c, desc, scope, m.t)
 }
 
+func (m *manager) assertConfiguration(desc component.Descriptor, config component.Configuration) {
+	c := m.GetComponent(&desc)
+	if c == nil {
+		m.t.Fatalf("component not found for descriptor: %v", desc)
+	}
+	assertConfiguration(c, config, m.t)
+}
+
 type comp struct {
-	desc  component.Descriptor
-	scope lifecycle.Scope
+	name   string
+	desc   component.Descriptor
+	config component.Configuration
+	scope  lifecycle.Scope
 }
 
 func (c *comp) Descriptor() component.Descriptor {
@@ -346,6 +398,11 @@ func (c *comp) Descriptor() component.Descriptor {
 
 func (c *comp) Scope() lifecycle.Scope {
 	return c.scope
+}
+
+func (c *comp) Configure(config component.Configuration) error {
+	c.config = config
+	return nil
 }
 
 func (c *comp) Start(ctx context.Instance, scope lifecycle.Scope) error {
@@ -390,20 +447,11 @@ func (c *mockContext) Evaluate(t testing.TB, tmpl string) string {
 	return ""
 }
 
-func (c *mockContext) GetComponent(id component.ID) component.Instance {
+func (c *mockContext) GetComponent(req component.Requirement) component.Instance {
 	return nil
 }
 
-func (c *mockContext) GetComponentOrFail(id component.ID, t testing.TB) component.Instance {
-	t.Fatalf("unsupported")
-	return nil
-}
-
-func (c *mockContext) GetComponentForDescriptor(d component.Descriptor) component.Instance {
-	return nil
-}
-
-func (c *mockContext) GetComponentForDescriptorOrFail(d component.Descriptor, t testing.TB) component.Instance {
+func (c *mockContext) GetComponentOrFail(req component.Requirement, t testing.TB) component.Instance {
 	t.Fatalf("unsupported")
 	return nil
 }
@@ -415,6 +463,7 @@ func (c *mockContext) GetAllComponents() []component.Instance {
 func (c *mockContext) NewComponent(d component.Descriptor, scope lifecycle.Scope) (component.Instance, error) {
 	return nil, fmt.Errorf("unsupported")
 }
+
 func (c *mockContext) NewComponentOrFail(d component.Descriptor, scope lifecycle.Scope, t testing.TB) component.Instance {
 	t.Fatalf("unsupported")
 	return nil
@@ -443,8 +492,7 @@ func (c *mockContext) GetDefaultDescriptorOrFail(id component.ID, t testing.TB) 
 
 func descriptor(cid component.ID, variant component.Variant, reqs ...component.Requirement) component.Descriptor {
 	return component.Descriptor{
-		ID:       cid,
-		Variant:  variant,
+		Key:      component.Key{ID: cid, Variant: variant},
 		Requires: reqs,
 	}
 }

--- a/pkg/test/framework/runtime/dependency/manager_test.go
+++ b/pkg/test/framework/runtime/dependency/manager_test.go
@@ -386,7 +386,6 @@ func (m *manager) assertConfiguration(desc component.Descriptor, config componen
 }
 
 type comp struct {
-	name   string
 	desc   component.Descriptor
 	config component.Configuration
 	scope  lifecycle.Scope

--- a/pkg/test/framework/runtime/registries/registries.go
+++ b/pkg/test/framework/runtime/registries/registries.go
@@ -17,6 +17,8 @@ package registries
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/test/framework/runtime/components/echo"
+
 	"istio.io/istio/pkg/test/framework/api/component"
 	"istio.io/istio/pkg/test/framework/api/descriptors"
 	"istio.io/istio/pkg/test/framework/runtime/api"
@@ -35,18 +37,19 @@ import (
 )
 
 var (
+	environmentMap = make(map[component.Variant]*registry.Instance)
+
 	// Native environment registry.
 	Native = newEnvironment(descriptors.NativeEnvironment, native.NewEnvironment)
 
 	// Kube environment registry.
 	Kube = newEnvironment(descriptors.KubernetesEnvironment, kube.NewEnvironment)
-
-	environmentMap = make(map[component.Variant]*registry.Instance)
 )
 
 func init() {
 	// Register native components.
 	Native.Register(descriptors.Apps, true, apps.NewNativeComponent)
+	Native.Register(descriptors.Echo, true, echo.NewNativeComponent)
 	Native.Register(descriptors.Galley, true, galley.NewNativeComponent)
 	Native.Register(descriptors.Mixer, true, mixer.NewNativeComponent)
 	Native.Register(descriptors.Pilot, true, pilot.NewNativeComponent)
@@ -83,12 +86,12 @@ func newEnvironment(desc component.Descriptor, factory api.ComponentFactory) *re
 	// Register the environment component in the registry.
 	r.Register(desc, true, factory)
 
-	if desc.Variant == "" {
+	if desc.Key.Variant == "" {
 		panic("failed registering environment without variant")
 	}
-	if _, ok := environmentMap[desc.Variant]; ok {
-		panic(fmt.Sprintf("failed registering environment for duplicate variant: %s", desc.Variant))
+	if _, ok := environmentMap[desc.Key.Variant]; ok {
+		panic(fmt.Sprintf("failed registering environment for duplicate variant: %s", desc.Key.Variant))
 	}
-	environmentMap[desc.Variant] = r
+	environmentMap[desc.Key.Variant] = r
 	return r
 }

--- a/pkg/test/framework/runtime/registry/instance.go
+++ b/pkg/test/framework/runtime/registry/instance.go
@@ -20,7 +20,6 @@ import (
 
 	"istio.io/istio/pkg/test/framework/api/component"
 	"istio.io/istio/pkg/test/framework/runtime/api"
-	"istio.io/istio/pkg/test/framework/runtime/key"
 )
 
 var _ component.Defaults = &Instance{}
@@ -28,41 +27,45 @@ var _ component.Defaults = &Instance{}
 // Instance of a component registry
 type Instance struct {
 	defaults  map[component.ID]component.Descriptor
-	factories map[key.Instance]api.ComponentFactory
+	factories map[component.Key]api.ComponentFactory
 }
 
 // New component registry
 func New() *Instance {
 	return &Instance{
 		defaults:  make(map[component.ID]component.Descriptor),
-		factories: make(map[key.Instance]api.ComponentFactory),
+		factories: make(map[component.Key]api.ComponentFactory),
 	}
 }
 
 // Register a component
 func (r *Instance) Register(desc component.Descriptor, isDefault bool, factory api.ComponentFactory) {
-	if desc.ID == "" {
+	k := desc.Key
+	if k.ID == "" {
 		panic("attempting to register framework component without an ID")
 	}
 
-	k := key.For(desc)
 	if r.factories[k] != nil {
 		panic(fmt.Sprintf("duplicate components registered `%s`", desc.FriendlyName()))
 	}
 	r.factories[k] = factory
 
 	if isDefault {
-		if _, ok := r.defaults[desc.ID]; ok {
+		if _, ok := r.defaults[k.ID]; ok {
 			panic(fmt.Sprintf("default already set for component `%s`", desc.FriendlyName()))
 		}
-		r.defaults[desc.ID] = desc
+		r.defaults[k.ID] = desc
 	}
 }
 
 // GetFactory for a component
 func (r *Instance) GetFactory(desc component.Descriptor) (api.ComponentFactory, error) {
-	k := key.For(desc)
+	k := desc.Key
 	f := r.factories[k]
+	// If the key was a Variant and there was no factory for the variant, try the default factory.
+	if f == nil && desc.Key.Variant != "" {
+		f = r.factories[desc.Key.ID.GetKey()]
+	}
 	if f == nil {
 		return nil, fmt.Errorf("unknown component `%s`", desc.FriendlyName())
 	}

--- a/pkg/test/framework/runtime/settings.go
+++ b/pkg/test/framework/runtime/settings.go
@@ -53,7 +53,7 @@ func defaultSettings() *settings {
 	o.SetOutputLevel(scopes.CI.Name(), log.NoneLevel)
 
 	return &settings{
-		Environment: descriptors.NativeEnvironment.Variant,
+		Environment: descriptors.NativeEnvironment.Key.Variant,
 		LogOptions:  o,
 	}
 }

--- a/tests/integration2/echo/echo_test.go
+++ b/tests/integration2/echo/echo_test.go
@@ -1,0 +1,70 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package echo
+
+import (
+	"os"
+	"testing"
+
+	"istio.io/istio/pkg/test/framework/api/component"
+	"istio.io/istio/pkg/test/framework/api/ids"
+
+	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/api/components"
+	"istio.io/istio/pkg/test/framework/api/descriptors"
+	"istio.io/istio/pkg/test/framework/api/lifecycle"
+)
+
+// TODO(sven): Add additional testing of the echo component, this is just the basics.
+func TestEcho(t *testing.T) {
+	ctx := framework.GetContext(t)
+
+	// Echo is only supported on native environment right now, skip if we can't load that.
+	ctx.RequireOrSkip(t, lifecycle.Test, &descriptors.NativeEnvironment)
+
+	reqA := component.NewDescriptor(ids.Echo, "a")
+	reqA.Configuration = components.EchoConfig{Service: "a.echo", Version: "v1"}
+
+	reqB := component.NewDescriptor(ids.Echo, "b")
+	reqB.Configuration = components.EchoConfig{Service: "b.echo", Version: "v2"}
+	reqB.Requires = append(reqB.Requires, reqA)
+
+	ctx.RequireOrFail(t, lifecycle.Test, reqB)
+
+	echoA := components.GetEcho(reqA, ctx, t)
+	echoB := components.GetEcho(reqB, ctx, t)
+
+	// Verify the configuration was set appropriately.
+	if echoA.Config().Service != "a.echo" {
+		t.Fatalf("expected 'a.echo' but echoA service was %s", echoA.Config().Service)
+	}
+	if echoB.Config().Service != "b.echo" {
+		t.Fatalf("expected 'b.echo' but echoB service was %s", echoB.Config().Service)
+	}
+
+	be := echoB.EndpointsForProtocol(model.ProtocolHTTP)[0]
+	result := echoA.CallOrFail(be, components.EchoCallOptions{}, t)[0]
+
+	if !result.IsOK() {
+		t.Fatalf("HTTP Request unsuccessful: %s", result.Body)
+	}
+}
+
+// To opt-in to the test framework, implement a TestMain, and call test.Run.
+func TestMain(m *testing.M) {
+	rt, _ := framework.Run("echo_test", m)
+	os.Exit(rt)
+}

--- a/tests/integration2/examples/pilot/pilot_test.go
+++ b/tests/integration2/examples/pilot/pilot_test.go
@@ -16,23 +16,16 @@ package pilot
 
 import (
 	"fmt"
-	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/api/components"
-	"istio.io/istio/pkg/test/framework/api/context"
-	"istio.io/istio/pkg/test/framework/api/descriptors"
-	"istio.io/istio/pkg/test/framework/api/ids"
-	"istio.io/istio/pkg/test/framework/api/lifecycle"
 	"testing"
-
-	"istio.io/istio/pkg/test/framework"
-	"istio.io/istio/pkg/test/framework/api/components"
-	"istio.io/istio/pkg/test/framework/api/context"
-	"istio.io/istio/pkg/test/framework/api/descriptors"
-	"istio.io/istio/pkg/test/framework/api/ids"
-	"istio.io/istio/pkg/test/framework/api/lifecycle"
 
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/api/components"
+	"istio.io/istio/pkg/test/framework/api/context"
+	"istio.io/istio/pkg/test/framework/api/descriptors"
+	"istio.io/istio/pkg/test/framework/api/ids"
+	"istio.io/istio/pkg/test/framework/api/lifecycle"
 )
 
 var (


### PR DESCRIPTION
Each component can be created with a name and optionally a configuration. This allows multiple echo instances, policy backends, envoy proxies etcetera to be managed independently.