### PR TITLE
Remove calls to helm repo add

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,6 @@ export ENABLE_ISTIO_CNI ?= false
 # NOTE: env var EXTRA_HELM_SETTINGS can contain helm chart override settings, example:
 # EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.tag=v0.1-dev-foo"
 
-
-#ISTIO_HELM_REPO := https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/master-latest-daily/charts
-ISTIO_HELM_REPO := https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
-
 #-----------------------------------------------------------------------------
 # Output control
 #-----------------------------------------------------------------------------
@@ -634,13 +630,8 @@ $(HELM):
 $(HOME)/.helm:
 	$(HELM) init --client-only
 
-.PHONY: helm-repo-add
-
-helm-repo-add:
-	$(HELM) repo add istio.io ${ISTIO_HELM_REPO}
-
 # create istio-remote.yaml
-istio-remote.yaml: $(HELM) $(HOME)/.helm helm-repo-add
+istio-remote.yaml: $(HELM) $(HOME)/.helm
 	cat install/kubernetes/namespace.yaml > install/kubernetes/$@
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/$@
 	$(HELM) template --name=istio --namespace=istio-system \
@@ -650,7 +641,7 @@ istio-remote.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		install/kubernetes/helm/istio >> install/kubernetes/$@
 
 # create istio-init.yaml
-istio-init.yaml: $(HELM) $(HOME)/.helm helm-repo-add
+istio-init.yaml: $(HELM) $(HOME)/.helm
 	cat install/kubernetes/namespace.yaml > install/kubernetes/$@
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/$@
 	$(HELM) template --name=istio --namespace=istio-system \
@@ -660,7 +651,7 @@ istio-init.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 
 # creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml
 # Ensure that values-$filename is present in install/kubernetes/helm/istio
-isti%.yaml: $(HELM) $(HOME)/.helm helm-repo-add
+isti%.yaml: $(HELM) $(HOME)/.helm
 	cat install/kubernetes/namespace.yaml > install/kubernetes/$@
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/$@
 	$(HELM) template \
@@ -675,7 +666,7 @@ isti%.yaml: $(HELM) $(HOME)/.helm helm-repo-add
 		--values install/kubernetes/helm/istio/values-$@ \
 		install/kubernetes/helm/istio >> install/kubernetes/$@
 
-generate_yaml: $(HELM) $(HOME)/.helm helm-repo-add istio-init.yaml
+generate_yaml: $(HELM) $(HOME)/.helm istio-init.yaml
 	./install/updateVersion.sh -a ${HUB},${TAG} >/dev/null 2>&1
 	cat install/kubernetes/namespace.yaml > install/kubernetes/istio.yaml
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/istio.yaml
@@ -716,7 +707,7 @@ generate_yaml_coredump:
 # TODO(sdake) All this copy and paste needs to go.  This is easy to wrap up in
 #             isti%.yaml macro with value files per test scenario.  Will handle
 #             as a followup PR.
-generate_e2e_test_yaml: $(HELM) $(HOME)/.helm helm-repo-add istio-init.yaml
+generate_e2e_test_yaml: $(HELM) $(HOME)/.helm istio-init.yaml
 	#./install/updateVersion.sh -a ${HUB},${TAG} >/dev/null 2>&1
 	cat install/kubernetes/namespace.yaml > install/kubernetes/istio.yaml
 	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/istio.yaml

--- a/pkg/test/deployment/helm.go
+++ b/pkg/test/deployment/helm.go
@@ -146,10 +146,10 @@ func HelmTemplate(deploymentName, namespace, chartDir, workDir, valuesFile strin
 	}
 
 	// Adding cni dependency as a workaround for now.
-	if _, err := exec(fmt.Sprintf("helm --home %s repo add istio.io %s",
-		helmRepoDir, "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts")); err != nil {
-		return "", err
-	}
+	// if _, err := exec(fmt.Sprintf("helm --home %s repo add istio.io %s",
+	// 	helmRepoDir, "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts")); err != nil {
+	// 	return "", err
+	// }
 
 	// Package the chart dir.
 	if _, err := exec(fmt.Sprintf("helm --home %s package %s -d %s", helmRepoDir, chartDir, chartBuildDir)); err != nil {


### PR DESCRIPTION
As can be seen in this dummy PR (https://github.com/istio/istio/pull/11806), almost all tests are currently broken with the following error:

```sh
/home/prow/go/out/linux_amd64/release/helm repo add istio.io https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts
Error: Looks like "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts" is not a valid chart repository or cannot be reached: Failed to fetch https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts/index.yaml : 404 Not Found
Makefile:640: recipe for target 'helm-repo-add' failed
make[1]: *** [helm-repo-add] Error 1
```

Probably due to recent changes introduced by @sdake.

cc @duderino @wenchenglu