### PR TITLE
Add support for datadog tracing.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -191,6 +191,11 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
           - name: ISTIO_META_POD_NAME
             valueFrom:
               fieldRef:

--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -210,6 +210,11 @@ data:
         {{- else }}
           address: zipkin.{{ .Release.Namespace }}:9411
         {{- end }}
+      {{- else if eq .Values.global.proxy.tracer "datadog" }}
+      tracing:
+        datadog:
+          # Address of the Datadog Agent
+          address: {{ .Values.global.tracer.datadog.address }}
       {{- end }}
 
     {{- if .Values.global.proxy.envoyStatsd.enabled }}

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -124,7 +124,6 @@ data:
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
-        - --datadog
         - --datadogAgentAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetDatadog.GetAddress ]]" }}
       {{- end }}
@@ -168,7 +167,7 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        {{ if and (eq .Values.global.proxy.tracer "datadog") (eq .Values.global.tracer.datadog.address "") }}
+        {{ if eq .Values.global.proxy.tracer "datadog" }}
         - name: HOST_IP
           valueFrom:
             fieldRef:

--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -123,6 +123,10 @@ data:
       {{- else if eq .Values.global.proxy.tracer "zipkin" }}
         - --zipkinAddress
         - {{ "[[ .ProxyConfig.GetTracing.GetZipkin.GetAddress ]]" }}
+      {{- else if eq .Values.global.proxy.tracer "datadog" }}
+        - --datadog
+        - --datadogAgentAddress
+        - {{ "[[ .ProxyConfig.GetTracing.GetDatadog.GetAddress ]]" }}
       {{- end }}
         - --connectTimeout
         - {{ "[[ formatDuration .ProxyConfig.ConnectTimeout ]]" }}
@@ -164,6 +168,12 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        {{ if and (eq .Values.global.proxy.tracer "datadog") (eq .Values.global.tracer.datadog.address "") }}
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        {{ end }}
         - name: ISTIO_META_POD_NAME
           valueFrom:
             fieldRef:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -278,9 +278,8 @@ global:
       # zipkin service (port 9411) in the same namespace as the other istio components.
       address: ""
     datadog:
-      # Host:Port for submitting traces to the Datadog agent. If not specified, the host IP and
-      # default tracing port (8126) will be used.
-      address: ""
+      # Host:Port for submitting traces to the Datadog agent.
+      address: "$(HOST_IP):8126"
 
   # Default mtls policy. If true, mtls between services will be enabled by default.
   mtls:

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -229,7 +229,7 @@ global:
       host: # example: metrics-service.istio-system
       port: # example: 15000
 
-    # Specify which tracer to use. One of: lightstep, zipkin
+    # Specify which tracer to use. One of: lightstep, zipkin, datadog
     tracer: "zipkin"
 
   proxy_init:
@@ -276,6 +276,10 @@ global:
     zipkin:
       # Host:Port for reporting trace data in zipkin format. If not specified, will default to
       # zipkin service (port 9411) in the same namespace as the other istio components.
+      address: ""
+    datadog:
+      # Host:Port for submitting traces to the Datadog agent. If not specified, the host IP and
+      # default tracing port (8126) will be used.
       address: ""
 
   # Default mtls policy. If true, mtls between services will be enabled by default.

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -68,7 +68,6 @@ var (
 	lightstepAccessToken       string
 	lightstepSecure            bool
 	lightstepCacertPath        string
-	datadogEnabled             bool
 	datadogAgentAddress        string
 	connectTimeout             time.Duration
 	statsdUDPAddress           string
@@ -270,7 +269,7 @@ var (
 						},
 					},
 				}
