### PR TITLE
Align istio-gateways resource requests with sidecar

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/values.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/values.yaml
@@ -26,13 +26,13 @@ istio-ingressgateway:
   autoscaleMax: 5
   # specify replicaCount when autoscaleEnabled: false
   # replicaCount: 1
-  resources: {}
-    # limits:
-    #  cpu: 100m
-    #  memory: 128Mi
-    #requests:
-    #  cpu: 1800m
-    #  memory: 256Mi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 2000m
+      memory: 256Mi
   cpu:
     targetAverageUtilization: 80
   loadBalancerIP: ""
@@ -122,6 +122,13 @@ istio-egressgateway:
   autoscaleMax: 5
   # specify replicaCount when autoscaleEnabled: false
   # replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 2000m
+      memory: 256Mi
   cpu:
     targetAverageUtilization: 80
   serviceAnnotations: {}

--- a/install/kubernetes/helm/istio/test-values/values-e2e.yaml
+++ b/install/kubernetes/helm/istio/test-values/values-e2e.yaml
@@ -21,8 +21,24 @@ prometheus:
 gateways:
   istio-ingressgateway:
     autoscaleMax: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
   istio-egressgateway:
     enabled: true
+    autoscaleMax: 1
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
 
 mixer:
   policy:

--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -60,5 +60,21 @@ kiali:
   createDemoSecret: true
 
 gateways:
+  istio-ingressgateway:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
   istio-egressgateway:
     enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 40Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi


### PR DESCRIPTION
istio-ingressgateway uses default requests of `10m`. 
This PR aligns with proxy requests.

It override values in e2e and demo back to its original state.