### PR TITLE
Handle command aliases correctly in generated docs.

### DIFF
--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -183,12 +183,27 @@ func (g *generator) genCommand(cmd *cobra.Command) {
 	if cmd.Runnable() {
 		g.emit("<pre class=\"language-bash\"><code>", html.EscapeString(cmd.UseLine()))
 		g.emit("</code></pre>")
-	}
 
-	if len(cmd.Aliases) > 0 {
-		g.emit("<p>")
-		g.emit(cmd.Aliases...)
-		g.emit("<p>")
+		if len(cmd.Aliases) > 0 {
+			// first word in cmd.Use represents the command that is being aliased
+			word := cmd.Use
+			index := strings.Index(word, " ")
+			if index > 0 {
+				word = word[0:index]
+			}
+
+			g.emit("<div class=\"aliases\">")
+			line := cmd.UseLine()
+			for i, alias := range cmd.Aliases {
+				r := strings.Replace(line, word, alias, 1)
+				if i == 0 {
+					g.emit("<pre class=\"language-bash\"><code>", html.EscapeString(r))
+				} else {
+					g.emit(html.EscapeString(r))
+				}
+			}
+			g.emit("</code></pre></div>")
+		}
 	}
 
 	flags := cmd.NonInheritedFlags()


### PR DESCRIPTION
This outputs command aliases correctly in general HTML content. I'll figure out how to render these cleanly in the doc repo after this change goes in.

Fixes https://github.com/istio/istio.io/issues/3392