### PR TITLE
Revert #11522: fix routing when DNS is resolved

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -172,11 +172,6 @@ data:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-{{- if .Values.global.podDNSSearchNamespaces }}
-        - name: ISTIO_META_DNS_DOMAINS
-{{- $local := dict "first" true }}
-          value: {{ range $k, $v := .Values.global.podDNSSearchNamespaces }}{{- if not $local.first }},{{ end }}{{- $v }}{{- $_ := set $local "first" false }}{{- end }}
-{{- end }}
         - name: ISTIO_META_INTERCEPTION_MODE
           value: {{ "[[ or (index .ObjectMeta.Annotations \"sidecar.istio.io/interceptionMode\") .ProxyConfig.InterceptionMode.String ]]" }}
         {{- if .Values.global.network }}

--- a/pilot/cmd/pilot-agent/main.go
+++ b/pilot/cmd/pilot-agent/main.go
@@ -53,7 +53,6 @@ var (
 	registry         serviceregistry.ServiceRegistry
 	statusPort       uint16
 	applicationPorts []string
-	DNSDomain        string
 
 	// proxy config flags (named identically)
 	configPath                 string
@@ -186,16 +185,8 @@ var (
 					}
 				}
 			}
-
-			// Parse the DNSDomain based upon service registry type into a registry specific domain.
-			DNSDomain = getDNSDomain(DNSDomain)
-
-			// role.ServiceNode() returns a string based upon this META which isn't set in the proxy-init.
-			role.DNSDomains = make([]string, 1)
-			role.DNSDomains[0] = DNSDomain
-
-			// Obtain the SAN to later create a Envoy proxy.
-			pilotSAN = getPilotSAN(DNSDomain, ns)
+			role.DNSDomain = getDNSDomain(role.DNSDomain)
+			pilotSAN = getPilotSAN(role.DNSDomain, ns)
 
 			// resolve statsd address
 			if proxyConfig.StatsdUdpAddress != "" {
@@ -410,7 +401,7 @@ func init() {
 		"Proxy IP address. If not provided uses ${INSTANCE_IP} environment variable.")
 	proxyCmd.PersistentFlags().StringVar(&role.ID, "id", "",
 		"Proxy unique ID. If not provided uses ${POD_NAME}.${POD_NAMESPACE} from environment variables")
-	proxyCmd.PersistentFlags().StringVar(&DNSDomain, "domain", "",
+	proxyCmd.PersistentFlags().StringVar(&role.DNSDomain, "domain", "",
 		"DNS domain suffix. If not provided uses ${POD_NAMESPACE}.svc.cluster.local")
 	proxyCmd.PersistentFlags().StringVar(&role.TrustDomain, "trust-domain", "",
 		"The domain to use for identities")

--- a/pilot/cmd/pilot-agent/main_test.go
+++ b/pilot/cmd/pilot-agent/main_test.go
@@ -26,35 +26,35 @@ import (
 
 func TestNoPilotSanIfAuthenticationNone(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	role.TrustDomain = ""
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_NONE.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.BeNil())
 }
 
 func TestPilotSanIfAuthenticationMutualDomainEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = "my.domain"
+	role.DNSDomain = "my.domain"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://my.domain/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -63,47 +63,47 @@ func TestPilotSanIfAuthenticationMutualDomainNotEmptyKubernetes(t *testing.T) {
 // When pilot is started without a trust domain, the SPIFFE URI doesn't contain a host and is not valid
 func TestPilotSanIfAuthenticationMutualDomainEmptyConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualTrustDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotSanIfAuthenticationMutualTrustDomainAndDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = "my.domain"
+	role.DNSDomain = "my.domain"
 	role.TrustDomain = "secured"
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://secured/ns/anything/sa/istio-pilot-service-account"}))
 }
 
 func TestPilotDefaultDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	os.Setenv("POD_NAMESPACE", "default")
 
-	domain := getDNSDomain(DNSDomain)
+	domain := getDNSDomain(role.DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("default.svc.cluster.local"))
 	os.Unsetenv("POD_NAMESPACE")
@@ -111,42 +111,42 @@ func TestPilotDefaultDomainKubernetes(t *testing.T) {
 
 func TestPilotDefaultDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
+	role.DNSDomain = ""
 	registry = serviceregistry.ConsulRegistry
-	DNSDomain = ""
 
-	domain := getDNSDomain(DNSDomain)
+	domain := getDNSDomain(role.DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("service.consul"))
 }
 
 func TestPilotDefaultDomainOthers(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ""
+	role.DNSDomain = ""
 	registry = serviceregistry.MockRegistry
 
-	domain := getDNSDomain(DNSDomain)
+	domain := getDNSDomain(role.DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal(""))
 }
 
 func TestPilotDomain(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = "my.domain"
+	role.DNSDomain = "my.domain"
 	registry = serviceregistry.MockRegistry
 
-	domain := getDNSDomain(DNSDomain)
+	domain := getDNSDomain(role.DNSDomain)
 
 	g.Expect(domain).To(gomega.Equal("my.domain"))
 }
 
 func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = ".svc.cluster.local"
+	role.DNSDomain = ".svc.cluster.local"
 	role.TrustDomain = ""
 	registry = serviceregistry.KubernetesRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe://cluster.local/ns/anything/sa/istio-pilot-service-account"}))
 }
