### PR TITLE
Don't ignore kube-system when using Incremental EDS

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -747,8 +747,8 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 	c.services.handler.Append(func(obj interface{}, event model.Event) error {
 		svc := *obj.(*v1.Service)
 
-		// Do not handle "kube-system" services
-		if svc.Namespace == meta_v1.NamespaceSystem {
+		// Do not handle "kube-system" services unless using incremental EDS
+		if svc.Namespace == meta_v1.NamespaceSystem || c.EDSUpdater == nil {
 			return nil
 		}
 
@@ -788,8 +788,8 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 	c.endpoints.handler.Append(func(obj interface{}, event model.Event) error {
 		ep := obj.(*v1.Endpoints)
 
-		// Do not handle "kube-system" endpoints
-		if ep.Namespace == meta_v1.NamespaceSystem {
+		// Do not handle "kube-system" endpoints unless using incremental EDS
+		if ep.Namespace == meta_v1.NamespaceSystem || c.EDSUpdater == nil {
 			return nil
 		}
 

--- a/pilot/pkg/serviceregistry/kube/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller.go
@@ -748,7 +748,7 @@ func (c *Controller) AppendServiceHandler(f func(*model.Service, model.Event)) e
 		svc := *obj.(*v1.Service)
 
 		// Do not handle "kube-system" services unless using incremental EDS
-		if svc.Namespace == meta_v1.NamespaceSystem || c.EDSUpdater == nil {
+		if svc.Namespace == meta_v1.NamespaceSystem && c.EDSUpdater == nil {
 			return nil
 		}
 
@@ -789,7 +789,7 @@ func (c *Controller) AppendInstanceHandler(f func(*model.ServiceInstance, model.
 		ep := obj.(*v1.Endpoints)
 
 		// Do not handle "kube-system" endpoints unless using incremental EDS
-		if ep.Namespace == meta_v1.NamespaceSystem || c.EDSUpdater == nil {
+		if ep.Namespace == meta_v1.NamespaceSystem && c.EDSUpdater == nil {
 			return nil
 		}
 


### PR DESCRIPTION
This was originally ignored due to a high rate of updates from
kube-system. EDSInformer checks that there were actual meaningful
changes made, otherwise they are ignored. However, this was never used,
as the EDSUpdater is set after this is set up. This changes the code to
use EDSInformer, and removes the kube-system filter now that it is safe
to do so. In 1.1 EDSInformer is already always used.

I am not certain this is the best/safest approach here. As far as I can tell it is safe and works, even with PILOT_DIRECT_EDS=0, but I am not sure why EDSInformer wasn't always used to begin with. I may be missing something, or it may just have never been cleaned up.

https://github.com/istio/istio/issues/11658

Same change in 1.1: https://github.com/istio/istio/pull/12028