### PR TITLE
Add additional fields for ServiceRole, issue: #11516 (#11712)

### DIFF
--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3544,6 +3544,38 @@ func TestValidateServiceRole(t *testing.T) {
 			expectErrMsg: "at least 1 service must be specified for rule 1",
 		},
 		{
+			name: "has both methods and not_methods",
+			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
+				{
+					Services:   []string{"service0"},
+					Methods:    []string{"GET", "POST"},
+					NotMethods: []string{"DELETE"},
+				},
+			}},
+			expectErrMsg: "cannot have both regular and *not* attributes for the same kind (i.e. methods and not_methods) for rule 0",
+		},
+		{
+			name: "has both ports and not_ports",
+			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
+				{
+					Services: []string{"service0"},
+					Ports:    []int32{9080},
+					NotPorts: []int32{443},
+				},
+			}},
+			expectErrMsg: "cannot have both regular and *not* attributes for the same kind (i.e. ports and not_ports) for rule 0",
+		},
+		{
+			name: "has out of range port",
+			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
+				{
+					Services: []string{"service0"},
+					Ports:    []int32{9080, -80},
+				},
+			}},
+			expectErrMsg: "at least one port is not in the range of [0, 65535]",
+		},
+		{
 			name: "no key in constraint",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
@@ -3593,6 +3625,7 @@ func TestValidateServiceRole(t *testing.T) {
 				{
 					Services: []string{"service0"},
 					Methods:  []string{"GET", "POST"},
+					NotHosts: []string{"finances.google.com"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Key: "key", Values: []string{"value"}},

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -80,8 +80,11 @@ const (
 	attrDestUser      = "destination.user"      // service account, e.g. "bookinfo-productpage".
 	attrConnSNI       = "connection.sni"        // server name indication, e.g. "www.example.com".
 
+	// Envoy config attributes for ServiceRole rules.
 	methodHeader = ":method"
 	pathHeader   = ":path"
+	hostHeader   = ":authority"
+	portKey      = "port"
 )
 
 // serviceMetadata is a collection of different kind of information about a service.
@@ -555,6 +558,26 @@ func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption)
 	return &http_config.RBAC{Rules: rbac}
 }
 
+// appendRule appends a |rule| to |rules| if |rule| is not nil.
+func appendRule(rules *policyproto.Permission_AndRules, rule *policyproto.Permission) {
+	if rule == nil {
+		return
+	}
+	rules.AndRules.Rules = append(rules.AndRules.Rules, rule)
+}
+
+// appendNotRule appends a |notRule| to AndRules of |rules| if |notRule| is not nil.
+func appendNotRule(rules *policyproto.Permission_AndRules, notRule *policyproto.Permission) {
+	if notRule == nil {
+		return
+	}
+	rules.AndRules.Rules = append(rules.AndRules.Rules,
+		&policyproto.Permission{Rule: &policyproto.Permission_NotRule{
+			NotRule: notRule,
+		},
+		})
+}
+
 // convertToPermission converts a single AccessRule to a Permission.
 func convertToPermission(rule *rbacproto.AccessRule) *policyproto.Permission {
 	rules := &policyproto.Permission_AndRules{
@@ -563,29 +586,44 @@ func convertToPermission(rule *rbacproto.AccessRule) *policyproto.Permission {
 		},
 	}
 
+	if len(rule.Hosts) > 0 {
+		hostRule := permissionForKeyValues(hostHeader, rule.Hosts)
+		appendRule(rules, hostRule)
+	}
+
+	if len(rule.NotHosts) > 0 {
+		notHostRule := permissionForKeyValues(hostHeader, rule.NotHosts)
+		appendNotRule(rules, notHostRule)
+	}
+
 	if len(rule.Methods) > 0 {
 		methodRule := permissionForKeyValues(methodHeader, rule.Methods)
-		if methodRule != nil {
-			rules.AndRules.Rules = append(rules.AndRules.Rules, methodRule)
-		}
+		appendRule(rules, methodRule)
 	}
 
 	if len(rule.NotMethods) > 0 {
 		notMethodRule := permissionForKeyValues(methodHeader, rule.NotMethods)
-		if notMethodRule != nil {
-			rules.AndRules.Rules = append(rules.AndRules.Rules,
-				&policyproto.Permission{Rule: &policyproto.Permission_NotRule{
-					NotRule: notMethodRule,
-				},
-				})
-		}
+		appendNotRule(rules, notMethodRule)
 	}
 
 	if len(rule.Paths) > 0 {
 		pathRule := permissionForKeyValues(pathHeader, rule.Paths)
-		if pathRule != nil {
-			rules.AndRules.Rules = append(rules.AndRules.Rules, pathRule)
-		}
+		appendRule(rules, pathRule)
+	}
+
+	if len(rule.NotPaths) > 0 {
+		notPathRule := permissionForKeyValues(pathHeader, rule.NotPaths)
+		appendNotRule(rules, notPathRule)
+	}
+
+	if len(rule.Ports) > 0 {
+		portRule := permissionForKeyValues(portKey, convertPortsToString(rule.Ports))
+		appendRule(rules, portRule)
+	}
+
+	if len(rule.NotPorts) > 0 {
+		notPortRule := permissionForKeyValues(portKey, convertPortsToString(rule.NotPorts))
+		appendNotRule(rules, notPortRule)
 	}
 
 	if len(rule.Constraints) > 0 {
@@ -593,16 +631,13 @@ func convertToPermission(rule *rbacproto.AccessRule) *policyproto.Permission {
 		// key and this should already be caught in validation stage.
 		for _, constraint := range rule.Constraints {
 			p := permissionForKeyValues(constraint.Key, constraint.Values)
-			if p != nil {
-				rules.AndRules.Rules = append(rules.AndRules.Rules, p)
-			}
+			appendRule(rules, p)
 		}
 	}
 
 	if len(rules.AndRules.Rules) == 0 {
 		// None of above rule satisfied means the permission applies to all paths/methods/constraints.
-		rules.AndRules.Rules = append(rules.AndRules.Rules,
-			&policyproto.Permission{Rule: &policyproto.Permission_Any{Any: true}})
+		appendRule(rules, &policyproto.Permission{Rule: &policyproto.Permission_Any{Any: true}})
 	}
 
 	return &policyproto.Permission{Rule: rules}
@@ -725,17 +760,17 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 				Rule: &policyproto.Permission_DestinationIp{DestinationIp: cidr},
 			}, nil
 		}
-	case key == attrDestPort:
+	case key == attrDestPort || key == portKey:
 		converter = func(v string) (*policyproto.Permission, error) {
-			port, err := convertToPort(v)
+			portValue, err := convertToPort(v)
 			if err != nil {
 				return nil, err
 			}
 			return &policyproto.Permission{
-				Rule: &policyproto.Permission_DestinationPort{DestinationPort: port},
+				Rule: &policyproto.Permission_DestinationPort{DestinationPort: portValue},
 			}, nil
 		}
-	case key == pathHeader || key == methodHeader:
+	case key == pathHeader || key == methodHeader || key == hostHeader:
 		converter = func(v string) (*policyproto.Permission, error) {
 			return &policyproto.Permission{
 				Rule: &policyproto.Permission_Header{

--- a/pilot/pkg/networking/plugin/authz/rbac_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(pitlv2109, yangminzhu): Need to refactor all unit tests. Tests are becoming hard to maintain.
+
 package authz
 
 import (
@@ -432,6 +434,61 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-9"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"service-9"},
+						Ports:    []int32{9080, 3000},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-10"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"service-10"},
+						Hosts:    []string{"*.google.com"},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-11"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"service-11"},
+						NotHosts: []string{"finances.google.com"},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-12"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services:   []string{"backup_service"},
+						NotMethods: []string{"DELETE"},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-13"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						Services: []string{"service-13"},
+						NotPaths: []string{"/secret_path"},
+					},
+				},
+			},
+		},
 	}
 	bindings := []model.Config{
 		{
@@ -560,6 +617,12 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 				},
 			},
 		},
