### PR TITLE
Correct the app label for Gateway

### DIFF
--- a/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/autoscale.yaml
@@ -7,10 +7,12 @@ metadata:
   name: {{ $key }}
   namespace: {{ $spec.namespace | default $.Release.Namespace }}
   labels:
-    app: {{ $spec.labels.istio }}
     chart: {{ template "gateway.chart" $ }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 spec:
   maxReplicas: {{ $spec.autoscaleMax }}
   minReplicas: {{ $spec.autoscaleMin }}

--- a/install/kubernetes/helm/istio/charts/gateways/templates/clusterrole.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/clusterrole.yaml
@@ -6,10 +6,12 @@ kind: ClusterRole
 metadata:
   name: {{ $key }}-{{ $.Release.Namespace }}
   labels:
-    app: {{ $spec.labels.istio }}
     chart: {{ template "gateway.chart" $ }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 rules:
 - apiGroups: ["networking.istio.io"]
   resources: ["virtualservices", "destinationrules", "gateways"]

--- a/install/kubernetes/helm/istio/charts/gateways/templates/clusterrolebindings.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/clusterrolebindings.yaml
@@ -6,10 +6,12 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ $key }}-{{ $.Release.Namespace }}
   labels:
-    app: {{ $spec.labels.istio }}
     chart: {{ template "gateway.chart" $ }}
     heritage: {{ $.Release.Service }}
     release: {{ $.Release.Name }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
@@ -84,9 +84,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   selector:
+  {{- range $key, $spec := .Values }}
+  {{- if eq $key "istio-ingressgateway" }}
+  {{- if $spec.enabled }}
     {{- range $key, $val := $spec.labels }}
     {{ $key }}: {{ $val }}
     {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   servers:
   - port:
       number: 15011
@@ -125,7 +131,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   selector:
-    istio: egressgateway
+  {{- range $key, $spec := .Values }}
+  {{- if eq $key "istio-egressgateway" }}
+  {{- if $spec.enabled }}
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   servers:
   - hosts:
     - "*.global"
@@ -148,9 +162,15 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   selector:
+  {{- range $key, $spec := .Values }}
+  {{- if eq $key "istio-ingressgateway" }}
+  {{- if $spec.enabled }}
     {{- range $key, $val := $spec.labels }}
     {{ $key }}: {{ $val }}
     {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   servers:
   - hosts:
     - "*.global"
@@ -172,22 +192,28 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
-   workloadLabels:
+  workloadLabels:
+  {{- range $key, $spec := .Values }}
+  {{- if eq $key "istio-ingressgateway" }}
+  {{- if $spec.enabled }}
     {{- range $key, $val := $spec.labels }}
     {{ $key }}: {{ $val }}
     {{- end }}
-   filters:
-   - listenerMatch:
-       portNumber: 15443
-       listenerType: GATEWAY
-     insertPosition:
-       index: AFTER
-       relativeTo: envoy.filters.network.sni_cluster
-     filterName: envoy.filters.network.tcp_cluster_rewrite
-     filterType: NETWORK
-     filterConfig:
-       cluster_pattern: "\\.global$"
-       cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"       
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  filters:
+  - listenerMatch:
+      portNumber: 15443
+      listenerType: GATEWAY
+    insertPosition:
+      index: AFTER
+      relativeTo: envoy.filters.network.sni_cluster
+    filterName: envoy.filters.network.tcp_cluster_rewrite
+    filterType: NETWORK
+    filterConfig:
+      cluster_pattern: "\\.global$"
+      cluster_replacement: ".svc.{{ .Values.global.proxy.clusterDomain }}"
 ---
 ## To ensure all traffic to *.global is using mTLS
 apiVersion: networking.istio.io/v1alpha3

--- a/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/preconfigured.yaml
@@ -84,7 +84,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   selector:
-    istio: ingressgateway
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
   servers:
   - port:
       number: 15011
@@ -146,7 +148,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   selector:
-    istio: ingressgateway
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
   servers:
   - hosts:
     - "*.global"
@@ -169,7 +173,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
    workloadLabels:
-     istio: ingressgateway
+    {{- range $key, $val := $spec.labels }}
+    {{ $key }}: {{ $val }}
+    {{- end }}
    filters:
    - listenerMatch:
        portNumber: 15443


### PR DESCRIPTION
This is a bug when execute `helm template --name istio --namespace custom-system --values ./install/kubernetes/helm/istio/example-values/values-istio-gateways.yaml install/kubernetes/helm/istio >> istio-gateway.yaml`. `istio-gateway.yaml` has empty `app: ` for clusterrole/clusterrolebinding because the `labels: istio` is not defined in `values-istio-gateways.yaml`. Actually, it should use `$spec.labels.app` for `app`

Signed-off-by: clyang82 <clyang@cn.ibm.com>