### PR TITLE
Disable "xDS marshalling to Any" feature.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/envoyfilter.go
@@ -78,7 +78,7 @@ func insertUserFilters(in *plugin.InputParams, listener *xdsapi.Listener,
 				// http listener, http filter case
 				if f.FilterType == networking.EnvoyFilter_Filter_HTTP {
 					// Insert into http connection manager
-					insertHTTPFilter(listener.Name, &listener.FilterChains[cnum], httpConnectionManagers[cnum], f, util.IsProxyVersionGE11(in.Node))
+					insertHTTPFilter(listener.Name, &listener.FilterChains[cnum], httpConnectionManagers[cnum], f, util.IsXDSMarshalingToAnyEnabled(in.Node))
 				} else {
 					// http listener, tcp filter
 					insertNetworkFilter(listener.Name, &listener.FilterChains[cnum], f)
@@ -220,7 +220,7 @@ func listenerMatch(in *plugin.InputParams, listenerIP net.IP,
 }
 
 func insertHTTPFilter(listenerName string, filterChain *listener.FilterChain, hcm *http_conn.HttpConnectionManager,
-	envoyFilter *networking.EnvoyFilter_Filter, is11 bool) {
+	envoyFilter *networking.EnvoyFilter_Filter, isXDSMarshalingToAnyEnabled bool) {
 	filter := &http_conn.HttpFilter{
 		Name:       envoyFilter.FilterName,
 		ConfigType: &http_conn.HttpFilter_Config{Config: envoyFilter.FilterConfig},
@@ -264,7 +264,7 @@ func insertHTTPFilter(listenerName string, filterChain *listener.FilterChain, hc
 	filterStruct := listener.Filter{
 		Name: xdsutil.HTTPConnectionManager,
 	}
-	if is11 {
+	if isXDSMarshalingToAnyEnabled {
 		filterStruct.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(hcm)}
 	} else {
 		filterStruct.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(hcm)}

--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -212,7 +212,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarListeners(env *model.Environme
 			Name: xdsutil.TCPProxy,
 		}
 
-		if util.IsProxyVersionGE11(node) {
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(tcpProxy)}
 		} else {
 			filter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(tcpProxy)}
@@ -1426,7 +1426,7 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 			Name: xdsutil.FileAccessLog,
 		}
 
-		if util.IsProxyVersionGE11(node) {
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			buildAccessLog(fl, env)
 			acc.ConfigType = &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(fl)}
 		} else {
@@ -1592,7 +1592,7 @@ func buildCompleteFilterChain(pluginParams *plugin.InputParams, mutable *plugin.
 				filter := listener.Filter{
 					Name: xdsutil.HTTPConnectionManager,
 				}
-				if util.IsProxyVersionGE11(pluginParams.Node) {
+				if util.IsXDSMarshalingToAnyEnabled(pluginParams.Node) {
 					filter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(httpConnectionManagers[i])}
 				} else {
 					filter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(httpConnectionManagers[i])}

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -54,7 +54,7 @@ func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, co
 		acc := &accesslog.AccessLog{
 			Name: xdsutil.FileAccessLog,
 		}
-		if util.IsProxyVersionGE11(node) {
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			buildAccessLog(fl, env)
 			acc.ConfigType = &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(fl)}
 		} else {
@@ -68,7 +68,7 @@ func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, co
 	tcpFilter := &listener.Filter{
 		Name: xdsutil.TCPProxy,
 	}
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		tcpFilter.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		tcpFilter.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}
@@ -154,7 +154,7 @@ func buildOutboundNetworkFilters(env *model.Environment, node *model.Proxy,
 }
 
 // buildMongoFilter builds an outbound Envoy MongoProxy filter.
-func buildMongoFilter(statPrefix string, is11 bool) listener.Filter {
+func buildMongoFilter(statPrefix string, isXDSMarshalingToAnyEnabled bool) listener.Filter {
 	// TODO: add a watcher for /var/lib/istio/mongo/certs
 	// if certs are found use, TLS or mTLS clusters for talking to MongoDB.
 	// User is responsible for mounting those certs in the pod.
@@ -166,7 +166,7 @@ func buildMongoFilter(statPrefix string, is11 bool) listener.Filter {
 	out := listener.Filter{
 		Name: xdsutil.MongoProxy,
 	}
-	if is11 {
+	if isXDSMarshalingToAnyEnabled {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}
@@ -191,7 +191,7 @@ func buildOutboundAutoPassthroughFilterStack(env *model.Environment, node *model
 }
 
 // buildMySQLFilter builds an outbound Envoy MySQLProxy filter.
-func buildMySQLFilter(statPrefix string, is11 bool) listener.Filter {
+func buildMySQLFilter(statPrefix string, isXDSMarshalingToAnyEnabled bool) listener.Filter {
 	config := &mysql_proxy.MySQLProxy{
 		StatPrefix: statPrefix, // MySQL stats are prefixed with mysql.<statPrefix> by Envoy.
 	}
@@ -200,7 +200,7 @@ func buildMySQLFilter(statPrefix string, is11 bool) listener.Filter {
 		Name: xdsutil.MySQLProxy,
 	}
 
-	if is11 {
+	if isXDSMarshalingToAnyEnabled {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}

--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -323,7 +323,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		Metadata: util.BuildConfigInfoMetadata(virtualService.ConfigMeta),
 	}
 
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		out.TypedPerFilterConfig = make(map[string]*types.Any)
 	} else {
 		out.PerFilterConfig = make(map[string]*types.Struct)
@@ -459,7 +459,7 @@ func translateRoute(push *model.PushContext, node *model.Proxy, in *networking.H
 		Operation: getRouteOperation(out, virtualService.Name, port),
 	}
 	if fault := in.Fault; fault != nil {
-		if util.IsProxyVersionGE11(node) {
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			out.TypedPerFilterConfig[xdsutil.Fault] = util.MessageToAny(translateFault(node, in.Fault))
 		} else {
 			out.PerFilterConfig[xdsutil.Fault] = util.MessageToStruct(translateFault(node, in.Fault))

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -228,7 +228,7 @@ func (mixerplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConf
 	if in.Env.Mesh.MixerCheckServer == "" && in.Env.Mesh.MixerReportServer == "" {
 		return
 	}
-	is11 := util.IsProxyVersionGE11(in.Node)
+	isXDSMarshalingToAnyEnabled := util.IsXDSMarshalingToAnyEnabled(in.Node)
 	switch in.ListenerProtocol {
 	case plugin.ListenerProtocolHTTP:
 		// copy structs in place
@@ -236,7 +236,7 @@ func (mixerplugin) OnInboundRouteConfiguration(in *plugin.InputParams, routeConf
 			host := routeConfiguration.VirtualHosts[i]
 			for j := 0; j < len(host.Routes); j++ {
 				route := host.Routes[j]
-				if is11 {
+				if isXDSMarshalingToAnyEnabled {
 					route.TypedPerFilterConfig = addTypedServiceConfig(route.TypedPerFilterConfig, buildInboundRouteConfig(in.Push, in, in.ServiceInstance))
 				} else {
 					route.PerFilterConfig = addServiceConfig(route.PerFilterConfig, buildInboundRouteConfig(in.Push, in, in.ServiceInstance))
@@ -345,7 +345,7 @@ func buildOutboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node
 		Name: mixer,
 	}
 
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		out.ConfigType = &http_conn.HttpFilter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &http_conn.HttpFilter_Config{Config: util.MessageToStruct(config)}
@@ -369,7 +369,7 @@ func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node 
 		Name: mixer,
 	}
 
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		out.ConfigType = &http_conn.HttpFilter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &http_conn.HttpFilter_Config{Config: util.MessageToStruct(config)}
@@ -379,10 +379,10 @@ func buildInboundHTTPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node 
 }
 
 func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, httpRoute route.Route) route.Route {
-	is11 := util.IsProxyVersionGE11(in.Node)
+	isXDSMarshalingToAnyEnabled := util.IsXDSMarshalingToAnyEnabled(in.Node)
 
 	// default config, to be overridden by per-weighted cluster
-	if is11 {
+	if isXDSMarshalingToAnyEnabled {
 		httpRoute.TypedPerFilterConfig = addTypedServiceConfig(httpRoute.TypedPerFilterConfig, &mccpb.ServiceConfig{
 			DisableCheckCalls: disablePolicyChecks(outbound, in.Env.Mesh, in.Node),
 		})
@@ -397,7 +397,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 		case *route.RouteAction_Cluster:
 			_, _, hostname, _ := model.ParseSubsetKey(upstreams.Cluster)
 			attrs := addDestinationServiceAttributes(make(attributes), push, hostname)
-			if is11 {
+			if isXDSMarshalingToAnyEnabled {
 				httpRoute.TypedPerFilterConfig = addTypedServiceConfig(httpRoute.TypedPerFilterConfig, &mccpb.ServiceConfig{
 					DisableCheckCalls: disablePolicyChecks(outbound, in.Env.Mesh, in.Node),
 					MixerAttributes:   &mpb.Attributes{Attributes: attrs},
@@ -415,7 +415,7 @@ func modifyOutboundRouteConfig(push *model.PushContext, in *plugin.InputParams, 
 			for _, weighted := range upstreams.WeightedClusters.Clusters {
 				_, _, hostname, _ := model.ParseSubsetKey(weighted.Name)
 				attrs := addDestinationServiceAttributes(make(attributes), push, hostname)
-				if is11 {
+				if isXDSMarshalingToAnyEnabled {
 					weighted.TypedPerFilterConfig = addTypedServiceConfig(weighted.TypedPerFilterConfig, &mccpb.ServiceConfig{
 						DisableCheckCalls: disablePolicyChecks(outbound, in.Env.Mesh, in.Node),
 						MixerAttributes:   &mpb.Attributes{Attributes: attrs},
@@ -482,7 +482,7 @@ func buildOutboundTCPFilter(mesh *meshconfig.MeshConfig, attrsIn attributes, nod
 		Name: mixer,
 	}
 
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}
@@ -501,7 +501,7 @@ func buildInboundTCPFilter(mesh *meshconfig.MeshConfig, attrs attributes, node *
 		Name: mixer,
 	}
 
-	if util.IsProxyVersionGE11(node) {
+	if util.IsXDSMarshalingToAnyEnabled(node) {
 		out.ConfigType = &listener.Filter_TypedConfig{TypedConfig: util.MessageToAny(config)}
 	} else {
 		out.ConfigType = &listener.Filter_Config{Config: util.MessageToStruct(config)}

--- a/pilot/pkg/networking/util/util.go
+++ b/pilot/pkg/networking/util/util.go
@@ -35,6 +35,7 @@ import (
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/log"
 )
 
@@ -244,6 +245,11 @@ func SortVirtualHosts(hosts []route.VirtualHost) {
 func IsProxyVersionGE11(node *model.Proxy) bool {
 	ver, _ := node.GetProxyVersion()
 	return ver >= "1.1"
+}
+
+// IsXDSMarshalingToAnyEnabled controls whether "marshaling to Any" feature is enabled.
+func IsXDSMarshalingToAnyEnabled(node *model.Proxy) bool {
+	return IsProxyVersionGE11(node) && !pilot.DisableXDSMarshalingToAny()
 }
 
 // ResolveHostsInNetworksConfig will go through the Gateways addresses for all

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -131,6 +131,11 @@ var (
 	// EnableWaitCacheSync provides an option to specify whether it should wait
 	// for cache sync before Pilot bootstrap. Set env PILOT_ENABLE_WAIT_CACHE_SYNC = 0 to disable it.
 	EnableWaitCacheSync = os.Getenv("PILOT_ENABLE_WAIT_CACHE_SYNC") != "0"
+
+	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
+	DisableXDSMarshalingToAny = func() bool {
+		return len(os.Getenv("PILOT_DISABLE_XDS_MARSHALING_TO_ANY")) != 0
+	}
 )
 
 var (


### PR DESCRIPTION
Introducing a separate feature flag for "xDS marshalling to Any" feature and setting it to 'off' by default due to a regression found last minute that may be a 1.1 release blocker.

A bit of context: we have recently discovered that Envoy is not ignoring identical xDS pushes from Pilot which results in listeners/clusters being re-initialized and connections drained upon every xDS push from Pilot. There are two independent issues causing this:
1. A new feature was introduced on the Pilot side that changed how Pilot marshals xDS messages moving from typed structures to the use of Any: https://github.com/istio/istio/pull/11419
2. Envoy relies on stable hashing to tell if the newly pushed configuration is identical. However that hashing logic apparently is not stable for structures using Any. Here's one of related Envoy issues: https://github.com/envoyproxy/envoy/issues/6252

As a least regression-prone option the proposal is to disable "xDS marshalling to Any" feature for 1.1 release and re-enable it once we're ready to pull the most recent Envoy fixes.