### PR TITLE
Add threshold for rds.go codecov

### DIFF
--- a/codecov.threshold
+++ b/codecov.threshold
@@ -24,6 +24,7 @@ istio.io=5
 istio.io/istio/mixer/adapter/solarwinds/internal/papertrail/papertrail_logger.go=50
 istio.io/istio/pilot/pkg/config/memory/monitor.go=30
 istio.io/istio/pilot/pkg/proxy/envoy/v2=10
+istio.io/istio/pilot/pkg/proxy/envoy/v2/rds.go=25
 istio.io/istio/pilot/pkg/serviceregistry/consul/monitor.go=20
 istio.io/istio/pkg/mcp/creds/watcher.go=100
 istio.io/istio/pkg/mcp/source/source.go=90


### PR DESCRIPTION
Test is flakey, saying it has droppped coverage when it has not due to
it being nondeterministic.

https://github.com/istio/istio/issues/12316