### PR TITLE
Make dr selection in istio-system ns differently as we have default d…

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -502,9 +502,11 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return nil
 	}
 
-	// TODO: once we move default DestinationRule to root config namespace, remove the below line.
-	if proxy.ConfigNamespace != IstioSystemNamespace ||
-		(ps.Env != nil && ps.Env.Mesh != nil && ps.Env.Mesh.RootNamespace != "") {
+	// TODO: once we move default DestinationRule to root config namespace, remove the check below.
+	// Until then, we need an exception for istio-system namespace, as it happens to be the home of
+	// global dest rules for mTLS, as well as the home of the gateway proxy. The root config namespace
+	// is technically not supposed to have any proxy
+	if proxy.ConfigNamespace != IstioSystemNamespace {
 		// search through the DestinationRules in proxy's namespace first
 		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
 			if host, ok := MostSpecificHostMatch(service.Hostname,

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -502,11 +502,15 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return nil
 	}
 
-	// search through the DestinationRules in proxy's namespace first
-	if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
-		if host, ok := MostSpecificHostMatch(service.Hostname,
-			ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
-			return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
+	// TODO: once we move default DestinationRule to root config namespace, remove the below line.
+	if proxy.ConfigNamespace != IstioSystemNamespace ||
+		(ps.Env != nil && ps.Env.Mesh != nil && ps.Env.Mesh.RootNamespace != "") {
+		// search through the DestinationRules in proxy's namespace first
+		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
+			if host, ok := MostSpecificHostMatch(service.Hostname,
+				ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
+				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
+			}
 		}
 	}
 


### PR DESCRIPTION
…r installed for mtls mode

fixes: #12170

As we have default dr installed in istio-system namespace when mTLS mode enabled. So we do a tricky way  here to prevent the default dr override custom defined drs for individual services in different namespaces. 

TODO: until we enable root Config namespace and move the `default ` dr to it, we can restore this pr.