### PR TITLE
Fix RBAC to use workload name for destinatin.name

### DIFF
--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -1330,19 +1330,21 @@ func TestCreateServiceMetadata(t *testing.T) {
 		},
 	}
 	serviceInstance := &model.ServiceInstance{
+		Endpoint: model.NetworkEndpoint{UID: "kubernetes://svc-name.test-ns"},
 		Service: &model.Service{
 			Hostname: model.Hostname("svc-name.test-ns"),
 		},
 		Labels:         model.Labels{"version": "v1"},
 		ServiceAccount: "spiffe://xyz.com/sa/service-account/ns/test-ns",
 	}
-	actual := createServiceMetadata(&model.ServiceAttributes{Name: "svc-name", Namespace: "test-ns"}, serviceInstance)
+	actual := createServiceMetadata(serviceInstance)
 
 	if !reflect.DeepEqual(*actual, *expect) {
 		t.Errorf("expecting %v, but got %v", *expect, *actual)
 	}
 
-	actual = createServiceMetadata(&model.ServiceAttributes{Name: "svc-name", Namespace: ""}, serviceInstance)
+	serviceInstance.Endpoint.UID = "kubernetes://svc-name."
+	actual = createServiceMetadata(serviceInstance)
 	if actual != nil {
 		t.Errorf("expecting nil, but got %v", *actual)
 	}

--- a/pilot/pkg/networking/plugin/authz/util.go
+++ b/pilot/pkg/networking/plugin/authz/util.go
@@ -167,3 +167,14 @@ func extractActualServiceAccount(istioServiceAccount string) string {
 	}
 	return actualSA
 }
+
+func decodeEndpointUID(uid string) (name string, namespace string) {
+	kubePrefix := "kubernetes://"
+	if strings.HasPrefix(uid, kubePrefix) {
+		parts := strings.Split(strings.TrimPrefix(uid, kubePrefix), ".")
+		if len(parts) == 2 {
+			return parts[0], parts[1]
+		}
+	}
+	return "", ""
+}

--- a/pilot/pkg/networking/plugin/authz/util_test.go
+++ b/pilot/pkg/networking/plugin/authz/util_test.go
@@ -278,3 +278,25 @@ func TestExtractActualServiceAccount(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeEndpointUID(t *testing.T) {
+	empty := []string{"", ""}
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{in: "", want: empty},
+		{in: "abc://pod.ns", want: empty},
+		{in: "kubernetes://pod.bla.ns", want: empty},
+		{in: "kubernetes://pod-ns", want: empty},
+		{in: "kubernetes://pod.ns", want: []string{"pod", "ns"}},
+	}
+
+	for _, c := range cases {
+		gotName, gotNs := decodeEndpointUID(c.in)
+		got := []string{gotName, gotNs}
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("got %s but want %s", got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #12105

Note, it's not clear what the workload name mean on platform other than k8s, so we simply don't support destination.name and destination.namespace in this case.