### PR TITLE
issue #11244 - demo should install a default secret for kiali

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-auth.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-auth.yaml
@@ -23,3 +23,4 @@ servicegraph:
 
 kiali:
   enabled: true
+  createDemoSecret: true

--- a/install/kubernetes/helm/istio/values-istio-demo.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo.yaml
@@ -16,3 +16,4 @@ servicegraph:
 
 kiali:
   enabled: true
+  createDemoSecret: true

--- a/install/kubernetes/helm/subcharts/kiali/templates/demosecret.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/templates/demosecret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.createDemoSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kiali
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "kiali.name" . }}
+    chart: {{ template "kiali.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: Opaque
+data:
+  username: YWRtaW4=   # admin
+  passphrase: YWRtaW4= # admin
+{{- end }}

--- a/install/kubernetes/helm/subcharts/kiali/values.yaml
+++ b/install/kubernetes/helm/subcharts/kiali/values.yaml
@@ -33,3 +33,6 @@ dashboard:
   # Override the automatically detected Jaeger URL, useful when Jaeger service has no ExternalIPs
   # jaegerURL:
 prometheusAddr: http://prometheus:9090
+
+# When true, a secret will be created with a default username and password. Useful for demos.
+createDemoSecret: false


### PR DESCRIPTION
This is in response to @linsun and her desire to get the kiali secret created out of box with the demo profile for 1.1 builds. See https://github.com/istio/istio/issues/11244#issuecomment-462934826

This feature is already merged in the master branch - this PR just cherry picks to the 1.1 branch.

(cherry picked from commit 1ad4e29576da6c722dcf19fc5df703beede92a4d)