### PR TITLE
[WIP] Improve no-policy caching and perf in mixer

### DIFF
--- a/mixer/pkg/api/grpcServer_test.go
+++ b/mixer/pkg/api/grpcServer_test.go
@@ -164,6 +164,10 @@ func (ts *testState) Preprocess(ctx context.Context, req attribute.Bag, resp *at
 	return ts.preproc(ctx, req, resp)
 }
 
+func (ts *testState) HasCheckDestinations(ctx context.Context, req attribute.Bag) bool {
+	return true
+}
+
 func TestCheck(t *testing.T) {
 	ts, err := prepTestState()
 	if err != nil {

--- a/mixer/pkg/api/perf_test.go
+++ b/mixer/pkg/api/perf_test.go
@@ -112,6 +112,10 @@ func (bs *benchState) cleanupBenchState() {
 	bs.deleteGRPCServer()
 }
 
+func (ts *benchState) HasCheckDestinations(ctx context.Context, req attribute.Bag) bool {
+	return true
+}
+
 func (bs *benchState) Preprocess(ctx context.Context, requestBag attribute.Bag, responseBag *attribute.MutableBag) error {
 	return nil
 }

--- a/mixer/pkg/runtime/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher.go
@@ -121,8 +121,9 @@ const (
 
 func (d *Impl) HasCheckDestinations(ctx context.Context, bag attribute.Bag) bool {
 	s := d.getSession(ctx, tpb.TEMPLATE_VARIETY_CHECK, bag)
-	destinations := s.rc.Routes.GetDestinations(s.variety, getIdentityNamespace(s.bag))
-	return destinations.Count() > 0
+	destinations := s.rc.Routes.GetDestinations(s.variety, getIdentityNamespace(s.bag)).Count()
+	d.putSession(s)
+	return destinations > 0
 }
 
 // Check implementation of runtime.Impl.

--- a/mixer/pkg/runtime/dispatcher/dispatcher.go
+++ b/mixer/pkg/runtime/dispatcher/dispatcher.go
@@ -34,6 +34,10 @@ import (
 
 // Dispatcher dispatches incoming API calls to configured adapters.
 type Dispatcher interface {
+
+	// HasCheckDestinations...
+	HasCheckDestinations(ctx context.Context, requestBag attribute.Bag) bool
+
 	// Preprocess dispatches to the set of adapters that will run before any
 	// other adapters in Mixer (aka: the Check, Report, Quota adapters).
 	Preprocess(ctx context.Context, requestBag attribute.Bag, responseBag *attribute.MutableBag) error
@@ -114,6 +118,12 @@ const (
 	defaultValidDuration = 1 * time.Minute
 	defaultValidUseCount = 10000
 )
+
+func (d *Impl) HasCheckDestinations(ctx context.Context, bag attribute.Bag) bool {
+	s := d.getSession(ctx, tpb.TEMPLATE_VARIETY_CHECK, bag)
+	destinations := s.rc.Routes.GetDestinations(s.variety, getIdentityNamespace(s.bag))
+	return destinations.Count() > 0
+}
 
 // Check implementation of runtime.Impl.
 func (d *Impl) Check(ctx context.Context, bag attribute.Bag) (adapter.CheckResult, error) {


### PR DESCRIPTION
WARNING: I have not tested or attempted to validate anything in this PR yet. This PR is for discussion purposes only at this point.

What do we think about something like these changes to Mixer?

- short-circuit `Check` when no configured handlers match (meaning no APAs run -- potentially problematic depending on `match` clauses, though this can be moved around a bit)
- only return `destination.uid` as the sole referenced attribute (maximizing cache hit)
- increase the validity duration/count to provide more robustness and lower tail latency (hopefully)

This would be an alternative to disabling `Check` by default while (hopefully) still reducing the cost of `Check` w/o policy to near zero.

Thoughts?

/cc @geeknoid @mandarjog @kyessenov 