### PR TITLE
[CherryPick]Change IP addresses to show up as strings in label maps in accesslog …

### DIFF
--- a/mixer/adapter/stackdriver/log/log.go
+++ b/mixer/adapter/stackdriver/log/log.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -220,6 +221,8 @@ func toLabelMap(names []string, variables map[string]interface{}) map[string]str
 		switch vt := v.(type) {
 		case string:
 			out[name] = vt
+		case []byte:
+			out[name] = net.IP(vt).String()
 		default:
 			out[name] = fmt.Sprintf("%v", vt)
 		}
@@ -275,8 +278,8 @@ func toReq(mapping *config.Params_LogInfo_HttpRequestMapping, variables map[stri
 		req.Latency = latency
 	}
 
-	req.LocalIP = fmt.Sprintf("%v", variables[mapping.LocalIp])
-	req.RemoteIP = fmt.Sprintf("%v", variables[mapping.RemoteIp])
+	req.LocalIP = adapter.Stringify(variables[mapping.LocalIp])
+	req.RemoteIP = adapter.Stringify(variables[mapping.RemoteIp])
 	return req
 }
 

--- a/mixer/adapter/stackdriver/log/log_test.go
+++ b/mixer/adapter/stackdriver/log/log_test.go
@@ -17,6 +17,7 @@ package log
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -191,7 +192,7 @@ func TestHandleLogEntry(t *testing.T) {
 		{"req map",
 			map[string]info{"reqmap": {
 				tmpl:   template.Must(template.New("").Parse("literal")),
-				labels: []string{"foo"},
+				labels: []string{"foo", "source_ip"},
 				req: &config.Params_LogInfo_HttpRequestMapping{
 					Status:       "status",
 					LocalIp:      "localip",
@@ -205,21 +206,22 @@ func TestHandleLogEntry(t *testing.T) {
 			[]*logentry.Instance{{
 				Name: "reqmap",
 				Variables: map[string]interface{}{
-					"foo":      "bar",
-					"time":     fmt.Sprintf("%v", now),
-					"status":   int64(200),
-					"localip":  "127.0.0.1",
-					"remoteip": "1.0.0.127",
-					"latency":  time.Second,
-					"reqsize":  123,
-					"respsize": int64(456),
+					"foo":       "bar",
+					"time":      fmt.Sprintf("%v", now),
+					"status":    int64(200),
+					"localip":   "127.0.0.1",
+					"remoteip":  []byte(net.ParseIP("1.0.0.127")),
+					"source_ip": []byte(net.ParseIP("1.0.0.127")),
+					"latency":   time.Second,
+					"reqsize":   123,
+					"respsize":  int64(456),
 				},
 			}},
 			[]logging.Entry{
 				{
 					Timestamp: now,
 					Severity:  logging.Default,
-					Labels:    map[string]string{"foo": "bar"},
+					Labels:    map[string]string{"foo": "bar", "source_ip": "1.0.0.127"},
 					Payload:   "literal",
 					HTTPRequest: &logging.HTTPRequest{
 						Status:       200,

--- a/mixer/pkg/adapter/instanceUtil.go
+++ b/mixer/pkg/adapter/instanceUtil.go
@@ -43,11 +43,11 @@ func Stringify(v interface{}) string {
 			return strconv.FormatFloat(vv, 'f', -1, 64)
 		case bool:
 			return strconv.FormatBool(vv)
+		case []byte:
+			return net.IP(vv).String()
 		case time.Time:
 			return string(serializeTime(vv))
 		case time.Duration:
-			return vv.String()
-		case net.IP:
 			return vv.String()
 		case EmailAddress:
 			return string(vv)


### PR DESCRIPTION
CherryPick (#11740) from Master to release 1.1 for 1.1.1 release

Change IP addresses to show up as strings in http req  in accesslog

Fix lint errors

Fix lint errors

Use stringify function

Updated based on feedback