### PR TITLE
Fix access log config when xds mashaling to any is disabled

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/listener.go
+++ b/pilot/pkg/networking/core/v1alpha3/listener.go
@@ -1426,8 +1426,11 @@ func buildHTTPConnectionManager(node *model.Proxy, env *model.Environment, httpO
 			Name: xdsutil.FileAccessLog,
 		}
 
-		if util.IsXDSMarshalingToAnyEnabled(node) {
+		if util.IsProxyVersionGE11(node) {
 			buildAccessLog(fl, env)
+		}
+
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			acc.ConfigType = &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(fl)}
 		} else {
 			acc.ConfigType = &accesslog.AccessLog_Config{Config: util.MessageToStruct(fl)}

--- a/pilot/pkg/networking/core/v1alpha3/networkfilter.go
+++ b/pilot/pkg/networking/core/v1alpha3/networkfilter.go
@@ -54,8 +54,10 @@ func setAccessLogAndBuildTCPFilter(env *model.Environment, node *model.Proxy, co
 		acc := &accesslog.AccessLog{
 			Name: xdsutil.FileAccessLog,
 		}
-		if util.IsXDSMarshalingToAnyEnabled(node) {
+		if util.IsProxyVersionGE11(node) {
 			buildAccessLog(fl, env)
+		}
+		if util.IsXDSMarshalingToAnyEnabled(node) {
 			acc.ConfigType = &accesslog.AccessLog_TypedConfig{TypedConfig: util.MessageToAny(fl)}
 		} else {
 			acc.ConfigType = &accesslog.AccessLog_Config{Config: util.MessageToStruct(fl)}


### PR DESCRIPTION
Related to https://github.com/istio/istio/issues/12162
Fix after this change: https://github.com/istio/istio/pull/12412

When Pilot is run with `PILOT_DISABLE_XDS_MARSHALING_TO_ANY=true`, the access log configuration is never built. This change will gate the build on the version instead of the marshaling.