### PR TITLE
Copy all values from subcharts values to the main values

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -11,6 +11,12 @@ global:
   # monitoring port used by mixer, pilot, galley
   monitoringPort: 15014
 
+
+  # Gateway used for legacy k8s Ingress resources. By default it is
+  # using 'istio:ingress', to match 0.8 config. It requires that
+  # ingress.enabled is set to true. You can also set it
+  # to ingressgateway, or any other gateway you define in the 'gateway'
+  # section.
   k8sIngress:
     enabled: false
     # Gateway used for legacy k8s Ingress resources. By default it is

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -1,105 +1,3 @@
-#
-# Gateways Configuration, refer to the charts/gateways/values.yaml
-# for detailed configuration
-#
-gateways:
-  enabled: true
-
-#
-# sidecar-injector webhook configuration, refer to the
-# charts/sidecarInjectorWebhook/values.yaml for detailed configuration
-#
-sidecarInjectorWebhook:
-  enabled: true
-  # If true, webhook or istioctl injector will rewrite PodSpec for liveness
-  # health check to redirect request to sidecar. This makes liveness check work
-  # even when mTLS is enabled.
-  rewriteAppHTTPProbe: false
-
-#
-# galley configuration, refer to charts/galley/values.yaml
-# for detailed configuration
-#
-galley:
-  enabled: true
-
-#
-# mixer configuration
-#
-mixer:
-  policy:
-    enabled: true
-  telemetry:
-    enabled: true
-
-#
-# pilot configuration
-#
-pilot:
-  enabled: true
-  traceSampling: 1.0
-
-#
-# security configuration
-#
-security:
-  enabled: true
-
-#
-# nodeagent configuration
-#
-nodeagent:
-  enabled: false
-
-#
-# ingress configuration
-#
-ingress:
-  enabled: false
-
-#
-# addon grafana configuration
-#
-grafana:
-  enabled: false
-
-#
-# addon prometheus configuration
-#
-prometheus:
-  enabled: true
-
-#
-# addon servicegraph configuration
-#
-servicegraph:
-  enabled: false
-
-#
-# addon jaeger tracing configuration
-#
-tracing:
-  enabled: false
-
-#
-# addon kiali tracing configuration
-#
-kiali:
-  enabled: false
-
-#
-# Istio CNI plugin enabled
-#   If true, the privileged initContainer istio-init is not needed to perform the traffic redirect
-#   settings for the istio-proxy.
-#
-istio_cni:
-  enabled: false
-
-# addon Istio CoreDNS configuration
-#
-istiocoredns:
-  enabled: false
-
 # Common settings used among istio subcharts.
 global:
   # Default hub for Istio images.
@@ -415,3 +313,627 @@ global:
   # This field is set to false by default, so 'helm template ...'
   # will ignore the helm test yaml files when generating the template
   enableHelmTest: false