-			} else if datadogEnabled {
+			} else if datadogAgentAddress != "" {
 				proxyConfig.Tracing = &meshconfig.Tracing{
 					Tracer: &meshconfig.Tracing_Datadog_{
 						Datadog: &meshconfig.Tracing_Datadog{
@@ -520,8 +519,6 @@ func init() {
 		"Should connection to the LightStep Satellite pool be secure")
 	proxyCmd.PersistentFlags().StringVar(&lightstepCacertPath, "lightstepCacertPath", "",
 		"Path to the trusted cacert used to authenticate the pool")
-	proxyCmd.PersistentFlags().BoolVar(&datadogEnabled, "datadog", false,
-		"Use the Datadog tracing provider")
 	proxyCmd.PersistentFlags().StringVar(&datadogAgentAddress, "datadogAgentAddress", "",
 		"Address of the Datadog Agent")
 	proxyCmd.PersistentFlags().DurationVar(&connectTimeout, "connectTimeout",

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -68,6 +68,8 @@ var (
 	lightstepAccessToken       string
 	lightstepSecure            bool
 	lightstepCacertPath        string
+	datadogEnabled             bool
+	datadogAgentAddress        string
 	connectTimeout             time.Duration
 	statsdUDPAddress           string
 	envoyMetricsServiceAddress string
@@ -265,6 +267,14 @@ var (
 					Tracer: &meshconfig.Tracing_Zipkin_{
 						Zipkin: &meshconfig.Tracing_Zipkin{
 							Address: zipkinAddress,
+						},
+					},
+				}
+			} else if datadogEnabled {
+				proxyConfig.Tracing = &meshconfig.Tracing{
+					Tracer: &meshconfig.Tracing_Datadog_{
+						Datadog: &meshconfig.Tracing_Datadog{
+							Address: datadogAgentAddress,
 						},
 					},
 				}
@@ -510,6 +520,10 @@ func init() {
 		"Should connection to the LightStep Satellite pool be secure")
 	proxyCmd.PersistentFlags().StringVar(&lightstepCacertPath, "lightstepCacertPath", "",
 		"Path to the trusted cacert used to authenticate the pool")
+	proxyCmd.PersistentFlags().BoolVar(&datadogEnabled, "datadog", false,
+		"Use the Datadog tracing provider")
+	proxyCmd.PersistentFlags().StringVar(&datadogAgentAddress, "datadogAgentAddress", "",
+		"Address of the Datadog Agent")
 	proxyCmd.PersistentFlags().DurationVar(&connectTimeout, "connectTimeout",
 		timeDuration(values.ConnectTimeout),
 		"Connection timeout used by Envoy for supporting services")

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1083,6 +1083,17 @@ func ValidateZipkinCollector(z *meshconfig.Tracing_Zipkin) error {
 	return ValidateProxyAddress(z.GetAddress())
 }
 
+// ValidateDatadogCollector validates the configuration for sending envoy spans to Datadog
+func ValidateDatadogCollector(d *meshconfig.Tracing_Datadog) error {
+	var errs error
+	if d.GetAddress() != "" {
+		if err := ValidateProxyAddress(d.GetAddress()); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid datadog address:"))
+		}
+	}
+	return errs
+}
+
 // ValidateConnectTimeout validates the envoy conncection timeout
 func ValidateConnectTimeout(timeout *types.Duration) error {
 	if err := ValidateDuration(timeout); err != nil {
@@ -1165,6 +1176,12 @@ func ValidateProxyConfig(config *meshconfig.ProxyConfig) (errs error) {
 	if tracer := config.GetTracing().GetZipkin(); tracer != nil {
 		if err := ValidateZipkinCollector(tracer); err != nil {
 			errs = multierror.Append(errs, multierror.Prefix(err, "invalid zipkin config:"))
+		}
+	}
+
+	if tracer := config.GetTracing().GetDatadog(); tracer != nil {
+		if err := ValidateDatadogCollector(tracer); err != nil {
+			errs = multierror.Append(errs, multierror.Prefix(err, "invalid datadog config:"))
 		}
 	}
 

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1085,13 +1085,8 @@ func ValidateZipkinCollector(z *meshconfig.Tracing_Zipkin) error {
 
 // ValidateDatadogCollector validates the configuration for sending envoy spans to Datadog
 func ValidateDatadogCollector(d *meshconfig.Tracing_Datadog) error {
-	var errs error
-	if d.GetAddress() != "" {
-		if err := ValidateProxyAddress(d.GetAddress()); err != nil {
-			errs = multierror.Append(errs, multierror.Prefix(err, "invalid datadog address:"))
-		}
-	}
-	return errs
+	// If the address contains $(HOST_IP), replace it with a valid IP before validation.
+	return ValidateProxyAddress(strings.Replace(d.GetAddress(), "$(HOST_IP)", "127.0.0.1", 1))
 }
 
 // ValidateConnectTimeout validates the envoy conncection timeout

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -813,6 +813,49 @@ func TestValidateProxyConfig(t *testing.T) {
 			),
 			isValid: false,
 		},
+		{
+			name: "datadog without address",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Datadog_{
+							Datadog: &meshconfig.Tracing_Datadog{},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
+		{
+			name: "datadog with correct address",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Datadog_{
+							Datadog: &meshconfig.Tracing_Datadog{
+								Address: "datadog-agent:8126",
+							},
+						},
+					}
+				},
+			),
+			isValid: true,
+		},
+		{
+			name: "datadog with invalid address",
+			in: modify(valid,
+				func(c *meshconfig.ProxyConfig) {
+					c.Tracing = &meshconfig.Tracing{
+						Tracer: &meshconfig.Tracing_Datadog_{
+							Datadog: &meshconfig.Tracing_Datadog{
+								Address: "address-missing-port-number",
+							},
+						},
+					}
+				},
+			),
+			isValid: false,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -824,7 +824,7 @@ func TestValidateProxyConfig(t *testing.T) {
 					}
 				},
 			),
-			isValid: true,
+			isValid: false,
 		},
 		{
 			name: "datadog with correct address",

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -313,15 +313,11 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 			opts["lightstepSecure"] = tracer.Lightstep.Secure
 			opts["lightstepCacertPath"] = tracer.Lightstep.CacertPath
 		case *meshconfig.Tracing_Datadog_:
-			opts["hostIP"] = os.Getenv("HOST_IP")
-			opts["datadog"] = true
-			if tracer.Datadog.Address != "" {
-				h, p, err = GetHostPort("Datadog", tracer.Datadog.Address)
-				if err != nil {
-					return "", err
-				}
-				StoreHostPort(h, p, "datadogAgentAddress", opts)
+			h, p, err = GetHostPort("Datadog", tracer.Datadog.Address)
+			if err != nil {
+				return "", err
 			}
+			StoreHostPort(h, p, "datadog", opts)
 		}
 	}
 

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -312,6 +312,16 @@ func WriteBootstrap(config *meshconfig.ProxyConfig, node string, epoch int, pilo
 			opts["lightstepToken"] = lightstepAccessTokenPath
 			opts["lightstepSecure"] = tracer.Lightstep.Secure
 			opts["lightstepCacertPath"] = tracer.Lightstep.CacertPath
+		case *meshconfig.Tracing_Datadog_:
+			opts["hostIP"] = os.Getenv("HOST_IP")
+			opts["datadog"] = true
+			if tracer.Datadog.Address != "" {
+				h, p, err = GetHostPort("Datadog", tracer.Datadog.Address)
+				if err != nil {
+					return "", err
+				}
+				StoreHostPort(h, p, "datadogAgentAddress", opts)
+			}
 		}
 	}
 

--- a/pkg/bootstrap/bootstrap_config_test.go
+++ b/pkg/bootstrap/bootstrap_config_test.go
@@ -37,6 +37,7 @@ import (
 // cp $TOP/out/linux_amd64/release/bootstrap/all/envoy-rev0.json pkg/bootstrap/testdata/all_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/auth/envoy-rev0.json pkg/bootstrap/testdata/auth_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/default/envoy-rev0.json pkg/bootstrap/testdata/default_golden.json
+// cp $TOP/out/linux_amd64/release/bootstrap/tracing_datadog/envoy-rev0.json pkg/bootstrap/testdata/tracing_datadog_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_lightstep/envoy-rev0.json pkg/bootstrap/testdata/tracing_lightstep_golden.json
 // cp $TOP/out/linux_amd64/release/bootstrap/tracing_zipkin/envoy-rev0.json pkg/bootstrap/testdata/tracing_zipkin_golden.json
 func TestGolden(t *testing.T) {
@@ -71,6 +72,9 @@ func TestGolden(t *testing.T) {
 		},
 		{
 			base: "tracing_zipkin",
+		},
+		{
+			base: "tracing_datadog",
 		},
 		{
 			// Specify zipkin/statsd address, similar with the default config in v1 tests

--- a/pkg/bootstrap/testdata/tracing_datadog.proto
+++ b/pkg/bootstrap/testdata/tracing_datadog.proto
@@ -1,0 +1,10 @@
+config_path:               "/etc/istio/proxy"
+binary_path:               "/usr/local/bin/envoy"
+service_cluster:           "istio-proxy"
+drain_duration:            {seconds: 2}
+parent_shutdown_duration:  {seconds: 3}
+discovery_address:         "istio-pilot:15010"
+connect_timeout:           {seconds: 1}
+proxy_admin_port:          15000
+control_plane_auth_policy: NONE
+tracing:                   { datadog: {} }

--- a/pkg/bootstrap/testdata/tracing_datadog.proto
+++ b/pkg/bootstrap/testdata/tracing_datadog.proto
@@ -7,4 +7,4 @@ discovery_address:         "istio-pilot:15010"
 connect_timeout:           {seconds: 1}
 proxy_admin_port:          15000
 control_plane_auth_policy: NONE
-tracing:                   { datadog: {} }
+tracing:                   { datadog: { address: "localhost:8126" } }

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -1,19 +1,13 @@
 {
   "node": {
-    "id": "{{ .nodeID }}",
-    "cluster": "{{ .cluster }}",
+    "id": "sidecar~1.2.3.4~foo~bar",
+    "cluster": "istio-proxy",
     "locality": {
-      {{ if .region }}
-      "region": "{{ .region }}",
-      {{ end }}
-      {{ if .zone }}
-      "zone": "{{ .zone }}",
-      {{ end }}
-      {{ if .sub_zone }}
-      "sub_zone": "{{ .sub_zone }}",
-      {{ end }}
+      
+      
+      
     },
-    "metadata": {{ .meta_json_str }}
+    "metadata": {"ISTIO_META_INSTANCE_IPS":"10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6","istio":"sidecar"}
   },
   "stats_config": {
     "use_all_default_tags": false,
@@ -54,11 +48,24 @@
     "stats_matcher": {
       "inclusion_list": {
         "patterns": [
-          {{- range $a, $s := .inclusionPatterns }}
             {
-              "prefix": "{{$s}}"
+              "prefix": "cluster_manager"
             },
-          {{- end }}
+            {
+              "prefix": "listener_manager"
+            },
+            {
+              "prefix": "http_mixer_filter"
+            },
+            {
+              "prefix": "tcp_mixer_filter"
+            },
+            {
+              "prefix": "server"
+            },
+            {
+              "prefix": "cluster.xds-grpc"
+            },
         ]
       }
     }
@@ -68,7 +75,7 @@
     "address": {
       "socket_address": {
         "address": "127.0.0.1",
-        "port_value": {{ .config.ProxyAdminPort }}
+        "port_value": 15000
       }
     }
   },
@@ -102,7 +109,7 @@
             "socket_address": {
               "protocol": "TCP",
               "address": "127.0.0.1",
-              "port_value": {{ .config.ProxyAdminPort }}
+              "port_value": 15000
             }
           }
         ]
@@ -110,40 +117,12 @@
       {
         "name": "xds-grpc",
         "type": "STRICT_DNS",
-        "connect_timeout": "{{ .connect_timeout }}",
+        "connect_timeout": "1s",
         "lb_policy": "ROUND_ROBIN",
-        {{ if eq .config.ControlPlaneAuthPolicy 1 }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "tls_certificates": [
-              {
-                "certificate_chain": {
-                  "filename": "/etc/certs/cert-chain.pem"
-                },
-                "private_key": {
-                  "filename": "/etc/certs/key.pem"
-                }
-              }
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "/etc/certs/root-cert.pem"
-              },
-              "verify_subject_alt_name": [
-                {{- range $a, $s := .pilot_SAN }}
-                "{{$s}}"
-                {{- end}}
-              ]
-            }
-          }
-        },
-        {{ end }}
+        
         "hosts": [
           {
-            "socket_address": {{ .pilot_grpc_address }}
+            "socket_address": {"address": "istio-pilot", "port_value": 15010}
           }
         ],
         "circuit_breakers": {
@@ -169,48 +148,7 @@
         },
         "http2_protocol_options": { }
       }
-      {{ if .zipkin }}
-      ,
-      {
-        "name": "zipkin",
-        "type": "STRICT_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .zipkin }}
-          }
-        ]
-      }
-      {{ else if .lightstep }}
-      ,
-      {
-        "name": "lightstep",
-        "http2_protocol_options": {},
-        {{ if .lightstepSecure }}
-        "tls_context": {
-          "common_tls_context": {
-            "alpn_protocols": [
-              "h2"
-            ],
-            "validation_context": {
-              "trusted_ca": {
-                "filename": "{{ .lightstepCacertPath }}"
-              }
-            }
-          }
-        },
-        {{ end }}
-        "type": "LOGICAL_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .lightstep }}
-          }
-        ]
-      }
-      {{ else if .datadog }}
+      
       ,
       {
         "name": "datadog_agent",
@@ -219,32 +157,16 @@
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
-            {{ if .datadogAgentAddress }}
-            "socket_address": {{ .datadogAgentAddress }}
-            {{ else }}
+            
             "socket_address": {
-              "address": "{{ .hostIP }}",
+              "address": "",
               "port_value": 8126
             }
-            {{ end }}
+            
           }
         ]
       }
