### PR TITLE
mixer: eliminate auto conversion to duration

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -263,7 +263,7 @@ spec:
     requestSize: request.size | 0
     requestId: request.headers["x-request-id"] | ""
     clientTraceId: request.headers["x-client-trace-id"] | ""
-    latency: response.duration | "0ms"
+    latency: response.duration | duration("0ms")
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
     requestedServerName: connection.requested_server_name | ""
     userAgent: request.useragent | ""
@@ -309,7 +309,7 @@ spec:
     destinationOwner: destination.owner | ""
     destinationPrincipal: destination.principal | ""
     protocol: context.protocol | "tcp"
-    connectionDuration: connection.duration | "0ms"
+    connectionDuration: connection.duration | duration("0ms")
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
     requestedServerName: connection.requested_server_name | ""
     receivedBytes: connection.received.bytes | 0
@@ -402,7 +402,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-  value: response.duration | "0ms"
+  value: response.duration | duration("0ms")
   dimensions:
     reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source", "destination")
     source_workload: source.workload.name | "unknown"

--- a/mixer/pkg/il/testing/tests.go
+++ b/mixer/pkg/il/testing/tests.go
@@ -2615,7 +2615,13 @@ fn eval() duration
 end`,
 	},
 	{
-		E:    `adur | "19ms"`,
+		E:    `duration("19ms")`,
+		Type: descriptor.DURATION,
+		I:    map[string]interface{}{},
+		R:    duration19,
+	},
+	{
+		E:    `adur | duration("19ms")`,
 		Type: descriptor.DURATION,
 		I:    map[string]interface{}{},
 		R:    duration19,
@@ -2625,13 +2631,14 @@ end`,
 fn eval() duration
   tresolve_i "adur"
   jnz L0
