### PR TITLE
fix regression causing 404s..

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -637,6 +637,6 @@ func GetUniqueSuffixes(stringSlice []string) []string {
 		out = append(out, domain)
 	}
 
-	sort.Stable(out)
+	sort.Strings(out)
 	return out
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -610,24 +610,31 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 // GetUniqueSuffixes Return a slice containing the strings with the longesest
 // unique suffixes
 func GetUniqueSuffixes(stringSlice []string) []string {
-	out := []string{}
+	stringMap := make(map[string]bool)
 
-	// Iterate through the slice finding longest strings with unique suffixes
+	// Indicate all strings in map are valid
 	for _, stringOne := range stringSlice {
-		workString := ""
+		stringMap[stringOne] = true
+	}
+
+	// Iterate the list falsifying strings that don't meet criteria
+	for _, stringOne := range stringSlice {
 		for _, stringTwo := range stringSlice {
-			// If strings have same suffix
-			if strings.HasSuffix(stringOne, stringTwo) {
-				// Keep the longest string from the first range
-				if len(stringOne) > len(stringTwo) {
-					workString = stringOne
+			// Potentially falisify matching strings with same suffix
+			if stringOne != stringTwo && strings.HasSuffix(stringTwo, stringOne) {
+				// Falsify the shortest string
+				if len(stringOne) < len(stringTwo) {
+					stringMap[stringOne] = false
 				}
 			}
 		}
+	}
 
-		// Append first range working string if a new one was found
-		if workString != "" {
-			out = append(out, workString)
+	// Produce a slice from the map of non-falsified strings
+	out := []string{}
+	for uniqueString, v := range stringMap {
+		if v == true {
+			out = append(out, uniqueString)
 		}
 	}
 	return out

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -17,6 +17,7 @@ package model
 import (
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -607,8 +608,12 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 	return InterceptionRedirect
 }
 
-// GetUniqueSuffixes Return a slice containing the strings with the longesest
-// unique suffixes
+// GetUniqueSuffixes returns a list of longest unique DNS suffixes for a proxy
+// from all possible DNS suffixes provided to it. For example, given DNS suffixes
+// global, foo.global, ns1, ns1.svc, ns1.svc.cluster, ns1.svc.cluster.local
+// this function returns foo.global and ns1.svc.cluster.local as the two longest
+// and unique DNS suffixes. This will then be used by RDS code to generate all possible
+// combinations of virtual hosts for a given service.
 func GetUniqueSuffixes(stringSlice []string) []string {
 	domainMap := map[string]struct{}{}
 
@@ -632,5 +637,6 @@ func GetUniqueSuffixes(stringSlice []string) []string {
 		out = append(out, domain)
 	}
 
+	sort.Stable(out)
 	return out
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -610,32 +610,27 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 // GetUniqueSuffixes Return a slice containing the strings with the longesest
 // unique suffixes
 func GetUniqueSuffixes(stringSlice []string) []string {
-	stringMap := make(map[string]bool)
+	domainMap := map[string]struct{}{}
 
-	// Indicate all strings in map are valid
-	for _, stringOne := range stringSlice {
-		stringMap[stringOne] = true
-	}
-
-	// Iterate the list falsifying strings that don't meet criteria
-	for _, stringOne := range stringSlice {
-		for _, stringTwo := range stringSlice {
-			// Potentially falisify matching strings with same suffix
-			if stringOne != stringTwo && strings.HasSuffix(stringTwo, stringOne) {
-				// Falsify the shortest string
-				if len(stringOne) < len(stringTwo) {
-					stringMap[stringOne] = false
+	// Iterate through the slice finding longest strings with unique suffixes
+	for i := 0; i < len(stringSlice); i++ {
+		domainMap[stringSlice[i]] = struct{}{}
+		for j := 0; j < len(stringSlice); j++ {
+			if j != i {
+				// If strings have same suffix
+				if strings.HasSuffix(stringSlice[j], stringSlice[i]) {
+					delete(domainMap, stringSlice[i])
+					domainMap[stringSlice[j]] = struct{}{}
 				}
 			}
 		}
 	}
 
-	// Produce a slice from the map of non-falsified strings
-	out := []string{}
-	for uniqueString, v := range stringMap {
-		if v == true {
-			out = append(out, uniqueString)
-		}
+	out := make([]string, 0, len(domainMap))
+
+	for domain := range domainMap {
+		out = append(out, domain)
 	}
+
 	return out
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -85,6 +85,10 @@ func TestGetUniqueSuffixes(t *testing.T) {
 			in:  []string{"global", "istio-system.global", "global"},
 			out: []string{"istio-system.global"},
 		},
+		{
+			in:  []string{"global", "istio-system.global", "default.svc.local"},
+			out: []string{"istio-system.global", "default.svc.local"},
+		},
 	}
 	for _, datum := range data {
 		out := model.GetUniqueSuffixes(datum.in)

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -79,7 +79,7 @@ func TestGetUniqueSuffixes(t *testing.T) {
 	}{
 		{
 			in:  []string{"part1.part2.com", "part2.com", "default.svc.local", "kube.default.svc.local"},
-			out: []string{"part1.part2.com", "kube.default.svc.local"},
+			out: []string{"kube.default.svc.local", "part1.part2.com"},
 		},
 		{
 			in:  []string{"global", "istio-system.global", "global"},
@@ -87,13 +87,13 @@ func TestGetUniqueSuffixes(t *testing.T) {
 		},
 		{
 			in:  []string{"global", "istio-system.global", "default.svc.local"},
-			out: []string{"istio-system.global", "default.svc.local"},
+			out: []string{"default.svc.local", "istio-system.global"},
 		},
 	}
 	for _, datum := range data {
 		out := model.GetUniqueSuffixes(datum.in)
 		if !reflect.DeepEqual(datum.out, out) {
-			t.Errorf("GetSuperString() =>\n Got %s\nwant %s", out, datum.out)
+			t.Errorf("GetUniqueSuffixes() =>\n Got %s\nwant %s", out, datum.out)
 		}
 	}
 }


### PR DESCRIPTION
PR https://github.com/istio/istio/pull/11522 introduced the logic to generate Vhosts for multiple DNS domains in RDS code. However, it also introduced a regression such that only only one of these dns domains is picked up in the model.GetUniqueSuffixes code. As a result anyone with the values-istio-multicluster-gateway.yaml or anyone defining multiple DNS search domains in their pods will lose the ability to address services by their short names such as http://productpage, or http://productpage.default, etc.. That will cause a lot of applications to break as envoy will start issuing 404s for `Host: productpage`..