### PR TITLE
#12594 Add flag to enable/disable gRPC tracing

### DIFF
--- a/galley/cmd/galley/cmd/server.go
+++ b/galley/cmd/galley/cmd/server.go
@@ -126,6 +126,8 @@ func serverCmd() *cobra.Command {
 	// server config
 	serverCmd.PersistentFlags().StringVarP(&serverArgs.APIAddress, "server-address", "", serverArgs.APIAddress,
 		"Address to use for Galley's gRPC API, e.g. tcp://127.0.0.1:9092 or unix:///path/to/file")
+	serverCmd.PersistentFlags().BoolVarP(&serverArgs.EnableGRPCTracing, "server-enableGrpcTracing", "", serverArgs.EnableGRPCTracing,
+		"Enable gRPC request tracing")
 	serverCmd.PersistentFlags().UintVarP(&serverArgs.MaxReceivedMessageSize, "server-maxReceivedMessageSize", "", serverArgs.MaxReceivedMessageSize,
 		"Maximum size of individual gRPC messages")
 	serverCmd.PersistentFlags().UintVarP(&serverArgs.MaxConcurrentStreams, "server-maxConcurrentStreams", "", serverArgs.MaxConcurrentStreams,

--- a/galley/pkg/server/args.go
+++ b/galley/pkg/server/args.go
@@ -102,6 +102,7 @@ type Args struct {
 func DefaultArgs() *Args {
 	return &Args{
 		APIAddress:                "tcp://0.0.0.0:9901",
+		EnableGRPCTracing:         false,
 		MaxReceivedMessageSize:    1024 * 1024,
 		MaxConcurrentStreams:      1024,
 		IntrospectionOptions:      ctrlz.DefaultOptions(),

--- a/galley/pkg/server/args_test.go
+++ b/galley/pkg/server/args_test.go
@@ -24,6 +24,10 @@ func TestDefaultArgs(t *testing.T) {
 		t.Fatalf("unexpected APIAddress: %v", a.APIAddress)
 	}
 
+	if a.EnableGRPCTracing {
+		t.Fatal("EnableGrpcTracing should be false")
+	}
+
 	if a.MaxReceivedMessageSize != 1024*1024 {
 		t.Fatalf("unexpected MaxReceivedMessageSize: %d", a.MaxReceivedMessageSize)
 	}

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: {{ template "galley.name" . }}
         chart: {{ template "galley.chart" . }}
         heritage: {{ .Release.Service }}
-        release: {{ .Release.Name }}      
+        release: {{ .Release.Name }}
         istio: galley
       annotations:
         sidecar.istio.io/inject: "false"
@@ -67,6 +67,9 @@ spec:
 {{- if $.Values.global.logging.level }}
           - --log_output_level={{ $.Values.global.logging.level }}
 {{- end}}
+{{- if .Values.global.enableGrpcTracing }}
+          - --enableGrpcTracing=true
+{{- end }}
           volumeMounts:
           - name: certs
             mountPath: /etc/certs

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -132,6 +132,9 @@
       {{- if $.Values.global.trustDomain }}
         - --trust-domain={{ $.Values.global.trustDomain }}
       {{- end }}
+      {{- if .Values.global.enableGrpcTracing }}
+          - --enableGrpcTracing=true
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
 {{- end }}
           - --keepaliveMaxServerConnectionAge
           - "{{ .Values.keepaliveMaxServerConnectionAge }}"
+{{- if .Values.global.enableGrpcTracing }}
+          - --enableGrpcTracing=true
+{{- end }}
           ports:
           - containerPort: 8080
           - containerPort: 15010

--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -93,7 +93,7 @@ kiali:
 #
 certmanager:
   enabled: false
-  
+
 #
 # Istio CNI plugin enabled
 #   This must be enabled to use the CNI plugin in Istio.  The CNI plugin is installed separately.
@@ -236,7 +236,7 @@ global:
     # available to scrape via the Envoy admin port at either /stats or /stats/prometheus.
     #
     # See https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto
-    # for details about Envoy's Metrics Service API. 
+    # for details about Envoy's Metrics Service API.
     #
     # Disabled by default.
     envoyMetricsService:
@@ -403,7 +403,7 @@ global:
   #   services or ServiceEntries for the destination port
   # REGISTRY_ONLY - restrict outbound traffic to services defined in the service registry as well
   #   as those defined through ServiceEntries
-  # ALLOW_ANY is the default in 1.1.  This means each pod will be able to make outbound requests 
+  # ALLOW_ANY is the default in 1.1.  This means each pod will be able to make outbound requests
   # to services outside of the mesh without any ServiceEntry.
   # REGISTRY_ONLY was the default in 1.0.  If this behavior is desired, set the value below to REGISTRY_ONLY.
   outboundTrafficPolicy:
@@ -418,7 +418,7 @@ global:
   # rules should be exported to. Currently only one value can be provided in this list. This value
   # should be one of the following two options:
   # * implies these objects are visible to all namespaces, enabling any sidecar to talk to any other sidecar.
-  # . implies these objects are visible to only to sidecars in the same namespace, or if imported as a Sidecar.egress.host  
+  # . implies these objects are visible to only to sidecars in the same namespace, or if imported as a Sidecar.egress.host
   #defaultConfigVisibilitySettings:
   #- '*'
 
@@ -482,3 +482,6 @@ global:
   # This field is set to false by default, so 'helm template ...'
   # will ignore the helm test yaml files when generating the template
   enableHelmTest: false
+
+  # Enable gRPC-level tracing of requests, served at /debug/events and /debug/requests
+  enableGrpcTracing: false

--- a/mixer/cmd/mixs/cmd/server.go
+++ b/mixer/cmd/mixs/cmd/server.go
@@ -74,6 +74,8 @@ func serverCmd(info map[string]template.Info, adapters []adapter.InfoFn, printf,
 		"Path to the file for the readiness probe.")
 	serverCmd.PersistentFlags().DurationVar(&sa.ReadinessProbeOptions.UpdateInterval, "readinessProbeInterval", sa.ReadinessProbeOptions.UpdateInterval,
 		"Interval of updating file for the readiness probe.")
+	serverCmd.PersistentFlags().BoolVar(&sa.EnableGRPCTracing, "enableGrpcTracing", sa.EnableGRPCTracing,
+		"Enable gRPC request tracing")
 	serverCmd.PersistentFlags().BoolVar(&sa.EnableProfiling, "profile", sa.EnableProfiling,
 		"Enable profiling via web interface host:port/debug/pprof")
 

--- a/pilot/cmd/pilot-discovery/main.go
+++ b/pilot/cmd/pilot-discovery/main.go
@@ -148,6 +148,9 @@ func init() {
 	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.DiscoveryOptions.EnableCaching, "discoveryCache", true,
 		"Enable caching discovery service responses")
 
+	discoveryCmd.PersistentFlags().BoolVar(&serverArgs.EnableGRPCTracing, "enableGrpcTracing", false,
+		"Enable gRPC request tracing")
+
 	// Attach the Istio logging options to the command.
 	loggingOptions.AttachCobraFlags(rootCmd)
 

--- a/pilot/pkg/bootstrap/server.go
+++ b/pilot/pkg/bootstrap/server.go
@@ -115,10 +115,6 @@ var (
 )
 
 func init() {
-	// get the grpc server wired up
-	// This should only be set before any RPCs are sent or received by this program.
-	grpc.EnableTracing = true
-
 	// Export pilot version as metric for fleet analytics.
 	pilotVersion := prom.NewGaugeVec(prom.GaugeOpts{
 		Name: "pilot_info",
@@ -176,6 +172,7 @@ type PilotArgs struct {
 	Plugins            []string
 	MCPMaxMessageSize  int
 	KeepaliveOptions   *istiokeepalive.Options
+	EnableGRPCTracing  bool
 	// ForceStop is set as true when used for testing to make the server stop quickly
 	ForceStop bool
 }
@@ -212,6 +209,10 @@ var podNamespaceVar = env.RegisterStringVar("POD_NAMESPACE", "", "")
 
 // NewServer creates a new Server instance based on the provided arguments.
 func NewServer(args PilotArgs) (*Server, error) {
+	// get the grpc server wired up
+	// This should only be set before any RPCs are sent or received by this program.
+	grpc.EnableTracing = args.EnableGRPCTracing
+
 	// If the namespace isn't set, try looking it up from the environment.
 	if args.Namespace == "" {
 		args.Namespace = podNamespaceVar.Get()


### PR DESCRIPTION
The motivation for this PR is reducing memory footprint of pilot. Some flags have been already found in the programmatic configuration, just not used.

Adding `--enableGrpcTracing` argument to pilot, mixer and galley. During installation this can be controlled through `global.enableGrpcTracing` - I did not create specific flags for each of the servers as the ability to debug system is more of a production/test installation rather than per-server.

#12594 suggests `pilot.tracing.` prefix but I found this too confusing, as here it's not a part of Jaeger+Zipkin tracing functionality.