### PR TITLE
Clarify use and generation of intermediate certifiates for multicluster

### DIFF
--- a/samples/certs/Makefile
+++ b/samples/certs/Makefile
@@ -1,0 +1,98 @@
+.SUFFIXES: .csr .pem .conf
+.PRECIOUS: %/ca-key.pem %/ca-cert.pem %/cert-chain.pem
+#.PRECIOUS: %/cluster-ca.csr %/intermediate.conf
+
+.DEFAULT_GOAL := help
+
+#------------------------------------------------------------------------
+# variables: root CA
+ROOTCA_DAYS ?= 3650 					# 10 years
+ROOTCA_SUBJ ?= "/O=Istio/CN=Istio Root CA"
+
+#------------------------------------------------------------------------
+# variables: intermediate CA (Citadel)
+CITADEL_SERIAL ?= $(shell echo $$PPID) 	# certificate serial number (uses current PID)
+CITADEL_DAYS ?= 730						# 2 years
+# Additional variables are defined in %/intermediate.conf target below.
+
+#------------------------------------------------------------------------
+##help:		print this help message
+.PHONY: help
+
+help: Makefile
+	@sed -n 's/^##//p' $<
+
+#------------------------------------------------------------------------
+##root-ca:	generate root CA files (key and certifcate) in current directory
+.PHONY: root-ca
+
+root-ca: root-key.pem root-cert.pem
+
+root-cert.pem: root-cert.csr root-key.pem
+	@echo "generating $@"
+	@openssl x509 -req -sha256 -days $(ROOTCA_DAYS) -signkey root-key.pem -in $< -out $@
+	@rm $<
+
+root-cert.csr: root-key.pem
+	@echo "generating $@"
+	@openssl req -new -sha256 -subj $(ROOTCA_SUBJ) -key $< -out $@ 
+
+root-key.pem:
+	@echo "generating $@"
+	@openssl genrsa -out $@ 4096
+
+#------------------------------------------------------------------------
+##<name>-certs:	generate Citadel certificates for <name>. Includes all PEM files needed.
+
+.PHONY: %-certs
+
+%-certs: %/cert-chain.pem root-cert.pem
+	@echo "Citadel inputs stored in $(dir $<)"
+	@cp root-cert.pem $(dir $<)
+
+%/cert-chain.pem: %/ca-cert.pem root-cert.pem
+	@echo "generating $@"
+	@cat $^ > $@
+
+%/ca-cert.pem: %/cluster-ca.csr root-key.pem root-cert.pem
+	@echo "generating $@"
+	@openssl x509 -req -days $(CITADEL_DAYS) -sha256 \
+		-CA root-cert.pem -CAkey root-key.pem -set_serial $(CITADEL_SERIAL) \
+		-extensions req_ext -extfile $(dir $<)/intermediate.conf \
+		-in $< -out $@
+
+%/cluster-ca.csr: L=$(dir $@)
+%/cluster-ca.csr: %/ca-key.pem %/intermediate.conf
+	@echo "generating $@"
+	@openssl req -new -batch -sha256 $(UTF8) \
+		-config $(L)/intermediate.conf \
+		-key $< -out $@ 
+
+%/ca-key.pem:
+	@echo "generating $@"
+	@mkdir -p $(dir $@)
+	@openssl genrsa -out $@ 4096
+
+%/intermediate.conf: L=$(dir $@)
+%/intermediate.conf:
+	@echo "[ req ]" > $@
+	@echo "encrypt_key = no" >> $@
+	@echo "prompt = no" >> $@
+	@echo "utf8 = yes" >> $@
+	@echo "default_md = sha256" >> $@
+	@echo "default_bits = 4096" >> $@
+	@echo "req_extensions = req_ext" >> $@
+	@echo "x509_extensions = req_ext" >> $@
+	@echo "distinguished_name = req_dn" >> $@
+	@echo "[ req_ext ]" >> $@
+	@echo "subjectKeyIdentifier = hash" >> $@
+	@echo "basicConstraints = critical, CA:true, pathlen:0" >> $@
+	@echo "keyUsage = critical, digitalSignature, nonRepudiation, keyEncipherment, keyCertSign" >> $@
+	@echo "subjectAltName=@san" >> $@
+	@echo "[ san ]" >> $@
+	@echo "URI.1 = spiffe://cluster.local/ns/istio-system/sa/citadel" >> $@
+	@echo "URI.2 = spiffe://$(L:/=)/ns/istio-system/sa/citadel" >> $@
+	@echo "[ req_dn ]" >> $@
+	@echo "O = Istio" >> $@
+	@echo "CN = Intermediate CA" >> $@
+	@echo "L = $(L:/=)" >> $@

