### PR TITLE
Add configurable Mixer transport error retry

### DIFF
--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -54,13 +54,15 @@ const (
 	// workload-bound annotations for controlling mixerfilter
 	policyCheckAnnotation = "policy.istio.io/check"
 
-	// workload-bound annotation for max retries on transport error
+	// workload-bound annotation for max number of retries on transport error
 	policyCheckRetriesAnnotation = "policy.istio.io/checkRetries"
 
-	// workload-bound annotation for base time to wait between retries
+	// workload-bound annotation for base time to wait between retries, will be adjusted by backoff and jitter.
+	// In duration format. Example: 80ms.
 	policyCheckBaseRetryWaitTimeAnnotation = "policy.istio.io/checkBaseRetryWaitTime"
 
 	// workload-bound annotation for max time to wait between retries
+	// In duration format. Example: 1000ms.
 	policyCheckMaxRetryWaitTimeAnnotation = "policy.istio.io/checkMaxRetryWaitTime"
 
 	// force enable policy checks for both inbound and outbound calls
@@ -277,7 +279,7 @@ func buildTransport(mesh *meshconfig.MeshConfig, node *model.Proxy) *mccpb.Trans
 	if annotation, ok := node.Metadata[policyCheckRetriesAnnotation]; ok {
 		retries, err := strconv.Atoi(annotation)
 		if err != nil {
-			log.Warnf("unable to parse retry limit %v.", annotation)
+			log.Warnf("unable to parse retry limit %q.", annotation)
 		} else {
 			networkFailPolicy.MaxRetry = uint32(retries)
 		}
@@ -286,7 +288,7 @@ func buildTransport(mesh *meshconfig.MeshConfig, node *model.Proxy) *mccpb.Trans
 	if annotation, ok := node.Metadata[policyCheckBaseRetryWaitTimeAnnotation]; ok {
 		dur, err := time.ParseDuration(annotation)
 		if err != nil {
-			log.Warnf("unable to parse base retry wait time %v.", annotation)
+			log.Warnf("unable to parse base retry wait time %q.", annotation)
 		} else {
 			networkFailPolicy.BaseRetryWait = types.DurationProto(dur)
 		}
@@ -295,7 +297,7 @@ func buildTransport(mesh *meshconfig.MeshConfig, node *model.Proxy) *mccpb.Trans
 	if annotation, ok := node.Metadata[policyCheckMaxRetryWaitTimeAnnotation]; ok {
 		dur, err := time.ParseDuration(annotation)
 		if err != nil {
-			log.Warnf("unable to parse max retry wait time %v.", annotation)
+			log.Warnf("unable to parse max retry wait time %q.", annotation)
 		} else {
 			networkFailPolicy.MaxRetryWait = types.DurationProto(dur)
 		}

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -52,6 +53,15 @@ const (
 
 	// workload-bound annotations for controlling mixerfilter
 	policyCheckAnnotation = "policy.istio.io/check"
+
+	// workload-bound annotation for max retries on transport error
+	policyCheckRetriesAnnotation = "policy.istio.io/checkRetries"
+
+	// workload-bound annotation for base time to wait between retries
+	policyCheckBaseRetryWaitTimeAnnotation = "policy.istio.io/checkBaseRetryWaitTime"
+
+	// workload-bound annotation for max time to wait between retries
+	policyCheckMaxRetryWaitTimeAnnotation = "policy.istio.io/checkMaxRetryWaitTime"
 
 	// force enable policy checks for both inbound and outbound calls
 	policyCheckEnable = "enable"
@@ -247,25 +257,54 @@ func buildUpstreamName(address string) string {
 
 func buildTransport(mesh *meshconfig.MeshConfig, node *model.Proxy) *mccpb.TransportConfig {
 	// default to mesh
-	networkFailPolicy := mccpb.FAIL_CLOSE
+	policy := mccpb.FAIL_CLOSE
 	if mesh.PolicyCheckFailOpen {
-		networkFailPolicy = mccpb.FAIL_OPEN
+		policy = mccpb.FAIL_OPEN
 	}
 
 	// apply proxy-level overrides
-	if policy, ok := node.Metadata[policyCheckAnnotation]; ok {
-		switch policy {
+	if annotation, ok := node.Metadata[policyCheckAnnotation]; ok {
+		switch annotation {
 		case policyCheckEnable:
-			networkFailPolicy = mccpb.FAIL_CLOSE
+			policy = mccpb.FAIL_CLOSE
 		case policyCheckEnableAllow, policyCheckDisable:
-			networkFailPolicy = mccpb.FAIL_OPEN
+			policy = mccpb.FAIL_OPEN
+		}
+	}
+
+	networkFailPolicy := &mccpb.NetworkFailPolicy{Policy: policy}
+
+	if annotation, ok := node.Metadata[policyCheckRetriesAnnotation]; ok {
+		retries, err := strconv.Atoi(annotation)
+		if err != nil {
+			log.Warnf("unable to parse retry limit %v.", annotation)
+		} else {
+			networkFailPolicy.MaxRetry = uint32(retries)
+		}
+	}
+
+	if annotation, ok := node.Metadata[policyCheckBaseRetryWaitTimeAnnotation]; ok {
+		dur, err := time.ParseDuration(annotation)
+		if err != nil {
+			log.Warnf("unable to parse base retry wait time %v.", annotation)
+		} else {
+			networkFailPolicy.BaseRetryWait = types.DurationProto(dur)
+		}
+	}
+
+	if annotation, ok := node.Metadata[policyCheckMaxRetryWaitTimeAnnotation]; ok {
+		dur, err := time.ParseDuration(annotation)
+		if err != nil {
+			log.Warnf("unable to parse max retry wait time %v.", annotation)
+		} else {
+			networkFailPolicy.MaxRetryWait = types.DurationProto(dur)
 		}
 	}
 
 	res := &mccpb.TransportConfig{
 		CheckCluster:      buildUpstreamName(mesh.MixerCheckServer),
 		ReportCluster:     buildUpstreamName(mesh.MixerReportServer),
-		NetworkFailPolicy: &mccpb.NetworkFailPolicy{Policy: networkFailPolicy},
+		NetworkFailPolicy: networkFailPolicy,
 	}
 
 	return res

--- a/pilot/pkg/networking/plugin/mixer/mixer_test.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer_test.go
@@ -1,0 +1,95 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mixer
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+
+	meshconfig "istio.io/api/mesh/v1alpha1"
+	mccpb "istio.io/api/mixer/v1/config/client"
+	"istio.io/istio/pilot/pkg/model"
+	context "istio.io/istio/pilot/pkg/model"
+)
+
+func TestTransportConfig(t *testing.T) {
+	cases := []struct {
+		mesh   meshconfig.MeshConfig
+		node   model.Proxy
+		expect *mccpb.NetworkFailPolicy
+	}{
+		{
+			// defaults set
+			mesh: context.DefaultMeshConfig(),
+			node: model.Proxy{
+				Metadata: map[string]string{},
+			},
+			expect: &mccpb.NetworkFailPolicy{
+				Policy: mccpb.FAIL_CLOSE,
+			},
+		},
+		{
+			// retry and retry times set
+			mesh: context.DefaultMeshConfig(),
+			node: model.Proxy{
+				Metadata: map[string]string{
+					policyCheckRetriesAnnotation:           "5",
+					policyCheckBaseRetryWaitTimeAnnotation: "1m",
+					policyCheckMaxRetryWaitTimeAnnotation:  "1.5s",
+				},
+			},
+			expect: &mccpb.NetworkFailPolicy{
+				Policy:        mccpb.FAIL_CLOSE,
+				MaxRetry:      5,
+				BaseRetryWait: types.DurationProto(1 * time.Minute),
+				MaxRetryWait:  types.DurationProto(1500 * time.Millisecond),
+			},
+		},
+		{
+			// just retry amount set
+			mesh: context.DefaultMeshConfig(),
+			node: model.Proxy{
+				Metadata: map[string]string{
+					policyCheckRetriesAnnotation: "1",
+				},
+			},
+			expect: &mccpb.NetworkFailPolicy{
+				Policy:   mccpb.FAIL_CLOSE,
+				MaxRetry: 1,
+			},
+		},
+		{
+			// fail open from node metadata
+			mesh: context.DefaultMeshConfig(),
+			node: model.Proxy{
+				Metadata: map[string]string{
+					policyCheckAnnotation: policyCheckDisable,
+				},
+			},
+			expect: &mccpb.NetworkFailPolicy{
+				Policy: mccpb.FAIL_OPEN,
+			},
+		},
+	}
+	for _, c := range cases {
+		tc := buildTransport(&c.mesh, &c.node)
+		if !reflect.DeepEqual(tc.NetworkFailPolicy, c.expect) {
+			t.Errorf("got %v, expected %v", tc.NetworkFailPolicy, c.expect)
+		}
+	}
+}


### PR DESCRIPTION
Adds annotations for the number of retries, base wait time, and max wait
time to configure Mixer transport error retry policy. If values are not
provided, they will be left unset; defaults will be provided in
istio/proxy.