### PR TITLE
wip: locality lb overlapping distribute

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -123,8 +123,8 @@ func buildEnvForClustersWithDistribute() *model.Environment {
 				{
 					From: "region1/zone1/subzone1",
 					To: map[string]uint32{
-						"region1/zone1/subzone1": 90,
-						"region1/zone1/subzone2": 5,
+						"region1/zone1/subzone1": 80,
+						"region1/zone1/subzone2": 15,
 						"region1/zone1/subzone3": 5,
 					},
 				},
@@ -237,11 +237,13 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "zone1",
 						SubZone: "subzone1",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
+				},
+				{
+					Locality: &envoycore.Locality{
+						Region:  "region1",
+						Zone:    "zone1",
+						SubZone: "subzone1",
 					},
-					Priority: 0,
 				},
 				{
 					Locality: &envoycore.Locality{
@@ -249,11 +251,6 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "zone1",
 						SubZone: "subzone2",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
-					},
-					Priority: 0,
 				},
 				{
 					Locality: &envoycore.Locality{
@@ -261,11 +258,6 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "zone1",
 						SubZone: "subzone3",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
-					},
-					Priority: 0,
 				},
 				{
 					Locality: &envoycore.Locality{
@@ -273,11 +265,6 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "zone2",
 						SubZone: "",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
-					},
-					Priority: 0,
 				},
 				{
 					Locality: &envoycore.Locality{
@@ -285,11 +272,6 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "",
 						SubZone: "",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
-					},
-					Priority: 0,
 				},
 				{
 					Locality: &envoycore.Locality{
@@ -297,11 +279,6 @@ func buildFakeCluster() *apiv2.Cluster {
 						Zone:    "",
 						SubZone: "",
 					},
-					LbEndpoints: []endpoint.LbEndpoint{},
-					LoadBalancingWeight: &types.UInt32Value{
-						Value: 1,
-					},
-					Priority: 0,
 				},
 			},
 		},

--- a/pilot/pkg/networking/util/util_test.go
+++ b/pilot/pkg/networking/util/util_test.go
@@ -278,6 +278,38 @@ func TestConvertLocality(t *testing.T) {
 	}
 }
 
+func TestLbPriority(t *testing.T) {
+	tests := []struct {
+		proxy    string
+		endpoint string
+		expected int
+	}{
+		{
+			proxy:    "us-west/zone2",
+			endpoint: "us-west/zone2",
+			expected: 0,
+		},
+		{
+			proxy:    "us-west/zone2",
+			endpoint: "us-west/zone1",
+			expected: 2,
+		},
+		{
+			proxy:    "us-west/zone2",
+			endpoint: "us-east/zone1",
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+
+		priority := LbPriority(ConvertLocality(tt.proxy), ConvertLocality(tt.endpoint))
+		if priority != tt.expected {
+			t.Errorf("Expected matching result %v, but got %v", tt.expected, priority)
+		}
+	}
+}
+
 func TestLocalityMatch(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
The old code depended on the original LB weight, which was often/always
nil. The original LB weight should not be used in the calculation, we
should instead just distribute evenly to all endpoints in the same
locality.

Fixes https://github.com/istio/istio/issues/12570