### PR TITLE
[Kiali][release-1.1] Tell kiali about the new Pilot /version endpoint used to obtain Istio version

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/configmap.yaml
@@ -14,6 +14,8 @@ data:
     server:
       port: 20001
     external_services:
+      istio:
+        url_service_version: http://istio-pilot:8080/version
       jaeger:
         url: {{ .Values.dashboard.jaegerURL }}
       grafana:


### PR DESCRIPTION
This should address https://github.com/istio/istio/issues/11832 - this PR is required due to a recent change in Istio 1.1.0-snapshot.6 