### PR TITLE
[Galley] Standardize worker thread lifecycles

### DIFF
--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -17,14 +17,13 @@ package runtime
 import (
 	"time"
 
-	"github.com/pkg/errors"
-
 	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/groups"
 	"istio.io/istio/galley/pkg/runtime/monitoring"
 	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/galley/pkg/util"
 	"istio.io/istio/pkg/log"
 )
 
@@ -37,16 +36,10 @@ type Processor struct {
 	source Source
 
 	// events channel that was obtained from source
-	events chan resource.Event
+	eventCh chan resource.Event
 
 	// handler for events.
 	handler processing.Handler
-
-	// channel that gets closed during Shutdown.
-	done chan struct{}
-
-	// channel that signals the background process as being stopped.
-	stopped chan struct{}
 
 	// The current in-memory configuration State
 	state *State
@@ -56,6 +49,8 @@ type Processor struct {
 
 	// lastEventTime records the last time an event was received.
 	lastEventTime time.Time
+
+	worker *util.Worker
 }
 
 type postProcessHookFn func()
@@ -77,8 +72,8 @@ func newProcessor(
 		state:           state,
 		source:          src,
 		postProcessHook: postProcessHook,
-		done:            make(chan struct{}),
-		stopped:         make(chan struct{}),
+		worker:          util.NewWorker("runtime processor", scope),
+		eventCh:         make(chan resource.Event, 1024),
 		lastEventTime:   now,
 	}
 }