+
+		generateSimpleServiceRoleBindingAllGroups("service-role-9", "service-role-binding-9"),
+		generateSimpleServiceRoleBindingAllGroups("service-role-10", "service-role-binding-10"),
+		generateSimpleServiceRoleBindingAllGroups("service-role-11", "service-role-binding-11"),
+		generateSimpleServiceRoleBindingAllGroups("service-role-12", "service-role-binding-12"),
+		generateSimpleServiceRoleBindingAllGroups("service-role-13", "service-role-binding-13"),
 	}
 
 	policy1 := &policy.Policy{
@@ -902,6 +965,72 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 		}},
 	}
 
+	policy9 := &policy.Policy{
+		Permissions: []*policy.Permission{
+			{
+				Rule: &policy.Permission_AndRules{
+					AndRules: &policy.Permission_Set{
+						Rules: []*policy.Permission{
+							{
+								Rule: generateDestinationPortRule([]uint32{9080, 3000}),
+							},
+						},
+					},
+				},
+			},
+		},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
+									[]string{attrRequestClaims, "groups"}, "group*"),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	policy10 := &policy.Policy{
+		Permissions: []*policy.Permission{
+			{
+				Rule: &policy.Permission_AndRules{
+					AndRules: &policy.Permission_Set{
+						Rules: []*policy.Permission{
+							{
+								Rule: generateHeaderRule([]*route.HeaderMatcher{
+									{Name: hostHeader, HeaderMatchSpecifier: &route.HeaderMatcher_SuffixMatch{SuffixMatch: ".google.com"}},
+								}),
+							},
+						},
+					},
+				},
+			},
+		},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
+									[]string{attrRequestClaims, "groups"}, "group*"),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+
+	policy11 := generateSimplePolicyForNotRuleWithHeader(hostHeader, "finances.google.com")
+	policy12 := generateSimplePolicyForNotRuleWithHeader(methodHeader, "DELETE")
+	policy13 := generateSimplePolicyForNotRuleWithHeader(pathHeader, "/secret_path")
+
 	expectRbac1 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
