### PR TITLE
Allows cleanup.sh to run non-interactively in terminal

### DIFF
--- a/samples/bookinfo/platform/kube/cleanup.sh
+++ b/samples/bookinfo/platform/kube/cleanup.sh
@@ -17,7 +17,7 @@
 SCRIPTDIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 # only ask if in interactive mode
-if [[ -t 0 ]];then
+if [[ -t 0 && -z ${NAMESPACE} ]];then
   echo -n "namespace ? [default] "
   read -r NAMESPACE
 fi


### PR DESCRIPTION
This change allows cleanup.sh to run non-interactively in standard terminals.
For example: NAMESPACE="test123" ./cleanup.sh