### PR TITLE
fix EndpointShardsByService concurrent access

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -148,7 +148,7 @@ var (
 	proxiesConvergeDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name:    "pilot_proxy_convergence_time",
 		Help:    "Delay between config change and all proxies converging.",
-		Buckets: []float64{.01, .1, 1, 3, 5, 10, 30},
+		Buckets: []float64{1, 3, 5, 10, 20, 30, 50, 100},
 	})
 
 	pushContextErrors = prometheus.NewCounter(prometheus.CounterOpts{

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -705,7 +705,9 @@ func (s *DiscoveryServer) loadAssignmentsForClusterIsolated(proxy *model.Proxy, 
 	}
 
 	// The service was never updated - do the full update
+	s.mutex.RLock()
 	se, f := s.EndpointShardsByService[string(hostname)]
+	s.mutex.RUnlock()
 	if !f {
 		// Shouldn't happen here - but just in case fallback
 		return s.loadAssignmentsForClusterLegacy(push, clusterName)


### PR DESCRIPTION
Fixes #12339

1. Protects EndpointShardsByService using mutex read lock
2. Opportunistically updates bucketization for convergence time metric. 