### PR TITLE
Remove "when: always" from CircleCI configuration for integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,8 +506,6 @@ jobs:
       - run: docker images
       - run:
           no_output_timeout: 20m
-          # Run the test even if previous failed
-          when: always
           name: make test.integration.kube
           command: |
             make test.integration.kube T="-v" | tee -a /go/out/tests/build-log.txt


### PR DESCRIPTION
This causes the integration tests to run, even if the previous steps fail.