@@ -155,12 +155,12 @@ func TestPilotSanIfAuthenticationMutualStdDomainKubernetes(t *testing.T) {
 // When pilot is started without a trust domain, the SPIFFE URI doesn't contain a host and is not valid
 func TestPilotSanIfAuthenticationMutualStdDomainConsul(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	DNSDomain = "service.consul"
+	role.DNSDomain = "service.consul"
 	role.TrustDomain = ""
 	registry = serviceregistry.ConsulRegistry
 	controlPlaneAuthPolicy = meshconfig.AuthenticationPolicy_MUTUAL_TLS.String()
 
-	pilotSAN := getPilotSAN(DNSDomain, "anything")
+	pilotSAN := getPilotSAN(role.DNSDomain, "anything")
 
 	g.Expect(pilotSAN).To(gomega.Equal([]string{"spiffe:///ns/anything/sa/istio-pilot-service-account"}))
 }

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -88,7 +88,7 @@ type Proxy struct {
 
 	// DNSDomain defines the DNS domain suffix for short hostnames (e.g.
 	// "default.svc.cluster.local")
-	DNSDomains []string
+	DNSDomain string
 
 	// ConfigNamespace defines the namespace where this proxy resides
 	// for the purposes of network scoping.
@@ -139,7 +139,7 @@ func (node *Proxy) ServiceNode() string {
 		ip = node.IPAddresses[0]
 	}
 	return strings.Join([]string{
-		string(node.Type), ip, node.ID, node.DNSDomains[0],
+		string(node.Type), ip, node.ID, node.DNSDomain,
 	}, serviceNodeSeparator)
 
 }
@@ -284,7 +284,7 @@ func ParseServiceNodeWithMetadata(s string, metadata map[string]string) (*Proxy,
 	}
 
 	out.ID = parts[2]
-	out.DNSDomains = getProxyMetadataDNSDomains(out, parts[3])
+	out.DNSDomain = parts[3]
 	return out, nil
 }
 
@@ -303,30 +303,12 @@ func GetProxyConfigNamespace(proxy *Proxy) string {
 
 	// if not found, for backward compatibility, extract the namespace from
 	// the proxy domain. this is a k8s specific hack and should be enabled
-	parts := strings.Split(proxy.DNSDomains[0], ".")
+	parts := strings.Split(proxy.DNSDomain, ".")
 	if len(parts) > 1 { // k8s will have namespace.<domain>
 		return parts[0]
 	}
 
 	return ""
-}
-
-// getProxyMetadataDNSDomains returns a slice containing every DNS Domain that
-// has been injected into the proxy via the environment variable ISTIO_META_DNS_DOMAINS
-func getProxyMetadataDNSDomains(proxy *Proxy, parts string) []string {
-	if proxy == nil {
-		return nil
-	}
-
-	// If ISTIO_META_DNS_DOMAINS contains a list, produce and return a
-	//  list of unique suffixes
-	if nodeMetadataDNSDomains, found := proxy.Metadata[NodeMetadataDNSDomains]; found {
-		nodeMetadataDNSDomainsUnique := GetUniqueSuffixes(strings.Split(nodeMetadataDNSDomains, ","))
-		return nodeMetadataDNSDomainsUnique
-	}
-
-	// Otherwise just return the DNSDomain
-	return []string{parts}
 }
 
 const (
@@ -550,9 +532,6 @@ const (
 	// If not set, Pilot uses the default SDS token path.
 	NodeMetadataSdsTokenPath = "SDS_TOKEN_PATH"
 
-	// NodeMetaDataDNSDomains is the list of DNS domains used for resolution
-	NodeMetadataDNSDomains = "DNS_DOMAINS"
-
 	// NodeMetadataPolicyCheckRetries determines the policy for behavior when unable to connect to mixer
 	// If not set, FAIL_CLOSE is set, rejecting requests.
 	NodeMetadataPolicyCheck = "policy.istio.io/check"
@@ -605,30 +584,4 @@ func (node *Proxy) GetInterceptionMode() TrafficInterceptionMode {
 	}
 
 	return InterceptionRedirect
-}
-
-// GetUniqueSuffixes Return a slice containing the strings with the longesest
-// unique suffixes
-func GetUniqueSuffixes(stringSlice []string) []string {
-	out := []string{}
-
-	// Iterate through the slice finding longest strings with unique suffixes
-	for _, stringOne := range stringSlice {
-		workString := ""
-		for _, stringTwo := range stringSlice {
-			// If strings have same suffix
-			if strings.HasSuffix(stringOne, stringTwo) {
-				// Keep the longest string from the first range
-				if len(stringOne) > len(stringTwo) {
-					workString = stringOne
-				}
-			}
-		}
-
-		// Append first range working string if a new one was found
-		if workString != "" {
-			out = append(out, workString)
-		}
-	}
-	return out
 }

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -38,7 +38,7 @@ func TestServiceNode(t *testing.T) {
 				Type:        model.Ingress,
 				ID:          "random",
 				IPAddresses: []string{"10.3.3.3"},
-				DNSDomains:  []string{"local"},
+				DNSDomain:   "local",
 			},
 			out: "ingress~10.3.3.3~random~local",
 		},
