### PR TITLE
Enable retries for specified status codes

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
@@ -29,8 +29,8 @@ import (
 // DefaultPolicy gets a copy of the default retry policy.
 func DefaultPolicy() *route.RetryPolicy {
 	policy := route.RetryPolicy{
-		NumRetries:           &types.UInt32Value{Value: 10},
-		RetryOn:              "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted",
+		NumRetries:           &types.UInt32Value{Value: 2},
+		RetryOn:              "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
 		RetriableStatusCodes: []uint32{http.StatusServiceUnavailable},
 		RetryHostPredicate: []*route.RetryPolicy_RetryHostPredicate{
 			{

--- a/pilot/pkg/proxy/envoy/v2/testdata/none_rds.json
+++ b/pilot/pkg/proxy/envoy/v2/testdata/none_rds.json
@@ -23,9 +23,9 @@
                   "HostRewriteSpecifier": null,
                   "timeout": 0,
                   "retry_policy": {
-                    "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted",
+                    "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                     "num_retries": {
-                      "value": 10
+                      "value": 2
                     },
                     "retry_host_predicate": [
                       {
@@ -144,9 +144,9 @@
                   "HostRewriteSpecifier": null,
                   "timeout": 0,
                   "retry_policy": {
-                    "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted",
+                    "retry_on": "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,retriable-status-codes",
                     "num_retries": {
-                      "value": 10
+                      "value": 2
                     },
                     "retry_host_predicate": [
                       {


### PR DESCRIPTION
This PR enables the retriable status code flag in retry_on, this is needed before the status code values can be evaluated for retries.

The PR also reduces the number of retries to 2 as discussed with @rshriram @nmittler and @duderino