### PR TITLE
Locality label istio-locality in k8s should not contain `/`, use `.`

### DIFF
--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -392,11 +392,8 @@ func (si *ServiceInstance) GetLocality() string {
 	if si.Endpoint.Locality != "" {
 		return si.Endpoint.Locality
 	}
-	if strings.Contains(si.Labels[LocalityLabel], k8sSeparator) {
-		// replace "." with "/"
-		si.Labels[LocalityLabel] = strings.Replace(si.Labels[LocalityLabel], k8sSeparator, "/", -1)
-	}
-	return si.Labels[LocalityLabel]
+	// replace "." with "/"
+	return strings.Replace(si.Labels[LocalityLabel], k8sSeparator, "/", -1)
 }
 
 // IstioEndpoint has the information about a single address+port for a specific

--- a/pilot/pkg/model/service.go
+++ b/pilot/pkg/model/service.go
@@ -111,7 +111,11 @@ const (
 
 	// LocalityLabel indicates the region/zone/subzone of an instance. It is used if the native
 	// registry doesn't provide one.
+	//
+	// Note: because k8s labels does not support `/`, so we use `.` instead in k8s.
 	LocalityLabel = "istio-locality"
+	// k8s istio-locality label separator
+	k8sSeparator = "."
 )
 
 // Port represents a network port where a service is listening for
@@ -387,6 +391,10 @@ type ServiceInstance struct {
 func (si *ServiceInstance) GetLocality() string {
 	if si.Endpoint.Locality != "" {
 		return si.Endpoint.Locality
+	}
+	if strings.Contains(si.Labels[LocalityLabel], k8sSeparator) {
+		// replace "." with "/"
+		si.Labels[LocalityLabel] = strings.Replace(si.Labels[LocalityLabel], k8sSeparator, "/", -1)
 	}
 	return si.Labels[LocalityLabel]
 }

--- a/pilot/pkg/model/service_test.go
+++ b/pilot/pkg/model/service_test.go
@@ -442,3 +442,57 @@ func TestIsValidSubsetKey(t *testing.T) {
 		}
 	}
 }
+
+func TestGetLocality(t *testing.T) {
+	cases := []struct {
+		name     string
+		instance ServiceInstance
+		expected string
+	}{
+		{
+			name: "endpoint with locality",
+			instance: ServiceInstance{
+				Endpoint: NetworkEndpoint{
+					Locality: "region/zone/subzone-1",
+				},
+				Labels: Labels{
+					LocalityLabel: "region/zone/subzone-2",
+				},
+			},
+			expected: "region/zone/subzone-1",
+		},
+		{
+			name: "endpoint without locality, parse from labels",
+			instance: ServiceInstance{
+				Endpoint: NetworkEndpoint{
+					Locality: "",
+				},
+				Labels: Labels{
+					LocalityLabel: "region/zone/subzone-2",
+				},
+			},
+			expected: "region/zone/subzone-2",
+		},
+		{
+			name: "istio-locality label with k8s label separator",
+			instance: ServiceInstance{
+				Endpoint: NetworkEndpoint{
+					Locality: "",
+				},
+				Labels: Labels{
+					LocalityLabel: "region" + k8sSeparator + "zone" + k8sSeparator + "subzone-2",
+				},
+			},
+			expected: "region/zone/subzone-2",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := testCase.instance.GetLocality()
+			if got != testCase.expected {
+				t.Errorf("expected locality %s, but got %s", testCase.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION

fixes: #12582 