### PR TITLE
Disable the "xDS marshaling to Any" feature by default

### DIFF
--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -108,6 +108,8 @@ spec:
           - name: PILOT_TRACE_SAMPLING
             value: "{{ .Values.traceSampling }}"
 {{- end }}
+          - name: PILOT_DISABLE_XDS_MARSHALING_TO_ANY
+            value: "1"
           resources:
 {{- if .Values.resources }}
 {{ toYaml .Values.resources | indent 12 }}

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -134,7 +134,7 @@ var (
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	DisableXDSMarshalingToAny = func() bool {
-		return len(os.Getenv("PILOT_DISABLE_XDS_MARSHALING_TO_ANY")) != 0
+		return os.Getenv("PILOT_DISABLE_XDS_MARSHALING_TO_ANY") == "1"
 	}
 )
 


### PR DESCRIPTION
This is supposed to address https://github.com/istio/istio/issues/12162 until the proper fix is in place (v1.1.1)

Initial plan was to keep the feature enabled by default and provide
a way to disable it by explicitly setting an env variable. Due to
a last-minute found regression this needs to be disabled by default.

We cannot disable it on a code level as tests won't pass (they assume
this feature is "on"). So this needs to be done on the installer level.