### PR TITLE
remove duplicated CRD

### DIFF
--- a/install/kubernetes/helm/istio-init/files/crd-10.yaml
+++ b/install/kubernetes/helm/istio-init/files/crd-10.yaml
@@ -88,27 +88,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: sidecars.networking.istio.io
-  labels:
-    app: istio-pilot
-    chart: istio
-    heritage: Tiller
-    release: istio
-spec:
-  group: networking.istio.io
-  names:
-    kind: Sidecar
-    plural: sidecars
-    singular: sidecar
-    categories:
-    - istio-io
-    - networking-istio-io
-  scope: Namespaced
-  version: v1alpha3 
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot


### PR DESCRIPTION
duplicated CRD also defined in [crd-11.yaml](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio-init/files/crd-11.yaml#L44); 

without removing one
```istio-master-20190318-09-16$ kubectl create -f install/kubernetes/istio-demo.yaml``` hit below error in latest master branch - 


```
Error from server (AlreadyExists): error when creating "install/kubernetes/istio-demo.yaml": customresourcedefinitions.apiextensions.k8s.io "sidecars.networking.istio.io" already exists
```