### PR TITLE
replace hardcoded cluster.local with func call

### DIFF
--- a/pilot/docker/envoy_pilot.yaml.tmpl
+++ b/pilot/docker/envoy_pilot.yaml.tmpl
@@ -74,9 +74,9 @@ static_resources:
             name: envoy.file_access_log
           http_filters:
           - config:
-              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
+                istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -84,7 +84,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.uid:
                         string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
                       destination.namespace:
@@ -111,7 +111,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: v1
@@ -154,9 +154,9 @@ static_resources:
             max_concurrent_streams: 1073741824
           http_filters:
           - config:
-              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
+                istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -164,7 +164,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.uid:
                         string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
                       destination.namespace:
@@ -191,7 +191,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: xDS
@@ -229,9 +229,9 @@ static_resources:
             name: envoy.file_access_log
           http_filters:
           - config:
-              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
+                istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -239,7 +239,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.uid:
                         string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
                       destination.namespace:
@@ -266,7 +266,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: v1
@@ -304,9 +304,9 @@ static_resources:
             name: envoy.file_access_log
           http_filters:
           - config:
-              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-pilot.{{ .PodNamespace }}.svc.cluster.local:
+                istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -314,7 +314,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.uid:
                         string_value: kubernetes://{{ .PodName }}.{{ .PodNamespace }}
                       destination.namespace:
@@ -341,7 +341,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-pilot.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-pilot.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: v1

--- a/pilot/docker/envoy_policy.yaml.tmpl
+++ b/pilot/docker/envoy_policy.yaml.tmpl
@@ -110,9 +110,9 @@ static_resources:
           generate_request_id: true
           http_filters:
           - config:
-              default_destination_service: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-policy.{{ .PodNamespace }}.svc.cluster.local:
+                istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -120,7 +120,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.service.uid:
                         string_value: istio://{{ .PodNamespace }}/services/istio-policy
                       destination.service.name:
@@ -153,7 +153,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: Check
@@ -193,9 +193,9 @@ static_resources:
           generate_request_id: true
           http_filters:
           - config:
-              default_destination_service: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-policy.{{ .PodNamespace }}.svc.cluster.local:
+                istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -203,7 +203,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.service.uid:
                         string_value: istio://{{ .PodNamespace }}/services/istio-policy
                       destination.service.name:
@@ -236,7 +236,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-policy.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-policy.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: Check

--- a/pilot/docker/envoy_telemetry.yaml.tmpl
+++ b/pilot/docker/envoy_telemetry.yaml.tmpl
@@ -81,9 +81,9 @@ static_resources:
           generate_request_id: true
           http_filters:
           - config:
-              default_destination_service: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-telemetry.{{ .PodNamespace }}.svc.cluster.local:
+                istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -91,7 +91,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.service.uid:
                         string_value: istio://{{ .PodNamespace }}/services/istio-telemetry
                       destination.service.name:
@@ -120,7 +120,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: Report
@@ -160,9 +160,9 @@ static_resources:
           generate_request_id: true
           http_filters:
           - config:
-              default_destination_service: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              default_destination_service: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               service_configs:
-                istio-telemetry.{{ .PodNamespace }}.svc.cluster.local:
+                istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}:
                   disable_check_calls: true
 {{- if .DisableReportCalls }}
                   disable_report_calls: true
@@ -170,7 +170,7 @@ static_resources:
                   mixer_attributes:
                     attributes:
                       destination.service.host:
-                        string_value: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+                        string_value: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
                       destination.service.uid:
                         string_value: istio://{{ .PodNamespace }}/services/istio-telemetry
                       destination.service.name:
@@ -199,7 +199,7 @@ static_resources:
             virtual_hosts:
             - domains:
               - '*'
-              name: istio-telemetry.{{ .PodNamespace }}.svc.cluster.local
+              name: istio-telemetry.{{ .PodNamespace }}.svc.{{  .ClusterDomainName }}
               routes:
               - decorator:
                   operation: Report


### PR DESCRIPTION
This PR addresses hardcoded `cluster.local` domain name. It adds one func which will get actually configured domain name at the runtime and then use it for rendering templates in proxy-agent.

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>