### PR TITLE
Add MultiNamespaceListerWatcher capability

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2184,6 +2184,7 @@
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",

--- a/pkg/listwatch/listwatch.go
+++ b/pkg/listwatch/listwatch.go
@@ -1,0 +1,179 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Provides multiple namespace listerWatcher. This implementation is Largely from
+// https://github.com/coreos/prometheus-operator/pkg/listwatch/listwatch.go
+
+package listwatch
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+// MultiNamespaceListerWatcher takes a list of namespaces and a
+// cache.ListerWatcher generator func and returns a single cache.ListerWatcher
+// capable of operating on multiple namespaces.
+func MultiNamespaceListerWatcher(namespaces []string, f func(string) cache.ListerWatcher) cache.ListerWatcher {
+	// If there is only one namespace then there is no need to create a proxy.
+	if len(namespaces) == 1 {
+		return f(namespaces[0])
+	}
+	var lws []cache.ListerWatcher
+	for _, n := range namespaces {
+		lws = append(lws, f(n))
+	}
+	return multiListerWatcher(lws)
+}
+
+// multiListerWatcher abstracts several cache.ListerWatchers, allowing them
+// to be treated as a single cache.ListerWatcher.
+type multiListerWatcher []cache.ListerWatcher
+
+// List implements the ListerWatcher interface.
+// It combines the output of the List method of every ListerWatcher into
+// a single result.
+func (mlw multiListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	l := metav1.List{}
+	var resourceVersions []string
+	for _, lw := range mlw {
+		list, err := lw.List(options)
+		if err != nil {
+			return nil, err
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return nil, err
+		}
+		metaObj, err := meta.ListAccessor(list)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range items {
+			l.Items = append(l.Items, runtime.RawExtension{Object: item.DeepCopyObject()})
+		}
+		resourceVersions = append(resourceVersions, metaObj.GetResourceVersion())
+	}
+	// Combine the resource versions so that the composite Watch method can
+	// distribute appropriate versions to each underlying Watch func.
+	l.ListMeta.ResourceVersion = strings.Join(resourceVersions, "/")
+	return &l, nil
+}
+
+// Watch implements the ListerWatcher interface.
+// It returns a watch.Interface that combines the output from the
+// watch.Interface of every cache.ListerWatcher into a single result chan.
+func (mlw multiListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	resourceVersions := make([]string, len(mlw))
+	// Allow resource versions to be "".
+	if options.ResourceVersion != "" {
+		rvs := strings.Split(options.ResourceVersion, "/")
+		if len(rvs) != len(mlw) {
+			return nil, fmt.Errorf("expected resource version to have %d parts to match the number of ListerWatchers", len(mlw))
+		}
+		resourceVersions = rvs
+	}
+	return newMultiWatch(mlw, resourceVersions, options)
+}
+
+// multiWatch abstracts multiple watch.Interface's, allowing them
+// to be treated as a single watch.Interface.
+type multiWatch struct {
+	result   chan watch.Event
+	stopped  chan struct{}
+	stoppers []func()
+}
+
+// newMultiWatch returns a new multiWatch or an error if one of the underlying
+// Watch funcs errored. The length of []cache.ListerWatcher and []string must
+// match.
+func newMultiWatch(lws []cache.ListerWatcher, resourceVersions []string, options metav1.ListOptions) (*multiWatch, error) {
+	var (
+		result   = make(chan watch.Event)
+		stopped  = make(chan struct{})
+		stoppers []func()
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(len(lws))
+
+	for i, lw := range lws {
+		o := options.DeepCopy()
+		o.ResourceVersion = resourceVersions[i]
+		w, err := lw.Watch(*o)
+		if err != nil {
+			return nil, err
+		}
+
+		go func() {
+			defer wg.Done()
+
+			for {
+				event, ok := <-w.ResultChan()
+				if !ok {
+					return
+				}
+
+				select {
+				case result <- event:
+				case <-stopped:
+					return
+				}
+			}
+		}()
+
+		stoppers = append(stoppers, w.Stop)
+	}
+
+	// result chan must be closed,
+	// once all event sender goroutines exited.
+	go func() {
+		wg.Wait()
+		close(result)
+	}()
+
+	return &multiWatch{
+		result:   result,
+		stoppers: stoppers,
+		stopped:  stopped,
+	}, nil
+}
+
+// ResultChan implements the watch.Interface interface.
+func (mw *multiWatch) ResultChan() <-chan watch.Event {
+	return mw.result
+}
+
+// Stop implements the watch.Interface interface.
+// It stops all of the underlying watch.Interfaces and closes the backing chan.
+// Can safely be called more than once.
+func (mw *multiWatch) Stop() {
+	select {
+	case <-mw.stopped:
+		// nothing to do, we are already stopped
+	default:
+		for _, stop := range mw.stoppers {
+			stop()
+		}
+		close(mw.stopped)
+	}
+	return
+}

--- a/pkg/listwatch/listwatch_test.go
+++ b/pkg/listwatch/listwatch_test.go
@@ -1,0 +1,185 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package listwatch
+
+import (
+	"sync"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ watch.Interface = &multiWatch{}
+
+func setupMultiWatch(n int, t *testing.T, rvs ...string) ([]*watch.FakeWatcher, *multiWatch) {
+	// Default resource versions to the correct length if none were passed.
+	if len(rvs) == 0 {
+		rvs = make([]string, n)
+	}
+	ws := make([]*watch.FakeWatcher, n)
+	lws := make([]cache.ListerWatcher, n)
+	for i := range ws {
+		w := watch.NewFake()
+		ws[i] = w
+		lws[i] = &cache.ListWatch{WatchFunc: func(_ metav1.ListOptions) (watch.Interface, error) {
+			return w, nil
+		}}
+	}
+	m, err := newMultiWatch(lws, rvs, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to create new multiWatch: %v", err)
+	}
+	return ws, m
+}
+
+func TestNewMultiWatch(t *testing.T) {
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected newMultiWatch to panic when number of resource versions is less than ListerWatchers")
+			}
+		}()
+		// Create a multiWatch from 2 ListerWatchers but only pass 1 resource version.
+		_, _ = setupMultiWatch(2, t, "1")
+	}()
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("newMultiWatch should not panic when number of resource versions matches ListerWatchers; got: %v", r)
+			}
+		}()
+		// Create a multiWatch from 2 ListerWatchers and pass 2 resource versions.
+		_, _ = setupMultiWatch(2, t, "1", "2")
+	}()
+}
+
+func TestMultiWatchResultChan(t *testing.T) {
+	ws, m := setupMultiWatch(10, t)
+	defer m.Stop()
+	var events []watch.Event
+	var wg sync.WaitGroup
+	for _, w := range ws {
+		w := w
+		wg.Add(1)
+		go func() {
+			w.Add(&runtime.Unknown{})
+		}()
+	}
+	go func() {
+		for {
+			event, ok := <-m.ResultChan()
+			if !ok {
+				break
+			}
+			events = append(events, event)
+			wg.Done()
+		}
+	}()
+	wg.Wait()
+	if len(events) != len(ws) {
+		t.Errorf("expected %d events but got %d", len(ws), len(events))
+	}
+}
+
+func TestMultiWatchStop(t *testing.T) {
+	ws, m := setupMultiWatch(10, t)
+	m.Stop()
+	var stopped int
+	for _, w := range ws {
+		_, running := <-w.ResultChan()
+		if !running && w.IsStopped() {
+			stopped++
+		}
+	}
+	if stopped != len(ws) {
+		t.Errorf("expected %d watchers to be stopped but got %d", len(ws), stopped)
+	}
+	select {
+	case <-m.stopped:
+		// all good, watcher is closed, proceed
+	default:
+		t.Error("expected multiWatch to be stopped")
+	}
+	_, running := <-m.ResultChan()
+	if running {
+		t.Errorf("expected multiWatch chan to be closed")
+	}
+}
+
+type mockListerWatcher struct {
+	evCh    chan watch.Event
+	stopped bool
+}
+
+func (m *mockListerWatcher) List(options metav1.ListOptions) (runtime.Object, error) {
+	return nil, nil
+}
+
+func (m *mockListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	return m, nil
+}
+
+func (m *mockListerWatcher) Stop() {
+	m.stopped = true
+}
+
+func (m *mockListerWatcher) ResultChan() <-chan watch.Event {
+	return m.evCh
+}
+
+func TestRacyMultiWatch(t *testing.T) {
+	evCh := make(chan watch.Event)
+	lw := &mockListerWatcher{evCh: evCh}
+
+	mw, err := newMultiWatch(
+		[]cache.ListerWatcher{lw},
+		[]string{"foo"},
+		metav1.ListOptions{},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// this will not block, as newMultiWatch started a goroutine,
+	// receiving that event and block on the dispatching it there.
+	evCh <- watch.Event{
+		Type: "foo",
+	}
+
+	if got := <-mw.ResultChan(); got.Type != "foo" {
+		t.Errorf("expected foo, got %s", got.Type)
+		return
+	}
+
+	// Enqueue event, do not dequeue it.
+	// In conjunction with go test -race this asserts
+	// if there is a race between stopping and dispatching an event
+	evCh <- watch.Event{
+		Type: "bar",
+	}
+	mw.Stop()
+
+	if got := lw.stopped; got != true {
+		t.Errorf("expected watcher to be closed true, got %t", got)
+	}
+
+	// some reentrant calls, should be non-blocking
+	mw.Stop()
+	mw.Stop()
+}


### PR DESCRIPTION
Add MultiNamespaceListerWatcher method into top `pkg` which can be used by
#11667 
#11932 

Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>