### PR TITLE
stackdriver adapter memory usage optimization

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -50,6 +50,11 @@ type buffered struct {
 	m      sync.Mutex
 	buffer []*monitoringpb.TimeSeries
 
+	// Guards merged time series
+	tsm          sync.Mutex
+	mergeTrigger int
+	mergedTS     map[uint64]*monitoringpb.TimeSeries
+
 	// retryBuffer holds timeseries that fail in push.
 	retryBuffer []*monitoringpb.TimeSeries
 	// retryCounter maps a timeseries to the attempts that it has been retried.
@@ -59,6 +64,8 @@ type buffered struct {
 	timeSeriesBatchSize int
 	retryLimit          int
 	pushInterval        time.Duration
+
+	env adapter.Env
 }
 
 // batchTimeSeries slices the given time series array with respect to the given batch size limit.
@@ -85,24 +92,55 @@ func (b *buffered) start(env adapter.Env, ticker *time.Ticker) {
 func (b *buffered) Record(toSend []*monitoringpb.TimeSeries) {
 	b.m.Lock()
 	b.buffer = append(b.buffer, toSend...)
+	if len(b.buffer) >= b.mergeTrigger {
+		// pull the trigger to merge buffered time series
+		b.env.ScheduleWork(func() {
+			b.mergeTimeSeries()
+		})
+	}
 	// TODO: gauge metric reporting how many bytes/timeseries we're holding right now
 	b.m.Unlock()
 }
 
-func (b *buffered) Send() {
+func (b *buffered) mergeTimeSeries() {
 	b.m.Lock()
-	if len(b.buffer) == 0 && len(b.retryBuffer) == 0 {
-		b.m.Unlock()
+	temp := b.buffer
+	b.buffer = make([]*monitoringpb.TimeSeries, 0, len(temp))
+	b.m.Unlock()
+
+	b.tsm.Lock()
+	for _, ts := range temp {
+		k := toKey(ts.Metric, ts.Resource)
+		if p, ok := b.mergedTS[k]; !ok {
+			b.mergedTS[k] = ts
+		} else {
+			if n, err := mergePoints(p, ts); err != nil {
+				b.l.Warningf("failed to merge time series %v and %v: %v", p, ts, err)
+			} else {
+				b.mergedTS[k] = n
+			}
+		}
+	}
+	b.tsm.Unlock()
+}
+
+func (b *buffered) Send() {
+	b.tsm.Lock()
+	if len(b.mergedTS) == 0 && len(b.retryBuffer) == 0 {
+		b.tsm.Unlock()
 		b.l.Debugf("No data to send to Stackdriver.")
 		return
 	}
 
-	toSend := b.buffer
-	b.buffer = make([]*monitoringpb.TimeSeries, 0, len(toSend))
-	b.m.Unlock()
+	tmpBuffer := b.mergedTS
+	b.mergedTS = make(map[uint64]*monitoringpb.TimeSeries)
+	b.tsm.Unlock()
 
-	mergedToSend := merge(toSend, b.l)
-	merged := append(b.retryBuffer, mergedToSend...)
+	toSend := make([]*monitoringpb.TimeSeries, 0, len(tmpBuffer))
+	for _, v := range tmpBuffer {
+		toSend = append(toSend, v)
+	}
+	merged := append(b.retryBuffer, toSend...)
 	b.retryBuffer = make([]*monitoringpb.TimeSeries, 0, len(b.retryBuffer))
 	batches := batchTimeSeries(merged, b.timeSeriesBatchSize)
 	// Spread monitoring API calls evenly over the push interval.

--- a/mixer/adapter/stackdriver/metric/merge.go
+++ b/mixer/adapter/stackdriver/metric/merge.go
@@ -25,65 +25,7 @@ import (
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-
-	"istio.io/istio/mixer/pkg/adapter"
 )
-
-const usec int32 = int32(1 * time.Microsecond)
-
-// We can only send 1 point per timeseries per ~minute, so for each batch we group together all points for the same timeseries.
-func merge(series []*monitoring.TimeSeries, logger adapter.Logger) []*monitoring.TimeSeries {
-	grouped := groupBySeries(series)
-	return mergeSeries(grouped, logger)
-}
-
-func groupBySeries(series []*monitoring.TimeSeries) map[uint64][]*monitoring.TimeSeries {
-	bySeries := make(map[uint64][]*monitoring.TimeSeries)
-	for _, ts := range series {
-		if ts.MetricKind == metricpb.MetricDescriptor_DELTA || ts.MetricKind == metricpb.MetricDescriptor_CUMULATIVE {
-			// DELTA and CUMULATIVE metrics cannot have the same start and end time, so if they are the same we munge
-			// the data by unit of least precision that Stackdriver stores (microsecond).
-			if compareUSec(ts.Points[0].Interval.StartTime, ts.Points[0].Interval.EndTime) == 0 {
-				ts.Points[0].Interval.EndTime = &timestamp.Timestamp{
-					Seconds: ts.Points[0].Interval.EndTime.Seconds,
-					Nanos:   ts.Points[0].Interval.EndTime.Nanos + usec,
-				}
-			}
-		}
-		k := toKey(ts.Metric, ts.Resource)
-		bySeries[k] = append(bySeries[k], ts)
-	}
-	return bySeries
-}
-
-func mergeSeries(bySeries map[uint64][]*monitoring.TimeSeries, logger adapter.Logger) []*monitoring.TimeSeries {
-	var err error
-	out := make([]*monitoring.TimeSeries, 0, len(bySeries))
-	for _, ts := range bySeries {
-		current := ts[0]
-		start := current.Points[0].Interval.StartTime
-		end := current.Points[0].Interval.EndTime
-		for i := 1; i < len(ts); i++ {
-			if current, err = mergePoints(current, ts[i]); err != nil {
-				logger.Warningf("failed to merge timeseries: %v", err)
-				continue
-			}
-			if compareUSec(start, ts[i].Points[0].Interval.StartTime) > 0 {
-				start = ts[i].Points[0].Interval.StartTime
-			}
-			if compareUSec(end, ts[i].Points[0].Interval.EndTime) < 0 {
-				end = ts[i].Points[0].Interval.EndTime
-			}
-		}
-
-		current.Points[0].Interval = &monitoring.TimeInterval{
-			StartTime: start,
-			EndTime:   end,
-		}
-		out = append(out, current)
-	}
-	return out
-}
 
 // Attempts to merge two timeseries; if they are not of the same type we return an error and a, unchanged, as the resulting timeseries.
 // Given the way that stackdriver metrics work, and our grouping by timeseries, we should never see two timeseries merged with different value types.
@@ -126,6 +68,12 @@ func mergePoints(a, b *monitoring.TimeSeries) (*monitoring.TimeSeries, error) {
 	default:
 		// illegal anyway, since we can't have DELTA/CUMULATIVE metrics on anything else
 		return a, fmt.Errorf("invalid type for DELTA metric: %v", a.Points[0].Value)
+	}
+	if compareUSec(a.Points[0].Interval.StartTime, b.Points[0].Interval.StartTime) > 0 {
+		a.Points[0].Interval.StartTime = b.Points[0].Interval.StartTime
+	}
+	if compareUSec(a.Points[0].Interval.EndTime, b.Points[0].Interval.EndTime) < 0 {
+		a.Points[0].Interval.EndTime = b.Points[0].Interval.EndTime
 	}
 	return a, nil
 }

--- a/mixer/adapter/stackdriver/metric/merge_test.go
+++ b/mixer/adapter/stackdriver/metric/merge_test.go
@@ -56,19 +56,8 @@ var (
 	}
 )
 
-// shorthand to save us some chars in test cases
-type ts []*monitoring.TimeSeries
-
 func makeTS(m *metric.Metric, mr *monitoredres.MonitoredResource, seconds int64, micros int32) *monitoring.TimeSeries {
 	return makeTSFull(m, mr, seconds, micros, 0, metric.MetricDescriptor_DELTA)
-}
-
-func makeTSDelta(m *metric.Metric, mr *monitoredres.MonitoredResource, seconds int64, micros int32, val int64) *monitoring.TimeSeries {
-	return makeTSFull(m, mr, seconds, micros, val, metric.MetricDescriptor_DELTA)
-}
-
-func makeTSCumulative(m *metric.Metric, mr *monitoredres.MonitoredResource, seconds int64, micros int32, val int64) *monitoring.TimeSeries {
-	return makeTSFull(m, mr, seconds, micros, val, metric.MetricDescriptor_CUMULATIVE)
 }
 
 func makeTSFull(m *metric.Metric, mr *monitoredres.MonitoredResource, seconds int64, micros int32, value int64,

--- a/mixer/adapter/stackdriver/metric/merge_test.go
+++ b/mixer/adapter/stackdriver/metric/merge_test.go
@@ -27,8 +27,6 @@ import (
 	"google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-
-	"istio.io/istio/mixer/pkg/adapter/test"
 )
 
 var (
@@ -97,88 +95,6 @@ func TestToUSec(t *testing.T) {
 	}
 }
 
-func TestMerge(t *testing.T) {
-	tests := []struct {
-		name  string
-		in    ts
-		start *timestamp.Timestamp
-		end   *timestamp.Timestamp
-		val   *monitoring.TypedValue
-	}{
-		{"one",
-			ts{makeTSDelta(m1, mr1, 1, 5, 456)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 5000},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 6000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 456}}},
-		{"dupe",
-			ts{makeTSDelta(m1, mr1, 1, 5, 1), makeTSDelta(m1, mr1, 1, 5, 1)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 5000},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 6000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 2}}},
-		{"out of order",
-			ts{makeTSDelta(m1, mr1, 2, 5, 1), makeTSDelta(m1, mr1, 1, 5, 1)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 5000},
-			&timestamp.Timestamp{Seconds: 2, Nanos: 6000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 2}}},
-		{"reversed",
-			ts{makeTSDelta(m1, mr1, 4, 1, 1), makeTSDelta(m1, mr1, 3, 1, 1), makeTSDelta(m1, mr1, 2, 1, 1), makeTSDelta(m1, mr1, 1, 1, 1)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 1000},
-			&timestamp.Timestamp{Seconds: 4, Nanos: 2000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 4}}},
-		{"out of order, overlapping times",
-			ts{makeTSDelta(m1, mr1, 1, 1, 1), makeTSDelta(m1, mr1, 1, 1, 2), makeTSDelta(m1, mr1, 1, 3, 3), makeTSDelta(m1, mr1, 1, 2, 4)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 1000},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 4000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 10}}},
-		{"larger time spans",
-			ts{makeTSDelta(m1, mr1, 1, 1, 7), makeTSDelta(m1, mr1, 1, 1, 3), makeTSDelta(m1, mr1, 1, 7, 4896), makeTSDelta(m1, mr1, 1, 5, 9485367)},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 1000},
-			&timestamp.Timestamp{Seconds: 1, Nanos: 8000},
-			&monitoring.TypedValue{Value: &monitoring.TypedValue_Int64Value{Int64Value: 9490273}}},
-	}
-
-	for idx, tt := range tests {
-		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			out := merge(tt.in, test.NewEnv(t))
-			if len(out) != 1 {
-				t.Fatalf("Wanted 1 output value, got: %v", out)
-			} else if len(out[0].Points) != 1 {
-				t.Fatalf("There should only ever be a single point, got: %v", out[0].Points)
-			}
-
-			if !reflect.DeepEqual(out[0].Points[0].Interval.StartTime, tt.start) {
-				t.Errorf("Got start time %v wanted %v; out: %v", out[0].Points[0].Interval.StartTime, tt.start, out[0].Points[0])
-			}
-			if !reflect.DeepEqual(out[0].Points[0].Interval.EndTime, tt.end) {
-				t.Errorf("Got end time %v wanted %v; out: %v", out[0].Points[0].Interval.EndTime, tt.end, out[0].Points[0])
-			}
-			if !reflect.DeepEqual(out[0].Points[0].Value, tt.val) {
-				t.Errorf("Got value %v wanted %v; out: %v", out[0].Points[0].Value, tt.val, out[0].Points[0])
-			}
-		})
-	}
-}
-
-func TestMerge_Errors(t *testing.T) {
-	env := test.NewEnv(t)
-	a := makeTSDelta(m1, mr1, 1, 1, 1)
-	b := makeTSDelta(m1, mr1, 1, 1, 1)
-	b.Points[0].Value = &monitoring.TypedValue{Value: &monitoring.TypedValue_DoubleValue{DoubleValue: 4.7}}
-	_ = merge([]*monitoring.TimeSeries{a, b}, env)
-	if len(env.GetLogs()) < 1 {
-		t.Fatalf("Expected bad data to be logged about, got no log entries")
-	} else if !strings.Contains(env.GetLogs()[0], "failed to merge timeseries") {
-		t.Fatalf("Expected log entry for failed merge, got entry: %v", env.GetLogs()[0])
-	}
-
-	c := makeTSDelta(m1, mr1, 1, 1, 1)
-	c.Points[0].Interval.EndTime = c.Points[0].Interval.StartTime
-	out := merge([]*monitoring.TimeSeries{c}, env)
-	if reflect.DeepEqual(out[0].Points[0].Interval.EndTime, out[0].Points[0].Interval.StartTime) {
-		t.Fatalf("After coalescing, DELTA metrics must not have the same start and end time, but we do: %v", out[0])
-	}
-}
-
 func TestToKey(t *testing.T) {
 	hashes := [4]uint64{
 		toKey(m1, mr1),
@@ -203,106 +119,6 @@ func TestToKey(t *testing.T) {
 		&monitoredres.MonitoredResource{Type: "m1", Labels: map[string]string{"foo": "bar"}})
 	if k1 != k2 {
 		t.Fatalf("Expected toKey on duplicates to have the same hash, got %d and %d instead", k1, k2)
-	}
-}
-
-func TestGroupBySeries(t *testing.T) {
-	m1mr1 := toKey(m1, mr1)
-	m1mr2 := toKey(m1, mr2)
-	m2mr1 := toKey(m2, mr1)
-	m2mr2 := toKey(m2, mr2)
-
-	tests := []struct {
-		name string
-		in   ts
-		out  map[uint64]ts
-	}{
-		{"empty",
-			ts{},
-			map[uint64]ts{}},
-		{"singleton",
-			ts{makeTSCumulative(m1, mr1, 1, 1, 0)},
-			map[uint64]ts{m1mr1: {makeTSCumulative(m1, mr1, 1, 1, 0)}}},
-		{"multiple points",
-			ts{makeTS(m1, mr1, 1, 1), makeTS(m1, mr1, 2, 2)},
-			map[uint64]ts{m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0), makeTSDelta(m1, mr1, 2, 2, 0)}}},
-		{"two metrics",
-			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr1, 1, 1)},
-			map[uint64]ts{
-				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)},
-				m2mr1: {makeTSDelta(m2, mr1, 1, 1, 0)}}},
-		{"two MRs",
-			ts{makeTS(m1, mr2, 1, 1), makeTS(m1, mr1, 1, 1)},
-			map[uint64]ts{
-				m1mr2: {makeTSDelta(m1, mr2, 1, 1, 0)},
-				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)}}},
-		{"disjoint",
-			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr2, 1, 1)},
-			map[uint64]ts{
-				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0)},
-				m2mr2: {makeTSDelta(m2, mr2, 1, 1, 0)}}},
-		{"disjoint, multiple points",
-			ts{makeTS(m1, mr1, 1, 1), makeTS(m2, mr2, 1, 1), makeTS(m1, mr1, 2, 2), makeTS(m2, mr2, 2, 2)},
-			map[uint64]ts{
-				m1mr1: {makeTSDelta(m1, mr1, 1, 1, 0), makeTSDelta(m1, mr1, 2, 2, 0)},
-				m2mr2: {makeTSDelta(m2, mr2, 1, 1, 0), makeTSDelta(m2, mr2, 2, 2, 0)}}},
-	}
-
-	for idx, tt := range tests {
-		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			out := groupBySeries(tt.in)
-			if len(out) != len(tt.out) {
-				t.Fatalf("Expected %d groups, got %d: %v", len(tt.out), len(out), out)
-			}
-			for key, vals := range tt.out {
-				if len(out[key]) != len(vals) {
-					t.Fatalf("Expected key %d in map to have %d entries, got: %v", key, len(vals), out)
-				}
-				for i := 0; i < len(vals); i++ {
-					if !reflect.DeepEqual(vals[i], out[key][i]) {
-						t.Errorf("Expected entries in group %d to match %v, got: %v", key, vals, out[key])
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestMergeSeries(t *testing.T) {
-	merged := makeTSCumulative(m1, mr1, 1, 1, 15)
-	merged.Points[0].Interval = &monitoring.TimeInterval{
-		StartTime: merged.Points[0].Interval.StartTime,
-		EndTime:   &timestamp.Timestamp{Seconds: 2, Nanos: 3 * usec},
-	}
-
-	tests := []struct {
-		name string
-		in   map[uint64][]*monitoring.TimeSeries
-		out  []*monitoring.TimeSeries
-	}{
-		{"empty",
-			map[uint64][]*monitoring.TimeSeries{},
-			[]*monitoring.TimeSeries{}},
-		{"singleton",
-			map[uint64][]*monitoring.TimeSeries{0: {makeTSCumulative(m1, mr1, 1, 1, 0)}},
-			[]*monitoring.TimeSeries{makeTSCumulative(m1, mr1, 1, 1, 0)}},
-		{"multiple points",
-			map[uint64][]*monitoring.TimeSeries{65425478798: {makeTSCumulative(m1, mr1, 1, 1, 7), makeTSCumulative(m1, mr1, 2, 2, 8)}},
-			[]*monitoring.TimeSeries{merged}},
-	}
-
-	for idx, tt := range tests {
-		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
-			out := mergeSeries(tt.in, test.NewEnv(t))
-			if len(out) != len(tt.out) {
-				t.Fatalf("Expected %d groups, got %d: %v", len(tt.out), len(out), out)
-			}
-			for i := 0; i < len(tt.out); i++ {
-				if !reflect.DeepEqual(out[i], tt.out[i]) {
-					t.Errorf("Expected out[%d] = %v, got %v; %v", i, tt.out[i], out[i], out)
-				}
-			}
-		})
 	}
 }
 
@@ -407,10 +223,14 @@ func TestMergePoints(t *testing.T) {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			a := makeTS(m1, mr1, 1, 1)
 			a.Points[0].Value = tt.a
-			b := makeTS(m1, mr1, 1, 1)
+			b := makeTS(m1, mr1, 2, 2)
 			b.Points[0].Value = tt.b
 
 			out, err := mergePoints(a, b)
+			wantInterval := &monitoring.TimeInterval{
+				StartTime: &timestamp.Timestamp{Seconds: 1, Nanos: 1000},
+				EndTime:   &timestamp.Timestamp{Seconds: 2, Nanos: 3000},
+			}
 			if err != nil || tt.err != "" {
 				if tt.err == "" {
 					t.Fatalf("merge(%v, %v) = '%s', wanted no err", a, b, err.Error())
@@ -419,6 +239,8 @@ func TestMergePoints(t *testing.T) {
 				}
 			} else if !reflect.DeepEqual(out.Points[0].Value, tt.out) {
 				t.Fatalf("merge(%v, %v) = %v, wanted value %v", a, b, out, tt.out)
+			} else if !reflect.DeepEqual(out.Points[0].Interval, wantInterval) {
+				t.Fatalf("merge(%v, %v) = %v, want interval %v", a, b, out, wantInterval)
 			}
 		})
 	}

--- a/mixer/adapter/stackdriver/metric/metric_test.go
+++ b/mixer/adapter/stackdriver/metric/metric_test.go
@@ -253,7 +253,8 @@ func TestRecord(t *testing.T) {
 	}
 	now := time.Now()
 	pbnow, _ := ptypes.TimestampProto(now)
-
+	pbend, _ := ptypes.TimestampProto(now)
+	pbend.Nanos += usec
 	tests := []struct {
 		name     string
 		vals     []*metrict.Instance
@@ -274,7 +275,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_GAUGE,
 				ValueType:  metricpb.MetricDescriptor_INT64,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value:    &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: int64(7)}},
 				}},
 			},