@@ -909,36 +1038,13 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 			"service-role-2": policy2,
 		},
 	}
-	expectRbac2 := &policy.RBAC{
-		Action: policy.RBAC_ALLOW,
-		Policies: map[string]*policy.Policy{
-			"service-role-2": policy2,
-		},
-	}
-	expectRbac3 := &policy.RBAC{
-		Action: policy.RBAC_ALLOW,
-		Policies: map[string]*policy.Policy{
-			"service-role-3": policy3,
-		},
-	}
-	expectRbac4 := &policy.RBAC{
-		Action: policy.RBAC_ALLOW,
-		Policies: map[string]*policy.Policy{
-			"service-role-4": policy4,
-		},
-	}
-	expectRbac5 := &policy.RBAC{
-		Action: policy.RBAC_ALLOW,
-		Policies: map[string]*policy.Policy{
-			"service-role-5": policy5,
-		},
-	}
-	expectRbac6 := &policy.RBAC{
-		Action: policy.RBAC_ALLOW,
-		Policies: map[string]*policy.Policy{
-			"service-role-6": policy6,
-		},
-	}
+
+	expectRbac2 := generateExpectRBACForSinglePolicy("service-role-2", policy2)
+	expectRbac3 := generateExpectRBACForSinglePolicy("service-role-3", policy3)
+	expectRbac4 := generateExpectRBACForSinglePolicy("service-role-4", policy4)
+	expectRbac5 := generateExpectRBACForSinglePolicy("service-role-5", policy5)
+	expectRbac6 := generateExpectRBACForSinglePolicy("service-role-6", policy6)
+
 	expectRbac7 := &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
@@ -951,6 +1057,11 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 			"service-role-8": policy8,
 		},
 	}
+	expectRbac9 := generateExpectRBACForSinglePolicy("service-role-9", policy9)
+	expectRbac10 := generateExpectRBACForSinglePolicy("service-role-10", policy10)
+	expectRbac11 := generateExpectRBACForSinglePolicy("service-role-11", policy11)
+	expectRbac12 := generateExpectRBACForSinglePolicy("service-role-12", policy12)
+	expectRbac13 := generateExpectRBACForSinglePolicy("service-role-13", policy13)
 
 	authzPolicies := newAuthzPoliciesWithRolesAndBindings(roles, bindings)
 	option := rbacOption{authzPolicies: authzPolicies}
@@ -1047,6 +1158,46 @@ func TestConvertRbacRulesToFilterConfig(t *testing.T) {
 			},
 			rbac:   expectRbac8,
 			option: rbacOption{authzPolicies: authzPolicies, forTCPFilter: true},
+		},
+		{
+			name: "ports rule",
+			service: &serviceMetadata{
+				name: "service-9",
+			},
+			rbac:   expectRbac9,
+			option: option,
+		},
+		{
+			name: "hosts rule",
+			service: &serviceMetadata{
+				name: "service-10",
+			},
+			rbac:   expectRbac10,
+			option: option,
+		},
+		{
+			name: "not_hosts rule",
+			service: &serviceMetadata{
+				name: "service-11",
+			},
+			rbac:   expectRbac11,
+			option: option,
+		},
+		{
+			name: "not_methods rule",
+			service: &serviceMetadata{
+				name: "backup_service",
+			},
+			rbac:   expectRbac12,
+			option: option,
+		},
+		{
+			name: "not_paths rule",
+			service: &serviceMetadata{
+				name: "service-13",
+			},
+			rbac:   expectRbac13,
+			option: option,
 		},
 	}
 

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin/authn"
 )
 
