### PR TITLE
Fixing an EDS racetest

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -807,7 +807,9 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 
 		// If location prioritized load balancing is enabled, prioritize endpoints.
 		if pilot.EnableLocalityLoadBalancing() {
+			edsClusterMutex.Lock()
 			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting)
+			edsClusterMutex.Unlock()
 		}
 
 		endpoints += len(l.Endpoints)
@@ -925,10 +927,12 @@ func endpointDiscoveryResponse(loadAssignments []*xdsapi.ClusterLoadAssignment) 
 		VersionInfo: versionInfo(),
 		Nonce:       nonce(),
 	}
+	edsClusterMutex.RLock()
 	for _, loadAssignment := range loadAssignments {
 		resource, _ := types.MarshalAny(loadAssignment)
 		out.Resources = append(out.Resources, *resource)
 	}
+	edsClusterMutex.RUnlock()
 
 	return out
 }


### PR DESCRIPTION
https://github.com/istio/istio/pull/11981 introduced a new racetest in `TestEDS` (see https://prow.k8s.io/view/gcs/istio-circleci/racetest/341195) as it modified the CLA while other goroutine was reading it.

/assign @hzxuzhonghu 