@@ -292,7 +293,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_STRING,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value:    &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_StringValue{StringValue: "asldkfj"}},
 				}},
 			},
@@ -310,7 +311,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_DELTA,
 				ValueType:  metricpb.MetricDescriptor_BOOL,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value:    &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_BoolValue{BoolValue: true}},
 				}},
 			},
@@ -328,7 +329,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
 						DistributionValue: &distribution.Distribution{
 							Count:         1,
@@ -351,7 +352,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
 						DistributionValue: &distribution.Distribution{
 							Count:         1,
@@ -374,7 +375,7 @@ func TestRecord(t *testing.T) {
 				MetricKind: metricpb.MetricDescriptor_CUMULATIVE,
 				ValueType:  metricpb.MetricDescriptor_DISTRIBUTION,
 				Points: []*monitoringpb.Point{{
-					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbnow},
+					Interval: &monitoringpb.TimeInterval{StartTime: pbnow, EndTime: pbend},
 					Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DistributionValue{
 						DistributionValue: &distribution.Distribution{
 							Count:         1,


### PR DESCRIPTION
Restrict buffer size to prevent excessive memory usage of stackdriver adapter. Right now sd adapter will buffer all timeseries and merge them before sending periodically, which consumes too much memory and does not work when mixer is under  load. This PR adds async merging limit the size of buffer. Test indicates the new logic consumes much less memory.