### PR TITLE
when proxy locality is empty, apply it with service instance locality

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -81,13 +81,6 @@ func (configgen *ConfigGeneratorImpl) BuildClusters(env *model.Environment, prox
 	// compute the proxy's locality. See if we have a CDS cache for that locality.
 	// If not, compute one.
 	locality := proxy.Locality
-	if util.IsLocalityEmpty(locality) {
-		// Get the locality from the proxy's service instances.
-		// We expect all instances to have the same locality. So its enough to look at the first instance
-		if len(instances) > 0 {
-			locality = util.ConvertLocality(instances[0].GetLocality())
-		}
-	}
 
 	switch proxy.Type {
 	case model.SidecarProxy:


### PR DESCRIPTION
This is a performance improment, instead of do it in `BuildClusters`.  I do it in `pushConnection`, and set it to Proxy struct.  So here may prevent repeated locality calculate.

Note: in case proxy not belong to any service instance, we still can not get its locality. In k8s, we should support retrieve directly from the node it resides in. 