### PR TITLE
add missing .pb.go to list of generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.descriptor_set  linguist-generated=true
 *.descriptor_set  -diff -merge
 *.pb.html linguist-generated=true
+*.pb.go linguist-generated=true


### PR DESCRIPTION
Generated files listed in `.gitattributes` included only `.pb.html`