### PR TITLE
Implement AuthorizationPolicy with workload selector. (#12050)

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -1455,9 +1455,6 @@ func ValidateServiceRole(name, namespace string, msg proto.Message) error {
 		errs = appendErrors(errs, fmt.Errorf("at least 1 rule must be specified"))
 	}
 	for i, rule := range in.Rules {
-		if len(rule.Services) == 0 {
-			errs = appendErrors(errs, fmt.Errorf("at least 1 service must be specified for rule %d", i))
-		}
 		// Regular rules and not rules (e.g. methods and not_methods should not be defined together).
 		sameAttributeKindError := "cannot have both regular and *not* attributes for the same kind (%s) for rule %d"
 		if len(rule.Methods) > 0 && len(rule.NotMethods) > 0 {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3522,32 +3522,9 @@ func TestValidateServiceRole(t *testing.T) {
 			expectErrMsg: "at least 1 rule must be specified",
 		},
 		{
-			name: "no service",
-			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
-				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
-					Constraints: []*rbac.AccessRule_Constraint{
-						{Key: "key", Values: []string{"value"}},
-						{Key: "key", Values: []string{"value"}},
-					},
-				},
-				{
-					Services: []string{},
-					Methods:  []string{"GET", "POST"},
-					Constraints: []*rbac.AccessRule_Constraint{
-						{Key: "key", Values: []string{"value"}},
-						{Key: "key", Values: []string{"value"}},
-					},
-				},
-			}},
-			expectErrMsg: "at least 1 service must be specified for rule 1",
-		},
-		{
 			name: "has both methods and not_methods",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services:   []string{"service0"},
 					Methods:    []string{"GET", "POST"},
 					NotMethods: []string{"DELETE"},
 				},
@@ -3558,7 +3535,6 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "has both ports and not_ports",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
 					Ports:    []int32{9080},
 					NotPorts: []int32{443},
 				},
@@ -3569,8 +3545,7 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "has out of range port",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
-					Ports:    []int32{9080, -80},
+					Ports: []int32{9080, -80},
 				},
 			}},
 			expectErrMsg: "at least one port is not in the range of [0, 65535]",
@@ -3579,8 +3554,7 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "has both first-class field and constraints",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
-					Ports:    []int32{9080},
+					Ports: []int32{9080},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "destination.port", Values: []string{"80"}},
 					},
@@ -3592,16 +3566,14 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "no key in constraint",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
+					Methods: []string{"GET", "POST"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Key: "key", Values: []string{"value"}},
 					},
 				},
 				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
+					Methods: []string{"GET", "POST"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Values: []string{"value"}},
@@ -3614,16 +3586,14 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "no value in constraint",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
+					Methods: []string{"GET", "POST"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Key: "key", Values: []string{"value"}},
 					},
 				},
 				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
