### PR TITLE
Remove `helm package -u` in favor of `helm package`

### DIFF
--- a/release/gcb/helm_charts.sh
+++ b/release/gcb/helm_charts.sh
@@ -42,13 +42,12 @@ CHARTS=(
 # Prepare helm setup
 mkdir -vp "$HELM_DIR"
 $HELM init --client-only
-$HELM repo add istio.io https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
 
 # Create a package for each charts and build the repo index.
 mkdir -vp "$HELM_BUILD_DIR"
 for CHART_PATH in "${CHARTS[@]}"
 do
-    $HELM package -u "$CHART_PATH" -d "$HELM_BUILD_DIR"
+    $HELM package "$CHART_PATH" -d "$HELM_BUILD_DIR"
 done
 
 $HELM repo index "$HELM_BUILD_DIR"


### PR DESCRIPTION
This work removes the ability to include packages from
external helm repositories.  This is to remove the
`helm dep update` step.

The hidden implication here is that CNI must be installed
indepently but still enabled in the chart for it to be used.

Not installing the CNI chart or manifest while enabling CNI
will result in sidecar injector failures.