### PR TITLE
[Kiali] changes for the next version (#11513)

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-description: Kiali is an open source project for service mesh observability, refer to https://github.com/kiali/kiali for details.
+description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
 name: kiali
 version: 1.1.0
-appVersion: 0.12
+appVersion: 0.14
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/clusterrole.yaml
@@ -74,6 +74,7 @@ rules:
   - statsds
   - stdios
   verbs:
+  - create
   - delete
   - get
   - list
@@ -86,6 +87,17 @@ rules:
   - serviceentries
   - virtualservices
   verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["authentication.istio.io"]
+  resources:
+  - policies
+  verbs:
+  - create
   - delete
   - get
   - list

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -48,11 +48,13 @@ spec:
             secretKeyRef:
               name: {{ .Values.dashboard.secretName }}
               key: {{ .Values.dashboard.usernameKey }}
+              optional: true
         - name: SERVER_CREDENTIALS_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.dashboard.secretName }}
               key: {{ .Values.dashboard.passphraseKey }}
+              optional: true
         - name: PROMETHEUS_SERVICE_URL
           value: {{ .Values.prometheusAddr }}
 {{- if .Values.contextPath }}

--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -4,7 +4,7 @@
 enabled: false
 replicaCount: 1
 hub: docker.io/kiali
-tag: v0.12
+tag: v0.14
 contextPath: /kiali
 nodeSelector: {}
 ingress:


### PR DESCRIPTION
I cherry-picked this over from master - this is issue #11513 - updates Kiali to the new v0.14 version. If Istio 1.1 wants to release with the latest Kiali release - this PR should be merged.

(cherry picked from commit 322452a3c2513520cd0abc380b0762f1e25d3a0a)