### PR TITLE
Use service hostname as SNI match for TLS ports if virtual service is missing

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/tls.go
+++ b/pilot/pkg/networking/core/v1alpha3/tls.go
@@ -117,9 +117,6 @@ func buildSidecarOutboundTLSFilterChainOpts(env *model.Environment, node *model.
 	out := make([]*filterChainOpts, 0)
 	for _, config := range configs {
 		virtualService := config.Spec.(*v1alpha3.VirtualService)
-		// Ports marked as TLS will have SNI routing if and only if they have an accompanying
-		// virtual service for the same host, and the said virtual service has a TLS route block.
-		// Otherwise we treat ports marked as TLS as opaque TCP services.
 		for _, tls := range virtualService.Tls {
 			for _, match := range tls.Match {
 				if matchTLS(match, proxyLabels, gateways, listenPort.Port) {
@@ -150,20 +147,24 @@ func buildSidecarOutboundTLSFilterChainOpts(env *model.Environment, node *model.
 		}
 	}
 
-	// HTTPS or TLS ports without associated virtual service will be treated as opaque TCP traffic.
+	// HTTPS or TLS ports without associated virtual service
 	if !hasTLSMatch {
 		var clusterName string
+		var sniHosts []string
 		// The service could be nil if we are being called in the context of a sidecar config with
 		// user specified port in the egress listener. Since we dont know the destination service
 		// and this piece of code is establishing the final fallback path, we set the
 		// tcp proxy cluster to a blackhole cluster
 		if service != nil {
 			clusterName = model.BuildSubsetKey(model.TrafficDirectionOutbound, "", service.Hostname, listenPort.Port)
+			// Use the hostname as the SNI value
+			sniHosts = []string{string(service.Hostname)}
 		} else {
 			clusterName = util.BlackHoleCluster
 		}
 
 		out = append(out, &filterChainOpts{
+			sniHosts:         sniHosts,
 			destinationCIDRs: []string{destinationIPAddress},
 			networkFilters:   buildOutboundNetworkFiltersWithSingleDestination(env, node, clusterName, listenPort),
 		})

--- a/tests/e2e/tests/pilot/externalservice_test.go
+++ b/tests/e2e/tests/pilot/externalservice_test.go
@@ -35,9 +35,15 @@ func TestServiceEntry(t *testing.T) {
 			shouldBeReachable: true,
 		},
 		{
-			name:              "UNREACHABLE_bing.com_over_google_80",
+			name:              "REACHABLE_www.google.com_over_google_443",
 			config:            "testdata/networking/v1alpha3/service-entry-google.yaml",
-			url:               "http://bing.com",
+			url:               "https://www.google.com",
+			shouldBeReachable: true,
+		},
+		{
+			name:              "UNREACHABLE_bing.com_over_google_443",
+			config:            "testdata/networking/v1alpha3/service-entry-google.yaml",
+			url:               "https://bing.com",
 			shouldBeReachable: false,
 		},
 		{

--- a/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
     name: tcp
   - port: 9090
     targetPort: {{.port4}}
-    name: https
+    name: tcp
 {{end}}
   - port: 70
     targetPort: {{.port5}}

--- a/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/app.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
     name: tcp
   - port: 9090
     targetPort: {{.port4}}
-    name: tcp
+    name: tcp-two
 {{end}}
   - port: 70
     targetPort: {{.port5}}

--- a/tests/e2e/tests/pilot/testdata/statefulset.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/statefulset.yaml.tmpl
@@ -9,7 +9,7 @@ spec:
   clusterIP: None
   ports:
   - port: 19090
-    name: https
+    name: tcp
   selector:
     app: {{.service}}
 ---


### PR DESCRIPTION
This resolves the common complaint that you need a virtualService with TLS
block to get SNI based routing for ports marked as TLS.

If a virtualService is specified and it matches the service host, it takes
precedance. Else, we fallback to using the service's hostname as SNI match.

This also fixes the bug where a service entry with TLS port but no virtual service
effectively ends up allowing traffic to any service on that port.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>