@@ -47,7 +47,7 @@ func TestServiceNode(t *testing.T) {
 				Type:        model.SidecarProxy,
 				ID:          "random",
 				IPAddresses: []string{"10.3.3.3", "10.4.4.4", "10.5.5.5", "10.6.6.6"},
-				DNSDomains:  []string{"local"},
+				DNSDomain:   "local",
 				Metadata: map[string]string{
 					"INSTANCE_IPS": "10.3.3.3,10.4.4.4,10.5.5.5,10.6.6.6",
 				},
@@ -68,28 +68,6 @@ func TestServiceNode(t *testing.T) {
 		}
 		if !reflect.DeepEqual(in, node.in) {
 			t.Errorf("ParseServiceNode(%q) => Got %#v, want %#v", node.out, in, node.in)
-		}
-	}
-}
-
-func TestGetUniqueSuffixes(t *testing.T) {
-	data := []struct {
-		in  []string
-		out []string
-	}{
-		{
-			in:  []string{"part1.part2.com", "part2.com", "default.svc.local", "kube.default.svc.local"},
-			out: []string{"part1.part2.com", "kube.default.svc.local"},
-		},
-		{
-			in:  []string{"global", "istio-system.global", "global"},
-			out: []string{"istio-system.global"},
-		},
-	}
-	for _, datum := range data {
-		out := model.GetUniqueSuffixes(datum.in)
-		if !reflect.DeepEqual(datum.out, out) {
-			t.Errorf("GetSuperString() =>\n Got %s\nwant %s", out, datum.out)
 		}
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/cluster_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster_test.go
@@ -170,7 +170,7 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, nodeType model.N
 			ClusterID:   "some-cluster-id",
 			Type:        model.SidecarProxy,
 			IPAddresses: []string{"6.6.6.6"},
-			DNSDomains:  []string{"com"},
+			DNSDomain:   "com",
 			Metadata:    meta,
 		}
 	case model.Router:
@@ -178,7 +178,7 @@ func buildTestClustersWithProxyMetadata(serviceHostname string, nodeType model.N
 			ClusterID:   "some-cluster-id",
 			Type:        model.Router,
 			IPAddresses: []string{"6.6.6.6"},
-			DNSDomains:  []string{"default.example.org"},
+			DNSDomain:   "default.example.org",
 			Metadata:    meta,
 		}
 	default:

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -220,9 +220,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 // a proxy node
 func generateVirtualHostDomains(service *model.Service, port int, node *model.Proxy) []string {
 	domains := []string{string(service.Hostname), fmt.Sprintf("%s:%d", service.Hostname, port)}
-	for _, domain := range node.DNSDomains {
-		domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, domain)...)
-	}
+	domains = append(domains, generateAltVirtualHosts(string(service.Hostname), port, node.DNSDomain)...)
 
 	if len(service.Address) > 0 && service.Address != model.UnspecifiedIP {
 		svcAddr := service.GetServiceAddressForProxy(node)

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -41,7 +41,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomains: []string{"local.campus.net"},
+				DNSDomain: "local.campus.net",
 			},
 			want: []string{"foo", "foo.local", "foo.local.campus", "foo.local.campus.net",
 				"foo:80", "foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
@@ -54,7 +54,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomains: []string{"remote.campus.net"},
+				DNSDomain: "remote.campus.net",
 			},
 			want: []string{"foo.local", "foo.local.campus", "foo.local.campus.net",
 				"foo.local:80", "foo.local.campus:80", "foo.local.campus.net:80"},