@@ -86,57 +81,40 @@ func newProcessor(
 // Start the processor. This will cause processor to listen to incoming events from the provider
 // and publish component configuration via the Distributor.
 func (p *Processor) Start() error {
-	scope.Info("Starting processor...")
+	return p.worker.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		scope.Info("Starting processor...")
 
-	if p.events != nil {
-		scope.Warn("Processor has already started")
-		return errors.New("already started")
-	}
+		err := p.source.Start(func(e resource.Event) {
+			p.eventCh <- e
+		})
+		if err != nil {
+			scope.Warnf("Unable to Start source: %v", err)
+			return err
+		}
 
-	events := make(chan resource.Event, 1024)
-	err := p.source.Start(func(e resource.Event) {
-		events <- e
+		go p.process(stopCh, stoppedCh)
+
+		return nil
 	})
-	if err != nil {
-		scope.Warnf("Unable to Start source: %v", err)
-		return err
-	}
-
-	p.events = events
-
-	go p.process()
-
-	return nil
 }
 
 // Stop the processor.
 func (p *Processor) Stop() {
 	scope.Info("Stopping processor...")
-
-	if p.events == nil {
-		scope.Warnf("Processor has already stopped")
-		return
-	}
-
-	p.source.Stop()
-
-	close(p.done)
-	<-p.stopped
-	close(p.events)
-
-	p.events = nil
-	p.done = nil
+	p.worker.Stop(p.source.Stop, func() {
+		close(p.eventCh)
+	})
 }
 
-func (p *Processor) process() {
-	scope.Debugf("Starting process loop")
+func (p *Processor) process(stopCh chan struct{}, stoppedCh chan struct{}) {
+	scope.Debug("Starting process loop")
 
 loop:
 	for {
 		select {
 
 		// Incoming events are received through p.events
-		case e := <-p.events:
+		case e := <-p.eventCh:
 			p.processEvent(e)
 
 		case <-p.state.strategy.Publish:
@@ -144,7 +122,7 @@ loop:
 			p.state.publish()
 
 		// p.done signals the graceful Shutdown of the processor.
-		case <-p.done:
+		case <-stopCh:
 			scope.Debug("Processor.process: done")
 			break loop
 		}
@@ -155,12 +133,17 @@ loop:
 	}
 
 	p.state.close()
-	close(p.stopped)
-	scope.Debugf("Process.process: Exiting process loop")
+	close(stoppedCh)
+
+	if scope.DebugEnabled() {
+		scope.Debugf("Process.process: Exiting process loop")
+	}
 }
 
 func (p *Processor) processEvent(e resource.Event) {
-	scope.Debugf("Incoming source event: %v", e)
+	if scope.DebugEnabled() {
+		scope.Debugf("Incoming source event: %v", e)
+	}
 	p.recordEvent()
 
 	if e.Kind == resource.FullSync {

--- a/galley/pkg/source/kube/builtin/source.go
+++ b/galley/pkg/source/kube/builtin/source.go
@@ -17,7 +17,6 @@ package builtin
 import (
 	"fmt"
 	"reflect"
-	"sync"
 
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/resource"
@@ -25,6 +24,7 @@ import (
 	"istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/source/kube/stats"
 	"istio.io/istio/galley/pkg/source/kube/tombstone"
+	"istio.io/istio/galley/pkg/util"
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -46,85 +46,72 @@ func newSource(sharedInformers informers.SharedInformerFactory, t *Type) runtime
 	return &source{
 		t:               t,
 		sharedInformers: sharedInformers,
+		worker:          util.NewWorker("built-in kubernetes source", log.Scope),
 	}
 }
 
 type source struct {
-	// Lock for changing the running state of the source
-	stateLock sync.Mutex
-
 	// The built-in type that is processed by this source.
 	t *Type
 
 	sharedInformers informers.SharedInformerFactory
 	informer        cache.SharedIndexInformer
 
-	// stopCh is used to quiesce the background activity during shutdown
-	stopCh  chan struct{}
 	handler resource.EventHandler
+
+	worker *util.Worker
 }
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
+	return s.worker.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		if handler == nil {
+			return fmt.Errorf("invalid handler")
+		}
 
-	if s.stopCh != nil {
-		return fmt.Errorf("already synchronizing resources: name='%s', gv='%v'",
-			s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
-	}
-	if handler == nil {
-		return fmt.Errorf("invalid handler")
-	}
+		log.Scope.Debugf("Starting source for %s(%v)", s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
 
-	log.Scope.Debugf("Starting source for %s(%v)", s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
+		s.handler = handler
+		s.informer = s.t.NewInformer(s.sharedInformers)
+		s.informer.AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					s.handleEvent(resource.Added, obj)
+				},
+				UpdateFunc: func(old, new interface{}) {
+					if s.t.IsEqual(old, new) {
+						// Periodic resync will send update events for all known resources.
+						// Two different versions of the same resource will always have different RVs.
+						return
+					}
+					s.handleEvent(resource.Updated, new)
+				},
+				DeleteFunc: func(obj interface{}) {
+					s.handleEvent(resource.Deleted, obj)
+				},
+			})
 
-	s.stopCh = make(chan struct{})
-	s.handler = handler
+		// Start CRD shared informer background process.
+		go func() {
+			s.informer.Run(stopCh)
 
-	s.informer = s.t.NewInformer(s.sharedInformers)
-	s.informer.AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				s.handleEvent(resource.Added, obj)
-			},
-			UpdateFunc: func(old, new interface{}) {
-				if s.t.IsEqual(old, new) {
-					// Periodic resync will send update events for all known resources.
-					// Two different versions of the same resource will always have different RVs.
-					return
-				}
-				s.handleEvent(resource.Updated, new)
-			},
-			DeleteFunc: func(obj interface{}) {
-				s.handleEvent(resource.Deleted, obj)
-			},
-		})
+			// Indicate that the informer has exited.
+			close(stoppedCh)
+		}()
 
-	// Start CRD shared informer background process.
-	go s.informer.Run(s.stopCh)
+		// Send the an event after the cache syncs.
+		go func() {
+			_ = cache.WaitForCacheSync(stopCh, s.informer.HasSynced)
+			handler(resource.FullSyncEvent)
+		}()
 
-	// Send the an event after the cache syncs.
-	go func() {
-		_ = cache.WaitForCacheSync(s.stopCh, s.informer.HasSynced)
-		handler(resource.FullSyncEvent)
-	}()
-
-	return nil
+		return nil
+	})
 }
 
 // Stop the source. This will stop publishing of events.
 func (s *source) Stop() {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
-
-	if s.stopCh == nil {
-		log.Scope.Warn("built-in kubernetes source already stopped")
-		return
-	}
-
-	close(s.stopCh)
-	s.stopCh = nil
+	s.worker.Stop(nil, nil)
 }
 
 func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
@@ -138,7 +125,9 @@ func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
 
 	fullName := resource.FullNameFromNamespaceAndName(object.GetNamespace(), object.GetName())
 
