### PR TITLE
Add connection configs for signature calculation of dynamic handler

### DIFF
--- a/mixer/pkg/runtime/handler/signature.go
+++ b/mixer/pkg/runtime/handler/signature.go
@@ -19,9 +19,10 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"io"
-	"istio.io/api/policy/v1beta1"
 	"reflect"
 	"sort"
+
+	"istio.io/api/policy/v1beta1"
 
 	"github.com/gogo/protobuf/proto"
 

--- a/mixer/pkg/runtime/handler/signature.go
+++ b/mixer/pkg/runtime/handler/signature.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"io"
+	"istio.io/api/policy/v1beta1"
 	"reflect"
 	"sort"
 
@@ -40,7 +41,7 @@ func (s signature) equals(other signature) bool {
 }
 
 // calculateSignature returns signature given handler and array of dynamic or static instances
-func calculateSignature(handler hndlr, insts interface{}) signature {
+func calculateSignature(handler hndlr, handlerConn *v1beta1.Connection, insts interface{}) signature {
 	if reflect.TypeOf(insts).Kind() != reflect.Slice {
 		return zeroSignature
 	}
@@ -65,6 +66,10 @@ func calculateSignature(handler hndlr, insts interface{}) signature {
 	if handler.AdapterParams() != nil &&
 		(reflect.ValueOf(handler.AdapterParams()).Kind() != reflect.Ptr || !reflect.ValueOf(handler.AdapterParams()).IsNil()) {
 		encoded = encoded && encode(buf, handler.AdapterParams())
+	}
+
+	if handlerConn != nil {
+		encoded = encoded && encode(buf, handlerConn)
 	}
 	for _, name := range instanceNames {
 		instance := instanceMap[name]

--- a/mixer/pkg/runtime/handler/signature_test.go
+++ b/mixer/pkg/runtime/handler/signature_test.go
@@ -48,7 +48,7 @@ func TestSignature_ProtoMarshalFailure(t *testing.T) {
 	p := &fakeProto{}
 
 	h := config.HandlerStatic{Name: "h1", Params: p, Adapter: &adapter.Info{Name: "a1"}}
-	s := calculateSignature(&h, []interface{}{})
+	s := calculateSignature(&h, nil, []interface{}{})
 
 	// The fake proto will fail serialization. It should return zero-signature.
 	if !reflect.DeepEqual(s, zeroSignature) {

--- a/mixer/pkg/runtime/handler/table.go
+++ b/mixer/pkg/runtime/handler/table.go
@@ -16,9 +16,10 @@ package handler
 
 import (
 	"context"
-	"istio.io/api/policy/v1beta1"
 	"strconv"
 	"time"
+
+	"istio.io/api/policy/v1beta1"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"


### PR DESCRIPTION
When using out-of-process adapter and only connection config is changed(such as address of that adapter), the handler isn't refreshed. This is because the signature doesn't include connection configs, thus old handler is still reused.
This PR add connection config to signature calculation.