### PR TITLE
Unblock ip6 tables to allow ipv6 traffic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -219,9 +219,10 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		}
 
 		// add an extra listener that binds to the port that is the recipient of the iptables redirect
+		// ><SB> Changing WildcardAddress
 		listeners = append(listeners, &xdsapi.Listener{
 			Name:           VirtualListenerName,
-			Address:        util.BuildAddress(WildcardAddress, uint32(mesh.ProxyListenPort)),
+			Address:        util.BuildAddress("::" /*WildcardAddress*/, uint32(mesh.ProxyListenPort)),
 			Transparent:    transparent,
 			UseOriginalDst: proto.BoolTrue,
 			FilterChains: []listener.FilterChain{
@@ -230,6 +231,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 				},
 			},
 		})
+		log.Warnf("><SB> Listeners for a sidecar proxy: %+v", listeners)
 	}
 
 	httpProxyPort := mesh.ProxyHttpPort

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -219,10 +219,9 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 		}
 
 		// add an extra listener that binds to the port that is the recipient of the iptables redirect
-		// ><SB> Changing WildcardAddress
 		listeners = append(listeners, &xdsapi.Listener{
 			Name:           VirtualListenerName,
-			Address:        util.BuildAddress("::" /*WildcardAddress*/, uint32(mesh.ProxyListenPort)),
+			Address:        util.BuildAddress(WildcardAddress, uint32(mesh.ProxyListenPort)),
 			Transparent:    transparent,
 			UseOriginalDst: proto.BoolTrue,
 			FilterChains: []listener.FilterChain{
@@ -231,7 +230,6 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 				},
 			},
 		})
-		log.Warnf("><SB> Listeners for a sidecar proxy: %+v", listeners)
 	}
 
 	httpProxyPort := mesh.ProxyHttpPort

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -354,10 +354,10 @@ fi
 # If ENABLE_INBOUND_IPV6 is unset (default unset), restrict IPv6 traffic.
 set +o nounset
 if [ -z "${ENABLE_INBOUND_IPV6}" ]; then
-  # Drop all inbound traffic except established connections.
   # TODO: support receiving IPv6 traffic in the same way as IPv4.
+  # Allow all ipv6 traffic inbound and outboud, whitebox mode for now
   ip6tables -F INPUT || true
-  ip6tables -A INPUT -m state --state ESTABLISHED -j ACCEPT || true
-  ip6tables -A INPUT -i lo -d ::1 -j ACCEPT || true
-  ip6tables -A INPUT -j REJECT || true
+  ip6tables -A INPUT -j ACCEPT || true
+  ip6tables -A OUTPUT -j ACCEPT || true
+  ip6tables -A FORWARD -j ACCEPT || true
 fi

--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -451,7 +451,15 @@ if [ -n "${ENABLE_INBOUND_IPV6}" ]; then
   # container-to-container traffic both of which explicitly use
   # localhost.
   ip6tables -t nat -A ISTIO_OUTPUT -d ::1/128 -j RETURN
-
+  
+  # Apply outbound IPv6 inclusions.
+  # TODO Need to figure out differentiation  between IPv4 and IPv6 ranges 
+  # for now process only "*"
+  if [ "${OUTBOUND_IP_RANGES_INCLUDE}" == "*" ]; then
+    # Wildcard specified. Redirect all remaining outbound traffic to Envoy.
+    ip6tables -t nat -A ISTIO_OUTPUT -j ISTIO_REDIRECT
+  fi 
+  
   for internalInterface in ${KUBEVIRT_INTERFACES}; do
       ip6tables -t nat -I PREROUTING 1 -i "${internalInterface}" -j RETURN
   done


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

Currently ip6tables block ipv6 traffic which makes impossible to test/develop anything with ipv6. This PR temporarily allows ipv6 traffic to unblock development and testing of ipv6 based services. 