### PR TITLE
Endpoint locality prioritization

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -39,7 +39,7 @@ func ApplyLocalityLBSetting(
 	// one of Distribute or Failover settings can be applied.
 	if localityLB.GetDistribute() != nil {
 		applyLocalityWeight(locality, loadAssignment, localityLB.GetDistribute())
-	} else if localityLB.GetFailover() != nil {
+	} else {
 		applyLocalityFailover(locality, loadAssignment, localityLB.GetFailover())
 	}
 }

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -788,7 +788,7 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 			l = filteredCLA
 		}
 
-		// If location prioritised load balancing is enabled, prioritise endpoints.
+		// If location prioritized load balancing is enabled, prioritize endpoints.
 		if pilot.EnableLocalityLoadBalancing() {
 			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting)
 		}

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
+
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
@@ -784,6 +786,11 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 				Policy:      l.Policy,
 			}
 			l = filteredCLA
+		}
+
+		// If location prioritised load balancing is enabled, prioritise endpoints.
+		if pilot.EnableLocalityLoadBalancing() {
+			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting)
 		}
 
 		endpoints += len(l.Endpoints)

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -113,6 +113,13 @@ var (
 		}
 		return time.Second * time.Duration(duration)
 	}
+
+	// EnableLocalityLoadBalancing provides an option to enable the LocalityLoadBalancerSetting feature
+	// as well as prioritizing the sending of traffic to a local locality. Set the environment variable to any value to enable.
+	// This is an experimental feature.
+	EnableLocalityLoadBalancing = func() bool {
+		return len(os.Getenv("PILOT_ENABLE_LOCALITY_LOAD_BALANCING")) != 0
+	}
 )
 
 var (


### PR DESCRIPTION
Defaults to off and has to be enabled via an env var in Pilot.

Signed-off-by: Liam White <liam@tetrate.io>