### PR TITLE
add adapter secret mount into telemetry deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -146,6 +146,12 @@
           optional: true
       - name: uds-socket
         emptyDir: {}
+{{- if $.Values.telemetry.gcpCredential.enabled }}
+      - name: {{ $.Values.telemetry.gcpCredential.volumeName }}
+        secret:
+          secretName: {{ $.Values.telemetry.gcpCredential.secretName }}
+          optional: true
+{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       containers:
@@ -207,6 +213,11 @@
 {{- if $.Values.global.useMCP }}
         - name: istio-certs
           mountPath: /etc/certs
+          readOnly: true
+{{- end }}
+{{- if $.Values.telemetry.gcpCredential.enabled }}
+        - name: {{ $.Values.telemetry.gcpCredential.volumeName }}
+          mountPath: {{ $.Values.telemetry.gcpCredential.volumeMountPath }}
           readOnly: true
 {{- end }}
         - name: uds-socket

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -150,6 +150,7 @@
       - name: adapter-secret
         secret:
           secretName: {{ $.Values.telemetry.adapterSecret.secretName }}
+          optional: true
 {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -146,11 +146,10 @@
           optional: true
       - name: uds-socket
         emptyDir: {}
-{{- if $.Values.telemetry.gcpCredential.enabled }}
-      - name: {{ $.Values.telemetry.gcpCredential.volumeName }}
+{{- if $.Values.telemetry.adapterSecret.enabled }}
+      - name: adapter-secret
         secret:
-          secretName: {{ $.Values.telemetry.gcpCredential.secretName }}
-          optional: true
+          secretName: {{ $.Values.telemetry.adapterSecret.secretName }}
 {{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
@@ -215,9 +214,9 @@
           mountPath: /etc/certs
           readOnly: true
 {{- end }}
-{{- if $.Values.telemetry.gcpCredential.enabled }}
-        - name: {{ $.Values.telemetry.gcpCredential.volumeName }}
-          mountPath: {{ $.Values.telemetry.gcpCredential.volumeMountPath }}
+{{- if $.Values.telemetry.adapterSecret.enabled }}
+        - name: adapter-secret
+          mountPath: /var/adapter/secret
           readOnly: true
 {{- end }}
         - name: uds-socket

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -11,6 +11,10 @@
           optional: true
       - name: uds-socket
         emptyDir: {}
+      - name: policy-adapter-secret
+        secret:
+          secretName: policy-adapter-secret
+          optional: true
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       containers:
@@ -134,6 +138,9 @@
           readOnly: true
         - name: uds-socket
           mountPath: /sock
+        - name: policy-adapter-secret
+          mountPath: /var/run/secrets/istio.io/policy/adapter
+          readOnly: true
 {{- end }}
 
 {{- define "telemetry_container" }}

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -214,7 +214,7 @@
           readOnly: true
 {{- end }}
         - name: telemetry-adapter-secret
-          mountPath: /var/run/secrets/adapter.mixer.istio.io
+          mountPath: /var/run/secrets/istio.io/telemetry/adapter
           readOnly: true
         - name: uds-socket
           mountPath: /sock

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -146,12 +146,10 @@
           optional: true
       - name: uds-socket
         emptyDir: {}
-{{- if $.Values.telemetry.adapterSecret.enabled }}
-      - name: adapter-secret
+      - name: telemetry-adapter-secret
         secret:
-          secretName: {{ $.Values.telemetry.adapterSecret.secretName }}
+          secretName: telemetry-adapter-secret
           optional: true
-{{- end }}
       affinity:
       {{- include "nodeaffinity" . | indent 6 }}
       containers:
@@ -215,11 +213,9 @@
           mountPath: /etc/certs
           readOnly: true
 {{- end }}
-{{- if $.Values.telemetry.adapterSecret.enabled }}
-        - name: adapter-secret
-          mountPath: /var/adapter/secret
+        - name: telemetry-adapter-secret
+          mountPath: /var/run/secrets/adapter.mixer.istio.io
           readOnly: true
-{{- end }}
         - name: uds-socket
           mountPath: /sock
         livenessProbe:

--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -33,7 +33,7 @@ telemetry:
 
   adapterSecret:
     enabled: false
-    secretName: adapter-creds
+    secretName: adapter-secret
 
 podAnnotations: {}
 nodeSelector: {}

--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -31,10 +31,6 @@ telemetry:
     # based on measurements 100ms p50 translates to p99 of under 1s. This is ok for telemetry which is inherently async.
     latencyThreshold: 100ms
 
-  adapterSecret:
-    enabled: false
-    secretName: adapter-secret
-
 podAnnotations: {}
 nodeSelector: {}
 

--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -31,6 +31,12 @@ telemetry:
     # based on measurements 100ms p50 translates to p99 of under 1s. This is ok for telemetry which is inherently async.
     latencyThreshold: 100ms
 
+  gcpCredential:
+    enabled: false
+    secretName: gcp-creds
+    volumeName: gcp-credentials
+    volumeMountPath: /etc/gcp-credentials
+
 podAnnotations: {}
 nodeSelector: {}
 

--- a/install/kubernetes/helm/istio/charts/mixer/values.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/values.yaml
@@ -31,11 +31,9 @@ telemetry:
     # based on measurements 100ms p50 translates to p99 of under 1s. This is ok for telemetry which is inherently async.
     latencyThreshold: 100ms
 
-  gcpCredential:
+  adapterSecret:
     enabled: false
-    secretName: gcp-creds
-    volumeName: gcp-credentials
-    volumeMountPath: /etc/gcp-credentials
+    secretName: adapter-creds
 
 podAnnotations: {}
 nodeSelector: {}


### PR DESCRIPTION
#11898 Add an handy helm option into telemetry deployment to load secret for mixer adapter.

/hold wait on verification