@@ -198,6 +199,75 @@ func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *po
 							Identifier: &policy.Principal_Metadata{
 								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
 									[]string{attrRequestClaims, "groups"}, claimName),
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+}
+
+// nolint:deadcode
+func generateExpectRBACForSinglePolicy(serviceRoleName string, rbacPolicy *policy.Policy) *policy.RBAC {
+	return &policy.RBAC{
+		Action: policy.RBAC_ALLOW,
+		Policies: map[string]*policy.Policy{
+			serviceRoleName: rbacPolicy,
+		},
+	}
+}
+
+// nolint:deadcode
+func generateSimpleServiceRoleBindingAllGroups(serviceRoleName, serviceRoleBindingName string) model.Config {
+	return model.Config{
+		ConfigMeta: model.ConfigMeta{Name: serviceRoleBindingName},
+		Spec: &rbacproto.ServiceRoleBinding{
+			Subjects: []*rbacproto.Subject{
+				{
+					Properties: map[string]string{
+						"request.auth.claims[groups]": "group*",
+					},
+				},
+			},
+			RoleRef: &rbacproto.RoleRef{
+				Kind: "ServiceRole",
+				Name: serviceRoleName,
+			},
+		},
+	}
+}
+
+// nolint: deadcode
+func generateSimplePolicyForNotRuleWithHeader(header string, exactMatch string) *policy.Policy {
+	return &policy.Policy{
+		Permissions: []*policy.Permission{
+			{
+				Rule: &policy.Permission_AndRules{
+					AndRules: &policy.Permission_Set{
+						Rules: []*policy.Permission{
+							{
+								Rule: &policy.Permission_NotRule{
+									NotRule: &policy.Permission{
+										Rule: generateHeaderRule([]*route.HeaderMatcher{
+											{Name: header, HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: exactMatch}},
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Principals: []*policy.Principal{{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_Metadata{
+								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
+									[]string{attrRequestClaims, "groups"}, "group*"),
 							},
 						},
 					},

--- a/pilot/pkg/networking/plugin/authz/util.go
+++ b/pilot/pkg/networking/plugin/authz/util.go
@@ -102,6 +102,14 @@ func convertToPort(v string) (uint32, error) {
 	return uint32(p), nil
 }
 
+func convertPortsToString(intPorts []int32) []string {
+	var ports []string
+	for _, port := range intPorts {
+		ports = append(ports, strconv.Itoa(int(port)))
+	}
+	return ports
+}
+
 // convertToHeaderMatcher converts a key, value string pair to a corresponding HeaderMatcher.
 func convertToHeaderMatcher(k, v string) *route.HeaderMatcher {
 	// We must check "*" first to make sure we'll generate a non empty value in the prefix/suffix case.

--- a/pilot/pkg/networking/plugin/authz/util_test.go
+++ b/pilot/pkg/networking/plugin/authz/util_test.go
@@ -170,6 +170,35 @@ func TestConvertToPort(t *testing.T) {
 	}
 }
 
+func TestConvertPortsToString(t *testing.T) {
+	testCases := []struct {
+		Name   string
+		V      []int32
+		Expect []string
+		Err    string
+	}{
+		{
+			Name:   "valid ports",
+			V:      []int32{80, 3000, 443},
+			Expect: []string{"80", "3000", "443"},
+		},
+		{
+			Name:   "valid port",
+			V:      []int32{9080},
+			Expect: []string{"9080"},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := convertPortsToString(tc.V)
+		for i := range tc.Expect {
+			if tc.Expect[i] != actual[i] {
+				t.Errorf("%s: expecting %s, but got %s", tc.Name, tc.Expect, actual)
+			}
+		}
+	}
+}
+
 func TestConvertToHeaderMatcher(t *testing.T) {
 	testCases := []struct {
 		Name   string

--- a/pilot/pkg/networking/plugin/authz/validate.go
+++ b/pilot/pkg/networking/plugin/authz/validate.go
@@ -28,11 +28,23 @@ func validateRuleForTCPFilter(rule *rbacproto.AccessRule) error {
 		return nil
 	}
 
+	if len(rule.Hosts) != 0 {
+		return fmt.Errorf("hosts(%v) not supported", rule.Hosts)
+	}
+	if len(rule.NotHosts) != 0 {
+		return fmt.Errorf("hosts(%v) not supported", rule.NotHosts)
+	}
 	if len(rule.Paths) != 0 {
 		return fmt.Errorf("paths(%v) not supported", rule.Paths)
 	}
+	if len(rule.NotPaths) != 0 {
+		return fmt.Errorf("not_paths(%v) not supported", rule.NotPaths)
+	}
 	if len(rule.Methods) != 0 {
 		return fmt.Errorf("methods(%v) not supported", rule.Methods)
+	}
+	if len(rule.NotMethods) != 0 {
+		return fmt.Errorf("not_methods(%v) not supported", rule.NotMethods)
 	}
 	for _, constraint := range rule.Constraints {
 		if strings.HasPrefix(constraint.Key, attrRequestHeader) {


### PR DESCRIPTION
Similar to #11712 from the `authz-v2` feature branch. This is to merge some changes from `authz-v2` to `master`. 

Support notPaths, notMethods, ports, notPorts, hosts, notHosts in ServiceRole (+ unit testing and refactoring).
PR for #11516.