### PR TITLE
Fix gateway tls mount path bug

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/gateway.yaml
@@ -20,8 +20,8 @@ spec:
       name: https-default
     tls:
       mode: SIMPLE
-      serverCertificate: /etc/istio/ingress-certs/tls.crt
-      privateKey: /etc/istio/ingress-certs/tls.key
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+      privateKey: /etc/istio/ingressgateway-certs/tls.key
     hosts:
     - "*"
 {{ end }}


### PR DESCRIPTION
- This fixes an issue where the gateway will serve empty responses to requests because the gateway resource was referencing the wrong path to the TLS assets.

It must be `/etc/istio/ingressgateway-certs` as referenced in the docs https://istio.io/docs/tasks/traffic-management/secure-ingress/