### PR TITLE
Small Url fix

### DIFF
--- a/install/kubernetes/ansible/README.md
+++ b/install/kubernetes/ansible/README.md
@@ -1,3 +1,3 @@
 # Installation using Ansible
 
-Please follow the installation instructions from [istio.io](https://preliminary.istio.io/docs/setup/kubernetes/ansible-install.html).
+Please follow the installation instructions from [istio.io](https://istio.io/docs/setup/kubernetes/ansible-install.html).


### PR DESCRIPTION
Remove 'preliminary' from the Url to the installation doc after 1.1 go live.