--- a/samples/certs/README.md
+++ b/samples/certs/README.md
@@ -13,8 +13,8 @@ The included sample files are:
 ## Generating Certificates for Bootstrapping Multicluster Chain of Trust
 
 Using the sample certificates to establish trust between multiple clusters is not recommended.
-Since we're missing the root CA's private key, we're unable to create new certificates for
-the clusters. Our only workable option is to use the **same** files for all clusters.
+Since the directory is missing the root CA's private key, we're unable to create new certificates
+for the clusters. Our only workable option is to use the **same** files for all clusters.
 A better alternative would be to assign a different intermediate CA to each cluster, all signed by
 a shared root CA. This will enable trust between workloads from different clusters as long as
 they share a common root CA.

--- a/samples/certs/README.md
+++ b/samples/certs/README.md
@@ -1,0 +1,37 @@
+# Sample Certificates for Citadel CA
+
+This directory contains sample pre-generated certificate and keys to demonstrate how an operator could configure Citadel with an existing root certificate, signing certificates and keys. In such
+a deployment, Citadel acts as an intermediate certificate authority (CA), under the given root CA.
+Instructions are available [here](https://istio.io/docs/tasks/security/plugin-ca-cert/).
+
+The included sample files are:
+
+- `root-cert.pem`: root CA certificate.
+- `ca-cert.pem` and `ca-cert.key`: Citadel intermediate certificate and corresponding private key.
+- `cert-chain.pem`: certificate trust chain.
+
+## Generating Certificates for Bootstrapping Multicluster Chain of Trust
+
+Using the sample certificates to establish trust between multiple clusters is not recommended.
+Since we're missing the root CA's private key, we're unable to create new certificates for
+the clusters. Our only workable option is to use the **same** files for all clusters.
+A better alternative would be to assign a different intermediate CA to each cluster, all signed by
+a shared root CA. This will enable trust between workloads from different clusters as long as
+they share a common root CA.
+
+The directory contains a `Makefile` for generating new root and intermediate certificates.
+The following `make` targets are defined:
+
+- `make root-ca`: this will generate a new root CA key and certificate.
+- `make $NAME-certs`: this will generate all needed files to bootstrap a new Citadel for cluster `$NAME` (e.g., `us-east`, `cluster01`, etc.).
+
+The intermediate CA files used for cluster `$NAME` are created under a directory named
+`$NAME`. By creating files under a directory, we can create them using the naming convention
+expected by Citadel's command line options. To differentiate between clusters, we include a
+`Location` (`L`) designation in the certificates `Subject` field, with the cluster's name.
+Similarly, we set the `Subject Alternate Name` field to include the cluster name as part
+of the SPIFFE identity.
+
+Note that the Makefile generates long lived intermediate certificates. While this might be
+acceptable for demonstration purposes, a more realistic and secure deployment would use short
+lived and automatically renewed certificates for the intermediate Citadels.


### PR DESCRIPTION
Document use and automate creation of intermediate certificate by Citadel.

The README.md explains how to generate and set-up shared root of trust for multiple clusters.
It makes use of the Makefile to automate certificate creation for Citadel trust chain.

With some more customization, the Makefile could replace some shell scripts that are currently being used in various tests.