### PR TITLE
Allow local loopback traffic not to be redirected

### DIFF
--- a/tools/deb/istio-iptables.sh
+++ b/tools/deb/istio-iptables.sh
@@ -299,9 +299,11 @@ iptables -t nat -N ISTIO_OUTPUT
 # Jump to the ISTIO_OUTPUT chain from OUTPUT chain for all tcp traffic.
 iptables -t nat -A OUTPUT -p tcp -j ISTIO_OUTPUT
 
-# Redirect app calls to back itself via Envoy when using the service VIP or endpoint
-# address, e.g. appN => Envoy (client) => Envoy (server) => appN.
-iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+if [ -z "${DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK_TO_ISTIO_PROXY-}" ]; then
+  # Redirect app calls to back itself via Envoy when using the service VIP or endpoint
+  # address, e.g. appN => Envoy (client) => Envoy (server) => appN.
+  iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT
+fi
 
 for uid in ${PROXY_UID}; do
   # Avoid infinite loops. Don't redirect Envoy traffic directly back to


### PR DESCRIPTION
If Envoy does not have a listener to send local loopback traffic to 127.0.0.1, the rule "iptables -t nat -A ISTIO_OUTPUT -o lo ! -d 127.0.0.1/32 -j ISTIO_REDIRECT" would cause infinite loop. For deployment that does not have server side proxy, environment variable DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK_TO_ISTIO_PROXY can be defined to be non-empty to avoid the fatal loop.