### PR TITLE
Deprecate non-working kube-inject options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,6 @@ export OUT_DIR=$(GO_TOP)/out
 export ISTIO_OUT:=$(GO_TOP)/out/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 export HELM=$(ISTIO_OUT)/helm
 
-# istioctl kube-inject uses builtin config only if this env var is set.
-export ISTIOCTL_USE_BUILTIN_DEFAULTS=1
-
 # scratch dir: this shouldn't be simply 'docker' since that's used for docker.save to store tar.gz files
 ISTIO_DOCKER:=${ISTIO_OUT}/docker_temp
 # Config file used for building istio:proxy container.

--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -265,13 +265,6 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 			// hub and tag params only work with ISTIOCTL_USE_BUILTIN_DEFAULTS
 			// so must be specified together. hub and tag no longer have defaults.
 			if hub != "" || tag != "" {
-				// ISTIOCTL_USE_BUILTIN_DEFAULTS is used to have legacy behavior.
-				if !getBoolEnv("ISTIOCTL_USE_BUILTIN_DEFAULTS", false) {
-					return errors.New("one of injectConfigFile or injectConfigMapName is required\n" +
-						"use the following command to get the current injector file\n" +
-						"kubectl -n istio-system get configmap istio-sidecar-injector " +
-						"-o=jsonpath='{.data.config}' > /tmp/injectConfigFile.yaml")
-				}
 
 				if hub == "" || tag == "" {
 					return fmt.Errorf("hub and tag are both required. got hub: '%v', tag: '%v'", hub, tag)
@@ -412,7 +405,9 @@ func init() {
 	injectCmd.PersistentFlags().BoolVar(&debugMode, "debug", false, "Use debug images and settings for the sidecar")
 
 	deprecatedFlags := []string{"coreDump", "imagePullPolicy", "includeIPRanges", "excludeIPRanges", "hub", "tag",
-		"includeInboundPorts", "excludeInboundPorts", "debug", "verbosity", "sidecarProxyUID", "setVersionString"}
+		"includeInboundPorts", "excludeInboundPorts", "debug", "verbosity", "sidecarProxyUID", "setVersionString",
+		"readinessFailureThreshold", "readinessInitialDelaySeconds", "readinessPeriodSeconds", "rewriteAppProbe",
+		"statusPort"}
 	for _, opt := range deprecatedFlags {
 		_ = injectCmd.PersistentFlags().MarkDeprecated(opt, "Use --injectConfigMapName or --injectConfigFile instead")
 	}

--- a/istioctl/cmd/istioctl/kubeinject.go
+++ b/istioctl/cmd/istioctl/kubeinject.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/spf13/cobra"
@@ -326,13 +325,6 @@ istioctl kube-inject -f deployment.yaml -o deployment-injected.yaml --injectConf
 		},
 	}
 )
-
-func getBoolEnv(key string, defaultVal bool) bool {
-	if svalue, ok := os.LookupEnv(key); ok {
-		return strings.ToLower(svalue) == "true" || svalue == "1"
-	}
-	return defaultVal
-}
 
 const (
 	defaultMeshConfigMapName   = "istio"


### PR DESCRIPTION
The documentation of `istioctl kube-inject` at https://preliminary.istio.io/docs/reference/commands/istioctl/#istioctl-kube-inject includes several options that don't work.

This PR deprecates those options so they don't appear in the documentation.  They haven't worked for a while, and probably should be removed in addition to being deprecated, but I don't want to break scripts now.

For https://github.com/istio/istio/issues/12078