### PR TITLE
Fix envoy filter matching logic

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
@@ -66,7 +66,11 @@ func insertUserFilters(in *plugin.InputParams, listener *xdsapi.Listener,
 				// because filter chains in a listener can have multiple protocols.
 				// for each filter chain, if the filter chain has a http connection manager,
 				// treat it as a http listener
-				if f.ListenerMatch == nil || f.ListenerMatch.ListenerProtocol != networking.EnvoyFilter_ListenerMatch_HTTP {
+				// ListenerProtocol defaults to ALL. But if user specified listener protocol TCP, then
+				// skip this filter chain as its a HTTP filter chain
+				if f.ListenerMatch != nil &&
+					!(f.ListenerMatch.ListenerProtocol == networking.EnvoyFilter_ListenerMatch_ALL ||
+						f.ListenerMatch.ListenerProtocol == networking.EnvoyFilter_ListenerMatch_HTTP) {
 					continue
 				}
 
@@ -84,7 +88,11 @@ func insertUserFilters(in *plugin.InputParams, listener *xdsapi.Listener,
 				// because filter chains in a listener can have multiple protocols.
 				// for each filter chain, if the filter chain does not have a http connection manager,
 				// treat it as a tcp listener
-				if f.ListenerMatch == nil || f.ListenerMatch.ListenerProtocol != networking.EnvoyFilter_ListenerMatch_TCP {
+				// ListenerProtocol defaults to ALL. But if user specified listener protocol HTTP, then
+				// skip this filter chain as its a TCP filter chain
+				if f.ListenerMatch != nil &&
+					!(f.ListenerMatch.ListenerProtocol == networking.EnvoyFilter_ListenerMatch_ALL ||
+						f.ListenerMatch.ListenerProtocol == networking.EnvoyFilter_ListenerMatch_TCP) {
 					continue
 				}
 


### PR DESCRIPTION
The current logic was inverted, causing the multicluster gateway setup to fail.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>