### PR TITLE
Reduce Pilot resource requests for demo

### DIFF
--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -25,6 +25,9 @@ pilot:
     requests:
       cpu: 10m
       memory: 100Mi
+    limits:
+      cpu: 100m
+      memory: 200Mi
 
 mixer:
   policy:

--- a/install/kubernetes/helm/istio/values-istio-demo-common.yaml
+++ b/install/kubernetes/helm/istio/values-istio-demo-common.yaml
@@ -21,6 +21,10 @@ global:
 
 pilot:
   traceSampling: 100.0
+  resources:
+    requests:
+      cpu: 10m
+      memory: 100Mi
 
 mixer:
   policy:


### PR DESCRIPTION
Currently demo uses 500m and 2GB, much more than needed