### PR TITLE
locally running address resolution test can fail

### DIFF
--- a/pilot/pkg/proxy/resolve.go
+++ b/pilot/pkg/proxy/resolve.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"istio.io/istio/pkg/log"
 )
 

--- a/pilot/pkg/proxy/resolve.go
+++ b/pilot/pkg/proxy/resolve.go
@@ -16,17 +16,18 @@ package proxy
 
 import (
 	"context"
-	"errors"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"time"
 
+	"github.com/pkg/errors"
 	"istio.io/istio/pkg/log"
 )
 
 // ErrResolveNoAddress error occurs when IP address resolution is attempted,
 // but no address was provided.
-var ErrResolveNoAddress = errors.New("no address specified")
+var ErrResolveNoAddress = stderrors.New("no address specified")
 
 // ResolveAddr resolves an authority address to an IP address. Incoming
 // addr can be an IP address or hostname. If addr is an IPv6 address, the IP
@@ -54,7 +55,7 @@ func ResolveAddr(addr string) (string, error) {
 	defer cancel()
 	addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if lookupErr != nil || len(addrs) == 0 {
-		return "", fmt.Errorf("lookup failed for IP address: %v", lookupErr)
+		return "", errors.WithMessage(lookupErr, "lookup failed for IP address")
 	}
 	var resolvedAddr string
 	ip := addrs[0].IP

--- a/pilot/pkg/proxy/resolve_test.go
+++ b/pilot/pkg/proxy/resolve_test.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -119,6 +120,10 @@ func TestResolveAddr(t *testing.T) {
 			if tc.errStr == "" {
 				t.Errorf("[%s] expected success, but saw error: %v", tc.name, err)
 			} else if err.Error() != tc.errStr {
+				if strings.Contains(err.Error(), "Temporary failure in name resolution") {
+					t.Logf("[%s] expected error %q, got %q", tc.name, tc.errStr, err.Error())
+					continue
+				}
 				t.Errorf("[%s] expected error %q, got %q", tc.name, tc.errStr, err.Error())
 			}
 		} else {


### PR DESCRIPTION
… with different message than on Travis and Prow.

Name resolution for bad IPv6 address can fail with "Temporary failure in name resolution".
Due to the use of host based DNS resolution (netdns set to cgo by default), we can't fully introspect the error to detect net.DNSError.Temporary()

- add cause error to returned error from ResolveAddress()
- ignore tests failure that include a "Temporary failure..." message