-      {{ end }}
-      {{ if .envoy_metrics_service }}
-      ,
-      {
-        "name": "envoy_metrics_service",
-        "type": "STRICT_DNS",
-        "connect_timeout": "1s",
-        "lb_policy": "ROUND_ROBIN",
-        "hosts": [
-          {
-            "socket_address": {{ .envoy_metrics_service }}
-          }
-        ]
-      }
-      {{ end }}
+      
     ],
     "listeners":[
       {
@@ -294,67 +216,17 @@
       }
     ]
   }
-  {{ if .zipkin }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.zipkin",
-      "config": {
-        "collector_cluster": "zipkin",
-        "collector_endpoint": "/api/v1/spans",
-        "trace_id_128bit": "true",
-        "shared_span_context": "false"
-      }
-    }
-  }
-  {{ else if .lightstep }}
-  ,
-  "tracing": {
-    "http": {
-      "name": "envoy.lightstep",
-      "config": {
-        "collector_cluster": "lightstep",
-        "access_token_file": "{{ .lightstepToken}}"
-      }
-    }
-  }
-  {{ else if .datadog }}
+  
   ,
   "tracing": {
     "http": {
       "name": "envoy.tracers.datadog",
       "config": {
         "collector_cluster": "datadog_agent",
-        "service_name": "{{ .cluster }}"
+        "service_name": "istio-proxy"
       }
     }
   }
