### PR TITLE
update field typo of kubernetesenv

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/config.yaml
@@ -898,7 +898,7 @@ spec:
     #
     # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
     #
-    # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
+    # kubeconfigPath: "mixer/adapter/kubernetes/kubeconfig"
 
 ---
 apiVersion: "config.istio.io/v1alpha2"

--- a/mixer/testdata/config/kubernetesenv.yaml
+++ b/mixer/testdata/config/kubernetesenv.yaml
@@ -11,7 +11,7 @@ spec:
     #
     # $ ln -s ~/.kube/config mixer/adapter/kubernetes/kubeconfig
     #
-    # kubeconfig_path: "mixer/adapter/kubernetes/kubeconfig"
+    # kubeconfigPath: "mixer/adapter/kubernetes/kubeconfig"
 
 ---
 apiVersion: "config.istio.io/v1alpha2"


### PR DESCRIPTION
According to https://istio.io/docs/reference/config/policy-and-telemetry/adapters/kubernetesenv/, the field should be `kubeconfigPath` instead of `kubeconfig_path`