### PR TITLE
Don't admit CRDs with unknown top-level keys

### DIFF
--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -48,6 +48,15 @@ var (
 	runtimeScheme = runtime.NewScheme()
 	codecs        = serializer.NewCodecFactory(runtimeScheme)
 	deserializer  = codecs.UniversalDeserializer()
+
+	// Expect AdmissionRequest to only include these top-level field names
+	validFields = map[string]bool{
+		"apiVersion": true,
+		"kind":       true,
+		"metadata":   true,
+		"spec":       true,
+		"status":     true,
+	}
 )
 
 func init() {
@@ -441,25 +450,34 @@ func (wh *Webhook) admitPilot(request *admissionv1beta1.AdmissionRequest) *admis
 
 	var obj crd.IstioKind
 	if err := yaml.Unmarshal(request.Object.Raw, &obj); err != nil {
+		scope.Infof("cannot decode configuration: %v", err)
 		reportValidationFailed(request, reasonYamlDecodeError)
 		return toAdmissionResponse(fmt.Errorf("cannot decode configuration: %v", err))
 	}
 
 	schema, exists := wh.descriptor.GetByType(crd.CamelCaseToKebabCase(obj.Kind))
 	if !exists {
+		scope.Infof("unrecognized type %v", obj.Kind)
 		reportValidationFailed(request, reasonUnknownType)
 		return toAdmissionResponse(fmt.Errorf("unrecognized type %v", obj.Kind))
 	}
 
 	out, err := crd.ConvertObject(schema, &obj, wh.domainSuffix)
 	if err != nil {
+		scope.Infof("error decoding configuration: %v", err)
 		reportValidationFailed(request, reasonCRDConversionError)
 		return toAdmissionResponse(fmt.Errorf("error decoding configuration: %v", err))
 	}
 
 	if err := schema.Validate(out.Name, out.Namespace, out.Spec); err != nil {
+		scope.Infof("configuration is invalid: %v", err)
 		reportValidationFailed(request, reasonInvalidConfig)
 		return toAdmissionResponse(fmt.Errorf("configuration is invalid: %v", err))
+	}
+
+	if reason, err := checkFields(request.Object.Raw, request.Kind.Kind, request.Namespace, obj.Name); err != nil {
+		reportValidationFailed(request, reason)
+		return toAdmissionResponse(err)
 	}
 
 	reportValidationPass(request)
@@ -481,8 +499,15 @@ func (wh *Webhook) admitMixer(request *admissionv1beta1.AdmissionRequest) *admis
 			reportValidationFailed(request, reasonYamlDecodeError)
 			return toAdmissionResponse(fmt.Errorf("cannot decode configuration: %v", err))
 		}
+
 		ev.Value = mixerCrd.ToBackEndResource(&obj)
 		ev.Key.Name = ev.Value.Metadata.Name
+
+		if reason, err := checkFields(request.Object.Raw, request.Kind.Kind, request.Namespace, ev.Key.Name); err != nil {
+			reportValidationFailed(request, reason)
+			return toAdmissionResponse(err)
+		}
+
 	case admissionv1beta1.Delete:
 		if request.Name == "" {
 			reportValidationFailed(request, reasonUnknownType)
@@ -503,4 +528,23 @@ func (wh *Webhook) admitMixer(request *admissionv1beta1.AdmissionRequest) *admis
 
 	reportValidationPass(request)
 	return &admissionv1beta1.AdmissionResponse{Allowed: true}
+}
+
+func checkFields(raw []byte, kind string, namespace string, name string) (string, error) {
+	trial := make(map[string]json.RawMessage)
+	if err := yaml.Unmarshal(raw, &trial); err != nil {
+		scope.Infof("cannot re-decode configuration: %v", err)
+		return reasonYamlDecodeError, fmt.Errorf("cannot re-decode configuration: %v", err)
+	}
+
+	for key := range trial {
+		if _, ok := validFields[key]; !ok {
+			scope.Infof("unknown field %q on %s resource %s/%s",
+				key, kind, namespace, name)
+			return reasonInvalidConfig, fmt.Errorf("unknown field %q on %s resource %s/%s",
+				key, kind, namespace, name)
+		}
+	}
+
+	return "", nil
 }

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -533,8 +533,8 @@ func (wh *Webhook) admitMixer(request *admissionv1beta1.AdmissionRequest) *admis
 func checkFields(raw []byte, kind string, namespace string, name string) (string, error) {
 	trial := make(map[string]json.RawMessage)
 	if err := yaml.Unmarshal(raw, &trial); err != nil {
-		scope.Infof("cannot re-decode configuration: %v", err)
-		return reasonYamlDecodeError, fmt.Errorf("cannot re-decode configuration: %v", err)
+		scope.Infof("cannot decode configuration fields: %v", err)
+		return reasonYamlDecodeError, fmt.Errorf("cannot decode configuration fields: %v", err)
 	}
 
 	for key := range trial {

--- a/galley/pkg/crd/validation/webhook_test.go
+++ b/galley/pkg/crd/validation/webhook_test.go
@@ -277,7 +277,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "valid create",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: valid},
 				Operation: admissionv1beta1.Create,
 			},
@@ -287,7 +287,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "valid update",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: valid},
 				Operation: admissionv1beta1.Create,
 			},
@@ -297,7 +297,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "unsupported operation",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: valid},
 				Operation: admissionv1beta1.Delete,
 			},
@@ -307,7 +307,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "invalid spec",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: invalidConfig},
 				Operation: admissionv1beta1.Create,
 			},
@@ -317,7 +317,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "corrupt object",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: append([]byte("---"), valid...)},
 				Operation: admissionv1beta1.Create,
 			},
@@ -327,7 +327,7 @@ func TestAdmitPilot(t *testing.T) {
 			name:  "invalid extra key create",
 			admit: wh.admitPilot,
 			in: &admissionv1beta1.AdmissionRequest{
-				Kind:      metav1.GroupVersionKind{}, // TODO
+				Kind:      metav1.GroupVersionKind{Kind: "mock"},
 				Object:    runtime.RawExtension{Raw: extraKeyConfig},
 				Operation: admissionv1beta1.Create,
 			},

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/wildcard-tls-wikipedia.yaml
@@ -50,4 +50,4 @@ spec:
         host: '*.wikipedia.org'
         port:
           number: 443
-weight: 100
+      weight: 100


### PR DESCRIPTION
Resolve part of https://github.com/istio/istio/issues/11634 by validating that all top level keys in CRDs are expected.

This helps with YaML files where if the tab is lost a field that should be part of the `Spec` becomes top-level and is ignored by validation and by Istio.
