### PR TITLE
Using constant instead of variable

### DIFF
--- a/mixer/adapter/fluentd/fluentd.go
+++ b/mixer/adapter/fluentd/fluentd.go
@@ -41,10 +41,7 @@ const (
 	defaultBufferSize    int64 = 1024
 	defaultMaxBatchBytes int64 = 8 * 1024 * 1024
 	defaultTimeout             = 1 * time.Minute
-)
-
-var (
-	defaultAddress = "localhost:24224"
+	defaultAddress             = "localhost:24224"
 )
 
 type (


### PR DESCRIPTION
defaultAddress is used for the `defaultConfig`. It never changes.
And other adapters all use constants for `defaultConfig`. So it's more appropriate to set defaultAddress as constant.