### PR TITLE
Fix bug in locality LB normalization

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -141,7 +141,7 @@ func applyLocalityFailover(
 	for i, priority := range priorities {
 		if i != priority {
 			// the LocalityLbEndpoints index in ClusterLoadAssignment.Endpoints
-			for index := range priorityMap[priority] {
+			for _, index := range priorityMap[priority] {
 				loadAssignment.Endpoints[index].Priority = uint32(i)
 			}
 		}


### PR DESCRIPTION
The priority needs to be normalized (so it is always has no gaps), so
priorities [0,2] should be changed to [0,1]. However, we were changing
the wrong endpoint's priorities.

