### PR TITLE
Add an e2e test to validate fault injection telemetry.

### DIFF
--- a/samples/bookinfo/networking/fault-injection-details-v1.yaml
+++ b/samples/bookinfo/networking/fault-injection-details-v1.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: details
+spec:
+  hosts:
+  - details
+  http:
+  - fault:
+      abort:
+        httpStatus: 555
+        percent: 100
+    route:
+    - destination:
+        host: details
+        subset: v1
+  - route:
+    - destination:
+        host: details
+        subset: v1
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: details
+spec:
+  host: details
+  subsets:
+  - name: v1
+    labels:
+      version: v1

--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -91,21 +91,22 @@ var (
 	ingressName        = "ingressgateway"
 	productPageTimeout = 60 * time.Second
 
-	networkingDir               = "networking"
-	policyDir                   = "policy"
-	rateLimitRule               = "mixer-rule-ratings-ratelimit"
-	denialRule                  = "mixer-rule-ratings-denial"
-	ingressDenialRule           = "mixer-rule-ingress-denial"
-	newTelemetryRule            = "mixer-rule-additional-telemetry"
-	kubeenvTelemetryRule        = "mixer-rule-kubernetesenv-telemetry"
-	destinationRuleAll          = "destination-rule-all"
-	routeAllRule                = "virtual-service-all-v1"
-	routeReviewsVersionsRule    = "virtual-service-reviews-v2-v3"
-	routeReviewsV3Rule          = "virtual-service-reviews-v3"
-	tcpDbRule                   = "virtual-service-ratings-db"
-	bookinfoGateway             = "bookinfo-gateway"
-	redisQuotaRollingWindowRule = "mixer-rule-ratings-redis-quota-rolling-window"
-	redisQuotaFixedWindowRule   = "mixer-rule-ratings-redis-quota-fixed-window"
+	networkingDir                = "networking"
+	policyDir                    = "policy"
+	rateLimitRule                = "mixer-rule-ratings-ratelimit"
+	denialRule                   = "mixer-rule-ratings-denial"
+	ingressDenialRule            = "mixer-rule-ingress-denial"
+	newTelemetryRule             = "mixer-rule-additional-telemetry"
+	kubeenvTelemetryRule         = "mixer-rule-kubernetesenv-telemetry"
+	destinationRuleAll           = "destination-rule-all"
+	routeAllRule                 = "virtual-service-all-v1"
+	routeReviewsVersionsRule     = "virtual-service-reviews-v2-v3"
+	routeReviewsV3Rule           = "virtual-service-reviews-v3"
+	tcpDbRule                    = "virtual-service-ratings-db"
+	bookinfoGateway              = "bookinfo-gateway"
+	redisQuotaRollingWindowRule  = "mixer-rule-ratings-redis-quota-rolling-window"
+	redisQuotaFixedWindowRule    = "mixer-rule-ratings-redis-quota-fixed-window"
+	faultInjectionNetworkingRule = "fault-injection-details-v1"
 
 	defaultRules []string
 	rules        []string
@@ -136,7 +137,7 @@ func (t *testConfig) Setup() (err error) {
 		rules = append(rules, *r)
 	}
 
-	rs = []*string{&routeReviewsVersionsRule, &routeReviewsV3Rule, &tcpDbRule}
+	rs = []*string{&routeReviewsVersionsRule, &routeReviewsV3Rule, &tcpDbRule, &faultInjectionNetworkingRule}
 	for _, r := range rs {
 		*r = filepath.Join(bookinfoSampleDir, networkingDir, *r)
 		rules = append(rules, *r)
@@ -936,6 +937,75 @@ func sendTraffic(t *testing.T, msg string, calls int64) *fhttp.HTTPRunnerResults
 		fatalf(t, "Generating traffic via fortio failed: %v", err)
 	}
 	return res
+}
+
+// This test validates that, for telemetry generated from FI, the destination workload information
+// is all unknown. This was added in response to an issue in which the mixer Report protocol implementation
+// was not properly accounting for attribute deletion in batches. The setup and execution mirror the repro
+// detailed in https://github.com/istio/istio/issues/11151.
+func TestFaultInjectionTelemetry(t *testing.T) {
+	if err := replaceRouteRule(faultInjectionNetworkingRule); err != nil {
+		fatalf(t, "failed to apply fault injection config: %v", err)
+	}
+	defer func() {
+		if err := replaceRouteRule(routeAllRule); err != nil {
+			t.Fatalf("Could not restore default routing config: %v", err)
+		}
+	}()
+
+	allowRuleSync()
+
+	// setup prometheus API
+	promAPI, err := promAPI()
+	if err != nil {
+		fatalf(t, "Could not build prometheus API client: %v", err)
+	}
+
+	sendTraffic(t, "Sending traffic...", 100)
+	allowPrometheusSync()
+
+	retry := util.Retrier{
+		BaseDelay: 30 * time.Second,
+		Retries:   4,
+	}
+
+	var vector model.Vector
+
+	retryFn := func(_ context.Context, i int) error {
+		t.Helper()
+		t.Logf("Trying to find metrics via promql (attempt %d)...", i)
+		fiReqsQuery := `sum(istio_requests_total{response_code="555", response_flags="FI"}) by (destination_workload, destination_app)`
+		t.Logf("prometheus query: %s", fiReqsQuery)
+		result, err := promAPI.Query(context.Background(), fiReqsQuery, time.Now())
+		if err != nil {
+			return fmt.Errorf("could not get results for query: %s: %v", fiReqsQuery, err)
+		}
+		if result.Type() != model.ValVector {
+			return fmt.Errorf("query result not a model.Vector; was %s", result.Type().String())
+		}
+		vector = result.(model.Vector)
+		return nil
+	}
+
+	if _, err := retry.Retry(context.Background(), retryFn); err != nil {
+		dumpMixerMetrics()
+		fatalf(t, "Could not get metrics from prometheus: %v", err)
+	}
+
+	if got, want := len(vector), 1; got != want {
+		t.Errorf("got %d different labels for destination_workload and destination_app, want %d", got, want)
+	}
+
+	got, err := vectorValue(vector, map[string]string{"destination_workload": "unknown", "destination_app": "unknown"})
+	if err != nil {
+		t.Errorf("could not get extract value from: %#v: %v", vector, err)
+	}
+
+	want := 50.0
+	if got < want {
+		t.Errorf("got %f total fault injected requests, want at least %f", got, want)
+	}
+
 }
 
 func TestMetricsAndRateLimitAndRulesAndBookinfo(t *testing.T) {


### PR DESCRIPTION
This attempts to provide validation of telemetry for FI to guard against
recurrence of issues such as: https://github.com/istio/istio/issues/11151.

It adds a new test in the mixer suite that installs custom virtual
service and destination rules that inject faults at 100% (using error code 555).

The test validates that the destination workload information is
"unknown" and that we receive telemetry with the `FI` response flag.

Ran this on a test cluster:

```
--- PASS: TestFaultInjectionTelemetry (59.17s)
    mixer_test.go:918: Sending traffic...
    retry.go:86: Trying to find metrics via promql (attempt 1)...
    retry.go:86: prometheus query: sum(istio_requests_total{response_code="555", response_flags="FI"}) by (destination_workload, destination_app)
PASS

```