### PR TITLE
merge top-level trafficPolicy should ignore null

### DIFF
--- a/pilot/pkg/model/destination_rule.go
+++ b/pilot/pkg/model/destination_rule.go
@@ -44,12 +44,11 @@ func (ps *PushContext) combineSingleDestinationRule(
 					fmt.Sprintf("Duplicate subset %s found while merging destination rules for %s",
 						subset.Name, string(resolvedHost)))
 			}
-
-			// If there is no top level policy and the incoming rule has top level
-			// traffic policy, use the one from the incoming rule.
-			if combinedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
-				combinedRule.TrafficPolicy = rule.TrafficPolicy
-			}
+		}
+		// If there is no top level policy and the incoming rule has top level
+		// traffic policy, use the one from the incoming rule.
+		if combinedRule.TrafficPolicy == nil && rule.TrafficPolicy != nil {
+			combinedRule.TrafficPolicy = rule.TrafficPolicy
 		}
 		return combinedDestRuleHosts, combinedDestRuleMap
 	}


### PR DESCRIPTION
I defined two same host destinationRules without subset:
 ```
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:

  name: httpbin-1
spec:
  host: httpbin
---
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: httpbin-2
spec:
  host: httpbin
  trafficPolicy:
    loadBalancer:
      simple: LEAST_CONN
```
expected the combined top-level cluster's  loadBalancer trafficPolicy is LEAST_CONN， but actual loadBalancer is null
```
 dzdx@macbook  ~/Documents/istio/pilot_debug  istioctl pc cluster sleep-68648fd5b5-b4k92 --fqdn httpbin.default.svc.cluster.local -o json
[
    {
        "name": "outbound|8000||httpbin.default.svc.cluster.local",
        "type": "EDS",
        "edsClusterConfig": {
            "edsConfig": {
                "ads": {}
            },
            "serviceName": "outbound|8000||httpbin.default.svc.cluster.local"
        },
        "connectTimeout": "1.000s",
        "circuitBreakers": {
            "thresholds": [
                {}
            ]
        }
    }
```

then, I add a subset to second destintionRule。the  combined top-level cluster's  loadbalancer policy is LEAST_CONN

```
apiVersion: networking.istio.io/v1alpha3
kind: DestinationRule
metadata:
  name: httpbin-2
spec:
  host: httpbin
  trafficPolicy:
    loadBalancer:
      simple: LEAST_CONN
  subsets:
  - name: "a"
    labels: {}
```
```
 dzdx@macbook  ~/Desktop  istioctl pc cluster sleep-68648fd5b5-b4k92 --fqdn httpbin.default.svc.cluster.local -o json
[
    {
        "name": "outbound|8000||httpbin.default.svc.cluster.local",
        "type": "EDS",
        "edsClusterConfig": {
            "edsConfig": {
                "ads": {}
            },
            "serviceName": "outbound|8000||httpbin.default.svc.cluster.local"
        },
        "connectTimeout": "1.000s",
        "lbPolicy": "LEAST_REQUEST",
        "circuitBreakers": {
            "thresholds": [
                {}
            ]
        }
    },
```

I expect that regardless of whether a destinationRule has a subset,  their trafficPolicy items can be merged in a way that ignores null