### PR TITLE
Fix destination rule selection issues

### DIFF
--- a/install/kubernetes/helm/istio/templates/configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/configmap.yaml
@@ -115,13 +115,12 @@ data:
     outboundTrafficPolicy:
       mode: {{ .Values.global.outboundTrafficPolicy.mode }}
 
-    {{- if .Values.global.configRootNamespace }}
     # The namespace to treat as the administrative root namespace for istio
-    # configuration. Set this field to a dedicated namespace if you want to
-    # all sidecars to be able to communicate with services in their
-    # namespace alone. This dedicated namespace should have a default
-    # Sidecar config
+    # configuration.
+    {{- if .Values.global.configRootNamespace }}
     rootNamespace: {{ .Values.global.configRootNamespace }}
+    {{- else }}    
+    rootNamespace: {{ .Release.Namespace }}
     {{- end }}
 
     {{- if .Values.global.defaultConfigVisibilitySettings }}

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -404,6 +404,7 @@ func DefaultMeshConfig() meshconfig.MeshConfig {
 		DisablePolicyChecks:               true,
 		PolicyCheckFailOpen:               false,
 		SidecarToTelemetrySessionAffinity: false,
+		RootNamespace:                     IstioSystemNamespace,
 		ProxyListenPort:                   15001,
 		ConnectTimeout:                    types.DurationProto(1 * time.Second),
 		IngressService:                    "istio-ingressgateway",

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -502,7 +502,7 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return nil
 	}
 
-	// HACK: If the proxy config namespace is same as the root config namespace
+	// If the proxy config namespace is same as the root config namespace
 	// look for dest rules in the service's namespace first. This hack is needed
 	// because sometimes, istio-system tends to become the root config namespace.
 	// Destination rules are defined here for global purposes. We dont want these

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -502,11 +502,21 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 		return nil
 	}
 
-	// search through the DestinationRules in proxy's namespace first
-	if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
-		if host, ok := MostSpecificHostMatch(service.Hostname,
-			ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
-			return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
+	// HACK: If the proxy config namespace is same as the root config namespace
+	// look for dest rules in the service's namespace first. This hack is needed
+	// because sometimes, istio-system tends to become the root config namespace.
+	// Destination rules are defined here for global purposes. We dont want these
+	// catch all destination rules to be the only dest rule, when processing CDS for
+	// proxies like the istio-ingressgateway or istio-egressgateway.
+	// If there are no service specific dest rules, we will end up picking up the same
+	// rules anyway, later in the code
+	if proxy.ConfigNamespace != ps.Env.Mesh.RootNamespace {
+		// search through the DestinationRules in proxy's namespace first
+		if ps.namespaceLocalDestRules[proxy.ConfigNamespace] != nil {
+			if host, ok := MostSpecificHostMatch(service.Hostname,
+				ps.namespaceLocalDestRules[proxy.ConfigNamespace].hosts); ok {
+				return ps.namespaceLocalDestRules[proxy.ConfigNamespace].destRule[host].config
+			}
 		}
 	}
 
@@ -520,9 +530,13 @@ func (ps *PushContext) DestinationRule(proxy *Proxy, service *Service) *Config {
 	}
 
 	// if no public/private rule in calling proxy's namespace matched, and no public rule in the
-	// target service's namespace matched, search for any public destination rule across all namespaces
-	if host, ok := MostSpecificHostMatch(service.Hostname, ps.allExportedDestRules.hosts); ok {
-		return ps.allExportedDestRules.destRule[host].config
+	// target service's namespace matched, search for any public destination rule in the config root namespace
+	// NOTE: This does mean that we are effectively ignoring private dest rules in the config root namespace
+	if ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace] != nil {
+		if host, ok := MostSpecificHostMatch(service.Hostname,
+			ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].hosts); ok {
+			return ps.namespaceExportedDestRules[ps.Env.Mesh.RootNamespace].destRule[host].config
+		}
 	}
 
 	return nil
