### PR TITLE
[Galley] Introduce processing.Listener

### DIFF
--- a/galley/pkg/runtime/processing/listener.go
+++ b/galley/pkg/runtime/processing/listener.go
@@ -1,0 +1,39 @@
+//  Copyright 2019 Istio Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package processing
+
+import "istio.io/istio/galley/pkg/runtime/resource"
+
+// Listener gets notified when resource of a given collection has changed.
+type Listener interface {
+	CollectionChanged(c resource.Collection)
+}
+
+// ListenerFromFn creates a listener based on the given function
+func ListenerFromFn(fn func(c resource.Collection)) Listener {
+	return &fnListener{
+		fn: fn,
+	}
+}
+
+var _ Listener = &fnListener{}
+
+type fnListener struct {
+	fn func(c resource.Collection)
+}
+
+func (h *fnListener) CollectionChanged(c resource.Collection) {
+	h.fn(c)
+}

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"istio.io/istio/galley/pkg/metadata"
@@ -37,13 +38,19 @@ type Processor struct {
 	// source interface for retrieving the events from.
 	source Source
 
+	distribute bool
+
+	// eventCh channel that was obtained from source
+	eventCh chan resource.Event
+
 	// handler for events.
 	handler processing.Handler
 
-	eventCh chan resource.Event
-
 	// The current in-memory configuration State
-	state *State
+	state         *State
+	stateStrategy *publish.Strategy
+
+	distributor publish.Distributor
 
 	// hook that gets called after each event processing. Useful for testing.
 	postProcessHook postProcessHookFn
@@ -51,32 +58,51 @@ type Processor struct {
 	// lastEventTime records the last time an event was received.
 	lastEventTime time.Time
 
+	// worker handles the lifecycle of the processing worker thread.
 	worker *util.Worker
+
+	// Condition used to notify callers of AwaitFullSync that the full sync has occurred.
+	fullSyncCond *sync.Cond
 }
 
 type postProcessHookFn func()
 
 // NewProcessor returns a new instance of a Processor
 func NewProcessor(src Source, distributor publish.Distributor, cfg *Config) *Processor {
-	state := newState(groups.Default, metadata.Types, cfg, publish.NewStrategyWithDefaults(), distributor)
-	return newProcessor(state, src, nil)
+	stateStrategy := publish.NewStrategyWithDefaults()
+
+	return newProcessor(src, cfg, metadata.Types, stateStrategy, distributor, nil)
 }
 
 func newProcessor(
-	state *State,
 	src Source,
+	cfg *Config,
+	schema *resource.Schema,
+	stateStrategy *publish.Strategy,
+	distributor publish.Distributor,
 	postProcessHook postProcessHookFn) *Processor {
-
 	now := time.Now()
-	return &Processor{
-		handler:         buildDispatcher(state),
-		state:           state,
+
+	p := &Processor{
+		stateStrategy:   stateStrategy,
+		distributor:     distributor,
 		source:          src,
 		eventCh:         make(chan resource.Event, 1024),
 		postProcessHook: postProcessHook,
 		worker:          util.NewWorker("runtime processor", scope),
 		lastEventTime:   now,
+		fullSyncCond:    sync.NewCond(&sync.Mutex{}),
 	}
+	stateListener := processing.ListenerFromFn(func(c resource.Collection) {
+		// When the state indicates a change occurred, update the publishing strategy
+		if p.distribute {
+			stateStrategy.OnChange()
+		}
+	})
+	p.state = newState(schema, cfg, stateListener)
+
+	p.handler = buildDispatcher(p.state)
+	return p
 }
 
 // Start the processor. This will cause processor to listen to incoming events from the provider
@@ -97,7 +123,7 @@ func (p *Processor) Start() error {
 		defer func() {
 			scope.Debugf("Process.process: Exiting worker thread")
 			close(p.eventCh)
-			p.state.close()
+			p.stateStrategy.Reset()
 		}()
 
 		defer p.source.Stop()
@@ -112,9 +138,10 @@ func (p *Processor) Start() error {
 				return
 			case e := <-p.eventCh:
 				p.processEvent(e)
-			case <-p.state.strategy.Publish:
+			case <-p.stateStrategy.Publish:
 				scope.Debug("Processor.process: publish")
-				p.state.publish()
+				s := p.state.buildSnapshot()
+				p.distributor.SetSnapshot(groups.Default, s)
 			}
 
 			if p.postProcessHook != nil {
@@ -132,6 +159,16 @@ func (p *Processor) Stop() {
 	p.worker.Stop()
 }
 
+// AwaitFullSync waits until the full sync event is received from the source. For testing purposes only.
+func (p *Processor) AwaitFullSync() {
+	p.fullSyncCond.L.Lock()
+	defer p.fullSyncCond.L.Unlock()
+
+	if !p.distribute {
+		p.fullSyncCond.Wait()
+	}
+}
+
 func (p *Processor) processEvent(e resource.Event) {
 	if scope.DebugEnabled() {
 		scope.Debugf("Incoming source event: %v", e)
@@ -140,7 +177,13 @@ func (p *Processor) processEvent(e resource.Event) {
 
 	if e.Kind == resource.FullSync {
 		scope.Infof("Synchronization is complete, starting distribution.")
-		p.state.onFullSync()
+
+		p.fullSyncCond.L.Lock()
+		p.distribute = true
+		p.fullSyncCond.Broadcast()
+		p.fullSyncCond.L.Unlock()
+
+		p.stateStrategy.OnChange()
 		return
 	}
 
@@ -153,12 +196,12 @@ func (p *Processor) recordEvent() {
 	p.lastEventTime = now
 }
 
-func buildDispatcher(states ...*State) *processing.Dispatcher {
+func buildDispatcher(state *State) *processing.Dispatcher {
 	b := processing.NewDispatcherBuilder()
-	for _, state := range states {
-		for _, spec := range state.schema.All() {
-			b.Add(spec.Collection, state)
-		}
+
+	for _, spec := range state.schema.All() {
+		b.Add(spec.Collection, state)
 	}
+
 	return b.Build()
 }

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -20,10 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"istio.io/istio/pkg/log"
+
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/galley/pkg/meshconfig"
 	"istio.io/istio/galley/pkg/runtime/groups"
+	runtimeLog "istio.io/istio/galley/pkg/runtime/log"
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/testing/resources"
@@ -31,9 +34,12 @@ import (
 )
 
 func TestProcessor_Start(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	src := NewInMemorySource()
 	distributor := snapshot.New(groups.IndexFunction)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
 	p := NewProcessor(src, distributor, cfg)
 
 	err := p.Start()
@@ -56,6 +62,10 @@ func (e *erroneousSource) Start(_ resource.EventHandler) error {
 func (e *erroneousSource) Stop() {}
 
 func TestProcessor_Start_Error(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	distributor := snapshot.New(groups.IndexFunction)
 	cfg := &Config{Mesh: meshconfig.NewInMemory()}
 	p := NewProcessor(&erroneousSource{}, distributor, cfg)
@@ -67,12 +77,15 @@ func TestProcessor_Start_Error(t *testing.T) {
 }
 
 func TestProcessor_Stop(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	src := NewInMemorySource()
 	distributor := snapshot.New(groups.IndexFunction)
-	strategy := publish.NewStrategyWithDefaults()
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	stateStrategy := publish.NewStrategyWithDefaults()
 
-	p := newProcessor(newState(groups.Default, resources.TestSchema, cfg, strategy, distributor), src, nil)
+	p := newTestProcessor(src, stateStrategy, distributor, nil)
 
 	err := p.Start()
 	if err != nil {
@@ -86,23 +99,29 @@ func TestProcessor_Stop(t *testing.T) {
 }
 
 func TestProcessor_EventAccumulation(t *testing.T) {
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
 	src := NewInMemorySource()
 	distributor := publish.NewInMemoryDistributor()
 	// Do not quiesce/timeout for an hour
-	strategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	stateStrategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
 
-	p := newProcessor(newState(groups.Default, resources.TestSchema, cfg, strategy, distributor), src, nil)
+	p := newTestProcessor(src, stateStrategy, distributor, nil)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer p.Stop()
+
+	p.AwaitFullSync()
 
 	k1 := resource.Key{Collection: resources.EmptyInfo.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
 
 	// Wait "long enough"
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Second * 1)
 
 	if distributor.NumSnapshots() != 0 {
 		t.Fatalf("snapshot shouldn't have been distributed: %+v", distributor)
@@ -110,25 +129,31 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 }
 
 func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
-	info, _ := resources.TestSchema.Lookup("type.googleapis.com/google.protobuf.Empty")
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
+	info, _ := resources.TestSchema.Lookup("empty")
 
 	src := NewInMemorySource()
 	distributor := publish.NewInMemoryDistributor()
 	// Do not quiesce/timeout for an hour
-	strategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	stateStrategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
 
-	p := newProcessor(newState(groups.Default, resources.TestSchema, cfg, strategy, distributor), src, nil)
+	p := newTestProcessor(src, stateStrategy, distributor, nil)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer p.Stop()
+
+	p.AwaitFullSync()
 
 	k1 := resource.Key{Collection: info.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
 
 	// Wait "long enough"
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Second * 1)
 
 	if distributor.NumSnapshots() != 0 {
 		t.Fatalf("snapshot shouldn't have been distributed: %+v", distributor)
@@ -136,12 +161,15 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 }
 
 func TestProcessor_Publishing(t *testing.T) {
-	info, _ := resources.TestSchema.Lookup("type.googleapis.com/google.protobuf.Empty")
+	// Set the log level to debug for codecov.
+	prevLevel := setDebugLogLevel()
+	defer restoreLogLevel(prevLevel)
+
+	info, _ := resources.TestSchema.Lookup("empty")
 
 	src := NewInMemorySource()
 	distributor := publish.NewInMemoryDistributor()
-	strategy := publish.NewStrategy(time.Millisecond, time.Millisecond, time.Microsecond)
-	cfg := &Config{Mesh: meshconfig.NewInMemory()}
+	stateStrategy := publish.NewStrategy(time.Millisecond, time.Millisecond, time.Microsecond)
 
 	processCallCount := sync.WaitGroup{}
 	hookFn := func() {
@@ -149,11 +177,14 @@ func TestProcessor_Publishing(t *testing.T) {
 	}
 	processCallCount.Add(3) // 1 for add, 1 for sync, 1 for publish trigger
 
-	p := newProcessor(newState(groups.Default, resources.TestSchema, cfg, strategy, distributor), src, hookFn)
+	p := newTestProcessor(src, stateStrategy, distributor, hookFn)
 	err := p.Start()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer p.Stop()
+
+	p.AwaitFullSync()
 
 	k1 := resource.Key{Collection: info.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
@@ -163,4 +194,19 @@ func TestProcessor_Publishing(t *testing.T) {
 	if distributor.NumSnapshots() != 1 {
 		t.Fatalf("snapshot should have been distributed: %+v", distributor)
 	}
+}
+
+func newTestProcessor(src Source, stateStrategy *publish.Strategy,
+	distributor publish.Distributor, hookFn postProcessHookFn) *Processor {
+	return newProcessor(src, cfg, resources.TestSchema, stateStrategy, distributor, hookFn)
+}
+
+func setDebugLogLevel() log.Level {
+	prev := runtimeLog.Scope.GetOutputLevel()
+	runtimeLog.Scope.SetOutputLevel(log.DebugLevel)
+	return prev
+}
+
+func restoreLogLevel(level log.Level) {
+	runtimeLog.Scope.SetOutputLevel(level)
 }

--- a/galley/pkg/runtime/state_test.go
+++ b/galley/pkg/runtime/state_test.go
@@ -23,11 +23,10 @@ import (
 
 	mcp "istio.io/api/mcp/v1alpha1"
 	"istio.io/istio/galley/pkg/meshconfig"
-	"istio.io/istio/galley/pkg/runtime/groups"
+	"istio.io/istio/galley/pkg/runtime/processing"
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/testing/resources"
-	"istio.io/istio/pkg/mcp/snapshot"
 )
 
 var (
@@ -59,14 +58,6 @@ func checkCreateTime(e *mcp.Resource, want time.Time) error {
 		return fmt.Errorf("wrong time: got %q want %q", got, want)
 	}
 	return nil
-}
-
-func TestStateName(t *testing.T) {
-	name := "testName"
-	s := newState(name, resources.TestSchema, cfg, publish.NewStrategyWithDefaults(), snapshot.New(groups.IndexFunction))
-	if s.name != name {
-		t.Fatalf("incorrect name: expected %s, found %s", name, s.name)
-	}
 }
 
 func TestState_DefaultSnapshot(t *testing.T) {
@@ -309,6 +300,10 @@ func TestState_String(t *testing.T) {
 }
 
 func newTestState() *State {
-	return newState(groups.Default, resources.TestSchema, cfg, publish.NewStrategyWithDefaults(),
-		snapshot.New(groups.IndexFunction))
+	stateStrategy := publish.NewStrategyWithDefaults()
+	stateListener := processing.ListenerFromFn(func(c resource.Collection) {
+		// When the state indicates a change occurred, update the publishing strategy
+		stateStrategy.OnChange()
+	})
+	return newState(resources.TestSchema, cfg, stateListener)
 }


### PR DESCRIPTION
This is a break-out PR from #11293. This changes the runtime
processor and state to use a listener callback for detecting when
a collection has changed.