### PR TITLE
[WIP] New prow e2e Multi-cluster test for Split Horizon EDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -649,6 +649,15 @@ istio-init.yaml: $(HELM) $(HOME)/.helm
 		--set global.hub=${HUB} \
 		install/kubernetes/helm/istio-init >> install/kubernetes/$@
 
+# create istio-multicluster-split-horizon.yaml
+istio-multicluster-split-horizon.yaml: $(HELM) $(HOME)/.helm
+	cat install/kubernetes/namespace.yaml > install/kubernetes/$@
+	cat install/kubernetes/helm/istio-init/files/crd-* >> install/kubernetes/$@
+	$(HELM) template --name=istio --namespace=istio-system \
+		--values install/kubernetes/helm/istio/values-istio-multicluster-split-horizon.yaml \
+		${EXTRA_HELM_SETTINGS} \
+		install/kubernetes/helm/istio >> install/kubernetes/$@
+
 # creates istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml
 # Ensure that values-$filename is present in install/kubernetes/helm/istio
 isti%.yaml: $(HELM) $(HOME)/.helm

--- a/install/kubernetes/helm/istio/values-istio-multicluster-split-horizon.yaml
+++ b/install/kubernetes/helm/istio/values-istio-multicluster-split-horizon.yaml
@@ -1,0 +1,25 @@
+# This is used to generate istio-multicluster-split-horizon.yaml, used for CI/CD.
+global:
+  controlPlaneSecurityEnabled: true
+  mtls:
+    enabled: true
+  proxy:
+    accessLogFile: "/dev/stdout"
+  outboundTrafficPolicy:
+    mode: ALLOW_ANY
+  meshExpansion:
+    enabled: true
+  meshNetworks:
+    network2:
+      endpoints:
+      - fromRegistry: N2_REGISTRY_TOKEN
+      gateways:
+      - address: 0.0.0.0
+        port: 443
+security:
+  selfSigned: false
+gateways:
+  istio-egressgateway:
+    enabled: false
+
+

