### PR TITLE
Move Distributor interface back to runtime.

### DIFF
--- a/galley/pkg/runtime/distributor.go
+++ b/galley/pkg/runtime/distributor.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package publish
+package runtime
 
 import (
 	"sync"

--- a/galley/pkg/runtime/distributor_test.go
+++ b/galley/pkg/runtime/distributor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Istio Authors
+// Copyright 2019 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package publish
+package runtime
 
 import (
 	"testing"

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -50,7 +50,7 @@ type Processor struct {
 	state         *State
 	stateStrategy *publish.Strategy
 
-	distributor publish.Distributor
+	distributor Distributor
 
 	// hook that gets called after each event processing. Useful for testing.
 	postProcessHook postProcessHookFn
@@ -68,7 +68,7 @@ type Processor struct {
 type postProcessHookFn func()
 
 // NewProcessor returns a new instance of a Processor
-func NewProcessor(src Source, distributor publish.Distributor, cfg *Config) *Processor {
+func NewProcessor(src Source, distributor Distributor, cfg *Config) *Processor {
 	stateStrategy := publish.NewStrategyWithDefaults()
 
 	return newProcessor(src, cfg, metadata.Types, stateStrategy, distributor, nil)
@@ -79,7 +79,7 @@ func newProcessor(
 	cfg *Config,
 	schema *resource.Schema,
 	stateStrategy *publish.Strategy,
-	distributor publish.Distributor,
+	distributor Distributor,
 	postProcessHook postProcessHookFn) *Processor {
 	now := time.Now()
 

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -104,7 +104,7 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 	defer restoreLogLevel(prevLevel)
 
 	src := NewInMemorySource()
-	distributor := publish.NewInMemoryDistributor()
+	distributor := NewInMemoryDistributor()
 	// Do not quiesce/timeout for an hour
 	stateStrategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
 
@@ -136,7 +136,7 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 	info, _ := resources.TestSchema.Lookup("empty")
 
 	src := NewInMemorySource()
-	distributor := publish.NewInMemoryDistributor()
+	distributor := NewInMemoryDistributor()
 	// Do not quiesce/timeout for an hour
 	stateStrategy := publish.NewStrategy(time.Hour, time.Hour, time.Millisecond)
 
@@ -168,7 +168,7 @@ func TestProcessor_Publishing(t *testing.T) {
 	info, _ := resources.TestSchema.Lookup("empty")
 
 	src := NewInMemorySource()
-	distributor := publish.NewInMemoryDistributor()
+	distributor := NewInMemoryDistributor()
 	stateStrategy := publish.NewStrategy(time.Millisecond, time.Millisecond, time.Microsecond)
 
 	processCallCount := sync.WaitGroup{}
@@ -197,7 +197,7 @@ func TestProcessor_Publishing(t *testing.T) {
 }
 
 func newTestProcessor(src Source, stateStrategy *publish.Strategy,
-	distributor publish.Distributor, hookFn postProcessHookFn) *Processor {
+	distributor Distributor, hookFn postProcessHookFn) *Processor {
 	return newProcessor(src, cfg, resources.TestSchema, stateStrategy, distributor, hookFn)
 }
 

--- a/galley/pkg/source/fs/source_test.go
+++ b/galley/pkg/source/fs/source_test.go
@@ -28,7 +28,6 @@ import (
 	"istio.io/istio/galley/pkg/meshconfig"
 	kubeMeta "istio.io/istio/galley/pkg/metadata/kube"
 	"istio.io/istio/galley/pkg/runtime"
-	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/source/fs"
 	"istio.io/istio/galley/pkg/source/kube/dynamic/converter"
@@ -480,7 +479,7 @@ func TestSnapshotDistribution(t *testing.T) {
 	s := newOrFail(t, dir)
 
 	// Create a snapshot distributor.
-	d := publish.NewInMemoryDistributor()
+	d := runtime.NewInMemoryDistributor()
 
 	// Create and start the runtime processor.
 	cfg := &runtime.Config{Mesh: meshconfig.NewInMemory()}


### PR DESCRIPTION
Distributor is an interface consumed by the runtime package.