### PR TITLE
Updates tests to match CNI install procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ ISTIO_DOCKER_HUB ?= docker.io/istio
 export ISTIO_DOCKER_HUB
 ISTIO_GCS ?= istio-release/releases/$(VERSION)
 ISTIO_URL ?= https://storage.googleapis.com/$(ISTIO_GCS)
-ISTIO_CNI_DOCKER_HUB ?= docker.io/istio
-export ISTIO_CNI_DOCKER_HUB
-ISTIO_CNI_DOCKER_TAG ?= master-latest-daily
-export ISTIO_CNI_DOCKER_TAG
+ISTIO_CNI_HUB ?= gcr.io/istio-release
+export ISTIO_CNI_HUB
+ISTIO_CNI_TAG ?= master-latest-daily
+export ISTIO_CNI_TAG
 
 # cumulatively track the directories/files to delete after a clean
 DIRS_TO_CLEAN:=

--- a/prow/e2e-simpleTests-cni.sh
+++ b/prow/e2e-simpleTests-cni.sh
@@ -30,25 +30,8 @@ set -x
 
 echo 'Running e2e_simple test with rbac, auth Tests and CNI enabled'
 
-echo 'Run the CNI deamon set'
-CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
-CNI_TAG=${CNI_TAG:-master-latest-daily}
-
-
-chartdir=$(pwd)/charts
-mkdir ${chartdir}
-helm init --client-only
-helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
-helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
-
-helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=istio-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
-
-kubectl apply -f istio-cni_install.yaml
-
 export ENABLE_ISTIO_CNI=true
-# cniBinDir setting is appropriate for GKE environments
-# HUB and TAG for the cni image will be based on the defaults checked in the cni repo
-#export EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.cniBinDir=/home/kubernetes/bin"
+
 # only gke-e2e-test-latest is enabled for Networkpolicy and Calico
 export RESOURCE_TYPE="gke-e2e-test-latest"
 # TODO - When the inline kube inject code defaults to using the configmap this setting can be removed.

--- a/prow/e2e-simpleTests-cni.sh
+++ b/prow/e2e-simpleTests-cni.sh
@@ -29,10 +29,26 @@ set -u
 set -x
 
 echo 'Running e2e_simple test with rbac, auth Tests and CNI enabled'
+
+echo 'Run the CNI deamon set'
+CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
+CNI_TAG=${CNI_TAG:-master-latest-daily}
+
+
+chartdir=$(pwd)/charts
+mkdir ${chartdir}
+helm init --client-only
+helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
+helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
+
+helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=istio-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+
+kubectl apply -f istio-cni_install.yaml
+
 export ENABLE_ISTIO_CNI=true
 # cniBinDir setting is appropriate for GKE environments
 # HUB and TAG for the cni image will be based on the defaults checked in the cni repo
-export EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.cniBinDir=/home/kubernetes/bin"
+#export EXTRA_HELM_SETTINGS="--set istio-cni.excludeNamespaces={} --set istio-cni.cniBinDir=/home/kubernetes/bin"
 # only gke-e2e-test-latest is enabled for Networkpolicy and Calico
 export RESOURCE_TYPE="gke-e2e-test-latest"
 # TODO - When the inline kube inject code defaults to using the configmap this setting can be removed.

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -47,6 +47,10 @@ export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 source "${ROOT}/prow/lib.sh"
 setup_e2e_cluster
 
+if [[ ${ENABLE_ISTIO_CNI} == true ]]; then
+   cni_run_daemon
+fi
+
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
 # e2e tests on prow use clusters borrowed from boskos, which cleans up the
 # clusters. There is no need to cleanup in the test jobs.

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -49,7 +49,6 @@ setup_e2e_cluster
 
 if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
    cni_run_daemon
-   cni_debug
 fi
 
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
@@ -81,7 +80,3 @@ time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \
   JUNIT_E2E_XML="${ARTIFACTS_DIR}/junit.xml" \
   make with_junit_report TARGET="${SINGLE_TEST}" ${E2E_TIMEOUT:+ E2E_TIMEOUT="${E2E_TIMEOUT}"}
-
-if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
-   cni_debug
-fi

--- a/prow/e2e-suite.sh
+++ b/prow/e2e-suite.sh
@@ -47,8 +47,9 @@ export CLEAN_CLUSTERS="${CLEAN_CLUSTERS:-True}"
 source "${ROOT}/prow/lib.sh"
 setup_e2e_cluster
 
-if [[ ${ENABLE_ISTIO_CNI} == true ]]; then
+if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
    cni_run_daemon
+   cni_debug
 fi
 
 E2E_ARGS+=("--test_logs_path=${ARTIFACTS_DIR}")
@@ -80,3 +81,7 @@ time ISTIO_DOCKER_HUB=$HUB \
   E2E_ARGS="${E2E_ARGS[*]}" \
   JUNIT_E2E_XML="${ARTIFACTS_DIR}/junit.xml" \
   make with_junit_report TARGET="${SINGLE_TEST}" ${E2E_TIMEOUT:+ E2E_TIMEOUT="${E2E_TIMEOUT}"}
