### PR TITLE
fix gateway upgrade issue.

### DIFF
--- a/install/kubernetes/helm/istio/charts/grafana/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/gateway.yaml
@@ -54,7 +54,7 @@ spec:
   hosts:
   - "*"
   gateways:
-  - {{ .Release.Namespace }}/istio-grafana-gateway
+  - istio-grafana-gateway
   http:
   - match:
     - port: 15031

--- a/install/kubernetes/helm/istio/charts/kiali/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/gateway.yaml
@@ -54,7 +54,7 @@ spec:
   hosts:
   - "*"
   gateways:
-  - {{ .Release.Namespace }}/istio-kiali-gateway
+  - istio-kiali-gateway
   http:
   - match:
     - port: 15029

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/gateway.yaml
@@ -54,7 +54,7 @@ spec:
   hosts:
   - "*"
   gateways:
-  - {{ .Release.Namespace }}/istio-prometheus-gateway
+  - istio-prometheus-gateway
   http:
   - match:
     - port: 15030

--- a/install/kubernetes/helm/istio/charts/tracing/templates/gateway.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/gateway.yaml
@@ -39,7 +39,7 @@ spec:
   hosts:
   - "*"
   gateways:
-  - {{ .Release.Namespace }}/istio-tracing-gateway
+  - istio-tracing-gateway
   http:
   - match:
     - port: 15032


### PR DESCRIPTION
Fix: https://github.com/istio/istio/issues/12286 helm upgrade with addons gateway enabled failed with 
```
Error: UPGRADE FAILED: failed to create resource: admission webhook "pilot.validation.istio.io" denied the request: configuration is invalid: domain name "istio-system/istio-grafana-gateway" invalid (label "istio-system/istio-grafana-gateway" invalid)
```

Check https://github.com/istio/istio/issues/12286#issuecomment-470025855 for the detailed reasons.