### PR TITLE
Testing: configurable ports for Echo

### DIFF
--- a/pkg/test/application/echo/echo.go
+++ b/pkg/test/application/echo/echo.go
@@ -83,7 +83,7 @@ func (a *echo) GetPorts() model.PortList {
 func (a *echo) start() (err error) {
 	defer func() {
 		if err != nil {
-			a.Close()
+			_ = a.Close()
 		}
 	}()
 
@@ -273,7 +273,7 @@ func listenOnPort(port int) (net.Listener, int, error) {
 }
 
 func listenOnUDS(uds string) (net.Listener, error) {
-	os.Remove(uds)
+	_ = os.Remove(uds)
 	ln, err := net.Listen("unix", uds)
 	if err != nil {
 		return nil, err

--- a/tests/integration/echo/echo_test.go
+++ b/tests/integration/echo/echo_test.go
@@ -30,8 +30,19 @@ func TestEcho(t *testing.T) {
 	// Echo is only supported on native environment right now, skip if we can't load that.
 	ctx.RequireOrSkip(t, environment.Native)
 
-	echoA := echo.NewOrFail(ctx, t, echo.Config{Service: "a.echo", Version: "v1"})
-	echoB := echo.NewOrFail(ctx, t, echo.Config{Service: "b.echo", Version: "v2"})
+	echoA := echo.NewOrFail(ctx, t, echo.Config{
+		Service: "a.echo",
+		Version: "v1",
+	})
+	echoB := echo.NewOrFail(ctx, t, echo.Config{
+		Service: "b.echo",
+		Version: "v2",
+		Ports: model.PortList{
+			{
+				Name:     "http",
+				Protocol: model.ProtocolHTTP,
+			},
+		}})
 
 	// Verify the configuration was set appropriately.
 	if echoA.Config().Service != "a.echo" {


### PR DESCRIPTION
The echo component currently assumes a hard-coded list of ports. We eventually want to replace the "apps" component with echo, but in order to do that we'll need to be able to tailor the port configuration for each instance.