### PR TITLE
enable workload to use sds fetching certificate at bootstrap time

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -197,6 +197,14 @@ spec:
             value: "true"
           {{- end }}
           {{- end }}
+          - name: ISTIO_META_WORKLOAD_SDS_ENABLED
+            value: "{{ $.Values.global.sds.enabled }}"
+          - name: ISTIO_META_K8S_JWT_PATH
+{{- if $.Values.global.sds.useTrustworthyJwt }}
+            value: "/var/run/secrets/tokens/istio-token"
+{{- else }}
+            value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
           {{- if $spec.env }}
           {{- range $key, $val := $spec.env }}
           - name: {{ $key }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -197,6 +197,7 @@ spec:
             value: "true"
           {{- end }}
           {{- end }}
+{{- if $.Values.global.sds.enabled }}
           - name: ISTIO_META_WORKLOAD_SDS_ENABLED
             value: "{{ $.Values.global.sds.enabled }}"
           - name: ISTIO_META_K8S_JWT_PATH
@@ -204,6 +205,7 @@ spec:
             value: "/var/run/secrets/tokens/istio-token"
 {{- else }}
             value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
 {{- end }}
           {{- if $spec.env }}
           {{- range $key, $val := $spec.env }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -175,6 +175,7 @@ data:
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"
         {{- end }}
+{{- if .Values.global.sds.enabled }}
         - name: ISTIO_META_WORKLOAD_SDS_ENABLED
           value: "{{ .Values.global.sds.enabled }}"
         - name: ISTIO_META_K8S_JWT_PATH
@@ -182,6 +183,7 @@ data:
           value: "/var/run/secrets/tokens/istio-token"
 {{- else }}
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
 {{- end }}
         {{ "[[ if .ObjectMeta.Annotations ]]" }}
         - name: ISTIO_METAJSON_ANNOTATIONS

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -176,6 +176,7 @@ data:
           value: "{{ .Values.global.network }}"
         {{- end }}
 {{- if .Values.global.sds.enabled }}
+        {{ "[[ if (isset .ObjectMeta.Annotations `sidecar.istio.io/enableSDS`) -]]" }}
         - name: ISTIO_META_WORKLOAD_SDS_ENABLED
           value: "{{ .Values.global.sds.enabled }}"
         - name: ISTIO_META_K8S_JWT_PATH
@@ -184,6 +185,7 @@ data:
 {{- else }}
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
+        {{ "[[ end -]]" }}
 {{- end }}
         {{ "[[ if .ObjectMeta.Annotations ]]" }}
         - name: ISTIO_METAJSON_ANNOTATIONS
@@ -256,6 +258,11 @@ data:
         - mountPath: /var/run/secrets/tokens
           name: istio-token
         {{- end }}
+        {{ "[[ if not (isset .ObjectMeta.Annotations `sidecar.istio.io/enableSDS`) -]]" }}
+        - mountPath: /etc/certs/
+          name: istio-certs
+          readOnly: true
+        {{ "[[ end -]]" }}
         {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "lightstep") .Values.global.tracer.lightstep.cacertPath }}
         - mountPath: {{ "[[ directory .ProxyConfig.GetTracing.GetLightstep.GetCacertPath ]]" }}
@@ -290,6 +297,22 @@ data:
               expirationSeconds: 43200
               audience: {{ .Values.global.trustDomain }}
       {{- end }}
