### PR TITLE
Export inject.injectionData()

### DIFF
--- a/pilot/pkg/kube/inject/inject.go
+++ b/pilot/pkg/kube/inject/inject.go
@@ -494,7 +494,7 @@ func directory(filepath string) string {
 	return dir
 }
 
-func injectionData(sidecarTemplate, version string, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec,
+func InjectionData(sidecarTemplate, version string, deploymentMetadata *metav1.ObjectMeta, spec *corev1.PodSpec,
 	metadata *metav1.ObjectMeta, proxyConfig *meshconfig.ProxyConfig, meshConfig *meshconfig.MeshConfig) (
 	*SidecarInjectionSpec, string, error) { // nolint: lll
 	if err := validateAnnotations(metadata.GetAnnotations()); err != nil {
@@ -696,7 +696,7 @@ func intoObject(sidecarTemplate string, meshconfig *meshconfig.MeshConfig, in ru
 		return out, nil
 	}
 
-	spec, status, err := injectionData(
+	spec, status, err := InjectionData(
 		sidecarTemplate,
 		sidecarTemplateVersionHash(sidecarTemplate),
 		deploymentMetadata,

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -559,7 +559,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		}
 	}
 
-	spec, status, err := injectionData(wh.sidecarConfig.Template, wh.sidecarTemplateVersion, &pod.ObjectMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig.DefaultConfig, wh.meshConfig) // nolint: lll
+	spec, status, err := InjectionData(wh.sidecarConfig.Template, wh.sidecarTemplateVersion, &pod.ObjectMeta, &pod.Spec, &pod.ObjectMeta, wh.meshConfig.DefaultConfig, wh.meshConfig) // nolint: lll
 	if err != nil {
 		log.Infof("Injection data: err=%v spec=%v\n", err, status)
 		return toAdmissionResponse(err)


### PR DESCRIPTION
By exporting the function we make it possible to import pilog/pkg/kube/inject and perform the sidecar injection without using the mutating webhook or istioctl injection. 