### PR TITLE
Remove test mgmt ports

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/lds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/lds_test.go
@@ -230,16 +230,14 @@ func TestLDSWithDefaultSidecar(t *testing.T) {
 
 	// Expect 6 listeners : 1 orig_dst, 1 http inbound + 4 outbound (http, tcp1, istio-policy and istio-telemetry)
 	// plus 2 extra due to the mem registry
-	// TODO: change to 6 once the mem registry thing is fixed
-	if (len(adsResponse.HTTPListeners) + len(adsResponse.TCPListeners)) != 8 {
+	if (len(adsResponse.HTTPListeners) + len(adsResponse.TCPListeners)) != 6 {
 		t.Fatalf("Expected 8 listeners, got %d\n", len(adsResponse.HTTPListeners)+len(adsResponse.TCPListeners))
 	}
 
 	// Expect 10 CDS clusters: 1 inbound + 7 outbound (2 http services, 1 tcp service, 2 istio-system services,
 	// and 2 subsets of http1), 1 blackhole, 1 passthrough
 	// plus 2 extra due to the mem registry
-	// TODO: change to 10 once the mem registry thing is fixed
-	if (len(adsResponse.Clusters) + len(adsResponse.EDSClusters)) != 12 {
+	if (len(adsResponse.Clusters) + len(adsResponse.EDSClusters)) != 10 {
 		t.Fatalf("Expected 12 Clusters in CDS output. Got %d", len(adsResponse.Clusters)+len(adsResponse.EDSClusters))
 	}
 

--- a/pilot/pkg/proxy/envoy/v2/mem.go
+++ b/pilot/pkg/proxy/envoy/v2/mem.go
@@ -324,15 +324,7 @@ func (sd *MemServiceDiscovery) GetProxyServiceInstances(node *model.Proxy) ([]*m
 func (sd *MemServiceDiscovery) ManagementPorts(addr string) model.PortList {
 	sd.mutex.Lock()
 	defer sd.mutex.Unlock()
-	return model.PortList{{
-		Name:     "http",
-		Port:     3333,
-		Protocol: model.ProtocolHTTP,
-	}, {
-		Name:     "custom",
-		Port:     9999,
-		Protocol: model.ProtocolTCP,
-	}}
+	return nil
 }
 
 // WorkloadHealthCheckInfo implements discovery interface

--- a/tests/integration2/pilot/sidecar_api_test.go
+++ b/tests/integration2/pilot/sidecar_api_test.go
@@ -158,34 +158,16 @@ func validateListenersNoConfig(t *testing.T, response *structpath.Structpath, mi
 			Equals("FAIL_CLOSE", "{.transport.network_fail_policy.policy}")
 
 	})
-	t.Run("validate-legacy-port-3333", func(t *testing.T) {
-		// Deprecated: Should be removed as no longer needed
-		response.ForTest(t).
-			Select("{.resources[?(@.address.socketAddress.portValue==3333)]}").
-			Equals("10.2.0.1", "{.address.socketAddress.address}").
-			Equals("envoy.tcp_proxy", "{.filterChains[0].filters[*].name}").
-			Equals("inbound|3333|http|mgmtCluster", "{.filterChains[0].filters[*].config.cluster}").
-			Equals(false, "{.deprecatedV1.bindToPort}").
-			NotExists("{.useOriginalDst}")
-	})
-	t.Run("validate-legacy-port-9999", func(t *testing.T) {
-		// Deprecated: Should be removed as no longer needed
-		response.ForTest(t).
-			Select("{.resources[?(@.address.socketAddress.portValue==9999)]}").
-			Equals("10.2.0.1", "{.address.socketAddress.address}").
-			Equals("envoy.tcp_proxy", "{.filterChains[0].filters[*].name}").
-			Equals("inbound|9999|custom|mgmtCluster", "{.filterChains[0].filters[*].config.cluster}").
-			Equals(false, "{.deprecatedV1.bindToPort}").
-			NotExists("{.useOriginalDst}")
-	})
 	t.Run("iptables-forwarding-listener", func(t *testing.T) {
 		response.ForTest(t).
 			Select("{.resources[?(@.address.socketAddress.portValue==15001)]}").
 			Equals("virtual", "{.name}").
 			Equals("0.0.0.0", "{.address.socketAddress.address}").
 			Equals("envoy.tcp_proxy", "{.filterChains[0].filters[*].name}").
-			Equals("BlackHoleCluster", "{.filterChains[0].filters[0].config.cluster}").
-			Equals("BlackHoleCluster", "{.filterChains[0].filters[0].config.stat_prefix}").
+			// Current default for egress is allowed ( based on user feedback ).
+			// TODO: add test for blocked by default, based on setting.
+			Equals("PassthroughCluster", "{.filterChains[0].filters[0].config.cluster}").
+			Equals("PassthroughCluster", "{.filterChains[0].filters[0].config.stat_prefix}").
 			Equals(true, "{.useOriginalDst}")
 	})
 }


### PR DESCRIPTION
Martin removed the dangerous endpoints, this removes the not-used mgmt ports.

Mem registry will be removed in master -  it's used by a number of tests that need to be converted.