### PR TITLE
Create a new shard if none exists during service account mapping

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -371,8 +371,17 @@ func (s *DiscoveryServer) updateServiceShards(push *model.PushContext) error {
 
 	s.mutex.Lock()
 	for k, v := range svc2account {
-		ep := s.EndpointShardsByService[k]
-		ep.ServiceAccounts = v
+		if ep := s.EndpointShardsByService[k]; ep != nil {
+			ep.ServiceAccounts = v
+			continue
+		}
+		// we have not seen this service before.
+		// We will let edsUpdate() add endpoints to the list.
+		// Just record service accounts here.
+		s.EndpointShardsByService[k] = &EndpointShards{
+			Shards:          map[string][]*model.IstioEndpoint{},
+			ServiceAccounts: v,
+		}
 	}
 	s.mutex.Unlock()
 


### PR DESCRIPTION
fixes #12303

```istio.io/istio/pilot/pkg/proxy/envoy/v2.(*DiscoveryServer).updateServiceShards(0xc420617130, 0xc5cf71ed00, 0xc5cf71ed00, 0x0)
	/workspace/go/src/istio.io/istio/pilot/pkg/proxy/envoy/v2/eds.go:375 +0x997
istio.io/istio/pilot/pkg/proxy/envoy/v2.(*DiscoveryServer).Push(0xc420617130, 0x1, 0xc5cdada030)
	/workspace/go/src/istio.io/istio/pilot/pkg/proxy/envoy/v2/discovery.go:329 +0x37e
 ```
 

