### PR TITLE
Upgrade cert-manager to v0.6.2

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-certmanager-11.yaml
@@ -1,45 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterissuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: certmanager
-    chart: certmanager
-    heritage: Tiller
-    release: istio
-spec:
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: ClusterIssuer
-    plural: clusterissuers
-  scope: Cluster
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: issuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
-  labels:
-    app: certmanager
-    chart: certmanager
-    heritage: Tiller
-    release: istio
-spec:
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Issuer
-    plural: issuers
-  scope: Namespaced
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: certificates.certmanager.k8s.io
+  name: orders.certmanager.k8s.io
   annotations:
     "helm.sh/hook": crd-install
   labels:
@@ -49,18 +11,15 @@ metadata:
     release: istio
 spec:
   additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .spec.secretName
-      name: Secret
+    - JSONPath: .status.state
+      name: State
       type: string
     - JSONPath: .spec.issuerRef.name
       name: Issuer
       type: string
       priority: 1
-    - JSONPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
+    - JSONPath: .status.reason
+      name: Reason
       type: string
       priority: 1
     - JSONPath: .metadata.creationTimestamp
@@ -72,10 +31,43 @@ spec:
       type: date
   group: certmanager.k8s.io
   version: v1alpha1
-  scope: Namespaced
   names:
-    kind: Certificate
-    plural: certificates
-    shortNames:
-      - cert
-      - certs
+    kind: Order
+    plural: orders
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
+  labels:
+    app: certmanager
+    chart: certmanager
+    heritage: Tiller
+    release: istio
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.state
+      name: State
+      type: string
+    - JSONPath: .spec.dnsName
+      name: Domain
+      type: string
+    - JSONPath: .status.reason
+      name: Reason
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+      name: Age
+      type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced

--- a/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/configmap-crd-certmanager-11.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-crd-certmanager-11
+data:
+  crd-certmanager-11.yaml: |-
+{{.Files.Get "files/crd-certmanager-11.yaml" | printf "%s" | indent 4}}

--- a/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
+++ b/install/kubernetes/helm/istio-init/templates/job-crd-certmanager-11.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: istio-init-crd-certmanager-11
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: istio-init-service-account
+      containers:
+      - name: istio-init-crd-certmanager-11
+        image: "{{ .Values.global.hub }}/kubectl:{{ .Values.global.tag }}"
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        volumeMounts:
+        - name: crd-certmanager-11
+          mountPath: /etc/istio/crd-certmanager-11
+          readOnly: true
+        command: ["kubectl",  "apply", "-f", "/etc/istio/crd-certmanager-11/crd-certmanager-11.yaml"]
+      volumes:
+      - name: crd-certmanager-11
+        configMap:
+          name: istio-crd-certmanager-11
+      restartPolicy: OnFailure

--- a/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 name: certmanager
 version: 1.1.0
-appVersion: 0.5.0
+appVersion: 0.6.2
 tillerVersion: ">=2.7.2"

--- a/install/kubernetes/helm/istio/charts/certmanager/templates/rbac.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/templates/rbac.yaml
@@ -9,15 +9,10 @@ metadata:
     release: {{ .Release.Name }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
-    # TODO: remove endpoints once 0.4 is released. We include it here in case
-    # users use the 'master' version of the Helm chart with a 0.2.x release of
-    # certManager that still performs leader election with Endpoint resources.
-    # We advise users don't do this, but some will anyway and this will reduce
-    # friction.
-    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]

--- a/install/kubernetes/helm/istio/charts/certmanager/values.yaml
+++ b/install/kubernetes/helm/istio/charts/certmanager/values.yaml
@@ -5,7 +5,7 @@
 # restart, DestinationRules can be created using the ACME-signed certificates.
 enabled: false
 hub: quay.io/jetstack
-tag: v0.5.0
+tag: v0.6.2
 resources: {}
 nodeSelector: {}
 


### PR DESCRIPTION
Currently Istio ships with cert-manager v0.5.0 as an optional
dependency. This version is outdated and has known issues/limitations
with regards to certificates renewal, excessive calls to the ACME APIs,
etc.

This commit contains minimal changes necessary to upgrade the bundled
cert-manager to the most recent stable version. Changes are based on
the official Helm Charts distribution of cert-manager.

This has been tested both manually and via the means of the automated tooling under "tools/perf". See the corresponding PR against the "tools" repo: https://github.com/istio/tools/pull/72. That PR currently relies on hardcoded resource definitions to test this against more recent version of the cert-manager and will be updated once this PR gets merged and lands into a daily build.

I have discussed this extensively with a few owners and the consensus is that this is low risk change and should go with v1.1 as this (along with SDS) enables smooth cert renewals and better stability in general.