### PR TITLE
Implemented support for gateway service name in meshNetworks

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -426,8 +426,8 @@ global:
   # The second network, `network2`, in this example is defined differently with all endpoints
   # retrieved through the specified Multi-Cluster registry being mapped to network2. The
   # gateway is also defined differently with the name of the gateway service on the remote
-  # cluster. The public IP for the gateway will be determined from that remote service (not
-  # supported yet).
+  # cluster. The public IP for the gateway will be determined from that remote service (only
+  # LoadBalancer gateway service type is currently supported).
   #
   # meshNetworks:
   #   network1:
@@ -440,7 +440,7 @@ global:
   #     endpoints:
   #     - fromRegistry: reg1
   #     gateways:
-  #     - registryServiceName: istio-ingressgateway
+  #     - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local
   #       port: 443
   #
   meshNetworks: {}

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -56,11 +56,18 @@ type Service struct {
 	// Address specifies the service IPv4 address of the load balancer
 	Address string `json:"address,omitempty"`
 
-	// Protect concurrent ClusterVIPs read/write
+	// Protect concurrent read/write
 	Mutex sync.RWMutex
+
 	// ClusterVIPs specifies the service address of the load balancer
 	// in each of the clusters where the service resides
 	ClusterVIPs map[string]string `json:"cluster-vips,omitempty"`
+
+	// ExternalAddresses is a mapping between a cluster name and the load
+	// balancer address(es) to access the service. Used by the aggregator
+	// to aggregate the Attributes.LoadBalancerAddresses for clusters where
+	// the service resides
+	ExternalAddresses map[string][]string
 
 	// Ports is the set of network ports where the service is listening for
 	// connections
@@ -457,6 +464,8 @@ type ServiceAttributes struct {
 	// ExportTo defines the visibility of Service in
 	// a namespace when the namespace is imported.
 	ExportTo map[Visibility]bool
+	// LoadBalancerAddresses are addresses to access the services through the LB
+	LoadBalancerAddresses []string
 }
 
 // ServiceDiscovery enumerates Istio service instances.

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -109,7 +109,7 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 					}
 				}
 
-				// If a gateway address is provided in the configuration use it. If the gateway address 
+				// If a gateway address is provided in the configuration use it. If the gateway address
 				// in the config was a hostname it got already resolved and replaced with an IP address
 				// when loading the config
 				if gwIP := net.ParseIP(gw.GetAddress()); gwIP != nil {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -144,6 +144,13 @@ func (c *Controller) Services() ([]*model.Service, error) {
 				sp.Mutex.Lock()
 				sp.ClusterVIPs[r.ClusterID] = s.Address
 				sp.Mutex.Unlock()
+
+				if sp.ExternalAddresses == nil {
+					sp.ExternalAddresses = make(map[string][]string)
+				}
+				sp.Mutex.Lock()
+				sp.ExternalAddresses[r.ClusterID] = s.Attributes.LoadBalancerAddresses
+				sp.Mutex.Unlock()
 			}
 		}
 		clusterAddressesMutex.Unlock()

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -113,6 +113,19 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 	}
 	sort.Sort(sort.StringSlice(serviceaccounts))
 
+	var lbAddresses []string
+	if svc.Spec.Type == v1.ServiceTypeLoadBalancer && len(svc.Status.LoadBalancer.Ingress) > 0 {
+		lbAddresses = make([]string, len(svc.Status.LoadBalancer.Ingress))
+		for i, addr := range svc.Status.LoadBalancer.Ingress {
+			if len(addr.IP) > 0 {
+				lbAddresses[i] = addr.IP
+			}
+			if len(addr.Hostname) > 0 {
+				lbAddresses[i] = addr.Hostname
+			}
+		}
+	}
+
 	return &model.Service{
 		Hostname:        serviceHostname(svc.Name, svc.Namespace, domainSuffix),
 		Ports:           ports,
@@ -122,10 +135,11 @@ func convertService(svc v1.Service, domainSuffix string) *model.Service {
 		Resolution:      resolution,
 		CreationTime:    svc.CreationTimestamp.Time,
 		Attributes: model.ServiceAttributes{
-			Name:      svc.Name,
-			Namespace: svc.Namespace,
-			UID:       fmt.Sprintf("istio://%s/services/%s", svc.Namespace, svc.Name),
-			ExportTo:  exportTo,
+			Name:                  svc.Name,
+			Namespace:             svc.Namespace,
+			UID:                   fmt.Sprintf("istio://%s/services/%s", svc.Namespace, svc.Name),
+			ExportTo:              exportTo,
+			LoadBalancerAddresses: lbAddresses,
 		},
 	}
 }

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -276,6 +276,67 @@ func TestExternalClusterLocalServiceConversion(t *testing.T) {
 	}
 }
 
+func TestLBServiceConversion(t *testing.T) {
+	serviceName := "service1"
+	namespace := "default"
+
+	addresses := []v1.LoadBalancerIngress{
+		{
+			IP: "127.68.32.112",
+		},
+		{
+			IP: "127.68.32.113",
+		},
+		{
+			Hostname: "service.world.com",
+		},
+	}
+
+	extSvc := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					Protocol: v1.ProtocolTCP,
+				},
+			},
+			Type:         v1.ServiceTypeLoadBalancer,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: addresses,
+			},
+		},
+	}
+
+	service := convertService(extSvc, domainSuffix)
+	if service == nil {
+		t.Errorf("could not convert external service")
+	}
+
+	if len(service.Attributes.LoadBalancerAddresses) == 0 {
+		t.Errorf("no load balancer addresses found")
+	}
+
+	for i, addr := range addresses {
+		var want string
+		if len(addr.IP)>0 {
+			want = addr.IP
+		} else {
+			want = addr.Hostname
+		}
+		got := service.Attributes.LoadBalancerAddresses[i]
+		if got != want {
+			t.Errorf("Expected address %s but got %s", want, service.Attributes.LoadBalancerAddresses[i])
+		}
+	}
+ }
+
 func TestProbesToPortsConversion(t *testing.T) {
 
 	expected := model.PortList{

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -305,7 +305,7 @@ func TestLBServiceConversion(t *testing.T) {
 					Protocol: v1.ProtocolTCP,
 				},
 			},
-			Type:         v1.ServiceTypeLoadBalancer,
+			Type: v1.ServiceTypeLoadBalancer,
 		},
 		Status: v1.ServiceStatus{
 			LoadBalancer: v1.LoadBalancerStatus{
@@ -325,7 +325,7 @@ func TestLBServiceConversion(t *testing.T) {
 
 	for i, addr := range addresses {
 		var want string
-		if len(addr.IP)>0 {
+		if len(addr.IP) > 0 {
 			want = addr.IP
 		} else {
 			want = addr.Hostname
@@ -335,7 +335,7 @@ func TestLBServiceConversion(t *testing.T) {
 			t.Errorf("Expected address %s but got %s", want, service.Attributes.LoadBalancerAddresses[i])
 		}
 	}
- }
+}
 
 func TestProbesToPortsConversion(t *testing.T) {
 


### PR DESCRIPTION
This supports specifying a network's gateway service name (`registryServiceName`) instead of explicit address.
If the service is a LoadBalancer, Pilot will extract the external LB address(es) from the matching k8s service resource on that network.

Benefits:
* Users don't need to modify the primary's cluster ConfigMap with the remote gateway IP after setting up the remote cluster
* Dynamically update changes to the LB addresses instead of manually modifying the ConfigMap

Closes #11837