### PR TITLE
add the remote flag to the istioctl version command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ about: Report a bug to help us improve Istio
 {{ Minimal steps to reproduce the behavior }}
 
 **Version**
-{{ What version of Istio and Kubernetes are you using? Use `istioctl version` and `kubectl version` }}
+{{ What version of Istio and Kubernetes are you using? Use `istioctl version --remote` and `kubectl version` }}
 
 **Installation**
 {{ Please describe how Istio was installed }}


### PR DESCRIPTION
Without the remote flag, users will only post the version of istioctl binary. This should help new bug reporters make better bug reports. 😄
