### PR TITLE
remove deprecated service graph off demo profile

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -53,9 +53,6 @@ grafana:
 tracing:
   enabled: true
 
-servicegraph:
-  enabled: true
-
 kiali:
   enabled: true
   createDemoSecret: true


### PR DESCRIPTION


This is something we discussed for a long time but was not implemented.