### PR TITLE
Don't hide 'istioctl collateral'

### DIFF
--- a/pkg/collateral/cobra.go
+++ b/pkg/collateral/cobra.go
@@ -30,7 +30,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "collateral",
 		Short:  "Generate collateral support files for this program",
-		Hidden: true,
+		Hidden: false,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if all {
@@ -41,7 +41,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 				c.EmitHTMLFragmentWithFrontMatter = true
 			}
 
-			return EmitCollateral(root, &c)
+			return EmitCollateral(cmd, &c)
 		},
 	}
 
@@ -53,6 +53,11 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 	cmd.Flags().BoolVarP(&c.EmitYAML, "yaml", "", c.EmitYAML, "Produce YAML documentation files")
 	cmd.Flags().BoolVarP(&c.EmitHTMLFragmentWithFrontMatter, "html_fragment_with_front_matter",
 		"", c.EmitHTMLFragmentWithFrontMatter, "Produce an HTML documentation file with Hugo/Jekyll-compatible front matter.")
+
+	hiddenFlags := []string{"markdown", "man", "yaml", "html_fragment_with_front_matter"}
+	for _, opt := range hiddenFlags {
+		_ = cmd.Flags().MarkHidden(opt)
+	}
 
 	return cmd
 }

--- a/pkg/collateral/cobra.go
+++ b/pkg/collateral/cobra.go
@@ -41,7 +41,7 @@ func CobraCommand(root *cobra.Command, hdr *doc.GenManHeader) *cobra.Command {
 				c.EmitHTMLFragmentWithFrontMatter = true
 			}
 
-			return EmitCollateral(cmd, &c)
+			return EmitCollateral(root, &c)
 		},
 	}
 

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -55,40 +55,40 @@ type Control struct {
 // EmitCollateral produces a set of collateral files for a CLI command. You can
 // select to emit markdown to describe a command's function, man pages, YAML
 // descriptions, and bash completion files.
-func EmitCollateral(cmd *cobra.Command, c *Control) error {
+func EmitCollateral(root *cobra.Command, c *Control) error {
 	if c.EmitManPages {
-		if err := doc.GenManTree(cmd, &c.ManPageInfo, c.OutputDir); err != nil {
+		if err := doc.GenManTree(root, &c.ManPageInfo, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output manpage tree: %v", err)
 		}
 	}
 
 	if c.EmitMarkdown {
-		if err := doc.GenMarkdownTree(cmd, c.OutputDir); err != nil {
+		if err := doc.GenMarkdownTree(root, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output markdown tree: %v", err)
 		}
 	}
 
 	if c.EmitHTMLFragmentWithFrontMatter {
-		if err := genHTMLFragment(cmd, c.OutputDir+"/"+cmd.Name()+".html"); err != nil {
+		if err := genHTMLFragment(root, c.OutputDir+"/"+root.Name()+".html"); err != nil {
 			return fmt.Errorf("unable to output HTML fragment file: %v", err)
 		}
 	}
 
 	if c.EmitYAML {
-		if err := doc.GenYamlTree(cmd, c.OutputDir); err != nil {
+		if err := doc.GenYamlTree(root, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output YAML tree: %v", err)
 		}
 	}
 
 	if c.EmitBashCompletion {
-		if err := cmd.GenBashCompletionFile(c.OutputDir + "/" + cmd.Name() + ".bash"); err != nil {
+		if err := root.GenBashCompletionFile(c.OutputDir + "/" + root.Name() + ".bash"); err != nil {
 			return fmt.Errorf("unable to output bash completion file: %v", err)
 		}
-		cmd.Printf("Enable completions using `source %s/%s.bash`\n", c.OutputDir, cmd.Name())
+		root.Printf("Enable completions using `source %s/%s.bash`\n", c.OutputDir, root.Name())
 	}
 
 	if !c.EmitManPages && !c.EmitMarkdown && !c.EmitHTMLFragmentWithFrontMatter && !c.EmitYAML && !c.EmitBashCompletion {
-		cmd.Println("No output options specified, nothing generated.")
+		root.Println("No output options specified, nothing generated.")
 	}
 
 	return nil

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -83,9 +83,8 @@ func EmitCollateral(cmd *cobra.Command, c *Control) error {
 	if c.EmitBashCompletion {
 		if err := cmd.GenBashCompletionFile(c.OutputDir + "/" + cmd.Name() + ".bash"); err != nil {
 			return fmt.Errorf("unable to output bash completion file: %v", err)
-		} else {
-			cmd.Printf("Enable completions using `source %s/%s.bash`\n", c.OutputDir, cmd.Name())
 		}
+		cmd.Printf("Enable completions using `source %s/%s.bash`\n", c.OutputDir, cmd.Name())
 	}
 
 	if !c.EmitManPages && !c.EmitMarkdown && !c.EmitHTMLFragmentWithFrontMatter && !c.EmitYAML && !c.EmitBashCompletion {

--- a/pkg/collateral/control.go
+++ b/pkg/collateral/control.go
@@ -55,35 +55,41 @@ type Control struct {
 // EmitCollateral produces a set of collateral files for a CLI command. You can
 // select to emit markdown to describe a command's function, man pages, YAML
 // descriptions, and bash completion files.
-func EmitCollateral(root *cobra.Command, c *Control) error {
+func EmitCollateral(cmd *cobra.Command, c *Control) error {
 	if c.EmitManPages {
-		if err := doc.GenManTree(root, &c.ManPageInfo, c.OutputDir); err != nil {
+		if err := doc.GenManTree(cmd, &c.ManPageInfo, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output manpage tree: %v", err)
 		}
 	}
 
 	if c.EmitMarkdown {
-		if err := doc.GenMarkdownTree(root, c.OutputDir); err != nil {
+		if err := doc.GenMarkdownTree(cmd, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output markdown tree: %v", err)
 		}
 	}
 
 	if c.EmitHTMLFragmentWithFrontMatter {
-		if err := genHTMLFragment(root, c.OutputDir+"/"+root.Name()+".html"); err != nil {
+		if err := genHTMLFragment(cmd, c.OutputDir+"/"+cmd.Name()+".html"); err != nil {
 			return fmt.Errorf("unable to output HTML fragment file: %v", err)
 		}
 	}
 
 	if c.EmitYAML {
-		if err := doc.GenYamlTree(root, c.OutputDir); err != nil {
+		if err := doc.GenYamlTree(cmd, c.OutputDir); err != nil {
 			return fmt.Errorf("unable to output YAML tree: %v", err)
 		}
 	}
 
 	if c.EmitBashCompletion {
-		if err := root.GenBashCompletionFile(c.OutputDir + "/" + root.Name() + ".bash"); err != nil {
+		if err := cmd.GenBashCompletionFile(c.OutputDir + "/" + cmd.Name() + ".bash"); err != nil {
 			return fmt.Errorf("unable to output bash completion file: %v", err)
+		} else {
+			cmd.Printf("Enable completions using `source %s/%s.bash`\n", c.OutputDir, cmd.Name())
 		}
+	}
+
+	if !c.EmitManPages && !c.EmitMarkdown && !c.EmitHTMLFragmentWithFrontMatter && !c.EmitYAML && !c.EmitBashCompletion {
+		cmd.Println("No output options specified, nothing generated.")
 	}
 
 	return nil


### PR DESCRIPTION
Resolves https://github.com/istio/istio/issues/12607

I am not sure why this command was hidden.  Generating bash completions is very helpful.

In this PR I only expose the `--bash` and `--all` options.  I have no objection to exposing everything.  I don't know why everything was hidden so I am only exposing the options I have actually used in real life.