### PR TITLE
Support codecov.sh on mac

### DIFF
--- a/bin/codecov.sh
+++ b/bin/codecov.sh
@@ -37,7 +37,7 @@ if [ "${1:-}" != "" ]; then
     DIR="./$1/..."
 fi
 
-COVERAGEDIR="$(mktemp -d /tmp/XXXXX.coverage)"
+COVERAGEDIR="$(mktemp -d /tmp/istio_coverage.XXXXXXXXXX)"
 mkdir -p "$COVERAGEDIR"
 
 function cleanup() {

--- a/bin/testEnvLocalK8S.sh
+++ b/bin/testEnvLocalK8S.sh
@@ -28,7 +28,9 @@ export GO_TOP=${GO_TOP:-$(echo "${GOPATH}" | cut -d ':' -f1)}
 export ISTIO_GO=${GO_TOP}/src/istio.io/istio
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-   export GOOS_LOCAL=darwin
+  export GOOS_LOCAL=darwin
+  echo "kube-apiserver not supported on mac, skipping."
+  exit 0
 else
   export GOOS_LOCAL=${GOOS_LOCAL:-linux}
 fi


### PR DESCRIPTION
The codecov.sh script attempts to start the kube-apiserver as part of its init process. The binary is no longer available for mac, however, so the script fails.

The unit tests on mac no longer require apiserver (the tests that use apiserver already check if they're running on osx) so this should be a harmless change across the board.