### PR TITLE
Fix upgrade/downgrade issue, add guard for visibility and make it off…

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
@@ -196,8 +196,10 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: "*.global"
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
   exportTo:
   - '*'
+  {{- end }}
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL

--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -992,8 +992,10 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: istio-policy.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
   exportTo:
   - '*'
+  {{- end }}
   trafficPolicy:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     portLevelSettings:
@@ -1021,8 +1023,10 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: istio-telemetry.{{ .Release.Namespace }}.svc.{{ .Values.global.proxy.clusterDomain }}
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
   exportTo:
   - '*'
+  {{- end }}
   trafficPolicy:
     {{- if .Values.global.controlPlaneSecurityEnabled }}
     portLevelSettings:

--- a/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/enable-mesh-mtls.yaml
@@ -31,8 +31,10 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: "*.local"
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
   exportTo:
   - '*'
+  {{- end }}
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL
@@ -51,8 +53,10 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   host: "kubernetes.default.svc.{{ .Values.global.proxy.clusterDomain }}"
+  {{- if .Values.global.defaultConfigVisibilitySettings }}
   exportTo:
   - '*'
+  {{- end }}
   trafficPolicy:
     tls:
       mode: DISABLE

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -406,8 +406,8 @@ global:
   # should be one of the following two options:
   # * implies these objects are visible to all namespaces, enabling any sidecar to talk to any other sidecar.
   # . implies these objects are visible to only to sidecars in the same namespace, or if imported as a Sidecar.egress.host  
-  defaultConfigVisibilitySettings:
-  - '*'
+  #defaultConfigVisibilitySettings:
+  #- '*'
 
   sds:
     # SDS enabled. IF set to true, mTLS certificates for the sidecars will be


### PR DESCRIPTION
I hope the code is properly handling lack of the setting ( default value matches 1.0 behavior ).

Users can still enable it if they want a different setting - but it is an alpha feature, can't be required.