### PR TITLE
use YAML map nil value ({}) for meshNetworks

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -434,7 +434,7 @@ global:
   #     - registryServiceName: istio-ingressgateway
   #       port: 443
   #
-  meshNetworks:
+  meshNetworks: {}
 
   # Specifies whether helm test is enabled or not.
   # This field is set to false by default, so 'helm template ...'


### PR DESCRIPTION
since `meshNetworks` is a map, the correct nil value is {}
setting the nil value correctly will allow setting networks by
helm command line, using --set :

```
    --set global.meshNetworks.network2.endpoints[0].fromRegistry=remote_kubeconfig --set global.meshNetworks.network2.gateways[0].address=0.0.0.0 --set global.meshNetworks.network2.gateways[0].port=15443
```