### PR TITLE
It's safer to assume that default service protocol is tcp

### DIFF
--- a/pilot/pkg/serviceregistry/consul/conversion.go
+++ b/pilot/pkg/serviceregistry/consul/conversion.go
@@ -45,7 +45,7 @@ func convertLabels(labels []string) model.Labels {
 
 func convertPort(port int, name string) *model.Port {
 	if name == "" {
-		name = "http"
+		name = "tcp"
 	}
 
 	return &model.Port{

--- a/pilot/pkg/serviceregistry/consul/conversion_test.go
+++ b/pilot/pkg/serviceregistry/consul/conversion_test.go
@@ -35,7 +35,7 @@ var (
 		{"http2", 83, model.ProtocolHTTP2},
 		{"grpc", 84, model.ProtocolGRPC},
 		{"udp", 85, model.ProtocolUDP},
-		{"", 86, model.ProtocolHTTP},
+		{"", 86, model.ProtocolTCP},
 	}
 
 	goodLabels = []string{


### PR DESCRIPTION
Currently, if "protocol" service meta is null, "http" is used as the default value. It's safer to assume that the default service protocol is tcp.

Change-Id: I35b1cb6b4905c00025c6fc4fe384b7217979a5ba
Signed-off-by: zhaohuabing <zhaohuabing@gmail.com>