### PR TITLE
[Authz v2] Add additional fields for bindings and validation. (#11800)

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1476,19 +1476,49 @@ func ValidateServiceRole(name, namespace string, msg proto.Message) error {
 			if len(constraint.Values) == 0 {
 				errs = appendErrors(errs, fmt.Errorf("at least 1 value must be specified for constraint %d in rule %d", j, i))
 			}
+			if hasExistingFirstClassFieldInRole(constraint.Key, rule) {
+				errs = appendErrors(errs, fmt.Errorf("cannot define %s for rule %d because a similar first-class field has been defined", constraint.Key, i))
+			}
 		}
 	}
 	return errs
 }
 
+// Returns true if the user defines a constraint that already exists in the first-class fields, false
+// if none has overlapped.
+func hasExistingFirstClassFieldInRole(constraintKey string, rule *rbac.AccessRule) bool {
+	// Same as authz.attrDestPort
+	// Cannot use authz.attrDestPort since there is a import cycle. However, these constants can be
+	// defined at another place and both authz and model package can access them.
+	const attrDestPort = "destination.port"
+	if constraintKey == attrDestPort && len(rule.Ports) > 0 {
+		return true
+	}
+	if constraintKey == attrDestPort && len(rule.NotPorts) > 0 {
+		return true
+	}
+	return false
+}
+
+// ValidateServiceRoleBinding checks that ServiceRoleBinding is well-formed.
 func checkServiceRoleBinding(in *rbac.ServiceRoleBinding) error {
 	var errs error
 	if len(in.Subjects) == 0 {
 		errs = appendErrors(errs, fmt.Errorf("at least 1 subject must be specified"))
 	}
 	for i, subject := range in.Subjects {
-		if len(subject.User) == 0 && len(subject.Group) == 0 && len(subject.Properties) == 0 {
-			errs = appendErrors(errs, fmt.Errorf("at least 1 of user, group or properties must be specified for subject %d", i))
+		if isFirstClassFieldEmpty(subject) {
+			errs = appendErrors(errs, fmt.Errorf("empty subjects are not allowed. Found an empty subject at index %d", i))
+		}
+		for propertyKey := range subject.Properties {
+			if hasExistingFirstClassFieldInBinding(propertyKey, subject) {
+				errs = appendErrors(errs, fmt.Errorf("cannot define %s for binding %d because a similar first-class field has been defined", propertyKey, i))
+			}
+		}
+		// Since source.principal = "*" in binding properties is different than User: "*" from the old API,
+		// we want to remove ambiguity when the user defines "*" in names or not_names
+		if isStarInNames(subject.Names) || isStarInNames(subject.NotNames) {
+			errs = appendErrors(errs, fmt.Errorf("do not use * for names or not_names (in rule %d)", i))
 		}
 	}
 	if in.RoleRef == nil {
@@ -1527,6 +1557,42 @@ func ValidateAuthorizationPolicy(name, namespace string, msg proto.Message) erro
 		}
 	}
 	return nil
+}
+
+// isFirstClassFieldEmpty return false if there is at least one first class field (e.g. properties)
+func isFirstClassFieldEmpty(subject *rbac.Subject) bool {
+	return len(subject.User) == 0 && len(subject.Group) == 0 && len(subject.Properties) == 0 &&
+		len(subject.Namespaces) == 0 && len(subject.NotNamespaces) == 0 && len(subject.Groups) == 0 &&
+		len(subject.NotGroups) == 0 && len(subject.Ips) == 0 && len(subject.NotIps) == 0 &&
+		len(subject.Names) == 0 && len(subject.NotNames) == 0
+}
+
+// Returns true if the user defines a property that already exists in the first-class fields, false
+// if none has overlapped.
+// In the future when we introduce expression conditions in properties field, we might need to revisit
+// this function.
+func hasExistingFirstClassFieldInBinding(propertiesKey string, subject *rbac.Subject) bool {
+	switch propertiesKey {
+	case "source.principal":
+		return len(subject.Names) > 0
+	case "request.auth.claims[groups]":
+		return len(subject.Groups) > 0
+	case "source.namespace":
+		return len(subject.Namespaces) > 0
+	case "source.ip":
+		return len(subject.Ips) > 0
+	}
+	return false
+}
+
+// isStarInNames returns true if the user defines "*" as of the values for names or not_names in ServiceRoleBinding.
+func isStarInNames(names []string) bool {
+	for _, name := range names {
+		if name == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 func checkRbacConfig(name, typ string, msg proto.Message) error {

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1486,11 +1486,18 @@ func ValidateServiceRole(name, namespace string, msg proto.Message) error {
 
 // Returns true if the user defines a constraint that already exists in the first-class fields, false
 // if none has overlapped.
+// First-class fields are the immediate-level fields right after the `rules` field in a ServiceRole, e.g.
+// methods, services, etc., or after the `subjects` field in a binding, e.g. names, groups, etc. In shorts,
+// they are not fields under Constraints (in ServiceRole) and Properties (in binding).
+// This prevents the user from defining the same key, e.g. port of the serving service, in multiple places
+// in a ServiceRole definition.
 func hasExistingFirstClassFieldInRole(constraintKey string, rule *rbac.AccessRule) bool {
 	// Same as authz.attrDestPort
 	// Cannot use authz.attrDestPort since there is a import cycle. However, these constants can be
 	// defined at another place and both authz and model package can access them.
 	const attrDestPort = "destination.port"
+	// Only check for port since we only have ports (or not_ports) as first-class field and in destination.port
+	// in a ServiceRole definition.
 	if constraintKey == attrDestPort && len(rule.Ports) > 0 {
 		return true
 	}

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1585,7 +1585,7 @@ func hasExistingFirstClassFieldInBinding(propertiesKey string, subject *rbac.Sub
 	return false
 }
 
-// isStarInNames returns true if the user defines "*" as of the values for names or not_names in ServiceRoleBinding.
+// isStarInNames returns true if there is a "*" in the names slice.
 func isStarInNames(names []string) bool {
 	for _, name := range names {
 		if name == "*" {

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -61,8 +61,9 @@ const (
 	attrRequestHeader = "request.headers" // header name is surrounded by brackets, e.g. "request.headers[User-Agent]".
 
 	// attributes that could be used in a ServiceRoleBinding property.
-	attrSrcIP              = "source.ip"                   // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
-	attrSrcNamespace       = "source.namespace"            // e.g. "default".
+	attrSrcIP        = "source.ip"        // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
+	attrSrcNamespace = "source.namespace" // e.g. "default".
+	// TODO(pitlv2109): Since attrSrcUser will be deprecated, maybe remove this and use attrSrcPrincipal consistently everywhere?
 	attrSrcUser            = "source.user"                 // source identity, e.g. "cluster.local/ns/default/sa/productpage".
 	attrSrcPrincipal       = "source.principal"            // source identity, e,g, "cluster.local/ns/default/sa/productpage".
 	attrRequestPrincipal   = "request.auth.principal"      // authenticated principal of the request.
@@ -70,6 +71,11 @@ const (
 	attrRequestPresenter   = "request.auth.presenter"      // authorized presenter of the credential.
 	attrRequestClaims      = "request.auth.claims"         // claim name is surrounded by brackets, e.g. "request.auth.claims[iss]".
 	attrRequestClaimGroups = "request.auth.claims[groups]" // groups claim.
+
+	// reserved string values in names and not_names in ServiceRoleBinding.
+	// This prevents ambiguity when the user defines "*" for names or not_names.
+	allUsers              = "allUsers"              // Allow all users, both authenticated and unauthenticated.
+	allAuthenticatedUsers = "allAuthenticatedUsers" // Allow all authenticated users.
 
 	// attributes that could be used in a ServiceRole constraint.
 	attrDestIP        = "destination.ip"        // supports both single ip and cidr, e.g. "10.1.2.3" or "10.1.0.0/16".
@@ -560,22 +566,20 @@ func convertRbacRulesToFilterConfig(service *serviceMetadata, option rbacOption)
 
 // appendRule appends a |rule| to |rules| if |rule| is not nil.
 func appendRule(rules *policyproto.Permission_AndRules, rule *policyproto.Permission) {
-	if rule == nil {
-		return
+	if rule != nil {
+		rules.AndRules.Rules = append(rules.AndRules.Rules, rule)
 	}
-	rules.AndRules.Rules = append(rules.AndRules.Rules, rule)
 }
 
 // appendNotRule appends a |notRule| to AndRules of |rules| if |notRule| is not nil.
 func appendNotRule(rules *policyproto.Permission_AndRules, notRule *policyproto.Permission) {
-	if notRule == nil {
-		return
+	if notRule != nil {
+		rules.AndRules.Rules = append(rules.AndRules.Rules,
+			&policyproto.Permission{Rule: &policyproto.Permission_NotRule{
+				NotRule: notRule,
+			},
+			})
 	}
-	rules.AndRules.Rules = append(rules.AndRules.Rules,
-		&policyproto.Permission{Rule: &policyproto.Permission_NotRule{
-			NotRule: notRule,
-		},
-		})
 }
 
 // convertToPermission converts a single AccessRule to a Permission.
@@ -664,6 +668,7 @@ func convertToPrincipals(bindings []*rbacproto.ServiceRoleBinding, forTCPFilter 
 	return enforcedPrincipals, permissivePrincipals
 }
 
+// TODO(pitlv2109): Refactor first class fields.
 // convertToPrincipal converts a single subject to principal.
 func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policyproto.Principal {
 	ids := &policyproto.Principal_AndIds{
@@ -672,6 +677,7 @@ func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policypr
 		},
 	}
 
+	// TODO(pitlv2109): Delete this subject.User block of code once we rolled out 1.2?
 	if subject.User != "" {
 		if subject.User == "*" {
 			// Generate an any rule to grant access permission to anyone if the value is "*".
@@ -697,6 +703,7 @@ func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policypr
 		}
 	}
 
+	// TODO(pitlv2109): Same as above.
 	if subject.Group != "" {
 		if subject.Properties == nil {
 			subject.Properties = make(map[string]string)
@@ -711,7 +718,47 @@ func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policypr
 		subject.Properties[attrRequestClaimGroups] = subject.Group
 	}
 
-	if len(subject.Properties) != 0 {
+	if len(subject.Names) > 0 {
+		namesBinding := principalForKeyValues(attrSrcPrincipal, subject.Names, forTCPFilter)
+		appendID(namesBinding, ids)
+	}
+
+	if len(subject.NotNames) > 0 {
+		notNamesBinding := principalForKeyValues(attrSrcPrincipal, subject.NotNames, forTCPFilter)
+		appendNotID(notNamesBinding, ids)
+	}
+
+	if len(subject.Groups) > 0 {
+		groupsBinding := principalForKeyValues(attrRequestClaimGroups, subject.Groups, forTCPFilter)
+		appendID(groupsBinding, ids)
+	}
+
+	if len(subject.NotGroups) > 0 {
+		notGroupsBinding := principalForKeyValues(attrRequestClaimGroups, subject.NotGroups, forTCPFilter)
+		appendNotID(notGroupsBinding, ids)
+	}
+
+	if len(subject.Namespaces) > 0 {
+		namespacesBinding := principalForKeyValues(attrSrcNamespace, subject.Namespaces, forTCPFilter)
+		appendID(namespacesBinding, ids)
+	}
+
+	if len(subject.NotNamespaces) > 0 {
+		notNamespacesBinding := principalForKeyValues(attrSrcNamespace, subject.NotNamespaces, forTCPFilter)
+		appendNotID(notNamespacesBinding, ids)
+	}
+
+	if len(subject.Ips) > 0 {
+		ipsBinding := principalForKeyValues(attrSrcIP, subject.Ips, forTCPFilter)
+		appendID(ipsBinding, ids)
+	}
+
+	if len(subject.NotIps) > 0 {
+		notIpsBinding := principalForKeyValues(attrSrcIP, subject.NotIps, forTCPFilter)
+		appendNotID(notIpsBinding, ids)
+	}
+
+	if len(subject.Properties) > 0 {
 		// Use a separate key list to make sure the map iteration order is stable, so that the generated
 		// config is stable.
 		var keys []string
@@ -745,6 +792,44 @@ func convertToPrincipal(subject *rbacproto.Subject, forTCPFilter bool) *policypr
 	}
 
 	return &policyproto.Principal{Identifier: ids}
+}
+
+// principalForKeyValues converts an Istio first class field (e.g. namespaces, groups, ips, as opposed
+// to properties fields) to Envoy RBAC config and returns said field as a Principal or returns nil
+// if the field is empty.
+func principalForKeyValues(key string, values []string, forTCPFilter bool) *policyproto.Principal {
+	orIds := &policyproto.Principal_OrIds{
+		OrIds: &policyproto.Principal_Set{
+			Ids: make([]*policyproto.Principal, 0),
+		},
+	}
+	for _, value := range values {
+		id := principalForKeyValue(key, value, forTCPFilter)
+		if id != nil {
+			orIds.OrIds.Ids = append(orIds.OrIds.Ids, id)
+		}
+	}
+	if len(orIds.OrIds.Ids) > 0 {
+		return &policyproto.Principal{Identifier: orIds}
+	}
+	return nil
+}
+
+// appendId appends a list of orIds to andIds.
+func appendID(orIds *policyproto.Principal, andIds *policyproto.Principal_AndIds) {
+	if orIds != nil {
+		andIds.AndIds.Ids = append(andIds.AndIds.Ids, orIds)
+	}
+}
+
+// appendNotId appends a list of *not* orIds to andIds.
+func appendNotID(notOrIds *policyproto.Principal, andIds *policyproto.Principal_AndIds) {
+	if notOrIds != nil {
+		andIds.AndIds.Ids = append(andIds.AndIds.Ids,
+			&policyproto.Principal{Identifier: &policyproto.Principal_NotId{
+				NotId: notOrIds,
+			}})
+	}
 }
 
 func permissionForKeyValues(key string, values []string) *policyproto.Permission {
@@ -841,7 +926,10 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 		}
 	}
 
-	return &policyproto.Permission{Rule: orRules}
+	if len(orRules.OrRules.Rules) > 0 {
+		return &policyproto.Permission{Rule: orRules}
+	}
+	return nil
 }
 
 // Create a Principal based on the key and the value.
@@ -849,6 +937,24 @@ func permissionForKeyValues(key string, values []string) *policyproto.Permission
 // value: the value of a subject property.
 // forTCPFilter: the principal is used in the TCP filter.
 func principalForKeyValue(key, value string, forTCPFilter bool) *policyproto.Principal {
+	// Generate an any rule to grant access permission to anyone if the value is "*" for
+	// |attrSrcPrincipal|.
+	if key == attrSrcPrincipal {
+		if value == allUsers {
+			return &policyproto.Principal{
+				Identifier: &policyproto.Principal_Any{
+					Any: true,
+				},
+			}
+		}
+		// We don't allow users to use "*" in names or not_names. However, we will use "*" internally to
+		// refer to authenticated users, since existing code using regex to map "*" to all authenticated
+		// users.
+		if value == allAuthenticatedUsers {
+			value = "*"
+		}
+	}
+
 	if forTCPFilter {
 		switch key {
 		case attrSrcPrincipal:

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	rbacproto "istio.io/api/rbac/v1alpha1"
-	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin/authn"
 )
 
@@ -215,64 +214,5 @@ func generateExpectRBACForSinglePolicy(serviceRoleName string, rbacPolicy *polic
 		Policies: map[string]*policy.Policy{
 			serviceRoleName: rbacPolicy,
 		},
-	}
-}
-
-// nolint:deadcode
-func generateSimpleServiceRoleBindingAllGroups(serviceRoleName, serviceRoleBindingName string) model.Config {
-	return model.Config{
-		ConfigMeta: model.ConfigMeta{Name: serviceRoleBindingName},
-		Spec: &rbacproto.ServiceRoleBinding{
-			Subjects: []*rbacproto.Subject{
-				{
-					Properties: map[string]string{
-						"request.auth.claims[groups]": "group*",
-					},
-				},
-			},
-			RoleRef: &rbacproto.RoleRef{
-				Kind: "ServiceRole",
-				Name: serviceRoleName,
-			},
-		},
-	}
-}
-
-// nolint: deadcode
-func generateSimplePolicyForNotRuleWithHeader(header string, exactMatch string) *policy.Policy {
-	return &policy.Policy{
-		Permissions: []*policy.Permission{
-			{
-				Rule: &policy.Permission_AndRules{
-					AndRules: &policy.Permission_Set{
-						Rules: []*policy.Permission{
-							{
-								Rule: &policy.Permission_NotRule{
-									NotRule: &policy.Permission{
-										Rule: generateHeaderRule([]*route.HeaderMatcher{
-											{Name: header, HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: exactMatch}},
-										}),
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		Principals: []*policy.Principal{{
-			Identifier: &policy.Principal_AndIds{
-				AndIds: &policy.Principal_Set{
-					Ids: []*policy.Principal{
-						{
-							Identifier: &policy.Principal_Metadata{
-								Metadata: generateMetadataListMatcher(authn.AuthnFilterName,
-									[]string{attrRequestClaims, "groups"}, "group*"),
-							},
-						},
-					},
-				},
-			},
-		}},
 	}
 }


### PR DESCRIPTION
Similar to #11800 from `authz-v2` feature branch. 

Copied from #11800:

1. Support additional fields in ServiceRoleBinding as described in #11516.
2. Add checks to make sure no duplicated definition exists (e.g. a value in ports and destination.port).
3. Disallow users from using * as a value in names (list of subject.User (deprecated)) or not_names, since using * for source.principal and subject.User means differently. Current subject.User overrides source.principal if the user defines them both at the same time. Use allUsers and allAuthenticatedUsers (naming borrowed from IAM) instead, as discussed with @liminw.
