### PR TITLE
Merge timeseries when send triggered

### DIFF
--- a/mixer/adapter/stackdriver/metric/bufferedClient.go
+++ b/mixer/adapter/stackdriver/metric/bufferedClient.go
@@ -84,6 +84,7 @@ func batchTimeSeries(series []*monitoringpb.TimeSeries, tsLimit int) [][]*monito
 func (b *buffered) start(env adapter.Env, ticker *time.Ticker) {
 	env.ScheduleDaemon(func() {
 		for range ticker.C {
+			b.mergeTimeSeries()
 			b.Send()
 		}
 	})


### PR DESCRIPTION
Merge time series before periodic push. This is to accommodate case where traffic is not heavy enough to trigger buffer full merging.