### PR TITLE
Exclude Prometheus traffic in rule so that Kiali does not show it

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -827,7 +827,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: prometheus
     instances:

--- a/mixer/testdata/config/prometheus.yaml
+++ b/mixer/testdata/config/prometheus.yaml
@@ -206,7 +206,7 @@ metadata:
   name: promhttp
   namespace: istio-system
 spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*") == false)
   actions:
   - handler: prometheus
     instances:


### PR DESCRIPTION
Kiali now has a dashboard feature, which allows to show application metrics. For this it uses Prometheus to gather the data. Unfortunately this leads to showing traffic from unknown.
See also 
https://itnext.io/how-to-view-application-metrics-in-kiali-482bd1733942 for a longer explanation.

![bildschirmfoto 2019-03-05 um 09 56 55](https://user-images.githubusercontent.com/208246/53798346-5ea37580-3f38-11e9-8705-879cd387b3be.png)

The patch filters out traffic from Prometheus by using an addition in the match clause. This follows the example in #10480.

