### PR TITLE
Add namespace scoping to the Gateway 'port' names (#11509) (#12500)

### DIFF
--- a/pilot/pkg/model/gateway.go
+++ b/pilot/pkg/model/gateway.go
@@ -33,7 +33,12 @@ type MergedGateway struct {
 	// maps from port names to virtual hosts
 	// Used for RDS. No two port names share same port except for HTTPS
 	// The typical length of the value is always 1, except for HTTP (not HTTPS),
-	RDSRouteConfigNames map[string][]*networking.Server
+	ServersByRouteName map[string][]*networking.Server
+
+	// maps from server to a corresponding RDS route name
+	// Inverse of ServersByRouteName. Returning this as part of merge result allows to keep route name generation logic
+	// encapsulated within the model and, as a side effect, to avoid generating route names twice.
+	RouteNamesByServer map[*networking.Server]string
 }
 
 // MergeGateways combines multiple gateways targeting the same workload into a single logical Gateway.
@@ -45,7 +50,8 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 	servers := make(map[uint32][]*networking.Server)
 	tlsServers := make(map[uint32][]*networking.Server)
 	plaintextServers := make(map[uint32][]*networking.Server)
-	rdsRouteConfigNames := make(map[string][]*networking.Server)
+	serversByRouteName := make(map[string][]*networking.Server)
+	routeNamesByServer := make(map[*networking.Server]string)
 
 	log.Debugf("MergeGateways: merging %d gateways", len(gateways))
 	for _, config := range gateways {
@@ -73,19 +79,20 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 							config.Name, s.Port.Name, s.Port.Number, s.Port.Protocol, p[0].Port.Name, p[0].Port.Number, p[0].Port.Protocol)
 						continue
 					}
