### PR TITLE
Let `kubectl get` show additional columns for popular Istio CRDs

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -83,7 +83,7 @@ spec:
     name: Hosts
     type: string
   - JSONPath: .spec.location
-    description: Whether the service should be considered external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
+    description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
     name: Location
     type: string
   - JSONPath: .spec.resolution

--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -28,6 +28,13 @@ spec:
     description: The destination hosts to which traffic is being sent
     name: Hosts
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -55,6 +62,13 @@ spec:
     description: The name of a service from the service registry
     name: Host
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -90,6 +104,13 @@ spec:
     description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
     name: Resolution
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -865,6 +886,13 @@ spec:
     description: Optional expression to compute the type of the monitored resource this log entry is being recorded on
     name: Res Type
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1054,6 +1082,13 @@ spec:
     description: The name of the ServiceRole object being referenced
     name: Reference
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -19,6 +19,15 @@ spec:
     - networking-istio-io
   scope: Namespaced
   version: v1alpha3
+  additionalPrinterColumns:
+  - JSONPath: .spec.gateways
+    description: The names of gateways and sidecars that should apply these routes
+    name: Gateways
+    type: string
+  - JSONPath: .spec.hosts
+    description: The destination hosts to which traffic is being sent
+    name: Hosts
+    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -41,6 +50,11 @@ spec:
     - networking-istio-io
   scope: Namespaced
   version: v1alpha3
+  additionalPrinterColumns:
+  - JSONPath: .spec.host
+    description: The name of a service from the service registry
+    name: Host
+    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -63,6 +77,19 @@ spec:
     - networking-istio-io
   scope: Namespaced
   version: v1alpha3
+  additionalPrinterColumns:
+  - JSONPath: .spec.hosts
+    description: The hosts associated with the ServiceEntry
+    name: Hosts
+    type: string
+  - JSONPath: .spec.location
+    description: Whether the service should be considered external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
+    name: Location
+    type: string
+  - JSONPath: .spec.resolution
+    description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    name: Resolution
+    type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -825,6 +852,19 @@ spec:
     - policy-istio-io
   scope: Namespaced
   version: v1alpha2
+  additionalPrinterColumns:
+  - JSONPath: .spec.severity
+    description: The importance of the log entry
+    name: Severity
+    type: string
+  - JSONPath: .spec.timestamp
+    description: The time value for the log entry
+    name: Timestamp
+    type: string
+  - JSONPath: .spec.monitored_resource_type
+    description: Optional expression to compute the type of the monitored resource this log entry is being recorded on
+    name: Res Type
+    type: string
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1009,6 +1049,11 @@ spec:
     - rbac-istio-io
   scope: Namespaced
   version: v1alpha1
+  additionalPrinterColumns:
+  - JSONPath: .spec.roleRef.name
+    description: The name of the ServiceRole object being referenced
+    name: Reference
+    type: string
 ---
 kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
Provides the additional columns for `kubectl get` output requested by https://github.com/istio/istio/issues/11552

This PR attempts to add columns to the output of `kubectl get <istio-type>` so that more information is provided without having to fetch and parse through the YaML.  The goal is to be more like the output of `istioctl get` which is now deprecated.

Unfortunately much of Istio's CRD fields are arrays which don't work well with custom printer columns (see https://github.com/kubernetes/kubectl/issues/517 ).  This gets as as close as I could get.

If you feel too many or two field fields are displayed here please add comments here or on the Issue.