### PR TITLE
Push the istio-cni to gcr.io (cherrypick #10536)

### DIFF
--- a/release/gcb/cloud_builder.sh
+++ b/release/gcb/cloud_builder.sh
@@ -93,7 +93,7 @@ cp -r "${CNI_OUT}/docker" "/cni_tmp"
 
 go run ../istio/tools/license/get_dep_licenses.go --branch "${CB_BRANCH}" > LICENSES.txt
 add_license_to_tar_images "${REL_DOCKER_HUB}" "${ISTIO_VERSION}" "/cni_tmp"
-cp -r "/cni_tmp" "${OUTPUT_PATH}/"
+cp -r "/cni_tmp/docker" "${OUTPUT_PATH}/"
 
 # log where git thinks the build might be dirty
 git status


### PR DESCRIPTION
* Push the istio-cni to gcr.io

This fixes the scripting so the istio-cni is pushed
daily to gcr.io.

* Address review comments

Errant debugging left in commit.

cherrypick of  #10536