-					rdsName := GatewayRDSRouteName(s)
-					if rdsName == "" {
+					routeName := gatewayRDSRouteName(s, config.Namespace)
+					if routeName == "" {
 						log.Debugf("skipping server on gateway %s port %s.%d.%s: could not build RDS name from server",
 							config.Name, s.Port.Name, s.Port.Number, s.Port.Protocol)
 						continue
 					}
-					rdsRouteConfigNames[rdsName] = append(rdsRouteConfigNames[rdsName], s)
+					serversByRouteName[routeName] = append(serversByRouteName[routeName], s)
+					routeNamesByServer[s] = routeName
 				} else {
 					// We have duplicate port. Its not in plaintext servers. So, this has to be in TLS servers
 					// Check if this is also a HTTP server and if so, ensure uniqueness of port name
 					if IsHTTPServer(s) {
-						rdsName := GatewayRDSRouteName(s)
-						if rdsName == "" {
+						routeName := gatewayRDSRouteName(s, config.Namespace)
+						if routeName == "" {
 							log.Debugf("skipping server on gateway %s port %s.%d.%s: could not build RDS name from server",
 								config.Name, s.Port.Name, s.Port.Number, s.Port.Protocol)
 							continue
@@ -95,12 +102,13 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 						// WE cannot have two servers with same port name because we need the port name to distinguish one HTTPS server from another
 						// WE cannot merge two HTTPS servers even if their TLS settings have same path to the keys, because we don't know if the contents
 						// of the keys are same. So we treat them as effectively different TLS settings.
-						if _, exists := rdsRouteConfigNames[rdsName]; exists {
+						if _, exists := serversByRouteName[routeName]; exists {
 							log.Infof("skipping server on gateway %s port %s.%d.%s: non unique port name for HTTPS port",
 								config.Name, s.Port.Name, s.Port.Number, s.Port.Protocol)
 							continue
 						}
-						rdsRouteConfigNames[rdsName] = []*networking.Server{s}
+						serversByRouteName[routeName] = []*networking.Server{s}
+						routeNamesByServer[s] = routeName
 					}
 
 					// We have another TLS server on the same port. Can differentiate servers using SNI
@@ -119,7 +127,9 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 				}
 
 				if IsHTTPServer(s) {
-					rdsRouteConfigNames[GatewayRDSRouteName(s)] = []*networking.Server{s}
+					routeName := gatewayRDSRouteName(s, config.Namespace)
+					serversByRouteName[routeName] = []*networking.Server{s}
+					routeNamesByServer[s] = routeName
 				}
 			}
 			log.Debugf("MergeGateways: gateway %q merged server %v", name, s.Hosts)
@@ -135,9 +145,10 @@ func MergeGateways(gateways ...Config) *MergedGateway {
 	}
 
 	return &MergedGateway{
-		Names:               names,
-		Servers:             servers,
-		RDSRouteConfigNames: rdsRouteConfigNames,
+		Names:              names,
+		Servers:            servers,
+		ServersByRouteName: serversByRouteName,
+		RouteNamesByServer: routeNamesByServer,
 	}
 }
 
@@ -163,44 +174,6 @@ func IsHTTPServer(server *networking.Server) bool {
 	return false
 }
 
-// GatewayRDSRouteName generates the RDS route config name for gateway's servers.
-// Unlike sidecars where the RDS route name is the listener port number, gateways have a different
-// structure for RDS.
-// HTTP servers have route name set to http.<portNumber>.
-//   Multiple HTTP servers can exist on the same port and the code will combine all of them into
-//   one single RDS payload for http.<portNumber>
-// HTTPS servers with TLS termination (i.e. envoy decoding the content, and making outbound http calls to backends)
-// will use route name https.<portnumber>.<portName>. HTTPS servers using SNI passthrough or
-// non-HTTPS servers (e.g., TCP+TLS) with SNI passthrough will be setup as opaque TCP proxies without terminating
-// the SSL connection. They would inspect the SNI header and forward to the appropriate upstream as opaque TCP.
-//
-// Within HTTPS servers terminating TLS, user could setup multiple servers in the gateway. each server could have
-// one or more hosts but have different TLS certificates. In this case, we end up having separate filter chain
-// for each server, with the filter chain match matching on the server specific TLS certs and SNI headers.
-// We have two options here: either have all filter chains use the same RDS route name (e.g. "443") and expose
-// all virtual hosts on that port to every filter chain uniformly or expose only the set of virtual hosts
-// configured under the server for those certificates. We adopt the latter approach. In other words, each
-// filter chain in the multi-filter-chain listener will have a distinct RDS route name (https.<portnumber>.portname)
-// so that when a RDS request comes in, we serve the virtual hosts and associated routes for that server.
-//
-// Note that the common case is one where multiple servers are exposed under a single multi-SAN cert on a single port.
-// In this case, we have a single https.<portnumber>.portname RDS for the HTTPS server.
-// While we can use the same RDS route name for two servers (say HTTP and HTTPS) exposing the same set of hosts on
-// different ports, the optimization (one RDS instead of two) could quickly become useless the moment the set of
-// hosts on the two servers start differing -- necessitating the need for two different RDS routes.
-func GatewayRDSRouteName(server *networking.Server) string {
-	protocol := ParseProtocol(server.Port.Protocol)
-	if protocol.IsHTTP() {
-		return fmt.Sprintf("http.%d", server.Port.Number)
-	}
-
-	if protocol == ProtocolHTTPS && server.Tls != nil && !IsPassThroughServer(server) {
-		return fmt.Sprintf("https.%d.%s", server.Port.Number, server.Port.Name)
-	}
-
-	return ""
-}
-
 // IsPassThroughServer returns true if this server does TLS passthrough (auto or manual)
 func IsPassThroughServer(server *networking.Server) bool {
 	if server.Tls == nil {
@@ -213,6 +186,48 @@ func IsPassThroughServer(server *networking.Server) bool {
 	}
 
 	return false
+}
+
+// gatewayRDSRouteName generates the RDS route config name for gateway's servers.
+// Unlike sidecars where the RDS route name is the listener port number, gateways have a different
+// structure for RDS.
+// HTTP servers have route name set to http.<portNumber>.
+//   Multiple HTTP servers can exist on the same port and the code will combine all of them into
+//   one single RDS payload for http.<portNumber>
+// HTTPS servers with TLS termination (i.e. envoy decoding the content, and making outbound http calls to backends)
+// will use route name https.<portnumber>.<portName>.<namespace>. HTTPS servers using SNI passthrough or
+// non-HTTPS servers (e.g., TCP+TLS) with SNI passthrough will be setup as opaque TCP proxies without terminating
+// the SSL connection. They would inspect the SNI header and forward to the appropriate upstream as opaque TCP.
+//
+// Within HTTPS servers terminating TLS, user could setup multiple servers in the gateway. each server could have
+// one or more hosts but have different TLS certificates. In this case, we end up having separate filter chain
+// for each server, with the filter chain match matching on the server specific TLS certs and SNI headers.
+// We have two options here: either have all filter chains use the same RDS route name (e.g. "443") and expose
+// all virtual hosts on that port to every filter chain uniformly or expose only the set of virtual hosts
+// configured under the server for those certificates. We adopt the latter approach. In other words, each
+// filter chain in the multi-filter-chain listener will have a distinct RDS route name
+// (https.<portnumber>.portname.namespace) so that when a RDS request comes in, we serve the virtual hosts and
+// associated routes for that server.
+//
+// Note that the common case is one where multiple servers are exposed under a single multi-SAN cert on a single port.
+// In this case, we have a single https.<portnumber>.portname.namespace RDS for the HTTPS server.
+// While we can use the same RDS route name for two servers (say HTTP and HTTPS) exposing the same set of hosts on
+// different ports, the optimization (one RDS instead of two) could quickly become useless the moment the set of
+// hosts on the two servers start differing -- necessitating the need for two different RDS routes.
+//
+// Such contract means that port names must be unambiguous within the same namespace even if the ports belong to
+// different gateways. Using the same port name is allowed as long as they are in different namespaces.
+func gatewayRDSRouteName(server *networking.Server, namespace string) string {
+	protocol := ParseProtocol(server.Port.Protocol)
+	if protocol.IsHTTP() {
+		return fmt.Sprintf("http.%d", server.Port.Number)
+	}
+
+	if protocol == ProtocolHTTPS && server.Tls != nil && !IsPassThroughServer(server) {
+		return fmt.Sprintf("https.%d.%s.%s", server.Port.Number, server.Port.Name, namespace)
+	}
+
+	return ""
 }
 
 // convert ./host to currentNamespace/Host

--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -73,7 +73,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env *model.Environme
 			// We have a list of HTTP servers on this port. Build a single listener for the server port.
 			// We only need to look at the first server in the list as the merge logic
 			// ensures that all servers are of same type.
-			opts.filterChainOpts = []*filterChainOpts{configgen.createGatewayHTTPFilterChainOpts(node, env, push, servers[0], nil)}
+			routeName := mergedGateway.RouteNamesByServer[servers[0]]
+			opts.filterChainOpts = []*filterChainOpts{configgen.createGatewayHTTPFilterChainOpts(node, servers[0], routeName)}
 		} else {
 			// build http connection manager with TLS context, for HTTPS servers using simple/mutual TLS
 			// build listener with tcp proxy, with or without TLS context, for TCP servers
@@ -85,7 +86,8 @@ func (configgen *ConfigGeneratorImpl) buildGatewayListeners(env *model.Environme
 			for _, server := range servers {
 				if model.IsTLSServer(server) && model.IsHTTPServer(server) {
 					// This is a HTTPS server, where we are doing TLS termination. Build a http connection manager with TLS context
-					filterChainOpts = append(filterChainOpts, configgen.createGatewayHTTPFilterChainOpts(node, env, push, server, nil))
+					routeName := mergedGateway.RouteNamesByServer[server]
+					filterChainOpts = append(filterChainOpts, configgen.createGatewayHTTPFilterChainOpts(node, server, routeName))
 				} else {
 					// passthrough or tcp, yields multiple filter chains
 					filterChainOpts = append(filterChainOpts, configgen.createGatewayTCPFilterChainOpts(node, env, push, server, mergedGateway.Names)...)
@@ -207,12 +209,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 	log.Debugf("buildGatewayRoutes: gateways after merging: %v", merged)
 
 	// make sure that there is some server listening on this port
-	if _, ok := merged.RDSRouteConfigNames[routeName]; !ok {
-		log.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.RDSRouteConfigNames)
-		return nil, fmt.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.RDSRouteConfigNames)
+	if _, ok := merged.ServersByRouteName[routeName]; !ok {
+		log.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.ServersByRouteName)
+		return nil, fmt.Errorf("buildGatewayRoutes: could not find server for routeName %s, have %v", routeName, merged.ServersByRouteName)
 	}
 
-	servers := merged.RDSRouteConfigNames[routeName]
+	servers := merged.ServersByRouteName[routeName]
 
 	nameToServiceMap := make(map[model.Hostname]*model.Service, len(services))
 	for _, svc := range services {
@@ -318,13 +320,12 @@ func (configgen *ConfigGeneratorImpl) buildGatewayHTTPRouteConfig(env *model.Env
 
 // builds a HTTP connection manager for servers of type HTTP or HTTPS (mode: simple/mutual)
 func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
-	node *model.Proxy, _ *model.Environment, _ *model.PushContext, server *networking.Server, _ map[string]bool) *filterChainOpts {
+	node *model.Proxy, server *networking.Server, routeName string) *filterChainOpts {
 
 	serverProto := model.ParseProtocol(server.Port.Protocol)
 	// Are we processing plaintext servers or HTTPS servers?
 	// If plain text, we have to combine all servers into a single listener
 	if serverProto.IsHTTP() {
-		rdsName := model.GatewayRDSRouteName(server)
 		return &filterChainOpts{
 			// This works because we validate that only HTTPS servers can have same port but still different port names
 			// and that no two non-HTTPS servers can be on same port or share port names.
@@ -332,7 +333,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 			sniHosts:   nil,
 			tlsContext: nil,
 			httpOpts: &httpListenerOpts{
-				rds:              rdsName,
+				rds:              routeName,
 				useRemoteAddress: true,
 				direction:        http_conn.EGRESS, // viewed as from gateway to internal
 				connectionManager: &http_conn.HttpConnectionManager{
@@ -365,7 +366,7 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 		sniHosts:   getSNIHostsForServer(server),
 		tlsContext: buildGatewayListenerTLSContext(server, enableIngressSdsAgent),
 		httpOpts: &httpListenerOpts{
-			rds:              model.GatewayRDSRouteName(server),
+			rds:              routeName,
 			useRemoteAddress: true,
 			direction:        http_conn.EGRESS, // viewed as from gateway to internal
 			connectionManager: &http_conn.HttpConnectionManager{

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	routeA = "http.80"
-	routeB = "https.443.https.testns"
+	routeB = "https.443.https.my-gateway.testns"
 )
 
 // Regression for envoy restart and overlapping connections

--- a/pilot/pkg/proxy/envoy/v2/ads_test.go
+++ b/pilot/pkg/proxy/envoy/v2/ads_test.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	routeA = "http.80"
-	routeB = "https.443.https"
+	routeB = "https.443.https.testns"
 )
 
 // Regression for envoy restart and overlapping connections

--- a/pilot/pkg/proxy/envoy/v2/rds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/rds_test.go
@@ -59,7 +59,7 @@ func TestRDS(t *testing.T) {
 		}
 		defer cancel()
 
-		err = sendRDSReq(gatewayID(gatewayIP), []string{"http.80", "https.443.https"}, "", rdsr)
+		err = sendRDSReq(gatewayID(gatewayIP), []string{"http.80", "https.443.https.testns"}, "", rdsr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pilot/pkg/proxy/envoy/v2/rds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/rds_test.go
@@ -59,7 +59,7 @@ func TestRDS(t *testing.T) {
 		}
 		defer cancel()
 
-		err = sendRDSReq(gatewayID(gatewayIP), []string{"http.80", "https.443.https.testns"}, "", rdsr)
+		err = sendRDSReq(gatewayID(gatewayIP), []string{"http.80", "https.443.https.my-gateway.testns"}, "", rdsr)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Currently in order to configure ingressgateway to do TLS termination
using multiple secure virtual hosts with different certificates Istio
requires Gateway 'port' names to be globally unique (i.e. distinct).
I.e. two gateways cannot have secure port named 'https' even if they
reside in different namespaces. Behavior in such case is undefined.

This breaks namespace isolation as a user creating a Gateway in one
namespace might not have access to other namespaces hence can't
if the port name is already 'taken'. Behavior in such case is undefined
and likely to render other virtual hosts unavailable.

This change adds namespace scoping to Gateway port names by appending
namespace suffix to the HTTPS RDS routes. Port names still have to be
unique within the namespace boundaries, but this change makes adding
more specific scoping rather trivial.