+
+#
+# ingress configuration
+#
+ingress:
+  enabled: false
+  autoscaleEnabled: true
+  autoscaleMin: 1
+  autoscaleMax: 5
+  # specify replicaCount when autoscaleEnabled: false
+  # replicaCount: 1
+  nodeSelector: {}
+
+  service:
+    annotations: {}
+    loadBalancerIP: ""
+    type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+    #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
+    ports:
+      - port: 80
+        name: http
+        nodePort: 32000
+      - port: 443
+        name: https
+    selector:
+      istio: ingress
+
+#
+# Gateways Configuration
+# By default (if enabled) a pair of Ingress and Egress Gateways will be created for the mesh.
+# You can add more gateways in addition to the defaults but make sure those are uniquely named
+# and that NodePorts are not conflicting.
+# Disable specifc gateway by setting the `enabled` to false.
+#
+gateways:
+  enabled: true
+
+  istio-ingressgateway:
+    enabled: true
+    #
+    # Secret Discovery Service (SDS) configuration for ingress gateway.
+    #
+    sds:
+      # If true, ingress gateway fetches credentials from SDS server to handle TLS connections.
+      enabled: false
+      # SDS server that watches kubernetes secrets and provisions credentials to ingress gateway.
+      # This server runs in the same pod as ingress gateway.
+      image: node-agent-k8s
+    labels:
+      app: istio-ingressgateway
+      istio: ingressgateway
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 5
+    # specify replicaCount when autoscaleEnabled: false
+    # replicaCount: 1
+    resources: {}
+      # limits:
+      #  cpu: 100m
+      #  memory: 128Mi
+      #requests:
+      #  cpu: 1800m
+    #  memory: 256Mi
+    cpu:
+      targetAverageUtilization: 80
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    externalIPs: []
+    serviceAnnotations: {}
+    podAnnotations: {}
+    type: LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be
+    #externalTrafficPolicy: Local #change to Local to preserve source IP or Cluster for default behaviour or leave commented out
+    ports:
+      ## You can add custom gateway ports
+      - port: 80
+        targetPort: 80
+        name: http2
+        nodePort: 31380
+      - port: 443
+        name: https
+        nodePort: 31390
+      # Example of a port to add. Remove if not needed
+      - port: 31400
+        name: tcp
+        nodePort: 31400
+      ### PORTS FOR UI/metrics #####
+      ## Disable if not needed
+      - port: 15029
+        targetPort: 15029
+        name: https-kiali
+      - port: 15030
+        targetPort: 15030
+        name: https-prometheus
+      - port: 15031
+        targetPort: 15031
+        name: https-grafana
+      - port: 15032
+        targetPort: 15032
+        name: https-tracing
+        # This is the port where sni routing happens
+      - port: 15443
+        targetPort: 15443
+        name: tls
+    #### MESH EXPANSION PORTS  ########
+    # Pilot and Citadel MTLS ports are enabled in gateway - but will only redirect
+    # to pilot/citadel if global.meshExpansion settings are enabled.
+    # Delete these ports if mesh expansion is not enabled, to avoid
+    # exposing unnecessary ports on the web.
+    # You can remove these ports if you are not using mesh expansion
+    meshExpansionPorts:
+      - port: 15011
+        targetPort: 15011
+        name: tcp-pilot-grpc-tls
+      - port: 15004
+        targetPort: 15004
+        name: tcp-mixer-grpc-tls
+      - port: 8060
+        targetPort: 8060
+        name: tcp-citadel-grpc-tls
+      - port: 853
+        targetPort: 853
+        name: tcp-dns-tls
+    ####### end MESH EXPANSION PORTS ######
+    ##############
+    secretVolumes:
+      - name: ingressgateway-certs
+        secretName: istio-ingressgateway-certs
+        mountPath: /etc/istio/ingressgateway-certs
+      - name: ingressgateway-ca-certs
+        secretName: istio-ingressgateway-ca-certs
+        mountPath: /etc/istio/ingressgateway-ca-certs
+    ### Advanced options ############
+    env:
+      # A gateway with this mode ensures that pilot generates an additional
+      # set of clusters for internal services but without Istio mTLS, to
+      # enable cross cluster routing.
+      ISTIO_META_ROUTER_MODE: "sni-dnat"
+    nodeSelector: {}
+
+  istio-egressgateway:
+    enabled: true
+    labels:
+      app: istio-egressgateway
+      istio: egressgateway
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 5
+    # specify replicaCount when autoscaleEnabled: false
+    # replicaCount: 1
+    cpu:
+      targetAverageUtilization: 80
+    serviceAnnotations: {}
+    podAnnotations: {}
+    type: ClusterIP #change to NodePort or LoadBalancer if need be
+    ports:
+      - port: 80
+        name: http2
+      - port: 443
+        name: https
+        # This is the port where sni routing happens
+      - port: 15443
+        targetPort: 15443
+        name: tls
+    secretVolumes:
+      - name: egressgateway-certs
+        secretName: istio-egressgateway-certs
+        mountPath: /etc/istio/egressgateway-certs
+      - name: egressgateway-ca-certs
+        secretName: istio-egressgateway-ca-certs
+        mountPath: /etc/istio/egressgateway-ca-certs
+    #### Advanced options ########
+    env:
+      # Set this to "external" if and only if you want the egress gateway to
+      # act as a transparent SNI gateway that routes mTLS/TLS traffic to
+      # external services defined using service entries, where the service
+      # entry has resolution set to DNS, has one or more endpoints with
+      # network field set to "external". By default its set to "" so that
+      # the egress gateway sees the same set of endpoints as the sidecars
+      # preserving backward compatibility
+      # ISTIO_META_REQUESTED_NETWORK_VIEW: ""
+      # A gateway with this mode ensures that pilot generates an additional
+      # set of clusters for internal services but without Istio mTLS, to
+      # enable cross cluster routing.
+      ISTIO_META_ROUTER_MODE: "sni-dnat"
+    nodeSelector: {}
+
+  # Mesh ILB gateway creates a gateway of type InternalLoadBalancer,
+  # for mesh expansion. It exposes the mtls ports for Pilot,CA as well
+  # as non-mtls ports to support upgrades and gradual transition.
+  istio-ilbgateway:
+    enabled: false
+    labels:
+      app: istio-ilbgateway
+      istio: ilbgateway
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 5
+    # specify replicaCount when autoscaleEnabled: false
+    # replicaCount: 1
+    cpu:
+      targetAverageUtilization: 80
+    resources:
+      requests:
+        cpu: 800m
+        memory: 512Mi
+      #limits:
+      #  cpu: 1800m
+      #  memory: 256Mi
+    loadBalancerIP: ""
+    serviceAnnotations:
+      cloud.google.com/load-balancer-type: "internal"
+    podAnnotations: {}
+    type: LoadBalancer
+    ports:
+      ## You can add custom gateway ports - google ILB default quota is 5 ports,
+      - port: 15011
+        name: grpc-pilot-mtls
+      # Insecure port - only for migration from 0.8. Will be removed in 1.1
+      - port: 15010
+        name: grpc-pilot
+      - port: 8060
+        targetPort: 8060
+        name: tcp-citadel-grpc-tls
+      # Port 5353 is forwarded to kube-dns
+      - port: 5353
+        name: tcp-dns
+    secretVolumes:
+      - name: ilbgateway-certs
+        secretName: istio-ilbgateway-certs
+        mountPath: /etc/istio/ilbgateway-certs
+      - name: ilbgateway-ca-certs
+        secretName: istio-ilbgateway-ca-certs
+        mountPath: /etc/istio/ilbgateway-ca-certs
+    nodeSelector: {}
+
+#
+# sidecar-injector webhook configuration
+#
+sidecarInjectorWebhook:
+  enabled: true
+  replicaCount: 1
+  image: sidecar_injector
+  enableNamespacesByDefault: false
+  nodeSelector: {}
+  # If true, webhook or istioctl injector will rewrite PodSpec for liveness
+  # health check to redirect request to sidecar. This makes liveness check work
+  # even when mTLS is enabled.
+  rewriteAppHTTPProbe: false
+
+#
+# galley configuration, refer to charts/galley/values.yaml
+# for detailed configuration
+#
+galley:
+  enabled: true
+  replicaCount: 1
+  image: galley
+  nodeSelector: {}
+
+#
+# mixer configuration
+#
+mixer:
+  image: mixer
+
+  env:
+    GODEBUG: gctrace=2
+
+  policy:
+    replicaCount: 1
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 5
+    cpu:
+      targetAverageUtilization: 80
+
+  telemetry:
+    replicaCount: 1
+    autoscaleEnabled: true
+    autoscaleMin: 1
+    autoscaleMax: 5
+    cpu:
+      targetAverageUtilization: 80
+    sessionAffinityEnabled: false
+
+  podAnnotations: {}
+  nodeSelector: {}
+
+  adapters:
+    kubernetesenv:
+      enabled: true
+    stdio:
+      enabled: true
+      outputAsJson: true
+    prometheus:
+      enabled: true
+      metricsExpiryDuration: 10m
+    # Setting this to false sets the useAdapterCRDs mixer startup argument to false
+    useAdapterCRDs: true
+
+#
+# pilot configuration
+#
+pilot:
+  enabled: true
+  autoscaleEnabled: true
+  autoscaleMin: 1
+  autoscaleMax: 5
+  # specify replicaCount when autoscaleEnabled: false
+  # replicaCount: 1
+  image: pilot
+  sidecar: true
+  # Resources for a small pilot install
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2048Mi
+  env:
+    PILOT_PUSH_THROTTLE_COUNT: 100
+    GODEBUG: gctrace=2
+  cpu:
+    targetAverageUtilization: 80
+  nodeSelector: {}
+  traceSampling: 1.0
+
+#
+# security configuration
+#
+security:
+  enabled: true
+  replicaCount: 1
+  image: citadel
+  selfSigned: true # indicate if self-signed CA is used.
+  createMeshPolicy: true
+  nodeSelector: {}
+
+#
+# nodeagent configuration
+#
+nodeagent:
+  enabled: false
+  image: node-agent-k8s
+  env:
+    # name of authentication provider.
+    CA_PROVIDER: ""
+    # CA endpoint.
+    CA_ADDR: ""
+    # names of authentication provider's plugins.
+    Plugins: ""
+  nodeSelector: {}
+
+#
+# addon grafana configuration
+#
+grafana:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: grafana/grafana
+    tag: 5.4.0
+  ingress:
+    enabled: false
+    ## Used to create an Ingress record.
+    hosts:
+      - grafana.local
+    annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: grafana-tls
+    #   hosts:
+    #     - grafana.local
+  persist: false
+  storageClassName: ""
+  accessMode: ReadWriteMany
+  security:
+    enabled: false
+    secretName: grafana
+    usernameKey: username
+    passphraseKey: passphrase
+  nodeSelector: {}
+  contextPath: /grafana
+  service:
+    annotations: {}
+    name: http
+    type: ClusterIP
+    externalPort: 3000
+    loadBalancerIP:
+    loadBalancerSourceRanges:
+
+  gateway:
+    enabled: false
+
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          access: proxy
+          isDefault: true
+          jsonData:
+            timeInterval: 5s
+          editable: true
+
+  dashboardProviders:
+    dashboardproviders.yaml:
+      apiVersion: 1
+      providers:
+        - name: 'istio'
+          orgId: 1
+          folder: 'istio'
+          type: file
+          disableDeletion: false
+          options:
+            path: /var/lib/grafana/dashboards/istio
+
+#
+# addon prometheus configuration
+#
+prometheus:
+  enabled: true
+  replicaCount: 1
+  hub: docker.io/prom
+  tag: v2.3.1
+  retention: 6h
+  nodeSelector: {}
+
+  # Controls the frequency of prometheus scraping
+  scrapeInterval: 15s
+
+  contextPath: /prometheus
+
+  ingress:
+    enabled: false
+    ## Used to create an Ingress record.
+    hosts:
+      - prometheus.local
+    annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: prometheus-tls
+    #   hosts:
+    #     - prometheus.local
+
+  service:
+    annotations: {}
+    nodePort:
+      enabled: false
+      port: 32090
+
+  gateway:
+    enabled: false
+
+  security:
+    enabled: true
+
+#
+# addon servicegraph configuration
+#
+servicegraph:
+  enabled: false
+  replicaCount: 1
+  image: servicegraph
+  nodeSelector: {}
+  service:
+    annotations: {}
+    name: http
+    type: ClusterIP
+    externalPort: 8088
+    loadBalancerIP:
+    loadBalancerSourceRanges:
+  ingress:
+    enabled: false
+    # Used to create an Ingress record.
+    hosts:
+      - servicegraph.local
+    annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: servicegraph-tls
+    #   hosts:
+    #     - servicegraph.local
+  # prometheus address
+  prometheusAddr: http://prometheus:9090
+
+#
+# addon jaeger tracing configuration
+#
+tracing:
+  enabled: false
+
+  provider: jaeger
+  nodeSelector: {}
+
+  jaeger:
+    hub: docker.io/jaegertracing
+    tag: 1.9
+    memory:
+      max_traces: 50000
+
+  zipkin:
+    hub: docker.io/openzipkin
+    tag: 2
+    probeStartupDelay: 200
+    queryPort: 9411
+    resources:
+      limits:
+        cpu: 300m
+        memory: 900Mi
+      requests:
+        cpu: 150m
+        memory: 900Mi
+    javaOptsHeap: 700
+    # From: https://github.com/openzipkin/zipkin/blob/master/zipkin-server/src/main/resources/zipkin-server-shared.yml#L51
+    # Maximum number of spans to keep in memory.  When exceeded, oldest traces (and their spans) will be purged.
+    # A safe estimate is 1K of memory per span (each span with 2 annotations + 1 binary annotation), plus
+    # 100 MB for a safety buffer.  You'll need to verify in your own environment.
+    maxSpans: 500000
+    node:
+      cpus: 2
+
+  service:
+    annotations: {}
+    name: http
+    type: ClusterIP
+    externalPort: 9411
+
+  ingress:
+    enabled: false
+    # Used to create an Ingress record.
+    hosts:
+    # - tracing.local
+    annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: tracing-tls
+    #   hosts:
+    #     - tracing.local
+
+  gateway:
+    enabled: false
+    name: ingressgateway
+
+#
+# addon kiali tracing configuration
+#
+kiali:
+  enabled: false
+  replicaCount: 1
+  hub: docker.io/kiali
+  tag: v0.12
+  contextPath: /kiali
+  nodeSelector: {}
+  ingress:
+    enabled: false
+    ## Used to create an Ingress record.
+    hosts:
+      - kiali.local
+    annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: kiali-tls
+    #   hosts:
+    #     - kiali.local
+  gateway:
+    enabled: false
+  dashboard:
+    secretName: kiali
+    usernameKey: username
+    passphraseKey: passphrase
+
+    # Override the automatically detected Grafana URL, useful when Grafana service has no ExternalIPs
+    # grafanaURL:
+
+    # Override the automatically detected Jaeger URL, useful when Jaeger service has no ExternalIPs
+    # jaegerURL:
+  prometheusAddr: http://prometheus:9090
+
+  # When true, a secret will be created with a default username and password. Useful for demos.
+  createDemoSecret: false
+
+#
+# Istio CNI plugin enabled
+#   If true, the privileged initContainer istio-init is not needed to perform the traffic redirect
+#   settings for the istio-proxy.
+#
+istio_cni:
+  enabled: false
+
+# addon Istio CoreDNS configuration
+#
+istiocoredns:
+  enabled: false
+  replicaCount: 1
+  coreDNSImage: coredns/coredns:1.1.2
+  # Source code for the plugin can be found at
+  # https://github.com/istio-ecosystem/istio-coredns-plugin
+  # The plugin listens for DNS requests from coredns server at 127.0.0.1:8053
+  coreDNSPluginImage: istio/coredns-plugin:0.1-istio-1.1
+  nodeSelector: {}
+
+# Certmanager uses ACME to sign certificates. Since Istio gateways are
+# mounting the TLS secrets the Certificate CRDs must be created in the
+# istio-system namespace. Once the certificate has been created, the
+# gateway must be updated by adding 'secretVolumes'. After the gateway
+# restart, DestinationRules can be created using the ACME-signed certificates.
+certmanager:
+  enabled: false
+  hub: quay.io/jetstack
+  tag: v0.5.0
+  resources: {}
+  nodeSelector: {}


### PR DESCRIPTION
This allows doing a proper diff with 1.0, and gives user a way to see all the settings affecting the install
instead of having to go open 20 different files.

Overrides should not be affected - but we need to decide if we keep a values.yaml in the old place and update both (probably not - I can remove them based on review)