### PR TITLE
Istio proxy-status correction for 1.0.4

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -6,8 +6,8 @@ ARG istio_version
 ADD envoy /usr/local/bin/envoy
 
 # Environment variables indicating this proxy's version/capabilities as opaque string
-ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.2"
-# Environment variable indicating the exact proxy sha - for debugging or version-specific configs 
+ENV ISTIO_META_ISTIO_PROXY_VERSION "1.0.4"
+# Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 # Environment variable indicating the exact build, for debugging
 ENV ISTIO_META_ISTIO_VERSION $istio_version


### PR DESCRIPTION
Updates the ISTIO_META_ISTIO_PROXY_VERSION environment variable to the correct version. Addresses #12295.

Signed-off-by: Jason Clark <jason.clark.oss@gmail.com>