### PR TITLE
Update to grafana 6.0.0

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/values.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/values.yaml
@@ -5,7 +5,7 @@ enabled: false
 replicaCount: 1
 image:
   repository: grafana/grafana
-  tag: 5.4.0
+  tag: 6.0.0
 ingress:
   enabled: false
   ## Used to create an Ingress record.


### PR DESCRIPTION
This PR updates our default tag of grafana to track their latest release.