### PR TITLE
Adds a CNI option to the e2e tests

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -112,3 +112,7 @@ E2E tests have multiple options available while running them as follows:
 * `--installer <cmd>` - Use `helm` or `kubectl` to install Istio (default: kubectl)
 * `--kube_inject_configmap <configmap>` - Istioctl will use the specified configmap when running kube-inject (default: ""). This will normally be used with the CNI option to override the embedded initContainers insertion.
 * `--split_horizon` - Set up a split horizon EDS multi-cluster test environment (default: false)
+*
+* `--use_mcp` - If true will use MCP for configuring Istio components (default: true)
+* `--use_cni` - If true install the Istio CNI which will add the IP table rules for Envoy instead of the init container (default: false)
+* `--cniHelmRepo` - Location/name of the Istio-CNI helm (default: istio.io/istio-cni)

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-
 	"istio.io/istio/pkg/log"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/util"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -115,12 +115,8 @@ var (
 	clusterWide         = flag.Bool("cluster_wide", false, "If true Pilot/Mixer will observe all namespaces rather than just the testing namespace")
 	imagePullPolicy     = flag.String("image_pull_policy", "", "Specifies an override for the Docker image pull policy to be used")
 	multiClusterDir     = flag.String("cluster_registry_dir", "",
-<<<<<<< 02c8de72986c174ff7f8def317949ea59d13a919
-		"Directory name for the cluster registry config. When provided a multicluster test to be run across two clusters.")
-	splitHorizon             = flag.Bool("split_horizon", false, "Set up a split horizon EDS multi-cluster test environment")
-=======
 		"Directory name for the cluster registry config. When provided a multicluster test is run across two clusters.")
->>>>>>> Adds a CNI option to the e2e tests
+	splitHorizon             = flag.Bool("split_horizon", false, "Set up a split horizon EDS multi-cluster test environment")
 	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", true, "Use galley configuration validation webhook")
 	installer                = flag.String("installer", "kubectl", "Istio installer, default to kubectl, or helm")
 	useMCP                   = flag.Bool("use_mcp", true, "use MCP for configuring Istio components")
