### PR TITLE
fix mcp source unit test

### DIFF
--- a/pkg/mcp/source/source_test.go
+++ b/pkg/mcp/source/source_test.go
@@ -203,11 +203,7 @@ func (h *sourceTestHarness) Watch(req *Request, pushResponse PushResponseFunc) C
 		ch <- struct{}{}
 	}
 
-	return func() {
-		h.mu.Lock()
-		defer h.mu.Unlock()
-		delete(h.watchResponses, req.Collection)
-	}
+	return func() {}
 }
 
 func (h *sourceTestHarness) injectWatchResponse(response *WatchResponse) {
@@ -220,6 +216,7 @@ func (h *sourceTestHarness) injectWatchResponse(response *WatchResponse) {
 		for _, watch := range watches {
 			watch(response)
 		}
+		delete(h.pushResponseFuncs, collection)
 	} else {
 		h.watchResponses[collection] = response
 	}


### PR DESCRIPTION
TestSourceACKAddUpdateDelete and TestSourceACKAddUpdateDelete_Incremental unit tests are flakiness due to a bug in the unit test harness. Cherry-pick the unit test flakeiness fix from https://github.com/istio/istio/pull/12032. 

fixes https://github.com/istio/istio/issues/12070