### PR TITLE
remove helm repo add during upgrade test

### DIFF
--- a/tests/upgrade/test_crossgrade.sh
+++ b/tests/upgrade/test_crossgrade.sh
@@ -192,8 +192,6 @@ installIstioSystemAtVersionHelmTemplate() {
     if [[ "${release_path}" == *"1.1"* || "${release_path}" == *"master"* ]]; then
         # See https://preliminary.istio.io/docs/setup/kubernetes/helm-install/
         helm init --client-only
-        helm repo add istio.io https://storage.googleapis.com/istio-prerelease/daily-build/release-1.1-latest-daily/charts	
-        helm dependency update "${release_path}"
         for i in install/kubernetes/helm/istio-init/files/crd*yaml; do
             echo_and_run kubectl apply -f "${i}"
         done


### PR DESCRIPTION
per #11805

Looks like the upgrade test is failing with this error:

```Error: no repository definition for , , , , , , , , , , , , , , . Try 'helm repo add'``` since 2/14 thus there is no 1.1 build since 2/14.