### PR TITLE
enhance verify install command

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -109,7 +109,7 @@ func init() {
 	rootCmd.AddCommand(version.CobraCommandWithOptions(version.CobraOptions{GetRemoteVersion: getRemoteInfo}))
 	rootCmd.AddCommand(gendeployment.Command(&istioNamespace))
 
-	experimentalCmd.AddCommand(install.NewVerifyCommand())
+	experimentalCmd.AddCommand(install.NewVerifyCommand(&istioNamespace))
 	experimentalCmd.AddCommand(Rbac())
 	rootCmd.AddCommand(experimentalCmd)
 

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -168,7 +168,8 @@ func NewVerifyCommand(istioNamespaceFlag *string) *cobra.Command {
 istioctl verify-install -f istio-demo.yaml
 `,
 		RunE: func(c *cobra.Command, _ []string) error {
-			return verifyInstall(enableVerbose, istioNamespaceFlag, kubeConfigFlags, fileNameFlags.ToOptions(), c.OutOrStderr())
+			return verifyInstall(enableVerbose, istioNamespaceFlag, kubeConfigFlags,
+				fileNameFlags.ToOptions(), c.OutOrStderr())
 		},
 	}
 

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -33,7 +33,9 @@ import (
 	kube_meta "istio.io/istio/galley/pkg/metadata/kube"
 )
 
-func verifyInstall(restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
+func verifyInstall(enableVerbose bool, istioNamespaceFlag *string, restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
+	crdCount := 0
+	istioDeploymentCount := 0
 	if len(options.Filenames) == 0 {
 		return errors.New("--filename must be set")
 	}
@@ -79,6 +81,9 @@ func verifyInstall(restClientGetter resource.RESTClientGetter, options resource.
 			if err != nil {
 				return err
 			}
+			if namespace == *istioNamespaceFlag && strings.HasPrefix(name, "istio-") {
+				istioDeploymentCount++
+			}
 		case "Job":
 			job := &v1batch.Job{}
 			err = info.Client.
@@ -115,18 +120,26 @@ func verifyInstall(restClientGetter resource.RESTClientGetter, options resource.
 					return fmt.Errorf("istio installation fails or have not been completed - the required %s:%s is not ready due to: %v", kind, name, result.Error())
 				}
 			}
+			if kind == "CustomResourceDefinition" {
+				crdCount++
+			}
+		}
+		if enableVerbose {
+			fmt.Fprintf(writer, "%s: %s.%s checked successfully\n", kind, name, namespace)
 		}
 		return nil
 	})
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(writer, "Checked %v crds\n", crdCount)
+	fmt.Fprintf(writer, "Checked %v Istio Deployments\n", istioDeploymentCount)
 	fmt.Fprintf(writer, "Istio is installed successfully\n")
 	return nil
 }
 
 // NewVerifyCommand creates a new command for verifying Istio Installation Status
-func NewVerifyCommand() *cobra.Command {
+func NewVerifyCommand(istioNamespaceFlag *string) *cobra.Command {
 	var (
 		kubeConfigFlags = &genericclioptions.ConfigFlags{
 			Context:    strPtr(""),
@@ -140,6 +153,7 @@ func NewVerifyCommand() *cobra.Command {
 			Recursive: boolPtr(true),
 			Usage:     "Istio YAML installation file.",
 		}
+		enableVerbose bool
 	)
 	verifyInstallCmd := &cobra.Command{
 		Use:   "verify-install",
@@ -154,13 +168,15 @@ func NewVerifyCommand() *cobra.Command {
 istioctl verify-install -f istio-demo.yaml
 `,
 		RunE: func(c *cobra.Command, _ []string) error {
-			return verifyInstall(kubeConfigFlags, fileNameFlags.ToOptions(), c.OutOrStderr())
+			return verifyInstall(enableVerbose, istioNamespaceFlag, kubeConfigFlags, fileNameFlags.ToOptions(), c.OutOrStderr())
 		},
 	}
 
 	flags := verifyInstallCmd.PersistentFlags()
 	kubeConfigFlags.AddFlags(flags)
 	fileNameFlags.AddFlags(flags)
+	verifyInstallCmd.Flags().BoolVar(&enableVerbose, "enableVerbose", false,
+		"Enable verbose output")
 	return verifyInstallCmd
 }
 

--- a/istioctl/pkg/install/verify.go
+++ b/istioctl/pkg/install/verify.go
@@ -33,7 +33,8 @@ import (
 	kube_meta "istio.io/istio/galley/pkg/metadata/kube"
 )
 
-func verifyInstall(enableVerbose bool, istioNamespaceFlag *string, restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
+func verifyInstall(enableVerbose bool, istioNamespaceFlag *string,
+	restClientGetter resource.RESTClientGetter, options resource.FilenameOptions, writer io.Writer) error {
 	crdCount := 0
 	istioDeploymentCount := 0
 	if len(options.Filenames) == 0 {


### PR DESCRIPTION
-  Add --enableVerbose to output all checked resources, default is off: --enableVerbose=false

- Print the crd counts and istio deployment counts checked