### PR TITLE
Validate Citadel certificate can be used for a CA

### DIFF
--- a/security/pkg/pki/util/keycertbundle_test.go
+++ b/security/pkg/pki/util/keycertbundle_test.go
@@ -57,12 +57,12 @@ func TestKeyCertBundleWithRootCertFromFile(t *testing.T) {
 	for id, tc := range testCases {
 		bundle, err := NewKeyCertBundleWithRootCertFromFile(tc.rootCertFile)
 		if err != nil {
-			if len(tc.expectedErr) == 0 {
+			if tc.expectedErr == "" {
 				t.Errorf("%s: Unexpected error: %v", id, err)
 			} else if strings.Compare(err.Error(), tc.expectedErr) != 0 {
 				t.Errorf("%s: Unexpected error: %v VS (expected) %s", id, err, tc.expectedErr)
 			}
-		} else if len(tc.expectedErr) != 0 {
+		} else if tc.expectedErr != "" {
 			t.Errorf("%s: Expected error %s but succeeded", id, tc.expectedErr)
 		} else if bundle == nil {
 			t.Errorf("%s: the bundle should not be empty", id)
@@ -154,12 +154,12 @@ func TestCertOptionsAndRetrieveID(t *testing.T) {
 		}
 		opts, err := k.CertOptions()
 		if err != nil {
-			if len(tc.expectedErr) == 0 {
+			if tc.expectedErr == "" {
 				t.Errorf("%s: Unexpected error: %v", id, err)
 			} else if strings.Compare(err.Error(), tc.expectedErr) != 0 {
 				t.Errorf("%s: Unexpected error: %v VS (expected) %s", id, err, tc.expectedErr)
 			}
-		} else if len(tc.expectedErr) != 0 {
+		} else if tc.expectedErr != "" {
 			t.Errorf("%s: expected error %s but have error %v", id, tc.expectedErr, err)
 		} else {
 			compareCertOptions(opts, tc.certOptions, t)
@@ -290,12 +290,12 @@ func TestNewVerifiedKeyCertBundleFromFile(t *testing.T) {
 		_, err := NewVerifiedKeyCertBundleFromFile(
 			tc.caCertFile, tc.caKeyFile, tc.certChainFile, tc.rootCertFile)
 		if err != nil {
-			if len(tc.expectedErr) == 0 {
+			if tc.expectedErr == "" {
 				t.Errorf("%s: Unexpected error: %v", id, err)
 			} else if strings.Compare(err.Error(), tc.expectedErr) != 0 {
 				t.Errorf("%s: Unexpected error: %v VS (expected) %s", id, err, tc.expectedErr)
 			}
-		} else if len(tc.expectedErr) != 0 {
+		} else if tc.expectedErr != "" {
 			t.Errorf("%s: Expected error %s but succeeded", id, tc.expectedErr)
 		}
 	}


### PR DESCRIPTION
Validate the Citadel certificate can be used as a CA (i.e., has `certificate sign` capability)

(I accidentally started Citadel with a non CA certificate and this was only detected when things started failing at run-time...)

Replaces #12013