### PR TITLE
Lower resource requirements in demo profile

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo.yaml
@@ -4,6 +4,10 @@
 global:
   proxy:
     accessLogFile: "/dev/stdout"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
 
   disablePolicyChecks: false
   
@@ -17,6 +21,13 @@ mixer:
   adapters:
     stdio:
       enabled: true
+  resources:
+      requests:
+        cpu: 50m
+        memory: 100Mi
+      limits:
+        cpu: 100m
+        memory: 100Mi
  
 grafana:
   enabled: true


### PR DESCRIPTION
The new higher requirements in values.yaml prevent one from starting Istio on the IKS free clusters. Lowering the requirements to the earlier values (matching e3e test values) allows Istio to start.