### PR TITLE
Allow no hosts in the ServiceEntry validation

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2127,9 +2127,6 @@ func ValidateServiceEntry(name, namespace string, config proto.Message) (errs er
 		return fmt.Errorf("cannot cast to service entry")
 	}
 
-	if len(serviceEntry.Hosts) == 0 {
-		errs = appendErrors(errs, fmt.Errorf("service entry must have at least one host"))
-	}
 	for _, host := range serviceEntry.Hosts {
 		// Full wildcard is not allowed in the service entry.
 		if host == "*" {

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -2127,6 +2127,10 @@ func ValidateServiceEntry(name, namespace string, config proto.Message) (errs er
 		return fmt.Errorf("cannot cast to service entry")
 	}
 
+	if len(serviceEntry.Hosts) == 0 && len(serviceEntry.Addresses) == 0 {
+		errs = appendErrors(errs, fmt.Errorf("addresses and/or hosts must be specified"))
+	}
+
 	for _, host := range serviceEntry.Hosts {
 		// Full wildcard is not allowed in the service entry.
 		if host == "*" {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2992,14 +2992,14 @@ func TestValidateServiceEntries(t *testing.T) {
 
 		{name: "empty hosts", in: networking.ServiceEntry{
 			Ports: []*networking.Port{
-				{Number: 80, Protocol: "http", Name: "http-valid1"},
+				{Number: 9080, Protocol: "http", Name: "http-valid1"},
 			},
 			Endpoints: []*networking.ServiceEntry_Endpoint{
-				{Address: "in.google.com", Ports: map[string]uint32{"http-valid2": 9080}},
+				{Address: "in.google.com", Ports: map[string]uint32{"http-valid1": 9080}},
 			},
 			Resolution: networking.ServiceEntry_DNS,
 		},
-			valid: false},
+			valid: true},
 
 		{name: "bad hosts", in: networking.ServiceEntry{
 			Hosts: []string{"-"},

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -2990,7 +2990,8 @@ func TestValidateServiceEntries(t *testing.T) {
 		},
 			valid: true},
 
-		{name: "empty hosts", in: networking.ServiceEntry{
+		{name: "only addresses", in: networking.ServiceEntry{
+			Addresses: []string{"172.1.2.16"},
 			Ports: []*networking.Port{
 				{Number: 9080, Protocol: "http", Name: "http-valid1"},
 			},
@@ -3000,6 +3001,17 @@ func TestValidateServiceEntries(t *testing.T) {
 			Resolution: networking.ServiceEntry_DNS,
 		},
 			valid: true},
+
+		{name: "empty hosts and addresses", in: networking.ServiceEntry{
+			Ports: []*networking.Port{
+				{Number: 9080, Protocol: "http", Name: "http-valid1"},
+			},
+			Endpoints: []*networking.ServiceEntry_Endpoint{
+				{Address: "in.google.com", Ports: map[string]uint32{"http-valid1": 9080}},
+			},
+			Resolution: networking.ServiceEntry_DNS,
+		},
+			valid: false},
 
 		{name: "bad hosts", in: networking.ServiceEntry{
 			Hosts: []string{"-"},


### PR DESCRIPTION
In addition to changes I went through all references to the ServiceEntry's Hosts and couldn't find a reason that it should be required.

Closes #12493 

/assign @rshriram 