### PR TITLE
Improve resource lifecycle management and debuggability.

### DIFF
--- a/galley/pkg/testing/testdata/dataset.gen.go
+++ b/galley/pkg/testing/testdata/dataset.gen.go
@@ -185,7 +185,7 @@ var _datasetExtensionsV1beta1Ingress_basic_expectedJson = []byte(`{
     }
   ],
 
-  "type.googleapis.com/istio.networking.v1alpha3.VirtualService": [
+  "istio/networking/v1alpha3/virtualservices": [
   ]
 }
 `)

--- a/galley/pkg/testing/testdata/dataset/extensions/v1beta1/ingress_basic_expected.json
+++ b/galley/pkg/testing/testdata/dataset/extensions/v1beta1/ingress_basic_expected.json
@@ -25,6 +25,6 @@
     }
   ],
 
-  "type.googleapis.com/istio.networking.v1alpha3.VirtualService": [
+  "istio/networking/v1alpha3/virtualservices": [
   ]
 }

--- a/pkg/test/framework2/common/environment.go
+++ b/pkg/test/framework2/common/environment.go
@@ -12,15 +12,34 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package environment
+package common
 
-import "istio.io/istio/pkg/test/framework2/common"
-
-// Const version of names. These are used as part of API surface.
+// Keep the environment names here to avoid layering/circular dependency problems.
 
 const (
 	// Native environment name
-	Native = Name(common.Native)
+	Native EnvironmentName = "native"
 	// Kube environment name
-	Kube = Name(common.Kube)
+	Kube EnvironmentName = "kube"
 )
+
+// EnvironmentNames of supported environments
+func EnvironmentNames() []EnvironmentName {
+	return []EnvironmentName{
+		Native,
+		Kube,
+	}
+}
+
+// DefaultName is the name of the default environment
+func DefaultEnvironmentName() EnvironmentName {
+	return Native
+}
+
+// EnvironmentName of environment
+type EnvironmentName string
+
+// String implements fmt.Stringer
+func (n EnvironmentName) String() string {
+	return string(n)
+}

--- a/pkg/test/framework2/common/flags.go
+++ b/pkg/test/framework2/common/flags.go
@@ -18,8 +18,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-
-	"istio.io/istio/pkg/test/framework2/components/environment"
 )
 
 var (
@@ -45,7 +43,7 @@ func init() {
 		"Local working directory for creating logs/temp files. If left empty, os.TempDir() is used.")
 
 	flag.StringVar((*string)(&settingsFromCommandLine.Environment), "istio.test.env", string(settingsFromCommandLine.Environment),
-		fmt.Sprintf("Specify the environment to run the tests against. Allowed values are: %v", environment.Names()))
+		fmt.Sprintf("Specify the environment to run the tests against. Allowed values are: %v", EnvironmentNames()))
 
 	flag.BoolVar(&settingsFromCommandLine.NoCleanup, "istio.test.noCleanup", settingsFromCommandLine.NoCleanup,
 		"Do not cleanup resources after test completion")

