### PR TITLE
Add environment variables to allow configuring bookinfo hostnames

### DIFF
--- a/samples/bookinfo/src/productpage/productpage.py
+++ b/samples/bookinfo/src/productpage/productpage.py
@@ -57,27 +57,30 @@ from flask_bootstrap import Bootstrap
 Bootstrap(app)
 
 servicesDomain = "" if (os.environ.get("SERVICES_DOMAIN") == None) else "." + os.environ.get("SERVICES_DOMAIN")
+detailsHostname = "details" if (os.environ.get("DETAILS_HOSTNAME") == None) else os.environ.get("DETAILS_HOSTNAME")
+ratingsHostname = "ratings" if (os.environ.get("RATINGS_HOSTNAME") == None) else os.environ.get("RATINGS_HOSTNAME")
+reviewsHostname = "reviews" if (os.environ.get("REVIEWS_HOSTNAME") == None) else os.environ.get("REVIEWS_HOSTNAME")
 
 details = {
-    "name" : "http://details{0}:9080".format(servicesDomain),
+    "name" : "http://{0}{1}:9080".format(detailsHostname, servicesDomain),
     "endpoint" : "details",
     "children" : []
 }
 
 ratings = {
-    "name" : "http://ratings{0}:9080".format(servicesDomain),
+    "name" : "http://{0}{1}:9080".format(ratingsHostname, servicesDomain),
     "endpoint" : "ratings",
     "children" : []
 }
 
 reviews = {
-    "name" : "http://reviews{0}:9080".format(servicesDomain),
+    "name" : "http://{0}{1}:9080".format(reviewsHostname, servicesDomain),
     "endpoint" : "reviews",
     "children" : [ratings]
 }
 
 productpage = {
-    "name" : "http://details{0}:9080".format(servicesDomain),
+    "name" : "http://{0}{1}:9080".format(detailsHostname, servicesDomain),
     "endpoint" : "details",
     "children" : [details, reviews]
 }

--- a/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
+++ b/samples/bookinfo/src/reviews/reviews-application/src/main/java/application/rest/LibertyRestEndpoint.java
@@ -41,7 +41,8 @@ public class LibertyRestEndpoint extends Application {
     private final static Boolean ratings_enabled = Boolean.valueOf(System.getenv("ENABLE_RATINGS"));
     private final static String star_color = System.getenv("STAR_COLOR") == null ? "black" : System.getenv("STAR_COLOR");
     private final static String services_domain = System.getenv("SERVICES_DOMAIN") == null ? "" : ("." + System.getenv("SERVICES_DOMAIN"));
-    private final static String ratings_service = "http://ratings" + services_domain + ":9080/ratings";
+    private final static String ratings_hostname = System.getenv("RATINGS_HOSTNAME") == null ? "ratings" : System.getenv("RATINGS_HOSTNAME");
+    private final static String ratings_service = "http://" + ratings_hostname + services_domain + ":9080/ratings";
 
     private String getJsonResponse (String productId, int starsReviewer1, int starsReviewer2) {
     	String result = "{";


### PR DESCRIPTION
On Cloud Foundry the routes names are globally unique and to deploy potentially multiple versions of the bookinfo app to the same Cloud Foundry instance we need to be able to configure the hostnames that the bookinfo app uses. This adds `DETAILS_HOSTNAME`, `RATINGS_HOSTNAME`, and `REVIEWS_HOSTNAME` environment variables to the product page application and `RATINGS_HOSTNAME` env var to the ratings application. If they are not set it uses the current defaults and works exactly the same as it does now.