### PR TITLE
decouple webhook configuration reconciliation

### DIFF
--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -23,26 +23,67 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
+	"sync"
+	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/howeyc/fsnotify"
 	"k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	clientset "k8s.io/client-go/kubernetes"
 	admissionregistration "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
+	"istio.io/istio/pkg/kube"
 	"istio.io/pkg/log"
 )
 
 var scope = log.RegisterScope("validation", "CRD validation debugging", 0)
 
+type createInformerWebhookSource func(cl clientset.Interface, name string) cache.ListerWatcher
+
+var (
+	defaultCreateInformerWebhookSource = func(cl clientset.Interface, name string) cache.ListerWatcher {
+		return cache.NewListWatchFromClient(
+			cl.AdmissionregistrationV1beta1().RESTClient(),
+			"validatingwebhookconfigurations",
+			"",
+			fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", name)))
+	}
+)
+
+// WebhookConfig implements the validating admission webhook for validating Istio configuration.
+type WebhookConfig struct {
+	mu                            sync.RWMutex
+	cert                          *tls.Certificate
+	keyCertWatcher                *fsnotify.Watcher
+	configWatcher                 *fsnotify.Watcher
+	certFile                      string
+	keyFile                       string
+	caFile                        string
+	webhookConfigFile             string
+	clientset                     clientset.Interface
+	webhookName                   string
+	deploymentAndServiceNamespace string
+	deploymentName                string
+	ownerRefs                     []v1.OwnerReference
+	webhookConfiguration          *v1beta1.ValidatingWebhookConfiguration
+
+	// test hook for informers
+	createInformerWebhookSource createInformerWebhookSource
+}
+
 // Run an informer that watches the current webhook configuration
 // for changes.
-func (wh *Webhook) monitorWebhookChanges(stopC <-chan struct{}) chan struct{} {
+func (whc *WebhookConfig) monitorWebhookChanges(stopC <-chan struct{}) chan struct{} {
 	webhookChangedCh := make(chan struct{}, 1000)
 	_, controller := cache.NewInformer(
-		wh.createInformerWebhookSource(wh.clientset, wh.webhookName),
+		whc.createInformerWebhookSource(whc.clientset, whc.webhookName),
 		&v1beta1.ValidatingWebhookConfiguration{},
 		0,
 		cache.ResourceEventHandlerFuncs{
@@ -65,20 +106,20 @@ func (wh *Webhook) monitorWebhookChanges(stopC <-chan struct{}) chan struct{} {
 	return webhookChangedCh
 }
 
-func (wh *Webhook) createOrUpdateWebhookConfig() {
-	if wh.webhookConfiguration == nil {
+func (whc *WebhookConfig) createOrUpdateWebhookConfig() {
+	if whc.webhookConfiguration == nil {
 		scope.Error("validatingwebhookconfiguration update failed: no configuration loaded")
 		reportValidationConfigUpdateError(errors.New("no configuration loaded"))
 		return
 	}
 
-	client := wh.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
-	updated, err := createOrUpdateWebhookConfigHelper(client, wh.webhookConfiguration)
+	client := whc.clientset.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+	updated, err := createOrUpdateWebhookConfigHelper(client, whc.webhookConfiguration)
 	if err != nil {
-		scope.Errorf("%v validatingwebhookconfiguration update failed: %v", wh.webhookConfiguration.Name, err)
+		scope.Errorf("%v validatingwebhookconfiguration update failed: %v", whc.webhookConfiguration.Name, err)
 		reportValidationConfigUpdateError(err)
 	} else if updated {
-		scope.Infof("%v validatingwebhookconfiguration updated", wh.webhookConfiguration.Name)
+		scope.Infof("%v validatingwebhookconfiguration updated", whc.webhookConfiguration.Name)
 		reportValidationConfigUpdate()
 	}
 }
@@ -89,7 +130,7 @@ func createOrUpdateWebhookConfigHelper(
 	client admissionregistration.ValidatingWebhookConfigurationInterface,
 	webhookConfiguration *v1beta1.ValidatingWebhookConfiguration,
 ) (bool, error) {
-	current, err := client.Get(webhookConfiguration.Name, metav1.GetOptions{})
+	current, err := client.Get(webhookConfiguration.Name, v1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			if _, createErr := client.Create(webhookConfiguration); createErr != nil {
@@ -113,27 +154,27 @@ func createOrUpdateWebhookConfigHelper(
 	return false, nil
 }
 
-// Rebuild the validatingwebhookconfiguratio and save for subsequent calls to createOrUpdateWebhookConfig.
-func (wh *Webhook) rebuildWebhookConfig() error {
+// Rebuild the validatingwebhookconfiguration and save for subsequent calls to createOrUpdateWebhookConfig.
+func (whc *WebhookConfig) rebuildWebhookConfig() error {
 	webhookConfig, err := rebuildWebhookConfigHelper(
-		wh.caFile,
-		wh.webhookConfigFile,
-		wh.webhookName,
-		wh.ownerRefs)
+		whc.caFile,
+		whc.webhookConfigFile,
+		whc.webhookName,
+		whc.ownerRefs)
 	if err != nil {
 		reportValidationConfigLoadError(err)
 		scope.Errorf("validatingwebhookconfiguration (re)load failed: %v", err)
 		return err
 	}
-	wh.webhookConfiguration = webhookConfig
+	whc.webhookConfiguration = webhookConfig
 
 	// pretty-print the validatingwebhookconfiguration as YAML
 	var webhookYAML string
-	if b, err := yaml.Marshal(wh.webhookConfiguration); err == nil {
+	if b, err := yaml.Marshal(whc.webhookConfiguration); err == nil {
 		webhookYAML = string(b)
 	}
 	scope.Infof("%v validatingwebhookconfiguration (re)loaded: \n%v",
-		wh.webhookConfiguration.Name, webhookYAML)
+		whc.webhookConfiguration.Name, webhookYAML)
 
 	reportValidationConfigLoad()
 
@@ -165,7 +206,7 @@ func loadCaCertPem(in io.Reader) ([]byte, error) {
 // cleaned up when istio-galley is deleted.
 func rebuildWebhookConfigHelper(
 	caFile, webhookConfigFile, webhookName string,
-	ownerRefs []metav1.OwnerReference,
+	ownerRefs []v1.OwnerReference,
 ) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	// load and validate configuration
 	webhookConfigData, err := ioutil.ReadFile(webhookConfigFile)
@@ -185,7 +226,7 @@ func rebuildWebhookConfigHelper(
 			webhookConfig.Webhooks[i].FailurePolicy = &failurePolicy
 		}
 		if webhookConfig.Webhooks[i].NamespaceSelector == nil {
-			webhookConfig.Webhooks[i].NamespaceSelector = &metav1.LabelSelector{}
+			webhookConfig.Webhooks[i].NamespaceSelector = &v1.LabelSelector{}
 		}
 	}
 
@@ -215,17 +256,161 @@ func rebuildWebhookConfigHelper(
 }
 
 // Reload the server's cert/key for TLS from file.
-func (wh *Webhook) reloadKeyCert() {
-	pair, err := tls.LoadX509KeyPair(wh.certFile, wh.keyFile)
+func (whc *WebhookConfig) reloadKeyCert() {
+	pair, err := tls.LoadX509KeyPair(whc.certFile, whc.keyFile)
 	if err != nil {
 		reportValidationCertKeyUpdateError(err)
 		scope.Errorf("Cert/Key reload error: %v", err)
 		return
 	}
-	wh.mu.Lock()
-	wh.cert = &pair
-	wh.mu.Unlock()
+	whc.mu.Lock()
+	whc.cert = &pair
+	whc.mu.Unlock()
 
 	reportValidationCertKeyUpdate()
 	scope.Info("Cert and Key reloaded")
+}
+
+// NewWebhookConfig manages validating webhook configuration.
+func NewWebhookConfig(p WebhookParameters) (*WebhookConfig, error) {
+	pair, err := tls.LoadX509KeyPair(p.CertFile, p.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	// This is not strictly necessary, but is a workaround for having the dashboard pass. The migration
+	// to OpenCensus metrics means that zero value metrics are not exported, and the dashboard tests
+	// expect data for metrics.
+	reportValidationCertKeyUpdate()
+	certKeyWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	// watch the parent directory of the target files so we can catch
+	// symlink updates of k8s secrets
+	for _, file := range []string{p.CertFile, p.KeyFile, p.CACertFile, p.WebhookConfigFile} {
+		watchDir, _ := filepath.Split(file)
+		if err := certKeyWatcher.Watch(watchDir); err != nil {
+			return nil, fmt.Errorf("could not watch %v: %v", file, err)
+		}
+	}
+
+	// configuration must be updated whenever the caBundle changes.
+	// NOTE: Use a separate watcher to differentiate config/ca from cert/key updates. This is
+	// useful to avoid unnecessary updates and, more importantly, makes its easier to more
+	// accurately capture logs/metrics when files change.
+	configWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range []string{p.CACertFile, p.WebhookConfigFile} {
+		watchDir, _ := filepath.Split(file)
+		if err := configWatcher.Watch(watchDir); err != nil {
+			return nil, fmt.Errorf("could not watch %v: %v", file, err)
+		}
+	}
+
+	whc := &WebhookConfig{
+		keyCertWatcher:                certKeyWatcher,
+		configWatcher:                 configWatcher,
+		certFile:                      p.CertFile,
+		keyFile:                       p.KeyFile,
+		cert:                          &pair,
+		caFile:                        p.CACertFile,
+		webhookConfigFile:             p.WebhookConfigFile,
+		clientset:                     p.Clientset,
+		webhookName:                   p.WebhookName,
+		deploymentName:                p.DeploymentName,
+		deploymentAndServiceNamespace: p.DeploymentAndServiceNamespace,
+		createInformerWebhookSource:   defaultCreateInformerWebhookSource,
+	}
+
+	if galleyDeployment, err := whc.clientset.AppsV1().Deployments(whc.deploymentAndServiceNamespace).Get(whc.deploymentName, v1.GetOptions{}); err != nil { // nolint: lll
+		scope.Warnf("Could not find %s/%s deployment to set ownerRef. The validatingwebhookconfiguration must be deleted manually",
+			whc.deploymentAndServiceNamespace, whc.deploymentName)
+	} else {
+		whc.ownerRefs = []v1.OwnerReference{
+			*v1.NewControllerRef(
+				galleyDeployment,
+				appsv1.SchemeGroupVersion.WithKind("Deployment"),
+			),
+		}
+	}
+
+	return whc, nil
+}
+
+//reconcile monitors the keycert and webhook configuration changes, rebuild and reconcile the configuration
+func (whc *WebhookConfig) reconcile(stopCh <-chan struct{}, enableValidation bool) {
+	defer whc.keyCertWatcher.Close() // nolint: errcheck
+	defer whc.configWatcher.Close()  // nolint: errcheck
+
+	// Try to create the initial webhook configuration (if it doesn't
+	// already exist). Setup a persistent monitor to reconcile the
+	// configuration if the observed configuration doesn't match
+	// the desired configuration.
+	if err := whc.rebuildWebhookConfig(); err == nil {
+		whc.createOrUpdateWebhookConfig()
+	}
+	webhookChangedCh := whc.monitorWebhookChanges(stopCh)
+
+	// use a timer to debounce file updates
+	var keyCertTimerC <-chan time.Time
+	var configTimerC <-chan time.Time
+
+	for {
+		select {
+		case <-keyCertTimerC:
+			keyCertTimerC = nil
+			whc.reloadKeyCert()
+		case <-configTimerC:
+			configTimerC = nil
+
+			// rebuild the desired configuration and reconcile with the
+			// existing configuration.
+			if err := whc.rebuildWebhookConfig(); err == nil {
+				whc.createOrUpdateWebhookConfig()
+			}
+		case <-webhookChangedCh:
+			// reconcile the desired configuration
+			whc.createOrUpdateWebhookConfig()
+		case event, more := <-whc.keyCertWatcher.Event:
+			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
+				keyCertTimerC = time.After(watchDebounceDelay)
+			}
+		case event, more := <-whc.configWatcher.Event:
+			if more && (event.IsModify() || event.IsCreate()) && configTimerC == nil {
+				configTimerC = time.After(watchDebounceDelay)
+			}
+		case err := <-whc.keyCertWatcher.Error:
+			scope.Errorf("keyCertWatcher error: %v", err)
+		case err := <-whc.configWatcher.Error:
+			scope.Errorf("configWatcher error: %v", err)
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// ReconcileWebhookConfiguration reconciles the ValidatingWebhookConfiguration
+func ReconcileWebhookConfiguration(webhookServerReady chan struct{}, stopCh <-chan struct{}, kubeConfig string, vc *WebhookParameters) {
+
+	clientset, err := kube.CreateClientset(kubeConfig, "")
+	if err != nil {
+		log.Fatalf("could not create k8s clientset: %v", err)
+	}
+	vc.Clientset = clientset
+
+	whc, err := NewWebhookConfig(*vc)
+	if err != nil {
+		log.Fatalf("cannot create validation webhook config: %v", err)
+	}
+
+	if vc.EnableValidation {
+		//wait for galley endpoint to be available before register ValidatingWebhookConfiguration
+		<-webhookServerReady
+		whc.reconcile(stopCh, vc.EnableValidation)
+	} else {
+		whc.reconcile(stopCh, vc.EnableValidation)
+	}
+
 }

--- a/galley/pkg/crd/validation/config.go
+++ b/galley/pkg/crd/validation/config.go
@@ -340,7 +340,7 @@ func NewWebhookConfig(p WebhookParameters) (*WebhookConfig, error) {
 }
 
 //reconcile monitors the keycert and webhook configuration changes, rebuild and reconcile the configuration
-func (whc *WebhookConfig) reconcile(stopCh <-chan struct{}, enableValidation bool) {
+func (whc *WebhookConfig) reconcile(stopCh <-chan struct{}) {
 	defer whc.keyCertWatcher.Close() // nolint: errcheck
 	defer whc.configWatcher.Close()  // nolint: errcheck
 
@@ -408,9 +408,9 @@ func ReconcileWebhookConfiguration(webhookServerReady chan struct{}, stopCh <-ch
 	if vc.EnableValidation {
 		//wait for galley endpoint to be available before register ValidatingWebhookConfiguration
 		<-webhookServerReady
-		whc.reconcile(stopCh, vc.EnableValidation)
+		whc.reconcile(stopCh)
 	} else {
-		whc.reconcile(stopCh, vc.EnableValidation)
+		whc.reconcile(stopCh)
 	}
 
 }

--- a/galley/pkg/crd/validation/config_test.go
+++ b/galley/pkg/crd/validation/config_test.go
@@ -392,7 +392,7 @@ func TestReloadCert(t *testing.T) {
 	defer cleanup()
 	stop := make(chan struct{})
 	defer func() { close(stop) }()
-	go whc.reconcile(stop, true)
+	go whc.reconcile(stop)
 	checkCert(t, whc, testcerts.ServerCert, testcerts.ServerKey)
 	// Update cert/key files.
 	if err := ioutil.WriteFile(whc.certFile, testcerts.RotatedCert, 0644); err != nil { // nolint: vetshadow

--- a/galley/pkg/crd/validation/validation.go
+++ b/galley/pkg/crd/validation/validation.go
@@ -72,7 +72,7 @@ func webhookHTTPSHandlerReady(client httpClient, vc *WebhookParameters) error {
 }
 
 //RunValidation start running Galley validation mode
-func RunValidation(vc *WebhookParameters, kubeConfig string,
+func RunValidation(ready chan struct{}, vc *WebhookParameters, kubeConfig string,
 	livenessProbeController, readinessProbeController probe.Controller) {
 	log.Infof("Galley validation started with\n%s", vc)
 	mixerValidator := mixervalidate.NewDefaultValidator(false)
@@ -137,7 +137,9 @@ func RunValidation(vc *WebhookParameters, kubeConfig string,
 		}()
 	}
 
-	go wh.Run(stop)
+	go wh.Run(ready, stop)
+	defer wh.Stop()
+
 	cmd.WaitSignal(stop)
 }
 

--- a/galley/pkg/crd/validation/webhook.go
+++ b/galley/pkg/crd/validation/webhook.go
@@ -21,15 +21,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/howeyc/fsnotify"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -120,20 +117,14 @@ type WebhookParameters struct {
 
 	// Enable galley validation mode
 	EnableValidation bool
+
+	// Disable reconcile validatingwebhookconfiguration
+	DisableReconcileWebhookConfiguration bool
 }
 
-type createInformerWebhookSource func(cl clientset.Interface, name string) cache.ListerWatcher
 type createInformerEndpointSource func(cl clientset.Interface, namespace, name string) cache.ListerWatcher
 
 var (
-	defaultCreateInformerWebhookSource = func(cl clientset.Interface, name string) cache.ListerWatcher {
-		return cache.NewListWatchFromClient(
-			cl.AdmissionregistrationV1beta1().RESTClient(),
-			"validatingwebhookconfigurations",
-			"",
-			fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", name)))
-	}
-
 	defaultCreateInformerEndpointSource = func(cl clientset.Interface, namespace, name string) cache.ListerWatcher {
 		return cache.NewListWatchFromClient(
 			cl.CoreV1().RESTClient(),
@@ -158,6 +149,7 @@ func (p *WebhookParameters) String() string {
 	fmt.Fprintf(buf, "DeploymentName: %s\n", p.DeploymentName)
 	fmt.Fprintf(buf, "ServiceName: %s\n", p.ServiceName)
 	fmt.Fprintf(buf, "EnableValidation: %v\n", p.EnableValidation)
+	fmt.Fprintf(buf, "DisableReconcileWebhookConfiguration: %v\n", p.DisableReconcileWebhookConfiguration)
 
 	return buf.String()
 }
@@ -165,15 +157,16 @@ func (p *WebhookParameters) String() string {
 // DefaultArgs allocates an WebhookParameters struct initialized with Webhook's default configuration.
 func DefaultArgs() *WebhookParameters {
 	return &WebhookParameters{
-		Port:                          443,
-		CertFile:                      "/etc/certs/cert-chain.pem",
-		KeyFile:                       "/etc/certs/key.pem",
-		CACertFile:                    "/etc/certs/root-cert.pem",
-		DeploymentAndServiceNamespace: "istio-system",
-		DeploymentName:                "istio-galley",
-		ServiceName:                   "istio-galley",
-		WebhookName:                   "istio-galley",
-		EnableValidation:              true,
+		Port:                                 443,
+		CertFile:                             "/etc/certs/cert-chain.pem",
+		KeyFile:                              "/etc/certs/key.pem",
+		CACertFile:                           "/etc/certs/root-cert.pem",
+		DeploymentAndServiceNamespace:        "istio-system",
+		DeploymentName:                       "istio-galley",
+		ServiceName:                          "istio-galley",
+		WebhookName:                          "istio-galley",
+		EnableValidation:                     true,
+		DisableReconcileWebhookConfiguration: false,
 	}
 }
 
@@ -190,22 +183,13 @@ type Webhook struct {
 	validator store.BackendValidator
 
 	server                        *http.Server
-	keyCertWatcher                *fsnotify.Watcher
-	configWatcher                 *fsnotify.Watcher
-	certFile                      string
-	keyFile                       string
-	caFile                        string
-	webhookConfigFile             string
 	clientset                     clientset.Interface
 	deploymentAndServiceNamespace string
 	deploymentName                string
 	serviceName                   string
 	webhookName                   string
-	ownerRefs                     []v1.OwnerReference
-	webhookConfiguration          *v1beta1.ValidatingWebhookConfiguration
 
 	// test hook for informers
-	createInformerWebhookSource  createInformerWebhookSource
 	createInformerEndpointSource createInformerEndpointSource
 }
 
@@ -215,70 +199,20 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 	if err != nil {
 		return nil, err
 	}
-	// This is not strictly necessary, but is a workaround for having the dashboard pass. The migration
-	// to OpenCensus metrics means that zero value metrics are not exported, and the dashboard tests
-	// expect data for metrics.
-	reportValidationCertKeyUpdate()
-	certKeyWatcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	// watch the parent directory of the target files so we can catch
-	// symlink updates of k8s secrets
-	for _, file := range []string{p.CertFile, p.KeyFile, p.CACertFile, p.WebhookConfigFile} {
-		watchDir, _ := filepath.Split(file)
-		if err := certKeyWatcher.Watch(watchDir); err != nil {
-			return nil, fmt.Errorf("could not watch %v: %v", file, err)
-		}
-	}
-
-	// configuration must be updated whenever the caBundle changes.
-	// NOTE: Use a separate watcher to differentiate config/ca from cert/key updates. This is
-	// useful to avoid unnecessary updates and, more importantly, makes its easier to more
-	// accurately capture logs/metrics when files change.
-	configWatcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-	for _, file := range []string{p.CACertFile, p.WebhookConfigFile} {
-		watchDir, _ := filepath.Split(file)
-		if err := configWatcher.Watch(watchDir); err != nil {
-			return nil, fmt.Errorf("could not watch %v: %v", file, err)
-		}
-	}
 
 	wh := &Webhook{
 		server: &http.Server{
 			Addr: fmt.Sprintf(":%v", p.Port),
 		},
-		keyCertWatcher:                certKeyWatcher,
-		configWatcher:                 configWatcher,
-		certFile:                      p.CertFile,
-		keyFile:                       p.KeyFile,
 		cert:                          &pair,
 		descriptor:                    p.PilotDescriptor,
 		validator:                     p.MixerValidator,
-		caFile:                        p.CACertFile,
-		webhookConfigFile:             p.WebhookConfigFile,
 		clientset:                     p.Clientset,
 		deploymentName:                p.DeploymentName,
 		serviceName:                   p.ServiceName,
 		webhookName:                   p.WebhookName,
 		deploymentAndServiceNamespace: p.DeploymentAndServiceNamespace,
-		createInformerWebhookSource:   defaultCreateInformerWebhookSource,
 		createInformerEndpointSource:  defaultCreateInformerEndpointSource,
-	}
-
-	if galleyDeployment, err := wh.clientset.AppsV1().Deployments(wh.deploymentAndServiceNamespace).Get(wh.deploymentName, v1.GetOptions{}); err != nil { // nolint: lll
-		scope.Warnf("Could not find %s/%s deployment to set ownerRef. The validatingwebhookconfiguration must be deleted manually",
-			wh.deploymentAndServiceNamespace, wh.deploymentName)
-	} else {
-		wh.ownerRefs = []v1.OwnerReference{
-			*v1.NewControllerRef(
-				galleyDeployment,
-				appsv1.SchemeGroupVersion.WithKind("Deployment"),
-			),
-		}
 	}
 
 	// mtls disabled because apiserver webhook cert usage is still TBD.
@@ -292,20 +226,18 @@ func NewWebhook(p WebhookParameters) (*Webhook, error) {
 	return wh, nil
 }
 
-func (wh *Webhook) stop() {
-	wh.keyCertWatcher.Close() // nolint: errcheck
-	wh.configWatcher.Close()  // nolint: errcheck
-	wh.server.Close()         // nolint: errcheck
+//Stop the server
+func (wh *Webhook) Stop() {
+	wh.server.Close() // nolint: errcheck
 }
 
 // Run implements the webhook server
-func (wh *Webhook) Run(stopCh <-chan struct{}) {
+func (wh *Webhook) Run(ready chan struct{}, stopCh <-chan struct{}) {
 	go func() {
 		if err := wh.server.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 			scope.Fatalf("admission webhook ListenAndServeTLS failed: %v", err)
 		}
 	}()
-	defer wh.stop()
 
 	// During initial Istio installation its possible for custom
 	// resources to be created concurrently with galley startup. This
@@ -319,51 +251,8 @@ func (wh *Webhook) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	// Try to create the initial webhook configuration (if it doesn't
-	// already exist). Setup a persistent monitor to reconcile the
-	// configuration if the observed configuration doesn't match
-	// the desired configuration.
-	if err := wh.rebuildWebhookConfig(); err == nil {
-		wh.createOrUpdateWebhookConfig()
-	}
-	webhookChangedCh := wh.monitorWebhookChanges(stopCh)
+	ready <- struct{}{}
 
-	// use a timer to debounce file updates
-	var keyCertTimerC <-chan time.Time
-	var configTimerC <-chan time.Time
-
-	for {
-		select {
-		case <-keyCertTimerC:
-			keyCertTimerC = nil
-			wh.reloadKeyCert()
-		case <-configTimerC:
-			configTimerC = nil
-
-			// rebuild the desired configuration and reconcile with the
-			// existing configuration.
-			if err := wh.rebuildWebhookConfig(); err == nil {
-				wh.createOrUpdateWebhookConfig()
-			}
-		case <-webhookChangedCh:
-			// reconcile the desired configuration
-			wh.createOrUpdateWebhookConfig()
-		case event, more := <-wh.keyCertWatcher.Event:
-			if more && (event.IsModify() || event.IsCreate()) && keyCertTimerC == nil {
-				keyCertTimerC = time.After(watchDebounceDelay)
-			}
-		case event, more := <-wh.configWatcher.Event:
-			if more && (event.IsModify() || event.IsCreate()) && configTimerC == nil {
-				configTimerC = time.After(watchDebounceDelay)
-			}
-		case err := <-wh.keyCertWatcher.Error:
-			scope.Errorf("keyCertWatcher error: %v", err)
-		case err := <-wh.configWatcher.Error:
-			scope.Errorf("configWatcher error: %v", err)
-		case <-stopCh:
-			return
-		}
-	}
 }
 
 func (wh *Webhook) getCert(*tls.ClientHelloInfo) (*tls.Certificate, error) {

--- a/galley/pkg/server/components/validation.go
+++ b/galley/pkg/server/components/validation.go
@@ -28,7 +28,10 @@ func NewValidation(kubeConfig string, params *validation.WebhookParameters, live
 		// start
 		func() error {
 			if params.EnableValidation {
-				go validation.RunValidation(params, kubeConfig, liveness, readiness)
+				webhookServerReady := make(chan struct{})
+				stopCh := make(chan struct{})
+				go validation.RunValidation(webhookServerReady, stopCh, params, kubeConfig, liveness, readiness)
+				go validation.ReconcileWebhookConfiguration(webhookServerReady, stopCh, params, kubeConfig)
 			}
 			return nil
 		},


### PR DESCRIPTION
The webhook configuration reconciliation loop should be decoupled from the http handler running. This will ensure the latest desired configuration (e.g. enabled vs. disabled) is always accurate, regardless of the ordering between the old and new pod's lifecycle.

Separated the code from #10651

Signed-off-by: clyang82 <clyang@cn.ibm.com>