### PR TITLE
Add the network attribute to the reports

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -106,6 +106,8 @@ spec:
       valueType: STRING
     context.reporter.uid:
       valueType: STRING
+    context.reporter.network:
+      valueType: STRING
     api.service:
       valueType: STRING
     api.version:

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -98,6 +98,7 @@ func (mixerplugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.Mu
 		"source.namespace":      attrNamespace(in.Node),
 		"context.reporter.uid":  attrUID(in.Node),
 		"context.reporter.kind": attrStringValue("outbound"),
+		"context.reporter.network": attrNetwork(in.Node),
 	}
 
 	switch in.ListenerProtocol {
@@ -129,6 +130,7 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 		"destination.namespace": attrNamespace(in.Node),
 		"context.reporter.uid":  attrUID(in.Node),
 		"context.reporter.kind": attrStringValue("inbound"),
+		"context.reporter.network": attrNetwork(in.Node),
 	}
 
 	switch address := mutable.Listener.Address.Address.(type) {
@@ -582,6 +584,13 @@ func attrNamespace(node *model.Proxy) attribute {
 	parts := strings.Split(node.ID, ".")
 	if len(parts) >= 2 {
 		return attrStringValue(parts[1])
+	}
+	return attrStringValue("")
+}
+
+func attrNetwork(node *model.Proxy) attribute {
+	if network, found := node.Metadata[model.NodeMetadataNetwork]; found {
+		return attrStringValue(network)
 	}
 	return attrStringValue("")
 }

--- a/pilot/pkg/networking/plugin/mixer/mixer.go
+++ b/pilot/pkg/networking/plugin/mixer/mixer.go
@@ -98,7 +98,10 @@ func (mixerplugin) OnOutboundListener(in *plugin.InputParams, mutable *plugin.Mu
 		"source.namespace":      attrNamespace(in.Node),
 		"context.reporter.uid":  attrUID(in.Node),
 		"context.reporter.kind": attrStringValue("outbound"),
-		"context.reporter.network": attrNetwork(in.Node),
+	}
+
+	if network, found := in.Node.Metadata[model.NodeMetadataNetwork]; found {
+		attrs["context.reporter.network"] = attrStringValue(network)
 	}
 
 	switch in.ListenerProtocol {
@@ -130,7 +133,10 @@ func (mixerplugin) OnInboundListener(in *plugin.InputParams, mutable *plugin.Mut
 		"destination.namespace": attrNamespace(in.Node),
 		"context.reporter.uid":  attrUID(in.Node),
 		"context.reporter.kind": attrStringValue("inbound"),
-		"context.reporter.network": attrNetwork(in.Node),
+	}
+
+	if network, found := in.Node.Metadata[model.NodeMetadataNetwork]; found {
+		attrs["context.reporter.network"] = attrStringValue(network)
 	}
 
 	switch address := mutable.Listener.Address.Address.(type) {
@@ -584,13 +590,6 @@ func attrNamespace(node *model.Proxy) attribute {
 	parts := strings.Split(node.ID, ".")
 	if len(parts) >= 2 {
 		return attrStringValue(parts[1])
-	}
-	return attrStringValue("")
-}
-
-func attrNetwork(node *model.Proxy) attribute {
-	if network, found := node.Metadata[model.NodeMetadataNetwork]; found {
-		return attrStringValue(network)
 	}
 	return attrStringValue("")
 }


### PR DESCRIPTION
Targeting a multi-cluster environment where proxies from various networks are sending reports to the primary Mixer (aka Cluster-aware/Split Horizon EDS).
Adding the network as an  additional reporter context attribute will allow users to filter telemetry based on the network/cluster it was reported from.