### PR TITLE
Disable HTTP keep alives

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -502,21 +502,11 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return nil
 	}
 
-	// TODO: once we move default DestinationRule to root config namespace,
-	// remove the hacky check below.  Until then, we need an exception for
-	// istio-system namespace, as it happens to be the home of global dest
-	// rules for mTLS, as well as the home of the gateway proxy. The root
-	// config namespace is technically not supposed to have any proxy
-	// istio-ingressgateway and istio-egressgateway wont hit this if block.
-	// instead, dest rules will first be looked up from the service's own namespace
-	// if not found, we look at ALL dest rules across all namespaces. This is the old behavior
-	if proxy.ConfigNamespace != IstioSystemNamespace {
-		// search through the DestinationRules in proxy's namespace first
-		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
-			if host, ok := MostSpecificHostMatch(service.Hostname,
-				ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
-				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
-			}
+	// search through the DestinationRules in proxy's namespace first
+	if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
+		if host, ok := MostSpecificHostMatch(service.Hostname,
+			ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
+			return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
 		}
 	}
 
@@ -531,20 +521,8 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 
 	// if no public/private rule in calling proxy's namespace matched, and no public rule in the
 	// target service's namespace matched, search for any public destination rule across all namespaces
-	// if and only if there is no config root namespace defined. If a config root namespace is defined,
-	// only look for the destination rule from the config root namespace
-	if ps.Env != nil && ps.Env.Mesh != nil && ps.Env.Mesh.RootNamespace != "" {
-		if ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace] != nil {
-			if host, ok := MostSpecificHostMatch(service.Hostname,
-				ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].hosts); ok {
-				return ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].destRule[host].config
-			}
-		}
-	} else {
-		// no config root namespace. Look in all namespaces.
-		if host, ok := MostSpecificHostMatch(service.Hostname, ps.allExportedDestRules.hosts); ok {
-			return ps.allExportedDestRules.destRule[host].config
-		}
+	if host, ok := MostSpecificHostMatch(service.Hostname, ps.allExportedDestRules.hosts); ok {
+		return ps.allExportedDestRules.destRule[host].config
 	}
 
 	return nil

--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -980,6 +980,8 @@ func buildDefaultPassthroughCluster() *apiv2.Cluster {
 		Type:           apiv2.Cluster_ORIGINAL_DST,
 		ConnectTimeout: 1 * time.Second,
 		LbPolicy:       apiv2.Cluster_ORIGINAL_DST_LB,
+		// Disable keep alive
+		MaxRequestsPerConnection: &types.UInt32Value{Value: 1},
 	}
 	return cluster
 }
@@ -992,6 +994,10 @@ func buildDefaultCluster(env *model.Environment, name string, discoveryType apiv
 		Name: name,
 		Type: discoveryType,
 	}
+
+	// Default to 1 request per connection. This effectively disables HTTP keep-alives for both H1 and H2
+	// and eliminates a bunch of 503 issues
+	cluster.MaxRequestsPerConnection = &types.UInt32Value{Value: 1}
 
 	if discoveryType == apiv2.Cluster_STRICT_DNS || discoveryType == apiv2.Cluster_LOGICAL_DNS {
 		cluster.DnsLookupFamily = apiv2.Cluster_V4_ONLY

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c-add-subset.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c-add-subset.yaml
@@ -4,8 +4,11 @@ metadata:
   name: destination-rule-c
 spec:
   host: c
-  {{if eq .globalMTlsEnable "true"}}
   trafficPolicy:
+    connectionPool:
+      http:
+        maxRequestsPerConnection: 1
+  {{if eq .globalMTlsEnable "true"}}
     tls:
       mode: ISTIO_MUTUAL
   {{end}}

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c-del-subset.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c-del-subset.yaml
@@ -4,8 +4,11 @@ metadata:
   name: destination-rule-c
 spec:
   host: c
-  {{if eq .globalMTlsEnable "true"}}
   trafficPolicy:
+    connectionPool:
+      http:
+        maxRequestsPerConnection: 1
+  {{if eq .globalMTlsEnable "true"}}
     tls:
       mode: ISTIO_MUTUAL
   {{end}}

--- a/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c.yaml
+++ b/tests/e2e/tests/pilot/testdata/networking/v1alpha3/rule-503test-destinationrule-c.yaml
@@ -4,8 +4,11 @@ metadata:
   name: destination-rule-c
 spec:
   host: c
-  {{if eq .globalMTlsEnable "true"}}
   trafficPolicy:
+    connectionPool:
+      http:
+        maxRequestsPerConnection: 1
+  {{if eq .globalMTlsEnable "true"}}
     tls:
       mode: ISTIO_MUTUAL
   {{end}}


### PR DESCRIPTION
addresses #9113 and other 503 issues.
Rationale: we currently set http keep alive and disable all idle timeouts. So, all connections (between envoys) are perpetual. However, the clients behave differently. Some clients will terminate a connection after set number of requests or will not honor perpetual HTTP connections (i.e. they require a HTTP keep alive should one choose to use it). So these clients will terminate the connection after the preset number of requests or a timer expires. This will cause 503 issues as our Envoys try to send a request on an existing connection.

#12188 tries to address this by adding a retry option for all 503 codes universally. Not many users are comfortable with this option as the default. The alternative, of not setting any retry, will cause  a class of 503 issues as seen by #9113 and related issues.

This PR attempts to disable HTTP keep alives completely. end users wishing to enable it can always use the destination rule to enable the keep alive and control the longevity of the keep alive connection.


Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>