### PR TITLE
[Galley] Standardize worker thread lifecycles

### DIFF
--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -15,9 +15,9 @@
 package runtime
 
 import (
+	"context"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"istio.io/istio/galley/pkg/metadata"
 	"istio.io/istio/galley/pkg/runtime/groups"
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
+	"istio.io/istio/galley/pkg/util"
 	"istio.io/istio/pkg/log"
 )
 
@@ -36,17 +37,8 @@ type Processor struct {
 	// source interface for retrieving the events from.
 	source Source
 
-	// events channel that was obtained from source
-	events chan resource.Event
-
 	// handler for events.
 	handler processing.Handler
-
-	// channel that gets closed during Shutdown.
-	done chan struct{}
-
-	// channel that signals the background process as being stopped.
-	stopped chan struct{}
 
 	// The current in-memory configuration State
 	state *State
@@ -56,6 +48,8 @@ type Processor struct {
 
 	// lastEventTime records the last time an event was received.
 	lastEventTime time.Time
+
+	worker *util.Worker
 }
 
 type postProcessHookFn func()
@@ -77,8 +71,7 @@ func newProcessor(
 		state:           state,
 		source:          src,
 		postProcessHook: postProcessHook,
-		done:            make(chan struct{}),
-		stopped:         make(chan struct{}),
+		worker:          util.NewWorker("runtime processor", scope),
 		lastEventTime:   now,
 	}
 }
