### PR TITLE
expose status-port in gateway by default

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -73,6 +73,9 @@ istio-ingressgateway:
   - port: 15443
     targetPort: 15443
     name: tls
+  - port: 15020
+    targetPort: 15020
+    name: status-port
   #### MESH EXPANSION PORTS  ########
   # Pilot and Citadel MTLS ports are enabled in gateway - but will only redirect
   # to pilot/citadel if global.meshExpansion settings are enabled.


### PR DESCRIPTION
https://github.com/istio/istio/issues/9385 

with Istio ingress-gateway support for hc(readiness probe), expose status port(15020) by default to avoid ppl manually updating deploy yaml file(when istio ingress-gateway acts as 2nd LB which requires support hc). 