### PR TITLE
Hide most logging CLI options from istioctl

### DIFF
--- a/istioctl/cmd/istioctl/main.go
+++ b/istioctl/cmd/istioctl/main.go
@@ -103,6 +103,11 @@ func init() {
 
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)
+	hiddenFlags := []string{"log_as_json", "log_rotate", "log_rotate_max_age", "log_rotate_max_backups",
+		"log_rotate_max_size", "log_stacktrace_level", "log_target", "log_caller"}
+	for _, opt := range hiddenFlags {
+		_ = rootCmd.PersistentFlags().MarkHidden(opt)
+	}
 
 	cmd.AddFlags(rootCmd)
 


### PR DESCRIPTION
The log rotation and related options are valuable for Istio CLIs that run on servers.  For the user-facing _istioctl_ CLI they just distract and cause the actual command usage to scroll away.

Implements https://github.com/istio/istio/issues/12463

This PR keeps `--log_output_level` (although that is the longest one.  It is the only one I have used in 2 years.)