-	log.Scope.Debugf("Sending event: [%v] from: %s", kind, s.t.GetSpec().CanonicalResourceName())
+	if log.Scope.DebugEnabled() {
+		log.Scope.Debugf("Sending event: [%v] from: %s", kind, s.t.GetSpec().CanonicalResourceName())
+	}
 
 	event := resource.Event{
 		Kind: kind,
@@ -172,7 +161,10 @@ func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
 		event.Entry.Item = item
 	}
 
-	log.Scope.Debugf("Dispatching source event: %v", event)
+	if log.Scope.DebugEnabled() {
+		log.Scope.Debugf("Dispatching source event: %v", event)
+	}
+
 	s.handler(event)
 	stats.RecordEventSuccess()
 }

--- a/galley/pkg/source/kube/dynamic/source.go
+++ b/galley/pkg/source/kube/dynamic/source.go
@@ -16,7 +16,6 @@ package dynamic
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"istio.io/istio/galley/pkg/runtime"
@@ -26,6 +25,7 @@ import (
 	sourceSchema "istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/source/kube/stats"
 	"istio.io/istio/galley/pkg/source/kube/tombstone"
+	"istio.io/istio/galley/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,9 +40,6 @@ var _ runtime.Source = &source{}
 
 // source is a simplified client interface for listening/getting Kubernetes resources in an unstructured way.
 type source struct {
-	// Lock for changing the running state of the source
-	stateLock sync.Mutex
-
 	cfg *converter.Config
 
 	spec sourceSchema.ResourceSpec
@@ -52,13 +49,12 @@ type source struct {
 	// The dynamic resource interface for accessing custom resources dynamically.
 	resourceClient dynamic.ResourceInterface
 
-	// stopCh is used to quiesce the background activity during shutdown
-	stopCh chan struct{}
-
 	// SharedIndexInformer for watching/caching resources
 	informer cache.SharedIndexInformer
 
 	handler resource.EventHandler
+
+	worker *util.Worker
 }
 
 // New returns a new instance of a dynamic source for the given schema.
@@ -77,80 +73,70 @@ func New(
 		cfg:            cfg,
 		resyncPeriod:   resyncPeriod,
 		resourceClient: resourceClient,
+		worker:         util.NewWorker("dynamic source", log.Scope),
 	}, nil
 }
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
+	return s.worker.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		if handler == nil {
+			return fmt.Errorf("invalid event handler")
+		}
 
-	if s.stopCh != nil {
-		return fmt.Errorf("already synchronizing resources: name='%s', gv='%v'",
-			s.spec.Singular, s.spec.GroupVersion())
-	}
-	if handler == nil {
-		return fmt.Errorf("invalid event handler")
-	}
+		log.Scope.Debugf("Starting source for %s(%v)", s.spec.Singular, s.spec.GroupVersion())
 
-	log.Scope.Debugf("Starting source for %s(%v)", s.spec.Singular, s.spec.GroupVersion())
-
-	s.stopCh = make(chan struct{})
-	s.handler = handler
-
-	s.informer = cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (k8sRuntime.Object, error) {
-				return s.resourceClient.List(options)
+		s.handler = handler
+		s.informer = cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (k8sRuntime.Object, error) {
+					return s.resourceClient.List(options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.Watch = true
+					return s.resourceClient.Watch(options)
+				},
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.Watch = true
-				return s.resourceClient.Watch(options)
-			},
-		},
-		&unstructured.Unstructured{},
-		s.resyncPeriod,
-		cache.Indexers{})
+			&unstructured.Unstructured{},
+			s.resyncPeriod,
+			cache.Indexers{})
 
