### PR TITLE
Disable policy check, but still install policy

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -36,7 +36,7 @@ mixer:
   enabled: true
   policy:
     # if policy is enabled the global.disablePolicyChecks has affect.
-    enabled: false
+    enabled: true
 
   telemetry:
     enabled: true


### PR DESCRIPTION
This is needed because
1. During an upgrade, old policy is not left behind.
2. Upgrades do not result in a 503, because istio-policy goes away.