### PR TITLE
add preStop hook to enable true graceful rolling update

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -164,6 +164,10 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/bash", "-c", "sleep 30"]
           resources:
 {{- if $spec.resources }}
 {{ toYaml $spec.resources | indent 12 }}


### PR DESCRIPTION
Through my testing, the rolling update of gateway itself is not graceful and it can be quite risky if someone has `HPA` turn on.

Adding a `preStop` hook will ensure that the requests that are going to the old pods are still being handled until all the traffic goes to the new pod. 

Sleep 30 seconds should be good enough. 