### PR TITLE
Remove new labels, break helm template upgrade/downgrade

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -18,10 +18,6 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "galley.name" . }}
-        chart: {{ template "galley.chart" . }}
-        heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}      
         istio: galley
       annotations:
         sidecar.istio.io/inject: "false"

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -24,9 +24,6 @@ spec:
   template:
     metadata:
       labels:
-        chart: {{ template "gateway.chart" $ }}
-        heritage: {{ $.Release.Service }}
-        release: {{ $.Release.Name }}
         {{- range $key, $val := $spec.labels }}
         {{ $key }}: {{ $val }}
         {{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -19,10 +19,6 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "security.name" . }}
-        chart: {{ template "security.chart" . }}
-        heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}
         istio: citadel
       annotations:
         sidecar.istio.io/inject: "false"


### PR DESCRIPTION
Adding labels make kubectl unhappy: 

```
&{0xc4201143c0 0xc420396150 istio-system istio-galley /workspace/istio-master/go/src/github.com/costinm/istio-install/test/istio-system-1.0.6.yaml 0xc42000c520 98311441 false}
for: "/workspace/istio-master/go/src/github.com/costinm/istio-install/test/istio-system-1.0.6.yaml": Deployment.apps "istio-galley" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"istio":"galley"}: `selector` does not match template `labels`
Error from server (Invalid): error when applying patch:
```