+      {{ "[[ if not (isset .ObjectMeta.Annotations `sidecar.istio.io/enableSDS`) -]]" }}
+      - name: istio-certs
+        secret:
+          optional: true
+          {{ "[[ if eq .Spec.ServiceAccountName \"\" -]]" }}
+          secretName: istio.default
+          {{ "[[ else -]]" }}
+          secretName: {{ "[[ printf \"istio.%s\" .Spec.ServiceAccountName ]]"  }}
+          {{ "[[ end -]]" }}
+        {{ "[[- if isset .ObjectMeta.Annotations `sidecar.istio.io/userVolume` ]]" }}
+        {{ "[[ range $index, $value := fromJSON (index .ObjectMeta.Annotations `sidecar.istio.io/userVolume`) ]]" }}
+      - name: {{ "\"[[ $index ]]\"" }}
+        {{ "[[ toYaml $value | indent 2 ]]" }}
+        {{ "[[ end ]]" }}
+        {{ "[[ end ]]" }}
+      {{ "[[ end -]]" }}
       {{- else }}
       - name: istio-certs
         secret:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -175,6 +175,14 @@ data:
         - name: ISTIO_META_NETWORK
           value: "{{ .Values.global.network }}"
         {{- end }}
+        - name: ISTIO_META_WORKLOAD_SDS_ENABLED
+          value: "{{ .Values.global.sds.enabled }}"
+        - name: ISTIO_META_K8S_JWT_PATH
+{{- if .Values.global.sds.useTrustworthyJwt }}
+          value: "/var/run/secrets/tokens/istio-token"
+{{- else }}
+          value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
         {{ "[[ if .ObjectMeta.Annotations ]]" }}
         - name: ISTIO_METAJSON_ANNOTATIONS
           value: |

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -77,8 +77,6 @@ var (
 	concurrency              int
 	templateFile             string
 	disableInternalTelemetry bool
-	sdsEnabled               bool
-	k8sServiceAccountJWTPath string
 	loggingOptions           = log.DefaultOptions()
 
 	wg sync.WaitGroup
@@ -277,12 +275,6 @@ var (
 						opts["DisableReportCalls"] = "true"
 					}
 
-					opts["K8sSAJWTPath"] = k8sServiceAccountJWTPath
-
-					if sdsEnabled {
-						opts["SDSEnabled"] = "enable"
-					}
-
 					tmpl, err := template.ParseFiles(templateFile)
 					if err != nil {
 						return err
@@ -476,11 +468,6 @@ func init() {
 		"Disable internal telemetry")
 	proxyCmd.PersistentFlags().BoolVar(&controlPlaneBootstrap, "controlPlaneBootstrap", true,
 		"Process bootstrap provided via templateFile to be used by control plane components.")
-
-	proxyCmd.PersistentFlags().StringVar(&k8sServiceAccountJWTPath, "k8sServiceAccountJWTPath", "",
-		"The JWT path of k8s service account.")
-	proxyCmd.PersistentFlags().BoolVar(&sdsEnabled, "sdsEnabled", false,
-		"Flag to indicate if SDS(secret discovery service) is enabled.")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -77,6 +77,8 @@ var (
 	concurrency              int
 	templateFile             string
 	disableInternalTelemetry bool
+	sdsEnabled               bool
+	k8sServiceAccountJWTPath string
 	loggingOptions           = log.DefaultOptions()
 
 	wg sync.WaitGroup
@@ -274,6 +276,13 @@ var (
 					if disableInternalTelemetry {
 						opts["DisableReportCalls"] = "true"
 					}
+
+					opts["K8sSAJWTPath"] = k8sServiceAccountJWTPath
+
+					if sdsEnabled {
+						opts["SDSEnabled"] = "enable"
+					}
+
 					tmpl, err := template.ParseFiles(templateFile)
 					if err != nil {
 						return err
@@ -467,6 +476,11 @@ func init() {
 		"Disable internal telemetry")
 	proxyCmd.PersistentFlags().BoolVar(&controlPlaneBootstrap, "controlPlaneBootstrap", true,
 		"Process bootstrap provided via templateFile to be used by control plane components.")
+
+	proxyCmd.PersistentFlags().StringVar(&k8sServiceAccountJWTPath, "k8sServiceAccountJWTPath", "",
+		"The JWT path of k8s service account.")
+	proxyCmd.PersistentFlags().BoolVar(&sdsEnabled, "sdsEnabled", false,
+		"Flag to indicate if SDS(secret discovery service) is enabled.")
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -274,7 +274,6 @@ var (
 					if disableInternalTelemetry {
 						opts["DisableReportCalls"] = "true"
 					}
-
 					tmpl, err := template.ParseFiles(templateFile)
 					if err != nil {
 						return err

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -255,6 +256,14 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 
 	// Support multiple network interfaces
 	meta["ISTIO_META_INSTANCE_IPS"] = strings.Join(nodeIPs, ",")
+	opts["sdsEnabled"] = false
+
+	se, err := strconv.ParseBool(meta["WORKLOAD_SDS_ENABLED"])
+	if err == nil && se == true {
+		opts["sdsEnabled"] = true
+	}
+
+	opts["k8sJwtPath"] = meta["K8S_JWT_PATH"]
 
 	ba, err := json.Marshal(meta)
 	if err != nil {

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -113,6 +113,96 @@
         "connect_timeout": "{{ .connect_timeout }}",
         "lb_policy": "ROUND_ROBIN",
         {{ if eq .config.ControlPlaneAuthPolicy 1 }}
+        {{ if .sdsEnabled }}
+        "tls_context": {
+          "common_tls_context": {
+            "alpn_protocols": [
+              "h2"
+            ],
+            "tls_certificate_sds_secret_configs":[
+              {
+                 "name":"default",
+                 "sds_config":{
+                    "api_config_source":{
+                       "api_type":"GRPC",
+                       "grpc_services":[
+                          {
+                             "google_grpc":{
+                                "target_uri":"unix:/var/run/sds/uds_path",
+                                "channel_credentials":{
+                                   "local_credentials":{
+     
+                                   }
+                                },
+                                "call_credentials":[
+                                  {
+                                    "from_plugin":{
+                                      "name":"envoy.grpc_credentials.file_based_metadata",
+                                      "config":{
+                                        "secret_data":{
+                                          "filename": "{{ .k8sJwtPath }}"
+                                        },
+                                        "header_key":"istio_sds_credentail_header-bin"
+                                      }
+                                    }
+                                 }
+                                ],
+                                "stat_prefix":"sdsstat",
+                                "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata"
+                             }
+                          }
+                       ]
+                    }
+                 }
+              }
+           ],
+           "combined_validation_context":{
+            "default_validation_context":{
+               "verify_subject_alt_name":[
+                {{- range $a, $s := .pilot_SAN }}
+                "{{$s}}"
+                {{- end}}
+               ]
+            },
+            "validation_context_sds_secret_config":{
+               "name":"ROOTCA",
+               "sds_config":{
+                  "api_config_source":{
+                     "api_type":"GRPC",
+                     "grpc_services":[
+                        {
+                           "google_grpc":{
+                              "target_uri":"unix:/var/run/sds/uds_path",
+                              "channel_credentials":{
+                                 "local_credentials":{
+   
+                                 }
+                              },
+                              "call_credentials":[
+                                 {
+                                    "from_plugin":{
+                                      "name":"envoy.grpc_credentials.file_based_metadata",
+                                      "config":{
+                                        "secret_data":{
+                                          "filename": "{{ .k8sJwtPath }}"
+                                        },
+                                        "header_key":"istio_sds_credentail_header-bin"
+                                      }
+                                    }
+                                 }
+                              ],
+                              "stat_prefix":"sdsstat",
+                              "credentials_factory_name":"envoy.grpc_credentials.file_based_metadata"
+                           }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+          }, 
+        {{ else }}
         "tls_context": {
           "common_tls_context": {
             "alpn_protocols": [
@@ -140,6 +230,7 @@
             }
           }
         },
+        {{ end }} 
         {{ end }}
         "hosts": [
           {


### PR DESCRIPTION
https://github.com/istio/istio/issues/9035, https://github.com/istio/istio/issues/5891

enable workload to use sds fetching certificate at bootstrap time, this is required to switch from secret mount to sds at sidecar bootstrap time(will send a separated PR for control plane like pilot and mixer).
make to 1.1 asked from https://github.com/istio/istio/issues/11434