-  {{ end }}
-  {{ if or .envoy_metrics_service .statsd }}
-  ,
-  "stats_sinks": [
-    {{ if .envoy_metrics_service }}
-    {
-      "name": "envoy.metrics_service",
-      "config": {
-        "grpc_service": {
-          "envoy_grpc": {
-            "cluster_name": "envoy_metrics_service"
-          }
-        }
-      }
-    },
-    {{ end }}
-    {{ if .statsd }}
-    {
-      "name": "envoy.statsd",
-      "config": {
-        "address": {
-          "socket_address": {{ .statsd }}
-        }
-      }
-    },
-    {{ end }}
-  ]
-  {{ end }}
+  
+  
 }

--- a/pkg/bootstrap/testdata/tracing_datadog_golden.json
+++ b/pkg/bootstrap/testdata/tracing_datadog_golden.json
@@ -157,12 +157,7 @@
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
-            
-            "socket_address": {
-              "address": "",
-              "port_value": 8126
-            }
-            
+            "socket_address": {"address": "localhost", "port_value": 8126}
           }
         ]
       }

--- a/tools/deb/envoy_bootstrap_v2.json
+++ b/tools/deb/envoy_bootstrap_v2.json
@@ -219,14 +219,7 @@
         "lb_policy": "ROUND_ROBIN",
         "hosts": [
           {
-            {{ if .datadogAgentAddress }}
-            "socket_address": {{ .datadogAgentAddress }}
-            {{ else }}
-            "socket_address": {
-              "address": "{{ .hostIP }}",
-              "port_value": 8126
-            }
-            {{ end }}
+            "socket_address": {{ .datadog }}
           }
         ]
       }


### PR DESCRIPTION
This PR adds the option of using Datadog for tracing in istio.
The `istio.io/api` dependency is bumped in this PR to access the new config item.

Related issues: #6314 
