### PR TITLE
Add some missing fields in zipkin template in tracing subchart

### DIFF
--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
@@ -3,22 +3,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-zipkin
+  name: istio-tracing
   namespace: {{ .Release.Namespace }}
   labels:
     app: zipkin
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    release: {{ .Release.Name }}
+    chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   template:
     metadata:
       labels:
         app: zipkin
+        chart: {{ template "tracing.chart" . }}
+        heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
+{{- if .Values.global.priorityClassName }}
+      priorityClassName: "{{ .Values.global.priorityClassName }}"
+{{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: zipkin
           image: "{{ .Values.zipkin.hub }}/zipkin:{{ .Values.zipkin.tag }}"
           ports:
             - containerPort: {{ .Values.zipkin.queryPort }}
@@ -51,5 +59,7 @@ spec:
               value: "mem"
             - name: ZIPKIN_STORAGE_MEM_MAXSPANS
               value: "{{ .Values.zipkin.maxSpans }}"
+      affinity:
+      {{- include "nodeaffinity" . | indent 6 }}
 
 {{ end }}

--- a/install/kubernetes/helm/istio/charts/tracing/values.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/values.yaml
@@ -1,5 +1,5 @@
 #
-# addon jeager tracing configuration
+# addon jaeger tracing configuration
 #
 enabled: false
 


### PR DESCRIPTION
To be consistent with jaeger template in tracing subchart, this pr add some missing fields in zipkin template.
1. add field `priorityClassName`
2. add field `nodeAffinity`
3. add sidecar annotation


Signed-off-by: mathspanda <mathspanda826@gmail.com>