--- a/install/updateVersion.sh
+++ b/install/updateVersion.sh
@@ -153,7 +153,7 @@ function gen_istio_files() {
             gen_file $target "${DEST_DIR}"
         done
     else
-        for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml istio-multicluster.yaml istio-auth-multicluster.yaml istio-remote.yaml istio-mcp.yaml istio-auth-mcp.yaml;do
+        for target in istio.yaml istio-auth.yaml istio-one-namespace.yaml istio-one-namespace-auth.yaml istio-one-namespace-trust-domain.yaml istio-multicluster.yaml istio-auth-multicluster.yaml istio-remote.yaml istio-mcp.yaml istio-auth-mcp.yaml istio-multicluster-split-horizon.yaml;do
             gen_file $target "${DEST_DIR}"
         done
     fi

--- a/prow/istio-pilot-e2e-split-horizon-eds.sh
+++ b/prow/istio-pilot-e2e-split-horizon-eds.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2019 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export RESOURCE_TYPE="${RESOURCE_TYPE:-gke-e2e-test}"
+export OWNER="istio-multicluster-split-horizon-e2e"
+
+export SETUP_CLUSTERREG="True"
+CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
+export CLUSTERREG_DIR
+
+./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_multicluster_split_horizon "$@"

--- a/prow/istio-pilot-multicluster-e2e.sh
+++ b/prow/istio-pilot-multicluster-e2e.sh
@@ -23,4 +23,5 @@ CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
 export CLUSTERREG_DIR
 
 #echo 'Running pilot multi-cluster e2e tests (v1alpha1, noauth)'
-./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
+#./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
+./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_multicluster_split_horizon "$@"

--- a/prow/istio-pilot-multicluster-e2e.sh
+++ b/prow/istio-pilot-multicluster-e2e.sh
@@ -23,4 +23,5 @@ CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
 export CLUSTERREG_DIR
 
 #echo 'Running pilot multi-cluster e2e tests (v1alpha1, noauth)'
-./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
+#./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
+./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_multicluster_split_horizon "$@"

--- a/prow/istio-pilot-multicluster-e2e.sh
+++ b/prow/istio-pilot-multicluster-e2e.sh
@@ -23,5 +23,4 @@ CLUSTERREG_DIR="${CLUSTERREG_DIR:-$(mktemp -d /tmp/clusterregXXX)}"
 export CLUSTERREG_DIR
 
 #echo 'Running pilot multi-cluster e2e tests (v1alpha1, noauth)'
-#./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"
-./prow/e2e-suite.sh --timeout 50 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_multicluster_split_horizon "$@"
+./prow/e2e-suite.sh --timeout 35 --cluster_registry_dir="$CLUSTERREG_DIR" --single_test e2e_pilotv2_v1alpha3 "$@"

--- a/tests/e2e/framework/app_manager.go
+++ b/tests/e2e/framework/app_manager.go
@@ -43,21 +43,23 @@ type App struct {
 
 // AppManager organize and deploy apps
 type AppManager struct {
-	Apps       []*App
-	tmpDir     string
-	namespace  string
-	istioctl   *Istioctl
-	active     bool
-	Kubeconfig string
+	Apps             []*App
+	tmpDir           string
+	namespace        string
+	istioctl         *Istioctl
+	active           bool
+	Kubeconfig       string
+	checkDeployments bool
 }
 
 // NewAppManager create a new AppManager
-func NewAppManager(tmpDir, namespace string, istioctl *Istioctl, kubeconfig string) *AppManager {
+func NewAppManager(tmpDir, namespace string, istioctl *Istioctl, kubeconfig string, checkDeployments bool) *AppManager {
 	return &AppManager{
-		namespace:  namespace,
-		tmpDir:     tmpDir,
-		istioctl:   istioctl,
-		Kubeconfig: kubeconfig,
+		namespace:        namespace,
+		tmpDir:           tmpDir,
+		istioctl:         istioctl,
+		Kubeconfig:       kubeconfig,
+		checkDeployments: checkDeployments,
 	}
 }
 
@@ -120,7 +122,10 @@ func (am *AppManager) Setup() error {
 			return err
 		}
 	}
-	return am.CheckDeployments()
+	if am.checkDeployments {
+		return am.CheckDeployments()
+	}
+	return nil
 }
 
 // Teardown currently does nothing, only to satisfied cleanable{}

--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -51,6 +51,7 @@ const (
 	mcNonAuthInstallFileNamespace  = "istio-multicluster.yaml"
 	mcAuthInstallFileNamespace     = "istio-auth-multicluster.yaml"
 	mcRemoteInstallFile            = "istio-remote.yaml"
+	mcSplitHorizonInstallFile      = "istio-multicluster-split-horizon.yaml"
 	istioSystem                    = "istio-system"
 	istioIngressServiceName        = "istio-ingress"
 	istioIngressLabel              = "ingress"
@@ -68,6 +69,7 @@ const (
 	rootCertFileName               = "samples/certs/root-cert.pem"
 	certChainFileName              = "samples/certs/cert-chain.pem"
 	helmInstallerName              = "helm"
+	remoteNetworkName              = "network2"
 	// CRD files that should be installed during testing
 	// NB: these files come from the directory install/kubernetes/helm/istio-init/files/*crd*
 	//     and contain all CRDs used by Istio during runtime
@@ -111,6 +113,7 @@ var (
 	imagePullPolicy     = flag.String("image_pull_policy", "", "Specifies an override for the Docker image pull policy to be used")
 	multiClusterDir     = flag.String("cluster_registry_dir", "",
 		"Directory name for the cluster registry config. When provided a multicluster test to be run across two clusters.")
+	splitHorizon             = flag.Bool("split_horizon", false, "Set up a split horizon EDS multi-cluster test environment")
 	useGalleyConfigValidator = flag.Bool("use_galley_config_validator", true, "Use galley configuration validation webhook")
 	installer                = flag.String("installer", "kubectl", "Istio installer, default to kubectl, or helm")
 	useMCP                   = flag.Bool("use_mcp", true, "use MCP for configuring Istio components")
@@ -279,10 +282,18 @@ func newKubeInfo(tmpDir, runID, baseVersion string) (*KubeInfo, error) {
 			remoteI.localPath = filepath.Join(releaseDir, "/bin/istioctl")
 			remoteI.defaultProxy = true
 		}
-		aRemote = NewAppManager(tmpDir, *namespace, remoteI, remoteKubeConfig)
+		if *splitHorizon {
+			// For remote Istio configuration in a split horizon test we don't wait
+			// for the deployments because they won't be able to connect to Pilot
+			// until their service is added by watching the remote k8s api. Adding
+			// the remote k8s api watcher is done later on in the test.
+			aRemote = NewAppManager(tmpDir, *namespace, remoteI, remoteKubeConfig, false)
+		} else {
+			aRemote = NewAppManager(tmpDir, *namespace, remoteI, remoteKubeConfig, true)
+		}
 	}
 
-	a := NewAppManager(tmpDir, *namespace, i, kubeConfig)
+	a := NewAppManager(tmpDir, *namespace, i, kubeConfig, true)
 
 	kubeAccessor, err := testKube.NewAccessor(kubeConfig, tmpDir)
 	if err != nil {
@@ -463,10 +474,10 @@ func (k *KubeInfo) doGetIngress(serviceName string, podLabel string, lock sync.L
 	}
 	if k.localCluster {
 		*ingress, *ingressErr = util.GetIngress(serviceName, podLabel,
-			k.Istioctl.istioNamespace, k.KubeConfig, util.NodePortServiceType)
+			k.Istioctl.istioNamespace, k.KubeConfig, util.NodePortServiceType, true)
 	} else {
 		*ingress, *ingressErr = util.GetIngress(serviceName, podLabel,
-			k.Istioctl.istioNamespace, k.KubeConfig, util.LoadBalancerServiceType)
+			k.Istioctl.istioNamespace, k.KubeConfig, util.LoadBalancerServiceType, true)
 	}
 
 	// So far we only do http ingress
@@ -643,16 +654,20 @@ func (k *KubeInfo) deepCopy(src map[string][]string) map[string][]string {
 func (k *KubeInfo) deployIstio() error {
 	istioYaml := nonAuthInstallFileNamespace
 	if *multiClusterDir != "" {
-		istioYaml = mcNonAuthInstallFileNamespace
-	}
-	if *clusterWide {
+		if *splitHorizon {
+			istioYaml = mcSplitHorizonInstallFile
+		} else {
+			if *authEnable {
+				istioYaml = mcAuthInstallFileNamespace
+			} else {
+				istioYaml = mcNonAuthInstallFileNamespace
+			}
+		}
+	} else if *clusterWide {
 		istioYaml = getClusterWideInstallFile()
 	} else {
 		if *authEnable {
 			istioYaml = authInstallFileNamespace
-			if *multiClusterDir != "" {
-				istioYaml = mcAuthInstallFileNamespace
-			}
 		}
 		if *trustDomainEnable {
 			istioYaml = trustDomainFileNamespace
@@ -716,7 +731,13 @@ func (k *KubeInfo) deployIstio() error {
 		}
 
 		testIstioYaml := filepath.Join(k.TmpDir, "yaml", mcRemoteInstallFile)
-		if err := k.generateRemoteIstio(testIstioYaml, *useAutomaticInjection, *proxyHub, *proxyTag); err != nil {
+		var err error
+		if *splitHorizon {
+			err = k.generateRemoteIstioForSplitHorizon(testIstioYaml, remoteNetworkName, *proxyHub, *proxyTag)
+		} else {
+			err = k.generateRemoteIstio(testIstioYaml, *useAutomaticInjection, *proxyHub, *proxyTag)
+		}
+		if err != nil {
 			log.Errorf("Generating Remote yaml %s failed", testIstioYaml)
 			return err
 		}
@@ -1080,6 +1101,11 @@ func (k *KubeInfo) generateIstio(src, dst string) error {
 	if *localCluster {
 		content = []byte(strings.Replace(string(content), util.LoadBalancerServiceType,
 			util.NodePortServiceType, 1))
+	}
+
+	if *splitHorizon {
+		registryName := filepath.Base(k.RemoteKubeConfig)
+		content = replacePattern(content, "N2_REGISTRY_TOKEN", registryName)
 	}
 
 	err = ioutil.WriteFile(dst, content, 0600)

--- a/tests/e2e/framework/multicluster.go
+++ b/tests/e2e/framework/multicluster.go
@@ -133,6 +133,53 @@ func (k *KubeInfo) generateRemoteIstio(dst string, useAutoInject bool, proxyHub,
 	return nil
 }
 
+func (k *KubeInfo) generateRemoteIstioForSplitHorizon(dst string, network string, proxyHub, proxyTag string) (err error) {
+	// Get the ingress gateway address of the primary cluster
+	var primaryGwAddr string
+	if k.localCluster {
+		primaryGwAddr, err = util.GetIngress(istioIngressGatewayServiceName, istioIngressGatewayLabel,
+			k.Namespace, k.KubeConfig, util.NodePortServiceType, false)
+	} else {
+		primaryGwAddr, err = util.GetIngress(istioIngressGatewayServiceName, istioIngressGatewayLabel,
+			k.Namespace, k.KubeConfig, util.LoadBalancerServiceType, false)
+	}
+	if err != nil {
+		log.Errora("failed to get the ingress gateway address of the primary cluster", err)
+		return err
+	}
+
+	var helmSetContent string
+	helmSetContent += " --set global.mtls.enabled=true"
+	helmSetContent += " --set gateways.enabled=true"
+	helmSetContent += " --set security.selfSigned=false"
+	helmSetContent += " --set global.controlPlaneSecurityEnabled=true"
+	helmSetContent += " --set global.createRemoteSvcEndpoints=true"
+	helmSetContent += " --set global.remotePilotCreateSvcEndpoint=true"
+	helmSetContent += " --set global.remotePilotAddress=" + primaryGwAddr
+	helmSetContent += " --set global.remotePolicyAddress=" + primaryGwAddr
+	helmSetContent += " --set global.remoteTelemetryAddress=" + primaryGwAddr
+	helmSetContent += " --set gateways.istio-ingressgateway.env.ISTIO_META_NETWORK=\"" + network + "\""
+	helmSetContent += " --set global.network=\"" + network + "\""
+	if proxyHub != "" && proxyTag != "" {
+		helmSetContent += " --set global.hub=" + proxyHub + " --set global.tag=" + proxyTag
+	}
+
+	err = util.HelmClientInit()
+	if err != nil {
+		log.Errorf("couldn't run helm init %v", err)
+		return err
+	}
+
+	chartDir := filepath.Join(k.ReleaseDir, "install/kubernetes/helm/istio")
+	helmSetContent += " --values " + filepath.Join(k.ReleaseDir, "install/kubernetes/helm/istio/values-istio-remote.yaml")
+	err = util.HelmTemplate(chartDir, "istio-remote", k.Namespace, helmSetContent, dst)
+	if err != nil {
+		log.Errorf("cannot write remote into generated yaml file %s: %v", dst, err)
+		return err
+	}
+	return nil
+}
+
 func (k *KubeInfo) createCacerts(remoteCluster bool) (err error) {
 	kc := k.KubeConfig
 	cluster := "primary"

--- a/tests/e2e/tests/multicluster/split_horizon_test.go
+++ b/tests/e2e/tests/multicluster/split_horizon_test.go
@@ -1,0 +1,404 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/multierr"
+
+	"istio.io/istio/pkg/log"
+	"istio.io/istio/tests/e2e/framework"
+	"istio.io/istio/tests/util"
+)
+
+const (
+	defaultRetryBudget             = 10
+	retryDelay                     = time.Second
+	istioIngressGatewayServiceName = "istio-ingressgateway"
+	istioIngressGatewayLabel       = "ingressgateway"
+	istioMeshConfigMapName         = "istio"
+	defaultPropagationDelay        = 5 * time.Second
+	maxDeploymentTimeout           = 480 * time.Second
+	primaryCluster                 = framework.PrimaryCluster
+	remoteCluster                  = framework.RemoteCluster
+	clusterAwareGateway            = `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cluster-aware-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 443
+      name: tls
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
+    hosts:
+    - "*.local"
+`
+)
+
+var (
+	tc = &testConfig{}
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	check(framework.InitLogging(), "cannot setup logging")
+	check(setTestConfig(), "could not create TestConfig")
+	tc.Cleanup.RegisterCleanable(tc)
+	os.Exit(tc.RunTest(m))
+}
+
+func TestRemoteInstanceAcessible(t *testing.T) {
+	// Get the sleep pod name
+	podName, err := util.GetPodName("sample", "app=sleep", tc.Kube.KubeConfig)
+	if err != nil {
+		t.Fatalf("couldn't get the sleep pod name. Error: %s", err.Error())
+	}
+
+	// Out of the 10 tries no response from remote cluster therefore fail the test
+	runRetriableTest(t, "GetResponseFromRemote", defaultRetryBudget, func() error {
+		output, err := util.PodExec("sample", podName, "sleep", "curl helloworld.sample:5000/hello", false, tc.Kube.KubeConfig)
+		if err != nil {
+			t.Fatalf("couldn't execute a curl call from the sleep pod. Error: %s", err.Error())
+		}
+
+		// Check whether the response is from remote cluster (v2). If it is then the
+		// test is successful
+		if strings.Index(output, "Hello version: v2") >= 0 {
+			log.Info("got response from the helloworld v2 instance (remote cluster)")
+			return nil
+		}
+		return fmt.Errorf("received only responses from primary (v1) while expecting at least one response from remote (v2)")
+	})
+}
+
+func setTestConfig() error {
+	cc, err := framework.NewCommonConfig("split_horizon_test")
+	if err != nil {
+		return err
+	}
+	tc.CommonConfig = cc
+
+	if tc.Kube.RemoteKubeConfig == "" {
+		return fmt.Errorf("no RemoteKubeConfig")
+	}
+
+	appDir, err := ioutil.TempDir(os.TempDir(), "split_horizon_test")
+	if err != nil {
+		return err
+	}
+	tc.AppDir = appDir
+
+	// Extra system configuration required for the pilot tests.
+	tc.extraConfig = make(map[string]*deployableConfig)
+
+	// Deplyment configration for the primary cluster
+	if kc, ok := tc.Kube.Clusters[primaryCluster]; ok {
+		tc.extraConfig[primaryCluster] = &deployableConfig{
+			Namespace:      "sample",
+			IstioInjection: true,
+			YamlFiles: []yamlFile{
+				{
+					// Select the service from the yaml file
+					Name:         "testdata/helloworld.yaml",
+					LabelSeletor: "app=helloworld",
+				},
+				{
+					// Select the v1 deployment from the yaml file
+					Name:         "testdata/helloworld.yaml",
+					LabelSeletor: "version=v1",
+				},
+				{
+					// sleep service yaml file
+					Name: "testdata/sleep.yaml",
+				},
+			},
+			kubeconfig: kc,
+		}
+	}
+
+	if kc, ok := tc.Kube.Clusters[remoteCluster]; ok {
+		tc.extraConfig[remoteCluster] = &deployableConfig{
+			Namespace:      "sample",
+			IstioInjection: true,
+			YamlFiles: []yamlFile{
+				{
+					// Select the service from the yaml file
+					Name:         "testdata/helloworld.yaml",
+					LabelSeletor: "app=helloworld",
+				},
+				{
+					// Select the v2 deployment from the yaml file
+					Name:         "testdata/helloworld.yaml",
+					LabelSeletor: "version=v2",
+				},
+			},
+			kubeconfig: kc,
+		}
+	}
+
+	return nil
+}
+
+func check(err error, msg string) {
+	if err != nil {
+		log.Errorf("%s. Error %s", msg, err)
+		os.Exit(-1)
+	}
+}
+
+// runRetriableTest runs the given test function the provided number of times.
+func runRetriableTest(t *testing.T, testName string, retries int, f func() error, errorFunc ...func()) {
+	t.Run(testName, func(t *testing.T) {
+		remaining := retries
+		for {
+			// Call the test function.
+			remaining--
+			err := f()
+			if err == nil {
+				// Test succeeded, we're done here.
+				return
+			}
+
+			if remaining == 0 {
+				// We're out of retries - fail the test now.
+				for _, e := range errorFunc {
+					if e != nil {
+						e()
+					}
+				}
+				t.Fatal(err)
+			}
+
+			// Wait for a bit before retrying.
+			retries--
+			time.Sleep(retryDelay)
+		}
+	})
+}
+
+type yamlFile struct {
+	Name         string
+	LabelSeletor string
+}
+type resource struct {
+	// Kind of the resource
+	Kind string
+	// Name of the resource
+	Name string
+}
+
+// deployableConfig is a collection of configs that are applied/deleted as a single unit.
+type deployableConfig struct {
+	Namespace      string
+	IstioInjection bool
+	YamlFiles      []yamlFile
+
+	// List of resources must be removed during deployableConfig setup, and restored
+	// during teardown. These resources must exist before deployableConfig setup runs, and should be
+	// in the same namespace defined above. Typically, they are added by the default Istio installation
+	// (e.g the default global authentication policy) and need to be modified for tests.
+	Removes    []resource
+	applied    []string
+	removed    []string
+	kubeconfig string
+}
+
+// Setup pushes the config and waits for it to propagate to all nodes in the cluster.
+func (c *deployableConfig) Setup() error {
+	c.removed = []string{}
+	for _, r := range c.Removes {
+		content, err := util.KubeGetYaml(c.Namespace, r.Kind, r.Name, c.kubeconfig)
+		if err != nil {
+			// Run the teardown function now and return
+			_ = c.Teardown()
+			return err
+		}
+		if err := util.KubeDeleteContents(c.Namespace, content, c.kubeconfig); err != nil {
+			// Run the teardown function now and return
+			_ = c.Teardown()
+			return err
+		}
+		c.removed = append(c.removed, content)
+	}
+
+	if c.Namespace != tc.Kube.Namespace {
+		if err := util.CreateNamespace(c.Namespace, c.kubeconfig); err != nil {
+			_ = c.Teardown()
+			return err
+		}
+	}
+
+	if c.IstioInjection {
+		if err := util.LabelNamespace(c.Namespace, "istio-injection=enabled", c.kubeconfig); err != nil {
+			_ = c.Teardown()
+			return err
+		}
+	}
+
+	c.applied = []string{}
+	// Apply the yaml file(s)
+	for _, yamlFile := range c.YamlFiles {
+		kubeCmd := "apply"
+		if len(yamlFile.LabelSeletor) > 0 {
+			kubeCmd += " -l " + yamlFile.LabelSeletor
+		}
+		if err := util.KubeCommand(kubeCmd, c.Namespace, yamlFile.Name, c.kubeconfig); err != nil {
+			// Run the teardown function now and return
+			_ = c.Teardown()
+			return err
+		}
+		c.applied = append(c.applied, yamlFile.Name)
+	}
+
+	// Wait until the deployments are ready
+	if err := util.CheckDeployments(c.Namespace, maxDeploymentTimeout, c.kubeconfig); err != nil {
+		_ = c.Teardown()
+		return err
+	}
+
+	return nil
+}
+
+// Teardown deletes the deployed configuration.
+func (c *deployableConfig) Teardown() error {
+	err := c.TeardownNoDelay()
+
+	// Sleep for a while to allow the change to propagate.
+	time.Sleep(c.propagationDelay())
+	return err
+}
+
+// Teardown deletes the deployed configuration.
+func (c *deployableConfig) TeardownNoDelay() error {
+	var err error
+	for _, yamlFile := range c.applied {
+		err = multierr.Append(err, util.KubeDelete(c.Namespace, yamlFile, c.kubeconfig))
+	}
+	// Restore configs that was removed
+	for _, yaml := range c.removed {
+		err = multierr.Append(err, util.KubeApplyContents(c.Namespace, yaml, c.kubeconfig))
+	}
+	c.applied = []string{}
+	return err
+}
+
+func (c *deployableConfig) propagationDelay() time.Duration {
+	// With multiple clusters, it takes more time to propagate.
+	return defaultPropagationDelay * time.Duration(len(tc.Kube.Clusters))
+}
+
+type testConfig struct {
+	*framework.CommonConfig
+	AppDir      string
+	extraConfig map[string]*deployableConfig
+}
+
+// Setup initializes the test environment and waits for all pods to be in the running state.
+func (t *testConfig) Setup() (err error) {
+	// Wait for all the pods to be in the running state before starting tests.
+	for cluster, kc := range t.Kube.Clusters {
+		log.Infof("Making sure all pods are running on cluster: %s", cluster)
+		if err == nil && !util.CheckPodsRunning(t.Kube.Namespace, kc) {
+			err = fmt.Errorf("can't get all pods running in %s cluster", cluster)
+			break
+		}
+		log.Info("All pods are running")
+	}
+
+	// Update the meshNetworks within the mesh config with the gateway address of the remote
+	// cluster.
+	remoteGwAddr, err := util.GetIngress(istioIngressGatewayServiceName, istioIngressGatewayLabel,
+		t.Kube.Namespace, t.Kube.RemoteKubeConfig, util.LoadBalancerServiceType, false)
+	if err != nil {
+		return
+	}
+	util.ReplaceInConfigMap(tc.Kube.Namespace, istioMeshConfigMapName,
+		fmt.Sprintf("s/0.0.0.0/%s/", remoteGwAddr), tc.Kube.KubeConfig)
+
+	// Add the remote cluster into the mesh by adding the secret
+	if err = addRemoteCluster(); err != nil {
+		return err
+	}
+
+	// Wait until the deployments on remote cluster are all ready
+	err = util.CheckDeployments(tc.Kube.Namespace, maxDeploymentTimeout, tc.Kube.RemoteKubeConfig)
+	if err != nil {
+		return
+	}
+
+	// Apply the cluster-aware gateway for the auto SNI-based passthrough. Applied to primary but
+	// effective for all clusters.
+	err = util.KubeApplyContents(tc.Kube.Namespace, clusterAwareGateway, tc.Kube.KubeConfig)
+
+	// Clusters are now ready for testing
+
+	// Deploy additional configuration/apps
+	for _, ec := range t.extraConfig {
+		err = ec.Setup()
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// Teardown shuts down the test environment.
+func (t *testConfig) Teardown() (err error) {
+	// Delete the remote cluster secret
+	if err = deleteRemoteCluster(); err != nil {
+		return err
+	}
+
+	// Remove additional configuration.
+	for _, ec := range t.extraConfig {
+		e := ec.Teardown()
+		if e != nil {
+			err = multierr.Append(err, e)
+		}
+	}
+	return
+}
+
+func addRemoteCluster() error {
+	if err := util.CreateMultiClusterSecret(tc.Kube.Namespace, tc.Kube.RemoteKubeConfig, tc.Kube.KubeConfig); err != nil {
+		log.Errorf("Unable to create remote cluster secret on primary cluster %s", err.Error())
+		return err
+	}
+	time.Sleep(defaultPropagationDelay)
+	return nil
+}
+
+func deleteRemoteCluster() error {
+	if err := util.DeleteMultiClusterSecret(tc.Kube.Namespace, tc.Kube.RemoteKubeConfig, tc.Kube.KubeConfig); err != nil {
+		return err
+	}
+	time.Sleep(defaultPropagationDelay)
+	return nil
+}

--- a/tests/e2e/tests/multicluster/testdata/helloworld.yaml
+++ b/tests/e2e/tests/multicluster/testdata/helloworld.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: helloworld
+  labels:
+    app: helloworld
+spec:
+  ports:
+  - port: 5000
+    name: http
+  selector:
+    app: helloworld
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld-v1
+  labels:
+    version: v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helloworld
+        version: v1
+    spec:
+      containers:
+      - name: helloworld
+        image: istio/examples-helloworld-v1
+        resources:
+          requests:
+            cpu: "100m"
+        imagePullPolicy: IfNotPresent #Always
+        ports:
+        - containerPort: 5000
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld-v2
+  labels:
+    version: v2
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: helloworld
+        version: v2
+    spec:
+      containers:
+      - name: helloworld
+        image: istio/examples-helloworld-v2
+        resources:
+          requests:
+            cpu: "100m"
+        imagePullPolicy: IfNotPresent #Always
+        ports:
+        - containerPort: 5000

--- a/tests/e2e/tests/multicluster/testdata/sleep.yaml
+++ b/tests/e2e/tests/multicluster/testdata/sleep.yaml
@@ -1,0 +1,53 @@
+# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Sleep service
+##################################################################################################
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sleep
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sleep
+  labels:
+    app: sleep
+spec:
+  ports:
+  - port: 80
+    name: http
+  selector:
+    app: sleep
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: sleep
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sleep
+    spec:
+      serviceAccountName: sleep
+      containers:
+      - name: sleep
+        image: pstauffer/curl
+        command: ["/bin/sleep", "3650d"]
+        imagePullPolicy: IfNotPresent
+---

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -221,7 +221,7 @@ test/local/auth/e2e_bookinfo_trustdomain: out_dir generate_yaml
 		--auth_enable=true --trust_domain_enable --egress=true --ingress=false --rbac_enable=false \
 		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
-test/local/auth/e2e_split_horizon: out_dir generate_e2e_yaml
+test/local/auth/e2e_split_horizon: out_dir generate_yaml
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/multicluster \
 		--split_horizon \
 		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}

--- a/tests/istio.mk
+++ b/tests/istio.mk
@@ -145,6 +145,8 @@ e2e_bookinfo_trustdomain: | istioctl test/local/auth/e2e_bookinfo_trustdomain
 
 e2e_pilotv2_auth_sds: | istioctl test/local/auth/e2e_sds_pilotv2
 
+e2e_multicluster_split_horizon: | istioctl test/local/auth/e2e_split_horizon
+
 # This is used to keep a record of the test results.
 CAPTURE_LOG=| tee -a ${OUT_DIR}/tests/build-log.txt
 
@@ -217,6 +219,11 @@ test/local/auth/e2e_bookinfo_envoyv2: out_dir generate_yaml
 test/local/auth/e2e_bookinfo_trustdomain: out_dir generate_yaml
 	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/bookinfo \
 		--auth_enable=true --trust_domain_enable --egress=true --ingress=false --rbac_enable=false \
+		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
+
+test/local/auth/e2e_split_horizon: out_dir generate_e2e_yaml
+	set -o pipefail; go test -v -timeout 25m ./tests/e2e/tests/multicluster \
+		--split_horizon \
 		--cluster_wide ${E2E_ARGS} ${T} ${EXTRA_E2E_ARGS} ${CAPTURE_LOG}
 
 test/local/noauth/e2e_mixer_envoyv2: export EXTRA_HELM_SETTINGS=--set mixer.adapters.stdio.enabled=false

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -131,6 +131,17 @@ func DeleteDeployment(d string, n string, kubeconfig string) error {
 	return err
 }
 
+// LabelNamespace will add a label to the kubernetes namespace
+func LabelNamespace(n, label, kubeconfig string) error {
+	if _, err := Shell("kubectl label namespace %s %s --kubeconfig=%s", n, label, kubeconfig); err != nil {
+		if !strings.Contains(err.Error(), "AlreadyExists") {
+			return err
+		}
+	}
+	log.Infof("label %s added to namespace %s", label, n)
+	return nil
+}
+
 // NamespaceDeleted check if a kubernete namespace is deleted
 func NamespaceDeleted(n string, kubeconfig string) (bool, error) {
 	output, err := ShellSilent("kubectl get namespace %s -o name --kubeconfig=%s", n, kubeconfig)
@@ -166,6 +177,12 @@ func kubeCommand(subCommand, namespace, yamlFileName string, kubeconfig string) 
 // KubeApply kubectl apply from file
 func KubeApply(namespace, yamlFileName string, kubeconfig string) error {
 	_, err := Shell(kubeCommand("apply", namespace, yamlFileName, kubeconfig))
+	return err
+}
+
+// KubeCommand will execut a kubectl command withe the specified yaml file
+func KubeCommand(command, namespace, yamlFileName string, kubeconfig string) error {
+	_, err := Shell(kubeCommand(command, namespace, yamlFileName, kubeconfig))
 	return err
 }
 
@@ -267,7 +284,7 @@ func getRetrier(serviceType string) Retrier {
 // GetIngress get istio ingress ip and port. Could relate to either Istio Ingress or to
 // Istio Ingress Gateway, by serviceName and podLabel. Handles two cases: when the Ingress/Ingress Gateway
 // Kubernetes Service is a LoadBalancer or NodePort (for tests within the  cluster, including for minikube)
-func GetIngress(serviceName, podLabel, namespace, kubeconfig string, serviceType string) (string, error) {
+func GetIngress(serviceName, podLabel, namespace, kubeconfig string, serviceType string, sanityCheck bool) (string, error) {
 
 	retry := getRetrier(serviceType)
 	var ingress string
@@ -298,6 +315,10 @@ func GetIngress(serviceName, podLabel, namespace, kubeconfig string, serviceType
 
 	ctx, cancel := context.WithTimeout(ctx, 300*time.Second)
 	defer cancel()
+
+	if !sanityCheck {
+		return ingress, nil
+	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	ingressURL := fmt.Sprintf("http://%s", ingress)
@@ -861,6 +882,18 @@ func DeleteMultiClusterSecret(namespace string, RemoteKubeConfig string, localKu
 		log.Errorf("Failed to delete secret %s: %v", secretName, err)
 	} else {
 		log.Infof("Deleted secret %s", secretName)
+	}
+	return err
+}
+
+// ReplaceInConfigMap will modify an existing configmap with the provided sed expression
+func ReplaceInConfigMap(namespace string, configmapName string, sedExpression string, kubeconfig string) error {
+	_, err := ShellMuteOutput("kubectl get configmap/%s -n %s --kubeconfig=%s -o yaml | sed \"%s\" | kubectl replace --kubeconfig=%s -f -",
+		configmapName, namespace, kubeconfig, sedExpression, kubeconfig)
+	if err != nil {
+		log.Errorf("Failed to edit the configmap %s: %v", configmapName, err)
+	} else {
+		log.Infof("Configmap %s updated with sed expression %s", configmapName, sedExpression)
 	}
 	return err
 }


### PR DESCRIPTION
This is a new prow e2e integration test.
It is testing the cluster-aware multicluster feature (aka Split Horizon EDS) by setting up two clusters. One of them is the primary and the other one is remote and traffic from primary to remote is going through the remote ingress gateway.

After setting up the test environment on the two clusters the test is:
1. Deploying `helloworld v1` and `sleep` on primary cluster
1. Deploying `helloworld v2` on remote cluster
1. Executing from within the `sleep` container a call to the helloworld service multiple types
1. Verify that at least one response is coming back from v2 (remote cluster)

It's basically going through the steps described in [the cluster-aware example](https://preliminary.istio.io/docs/examples/multicluster/split-horizon-eds/).

Another PR in `test-infra` will add this test to the rest of prow tests.