### PR TITLE
[mixer-e2e-test] add retry to prometheus query in check cache test

### DIFF
--- a/tests/e2e/tests/mixer/mixer_test.go
+++ b/tests/e2e/tests/mixer/mixer_test.go
@@ -883,7 +883,7 @@ func testCheckCache(t *testing.T, visit func() error, app string) {
 		}
 		t.Logf("New cache hits: %v", got)
 		if got == prior {
-			return errors.New("got check cache hit 0 want at least 1")
+			return fmt.Errorf("got new check cache hit %v, want at least %v", got, prior+1)
 		}
 		return nil
 	}


### PR DESCRIPTION
Make prometheus sync period configurable so that check cache could sleep a little bit longer.

Another attempt to fix check cache test flake: #10786 

/assign @douglas-reid 
/assign @utka 