### PR TITLE
GCP_OPTS should not be quoted

### DIFF
--- a/tools/setup_perf_cluster.sh
+++ b/tools/setup_perf_cluster.sh
@@ -93,19 +93,19 @@ function ExecuteEval() {
 
 
 function create_cluster() {
-  Execute gcloud container clusters create "$CLUSTER_NAME" "$GCP_OPTS" --machine-type="$MACHINE_TYPE" --num-nodes="$NUM_NODES" --no-enable-legacy-authorization
+  Execute gcloud container clusters create "$CLUSTER_NAME" ${GCP_OPTS} --machine-type="$MACHINE_TYPE" --num-nodes="$NUM_NODES" --no-enable-legacy-authorization
 }
 
 function delete_cluster() {
   echo "Deleting CLUSTER_NAME=$CLUSTER_NAME"
-  Execute gcloud container clusters delete "$CLUSTER_NAME" "$GCP_OPTS" -q
+  Execute gcloud container clusters delete "$CLUSTER_NAME" ${GCP_OPTS} -q
 }
 
 function create_vm() {
   echo "Obtaining latest ubuntu xenial image name... (takes a few seconds)..."
   VM_IMAGE=${VM_IMAGE:-$(gcloud compute images list --standard-images --filter=name~ubuntu-1604-xenial --limit=1 --uri)}
   echo "Creating VM_NAME=$VM_NAME using VM_IMAGE=$VM_IMAGE"
-  Execute gcloud compute instances create "$VM_NAME" "$GCP_OPTS" --machine-type "$MACHINE_TYPE" --image "$VM_IMAGE"
+  Execute gcloud compute instances create "$VM_NAME" ${GCP_OPTS} --machine-type "$MACHINE_TYPE" --image "$VM_IMAGE"
   echo "Waiting a bit for the VM to come up..."
   #TODO: 'wait for vm to be ready'
   sleep 45
@@ -113,16 +113,16 @@ function create_vm() {
 
 function delete_vm() {
   echo "Deleting VM_NAME=$VM_NAME"
-  Execute gcloud compute instances delete "$VM_NAME" "$GCP_OPTS" -q
+  Execute gcloud compute instances delete "$VM_NAME" ${GCP_OPTS} -q
 }
 
 function run_on_vm() {
   echo "*** Remote run: \"$1\"" 1>&2
-  Execute gcloud compute ssh "$VM_NAME" "$GCP_OPTS" --command "$1"
+  Execute gcloud compute ssh "$VM_NAME" ${GCP_OPTS} --command "$1"
 }
 
 function setup_vm() {
-  Execute gcloud compute instances add-tags "$VM_NAME" "$GCP_OPTS" --tags https-server
+  Execute gcloud compute instances add-tags "$VM_NAME" ${GCP_OPTS} --tags https-server
   # shellcheck disable=SC2016
   run_on_vm '(sudo add-apt-repository ppa:gophers/archive > /dev/null && sudo apt-get update > /dev/null && sudo apt-get upgrade --no-install-recommends -y && sudo apt-get install --no-install-recommends -y golang-1.10-go make && mv .bashrc .bashrc.orig && (echo "export PATH=/usr/lib/go-1.10/bin:\$PATH:~/go/bin"; cat .bashrc.orig) > ~/.bashrc ) < /dev/null'
 }
@@ -145,7 +145,7 @@ function run_fortio_on_vm() {
 }
 
 function get_vm_ip() {
-  VM_IP=$(gcloud compute instances describe "$VM_NAME" "$GCP_OPTS" |grep natIP|awk -F": " '{print $2}')
+  VM_IP=$(gcloud compute instances describe "$VM_NAME" ${GCP_OPTS} |grep natIP|awk -F": " '{print $2}')
   VM_URL="http://$VM_IP:443/fortio/"
   echo "+++ VM Ip is $VM_IP - visit (http on port 443 is not a typo:) $VM_URL"
 }
@@ -166,7 +166,7 @@ function delete_istio() {
 }
 
 function kubectl_setup() {
-  Execute gcloud container clusters get-credentials "$CLUSTER_NAME" "$GCP_OPTS"
+  Execute gcloud container clusters get-credentials "$CLUSTER_NAME" ${GCP_OPTS}
 }
 
 function install_non_istio_svc() {


### PR DESCRIPTION
* Context
I am fixing `tools/setup_perf_cluster.sh` so that I can generate update docs/concepts/performance-and-scalability of version 1.1

I run `sh -x tools/setup_perf_cluster.sh` and see the below command. The single quotation mark block is not recognized by gcloud.
```
$ gcloud compute instances create fortio-vm '--project=lambdai-experiment --zone=us-west1-a'  blabla
ERROR: (gcloud) The project property must be set to a valid project ID, not the project name [lambdai-experiment --zone=us-west1-a]
```

* Solution
This PR is to eliminate single quotation mark by expanding the GCP_OPTS in the naive approach