+					Methods: []string{"GET", "POST"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Key: "key", Values: []string{}},
@@ -3636,7 +3606,6 @@ func TestValidateServiceRole(t *testing.T) {
 			name: "success proto",
 			in: &rbac.ServiceRole{Rules: []*rbac.AccessRule{
 				{
-					Services: []string{"service0"},
 					Methods:  []string{"GET", "POST"},
 					NotHosts: []string{"finances.google.com"},
 					Constraints: []*rbac.AccessRule_Constraint{
@@ -3645,8 +3614,7 @@ func TestValidateServiceRole(t *testing.T) {
 					},
 				},
 				{
-					Services: []string{"service0"},
-					Methods:  []string{"GET", "POST"},
+					Methods: []string{"GET", "POST"},
 					Constraints: []*rbac.AccessRule_Constraint{
 						{Key: "key", Values: []string{"value"}},
 						{Key: "key", Values: []string{"value"}},

--- a/pilot/pkg/networking/plugin/authz/rbac.go
+++ b/pilot/pkg/networking/plugin/authz/rbac.go
@@ -147,6 +147,12 @@ func (service serviceMetadata) match(rule *rbacproto.AccessRule) bool {
 	}
 
 	// Check if the constraints are matched.
+	return service.areConstraintsMatched(rule)
+}
+
+// areConstraintsMatched returns True if the calling service's attributes and/or labels match to
+// the ServiceRole constraints.
+func (service serviceMetadata) areConstraintsMatched(rule *rbacproto.AccessRule) bool {
 	for _, constraint := range rule.Constraints {
 		if !attributesEnforcedInPlugin(constraint.Key) {
 			continue
@@ -171,7 +177,6 @@ func (service serviceMetadata) match(rule *rbacproto.AccessRule) bool {
 			return false
 		}
 	}
-
 	return true
 }
 
@@ -440,7 +445,14 @@ func buildTCPFilter(service *serviceMetadata, option rbacOption, is11 bool) *lis
 	option.forTCPFilter = true
 	// The result of convertRbacRulesToFilterConfig() is wrapped in a config for http filter, here we
 	// need to extract the generated rules and put in a config for network filter.
-	config := convertRbacRulesToFilterConfig(service, option)
+	var config *http_config.RBAC
+	if option.authzPolicies.IsRbacV2 {
+		rbacLog.Debugf("used RBAC v2 for TCP filter")
+		config = convertRbacRulesToFilterConfigV2(service, option)
+	} else {
+		rbacLog.Debugf("used RBAC v1 for TCP filter")
+		config = convertRbacRulesToFilterConfig(service, option)
+	}
 	tcpConfig := listener.Filter{
 		Name: rbacTCPFilterName,
 	}
@@ -464,7 +476,14 @@ func buildTCPFilter(service *serviceMetadata, option rbacOption, is11 bool) *lis
 // service which is co-located with the sidecar proxy.
 func buildHTTPFilter(service *serviceMetadata, option rbacOption, is11 bool) *http_conn.HttpFilter {
 	option.forTCPFilter = false
-	config := convertRbacRulesToFilterConfig(service, option)
+	var config *http_config.RBAC
+	if option.authzPolicies.IsRbacV2 {
+		rbacLog.Debugf("used RBAC v2 for HTTP filter")
+		config = convertRbacRulesToFilterConfigV2(service, option)
+	} else {
+		rbacLog.Debugf("used RBAC v1 for HTTP filter")
+		config = convertRbacRulesToFilterConfig(service, option)
+	}
 	rbacLog.Debugf("generated http filter config: %v", *config)
 	out := &http_conn.HttpFilter{
 		Name: rbacHTTPFilterName,

--- a/pilot/pkg/networking/plugin/authz/rbac_v2.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_v2.go
@@ -1,0 +1,123 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authz converts Istio authorization policies (ServiceRole and AuthorizationPolicy)
+// to corresponding filter config that is used by the envoy RBAC filter to enforce access control to
+// the service co-located with envoy.
+// Currently the config is only generated for sidecar node on inbound HTTP/TCP listener. The generation
+// is controlled by ClusterRbacConfig (a singleton custom resource with cluster scope). User could disable
+// this plugin by either deleting the ClusterRbacConfig or set the ClusterRbacConfig.mode to OFF.
+// Note: ClusterRbacConfig is not created with default istio installation which means this plugin doesn't
+// generate any RBAC config by default.
+//
+// Changes from rbac_v2.go compared to rbac.go:
+// * Deprecate ServiceRoleBinding. Only support two CRDs: ServiceRole and AuthorizationPolicy.
+// * Allow multiple bindings and roles in one CRD, i.e. Authorization.
+// * Support workload selector.
+package authz
+
+import (
+	"fmt"
+
+	http_config "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/rbac/v2"
+	policyproto "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+// convertRbacRulesToFilterConfigV2 is the successor of convertRbacRulesToFilterConfig, which supports
+// converting AuthorizationPolicy.
+func convertRbacRulesToFilterConfigV2(service *serviceMetadata, option rbacOption) *http_config.RBAC {
+	rbac := &policyproto.RBAC{
+		Action:   policyproto.RBAC_ALLOW,
+		Policies: map[string]*policyproto.Policy{},
+	}
+
+	if option.globalPermissiveMode {
+		// Permissive Mode will be ignored.
+		rbacLog.Warnf("Permissive mode is not supported for service %s.", service.name)
+		// TODO(pitlv2109): Handle permissive mode in the future.
+		return &http_config.RBAC{Rules: rbac}
+	}
+
+	namespace := service.attributes[attrDestNamespace]
+	if option.authzPolicies == nil || option.authzPolicies.NamespaceToAuthorizationConfigV2 == nil {
+		return &http_config.RBAC{Rules: rbac}
+	}
+	var authorizationConfigV2FromNamespace, present = option.authzPolicies.NamespaceToAuthorizationConfigV2[namespace]
+	if !present {
+		return &http_config.RBAC{Rules: rbac}
+	}
+	// Get all AuthorizationPolicy Istio config from this namespace.
+	allAuthzPolicies := authorizationConfigV2FromNamespace.AuthzPolicies
+	for _, authzPolicy := range allAuthzPolicies {
+		// If a WorkloadSelector is used in the AuthorizationPolicy config and does not match this service, skip this
+		// AuthorizationPolicy.
+		serviceLabelsCollection := model.LabelsCollection{service.labels}
+		if authzPolicy.Policy.WorkloadSelector != nil &&
+			!(serviceLabelsCollection.IsSupersetOf(authzPolicy.Policy.WorkloadSelector.Labels)) {
+			continue
+		}
+		for i, binding := range authzPolicy.Policy.Allow {
+			permissions := make([]*policyproto.Permission, 0)
+			role := option.authzPolicies.RoleForNameAndNamespace(binding.RoleRef.Name, namespace)
+			for _, rule := range role.Rules {
+				// Check to make sure that the current service (caller) is the one this rule is applying to.
+				if !service.areConstraintsMatched(rule) {
+					rbacLog.Debugf("rule has constraints but doesn't match with the service (found in %s)", binding.RoleRef.Name)
+					continue
+				}
+				if option.forTCPFilter {
+					// TODO(yangminzhu): Add metrics.
+					if err := validateRuleForTCPFilter(rule); err != nil {
+						// It's a user misconfiguration if a HTTP rule is specified to a TCP service.
+						// For safety consideration, we ignore the whole rule which means no access is opened to
+						// the TCP service in this case.
+						rbacLog.Debugf("rules[%d] ignored, found HTTP only rule for a TCP service: %v", i, err)
+						continue
+					}
+				}
+				// Generate the policy if the service is matched and validated to the services specified in
+				// ServiceRole.
+				permissions = append(permissions, convertToPermission(rule))
+			}
+			if len(permissions) == 0 {
+				rbacLog.Debugf("role %s skipped for no rule matched", binding.RoleRef.Name)
+				continue
+			}
+
+			if option.forTCPFilter {
+				if err := validateBindingsForTCPFilter([]*rbacproto.ServiceRoleBinding{binding}); err != nil {
+					rbacLog.Debugf("role %s skipped, found HTTP only binding for a TCP service: %v", binding.RoleRef.Name, err)
+					continue
+				}
+			}
+
+			enforcedPrincipals, _ := convertToPrincipals([]*rbacproto.ServiceRoleBinding{binding}, option.forTCPFilter)
+
+			if len(enforcedPrincipals) == 0 {
+				rbacLog.Debugf("role %s skipped for no principals found", binding.RoleRef.Name)
+				continue
+			}
+
+			policyName := fmt.Sprintf("authz-policy-%s-allow[%d]", authzPolicy.Name, i)
+			rbac.Policies[policyName] = &policyproto.Policy{
+				Permissions: permissions,
+				Principals:  enforcedPrincipals,
+			}
+		}
+	}
+	return &http_config.RBAC{Rules: rbac}
+}

--- a/pilot/pkg/networking/plugin/authz/rbac_v2_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_v2_test.go
@@ -1,0 +1,305 @@
+package authz
+
+import (
+	"reflect"
+	"testing"
+
+	"istio.io/istio/pilot/pkg/networking/plugin/authn"
+
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	policy "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v2alpha"
+	metadata "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
+
+	rbacproto "istio.io/api/rbac/v1alpha1"
+	"istio.io/istio/pilot/pkg/model"
+)
+
+func TestConvertRbacRulesToFilterConfigV2(t *testing.T) {
+	roles := []model.Config{
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-1"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						NotMethods: []string{"DELETE"},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "service-role-2"},
+			Spec: &rbacproto.ServiceRole{
+				Rules: []*rbacproto.AccessRule{
+					{
+						NotMethods: []string{"DELETE"},
+						Constraints: []*rbacproto.AccessRule_Constraint{
+							{Key: "destination.labels[app]", Values: []string{"foo"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	bindings := []model.Config{
+		{
+			ConfigMeta: model.ConfigMeta{Name: "authz-policy-single-binding"},
+			Spec: &rbacproto.AuthorizationPolicy{
+				Allow: []*rbacproto.ServiceRoleBinding{
+					{
+						Subjects: []*rbacproto.Subject{
+							{
+								Names: []string{"allUsers"},
+							},
+						},
+						RoleRef: &rbacproto.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "authz-policy-multiple-bindings-with-selector"},
+			Spec: &rbacproto.AuthorizationPolicy{
+				WorkloadSelector: &rbacproto.WorkloadSelector{
+					Labels: map[string]string{
+						"app": "productpage",
+					},
+				},
+				Allow: []*rbacproto.ServiceRoleBinding{
+					{
+						Subjects: []*rbacproto.Subject{
+							{
+								Names: []string{"allUsers"},
+							},
+						},
+						RoleRef: &rbacproto.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+					},
+					{
+						Subjects: []*rbacproto.Subject{
+							{
+								Namespaces: []string{"testing"},
+							},
+						},
+						RoleRef: &rbacproto.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "authz-policy-selector-with-no-match"},
+			Spec: &rbacproto.AuthorizationPolicy{
+				WorkloadSelector: &rbacproto.WorkloadSelector{
+					Labels: map[string]string{
+						"app": "bar",
+					},
+				},
+				Allow: []*rbacproto.ServiceRoleBinding{
+					{
+						Subjects: []*rbacproto.Subject{
+							{
+								Names: []string{"allUsers"},
+							},
+						},
+						RoleRef: &rbacproto.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-2",
+						},
+					},
+				},
+			},
+		},
+		{
+			ConfigMeta: model.ConfigMeta{Name: "authz-policy-single-binding-all-authned-users"},
+			Spec: &rbacproto.AuthorizationPolicy{
+				Allow: []*rbacproto.ServiceRoleBinding{
+					{
+						Subjects: []*rbacproto.Subject{
+							{
+								Names: []string{"allAuthenticatedUsers"},
+							},
+						},
+						RoleRef: &rbacproto.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	notDeleteMethodPermissions := []*policy.Permission{
+		{
+			Rule: &policy.Permission_AndRules{
+				AndRules: &policy.Permission_Set{
+					Rules: []*policy.Permission{
+						{
+							Rule: &policy.Permission_NotRule{
+								NotRule: &policy.Permission{
+									Rule: generateHeaderRule([]*route.HeaderMatcher{
+										{Name: methodHeader, HeaderMatchSpecifier: &route.HeaderMatcher_ExactMatch{ExactMatch: "DELETE"}},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	anyPrincipals := []*policy.Principal{{
+		Identifier: &policy.Principal_AndIds{
+			AndIds: &policy.Principal_Set{
+				Ids: []*policy.Principal{
+					{
+						Identifier: &policy.Principal_OrIds{
+							OrIds: &policy.Principal_Set{
+								Ids: []*policy.Principal{
+									{
+										Identifier: &policy.Principal_Any{
+											Any: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	anyAuthenticatedPrincipals := []*policy.Principal{{
+		Identifier: &policy.Principal_AndIds{
+			AndIds: &policy.Principal_Set{
+				Ids: []*policy.Principal{
+					{
+						Identifier: &policy.Principal_OrIds{
+							OrIds: &policy.Principal_Set{
+								Ids: []*policy.Principal{
+									{
+										Identifier: &policy.Principal_Metadata{
+											Metadata: generateMetadataStringMatcher(
+												attrSrcPrincipal, &metadata.StringMatcher{
+													MatchPattern: &metadata.StringMatcher_Regex{
+														Regex: ".*",
+													}},
+												authn.AuthnFilterName),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+	testingNamespacePrincipals := []*policy.Principal{
+		{
+			Identifier: &policy.Principal_AndIds{
+				AndIds: &policy.Principal_Set{
+					Ids: []*policy.Principal{
+						{
+							Identifier: &policy.Principal_OrIds{
+								OrIds: &policy.Principal_Set{
+									Ids: []*policy.Principal{
+										{
+											Identifier: &policy.Principal_Metadata{
+												Metadata: generateMetadataStringMatcher(
+													attrSrcPrincipal, &metadata.StringMatcher{
+														MatchPattern: &metadata.StringMatcher_Regex{Regex: `.*/ns/testing/.*`}}, authn.AuthnFilterName),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	policy1 := &policy.Policy{
+		Permissions: notDeleteMethodPermissions,
+		Principals:  anyPrincipals,
+	}
+	policy2 := &policy.Policy{
+		Permissions: notDeleteMethodPermissions,
+		Principals:  anyPrincipals,
+	}
+	policy3 := &policy.Policy{
+		Permissions: notDeleteMethodPermissions,
+		Principals:  testingNamespacePrincipals,
+	}
+	policy4 := &policy.Policy{
+		Permissions: notDeleteMethodPermissions,
+		Principals:  anyAuthenticatedPrincipals,
+	}
+
+	expectRbac1 := generateExpectRBACWithAuthzPolicyKeysAndRbacPolicies([]string{
+		"authz-policy-authz-policy-single-binding-allow[0]"},
+		[]*policy.Policy{policy1})
+	expectRbac2 := generateExpectRBACWithAuthzPolicyKeysAndRbacPolicies([]string{
+		"authz-policy-authz-policy-multiple-bindings-with-selector-allow[0]",
+		"authz-policy-authz-policy-multiple-bindings-with-selector-allow[1]",
+		"authz-policy-authz-policy-single-binding-allow[0]"},
+		[]*policy.Policy{policy2, policy3, policy1})
+	expectRbac3 := generateExpectRBACWithAuthzPolicyKeysAndRbacPolicies([]string{
+		"authz-policy-authz-policy-single-binding-all-authned-users-allow[0]",
+		"authz-policy-authz-policy-single-binding-allow[0]"},
+		[]*policy.Policy{policy4, policy1})
+
+	authzPolicies := newAuthzPoliciesWithRolesAndBindings(roles, bindings)
+	option := rbacOption{authzPolicies: authzPolicies}
+	option.authzPolicies.IsRbacV2 = true
+
+	testCases := []struct {
+		name    string
+		service *serviceMetadata
+		rbac    *policy.RBAC
+		option  rbacOption
+	}{
+		{
+			name: "service with single binding",
+			service: &serviceMetadata{
+				name: "service-1",
+			},
+			rbac:   expectRbac1,
+			option: option,
+		},
+		{
+			name: "service with multiple bindings and workload selector",
+			service: &serviceMetadata{
+				name:   "productpage",
+				labels: map[string]string{"app": "productpage"},
+			},
+			rbac:   expectRbac2,
+			option: option,
+		},
+		{
+			name: "service no selector matched",
+			service: &serviceMetadata{
+				name:   "service-2",
+				labels: map[string]string{"app": "foo"},
+			},
+			rbac:   expectRbac3,
+			option: option,
+		},
+	}
+
+	for _, tc := range testCases {
+		rbac := convertRbacRulesToFilterConfigV2(tc.service, tc.option)
+		if !reflect.DeepEqual(*tc.rbac, *rbac.Rules) {
+			t.Errorf("%s want:\n%v\nbut got:\n%v", tc.name, *tc.rbac, *rbac.Rules)
+		}
+	}
+}

--- a/pilot/pkg/networking/plugin/authz/test_helper.go
+++ b/pilot/pkg/networking/plugin/authz/test_helper.go
@@ -208,11 +208,31 @@ func generatePolicyWithHTTPMethodAndGroupClaim(methodName, claimName string) *po
 }
 
 // nolint:deadcode
-func generateExpectRBACForSinglePolicy(serviceRoleName string, rbacPolicy *policy.Policy) *policy.RBAC {
+func generateExpectRBACForSinglePolicy(authzPolicyKey string, rbacPolicy *policy.Policy) *policy.RBAC {
+	// If |serviceRoleName| is empty, which means the current service does not have any matched ServiceRoles.
+	if authzPolicyKey == "" {
+		return &policy.RBAC{
+			Action:   policy.RBAC_ALLOW,
+			Policies: map[string]*policy.Policy{},
+		}
+	}
 	return &policy.RBAC{
 		Action: policy.RBAC_ALLOW,
 		Policies: map[string]*policy.Policy{
-			serviceRoleName: rbacPolicy,
+			authzPolicyKey: rbacPolicy,
 		},
+	}
+}
+
+// nolint: deadcode
+func generateExpectRBACWithAuthzPolicyKeysAndRbacPolicies(authzPolicyKeys []string, rbacPolicies []*policy.Policy) *policy.RBAC {
+	policies := map[string]*policy.Policy{}
+	for i, authzPolicyKey := range authzPolicyKeys {
+		policies[authzPolicyKey] = rbacPolicies[i]
+	}
+
+	return &policy.RBAC{
+		Action:   policy.RBAC_ALLOW,
+		Policies: policies,
 	}
 }


### PR DESCRIPTION
Implement AuthorizationPolicy CRD that was introduced at #12318 for Enforced Mode. AuthorizationPolicy allows grouping multiple RBAC bindings in one policy. It also allows selecting the workload using the labels and deprecates/ignores the `services` fields in ServiceRole. 

This is cherry-picked from #12050. 

For #12394