### PR TITLE
Fixes #11818. Select Sidecars by Workload/Pod labels instead of Servi…

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -183,9 +183,8 @@ func (node *Proxy) GetRouterMode() RouterMode {
 //
 // Listener generation code will still use the SidecarScope object directly
 // as it needs the set of services for each listener port.
-func (node *Proxy) SetSidecarScope(ps *PushContext) {
-	instances := node.ServiceInstances
-	node.SidecarScope = ps.getSidecarScope(node, instances)
+func (node *Proxy) SetSidecarScope(workloadLabels Labels, ps *PushContext) {
+	node.SidecarScope = ps.getSidecarScope(node, workloadLabels)
 }
 
 func (node *Proxy) SetServiceInstances(env *Environment) error {

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -183,7 +183,7 @@ func (node *Proxy) GetRouterMode() RouterMode {
 //
 // Listener generation code will still use the SidecarScope object directly
 // as it needs the set of services for each listener port.
-func (node *Proxy) SetSidecarScope(workloadLabels Labels, ps *PushContext) {
+func (node *Proxy) SetSidecarScope(workloadLabels LabelsCollection, ps *PushContext) {
 	node.SidecarScope = ps.getSidecarScope(node, workloadLabels)
 }
 

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -429,12 +429,7 @@ func (ps *PushContext) VirtualServices(proxy *Proxy, gateways map[string]bool) [
 //
 // Callers can check if the sidecarScope is from user generated object or not
 // by checking the sidecarScope.Config field, that contains the user provided config
-func (ps *PushContext) getSidecarScope(proxy *Proxy, proxyInstances []*ServiceInstance) *SidecarScope {
-
-	var workloadLabels LabelsCollection
-	for _, w := range proxyInstances {
-		workloadLabels = append(workloadLabels, w.Labels)
-	}
+func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels Labels) *SidecarScope {
 
 	// Find the most specific matching sidecar config from the proxy's
 	// config namespace If none found, construct a sidecarConfig on the fly
@@ -451,7 +446,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, proxyInstances []*ServiceIn
 				// if there is a workload selector, check for matching workload labels
 				if sidecar.GetWorkloadSelector() != nil {
 					workloadSelector := Labels(sidecar.GetWorkloadSelector().GetLabels())
-					if !workloadLabels.IsSupersetOf(workloadSelector) {
+					if !workloadSelector.SubsetOf(workloadLabels) {
 						continue
 					}
 					return wrapper
@@ -459,7 +454,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, proxyInstances []*ServiceIn
 				defaultSidecar = wrapper
 				continue
 			}
-			// Not sure when this can heppn (Config = nil ?)
+			// Not sure when this can happen (Config = nil ?)
 			if defaultSidecar != nil {
 				return defaultSidecar // still return the valid one
 			}

--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -429,7 +429,7 @@ func (ps *PushContext) VirtualServices(proxy *Proxy, gateways map[string]bool) [
 //
 // Callers can check if the sidecarScope is from user generated object or not
 // by checking the sidecarScope.Config field, that contains the user provided config
-func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels Labels) *SidecarScope {
+func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels LabelsCollection) *SidecarScope {
 
 	// Find the most specific matching sidecar config from the proxy's
 	// config namespace If none found, construct a sidecarConfig on the fly
@@ -446,7 +446,7 @@ func (ps *PushContext) getSidecarScope(proxy *Proxy, workloadLabels Labels) *Sid
 				// if there is a workload selector, check for matching workload labels
 				if sidecar.GetWorkloadSelector() != nil {
 					workloadSelector := Labels(sidecar.GetWorkloadSelector().GetLabels())
-					if !workloadSelector.SubsetOf(workloadLabels) {
+					if !workloadLabels.IsSupersetOf(workloadSelector) {
 						continue
 					}
 					return wrapper

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -935,16 +935,15 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 	}
 }
 
-func (s *DiscoveryServer) workloadLabels(proxy *model.Proxy) model.Labels {
-	var workloadLabels model.Labels
+func (s *DiscoveryServer) workloadLabels(proxy *model.Proxy) model.LabelsCollection {
 	ipAddresses := proxy.IPAddresses
-	if len(ipAddresses) == 0 {
-		return workloadLabels
+	labels := make([]model.Labels, 0, len(ipAddresses))
+	for _, ip := range ipAddresses {
+		if workload := s.WorkloadsByID[ip]; workload != nil {
+			labels = append(labels, workload.Labels)
+		}
 	}
-	if workload := s.WorkloadsByID[ipAddresses[0]]; workload != nil {
-		workloadLabels = workload.Labels
-	}
-	return workloadLabels
+	return labels
 }
 
 // Send with timeout

--- a/pilot/pkg/proxy/envoy/v2/ads.go
+++ b/pilot/pkg/proxy/envoy/v2/ads.go
@@ -937,7 +937,11 @@ func (s *DiscoveryServer) removeCon(conID string, con *XdsConnection) {
 
 func (s *DiscoveryServer) workloadLabels(proxy *model.Proxy) model.Labels {
 	var workloadLabels model.Labels
-	if workload := s.WorkloadsByID[proxy.IPAddresses[0]]; workload != nil {
+	ipAddresses := proxy.IPAddresses
+	if len(ipAddresses) == 0 {
+		return workloadLabels
+	}
+	if workload := s.WorkloadsByID[ipAddresses[0]]; workload != nil {
 		workloadLabels = workload.Labels
 	}
 	return workloadLabels


### PR DESCRIPTION
…ce labels

This PR is an attempt to fix #11818.

I don't know if I missed some parts, but however I am trying:)

The problem reported in the issue is that the workload selectors of the Sidecar instances match against the labels of the Services which in turn lead to the proxies, but that doesn't work for consumer only services. 

This PR changes this by getting the workload labels from the DiscoveryServer for the current proxy and uses these labels as the basis for the selection of the Sidecar instance.

There's just a few open questions:
- The member holding the workload labels is called `WorkloadsByID`, suggesting that its keys would be the IDs of the proxies. Instead the only place I could find where this map is filled is the kube serviceregistry which feeds the pod ip as the id:
https://github.com/istio/istio/blob/190d4c1c59328e2aca2611f3056a03d45c583ca8/pilot/pkg/serviceregistry/kube/pod.go#L86
- I didn't find any specific tests that would cover Sidecars right now, and most of what I ran locally succeeded despite the change. Running the tests locally isn't easy for me, so let's see what the CI says. Local manual testing worked for me and also picked up dynamic changes to Sidecars and Pod labels (I know that doesn't count much without automated tests :P)
- This is a breaking change for existing users, is it still possible to fix this issue on 1.1.x assuming that Istio somehow follows semver? 