### PR TITLE
Don't ignore kube-system in EDS

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/yl2chen/cidranger"
 	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -699,11 +698,6 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 			}
 		}
 
-		// Do not handle "kube-system" services
-		if svc.Namespace == meta_v1.NamespaceSystem {
-			return nil
-		}
-
 		log.Infof("Handle service %s in namespace %s", svc.Name, svc.Namespace)
 
 		hostname := svc.Name + "." + svc.Namespace
@@ -763,10 +757,6 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 			}
 		}
 
-		// Do not handle "kube-system" endpoints
-		if ep.Namespace == meta_v1.NamespaceSystem {
-			return nil
-		}
 		c.updateEDS(ep, event)
 
 		return nil


### PR DESCRIPTION
This was originally ignored due to a high rate of updates from
kube-system. EDSInformer now checks that there were actual meaningful
changes made, otherwise they are ignored, so this is no longer and
issue.

https://github.com/istio/istio/issues/11658