### PR TITLE
Allow limiting Citadel to marked namespaces only

### DIFF
--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -160,8 +160,8 @@ func init() {
 	flags.StringVar(&opts.istioCaStorageNamespace, "citadel-storage-namespace", "istio-system", "Namespace where "+
 		"the Citadel pod is running. Will not be used if explicit file or other storage mechanism is specified.")
 	flags.BoolVar(&opts.explicitOptInRequired, "explicit-opt-in", false, "Specifies whether Citadel requires "+
-		"explicit opt-in for creating secrets. If set, only namespaces labeled with 'istio-injection=enabled' will "+
-		"have secrets created.")
+		"explicit opt-in for creating secrets. If set, only namespaces labeled with 'istio-managed=enabled' will "+
+		"have secrets created. This feature is only available in key and certificates delivered through secret volume mount.")
 
 	flags.StringVar(&opts.kubeConfigFile, "kube-config", "",
 		"Specifies path to kubeconfig file. This must be specified when not running inside a Kubernetes pod.")

--- a/security/cmd/istio_ca/main.go
+++ b/security/cmd/istio_ca/main.go
@@ -59,6 +59,9 @@ type cliOptions struct { // nolint: maligned
 	selfSignedCA        bool
 	selfSignedCACertTTL time.Duration
 
+	// if set, namespaces require explicit labeling to have Citadel generate secrets.
+	explicitOptInRequired bool
+
 	workloadCertTTL    time.Duration
 	maxWorkloadCertTTL time.Duration
 	// The length of certificate rotation grace period, configured as the ratio of the certificate TTL.
@@ -156,6 +159,9 @@ func init() {
 			cmd.ListenedNamespaceKey+"} environment variable. If neither is set, Citadel listens to all namespaces.")
 	flags.StringVar(&opts.istioCaStorageNamespace, "citadel-storage-namespace", "istio-system", "Namespace where "+
 		"the Citadel pod is running. Will not be used if explicit file or other storage mechanism is specified.")
+	flags.BoolVar(&opts.explicitOptInRequired, "explicit-opt-in", false, "Specifies whether Citadel requires "+
+		"explicit opt-in for creating secrets. If set, only namespaces labeled with 'istio-injection=enabled' will "+
+		"have secrets created.")
 
 	flags.StringVar(&opts.kubeConfigFile, "kube-config", "",
 		"Specifies path to kubeconfig file. This must be specified when not running inside a Kubernetes pod.")
@@ -300,7 +306,7 @@ func runCA() {
 	if !opts.serverOnly {
 		log.Infof("Creating Kubernetes controller to write issued keys and certs into secret ...")
 		// For workloads in K8s, we apply the configured workload cert TTL.
-		sc, err := controller.NewSecretController(ca,
+		sc, err := controller.NewSecretController(ca, opts.explicitOptInRequired,
 			opts.workloadCertTTL,
 			opts.workloadCertGracePeriodRatio, opts.workloadCertMinGracePeriod, opts.dualUse,
 			cs.CoreV1(), opts.signCACerts, opts.pkcs8Keys, listenedNamespaces, webhooks)

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -215,7 +215,6 @@ func (sc *SecretController) istioEnabledObject(obj metav1.Object) bool {
 
 	if ns.Labels != nil {
 		if v, ok := ns.Labels[label]; ok {
-			fmt.Println(ns.Labels[label])
 			switch strings.ToLower(v) {
 			case "enabled", "enable", "true", "yes", "y":
 				enabled = true
@@ -232,7 +231,7 @@ func (sc *SecretController) istioEnabledObject(obj metav1.Object) bool {
 // Handles the event where a service account is added.
 func (sc *SecretController) saAdded(obj interface{}) {
 	acct := obj.(*v1.ServiceAccount)
-	if sc.istioEnabledObject(acct.GetObjectMeta()) {
+	if !sc.explicitOptIn || sc.istioEnabledObject(acct.GetObjectMeta()) {
 		sc.upsertSecret(acct.GetName(), acct.GetNamespace())
 	}
 	sc.monitoring.ServiceAccountCreation.Inc()

--- a/security/pkg/k8s/controller/workloadsecret.go
+++ b/security/pkg/k8s/controller/workloadsecret.go
@@ -211,7 +211,7 @@ func GetSecretName(saName string) string {
 // Currently this looks at the object's namespace annotation, but could be
 // extended to allow hierarchy of global < namespace < object annotations/labels.
 func (sc *SecretController) istioEnabledObject(obj metav1.Object) bool {
-	const label = "istio-injection"
+	const label = "istio-managed"
 	enabled := !sc.explicitOptIn // for backward compatibility, Citadel always creates secrets
 	// @todo this should be changed to false once we communicate behavior change and ensure customers
 	// correctly mark their namespaces. Currently controlled via command line

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -416,7 +416,7 @@ func TestSecretOptIn(t *testing.T) {
 		client := fake.NewSimpleClientset()
 		controller, err := NewSecretController(createFakeCA(), tc.requireOptIn, defaultTTL,
 			defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
-			metav1.NamespaceAll, nil)
+			[]string{metav1.NamespaceAll}, nil, "")
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -415,7 +415,7 @@ func TestSecretOptIn(t *testing.T) {
 	for k, tc := range testCases {
 		client := fake.NewSimpleClientset()
 		controller, err := NewSecretController(createFakeCA(), tc.requireOptIn, defaultTTL,
-			defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
+			defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false, false,
 			[]string{metav1.NamespaceAll}, nil)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -58,10 +58,6 @@ func TestSecretController(t *testing.T) {
 		Resource: "secrets",
 		Version:  "v1",
 	}
-	gvrNS := schema.GroupVersionResource{
-		Resource: "namespaces",
-		Version:  "v1",
-	}
 	testCases := map[string]struct {
 		existingSecret   *v1.Secret
 		saToAdd          *v1.ServiceAccount
@@ -82,7 +78,6 @@ func TestSecretController(t *testing.T) {
 		"adding service account creates new secret": {
 			saToAdd: createServiceAccount("test", "test-ns"),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvrNS, "test-ns", "test-ns"),
 				ktesting.NewCreateAction(gvr, "test-ns", istioTestSecret),
 			},
 			gracePeriodRatio: defaultGracePeriodRatio,
@@ -100,15 +95,12 @@ func TestSecretController(t *testing.T) {
 			existingSecret:   istioTestSecret,
 			saToAdd:          createServiceAccount("test", "test-ns"),
 			gracePeriodRatio: defaultGracePeriodRatio,
-			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvrNS, "test-ns", "test-ns"),
-			},
-			shouldFail: false,
+			expectedActions:  []ktesting.Action{},
+			shouldFail:       false,
 		},
 		"adding service account retries when failed": {
 			saToAdd: createServiceAccount("test", "test-ns"),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvrNS, "test-ns", "test-ns"),
 				ktesting.NewCreateAction(gvr, "test-ns", istioTestSecret),
 				ktesting.NewCreateAction(gvr, "test-ns", istioTestSecret),
 				ktesting.NewCreateAction(gvr, "test-ns", istioTestSecret),
@@ -120,7 +112,6 @@ func TestSecretController(t *testing.T) {
 		"adding webhook service account": {
 			saToAdd: createServiceAccount(sidecarInjectorSvcAccount, "test-ns"),
 			expectedActions: []ktesting.Action{
-				ktesting.NewGetAction(gvrNS, "test-ns", "test-ns"),
 				ktesting.NewCreateAction(gvr, "test-ns",
 					ca.BuildSecret("test", sidecarInjectorSvcAccount, "test-ns", certChain, caKey, rootCert, nil, nil, IstioSecretType)),
 			},

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -396,7 +396,7 @@ func TestSecretOptIn(t *testing.T) {
 			ns:           createNS("disabled-ns", map[string]string{"istio-managed": "disabled"}),
 			secret:       ca.BuildSecret("test-sa", "istio.test-sa", "disabled-ns", nil, nil, nil, nil, nil, IstioSecretType),
 			expectedActions: []ktesting.Action{
-				ktesting.NewCreateAction(nsSchema, "", createNS("disabled-ns", map[string]string{"istio-injection": "disabled"})),
+				ktesting.NewCreateAction(nsSchema, "", createNS("disabled-ns", map[string]string{"istio-managed": "disabled"})),
 				ktesting.NewGetAction(nsSchema, "", "disabled-ns"),
 			},
 		},
@@ -405,7 +405,7 @@ func TestSecretOptIn(t *testing.T) {
 			ns:           createNS("enabled-ns", map[string]string{"istio-managed": "enabled"}),
 			secret:       ca.BuildSecret("test-sa", "istio.test-sa", "enabled-ns", nil, nil, nil, nil, nil, IstioSecretType),
 			expectedActions: []ktesting.Action{
-				ktesting.NewCreateAction(nsSchema, "", createNS("enabled-ns", map[string]string{"istio-injection": "enabled"})),
+				ktesting.NewCreateAction(nsSchema, "", createNS("enabled-ns", map[string]string{"istio-managed": "enabled"})),
 				ktesting.NewGetAction(nsSchema, "", "enabled-ns"),
 				ktesting.NewCreateAction(secretSchema, "enabled-ns", ca.BuildSecret("test-sa", "istio.test-sa", "enabled-ns", nil, nil, nil, nil, nil, IstioSecretType)),
 			},

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -393,7 +393,7 @@ func TestSecretOptIn(t *testing.T) {
 		},
 		"opt-in required, disabled label => disabled": {
 			requireOptIn: true,
-			ns:           createNS("disabled-ns", map[string]string{"istio-injection": "disabled"}),
+			ns:           createNS("disabled-ns", map[string]string{"istio-managed": "disabled"}),
 			secret:       ca.BuildSecret("test-sa", "istio.test-sa", "disabled-ns", nil, nil, nil, nil, nil, IstioSecretType),
 			expectedActions: []ktesting.Action{
 				ktesting.NewCreateAction(nsSchema, "", createNS("disabled-ns", map[string]string{"istio-injection": "disabled"})),
@@ -402,7 +402,7 @@ func TestSecretOptIn(t *testing.T) {
 		},
 		"opt-in required, enabled label => enabled": {
 			requireOptIn: true,
-			ns:           createNS("enabled-ns", map[string]string{"istio-injection": "enabled"}),
+			ns:           createNS("enabled-ns", map[string]string{"istio-managed": "enabled"}),
 			secret:       ca.BuildSecret("test-sa", "istio.test-sa", "enabled-ns", nil, nil, nil, nil, nil, IstioSecretType),
 			expectedActions: []ktesting.Action{
 				ktesting.NewCreateAction(nsSchema, "", createNS("enabled-ns", map[string]string{"istio-injection": "enabled"})),

--- a/security/pkg/k8s/controller/workloadsecret_test.go
+++ b/security/pkg/k8s/controller/workloadsecret_test.go
@@ -416,7 +416,7 @@ func TestSecretOptIn(t *testing.T) {
 		client := fake.NewSimpleClientset()
 		controller, err := NewSecretController(createFakeCA(), tc.requireOptIn, defaultTTL,
 			defaultGracePeriodRatio, defaultMinGracePeriod, false, client.CoreV1(), false,
-			[]string{metav1.NamespaceAll}, nil, "")
+			[]string{metav1.NamespaceAll}, nil)
 		if err != nil {
 			t.Errorf("failed to create secret controller: %v", err)
 		}


### PR DESCRIPTION
Citadel changed to optionally only act on explicitly marked namespaces:

- add command line flag (`--explicit-opt-in`) to require explicit opt-in to secrets (defaults to false to retain current behavior of always create).
- extend secret controller to consider namespace labels ( `istio-managed=enabled`) on service account creation. Note that the check is only done on SA creation - the NS label is not watched for changes. This could be improved by using k8s Informers/Caches, but seems less needed at this point.
- modify unit tests to retain previous behavior (i.e., always create secrets, explicit opt-in **not** required) and account for additional namespace access in list of actions.

Fixes #11415
Ref #11977

/assign @incfly @wattli 