### PR TITLE
Fix MCP Client Bug

### DIFF
--- a/pkg/mcp/client/client.go
+++ b/pkg/mcp/client/client.go
@@ -261,6 +261,11 @@ func (c *Client) Run(ctx context.Context) {
 				}
 			} else {
 				collection := req.TypeUrl
+
+				if req.ErrorDetail != nil {
+					break
+				}
+
 				if req.ErrorDetail == nil && collection != "" {
 					if state, ok := c.state[collection]; ok {
 						state.setVersion(version)


### PR DESCRIPTION
I have installed master latest build. I found that pilot throws the following exceptions per time.Nanosecond.
```
2019-02-25T15:25:01.944564Z	error	mcp	MCP: sending NACK for version= nonce=21405: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.944836Z	error	mcp	MCP: sending NACK for version= nonce=21406: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.945102Z	error	mcp	MCP: sending NACK for version= nonce=21407: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.945310Z	error	mcp	MCP: sending NACK for version= nonce=21408: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.945589Z	error	mcp	MCP: sending NACK for version= nonce=21409: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.945836Z	error	mcp	MCP: sending NACK for version= nonce=21410: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.946962Z	error	mcp	MCP: sending NACK for version= nonce=21411: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.947218Z	error	mcp	MCP: sending NACK for version= nonce=21412: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.947468Z	error	mcp	MCP: sending NACK for version= nonce=21413: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.947757Z	error	mcp	MCP: sending NACK for version= nonce=21414: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.948035Z	error	mcp	MCP: sending NACK for version= nonce=21415: error="proto: wrong wireType = 2 for field ConfigScope"
2019-02-25T15:25:01.948355Z	error	mcp	MCP: sending NACK for version= nonce=21416: 
```

My fix is just to throw the exception per a second to avoid high cpu consumption for pilot.