-	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) { s.handleEvent(resource.Added, obj) },
-		UpdateFunc: func(old, new interface{}) {
-			newRes := new.(*unstructured.Unstructured)
-			oldRes := old.(*unstructured.Unstructured)
-			if newRes.GetResourceVersion() == oldRes.GetResourceVersion() {
-				// Periodic resync will send update events for all known resources.
-				// Two different versions of the same resource will always have different RVs.
-				return
-			}
-			s.handleEvent(resource.Updated, new)
-		},
-		DeleteFunc: func(obj interface{}) { s.handleEvent(resource.Deleted, obj) },
+		s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) { s.handleEvent(resource.Added, obj) },
+			UpdateFunc: func(old, new interface{}) {
+				newRes := new.(*unstructured.Unstructured)
+				oldRes := old.(*unstructured.Unstructured)
+				if newRes.GetResourceVersion() == oldRes.GetResourceVersion() {
+					// Periodic resync will send update events for all known resources.
+					// Two different versions of the same resource will always have different RVs.
+					return
+				}
+				s.handleEvent(resource.Updated, new)
+			},
+			DeleteFunc: func(obj interface{}) { s.handleEvent(resource.Deleted, obj) },
+		})
+
+		// Start CRD shared informer background process.
+		go func() {
+			s.informer.Run(stopCh)
+
+			// Indicate that the informer has exited.
+			close(stoppedCh)
+		}()
+
+		// Send the an event after the cache syncs.
+		go func() {
+			_ = cache.WaitForCacheSync(stopCh, s.informer.HasSynced)
+			handler(resource.FullSyncEvent)
+		}()
+
+		return nil
 	})
-
-	// Start CRD shared informer background process.
-	go s.informer.Run(s.stopCh)
-
-	// Send the an event after the cache syncs.
-	go func() {
-		_ = cache.WaitForCacheSync(s.stopCh, s.informer.HasSynced)
-		handler(resource.FullSyncEvent)
-	}()
-
-	return nil
 }
 
 // Stop the source. This will stop publishing of events.
 func (s *source) Stop() {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
-
-	if s.stopCh == nil {
-		log.Scope.Errorf("already stopped")
-		return
-	}
-
-	close(s.stopCh)
-	s.stopCh = nil
+	s.worker.Stop(nil, nil)
 }
 
 func (s *source) handleEvent(c resource.EventKind, obj interface{}) {

--- a/galley/pkg/util/worker.go
+++ b/galley/pkg/util/worker.go
@@ -1,0 +1,113 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"sync"
+
+	"istio.io/istio/pkg/log"
+)
+
+// Worker is a utility to help manage the lifecycle of a worker thread.
+type Worker struct {
+	// name of the worker thread used for logging.
+	name string
+
+	// scope is the logging scope to be used for log messages.
+	scope log.Scope
+
+	// Lock for changing the running state of the source
+	stateLock sync.Mutex
+
+	// started indicates that the user has started this source (via Start).
+	started bool
+
+	// stopped indicates that the user has stopped this source (via Stop).
+	stopped bool
+
+	// stopCh is used to trigger the k8s informer to stop.
+	stopCh chan struct{}
+
+	// stoppedCh is used to indicate that the k8s informer has exited.
+	stoppedCh chan struct{}
+}
+
+// NewWorker creates a new worker with the given name and logging scope.
+func NewWorker(name string, scope *log.Scope) *Worker {
+	if scope == nil {
+		scope = log.FindScope(log.DefaultScopeName)
+	}
+	return &Worker{
+		name:      name,
+		scope:     *scope,
+		stopCh:    make(chan struct{}, 1),
+		stoppedCh: make(chan struct{}, 1),
+	}
+}
+
+// Start the worker thread via the provided function. The startWorkerThread function is
+// provided two control channels. When the user closes this worker, stopCh is closed to
+// signal that the worker thread should begin shutting down. Upon exiting, the worker
+// thread should in turn close stoppedCh to signal back to the worker that the thread
+// has terminated.
+func (w *Worker) Start(startWorkerThread func(stopCh chan struct{}, stoppedCh chan struct{}) error) error {
+	w.stateLock.Lock()
+	defer w.stateLock.Unlock()
+
+	if w.started {
+		return fmt.Errorf("%s already started", w.name)
+	}
+
+	err := startWorkerThread(w.stopCh, w.stoppedCh)
+	if err == nil {
+		w.started = true
+	}
+	return err
+}
+
+// Stop the worker thread. Once the worker thread has terminated, the provided cleanup
+// function is executed.
+func (w *Worker) Stop(preStopFn func(), postStopFn func()) {
+	w.stateLock.Lock()
+	if !w.started {
+		w.scope.Warnf("%s was never started", w.name)
+		w.stateLock.Unlock()
+		return
+	}
+	if w.stopped {
+		w.scope.Warnf("%s already stopped", w.name)
+		w.stateLock.Unlock()
+		return
+	}
+	w.stopped = true
+	w.stateLock.Unlock()
+
+	// Perform custom pre-stop processing.
+	if preStopFn != nil {
+		preStopFn()
+	}
+
+	// Signal to the worker thread that we're shutting down.
+	close(w.stopCh)
+
+	// Wait for the worker thread to exit.
+	<-w.stoppedCh
+
+	// Perform custom post-stop processing.
+	if postStopFn != nil {
+		postStopFn()
+	}
+}

