### PR TITLE
Hardcode .Values.global.monitoringPort to 15014

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           ports:
           - containerPort: 443
-          - containerPort: {{ .Values.global.monitoringPort }}
+          - containerPort: 15014
           - containerPort: 9901
           command:
           - /usr/local/bin/galley
@@ -56,7 +56,7 @@ spec:
 {{- end }}
           - --validation-webhook-config-file
           - /etc/config/validatingwebhookconfiguration.yaml
-          - --monitoringPort={{ .Values.global.monitoringPort }}
+          - --monitoringPort=15014
           volumeMounts:
           - name: certs
             mountPath: /etc/certs

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
   - port: 443
     name: https-validation
-  - port: {{ .Values.global.monitoringPort }}
+  - port: 15014
     name: http-monitoring
   - port: 9901
     name: grpc-mcp

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -26,10 +26,10 @@
 {{- end }}
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: {{ .Values.global.monitoringPort }}
+        - containerPort: 15014
         - containerPort: 42422
         args:
-          - --monitoringPort={{ .Values.global.monitoringPort }}
+          - --monitoringPort=15014
           - --address
           - unix:///sock/mixer.socket
 {{- if $.Values.global.useMCP }}
@@ -76,7 +76,7 @@
         livenessProbe:
           httpGet:
             path: /version
-            port: {{ .Values.global.monitoringPort }}
+            port: 15014
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: istio-proxy
@@ -168,10 +168,10 @@
 {{- end }}
         imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
         ports:
-        - containerPort: {{ .Values.global.monitoringPort }}
+        - containerPort: 15014
         - containerPort: 42422
         args:
-          - --monitoringPort={{ .Values.global.monitoringPort }}
+          - --monitoringPort=15014
           - --address
           - unix:///sock/mixer.socket
 {{- if $.Values.global.useMCP }}
@@ -228,7 +228,7 @@
         livenessProbe:
           httpGet:
             path: /version
-            port: {{ .Values.global.monitoringPort }}
+            port: 15014
           initialDelaySeconds: 5
           periodSeconds: 5
       - name: istio-proxy

--- a/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
   - name: grpc-mixer-mtls
     port: 15004
   - name: http-monitoring
-    port: {{ $.Values.global.monitoringPort }}
+    port: 15014
 {{- if eq $key "telemetry" }}
   - name: prometheus
     port: 42422

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           args:
           - "discovery"
-          - --monitoringAddr=:{{ .Values.global.monitoringPort }}
+          - --monitoringAddr=:15014
           - --domain
           - {{ .Values.global.proxy.clusterDomain }}
 {{- if .Values.global.oneNamespace }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
     name: https-xds # mTLS
   - port: 8080
     name: http-legacy-discovery # direct
-  - port: {{ .Values.global.monitoringPort }}
+  - port: 15014
     name: http-monitoring
   selector:
     istio: pilot

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - --grpc-hostname=citadel
             - --citadel-storage-namespace={{ .Release.Namespace }}
             - --custom-dns-names=istio-pilot-service-account.{{ .Release.Namespace }}:istio-pilot.{{ .Release.Namespace }}
-            - --monitoring-port={{ .Values.global.monitoringPort }}
+            - --monitoring-port=15014
           {{- if .Values.selfSigned }}
             - --self-signed-ca=true
           {{- else }}

--- a/install/kubernetes/helm/istio/charts/security/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
       targetPort: 8060
       protocol: TCP
     - name: http-monitoring
-      port: {{ .Values.global.monitoringPort }}
+      port: 15014
   selector:
     istio: citadel

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -136,9 +136,6 @@ global:
   # Default tag for Istio images.
   tag: release-1.1-latest-daily
 
-  # monitoring port used by mixer, pilot, galley
-  monitoringPort: 15014
-
   k8sIngress:
     enabled: false
     # Gateway used for legacy k8s Ingress resources. By default it is

--- a/tests/helm/templates/gateway.yaml
+++ b/tests/helm/templates/gateway.yaml
@@ -76,7 +76,7 @@ spec:
     - destination:
         host: istio-pilot.istio-system.svc.cluster.local
         port:
-          number: {{ .Values.global.monitoringPort }}
+          number: 15014
 
 ---
 


### PR DESCRIPTION
  We don't allow overriding the value in all places so make sure we
  don't allow users to override some and not all values. Hardcoding
  the port was an earlier design choice.

Comments from: https://github.com/istio/istio/pull/11421

 - (there was great debate about this in the past as well, and we decided on the hardcodes).
 - While the hardcode of port seems unintuitive, we decided on that course of action long ago.