@@ -810,7 +824,8 @@ func (ps *PushContext) initSidecarScopes(env *Environment) error {
 	var rootNSConfig *Config
 	if env.Mesh.RootNamespace != "" {
 		for _, sidecarConfig := range sidecarConfigs {
-			if sidecarConfig.Namespace == env.Mesh.RootNamespace {
+			if sidecarConfig.Namespace == env.Mesh.RootNamespace &&
+				sidecarConfig.Spec.(*networking.Sidecar).WorkloadSelector == nil {
 				rootNSConfig = &sidecarConfig
 				break
 			}

--- a/pilot/pkg/model/sidecar_test.go
+++ b/pilot/pkg/model/sidecar_test.go
@@ -118,7 +118,10 @@ func TestCreateSidecarScope(t *testing.T) {
 	for idx, tt := range tests {
 		t.Run(fmt.Sprintf("[%d] %s", idx, tt.name), func(t *testing.T) {
 			ps := NewPushContext()
-
+			meshConfig := DefaultMeshConfig()
+			ps.Env = &Environment{
+				Mesh: &meshConfig,
+			}
 			configuredServices := 0
 			if tt.services != nil {
 				for _, s := range tt.services {

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -64,7 +64,12 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 
 		ttl := time.Nanosecond * 100
-		push := &model.PushContext{}
+		meshConfig := model.DefaultMeshConfig()
+		push := &model.PushContext{
+			Env: &model.Environment{
+				Mesh: &meshConfig,
+			},
+		}
 		push.SetDestinationRules([]model.Config{
 			{
 				ConfigMeta: model.ConfigMeta{
@@ -119,7 +124,12 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Spec: virtualServiceWithSubset,
 		}
 
-		push := &model.PushContext{}
+		meshConfig := model.DefaultMeshConfig()
+		push := &model.PushContext{
+			Env: &model.Environment{
+				Mesh: &meshConfig,
+			},
+		}
 		push.SetDestinationRules([]model.Config{
 			{
 				ConfigMeta: model.ConfigMeta{
@@ -159,7 +169,13 @@ func TestBuildHTTPRoutes(t *testing.T) {
 			Spec: virtualServiceWithSubsetWithPortLevelSettings,
 		}
 
-		push := &model.PushContext{}
+		meshConfig := model.DefaultMeshConfig()
+		push := &model.PushContext{
+			Env: &model.Environment{
+				Mesh: &meshConfig,
+			},
+		}
+
 		push.SetDestinationRules([]model.Config{
 			{
 
@@ -209,7 +225,13 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		rule.Subsets = []*networking.Subset{networkingSubset}
 		cnfg.Spec = networkingDestinationRule
 
-		push := &model.PushContext{}
+		meshConfig := model.DefaultMeshConfig()
+		push := &model.PushContext{
+			Env: &model.Environment{
+				Mesh: &meshConfig,
+			},
+		}
+
 		push.SetDestinationRules([]model.Config{
 			cnfg})
 
@@ -231,7 +253,13 @@ func TestBuildHTTPRoutes(t *testing.T) {
 	t.Run("port selector based traffic policy", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 
-		push := &model.PushContext{}
+		meshConfig := model.DefaultMeshConfig()
+		push := &model.PushContext{
+			Env: &model.Environment{
+				Mesh: &meshConfig,
+			},
+		}
+
 		push.SetDestinationRules([]model.Config{
 			{
 				ConfigMeta: model.ConfigMeta{

--- a/tests/e2e/tests/pilot/routing_test.go
+++ b/tests/e2e/tests/pilot/routing_test.go
@@ -715,13 +715,16 @@ func TestDestinationRuleExportTo(t *testing.T) {
 		expectedSuccess bool
 		onFailure       func()
 	}{
-		{
-			testName:        "private destination rule in same namespace",
-			rules:           map[string][]string{tc.Kube.Namespace: {"destination-rule-c-private.yaml"}},
-			src:             "a",
-			dst:             "c",
-			expectedSuccess: true,
-		},
+		// TODO: this test cannot be enabled until we start running e2e tests in multiple namespaces or
+		// in a namespace other than istio-system - which happens to be the config root namespace
+		// only public rules work in the config root namespace
+		//{
+		//	testName:        "private destination rule in same namespace",
+		//	rules:           map[string][]string{tc.Kube.Namespace: {"destination-rule-c-private.yaml"}},
+		//	src:             "a",
+		//	dst:             "c",
+		//	expectedSuccess: true,
+		//},
 		{
 			testName:        "private destination rule in different namespaces",
 			rules:           map[string][]string{"dns1": {"destination-rule-c-private.yaml"}},


### PR DESCRIPTION
The workaround is to set istio-system as the config root namespace by default, and search in the proxy's namespace, service's namespace and in the config root namespace. If the proxy happens to be in istio-system namespace, first search in the service's namespace. 

This logic preserves all existing behavior of dest rules while providing the scoped selection required for sidecar. 
fixes https://github.com/istio/istio/issues/12198
fixes https://github.com/istio/istio/issues/12170
fixes https://github.com/istio/istio/issues/12066
supercedes https://github.com/istio/istio/pull/12216

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>