### PR TITLE
update node.js docker file to a supported version

### DIFF
--- a/samples/bookinfo/src/ratings/Dockerfile
+++ b/samples/bookinfo/src/ratings/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM node:4-slim
+FROM node:10-slim
 
 COPY package.json /opt/microservices/
 COPY ratings.js /opt/microservices/


### PR DESCRIPTION
The node.js version in the demo app is no longer supported, updating the docker image to a supported tags (https://hub.docker.com/_/node/?tab=description&page=75)