@@ -128,8 +124,8 @@ var (
 	enableEgressGateway      = flag.Bool("enable_egressgateway", false, "enable egress gateway, default to false")
 	useCNI                   = flag.Bool("use_cni", false,
 		"Install the Istio CNI which will add the IP table rules for Envoy instead of the init container")
-	cniHelmRepo              = flag.String("cni_helm_repo", "istio.io/istio-cni", "Name of the Istio CNI helm repo")
-	kubeInjectCM             = flag.String("kube_inject_configmap", "",
+	cniHelmRepo  = flag.String("cni_helm_repo", "istio.io/istio-cni", "Name of the Istio CNI helm repo")
+	kubeInjectCM = flag.String("kube_inject_configmap", "",
 		"Configmap to use by the istioctl kube-inject command.")
 	valueFile     = flag.String("valueFile", "", "Istio value yaml file when helm is used")
 	helmSetValues helmSetValueList
@@ -715,7 +711,7 @@ func (k *KubeInfo) deployIstio() error {
 	}
 
 	// Deploy the CNI if enabled
-	if *useCNI  {
+	if *useCNI {
 		err := k.deployCNI()
 		if err != nil {
 			log.Errorf("Unable to deply Istio CNI")
@@ -1197,24 +1193,23 @@ func (k *KubeInfo) deployCNI() error {
 			return err
 		}
 		return err
-	} else {
-		chartDir := filepath.Join(k.TmpDir, "cniChartDir")
-		err := util.HelmFetch(*cniHelmRepo, chartDir)
-		if err != nil {
-			log.Errorf("Helm fetch of %s failed", *cniHelmRepo)
-			return err
-		}
-		outputFile := filepath.Join(k.TmpDir, "istio-cni_install.yaml")
-		chartDir = filepath.Join(chartDir, "istio-cni")
-		err = util.HelmTemplate(chartDir, "istio-cni", k.Namespace, setValue, outputFile)
-		if err != nil {
-			log.Errorf("Helm template of istio-cni failed")
-			return err
-		}
-		err = util.KubeApply(k.Namespace, outputFile, k.KubeConfig)
-		if err != nil {
-			log.Errorf("Kubeapply istio-cni failed")
-		}
+	}
+	chartDir := filepath.Join(k.TmpDir, "cniChartDir")
+	err := util.HelmFetch(*cniHelmRepo, chartDir)
+	if err != nil {
+		log.Errorf("Helm fetch of %s failed", *cniHelmRepo)
 		return err
 	}
+	outputFile := filepath.Join(k.TmpDir, "istio-cni_install.yaml")
+	chartDir = filepath.Join(chartDir, "istio-cni")
+	err = util.HelmTemplate(chartDir, "istio-cni", k.Namespace, setValue, outputFile)
+	if err != nil {
+		log.Errorf("Helm template of istio-cni failed")
+		return err
+	}
+	err = util.KubeApply(k.Namespace, outputFile, k.KubeConfig)
+	if err != nil {
+		log.Errorf("Kubeapply istio-cni failed")
+	}
+	return err
 }

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"istio.io/istio/pkg/log"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/util"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"istio.io/istio/pkg/log"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/util"

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -29,9 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/hashicorp/go-multierror"
-
+	"github.com/pkg/errors"
 	"istio.io/istio/pkg/log"
 	testKube "istio.io/istio/pkg/test/kube"
 	"istio.io/istio/tests/util"
@@ -732,13 +731,13 @@ func (k *KubeInfo) deployIstio() error {
 		}
 
 		if CNIPodName == "" {
-			return errors.New("Timeout waiting for CNI to deploy")
+			return errors.New("timeout waiting for CNI to deploy")
 		}
 
 		// Check if the CNI Pod is running.  Note at this point only the CNI is deployed
 		// and it will be the only pod in the namespace
-		if CNIRunning := util.CheckPodsRunning(k.Namespace, k.KubeConfig); CNIRunning != true {
-			return errors.New("Timeout waiting for CNI to become ready")
+		if CNIRunning := util.CheckPodsRunning(k.Namespace, k.KubeConfig); !CNIRunning {
+			return errors.New("timeout waiting for CNI to become ready")
 		}
 
 	}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -1214,7 +1214,7 @@ func (k *KubeInfo) deployCNI() error {
 		//Assumes the CNI helm repo is available alongside the istio repo
 		err := util.HelmInstall(*cniHelmRepo, "istio-cni", "", k.Namespace, setValue)
 		if err != nil {
-			log.Errorf("Helm install istio-cni chart failed %s, setValue=%s, namespace=%s",
+			log.Errorf("Helm install istio-cni chart failed, setValue=%s, namespace=%s",
 				setValue, k.Namespace)
 			return err
 		}

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -68,12 +68,6 @@ EXTRA_E2E_ARGS ?= ${DEFAULT_EXTRA_E2E_ARGS}
 e2e_simple: istioctl generate_e2e_yaml e2e_simple_run
 e2e_kiali: istioctl generate_e2e_yaml e2e_kiali_run
 
-e2e_simple_cni: istioctl
-e2e_simple_cni: export ENABLE_ISTIO_CNI=true
-#TODO need to create the CNI helm charts and install the CNI
-e2e_simple_cni: export E2E_ARGS+=--kube_inject_configmap=istio-sidecar-injector
-e2e_simple_cni: generate_e2e_yaml e2e_simple_run
-
 e2e_simple_noauth: istioctl generate_e2e_yaml e2e_simple_noauth_run
 
 e2e_mixer: istioctl generate_e2e_yaml e2e_mixer_run

--- a/tests/util/helm_utils.go
+++ b/tests/util/helm_utils.go
@@ -103,3 +103,10 @@ func HelmTillerRunning() error {
 	log.Infof("Tiller is running")
 	return nil
 }
+
+// HelmFetch will fetch the charts from the provided repo. It is assumed the repo itself has
+// already been added.
+func HelmFetch(chartRepo, chartDir string) error {
+	_, err := Shell("helm fetch --untar --untardir " + chartDir + " " + chartRepo)
+	return err
+}


### PR DESCRIPTION
This change will install the CNI for any e2e test
when the flag is set. This allows testing the CNI with
any of the existing e2e test cases.