### PR TITLE
missing comment on exported function ConstructCustomDNSNames

### DIFF
--- a/security/pkg/k8s/controller/customdnsname.go
+++ b/security/pkg/k8s/controller/customdnsname.go
@@ -20,6 +20,8 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
+// ConstructCustomDNSNames creates DNS entries for given service accounts and allows
+// customization of the DNS names of specific service accounts
 func ConstructCustomDNSNames(serviceAccounts []string, serviceNames []string,
 	namespace string, customDNSNames string) map[string]*DNSNameEntry {
 	result := make(map[string]*DNSNameEntry)

--- a/security/pkg/k8s/controller/customdnsname.go
+++ b/security/pkg/k8s/controller/customdnsname.go
@@ -21,7 +21,12 @@ import (
 )
 
 // ConstructCustomDNSNames creates DNS entries for given service accounts and allows
-// customization of the DNS names of specific service accounts
+// customization of the DNS names used in the certificate SAN field.
+// By default the DNS name used in the SAN field are in the form of service.namespace
+// and service.namespace.svc. When a custom DNS is specified, we set an additional
+// DNS SAN for the service account.
+// The customDNSNames string contains a list of comma separated entries, with each
+// entry formatted as <service-account-name>:<custom-DNS-value-for-SAN>
 func ConstructCustomDNSNames(serviceAccounts []string, serviceNames []string,
 	namespace string, customDNSNames string) map[string]*DNSNameEntry {
 	result := make(map[string]*DNSNameEntry)


### PR DESCRIPTION
golint complains:
```sh
$ golint ./security/pkg/k8s/controller/customdnsname.go 
./security/pkg/k8s/controller/customdnsname.go:23:1: exported function ConstructCustomDNSNames should have comment or be unexported
```
