### PR TITLE
Set SDS token path in clusters when SDS_TOKEN_PATH is in Envoy metadata

### DIFF
--- a/pilot/pkg/model/authentication.go
+++ b/pilot/pkg/model/authentication.go
@@ -44,12 +44,12 @@ const (
 	// K8sSAJwtFileName is the token volume mount file name for k8s jwt token.
 	K8sSAJwtFileName = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
-	// fileBasedMetadataPlugName is File Based Metadata credentials plugin name.
-	fileBasedMetadataPlugName = "envoy.grpc_credentials.file_based_metadata"
+	// FileBasedMetadataPlugName is File Based Metadata credentials plugin name.
+	FileBasedMetadataPlugName = "envoy.grpc_credentials.file_based_metadata"
 
-	// k8sSAJwtTokenHeaderKey is the request header key for k8s jwt token.
+	// K8sSAJwtTokenHeaderKey is the request header key for k8s jwt token.
 	// Binary header name must has suffix "-bin", according to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md.
-	k8sSAJwtTokenHeaderKey = "istio_sds_credentail_header-bin"
+	K8sSAJwtTokenHeaderKey = "istio_sds_credentail_header-bin"
 
 	// IngressGatewaySdsUdsPath is the UDS path for ingress gateway to get credentials via SDS.
 	IngressGatewaySdsUdsPath = "unix:/var/run/ingress_gateway/sds"
@@ -127,14 +127,14 @@ func ConstructSdsSecretConfig(name, sdsUdsPath string, useK8sSATrustworthyJwt, u
 	// request key/cert.
 	if sdsTokenPath, found := metadata[NodeMetadataSdsTokenPath]; found && len(sdsTokenPath) > 0 {
 		log.Debugf("SDS token path is (%v)", sdsTokenPath)
-		gRPCConfig.CredentialsFactoryName = fileBasedMetadataPlugName
-		gRPCConfig.CallCredentials = constructgRPCCallCredentials(sdsTokenPath, k8sSAJwtTokenHeaderKey)
+		gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
+		gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(sdsTokenPath, K8sSAJwtTokenHeaderKey)
 	} else if useK8sSATrustworthyJwt {
-		gRPCConfig.CredentialsFactoryName = fileBasedMetadataPlugName
-		gRPCConfig.CallCredentials = constructgRPCCallCredentials(K8sSATrustworthyJwtFileName, k8sSAJwtTokenHeaderKey)
+		gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
+		gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey)
 	} else if useK8sSANormalJwt {
-		gRPCConfig.CredentialsFactoryName = fileBasedMetadataPlugName
-		gRPCConfig.CallCredentials = constructgRPCCallCredentials(K8sSAJwtFileName, k8sSAJwtTokenHeaderKey)
+		gRPCConfig.CredentialsFactoryName = FileBasedMetadataPlugName
+		gRPCConfig.CallCredentials = ConstructgRPCCallCredentials(K8sSAJwtFileName, K8sSAJwtTokenHeaderKey)
 	} else {
 		gRPCConfig.CallCredentials = []*core.GrpcService_GoogleGrpc_CallCredentials{
 			&core.GrpcService_GoogleGrpc_CallCredentials{
@@ -223,7 +223,7 @@ func ParseJwksURI(jwksURI string) (string, *Port, bool, error) {
 }
 
 // this function is used to construct SDS config which is only available from 1.1
-func constructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcService_GoogleGrpc_CallCredentials {
+func ConstructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcService_GoogleGrpc_CallCredentials {
 	// If k8s sa jwt token file exists, envoy only handles plugin credentials.
 	config := &v2alpha.FileBasedMetadataConfig{
 		SecretData: &core.DataSource{
@@ -240,7 +240,7 @@ func constructgRPCCallCredentials(tokenFileName, headerKey string) []*core.GrpcS
 		&core.GrpcService_GoogleGrpc_CallCredentials{
 			CredentialSpecifier: &core.GrpcService_GoogleGrpc_CallCredentials_FromPlugin{
 				FromPlugin: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin{
-					Name: fileBasedMetadataPlugName,
+					Name: FileBasedMetadataPlugName,
 					ConfigType: &core.GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig{
 						TypedConfig: any},
 				},

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -95,7 +95,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 				Filename: K8sSATrustworthyJwtFileName,
 			},
 		},
-		HeaderKey: k8sSAJwtTokenHeaderKey,
+		HeaderKey: K8sSAJwtTokenHeaderKey,
 	}
 
 	normalMetaConfig := &v2alpha.FileBasedMetadataConfig{
@@ -104,7 +104,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 				Filename: K8sSAJwtFileName,
 			},
 		},
-		HeaderKey: k8sSAJwtTokenHeaderKey,
+		HeaderKey: K8sSAJwtTokenHeaderKey,
 	}
 
 	cases := []struct {

--- a/pilot/pkg/model/authentication_test.go
+++ b/pilot/pkg/model/authentication_test.go
@@ -150,7 +150,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 			useTrustworthyJwt: true,
 			expected: &auth.SdsSecretConfig{
 				Name:      "spiffe://cluster.local/ns/bar/sa/foo",
-				SdsConfig: constructsdsconfighelper(K8sSATrustworthyJwtFileName, k8sSAJwtTokenHeaderKey, trustworthyMetaConfig),
+				SdsConfig: constructsdsconfighelper(K8sSATrustworthyJwtFileName, K8sSAJwtTokenHeaderKey, trustworthyMetaConfig),
 			},
 		},
 		{
@@ -159,7 +159,7 @@ func TestConstructSdsSecretConfig(t *testing.T) {
 			useNormalJwt:   true,
 			expected: &auth.SdsSecretConfig{
 				Name:      "spiffe://cluster.local/ns/bar/sa/foo",
-				SdsConfig: constructsdsconfighelper(K8sSAJwtFileName, k8sSAJwtTokenHeaderKey, normalMetaConfig),
+				SdsConfig: constructsdsconfighelper(K8sSAJwtFileName, K8sSAJwtTokenHeaderKey, normalMetaConfig),
 			},
 		},
 		{

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -92,3 +92,46 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	}
 	return rawClusters, nil
 }
+
+// Set the SDS token path if SDS_TOKEN_PATH is defined in the proxy metadata
+func SetSdsTokenPathFromProxyMetadata(c *xdsapi.Cluster, node *model.Proxy) {
+	if sdsTokenPath, found := node.Metadata[model.NodeMetadataSdsTokenPath]; found && len(sdsTokenPath) > 0 {
+		// Set the SDS token path in the TLS certificate config
+		if c.GetTlsContext() != nil && c.GetTlsContext().GetCommonTlsContext() != nil &&
+			c.GetTlsContext().GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs() != nil {
+			for _, sc := range c.GetTlsContext().GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs() {
+				if sc.GetSdsConfig() != nil && sc.GetSdsConfig().GetApiConfigSource() != nil &&
+					sc.GetSdsConfig().GetApiConfigSource().GetGrpcServices() != nil {
+					for _, svc := range sc.GetSdsConfig().GetApiConfigSource().GetGrpcServices() {
+						// If no call-credential in the cluster, no need to set SDS token path
+						if svc.GetGoogleGrpc() != nil && svc.GetGoogleGrpc().GetCallCredentials() != nil &&
+							svc.GetGoogleGrpc().GetCredentialsFactoryName() == model.FileBasedMetadataPlugName {
+							adsLog.Debugf("Set SDS token path in TLS context based on the proxy metadata")
+							svc.GetGoogleGrpc().CallCredentials =
+								model.ConstructgRPCCallCredentials(sdsTokenPath, model.K8sSAJwtTokenHeaderKey)
+						}
+					}
+				}
+			}
+		}
+
+		// Set the SDS token path in the TLS validation context
+		if c.GetTlsContext() != nil && c.GetTlsContext().GetCommonTlsContext() != nil &&
+			c.GetTlsContext().GetCommonTlsContext().GetCombinedValidationContext() != nil &&
+			c.GetTlsContext().GetCommonTlsContext().GetCombinedValidationContext().GetValidationContextSdsSecretConfig() != nil {
+			sc := c.GetTlsContext().GetCommonTlsContext().GetCombinedValidationContext().GetValidationContextSdsSecretConfig()
+			if sc.GetSdsConfig() != nil && sc.GetSdsConfig().GetApiConfigSource() != nil &&
+				sc.GetSdsConfig().GetApiConfigSource().GetGrpcServices() != nil {
+				for _, svc := range sc.GetSdsConfig().GetApiConfigSource().GetGrpcServices() {
+					// If no call-credential in the cluster, no need to set SDS token path
+					if svc.GetGoogleGrpc() != nil && svc.GetGoogleGrpc().GetCallCredentials() != nil &&
+						svc.GetGoogleGrpc().GetCredentialsFactoryName() == model.FileBasedMetadataPlugName {
+						adsLog.Debugf("Set SDS token path in validation context based on the proxy metadata")
+						svc.GetGoogleGrpc().CallCredentials =
+							model.ConstructgRPCCallCredentials(sdsTokenPath, model.K8sSAJwtTokenHeaderKey)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -81,22 +81,7 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	if sdsTokenPath, found := node.Metadata[model.NodeMetadataSdsTokenPath]; found && len(sdsTokenPath) > 0 {
 		// If SDS_TOKEN_PATh is in the node metadata, make a copy of rawClusters so that
 		// the path of SDS token will be applied to the copied clusters.
-		clusters := make([]*xdsapi.Cluster, 0)
-		for _, c := range rawClusters {
-			bytes, err := c.Marshal()
-			if err != nil {
-				adsLog.Warnf("Error when marshal cluster: %v, error: %v", c, err)
-				continue
-			}
-			cp := &xdsapi.Cluster{}
-			err = cp.Unmarshal(bytes)
-			if err != nil {
-				adsLog.Warnf("Error when unmarshal cluster, error: %v", err)
-				continue
-			}
-			clusters = append(clusters, cp)
-		}
-		rawClusters = clusters
+		rawClusters = CopyClusters(rawClusters)
 	}
 
 	for _, c := range rawClusters {
@@ -156,4 +141,26 @@ func SetTokenPathForSdsFromProxyMetadata(c *xdsapi.Cluster, node *model.Proxy) {
 			}
 		}
 	}
+}
+
+func CopyClusters(srcClusters []*xdsapi.Cluster) []*xdsapi.Cluster {
+	clusters := make([]*xdsapi.Cluster, 0)
+	if srcClusters == nil {
+		return clusters
+	}
+	for _, c := range srcClusters {
+		bytes, err := c.Marshal()
+		if err != nil {
+			adsLog.Warnf("Error when marshal cluster: %v, error: %v", c, err)
+			continue
+		}
+		cp := &xdsapi.Cluster{}
+		err = cp.Unmarshal(bytes)
+		if err != nil {
+			adsLog.Warnf("Error when unmarshal cluster, error: %v", err)
+			continue
+		}
+		clusters = append(clusters, cp)
+	}
+	return clusters
 }

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -79,7 +79,7 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	}
 
 	if sdsTokenPath, found := node.Metadata[model.NodeMetadataSdsTokenPath]; found && len(sdsTokenPath) > 0 {
-		// If SDS_TOKEN_PATh is in the node metadata, make a copy of rawClusters so that
+		// If SDS_TOKEN_PATH is in the node metadata, make a copy of rawClusters so that
 		// the path of SDS token will be applied to the copied clusters.
 		rawClusters = CopyClusters(rawClusters)
 	}

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -79,7 +79,7 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	}
 
 	for _, c := range rawClusters {
-		SetSdsTokenPathFromProxyMetadata(c, node)
+		SetTokenPathForSdsFromProxyMetadata(c, node)
 		if err = c.Validate(); err != nil {
 			retErr := fmt.Errorf("CDS: Generated invalid cluster for node %v: %v", node, err)
 			adsLog.Errorf("CDS: Generated invalid cluster for node %s: %v, %v", node.ID, err, c)
@@ -94,8 +94,8 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	return rawClusters, nil
 }
 
-// Set the SDS token path if SDS_TOKEN_PATH is defined in the proxy metadata
-func SetSdsTokenPathFromProxyMetadata(c *xdsapi.Cluster, node *model.Proxy) {
+// Set the token path for SDS if SDS_TOKEN_PATH is defined in the proxy metadata
+func SetTokenPathForSdsFromProxyMetadata(c *xdsapi.Cluster, node *model.Proxy) {
 	if sdsTokenPath, found := node.Metadata[model.NodeMetadataSdsTokenPath]; found && len(sdsTokenPath) > 0 {
 		// Set the SDS token path in the TLS certificate config
 		if c.GetTlsContext() != nil && c.GetTlsContext().GetCommonTlsContext() != nil &&

--- a/pilot/pkg/proxy/envoy/v2/cds.go
+++ b/pilot/pkg/proxy/envoy/v2/cds.go
@@ -79,6 +79,7 @@ func (s *DiscoveryServer) generateRawClusters(node *model.Proxy, push *model.Pus
 	}
 
 	for _, c := range rawClusters {
+		SetSdsTokenPathFromProxyMetadata(c, node)
 		if err = c.Validate(); err != nil {
 			retErr := fmt.Errorf("CDS: Generated invalid cluster for node %v: %v", node, err)
 			adsLog.Errorf("CDS: Generated invalid cluster for node %s: %v, %v", node.ID, err, c)

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -17,9 +17,17 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/gogo/protobuf/proto"
+
+	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
+	"istio.io/istio/pilot/pkg/model"
+	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 )
 
 func TestCDS(t *testing.T) {
@@ -54,4 +62,122 @@ func TestCDS(t *testing.T) {
 	// check that each mocked service and destination rule has a corresponding resource
 
 	// TODO: dynamic checks ( see EDS )
+}
+
+func TestSetSdsTokenPathFromProxyMetadata(t *testing.T) {
+	defaultTokenPath := "the-default-sds-token-path"
+	sdsTokenPath := "the-sds-token-path-in-metadata"
+	node := &model.Proxy{
+		Metadata: map[string]string{
+			"SDS_TOKEN_PATH": sdsTokenPath,
+		},
+	}
+	clusterExpected := &xdsapi.Cluster{
+		TlsContext: &auth.UpstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					&auth.SdsSecretConfig{
+						SdsConfig: &core.ConfigSource{
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													CredentialsFactoryName: model.FileBasedMetadataPlugName,
+													CallCredentials:        model.ConstructgRPCCallCredentials(sdsTokenPath, model.K8sSAJwtTokenHeaderKey),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							SdsConfig: &core.ConfigSource{
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														CredentialsFactoryName: model.FileBasedMetadataPlugName,
+														CallCredentials:        model.ConstructgRPCCallCredentials(sdsTokenPath, model.K8sSAJwtTokenHeaderKey),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster := &xdsapi.Cluster{
+		TlsContext: &auth.UpstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					&auth.SdsSecretConfig{
+						SdsConfig: &core.ConfigSource{
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													CredentialsFactoryName: model.FileBasedMetadataPlugName,
+													CallCredentials:        model.ConstructgRPCCallCredentials(defaultTokenPath, model.K8sSAJwtTokenHeaderKey),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							SdsConfig: &core.ConfigSource{
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
+														CallCredentials:        model.ConstructgRPCCallCredentials(defaultTokenPath, model.K8sSAJwtTokenHeaderKey),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	v2.SetSdsTokenPathFromProxyMetadata(cluster, node)
+
+	// The SDS token path should have been set based on the proxy metadata
+	if !proto.Equal(cluster, clusterExpected) {
+		t.Errorf("The cluster after setting SDS token path is not as expected! Expected:\n%v, actual:\n%v",
+			proto.MarshalTextString(clusterExpected), proto.MarshalTextString(cluster))
+	}
 }

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -64,7 +64,7 @@ func TestCDS(t *testing.T) {
 	// TODO: dynamic checks ( see EDS )
 }
 
-func TestSetSdsTokenPathFromProxyMetadata(t *testing.T) {
+func TestSetTokenPathForSdsFromProxyMetadata(t *testing.T) {
 	defaultTokenPath := "the-default-sds-token-path"
 	sdsTokenPath := "the-sds-token-path-in-metadata"
 	node := &model.Proxy{
@@ -173,7 +173,7 @@ func TestSetSdsTokenPathFromProxyMetadata(t *testing.T) {
 			},
 		},
 	}
-	v2.SetSdsTokenPathFromProxyMetadata(cluster, node)
+	v2.SetTokenPathForSdsFromProxyMetadata(cluster, node)
 
 	// The SDS token path should have been set based on the proxy metadata
 	if !proto.Equal(cluster, clusterExpected) {

--- a/pilot/pkg/proxy/envoy/v2/cds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/cds_test.go
@@ -181,3 +181,76 @@ func TestSetTokenPathForSdsFromProxyMetadata(t *testing.T) {
 			proto.MarshalTextString(clusterExpected), proto.MarshalTextString(cluster))
 	}
 }
+
+func TestCopyClusters(t *testing.T) {
+	defaultTokenPath := "the-default-sds-token-path"
+
+	cluster1 := &xdsapi.Cluster{
+		TlsContext: &auth.UpstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{
+					&auth.SdsSecretConfig{
+						SdsConfig: &core.ConfigSource{
+							ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+								ApiConfigSource: &core.ApiConfigSource{
+									ApiType: core.ApiConfigSource_GRPC,
+									GrpcServices: []*core.GrpcService{
+										{
+											TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+												GoogleGrpc: &core.GrpcService_GoogleGrpc{
+													CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
+													CallCredentials:        model.ConstructgRPCCallCredentials(defaultTokenPath, model.K8sSAJwtTokenHeaderKey),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	cluster2 := &xdsapi.Cluster{
+		TlsContext: &auth.UpstreamTlsContext{
+			CommonTlsContext: &auth.CommonTlsContext{
+				ValidationContextType: &auth.CommonTlsContext_CombinedValidationContext{
+					CombinedValidationContext: &auth.CommonTlsContext_CombinedCertificateValidationContext{
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							SdsConfig: &core.ConfigSource{
+								ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
+									ApiConfigSource: &core.ApiConfigSource{
+										ApiType: core.ApiConfigSource_GRPC,
+										GrpcServices: []*core.GrpcService{
+											{
+												TargetSpecifier: &core.GrpcService_GoogleGrpc_{
+													GoogleGrpc: &core.GrpcService_GoogleGrpc{
+														CredentialsFactoryName: "envoy.grpc_credentials.file_based_metadata",
+														CallCredentials:        model.ConstructgRPCCallCredentials(defaultTokenPath, model.K8sSAJwtTokenHeaderKey),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	clustersCopied := v2.CopyClusters([]*xdsapi.Cluster{cluster1, cluster2})
+
+	if len(clustersCopied) != 2 {
+		t.Error("The copying of clusters failed!")
+	} else if !proto.Equal(cluster1, clustersCopied[0]) {
+		t.Errorf("The copied cluster 1 is different from the actual cluster. Expected:\n%v, actual:\n%v",
+			proto.MarshalTextString(cluster1), proto.MarshalTextString(clustersCopied[0]))
+	} else if !proto.Equal(cluster2, clustersCopied[1]) {
+		t.Errorf("The copied cluster 2 is different from the actual cluster. Expected:\n%v, actual:\n%v",
+			proto.MarshalTextString(cluster2), proto.MarshalTextString(clustersCopied[1]))
+	}
+}

--- a/security/pkg/nodeagent/sds/sdsservice.go
+++ b/security/pkg/nodeagent/sds/sdsservice.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	pmodel "istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/log"
 	"istio.io/istio/security/pkg/nodeagent/cache"
 	"istio.io/istio/security/pkg/nodeagent/model"
@@ -46,10 +47,6 @@ const (
 	// credentialTokenHeaderKey is the header key in gPRC header which is used to
 	// pass credential token from envoy's SDS request to SDS service.
 	credentialTokenHeaderKey = "authorization"
-
-	// k8sSAJwtTokenHeaderKey is the request header key, header value is k8s sa jwt, which is set in
-	// https://github.com/istio/istio/blob/master/pilot/pkg/model/authentication.go
-	k8sSAJwtTokenHeaderKey = "istio_sds_credentail_header-bin"
 
 	// IngressGatewaySdsCaSuffix is the suffix of the sds resource name for root CA. All SDS requests
 	// for root CA sent by ingress gateway have suffix -cacert.
@@ -299,9 +296,9 @@ func getCredentialToken(ctx context.Context) (string, error) {
 
 	// Get credential token from request k8sSAJwtTokenHeader(`istio_sds_credentail_header`) if it exists;
 	// otherwise fallback to credentialTokenHeader('authorization').
-	if h, ok := metadata[k8sSAJwtTokenHeaderKey]; ok {
+	if h, ok := metadata[pmodel.K8sSAJwtTokenHeaderKey]; ok {
 		if len(h) != 1 {
-			return "", fmt.Errorf("credential token from %q must have 1 value in gRPC metadata but got %d", k8sSAJwtTokenHeaderKey, len(h))
+			return "", fmt.Errorf("credential token from %q must have 1 value in gRPC metadata but got %d", pmodel.K8sSAJwtTokenHeaderKey, len(h))
 		}
 		return h[0], nil
 	}


### PR DESCRIPTION
When SDS_TOKEN_PATH is in the Enovy metadata, set the SDS token path in clusters based on SDS_TOKEN_PATH.