@@ -86,81 +79,55 @@ func newProcessor(
 // Start the processor. This will cause processor to listen to incoming events from the provider
 // and publish component configuration via the Distributor.
 func (p *Processor) Start() error {
-	scope.Info("Starting processor...")
+	return p.worker.Start(func(ctx context.Context) {
+		scope.Info("Starting processor...")
+		eventCh := make(chan resource.Event, 1024)
+		defer func() {
+			scope.Debugf("Process.process: Exiting worker thread")
+			close(eventCh)
+			p.state.close()
+		}()
 
-	if p.events != nil {
-		scope.Warn("Processor has already started")
-		return errors.New("already started")
-	}
+		err := p.source.Start(func(e resource.Event) {
+			eventCh <- e
+		})
+		if err != nil {
+			panic(fmt.Sprintf("runtime unable to Start source: %v", err))
+		}
+		defer p.source.Stop()
 
-	events := make(chan resource.Event, 1024)
-	err := p.source.Start(func(e resource.Event) {
-		events <- e
+		scope.Debug("Starting process loop")
+
+		for {
+			select {
+			case <-ctx.Done():
+				// Graceful termination.
+				scope.Debug("Processor.process: done")
+				return
+			case e := <-eventCh:
+				p.processEvent(e)
+			case <-p.state.strategy.Publish:
+				scope.Debug("Processor.process: publish")
+				p.state.publish()
+			}
+
+			if p.postProcessHook != nil {
+				p.postProcessHook()
+			}
+		}
 	})
-	if err != nil {
-		scope.Warnf("Unable to Start source: %v", err)
-		return err
-	}
-
-	p.events = events
-
-	go p.process()
-
-	return nil
 }
 
 // Stop the processor.
 func (p *Processor) Stop() {
 	scope.Info("Stopping processor...")
-
-	if p.events == nil {
-		scope.Warnf("Processor has already stopped")
-		return
-	}
-
-	p.source.Stop()
-
-	close(p.done)
-	<-p.stopped
-	close(p.events)
-
-	p.events = nil
-	p.done = nil
-}
-
-func (p *Processor) process() {
-	scope.Debugf("Starting process loop")
-
-loop:
-	for {
-		select {
-
-		// Incoming events are received through p.events
-		case e := <-p.events:
-			p.processEvent(e)
-
-		case <-p.state.strategy.Publish:
-			scope.Debug("Processor.process: publish")
-			p.state.publish()
-
-		// p.done signals the graceful Shutdown of the processor.
-		case <-p.done:
-			scope.Debug("Processor.process: done")
-			break loop
-		}
-
-		if p.postProcessHook != nil {
-			p.postProcessHook()
-		}
-	}
-
-	p.state.close()
-	close(p.stopped)
-	scope.Debugf("Process.process: Exiting process loop")
+	p.worker.Stop()
 }
 
 func (p *Processor) processEvent(e resource.Event) {
-	scope.Debugf("Incoming source event: %v", e)
+	if scope.DebugEnabled() {
+		scope.Debugf("Incoming source event: %v", e)
+	}
 	p.recordEvent()
 
 	if e.Kind == resource.FullSync {

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -15,7 +15,6 @@
 package runtime
 
 import (
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -45,24 +44,6 @@ func TestProcessor_Start(t *testing.T) {
 	err = p.Start()
 	if err == nil {
 		t.Fatal("second start should have caused an error")
-	}
-}
-
-type erroneousSource struct{}
-
-func (e *erroneousSource) Start(_ resource.EventHandler) error {
-	return errors.New("cheese not found")
-}
-func (e *erroneousSource) Stop() {}
-
-func TestProcessor_Start_Error(t *testing.T) {
-	distributor := snapshot.New(groups.IndexFunction)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
-	p := NewProcessor(&erroneousSource{}, distributor, cfg)
-
-	err := p.Start()
-	if err == nil {
-		t.Fatal("expected error not found")
 	}
 }
 

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -15,6 +15,7 @@
 package runtime
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -44,6 +45,24 @@ func TestProcessor_Start(t *testing.T) {
 	err = p.Start()
 	if err == nil {
 		t.Fatal("second start should have caused an error")
+	}
+}
+
+type erroneousSource struct{}
+
+func (e *erroneousSource) Start(_ resource.EventHandler) error {
+	return errors.New("cheese not found")
+}
+func (e *erroneousSource) Stop() {}
+
+func TestProcessor_Start_Error(t *testing.T) {
+	distributor := snapshot.New(groups.IndexFunction)
+	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	p := NewProcessor(&erroneousSource{}, distributor, cfg)
+
+	err := p.Start()
+	if err == nil {
+		t.Fatal("expected error not found")
 	}
 }
 

--- a/galley/pkg/source/fs/source.go
+++ b/galley/pkg/source/fs/source.go
@@ -275,7 +275,7 @@ func (s *source) process(eventKind resource.EventKind, key fileResourceKey, r *f
 
 // Start implements runtime.Source
 func (s *source) Start(handler resource.EventHandler) error {
-	return s.worker.Start(func(ctx context.Context) {
+	return s.worker.Start(nil, func(ctx context.Context) {
 		s.handler = handler
 
 		watcher, err := fsnotify.NewWatcher()

--- a/galley/pkg/source/fs/source.go
+++ b/galley/pkg/source/fs/source.go
@@ -16,6 +16,7 @@ package fs
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
@@ -35,6 +36,7 @@ import (
 	"istio.io/istio/galley/pkg/source/kube/dynamic/converter"
 	"istio.io/istio/galley/pkg/source/kube/log"
 	"istio.io/istio/galley/pkg/source/kube/schema"
+	"istio.io/istio/galley/pkg/util"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	kubeJson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -59,8 +61,6 @@ type source struct {
 	// Config File Path
 	root string
 
-	donec chan struct{}
-
 	mu sync.RWMutex
 
 	// map to store namespace/name : shas
@@ -78,6 +78,8 @@ type source struct {
 	version int64
 
 	watcher *fsnotify.Watcher
+
+	worker *util.Worker
 }
 
 func (s *source) readFiles(root string) map[fileResourceKey]*fileResource {
@@ -106,7 +108,7 @@ func (s *source) readFiles(root string) map[fileResourceKey]*fileResource {
 }
 
 func (s *source) readFile(path string, info os.FileInfo, initial bool) []*fileResource {
-	result := []*fileResource{}
+	result := make([]*fileResource, 0)
 	if mode := info.Mode() & os.ModeType; !supportedExtensions[filepath.Ext(path)] || (mode != 0 && mode != os.ModeSymlink) {
 		return nil
 	}
@@ -228,8 +230,7 @@ func (s *source) initialCheck() {
 
 // Stop implements runtime.Source
 func (s *source) Stop() {
-	close(s.donec)
-	_ = s.watcher.Close()
+	s.worker.Stop()
 }
 
 func (s *source) process(eventKind resource.EventKind, key fileResourceKey, r *fileResource) {
@@ -274,17 +275,23 @@ func (s *source) process(eventKind resource.EventKind, key fileResourceKey, r *f
 
 // Start implements runtime.Source
 func (s *source) Start(handler resource.EventHandler) error {
-	s.handler = handler
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return err
-	}
-	s.watcher = watcher
-	_ = s.watcher.Watch(s.root)
-	s.initialCheck()
-	go func() {
+	return s.worker.Start(func(ctx context.Context) {
+		s.handler = handler
+
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			panic(err)
+		}
+		defer func() { _ = s.watcher.Close() }()
+
+		s.watcher = watcher
+		_ = s.watcher.Watch(s.root)
+		s.initialCheck()
 		for {
 			select {
+			case <-ctx.Done():
+				// Graceful shutdown.
+				return
 			// watch for events
 			case ev, more := <-s.watcher.Event:
 				if !more {
@@ -325,12 +332,9 @@ func (s *source) Start(handler resource.EventHandler) error {
 						}
 					}
 				}
-			case <-s.donec:
-				return
 			}
 		}
-	}()
-	return nil
+	})
 }
 
 // New returns a File System implementation of runtime.Source.
@@ -340,7 +344,7 @@ func New(root string, schema *schema.Instance, config *converter.Config) (runtim
 		root:             root,
 		kinds:            map[string]bool{},
 		fileResourceKeys: map[string][]*fileResourceKey{},
-		donec:            make(chan struct{}),
+		worker:           util.NewWorker("fs source", log.Scope),
 		shas:             map[fileResourceKey][sha1.Size]byte{},
 		version:          0,
 	}

--- a/galley/pkg/source/kube/builtin/source.go
+++ b/galley/pkg/source/kube/builtin/source.go
@@ -65,7 +65,7 @@ type source struct {
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	return s.worker.Start(func(ctx context.Context) {
+	return s.worker.Start(nil, func(ctx context.Context) {
 		if handler == nil {
 			panic("built-in kubernetes source provided with nil handler")
 		}

--- a/galley/pkg/source/kube/builtin/source.go
+++ b/galley/pkg/source/kube/builtin/source.go
@@ -92,16 +92,14 @@ func (s *source) Start(handler resource.EventHandler) error {
 				},
 			})
 
-		// Start CRD shared informer background process.
-		go s.informer.Run(ctx.Done())
-
 		// Send the an event after the cache syncs.
 		go func() {
 			_ = cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced)
 			handler(resource.FullSyncEvent)
 		}()
 
-		<-ctx.Done()
+		// Start CRD shared informer and wait for it to exit.
+		s.informer.Run(ctx.Done())
 	})
 }
 

--- a/galley/pkg/source/kube/builtin/source.go
+++ b/galley/pkg/source/kube/builtin/source.go
@@ -15,9 +15,9 @@
 package builtin
 
 import (
+	"context"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"istio.io/istio/galley/pkg/runtime"
 	"istio.io/istio/galley/pkg/runtime/resource"
@@ -25,6 +25,7 @@ import (
 	"istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/source/kube/stats"
 	"istio.io/istio/galley/pkg/source/kube/tombstone"
+	"istio.io/istio/galley/pkg/util"
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -46,85 +47,67 @@ func newSource(sharedInformers informers.SharedInformerFactory, t *Type) runtime
 	return &source{
 		t:               t,
 		sharedInformers: sharedInformers,
+		worker:          util.NewWorker("built-in kubernetes source", log.Scope),
 	}
 }
 
 type source struct {
-	// Lock for changing the running state of the source
-	stateLock sync.Mutex
-
 	// The built-in type that is processed by this source.
 	t *Type
 
 	sharedInformers informers.SharedInformerFactory
 	informer        cache.SharedIndexInformer
 
-	// stopCh is used to quiesce the background activity during shutdown
-	stopCh  chan struct{}
 	handler resource.EventHandler
+
+	worker *util.Worker
 }
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
+	return s.worker.Start(func(ctx context.Context) {
+		if handler == nil {
+			panic("built-in kubernetes source provided with nil handler")
+		}
 
-	if s.stopCh != nil {
-		return fmt.Errorf("already synchronizing resources: name='%s', gv='%v'",
-			s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
-	}
-	if handler == nil {
-		return fmt.Errorf("invalid handler")
-	}
+		log.Scope.Debugf("Starting source for %s(%v)", s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
 
-	log.Scope.Debugf("Starting source for %s(%v)", s.t.GetSpec().Singular, s.t.GetSpec().GroupVersion())
+		s.handler = handler
+		s.informer = s.t.NewInformer(s.sharedInformers)
+		s.informer.AddEventHandler(
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					s.handleEvent(resource.Added, obj)
+				},
+				UpdateFunc: func(old, new interface{}) {
+					if s.t.IsEqual(old, new) {
+						// Periodic resync will send update events for all known resources.
+						// Two different versions of the same resource will always have different RVs.
+						return
+					}
+					s.handleEvent(resource.Updated, new)
+				},
+				DeleteFunc: func(obj interface{}) {
+					s.handleEvent(resource.Deleted, obj)
+				},
+			})
 
-	s.stopCh = make(chan struct{})
-	s.handler = handler
+		// Start CRD shared informer background process.
+		go s.informer.Run(ctx.Done())
 
-	s.informer = s.t.NewInformer(s.sharedInformers)
-	s.informer.AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				s.handleEvent(resource.Added, obj)
-			},
-			UpdateFunc: func(old, new interface{}) {
-				if s.t.IsEqual(old, new) {
-					// Periodic resync will send update events for all known resources.
-					// Two different versions of the same resource will always have different RVs.
-					return
-				}
-				s.handleEvent(resource.Updated, new)
-			},
-			DeleteFunc: func(obj interface{}) {
-				s.handleEvent(resource.Deleted, obj)
-			},
-		})
+		// Send the an event after the cache syncs.
+		go func() {
+			_ = cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced)
+			handler(resource.FullSyncEvent)
+		}()
 
-	// Start CRD shared informer background process.
-	go s.informer.Run(s.stopCh)
-
-	// Send the an event after the cache syncs.
-	go func() {
-		_ = cache.WaitForCacheSync(s.stopCh, s.informer.HasSynced)
-		handler(resource.FullSyncEvent)
-	}()
-
-	return nil
+		<-ctx.Done()
+	})
 }
 
 // Stop the source. This will stop publishing of events.
 func (s *source) Stop() {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
-
-	if s.stopCh == nil {
-		log.Scope.Warn("built-in kubernetes source already stopped")
-		return
-	}
-
-	close(s.stopCh)
-	s.stopCh = nil
+	s.worker.Stop()
 }
 
 func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
@@ -138,7 +121,9 @@ func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
 
 	fullName := resource.FullNameFromNamespaceAndName(object.GetNamespace(), object.GetName())
 
-	log.Scope.Debugf("Sending event: [%v] from: %s", kind, s.t.GetSpec().CanonicalResourceName())
+	if log.Scope.DebugEnabled() {
+		log.Scope.Debugf("Sending event: [%v] from: %s", kind, s.t.GetSpec().CanonicalResourceName())
+	}
 
 	event := resource.Event{
 		Kind: kind,
@@ -172,7 +157,10 @@ func (s *source) handleEvent(kind resource.EventKind, obj interface{}) {
 		event.Entry.Item = item
 	}
 
-	log.Scope.Debugf("Dispatching source event: %v", event)
+	if log.Scope.DebugEnabled() {
+		log.Scope.Debugf("Dispatching source event: %v", event)
+	}
+
 	s.handler(event)
 	stats.RecordEventSuccess()
 }

--- a/galley/pkg/source/kube/builtin/source_test.go
+++ b/galley/pkg/source/kube/builtin/source_test.go
@@ -26,10 +26,12 @@ import (
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/source/kube/builtin"
 	"istio.io/istio/galley/pkg/source/kube/dynamic/converter"
+	kubeLog "istio.io/istio/galley/pkg/source/kube/log"
 	"istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/testing/events"
+	"istio.io/istio/pkg/log"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -60,6 +62,10 @@ var (
 )
 
 func TestNewWithUnknownSpecShouldError(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
@@ -78,19 +84,11 @@ func TestNewWithUnknownSpecShouldError(t *testing.T) {
 	}
 }
 
-func TestStartWithNilHandlerShouldError(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	// Create the source
-	_, informerFactory := kubeResources()
-	spec := builtin.GetType("Node").GetSpec()
-	s := newOrFail(t, informerFactory, spec)
-
-	err := s.Start(nil)
-	g.Expect(err).ToNot(BeNil())
-}
-
 func TestStartTwiceShouldError(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	g := NewGomegaWithT(t)
 
 	// Start the source.
@@ -107,6 +105,10 @@ func TestStartTwiceShouldError(t *testing.T) {
 }
 
 func TestStopTwiceShouldSucceed(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	// Start the source.
 	_, informerFactory := kubeResources()
 	spec := builtin.GetType("Node").GetSpec()
@@ -119,6 +121,10 @@ func TestStopTwiceShouldSucceed(t *testing.T) {
 }
 
 func TestUnknownResourceShouldNotCreateEvent(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client, informerFactory := kubeResources()
 	spec := builtin.GetType("Node").GetSpec()
 
@@ -129,9 +135,9 @@ func TestUnknownResourceShouldNotCreateEvent(t *testing.T) {
 
 	expectFullSync(t, ch)
 
-	node := &v1.Node{
+	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
-		Spec: v1.NodeSpec{
+		Spec: corev1.NodeSpec{
 			PodCIDR: "10.40.0.0/24",
 		},
 	}
@@ -149,6 +155,10 @@ func TestUnknownResourceShouldNotCreateEvent(t *testing.T) {
 }
 
 func TestNodes(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client, informerFactory := kubeResources()
 	spec := builtin.GetType("Node").GetSpec()
 
@@ -159,9 +169,9 @@ func TestNodes(t *testing.T) {
 
 	expectFullSync(t, ch)
 
-	node := &v1.Node{
+	node := &corev1.Node{
 		ObjectMeta: fakeObjectMeta,
-		Spec: v1.NodeSpec{
+		Spec: corev1.NodeSpec{
 			PodCIDR: "10.40.0.0/24",
 		},
 	}
@@ -213,6 +223,10 @@ func TestNodes(t *testing.T) {
 }
 
 func TestPods(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client, informerFactory := kubeResources()
 
 	spec := builtin.GetType("Pod").GetSpec()
@@ -224,18 +238,18 @@ func TestPods(t *testing.T) {
 
 	expectFullSync(t, ch)
 
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: fakeObjectMeta,
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
 					Name:            "c1",
 					Image:           "someImage",
-					ImagePullPolicy: v1.PullIfNotPresent,
-					Ports: []v1.ContainerPort{
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Ports: []corev1.ContainerPort{
 						{
 							Name:     "http",
-							Protocol: v1.ProtocolTCP,
+							Protocol: corev1.ProtocolTCP,
 							HostPort: 80,
 						},
 					},
@@ -290,6 +304,10 @@ func TestPods(t *testing.T) {
 }
 
 func TestServices(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client, informerFactory := kubeResources()
 
 	spec := builtin.GetType("Service").GetSpec()
@@ -301,14 +319,14 @@ func TestServices(t *testing.T) {
 
 	expectFullSync(t, ch)
 
-	svc := &v1.Service{
+	svc := &corev1.Service{
 		ObjectMeta: fakeObjectMeta,
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-			Ports: []v1.ServicePort{
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
 				{
 					Name:     "http",
-					Protocol: v1.ProtocolTCP,
+					Protocol: corev1.ProtocolTCP,
 					Port:     80,
 				},
 			},
@@ -361,6 +379,10 @@ func TestServices(t *testing.T) {
 }
 
 func TestEndpoints(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	client, informerFactory := kubeResources()
 
 	spec := builtin.GetType("Endpoints").GetSpec()
@@ -372,20 +394,20 @@ func TestEndpoints(t *testing.T) {
 
 	expectFullSync(t, ch)
 
-	eps := &v1.Endpoints{
+	eps := &corev1.Endpoints{
 		ObjectMeta: fakeObjectMeta,
-		Subsets: []v1.EndpointSubset{
+		Subsets: []corev1.EndpointSubset{
 			{
-				Addresses: []v1.EndpointAddress{
+				Addresses: []corev1.EndpointAddress{
 					{
 						Hostname: "fake.host.com",
 						IP:       "10.40.0.0",
 					},
 				},
-				Ports: []v1.EndpointPort{
+				Ports: []corev1.EndpointPort{
 					{
 						Name:     "http",
-						Protocol: v1.ProtocolTCP,
+						Protocol: corev1.ProtocolTCP,
 						Port:     80,
 					},
 				},
@@ -499,4 +521,14 @@ func toEvent(kind resource.EventKind, spec *schema.ResourceSpec, objectMeta meta
 	}
 
 	return event
+}
+
+func setDebugLogLevel() log.Level {
+	prev := kubeLog.Scope.GetOutputLevel()
+	kubeLog.Scope.SetOutputLevel(log.DebugLevel)
+	return prev
+}
+
+func restoreLogLevel(level log.Level) {
+	kubeLog.Scope.SetOutputLevel(level)
 }

--- a/galley/pkg/source/kube/dynamic/source.go
+++ b/galley/pkg/source/kube/dynamic/source.go
@@ -15,8 +15,7 @@
 package dynamic
 
 import (
-	"fmt"
-	"sync"
+	"context"
 	"time"
 
 	"istio.io/istio/galley/pkg/runtime"
@@ -26,6 +25,7 @@ import (
 	sourceSchema "istio.io/istio/galley/pkg/source/kube/schema"
 	"istio.io/istio/galley/pkg/source/kube/stats"
 	"istio.io/istio/galley/pkg/source/kube/tombstone"
+	"istio.io/istio/galley/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -40,9 +40,6 @@ var _ runtime.Source = &source{}
 
 // source is a simplified client interface for listening/getting Kubernetes resources in an unstructured way.
 type source struct {
-	// Lock for changing the running state of the source
-	stateLock sync.Mutex
-
 	cfg *converter.Config
 
 	spec sourceSchema.ResourceSpec
@@ -52,13 +49,12 @@ type source struct {
 	// The dynamic resource interface for accessing custom resources dynamically.
 	resourceClient dynamic.ResourceInterface
 
-	// stopCh is used to quiesce the background activity during shutdown
-	stopCh chan struct{}
-
 	// SharedIndexInformer for watching/caching resources
 	informer cache.SharedIndexInformer
 
 	handler resource.EventHandler
+
+	worker *util.Worker
 }
 
 // New returns a new instance of a dynamic source for the given schema.
@@ -77,80 +73,65 @@ func New(
 		cfg:            cfg,
 		resyncPeriod:   resyncPeriod,
 		resourceClient: resourceClient,
+		worker:         util.NewWorker("dynamic source", log.Scope),
 	}, nil
 }
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
+	return s.worker.Start(func(ctx context.Context) {
+		if handler == nil {
+			panic("dynamic source provided with nil event handler")
+		}
 
-	if s.stopCh != nil {
-		return fmt.Errorf("already synchronizing resources: name='%s', gv='%v'",
-			s.spec.Singular, s.spec.GroupVersion())
-	}
-	if handler == nil {
-		return fmt.Errorf("invalid event handler")
-	}
+		log.Scope.Debugf("Starting source for %s(%v)", s.spec.Singular, s.spec.GroupVersion())
 
-	log.Scope.Debugf("Starting source for %s(%v)", s.spec.Singular, s.spec.GroupVersion())
-
-	s.stopCh = make(chan struct{})
-	s.handler = handler
-
-	s.informer = cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (k8sRuntime.Object, error) {
-				return s.resourceClient.List(options)
+		s.handler = handler
+		s.informer = cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc: func(options metav1.ListOptions) (k8sRuntime.Object, error) {
+					return s.resourceClient.List(options)
+				},
+				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+					options.Watch = true
+					return s.resourceClient.Watch(options)
+				},
 			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.Watch = true
-				return s.resourceClient.Watch(options)
-			},
-		},
-		&unstructured.Unstructured{},
-		s.resyncPeriod,
-		cache.Indexers{})
+			&unstructured.Unstructured{},
+			s.resyncPeriod,
+			cache.Indexers{})
 
-	s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) { s.handleEvent(resource.Added, obj) },
-		UpdateFunc: func(old, new interface{}) {
-			newRes := new.(*unstructured.Unstructured)
-			oldRes := old.(*unstructured.Unstructured)
-			if newRes.GetResourceVersion() == oldRes.GetResourceVersion() {
-				// Periodic resync will send update events for all known resources.
-				// Two different versions of the same resource will always have different RVs.
-				return
-			}
-			s.handleEvent(resource.Updated, new)
-		},
-		DeleteFunc: func(obj interface{}) { s.handleEvent(resource.Deleted, obj) },
+		s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) { s.handleEvent(resource.Added, obj) },
+			UpdateFunc: func(old, new interface{}) {
+				newRes := new.(*unstructured.Unstructured)
+				oldRes := old.(*unstructured.Unstructured)
+				if newRes.GetResourceVersion() == oldRes.GetResourceVersion() {
+					// Periodic resync will send update events for all known resources.
+					// Two different versions of the same resource will always have different RVs.
+					return
+				}
+				s.handleEvent(resource.Updated, new)
+			},
+			DeleteFunc: func(obj interface{}) { s.handleEvent(resource.Deleted, obj) },
+		})
+
+		// Start CRD shared informer background process.
+		go s.informer.Run(ctx.Done())
+
+		// Send the an event after the cache syncs.
+		go func() {
+			_ = cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced)
+			handler(resource.FullSyncEvent)
+		}()
+
+		<-ctx.Done()
 	})
-
-	// Start CRD shared informer background process.
-	go s.informer.Run(s.stopCh)
-
-	// Send the an event after the cache syncs.
-	go func() {
-		_ = cache.WaitForCacheSync(s.stopCh, s.informer.HasSynced)
-		handler(resource.FullSyncEvent)
-	}()
-
-	return nil
 }
 
 // Stop the source. This will stop publishing of events.
 func (s *source) Stop() {
-	s.stateLock.Lock()
-	defer s.stateLock.Unlock()
-
-	if s.stopCh == nil {
-		log.Scope.Errorf("already stopped")
-		return
-	}
-
-	close(s.stopCh)
-	s.stopCh = nil
+	s.worker.Stop()
 }
 
 func (s *source) handleEvent(c resource.EventKind, obj interface{}) {

--- a/galley/pkg/source/kube/dynamic/source.go
+++ b/galley/pkg/source/kube/dynamic/source.go
@@ -116,16 +116,14 @@ func (s *source) Start(handler resource.EventHandler) error {
 			DeleteFunc: func(obj interface{}) { s.handleEvent(resource.Deleted, obj) },
 		})
 
-		// Start CRD shared informer background process.
-		go s.informer.Run(ctx.Done())
-
 		// Send the an event after the cache syncs.
 		go func() {
 			_ = cache.WaitForCacheSync(ctx.Done(), s.informer.HasSynced)
 			handler(resource.FullSyncEvent)
 		}()
 
-		<-ctx.Done()
+		// Start CRD shared informer and wait for it to exit.
+		s.informer.Run(ctx.Done())
 	})
 }
 

--- a/galley/pkg/source/kube/dynamic/source.go
+++ b/galley/pkg/source/kube/dynamic/source.go
@@ -79,7 +79,7 @@ func New(
 
 // Start the source. This will commence listening and dispatching of events.
 func (s *source) Start(handler resource.EventHandler) error {
-	return s.worker.Start(func(ctx context.Context) {
+	return s.worker.Start(nil, func(ctx context.Context) {
 		if handler == nil {
 			panic("dynamic source provided with nil event handler")
 		}

--- a/galley/pkg/source/kube/dynamic/source_test.go
+++ b/galley/pkg/source/kube/dynamic/source_test.go
@@ -66,25 +66,6 @@ func TestNewSource(t *testing.T) {
 	_ = newOrFail(t, client, spec)
 }
 
-func TestStartWithNilHandlerShouldError(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	// Create the source
-	w, client := createMocks()
-	defer w.Stop()
-	spec := schema.ResourceSpec{
-		Kind:      "List",
-		Singular:  "List",
-		Plural:    "foos",
-		Target:    emptyInfo,
-		Converter: converter.Get("identity"),
-	}
-	s := newOrFail(t, client, spec)
-
-	err := s.Start(nil)
-	g.Expect(err).ToNot(BeNil())
-}
-
 func TestStartTwiceShouldError(t *testing.T) {
 	g := NewGomegaWithT(t)
 

--- a/galley/pkg/util/worker.go
+++ b/galley/pkg/util/worker.go
@@ -65,10 +65,10 @@ func NewWorker(name string, scope *log.Scope) *Worker {
 	return worker
 }
 
-// Start the worker thread via the provided lambda. The run lambda is run in a
+// Start the worker thread via the provided lambda. The runFn lambda is run in a
 // go routine and is provided a context to trigger the exit of the function. If
 // this Worker was already started, returns an error.
-func (w *Worker) Start(run func(c context.Context)) error {
+func (w *Worker) Start(runFn func(c context.Context)) error {
 	w.stateLock.Lock()
 	defer w.stateLock.Unlock()
 
@@ -79,7 +79,7 @@ func (w *Worker) Start(run func(c context.Context)) error {
 
 	go func() {
 		// Run the user-supplied lambda
-		run(w.ctx)
+		runFn(w.ctx)
 
 		// Signal back to the Stop method that the worker thread has stopped.
 		close(w.stoppedCh)

--- a/galley/pkg/util/worker.go
+++ b/galley/pkg/util/worker.go
@@ -1,0 +1,112 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"istio.io/istio/pkg/log"
+)
+
+// Worker is a utility to help manage the lifecycle of a worker thread.
+type Worker struct {
+	// name of the worker thread used for logging.
+	name string
+
+	// scope is the logging scope to be used for log messages.
+	scope log.Scope
+
+	// Lock for changing the running state of the source
+	stateLock sync.Mutex
+
+	// started indicates that the user has started this source (via Start).
+	started bool
+
+	// stopped indicates that the user has stopped this source (via Stop).
+	stopped bool
+
+	// ctx is the context used to run the worker thread.
+	ctx context.Context
+
+	// ctxCancel is the ctxCancel function for ctx.
+	ctxCancel context.CancelFunc
+
+	// stoppedCh is used to indicate that the k8s informer has exited.
+	stoppedCh chan struct{}
+}
+
+// NewWorker creates a new worker with the given name and logging scope.
+func NewWorker(name string, scope *log.Scope) *Worker {
+	if scope == nil {
+		scope = log.FindScope(log.DefaultScopeName)
+	}
+	worker := &Worker{
+		name:      name,
+		scope:     *scope,
+		stoppedCh: make(chan struct{}, 1),
+	}
+
+	// Create the run context.
+	worker.ctx, worker.ctxCancel = context.WithCancel(context.Background())
+	return worker
+}
+
+// Start the worker thread via the provided lambda. The run lambda is run in a
+// go routine and is provided a context to trigger the exit of the function. If
+// this Worker was already started, returns an error.
+func (w *Worker) Start(run func(c context.Context)) error {
+	w.stateLock.Lock()
+	defer w.stateLock.Unlock()
+
+	if w.started {
+		return fmt.Errorf("%s already started", w.name)
+	}
+	w.started = true
+
+	go func() {
+		// Run the user-supplied lambda
+		run(w.ctx)
+
+		// Signal back to the Stop method that the worker thread has stopped.
+		close(w.stoppedCh)
+	}()
+
+	return nil
+}
+
+// Stop the worker thread and waits for it to exit gracefully.
+func (w *Worker) Stop() {
+	w.stateLock.Lock()
+	if !w.started {
+		w.scope.Warnf("%s was never started", w.name)
+		w.stateLock.Unlock()
+		return
+	}
+	if w.stopped {
+		w.scope.Warnf("%s already stopped", w.name)
+		w.stateLock.Unlock()
+		return
+	}
+	w.stopped = true
+	w.stateLock.Unlock()
+
+	// Signal to the worker thread that we're shutting down.
+	w.ctxCancel()
+
+	// Wait for the worker thread to exit.
+	<-w.stoppedCh
+}

--- a/galley/pkg/util/worker_test.go
+++ b/galley/pkg/util/worker_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"istio.io/istio/galley/pkg/util"
+)
+
+func TestStopBeforeStartShouldNotPanic(t *testing.T) {
+	w := newWorker()
+	w.Stop()
+}
+
+func TestStartTwiceShouldFail(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	startFn := func(ctx context.Context) {
+		<-ctx.Done()
+	}
+
+	err := w.Start(startFn)
+	g.Expect(err).To(BeNil())
+	defer w.Stop()
+
+	// Second call should fail
+	err = w.Start(startFn)
+	g.Expect(err).ToNot(BeNil())
+}
+
+func TestStopWaitsForRunToExit(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	w := newWorker()
+
+	count := 0
+
+	var workerStopTime time.Time
+	startFn := func(ctx context.Context) {
+		count++
+		<-ctx.Done()
+
+		workerStopTime = time.Now()
+
+		// Wait a bit to make sure that the next event occurs after.
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	err := w.Start(startFn)
+	g.Expect(err).To(BeNil())
+
+	// Now stop it.
+	w.Stop()
+	stopReturned := time.Now()
+
+	g.Expect(count).To(Equal(1))
+	if !workerStopTime.Before(stopReturned) {
+		t.Fatalf("unexpected time ordering: worker stopped: %v, Stop() returned: %v",
+			workerStopTime, stopReturned)
+	}
+}
+
+func newWorker() *util.Worker {
+	return util.NewWorker("testWorker", nil)
+}


### PR DESCRIPTION
We currently have several worker classes that follow a similar lifecycle pattern, but are inconsistent. This PR makes standardizes the lifecycle management logic into a new Worker class.