### PR TITLE
Do not reject entire batch of updates, if items get past validation.

### DIFF
--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -141,7 +141,7 @@ func (c *Controller) Apply(change *sink.Change) error {
 		if obj.Metadata.CreateTime != nil {
 			var err error
 			if createTime, err = types.TimestampFromProto(obj.Metadata.CreateTime); err != nil {
-				log.Warnf("Discarding Incoming MCP Resource: invalid resource timestamp (%s/%s): %v", namespace, name, err)
+				log.Warnf("Discarding incoming MCP resource: invalid resource timestamp (%s/%s): %v", namespace, name, err)
 				continue
 			}
 		}

--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -141,7 +141,8 @@ func (c *Controller) Apply(change *sink.Change) error {
 		if obj.Metadata.CreateTime != nil {
 			var err error
 			if createTime, err = types.TimestampFromProto(obj.Metadata.CreateTime); err != nil {
-				return fmt.Errorf("failed to parse %v create_time: %v", obj.Metadata.Name, err)
+				log.Warnf("Discarding Incoming MCP Resource: invalid resource timestamp (%s/%s): %v", namespace, name, err)
+				continue
 			}
 		}
 
@@ -162,7 +163,8 @@ func (c *Controller) Apply(change *sink.Change) error {
 		}
 
 		if err := schema.Validate(conf.Name, conf.Namespace, conf.Spec); err != nil {
-			return err
+			log.Warnf("Discarding incoming MCP resource: validation failed (%s/%s): %v", conf.Namespace, conf.Name, err)
+			continue
 		}
 
 		namedConfig, ok := innerStore[conf.Namespace]

--- a/pilot/pkg/config/coredatamodel/controller.go
+++ b/pilot/pkg/config/coredatamodel/controller.go
@@ -141,6 +141,7 @@ func (c *Controller) Apply(change *sink.Change) error {
 		if obj.Metadata.CreateTime != nil {
 			var err error
 			if createTime, err = types.TimestampFromProto(obj.Metadata.CreateTime); err != nil {
+				// Do not return an error, instead discard the resources so that Pilot can process the rest.
 				log.Warnf("Discarding incoming MCP resource: invalid resource timestamp (%s/%s): %v", namespace, name, err)
 				continue
 			}
@@ -163,6 +164,7 @@ func (c *Controller) Apply(change *sink.Change) error {
 		}
 
 		if err := schema.Validate(conf.Name, conf.Namespace, conf.Spec); err != nil {
+			// Do not return an error, instead discard the resources so that Pilot can process the rest.
 			log.Warnf("Discarding incoming MCP resource: validation failed (%s/%s): %v", conf.Namespace, conf.Name, err)
 			continue
 		}

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -672,3 +672,46 @@ func makeMessage(value []byte, responseMessageName string) (proto.Message, error
 
 	return nil, err
 }
+
+func TestInvalidResource(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController(testControllerOptions)
+
+	gw := proto.Clone(gateway).(*networking.Gateway)
+	gw.Servers[0].Hosts = nil
+
+	message0 := convertToResource(g, model.Gateway.MessageName, []proto.Message{gw})
+
+	change := convert(
+		[]proto.Message{message0[0]},
+		[]string{"bar-namespace/foo"},
+		model.Gateway.Collection, model.Gateway.MessageName)
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	entries, err := controller.List(model.Gateway.Type, "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(entries).To(gomega.HaveLen(0))
+}
+
+func TestInvalidResource_BadTimestamp(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	controller := coredatamodel.NewController(testControllerOptions)
+
+	message0 := convertToResource(g, model.Gateway.MessageName, []proto.Message{gateway})
+	change := convert(
+		[]proto.Message{message0[0]},
+		[]string{"bar-namespace/foo"},
+		model.Gateway.Collection, model.Gateway.MessageName)
+	change.Objects[0].Metadata.CreateTime = &types.Timestamp{
+		Seconds: - 1,
+		Nanos: -1,
+	}
+
+	err := controller.Apply(change)
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+
+	entries, err := controller.List(model.Gateway.Type, "")
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+	g.Expect(entries).To(gomega.HaveLen(0))
+}

--- a/pilot/pkg/config/coredatamodel/controller_test.go
+++ b/pilot/pkg/config/coredatamodel/controller_test.go
@@ -704,8 +704,8 @@ func TestInvalidResource_BadTimestamp(t *testing.T) {
 		[]string{"bar-namespace/foo"},
 		model.Gateway.Collection, model.Gateway.MessageName)
 	change.Objects[0].Metadata.CreateTime = &types.Timestamp{
-		Seconds: - 1,
-		Nanos: -1,
+		Seconds: -1,
+		Nanos:   -1,
 	}
 
 	err := controller.Apply(change)


### PR DESCRIPTION
MCP Controller in Pilot is rejecting entire batch (by NACK) if the batch contains any invalid entries. In the case of an invalid entry making its way through the validation webhook, Pilot will reject entire batches if there is an erroneous entry.

This change updates the code so that, instead doing full rejection, the code will discard only the invalid config entries and ACK the change.