### PR TITLE
Avoid unnecessary service change events(#11971)

### DIFF
--- a/pilot/pkg/serviceregistry/consul/controller_test.go
+++ b/pilot/pkg/serviceregistry/consul/controller_test.go
@@ -36,9 +36,10 @@ var (
 	}
 	productpage = []*api.CatalogService{
 		{
-			Node:           "istio",
+			Node:           "istio-node",
 			Address:        "172.19.0.5",
-			ID:             "111-111-111",
+			ID:             "istio-node-id",
+			ServiceID:      "productpage",
 			ServiceName:    "productpage",
 			ServiceTags:    []string{"version|v1"},
 			ServiceAddress: "172.19.0.11",
@@ -47,27 +48,30 @@ var (
 	}
 	reviews = []*api.CatalogService{
 		{
-			Node:           "istio",
+			Node:           "istio-node",
 			Address:        "172.19.0.5",
-			ID:             "222-222-222",
+			ID:             "istio-node-id",
+			ServiceID:      "reviews-id",
 			ServiceName:    "reviews",
 			ServiceTags:    []string{"version|v1"},
 			ServiceAddress: "172.19.0.6",
 			ServicePort:    9081,
 		},
 		{
-			Node:           "istio",
+			Node:           "istio-node",
 			Address:        "172.19.0.5",
-			ID:             "333-333-333",
+			ID:             "istio-node-id",
+			ServiceID:      "reviews-id",
 			ServiceName:    "reviews",
 			ServiceTags:    []string{"version|v2"},
 			ServiceAddress: "172.19.0.7",
 			ServicePort:    9081,
 		},
 		{
-			Node:           "istio",
+			Node:           "istio-node",
 			Address:        "172.19.0.5",
-			ID:             "444-444-444",
+			ID:             "istio-node-id",
+			ServiceID:      "reviews-id",
 			ServiceName:    "reviews",
 			ServiceTags:    []string{"version|v3"},
 			ServiceAddress: "172.19.0.8",
@@ -77,9 +81,10 @@ var (
 	}
 	rating = []*api.CatalogService{
 		{
-			Node:           "istio",
+			Node:           "istio-node",
 			Address:        "172.19.0.6",
-			ID:             "555-555-555",
+			ID:             "istio-node-id",
+			ServiceID:      "rating-id",
 			ServiceName:    "rating",
 			ServiceTags:    []string{"version|v1"},
 			ServiceAddress: "172.19.0.12",


### PR DESCRIPTION
Unecessary service/instances change events are fired by consul registry,
causing TCP connections destroyed by Envoy
Fixes #11971

Change-Id: Iaf60a89175c9113cd8cde1556c9bf11d1a367e8f
Signed-off-by: zhaohuabing <zhaohuabing@gmail.com>