--- a/galley/pkg/util/worker_test.go
+++ b/galley/pkg/util/worker_test.go
@@ -1,0 +1,153 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/util"
+)
+
+func TestStopBeforeStartShouldNotHaveEffect(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	preStopCalled := false
+	postStopCalled := false
+	w.Stop(func() { preStopCalled = true }, func() { postStopCalled = true })
+	g.Expect(preStopCalled).To(BeFalse())
+	g.Expect(postStopCalled).To(BeFalse())
+}
+
+func TestStartTwiceShouldCallFuncOnce(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	count := 0
+	startFn := func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		count++
+		return nil
+	}
+
+	err := w.Start(startFn)
+	g.Expect(err).To(BeNil())
+	g.Expect(count).To(Equal(1))
+
+	// Second call should fail and not call startFn.
+	err = w.Start(startFn)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(count).To(Equal(1))
+}
+
+func TestStartWithError(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	expected := errors.New("fake error")
+	actual := w.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		return expected
+	})
+	g.Expect(actual).To(Equal(expected))
+}
+
+func TestStopTwiceShouldCallFuncOnce(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	// Start the worker thread.
+	err := w.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		go func() {
+			// Wait for the stop signal.
+			<-stopCh
+			// Signal that the thread has terminated.
+			close(stoppedCh)
+		}()
+		return nil
+	})
+	g.Expect(err).To(BeNil())
+
+	// Stop the worker.
+	preStopCount := 0
+	preStopFn := func() {
+		preStopCount++
+	}
+	postStopCount := 0
+	postStopFn := func() {
+		postStopCount++
+	}
+	w.Stop(preStopFn, postStopFn)
+	g.Expect(preStopCount).To(Equal(1))
+	g.Expect(postStopCount).To(Equal(1))
+
+	// Second call should do nothing.
+	w.Stop(preStopFn, postStopFn)
+	g.Expect(preStopCount).To(Equal(1))
+	g.Expect(postStopCount).To(Equal(1))
+}
+
+func TestPreStopBeforePostStop(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	// Start the worker thread.
+	var stopTime time.Time
+	err := w.Start(func(stopCh chan struct{}, stoppedCh chan struct{}) error {
+		go func() {
+			// Wait for the stop signal.
+			<-stopCh
+
+			// Store the time that the stop was received.
+			stopTime = time.Now()
+
+			// Sleep for a bit to force the post time to be later.
+			time.Sleep(10 * time.Millisecond)
+
+			// Signal that the thread has terminated.
+			close(stoppedCh)
+		}()
+		return nil
+	})
+	g.Expect(err).To(BeNil())
+
+	// Stop the worker.
+	var preStopTime time.Time
+	var postStopTime time.Time
+	preStopFn := func() {
+		preStopTime = time.Now()
+
+		// Sleep for a bit to force the stop time to be later.
+		time.Sleep(10 * time.Millisecond)
+	}
+	postStopFn := func() {
+		postStopTime = time.Now()
+	}
+	w.Stop(preStopFn, postStopFn)
+	if !preStopTime.Before(stopTime) || !stopTime.Before(postStopTime) {
+		t.Fatalf("unexpected time ordering: pre: %v, stopped: %v, post: %v", preStopTime, stopTime, postStopTime)
+	}
+}
+
+func newWorker() *util.Worker {
+	return util.NewWorker("testWorker", nil)
+}


### PR DESCRIPTION
We currently have several worker classes that follow a similar lifecycle pattern, but are inconsistent. This PR makes standardizes the lifecycle management logic into a new Worker class.