### PR TITLE
wait for certs to appear before starting envoy

### DIFF
--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -501,14 +501,15 @@ func waitForCerts(fname string, maxWait time.Duration) {
 			return
 		}
 		if !os.IsNotExist(err) { // another error (e.g., permission) - likely no point in waiting longer
-			log.Infof("error while waiting for certificates: %s", err.Error())
+			log.Errora("error while waiting for certificates:", err.Error())
 			return
 		}
 
 		now := time.Now()
 		if now.After(endWait) {
 			break
-		} else if now.After(nextLog) {
+		}
+		if now.After(nextLog) {
 			log.Infof("waiting for certificates")
 			logDelay = logDelay * 2
 			nextLog.Add(logDelay)


### PR DESCRIPTION
This PR waits (some time) for certificates to appear before starting envoy.

There are several open issues (#6508, #9466, #9659 and #10205) reporting Envoy restarting due to missing certs:
`[2018-10-22 22:44:11.130][56][critical][main] external/envoy/source/server/server.cc:78] error initializing configuration '/etc/istio/proxy/envoy.yaml': unable to read file: /etc/certs/root-cert.pem` (from issue #9466).

Envoy is automatically restarted and eventually the certificates are available, configuration is valid and Envoy loads successfully.

The root cause seems to be high delay in having certificates mounted. The process is as follows:
- t0: Pod is started with a new service account. Since certs volume for `/etc/certs` is marked `optional: true`, there is no need to wait for the secret before starting containers.
- t1: Citadel notices the new SA and creates a secret for it.
- t2: Kubelet periodically scans for secrets and populates the mount
- t3: envoy reads the secret

If t3-t0 is too high, envoy will terminate. Citadel time (t1) depends on current load, Kubelet sync time is not under our control (see below, defaults could be as high as 1 min). This PR avoid some of the restarts by testing for certificate existence inside pilot-agent before attempting to start Envoy. Waiting is only enabled when certificates are definitely required (i.e., when control plane authentication is enabled). For other cases, it falls back to the existing behavior. Additionally, pilot-agent only waits up to 2m before giving up and letting Envoy run its course (again - falling back to current behavior). Informational log messages are displayed with exponential backoff. Note that only logging is throttled, checking continues on much shorter period and would terminate as soon as certificates are available.

Fixes #6508 Fixes #9466 Fixes #9659 Fixes #10205.

For reference:
- https://kubernetes.io/docs/concepts/configuration/secret/#secret-and-pod-lifetime-interaction:
> When a pod is created via the API, there is no check whether a referenced secret exists. Once a pod is scheduled, the kubelet will try to fetch the secret value. If the secret cannot be fetched because it does not exist or because of a temporary lack of connection to the API server, kubelet will periodically retry.

- https://kubernetes.io/docs/concepts/configuration/secret/:
> Kubelet is checking whether the mounted secret is fresh on every periodic sync. However, it is using its local cache for getting the current value of the Secret. The type of the cache is configurable using the (ConfigMapAndSecretChangeDetectionStrategy field in KubeletConfiguration struct)... total delay from the moment when the Secret is updated to the moment when new keys are projected to the Pod can be as long as kubelet sync period + cache propagation delay