@@ -67,7 +67,7 @@ func TestGenerateVirtualHostDomains(t *testing.T) {
 			},
 			port: 80,
 			node: &model.Proxy{
-				DNSDomains: []string{"example.com"},
+				DNSDomain: "example.com",
 			},
 			want: []string{"foo.local.campus.net", "foo.local.campus.net:80"},
 		},

--- a/pilot/pkg/networking/core/v1alpha3/listener_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener_test.go
@@ -39,7 +39,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1"},
 		ID:          "v0.default",
-		DNSDomains:  []string{"default.example.org"},
+		DNSDomain:   "default.example.org",
 		Metadata: map[string]string{
 			model.NodeMetadataConfigNamespace: "not-default",
 			"ISTIO_PROXY_VERSION":             "1.1",

--- a/pilot/pkg/networking/core/v1alpha3/route/route_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route_test.go
@@ -47,7 +47,7 @@ func TestBuildHTTPRoutes(t *testing.T) {
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"1.1.1.1"},
 		ID:          "someID",
-		DNSDomains:  []string{"foo.com"},
+		DNSDomain:   "foo.com",
 		Metadata:    map[string]string{"ISTIO_PROXY_VERSION": "1.1"},
 	}
 	gatewayNames := map[string]bool{"some-gateway": true}

--- a/pilot/pkg/serviceregistry/kube/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller_test.go
@@ -451,7 +451,7 @@ func TestGetProxyServiceInstances(t *testing.T) {
 	svcNode.Type = model.Ingress
 	svcNode.IPAddresses = []string{"128.0.0.1"}
 	svcNode.ID = "pod1.nsa"
-	svcNode.DNSDomains = []string{"nsa.svc.cluster.local"}
+	svcNode.DNSDomain = "nsa.svc.cluster.local"
 	services, err := controller.GetProxyServiceInstances(&svcNode)
 	if err != nil {
 		t.Errorf("client encountered error during GetProxyServiceInstances(): %v", err)

--- a/pilot/pkg/serviceregistry/memory/discovery_mock.go
+++ b/pilot/pkg/serviceregistry/memory/discovery_mock.go
@@ -46,7 +46,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{HelloInstanceV0},
 		ID:          "v0.default",
-		DNSDomains:  []string{"default.svc.cluster.local"},
+		DNSDomain:   "default.svc.cluster.local",
 	}
 
 	// HelloProxyV1 is a mock proxy v1 of HelloService
@@ -54,7 +54,7 @@ var (
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{HelloInstanceV1},
 		ID:          "v1.default",
-		DNSDomains:  []string{"default.svc.cluster.local"},
+		DNSDomain:   "default.svc.cluster.local",
 	}
 
 	// Ingress is a mock proxy to IP 10.3.3.3
@@ -62,7 +62,7 @@ var (
 		Type:        model.Ingress,
 		IPAddresses: []string{"10.3.3.3"},
 		ID:          "ingress.default",
-		DNSDomains:  []string{"default.svc.cluster.local"},
+		DNSDomain:   "default.svc.cluster.local",
 	}
 
 	// MockDiscovery is an in-memory ServiceDiscover with mock services

--- a/tests/integration2/pilot/sidecar_api_test.go
+++ b/tests/integration2/pilot/sidecar_api_test.go
@@ -42,7 +42,7 @@ func TestSidecarListeners(t *testing.T) {
 		Type:        model.SidecarProxy,
 		IPAddresses: []string{"10.2.0.1"},
 		ID:          "app3.testns",
-		DNSDomains:  []string{"testns.cluster.local"},
+		DNSDomain:   "testns.cluster.local",
 	}
 
 	// ... and get listeners from Pilot for that proxy


### PR DESCRIPTION
Reverts istio/istio#11522

We cannot generate short name vhost match for multiple DNS suffixes as it will cause envoy RDS to error out saying there are duplicate hosts, causing fleet wide rds issues. For example, generating a vhost match for httpbin --> httpbin.default.global will break if there is already a httpbin service in the local cluster. This will cause two vhost matches

``` vhost:
-  domains: httpbin, httpbin.default.global
  route: httpbin.default.global
- domains: httpbin, httpbin.default.svc.cluster.local
   route: httpbin.default.svc.cluster.local
```

and envoy RDS update will fail with error
```
[2019-03-08 19:44:09.269][23][critical][main] [source/server/server.cc:86] error initializing configuration '/etc/envoy/envoy.yaml': Only unique values for domains are permitted. Duplicate entry of domain httpbin
[2019-03-08 19:44:09.270][23][info][main] [source/server/server.cc:513] exiting
Only unique values for domains are permitted. Duplicate entry of domain httpbin
```