### PR TITLE
enable egressgateway in multicluster deployment.

### DIFF
--- a/install/kubernetes/helm/istio/example-values/values-istio-multicluster-gateways.yaml
+++ b/install/kubernetes/helm/istio/example-values/values-istio-multicluster-gateways.yaml
@@ -21,6 +21,7 @@ istiocoredns:
 
 gateways:
   istio-egressgateway:
+    enabled: true
     env:
       # Needed to route traffic via egress gateway if desired.
       ISTIO_META_REQUESTED_NETWORK_VIEW: "external"


### PR DESCRIPTION
The egress gateway is by default disabled since https://github.com/istio/istio/pull/12114
In multicluster deployment, egress gateway is necessary.