+
+if [[ "${ENABLE_ISTIO_CNI:-false}" == true ]]; then
+   cni_debug
+fi

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -122,7 +122,7 @@ function cni_run_daemon() {
   chartdir=$(pwd)/charts
   mkdir "${chartdir}"
   helm init --client-only
-  helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
+  helm repo add istio.io https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/release-1.1-latest-daily/charts/
   helm fetch --untar --untardir "${chartdir}" istio.io/istio-cni
  
   helm template --values "${chartdir}"/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set hub="${ISTIO_CNI_HUB}" --set tag="${ISTIO_CNI_TAG}" --set pullPolicy=IfNotPresent --set logLevel="${CNI_LOGLVL:-debug}"  "${chartdir}"/istio-cni > istio-cni_install.yaml

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -112,3 +112,22 @@ function clone_cni() {
       cd "${TMP_DIR}" || return
   fi
 }
+
+function cni_run_daemon() {
+
+echo 'Run the CNI daemon set'
+CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
+CNI_TAG=${CNI_TAG:-master-latest-daily}
+
+
+chartdir=$(pwd)/charts
+mkdir ${chartdir}
+helm init --client-only
+helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
+helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
+
+helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=istio-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+
+kubectl apply -f istio-cni_install.yaml
+
+}

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -116,24 +116,17 @@ function clone_cni() {
 function cni_run_daemon() {
 
   echo 'Run the CNI daemon set'
-  CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
-  CNI_TAG=${CNI_TAG:-master-latest-daily}
- 
+  ISTIO_CNI_HUB=${ISTIO_CNI_HUB:-gcr.io/istio-release}
+  ISTIO_CNI_TAG=${ISTIO_CNI_TAG:-master-latest-daily}
 
   chartdir=$(pwd)/charts
-  mkdir ${chartdir}
+  mkdir "${chartdir}"
   helm init --client-only
   helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
-  helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
+  helm fetch --untar --untardir "${chartdir}" istio.io/istio-cni
  
-  helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+  helm template --values "${chartdir}"/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set hub="${ISTIO_CNI_HUB}" --set tag="${ISTIO_CNI_TAG}" --set pullPolicy=IfNotPresent --set logLevel="${CNI_LOGLVL:-debug}"  "${chartdir}"/istio-cni > istio-cni_install.yaml
 
   kubectl apply -f istio-cni_install.yaml
 
-}
-
-function cni_debug() {
-
-  kubectl get all -n kube-system
-  cat istio-cni_install.yaml
 }

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -126,7 +126,7 @@ helm init --client-only
 helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
 helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
 
-helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=istio-system --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
 
 kubectl apply -f istio-cni_install.yaml
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -115,19 +115,25 @@ function clone_cni() {
 
 function cni_run_daemon() {
 
-echo 'Run the CNI daemon set'
-CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
-CNI_TAG=${CNI_TAG:-master-latest-daily}
+  echo 'Run the CNI daemon set'
+  CNI_HUB=${CNI_HUB:-gcr.io/istio-release}
+  CNI_TAG=${CNI_TAG:-master-latest-daily}
+ 
 
+  chartdir=$(pwd)/charts
+  mkdir ${chartdir}
+  helm init --client-only
+  helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
+  helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
+ 
+  helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --namespace=kube-system --set "excludeNamespaces={}" --set cniBinDir=/home/kubernetes/bin --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
 
-chartdir=$(pwd)/charts
-mkdir ${chartdir}
-helm init --client-only
-helm repo add istio.io https://storage.googleapis.com/istio-release/releases/1.1.0-snapshot.6/charts
-helm fetch --untar --untardir ${chartdir} istio.io/istio-cni
+  kubectl apply -f istio-cni_install.yaml
 
-helm template --values ${chartdir}/istio-cni/values.yaml --name=istio-cni --set "excludeNamespaces={}" --set hub=${CNI_HUB} --set tag=${CNI_TAG} --set pullPolicy=IfNotPresent --set logLevel=${CNI_LOGLVL:-debug}  ${chartdir}/istio-cni > istio-cni_install.yaml
+}
 
-kubectl apply -f istio-cni_install.yaml
+function cni_debug() {
 
+  kubectl get all -n kube-system
+  cat istio-cni_install.yaml
 }

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -69,7 +69,7 @@ e2e_simple: istioctl generate_yaml e2e_simple_run
 
 e2e_simple_cni: istioctl
 e2e_simple_cni: export ENABLE_ISTIO_CNI=true
-e2e_simple_cni: export EXTRA_HELM_SETTINGS=--set istio-cni.excludeNamespaces={} --set istio-cni.pullPolicy=IfNotPresent --set istio-cni.tag=$(ISTIO_CNI_DOCKER_TAG) --set istio-cni.hub=$(ISTIO_CNI_DOCKER_HUB)
+#TODO need to create the CNI helm charts and install the CNI
 e2e_simple_cni: export E2E_ARGS+=--kube_inject_configmap=istio-sidecar-injector
 e2e_simple_cni: generate_yaml e2e_simple_run
 


### PR DESCRIPTION
The CNI install procedure was changed to eliminate dependant helm
templates.   Changes are required in the test routines to match.