### PR TITLE
Improving error message for sidecar readiness

### DIFF
--- a/pilot/cmd/pilot-agent/status/ready/probe.go
+++ b/pilot/cmd/pilot-agent/status/ready/probe.go
@@ -15,7 +15,6 @@
 package ready
 
 import (
-	"errors"
 	"fmt"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -31,11 +30,14 @@ type Probe struct {
 
 // Check executes the probe and returns an error is the probe fails.
 func (p *Probe) Check() error {
-	if err := p.checkInboundConfigured(); err != nil {
+	// First, check that Envoy has received a configuration update from Pilot.
+	if err := p.checkUpdated(); err != nil {
 		return err
 	}
 
-	return p.checkUpdated()
+	// Envoy has received some configuration, make sure that configuration has been received for
+	// all inbound ports.
+	return p.checkInboundConfigured()
 }
 
 // checkApplicationPorts verifies that Envoy has received configuration for all ports exposed by the application container.
@@ -77,5 +79,5 @@ func (p *Probe) checkUpdated() error {
 		return nil
 	}
 
-	return errors.New(s.String())
+	return fmt.Errorf("config not received from Pilot (is Pilot running?): %s", s.String())
 }


### PR DESCRIPTION
Currently, the readiness error message doesn't make it clear that
the issue is likely Pilot:

```
2019-02-25T07:22:20.019287Z	info	Envoy proxy is NOT ready: cds updates: 0 successful, 0 rejected; lds updates: 0 successful, 0 rejected
```

This PR should help users better diagnose these issues in the future.

This is a port of PR #12098 into the release-1.1 branch.