### PR TITLE
Various fixes for the Multicluster e2e test [master]

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-auth-multicluster.yaml
@@ -9,6 +9,9 @@ global:
     # destination rules or service annotations.
     enabled: true
 
+  proxy:
+    accessLogFile: "/dev/stdout"
+
   ## imagePullSecrets for all ServiceAccount. Must be set for any cluster configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/install/kubernetes/helm/istio/values-istio-multicluster.yaml
+++ b/install/kubernetes/helm/istio/values-istio-multicluster.yaml
@@ -9,6 +9,9 @@ global:
     # destination rules or service annotations.
     enabled: false
 
+  proxy:
+    accessLogFile: "/dev/stdout"
+
   ## imagePullSecrets for all ServiceAccount. Must be set for any cluster configured with private docker registry.
   # imagePullSecrets:
   #   - name: "private-registry-key"

--- a/prow/istio-pilot-multicluster-e2e.sh
+++ b/prow/istio-pilot-multicluster-e2e.sh
@@ -23,4 +23,4 @@ CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
 export CLUSTERREG_DIR
 
 #echo 'Running pilot multi-cluster e2e tests (v1alpha1, noauth)'
-./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
+./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -642,16 +642,16 @@ func (k *KubeInfo) deepCopy(src map[string][]string) map[string][]string {
 func (k *KubeInfo) deployIstio() error {
 	istioYaml := nonAuthInstallFileNamespace
 	if *multiClusterDir != "" {
-		istioYaml = mcNonAuthInstallFileNamespace
-	}
-	if *clusterWide {
+		if *authEnable {
+			istioYaml = mcAuthInstallFileNamespace
+		} else {
+			istioYaml = mcNonAuthInstallFileNamespace
+		}
+	} else if *clusterWide {
 		istioYaml = getClusterWideInstallFile()
 	} else {
 		if *authEnable {
 			istioYaml = authInstallFileNamespace
-			if *multiClusterDir != "" {
-				istioYaml = mcAuthInstallFileNamespace
-			}
 		}
 		if *trustDomainEnable {
 			istioYaml = trustDomainFileNamespace

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -105,6 +105,7 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 			log.Infof("Endpoint for service %s not found", svc)
 		}
 	}
+	helmSetContent += " --set security.selfSigned=false"
 	if !useAutoInject {
 		helmSetContent += " --set sidecarInjectorWebhook.enabled=false"
 		log.Infof("Remote cluster auto-sidecar injection disabled")

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -105,7 +105,12 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 			log.Infof("Endpoint for service %s not found", svc)
 		}
 	}
+	// Setting selfSigned to false because the primary and the remote clusters
+	// are running with a shared root CA
 	helmSetContent += " --set security.selfSigned=false"
+	// Enabling access log because some tests (e.g. TestGrpc) are validating
+	// based on the pods logs
+	helmSetContent += " --set global.proxy.accessLogFile=\"/dev/stdout\""
 	if !useAutoInject {
 		helmSetContent += " --set sidecarInjectorWebhook.enabled=false"
 		log.Infof("Remote cluster auto-sidecar injection disabled")

--- a/tests/e2e/tests/pilot/mesh_config_verify_test.go
+++ b/tests/e2e/tests/pilot/mesh_config_verify_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 const maxDeploymentTimeout = 480 * time.Second
+const propagationTime = 5 * time.Second
 
 func verifyMCMeshConfig(primaryPodNames, remotePodNames []string, appEPs map[string][]string) error {
 	retry := util.Retrier{
@@ -56,6 +57,7 @@ func addRemoteCluster() error {
 		log.Errorf("Unable to create remote cluster secret on local cluster %s", err.Error())
 		return err
 	}
+	time.Sleep(propagationTime)
 	return nil
 }
 
@@ -63,6 +65,7 @@ func deleteRemoteCluster() error {
 	if err := util.DeleteMultiClusterSecret(tc.Kube.Namespace, tc.Kube.RemoteKubeConfig, tc.Kube.KubeConfig); err != nil {
 		return err
 	}
+	time.Sleep(propagationTime)
 	return nil
 }
 
@@ -269,7 +272,7 @@ func verifyPod(istioctl *framework.Istioctl, podName string, appEPs map[string][
 	for app, portIPs := range epInfo {
 		for _, IPs := range portIPs {
 			if !verifyEndpoints(appEPs[app], IPs) {
-				err = fmt.Errorf("endpoints for app '%s' in proxy config in pod %s are not correct: %v vs %v", app, podName, IPs, appEPs[app])
+				err = fmt.Errorf("endpoints for app '%s' in proxy config in pod %s are not correct, got: %v but expected: %v", app, podName, IPs, appEPs[app])
 				log.Errorf("%v", err)
 				return err
 			}


### PR DESCRIPTION
The existing multicluster is almost continuously failing.
The test is testing direct connectivity between a primary and a remote cluster over flat network.

Fixes included by this PR:
* Choose the correct values file for the primary cluster
* Enable the access log which is used for validating tests
* Set `selfSigned` to false on both clusters for a shared root CA
* Increate the timeout because a typical execution is +40 mins
* When adding/removing a remote cluster, allow 5 secs for the changes to propogate

Fixes #11526 