### PR TITLE
Put back a couple settings for Kiali that were accidentally deleted.

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/values.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/values.yaml
@@ -1,11 +1,11 @@
 #
 # addon kiali
 #
-enabled: false
+enabled: false	# Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`.
 replicaCount: 1
 hub: docker.io/kiali
 tag: v0.14
-contextPath: /kiali
+contextPath: /kiali	# The root context path to access the Kiali UI.
 nodeSelector: {}
 ingress:
   enabled: false
@@ -22,15 +22,11 @@ ingress:
     #     - kiali.local
 
 dashboard:
-  secretName: kiali
-  usernameKey: username
-  passphraseKey: passphrase
-
-  # Override the automatically detected Grafana URL, useful when Grafana service has no ExternalIPs
-  # grafanaURL:
-
-  # Override the automatically detected Jaeger URL, useful when Jaeger service has no ExternalIPs
-  # jaegerURL:
+  secretName: kiali	# You must create a secret with this name - one is not provided out-of-box.
+  usernameKey: username	# This is the key name within the secret whose value is the actual username. 
+  passphraseKey: passphrase	# This is the key name within the secret whose value is the actual passphrase.
+  grafanaURL:  # If you have Grafana installed and it is accessible to client browsers, then set this to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown.
+  jaegerURL: # If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown.
 prometheusAddr: http://prometheus:9090
 
 # When true, a secret will be created with a default username and password. Useful for demos.


### PR DESCRIPTION
Some Kiali settings were accidently deleted when the new installation options for
release-1.1 was published. This is because these settings were commented out in
the values.yaml file for kiali under istio/kubernetes/helm/istio/charts/kiali.

Bug:#3660