--- a/pkg/test/framework2/common/settings.go
+++ b/pkg/test/framework2/common/settings.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"istio.io/istio/pkg/test/framework2/components/environment"
 )
 
 const (
@@ -72,7 +71,7 @@ func (s *Settings) Clone() *Settings {
 // DefaultSettings returns a default settings instance.
 func DefaultSettings() *Settings {
 	return &Settings{
-		Environment: environment.DefaultName().String(),
+		Environment: DefaultEnvironmentName().String(),
 		RunID:       uuid.New(),
 	}
 }

--- a/pkg/test/framework2/components/environment/environment.go
+++ b/pkg/test/framework2/components/environment/environment.go
@@ -16,13 +16,15 @@ package environment
 
 import (
 	"fmt"
+
+	"istio.io/istio/pkg/test/framework2/common"
 )
 
 // FactoryFn is used to create a new environment.
 type FactoryFn func(string, Context) (Instance, error)
 
 // Name of environment
-type Name string
+type Name common.EnvironmentName
 
 // String implements fmt.Stringer
 func (n Name) String() string {
@@ -36,7 +38,10 @@ func UnsupportedEnvironment(name Name) error {
 
 // Instance of environment.
 type Instance interface {
-	Name() Name
+	// TODO: This creates an import cycle. We should resolve this in the future.
+	FriendlyName() string
+
+	EnvironmentName() Name
 }
 
 // Context for environments

--- a/pkg/test/framework2/components/environment/kube/environment.go
+++ b/pkg/test/framework2/components/environment/kube/environment.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/framework2/resource"
 	"istio.io/istio/pkg/test/framework2/runtime"
@@ -40,9 +41,14 @@ type Environment struct {
 
 var _ environment.Instance = &Environment{}
 
-// Name implements environment.Instance
-func (e *Environment) Name() environment.Name {
+// EnvironmentName implements environment.Instance
+func (e *Environment) EnvironmentName() environment.Name {
 	return environment.Kube
+}
+
+// FriendlyIname implements resource.Instance
+func (e *Environment) FriendlyName() string {
+	return fmt.Sprintf("[Environment %s]", environment.Kube.String())
 }
 
 // New returns a new Kubernetes environment

--- a/pkg/test/framework2/components/environment/kube/namespace.go
+++ b/pkg/test/framework2/components/environment/kube/namespace.go
@@ -15,6 +15,7 @@
 package kube
 
 import (
+	"fmt"
 	"io"
 
 	"istio.io/istio/pkg/test/framework2/resource"
@@ -28,7 +29,12 @@ type Namespace struct {
 }
 
 var _ io.Closer = &Namespace{}
+var _ resource.Instance = &Namespace{}
 var _ resource.Dumper = &Namespace{}
+
+func (n *Namespace) FriendlyName() string {
+	return fmt.Sprintf("[Namespace %s]", n.Name)
+}
 
 // Close implements io.Closer
 func (n *Namespace) Close() error {

--- a/pkg/test/framework2/components/environment/native/native.go
+++ b/pkg/test/framework2/components/environment/native/native.go
@@ -15,6 +15,8 @@
 package native
 
 import (
+	"fmt"
+
 	meshConfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework/runtime/components/environment/native/service"
@@ -43,6 +45,11 @@ func New(_ environment.Context) (environment.Instance, error) {
 }
 
 // Type implements environment.Instance
-func (e *Environment) Name() environment.Name {
+func (e *Environment) EnvironmentName() environment.Name {
 	return environment.Native
+}
+
+// FriendlyName implements resource.Instance
+func (e *Environment) FriendlyName() string {
+	return fmt.Sprintf("[Environment %s]", environment.Native.String())
 }

--- a/pkg/test/framework2/components/galley/instance.go
+++ b/pkg/test/framework2/components/galley/instance.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"istio.io/istio/pkg/test/framework2/components/environment"
+
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
 	"istio.io/istio/pkg/test/framework2/resource"
 )
@@ -45,11 +46,11 @@ type Instance interface {
 
 // New returns a new Galley instance.
 func New(c resource.Context) (Instance, error) {
-	switch c.Environment().Name() {
+	switch c.Environment().EnvironmentName() {
 	case environment.Native:
 		return newNative(c, c.Environment().(*native.Environment))
 	default:
-		return nil, environment.UnsupportedEnvironment(c.Environment().Name())
+		return nil, environment.UnsupportedEnvironment(c.Environment().EnvironmentName())
 	}
 }
 

--- a/pkg/test/framework2/components/galley/native.go
+++ b/pkg/test/framework2/components/galley/native.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/galley/pkg/server"
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
 	"istio.io/istio/pkg/test/framework2/resource"
@@ -73,6 +74,13 @@ type nativeComponent struct {
 	meshConfigFile string
 
 	server *server.Server
+}
+
+var _ resource.Instance = &nativeComponent{}
+
+// FriendlyName implements resource.Instance
+func (c *nativeComponent) FriendlyName() string {
+	return "[Galley(native)]"
 }
 
 // Address of the Galley MCP Server.
@@ -211,15 +219,19 @@ func (c *nativeComponent) restart() error {
 // Close implements io.Closer.
 func (c *nativeComponent) Close() (err error) {
 	if c.client != nil {
+		scopes.Framework.Debugf("%s closing client", c.FriendlyName())
 		err = c.client.Close()
 		c.client = nil
 	}
 	if c.server != nil {
+		scopes.Framework.Debugf("%s closing server", c.FriendlyName())
 		err = multierror.Append(c.server.Close()).ErrorOrNil()
 		if err != nil {
 			scopes.Framework.Infof("Error while Galley server close during reset: %v", err)
 		}
 		c.server = nil
 	}
+
+	scopes.Framework.Debugf("%s close complete (err:%v)", err)
 	return
 }

--- a/pkg/test/framework2/components/istio/istio.go
+++ b/pkg/test/framework2/components/istio/istio.go
@@ -23,10 +23,11 @@ import (
 	"regexp"
 	"strings"
 
+	"istio.io/istio/pkg/test/framework2/components/environment"
+
 	"istio.io/istio/pkg/test"
 	"istio.io/istio/pkg/test/deployment"
 	"istio.io/istio/pkg/test/env"
-	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/framework2/components/environment/kube"
 	"istio.io/istio/pkg/test/framework2/resource"
 	"istio.io/istio/pkg/test/helm"
@@ -63,7 +64,7 @@ func Deploy(context resource.Context) error {
 		}
 	}()
 
-	switch context.Environment().Name() {
+	switch context.Environment().EnvironmentName() {
 	case environment.Kube:
 		s, err := newSettings(context.Settings())
 		if err != nil {
@@ -74,7 +75,7 @@ func Deploy(context resource.Context) error {
 			return err
 		}
 	default:
-		return environment.UnsupportedEnvironment(context.Environment().Name())
+		return environment.UnsupportedEnvironment(context.Environment().EnvironmentName())
 	}
 
 	return nil

--- a/pkg/test/framework2/components/istio/settings.go
+++ b/pkg/test/framework2/components/istio/settings.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
-	"istio.io/istio/pkg/test/framework2/common"
 
+	"istio.io/istio/pkg/test/framework2/common"
 	"istio.io/istio/pkg/test/env"
 
 	kubeCore "k8s.io/api/core/v1"
@@ -105,7 +105,7 @@ type settings struct {
 	// Indicates that the Ingress Gateway is not available. This typically happens in Minikube. The Ingress
 	// component will fall back to node-port in this case.
 	MinikubeIngress bool
-	
+
 	ChartRepo string
 
 	// The top-level Helm chart dir.

--- a/pkg/test/framework2/components/mixer/client.go
+++ b/pkg/test/framework2/components/mixer/client.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"istio.io/istio/pkg/test/framework2/components/environment"
 
 	"google.golang.org/grpc"
 
 	istioMixerV1 "istio.io/api/mixer/v1"
 	"istio.io/istio/mixer/pkg/attribute"
 	"istio.io/istio/mixer/pkg/server"
+	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/kube"
 )
 

--- a/pkg/test/framework2/components/mixer/kube.go
+++ b/pkg/test/framework2/components/mixer/kube.go
@@ -72,7 +72,7 @@ package mixer
 //func (c *kubeComponent) Configure(t testing.TB, scope lifecycle.Scope, contents string) {
 //	contents, err := c.env.Evaluate(contents)
 //	if err != nil {
-//		c.env.DumpState(t.Name())
+//		c.env.DumpState(t.EnvironmentName())
 //		t.Fatalf("Error expanding configuration template: %v", err)
 //	}
 //
@@ -132,7 +132,7 @@ package mixer
 //
 //		options := &testKube.PodSelectOptions{
 //			PodNamespace: pod.Namespace,
-//			PodName:      pod.Name,
+//			PodName:      pod.EnvironmentName,
 //		}
 //		forwarder, err := c.env.NewPortForwarder(options, 0, port)
 //		if err != nil {
@@ -173,7 +173,7 @@ package mixer
 //		return 0, fmt.Errorf("failed to retrieve service %s: %v", serviceType, err)
 //	}
 //	for _, portInfo := range svc.Spec.Ports {
-//		if portInfo.Name == grpcPortName {
+//		if portInfo.EnvironmentName == grpcPortName {
 //			return uint16(portInfo.TargetPort.IntValue()), nil
 //		}
 //	}

--- a/pkg/test/framework2/components/mixer/mixer.go
+++ b/pkg/test/framework2/components/mixer/mixer.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/gogo/googleapis/google/rpc"
+
 	istioMixerV1 "istio.io/api/mixer/v1"
 	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
@@ -49,11 +50,11 @@ func (c *CheckResponse) Succeeded() bool {
 
 // TODO: pass Galley in
 func New(c resource.Context, config *Config) (Instance, error) {
-	switch c.Environment().Name() {
+	switch c.Environment().EnvironmentName() {
 	case environment.Native:
 		return newNative(c, c.Environment().(*native.Environment), config)
 	default:
-		return nil, environment.UnsupportedEnvironment(c.Environment().Name())
+		return nil, environment.UnsupportedEnvironment(c.Environment().EnvironmentName())
 	}
 }
 

--- a/pkg/test/framework2/components/pilot/instance.go
+++ b/pkg/test/framework2/components/pilot/instance.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
 	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
 	"istio.io/istio/pkg/test/framework2/components/galley"
@@ -42,11 +43,11 @@ type Config struct {
 
 // New returns a new Galley instance.
 func New(c resource.Context, config *Config) (Instance, error) {
-	switch c.Environment().Name() {
+	switch c.Environment().EnvironmentName() {
 	case environment.Native:
 		return newNative(c, c.Environment().(*native.Environment), config)
 	default:
-		return nil, environment.UnsupportedEnvironment(c.Environment().Name())
+		return nil, environment.UnsupportedEnvironment(c.Environment().EnvironmentName())
 	}
 }
 

--- a/pkg/test/framework2/components/pilot/native.go
+++ b/pkg/test/framework2/components/pilot/native.go
@@ -30,6 +30,7 @@ import (
 
 var _ Instance = &nativeComponent{}
 var _ io.Closer = &nativeComponent{}
+var _ resource.Instance = &nativeComponent{}
 
 // NewNativeComponent factory function for the component
 func newNative(s resource.Context, e *native.Environment, config *Config) (Instance, error) {
@@ -38,6 +39,8 @@ func newNative(s resource.Context, e *native.Environment, config *Config) (Insta
 		stopChan:    make(chan struct{}),
 		config:      config,
 	}
+
+	s.TrackResource(instance)
 	return instance, instance.Start()
 }
 
@@ -48,6 +51,11 @@ type nativeComponent struct {
 	server   *bootstrap.Server
 	stopChan chan struct{}
 	config   *Config
+}
+
+// FriendlyName implements resource.Instance
+func (c *nativeComponent) FriendlyName() string {
+	return "[Pilot(native)]"
 }
 
 func (c *nativeComponent) Start() (err error) {

--- a/pkg/test/framework2/components/policybackend/client.go
+++ b/pkg/test/framework2/components/policybackend/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+
 	"istio.io/istio/pkg/test/fakes/policy"
 	"istio.io/istio/pkg/test/util/retry"
 )

--- a/pkg/test/framework2/components/policybackend/kube.go
+++ b/pkg/test/framework2/components/policybackend/kube.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/pkg/test/framework2/resource"
 
 	"istio.io/istio/pkg/test/deployment"
@@ -88,8 +89,8 @@ func newKube() (Instance, error) {
 type kubeComponent struct {
 	*client
 
-	kubeEnv    *kube.Environment
-	namespace  *kube.Namespace
+	kubeEnv   *kube.Environment
+	namespace *kube.Namespace
 
 	forwarder  testKube.PortForwarder
 	deployment *deployment.Instance

--- a/pkg/test/framework2/components/policybackend/native.go
+++ b/pkg/test/framework2/components/policybackend/native.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
 	"istio.io/istio/pkg/test/framework2/resource"
 

--- a/pkg/test/framework2/components/policybackend/policybackend.go
+++ b/pkg/test/framework2/components/policybackend/policybackend.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
+
 	"istio.io/istio/pkg/test/framework2/components/environment"
 	"istio.io/istio/pkg/test/framework2/components/environment/native"
 	"istio.io/istio/pkg/test/framework2/resource"
@@ -43,11 +44,11 @@ type Instance interface {
 }
 
 func New(s resource.Context) (Instance, error) {
-	switch s.Environment().Name() {
+	switch s.Environment().EnvironmentName() {
 	case environment.Native:
 		return newNative(s, s.Environment().(*native.Environment))
 	default:
-		return nil, environment.UnsupportedEnvironment(s.Environment().Name())
+		return nil, environment.UnsupportedEnvironment(s.Environment().EnvironmentName())
 	}
 }
 

--- a/pkg/test/framework2/operations.go
+++ b/pkg/test/framework2/operations.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
 	"istio.io/istio/pkg/test/framework2/common"
 	"istio.io/istio/pkg/test/framework2/components/environment/factory"
 	"istio.io/istio/pkg/test/framework2/runtime"

--- a/pkg/test/framework2/resource/context.go
+++ b/pkg/test/framework2/resource/context.go
@@ -23,7 +23,7 @@ import (
 type Context interface {
 	// TrackResource tracks a resource in this context. If the context is closed, then the resource will be
 	// cleaned up.
-	TrackResource(r interface{})
+	TrackResource(r Instance)
 
 	// The Environment in which the tests run
 	Environment() environment.Instance

--- a/pkg/test/framework2/resource/instance.go
+++ b/pkg/test/framework2/resource/instance.go
@@ -1,0 +1,22 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+// Instance of a resource.
+type Instance interface {
+
+	// Friendly name of the resource.
+	FriendlyName() string
+}

--- a/pkg/test/framework2/resource/resetter.go
+++ b/pkg/test/framework2/resource/resetter.go
@@ -18,4 +18,3 @@ package resource
 type Resetter interface {
 	Reset() error
 }
-

--- a/pkg/test/framework2/runtime/suitecontext.go
+++ b/pkg/test/framework2/runtime/suitecontext.go
@@ -40,7 +40,7 @@ type SuiteContext struct {
 var _ resource.Context = &SuiteContext{}
 
 func newSuiteContext(s *common.Settings, envFn environment.FactoryFn) (*SuiteContext, error) {
-	scopeID := fmt.Sprint("[suite(%s)]", s.TestID)
+	scopeID := fmt.Sprintf("[suite(%s)]", s.TestID)
 
 	c := &SuiteContext{
 		settings:    s,

--- a/tests/integration/galley/validation/validation_test.go
+++ b/tests/integration/galley/validation/validation_test.go
@@ -118,5 +118,6 @@ func TestMain(m *testing.M) {
 }
 
 func setup(s *runtime.SuiteContext) error {
+	// TODO: WE should do a require check at the framework level.
 	return istio.Deploy(s)
 }

--- a/tests/integration2/pilot/sidecar_api_test.go
+++ b/tests/integration2/pilot/sidecar_api_test.go
@@ -13,16 +13,13 @@ import (
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
 	"istio.io/istio/pilot/pkg/model"
-	"istio.io/istio/pkg/log"
-	"istio.io/istio/pkg/test/scopes"
 	"istio.io/istio/pkg/test/util/structpath"
 )
 
 func TestSidecarListeners(t *testing.T) {
 	// Call Requires to explicitly initialize dependencies that the test needs.
 	ctx := framework2.NewContext(t)
-	// TODO - remove prior to checkin
-	scopes.Framework.SetOutputLevel(log.DebugLevel)
+	defer ctx.Done(t)
 
 	// TODO: Limit to Native environment until the Kubernetes environment is supported in the Galley
 	// component
@@ -53,7 +50,7 @@ func TestSidecarListeners(t *testing.T) {
 	}
 
 	// Test the empty case where no config is loaded
-	err = pilotInst.WatchDiscovery(time.Second*10,
+	err = pilotInst.WatchDiscovery(time.Second*30,
 		func(response *xdsapi.DiscoveryResponse) (b bool, e error) {
 			validator := structpath.AssertThatProto(t, response)
 			if !validator.Accept("{.resources[?(@.address.socketAddress.portValue==%v)]}", 15001) {
@@ -77,7 +74,7 @@ func TestSidecarListeners(t *testing.T) {
 	}
 
 	// Now continue to watch on the same stream
-	err = pilotInst.WatchDiscovery(time.Second*10,
+	err = pilotInst.WatchDiscovery(time.Second*30,
 		func(response *xdsapi.DiscoveryResponse) (b bool, e error) {
 			validator := structpath.AssertThatProto(t, response)
 			if !validator.Accept("{.resources[?(@.address.socketAddress.portValue==27018)]}") {


### PR DESCRIPTION
- Add defer context.Done() to sidecar_api_test for resource cleanup.
- Ensure that Pilot's Close returns after the background go-routine is torn down.
- Properly register components/resources for cleanup purposes.
- Reverse the resource cleanup loop to make sure resource dependencies are
handled properly.
- Add friendly ids to test framework components to help with debugging.
- Refactor environment names to avoid cyclic dependencies.