### PR TITLE
Revert "fix DNs suffix extraction algorithm"

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -17,7 +17,6 @@ package model
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -608,35 +607,28 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 	return InterceptionRedirect
 }
 
-// GetUniqueSuffixes returns a list of longest unique DNS suffixes for a proxy
-// from all possible DNS suffixes provided to it. For example, given DNS suffixes
-// global, foo.global, ns1, ns1.svc, ns1.svc.cluster, ns1.svc.cluster.local
-// this function returns foo.global and ns1.svc.cluster.local as the two longest
-// and unique DNS suffixes. This will then be used by RDS code to generate all possible
-// combinations of virtual hosts for a given service.
+// GetUniqueSuffixes Return a slice containing the strings with the longesest
+// unique suffixes
 func GetUniqueSuffixes(stringSlice []string) []string {
-	domainMap := map[string]struct{}{}
+	out := []string{}
 
 	// Iterate through the slice finding longest strings with unique suffixes
-	for i := 0; i < len(stringSlice); i++ {
-		domainMap[stringSlice[i]] = struct{}{}
-		for j := 0; j < len(stringSlice); j++ {
-			if j != i {
-				// If strings have same suffix
-				if strings.HasSuffix(stringSlice[j], stringSlice[i]) {
-					delete(domainMap, stringSlice[i])
-					domainMap[stringSlice[j]] = struct{}{}
+	for _, stringOne := range stringSlice {
+		workString := ""
+		for _, stringTwo := range stringSlice {
+			// If strings have same suffix
+			if strings.HasSuffix(stringOne, stringTwo) {
+				// Keep the longest string from the first range
+				if len(stringOne) > len(stringTwo) {
+					workString = stringOne
 				}
 			}
 		}
+
+		// Append first range working string if a new one was found
+		if workString != "" {
+			out = append(out, workString)
+		}
 	}
-
-	out := make([]string, 0, len(domainMap))
-
-	for domain := range domainMap {
-		out = append(out, domain)
-	}
-
-	sort.Strings(out)
 	return out
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -79,21 +79,17 @@ func TestGetUniqueSuffixes(t *testing.T) {
 	}{
 		{
 			in:  []string{"part1.part2.com", "part2.com", "default.svc.local", "kube.default.svc.local"},
-			out: []string{"kube.default.svc.local", "part1.part2.com"},
+			out: []string{"part1.part2.com", "kube.default.svc.local"},
 		},
 		{
 			in:  []string{"global", "istio-system.global", "global"},
 			out: []string{"istio-system.global"},
 		},
-		{
-			in:  []string{"global", "istio-system.global", "default.svc.local"},
-			out: []string{"default.svc.local", "istio-system.global"},
-		},
 	}
 	for _, datum := range data {
 		out := model.GetUniqueSuffixes(datum.in)
 		if !reflect.DeepEqual(datum.out, out) {
-			t.Errorf("GetUniqueSuffixes() =>\n Got %s\nwant %s", out, datum.out)
+			t.Errorf("GetSuperString() =>\n Got %s\nwant %s", out, datum.out)
 		}
 	}
 }


### PR DESCRIPTION
Reverts istio/istio#12346

This is no longer needed. Reverting other PRs related to this as well. We cannot generate short name vhost match for multiple DNS suffixes as it will cause envoy RDS to error out saying there are duplicate hosts, causing fleet wide rds issues. For example, generating a vhost match for httpbin --> httpbin.default.global will break if there is already a httpbin service in the local cluster. This will cause two vhost matches

``` vhost:
-  domains: httpbin, httpbin.default.global
  route: httpbin.default.global
- domains: httpbin, httpbin.default.svc.cluster.local
   route: httpbin.default.svc.cluster.local
```

and envoy RDS update will fail with error
```
[2019-03-08 19:44:09.269][23][critical][main] [source/server/server.cc:86] error initializing configuration '/etc/envoy/envoy.yaml': Only unique values for domains are permitted. Duplicate entry of domain httpbin
[2019-03-08 19:44:09.270][23][info][main] [source/server/server.cc:513] exiting
Only unique values for domains are permitted. Duplicate entry of domain httpbin
```