### PR TITLE
add export to for istio components

### DIFF
--- a/install/kubernetes/global-default-sidecar-scope.yaml
+++ b/install/kubernetes/global-default-sidecar-scope.yaml
@@ -17,4 +17,5 @@ spec:
     - "./*"
     - "istio-system/istio-telemetry.istio-system.svc.cluster.local"
     - "istio-system/istio-policy.istio-system.svc.cluster.local"
+    - "istio-system/tracing.istio-system.svc.cluster.local"
 ---

--- a/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/service.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     istio: galley
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   ports:
   - port: 443

--- a/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
   annotations:
+    networking.istio.io/exportTo: "."    
     {{- range $key, $val := .Values.service.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}

--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ template "istiocoredns.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   selector:
     app: istiocoredns

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ template "kiali.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/service.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     istio: pilot
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   ports:
   - port: 15010

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     prometheus.io/scrape: 'true'
+    networking.istio.io/exportTo: "."
     {{- range $key, $val := .Values.service.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}

--- a/install/kubernetes/helm/istio/charts/security/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/service.yaml
@@ -11,6 +11,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     istio: citadel
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   ports:
     - name: grpc-citadel

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: servicegraph
   namespace: {{ .Release.Namespace }}
   annotations:
+    networking.istio.io/exportTo: "."
     {{- range $key, $val := .Values.service.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/service.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
     istio: sidecar-injector
+  annotations:
+    networking.istio.io/exportTo: "."
 spec:
   ports:
   - port: 443

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-    networking.istio.io/exportTo: "."
+    networking.istio.io/exportTo: "*"
 items:
 - apiVersion: v1
   kind: Service

--- a/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/service.yaml
@@ -8,6 +8,8 @@ metadata:
     chart: {{ template "tracing.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    networking.istio.io/exportTo: "."
 items:
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
in case global-default-sidecar-scope.yaml  is applied.

I didn't touch the ingress gateway services.  I'd imagine it needs to be global scoped?