### PR TITLE
Fix labels on manifests

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -563,6 +563,11 @@ kind: metric
 metadata:
   name: tcpconnectionsopened
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mixer.name" . }}
+    chart: {{ template "mixer.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   value: "1"
   dimensions:
@@ -589,6 +594,11 @@ kind: metric
 metadata:
   name: tcpconnectionsclosed
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mixer.name" . }}
+    chart: {{ template "mixer.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   value: "1"
   dimensions:
@@ -859,6 +869,11 @@ kind: rule
 metadata:
   name: promtcpconnectionopen
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mixer.name" . }}
+    chart: {{ template "mixer.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
   actions:
@@ -871,6 +886,11 @@ kind: rule
 metadata:
   name: promtcpconnectionclosed
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "mixer.name" . }}
+    chart: {{ template "mixer.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
   actions:

--- a/install/kubernetes/helm/istio/templates/_helpers.tpl
+++ b/install/kubernetes/helm/istio/templates/_helpers.tpl
@@ -28,7 +28,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "istio.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
I noticed there were 4 resources in the mixer chart that don't have the standard labels. (This breaks some of our process.) This PR adds the missing labels.

I also noticed the main istio chart uses the old style chart label of `istio-1.1.0` instead of the new `istio` label. This PR updates the helper to match the others.