### PR TITLE
endpoint add should trigger a full push

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -167,6 +167,7 @@ func newFakeController(t *testing.T) (*Controller, *FakeXdsUpdater) {
 		stop:             make(chan struct{}),
 	})
 	c.AppendInstanceHandler(func(instance *model.ServiceInstance, event model.Event) {
+		fx.EDSUpdate("", string(instance.Service.Hostname), nil)
 		t.Log("Instance event received")
 	})
 	c.AppendServiceHandler(func(service *model.Service, event model.Event) {


### PR DESCRIPTION
An alternative of #11905 

When endpoint added, treat it as a full push for xDS.  This can prevent gateways or sidecars listeners and clusters not refreshed issue.