### PR TITLE
istioctl validation improvements

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -144,7 +144,7 @@ func main() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }
 

--- a/istioctl/pkg/validate/validate_test.go
+++ b/istioctl/pkg/validate/validate_test.go
@@ -102,6 +102,15 @@ spec:
   - handler: handler-for-valid-rule.denier
     instances:
     - instance-for-valid-rule.checknothing`
+	invalidUnsupportedKey = `
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: productpage
+unexpected_junk:
+   still_more_junk:
+spec:
+  host: productpage`
 )
 
 func fromYAML(in string) *unstructured.Unstructured {
@@ -184,6 +193,12 @@ func TestValidateCommand(t *testing.T) {
 	invalidFilename, closeInvalidFile := createTestFile(t, invalid)
 	defer closeInvalidFile.Close()
 
+	unsupportedMixerRuleFilename, closeMixerRuleFile := createTestFile(t, unsupportedMixerRule)
+	defer closeMixerRuleFile.Close()
+
+	unsupportedKeyFilename, closeUnsupportedKeyFile := createTestFile(t, invalidUnsupportedKey)
+	defer closeUnsupportedKeyFile.Close()
+
 	cases := []struct {
 		name      string
 		args      []string
@@ -211,7 +226,12 @@ func TestValidateCommand(t *testing.T) {
 		},
 		{
 			name:      "unsupported mixer rule",
-			args:      []string{"--filename", unsupportedMixerRule},
+			args:      []string{"--filename", unsupportedMixerRuleFilename},
+			wantError: true,
+		},
+		{
+			name:      "invalid top-level key",
+			args:      []string{"--filename", unsupportedKeyFilename},
 			wantError: true,
 		},
 	}


### PR DESCRIPTION
Partially resolves https://github.com/istio/istio/issues/11634 by detecting bogus top-level YAML keys.

Resolves https://github.com/istio/istio/issues/11760 by printing the actual resource type being skipped instead of pretending anything istioctl doesn't validate is a mixer rule.

Validates every object in the YaML instead of stopping after the first error.

Changes the $? process exit code on for istioctl from 255 to 1, following exit level recommendations and allowing `xargs` to work (e.g. `find samples -name "*.yaml" | xargs -n 1 istioctl validate -f`)

Repairs a long-standing bug in the test of mixer validation error messages.