### PR TITLE
configure prometheus to monitor citadel.

### DIFF
--- a/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/configmap.yaml
@@ -131,6 +131,18 @@ data:
         action: keep
         regex: istio-galley;http-monitoring
 
+    - job_name: 'citadel'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names:
+          - {{ .Release.Namespace }}
+
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: istio-citadel;http-monitoring
+
     # scrape config for API servers
     - job_name: 'kubernetes-apiservers'
       kubernetes_sd_configs:


### PR DESCRIPTION
Metrics interface has been ready for citadel, so let's update prometheus configuration to monitor citadel.