### PR TITLE
Bump up integration2 k8s istio deployment timeout duration.

### DIFF
--- a/pkg/test/framework/runtime/components/environment/kube/settings.go
+++ b/pkg/test/framework/runtime/components/environment/kube/settings.go
@@ -47,8 +47,10 @@ const (
 	// LatestTag value
 	LatestTag = "latest"
 
-	// DefaultDeployTimeout for Istio
-	DefaultDeployTimeout = time.Second * 480
+	// DefaultDeployTimeout for Istio.
+	// TODO(incfly): double check Istio deployment time once we increase the cluster size,
+	// https://github.com/istio/istio/pull/12274 is merged.
+	DefaultDeployTimeout = time.Second * 900
 
 	// DefaultUndeployTimeout for Istio.
 	DefaultUndeployTimeout = time.Second * 600


### PR DESCRIPTION
Why it's 900 seconds, from a previous run,
https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio/12481/istio-integ-k8s-tests/4954/build-log.txt

```
2019-03-13T22:59:55.880239Z info CI Checking pods...
2019-03-13T23:11:03.394889Z info CI === SUCCEEDED: Deploy Istio ===
```

First Checking pods and finally SUCCEEDED, it's 12 minutes. 900 secs is 15min for safer.

Hopefully once we get https://github.com/istio/istio/pull/12274 landed, this can be faster.
