### PR TITLE
do not exclude rbac filters from gateways

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -301,7 +301,11 @@ func NewPlugin() plugin.Plugin {
 // OnOutboundListener is called whenever a new outbound listener is added to the LDS output for a given service
 // Can be used to add additional filters on the outbound path
 func (Plugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
-	return nil
+	if in.Node.Type != model.Router {
+		return nil
+	}
+
+	return setupFilters(in, mutable)
 }
 
 // OnInboundFilterChains is called whenever a plugin needs to setup the filter chains, including relevant filter chain configuration.
@@ -317,7 +321,10 @@ func (Plugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.MutableO
 	if in.Node.Type != model.SidecarProxy {
 		return nil
 	}
+	return setupFilters(in, mutable)
+}
 
+func setupFilters(in *plugin.InputParams, mutable *plugin.MutableObjects) error {
 	svc := in.ServiceInstance.Service.Hostname
 	attr := in.ServiceInstance.Service.Attributes
 	authzPolicies := in.Env.PushContext.AuthzPolicies


### PR DESCRIPTION
This is essential in multicluster with gateway scenario where we could 
apply RBAC at the ingress gateway to determine whether traffic for a 
particular global service is allowed or not.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>