-  apush_i 19000000
+  apush_s "19ms"
+  call duration
 L0:
   ret
 end`,
 	},
 	{
-		E:    `adur | "19ms"`,
+		E:    `adur | duration("19ms")`,
 		Type: descriptor.DURATION,
 		I: map[string]interface{}{
 			"adur": duration20,

--- a/mixer/pkg/lang/ast/expr.go
+++ b/mixer/pkg/lang/ast/expr.go
@@ -21,7 +21,6 @@ import (
 	"go/token"
 	"strconv"
 	"strings"
-	"time"
 
 	cfgpb "istio.io/api/policy/v1beta1"
 	dpb "istio.io/api/policy/v1beta1"
@@ -142,10 +141,13 @@ func newConstant(v string, vType dpb.ValueType) (*Constant, error) {
 		if unquoted, err = strconv.Unquote(v); err != nil {
 			return nil, err
 		}
-		if typedVal, err = time.ParseDuration(unquoted); err == nil {
-			vType = dpb.DURATION
-			break
-		}
+		// TODO: this is a breaking change as it changes how parsing is done but is necessary
+		/*
+			if typedVal, err = time.ParseDuration(unquoted); err == nil {
+				vType = dpb.DURATION
+				break
+			}
+		*/
 		// TODO: add support for other dpb ValueTypes serialized
 		// as string
 		typedVal = unquoted

--- a/mixer/pkg/lang/externs.go
+++ b/mixer/pkg/lang/externs.go
@@ -42,6 +42,7 @@ var Externs = map[string]interpreter.Extern{
 	"timestamp_le":      interpreter.ExternFromFn("timestamp_le", externTimestampLe),
 	"timestamp_gt":      interpreter.ExternFromFn("timestamp_gt", externTimestampGt),
 	"timestamp_ge":      interpreter.ExternFromFn("timestamp_ge", externTimestampGe),
+	"duration":          interpreter.ExternFromFn("duration", externDuration),
 	"dnsName":           interpreter.ExternFromFn("dnsName", ExternDNSName),
 	"dnsName_equal":     interpreter.ExternFromFn("dnsName_equal", ExternDNSNameEqual),
 	"email":             interpreter.ExternFromFn("email", ExternEmail),
@@ -67,6 +68,11 @@ var ExternFunctionMetadata = []ast.FunctionMetadata{
 	{
 		Name:          "timestamp",
 		ReturnType:    config.TIMESTAMP,
+		ArgumentTypes: []config.ValueType{config.STRING},
+	},
+	{
+		Name:          "duration",
+		ReturnType:    config.DURATION,
 		ArgumentTypes: []config.ValueType{config.STRING},
 	},
 	{
@@ -170,6 +176,14 @@ func externTimestampGt(t1 time.Time, t2 time.Time) bool {
 
 func externTimestampGe(t1 time.Time, t2 time.Time) bool {
 	return t1 == t2 || t2.Before(t1)
+}
+
+func externDuration(in string) (time.Duration, error) {
+	d, err := time.ParseDuration(in)
+	if err != nil {
+		return 0, fmt.Errorf("could not convert %q to DURATION", in)
+	}
+	return d, nil
 }
 
 // This IDNA profile is for performing validations, but does not otherwise modify the string.

--- a/mixer/pkg/lang/externs_test.go
+++ b/mixer/pkg/lang/externs_test.go
@@ -73,7 +73,7 @@ func TestExternDuration(t *testing.T) {
 		t.Fatalf("unexpected duration: %v", d)
 	}
 
-	d, err = externDuration("asdf")
+	_, err = externDuration("asdf")
 	if err == nil {
 		t.Fatalf("expected error for duration")
 	}

--- a/mixer/pkg/lang/externs_test.go
+++ b/mixer/pkg/lang/externs_test.go
@@ -64,6 +64,21 @@ func TestExternTimestamp(t *testing.T) {
 	}
 }
 
+func TestExternDuration(t *testing.T) {
+	d, err := externDuration("1m")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d != time.Minute {
+		t.Fatalf("unexpected duration: %v", d)
+	}
+
+	d, err = externDuration("asdf")
+	if err == nil {
+		t.Fatalf("expected error for duration")
+	}
+}
+
 func TestExternTimestamp_Error(t *testing.T) {
 	_, err := externTimestamp("AAA")
 	if err == nil {

--- a/mixer/testdata/config/accesslog.yaml
+++ b/mixer/testdata/config/accesslog.yaml
@@ -45,7 +45,7 @@ spec:
     requestSize: request.size | 0
     requestId: request.headers["x-request-id"] | ""
     clientTraceId: request.headers["x-client-trace-id"] | ""
-    latency: response.duration | "0ms"
+    latency: response.duration | duration("0ms")
     connectionMtls: connection.mtls | false
     requestedServerName: connection.requested_server_name | ""
     userAgent: request.useragent | ""

--- a/mixer/testdata/config/metrics.yaml
+++ b/mixer/testdata/config/metrics.yaml
@@ -33,7 +33,7 @@ metadata:
   name: requestduration
   namespace: istio-system
 spec:
-  value: response.duration | "0ms"
+  value: response.duration | duration("0ms")
   dimensions:
     reporter: conditional((context.reporter.kind | "inbound") == "outbound", "client", "server")
     source_namespace: source.namespace | "unknown"

--- a/mixer/testdata/config/tcp_accesslog.yaml
+++ b/mixer/testdata/config/tcp_accesslog.yaml
@@ -24,7 +24,7 @@ spec:
     destinationOwner: destination.owner | ""
     destinationPrincipal: destination.principal | ""
     protocol: context.protocol | "tcp"
-    connectionDuration: connection.duration | "0ms"
+    connectionDuration: connection.duration | duration("0ms")
     connectionMtls: connection.mtls | false
     requestedServerName: connection.requested_server_name | ""
     receivedBytes: connection.received.bytes | 0


### PR DESCRIPTION
Remove auto-conversion from "1m" to 1 * time.Minute in CEXL parsing.
The old behavior is problematic since it disallows string literal constants that are also durations, e.g. `"1m"`. Adds an extern to convert from a string to a duration explicitly.

/assign @bianpengyuan 
/assign @mandarjog 

Signed-off-by: Kuat Yessenov <kuat@google.com>