### PR TITLE
fix issue for generating custom gateway from chart.

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/serviceaccount.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/serviceaccount.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ $key }}-service-account
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
   labels:
-    app: {{ $spec.labels.istio }}
+    app: {{ $spec.labels.app }}
     chart: {{ template "gateway.chart" $ }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}


### PR DESCRIPTION
Label for `serviceaccount` will be invalid when generating custom gateway from helm chart with values file: https://github.com/istio/istio/blob/release-1.1/install/kubernetes/helm/istio/values-istio-gateways.yaml
```
root@master:~/istio-1.1.0-rc.0# helm template --name istio --namespace default --values ./install/kubernetes/helm/istio/values-istio-gateways.yaml ./install/kubernetes/helm/istio > istio-custom-gateways.yaml
root@master:~/istio-1.1.0-rc.0# kubectl apply -f istio-custom-gateways.yaml
error: error validating "istio-custom-gateways.yaml": error validating data: unknown object type "nil" in ServiceAccount.metadata.labels.app; if you choose to ignore these errors, turn validation off with --validate=false
```
