### PR TITLE
enable policy checks when mixer is enabled.

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -248,7 +248,7 @@ global:
   # disablePolicyChecks disables mixer policy checks.
   # if mixer.policy.enabled==true then disablePolicyChecks has affect.
   # Will set the value with same name in istio config map - pilot needs to be restarted to take effect.
-  disablePolicyChecks: true
+  disablePolicyChecks: false
 
   # policyCheckFailOpen allows traffic in cases when the mixer policy service cannot be reached.
   # Default is false which means the traffic is denied when the client is unable to connect to Mixer.


### PR DESCRIPTION
otherwise, even if mixer is enabled, policy checks remain disabled..