### PR TITLE
Adding timeouts in Galley processor tests

### DIFF
--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -62,7 +62,7 @@ type Processor struct {
 	// worker handles the lifecycle of the processing worker thread.
 	worker *util.Worker
 
-	// Condition used to notify callers of AwaitFullSync that the full sync has occurred.
+	// Condition used to notify callers of awaitFullSync that the full sync has occurred.
 	fullSyncCond *sync.Cond
 }
 
@@ -160,8 +160,8 @@ func (p *Processor) Stop() {
 	p.worker.Stop()
 }
 
-// AwaitFullSync waits until the full sync event is received from the source. For testing purposes only.
-func (p *Processor) AwaitFullSync(timeout time.Duration) error {
+// awaitFullSync waits until the full sync event is received from the source. For testing purposes only.
+func (p *Processor) awaitFullSync(timeout time.Duration) error {
 	return wait.WithTimeout(func() {
 		p.fullSyncCond.L.Lock()
 		defer p.fullSyncCond.L.Unlock()

--- a/galley/pkg/runtime/processor.go
+++ b/galley/pkg/runtime/processor.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/util"
 	"istio.io/istio/pkg/log"
+	"istio.io/istio/pkg/util/wait"
 )
 
 var scope = log.RegisterScope("runtime", "Galley runtime", 0)
@@ -160,13 +161,17 @@ func (p *Processor) Stop() {
 }
 
 // AwaitFullSync waits until the full sync event is received from the source. For testing purposes only.
-func (p *Processor) AwaitFullSync() {
-	p.fullSyncCond.L.Lock()
-	defer p.fullSyncCond.L.Unlock()
+func (p *Processor) AwaitFullSync(timeout time.Duration) error {
+	return wait.WithTimeout(func() {
+		p.fullSyncCond.L.Lock()
+		defer p.fullSyncCond.L.Unlock()
+		if p.distribute {
+			// Already synced. Nothing to do.
+			return
+		}
 
-	if !p.distribute {
 		p.fullSyncCond.Wait()
-	}
+	}, timeout)
 }
 
 func (p *Processor) processEvent(e resource.Event) {

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -204,7 +204,7 @@ func TestProcessor_Publishing(t *testing.T) {
 }
 
 func awaitFullSync(t *testing.T, p *Processor) {
-	if err := p.AwaitFullSync(timeout); err != nil {
+	if err := p.awaitFullSync(timeout); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/galley/pkg/runtime/processor_test.go
+++ b/galley/pkg/runtime/processor_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"istio.io/istio/pkg/log"
-
 	"github.com/gogo/protobuf/types"
 
 	"istio.io/istio/galley/pkg/meshconfig"
@@ -30,7 +28,13 @@ import (
 	"istio.io/istio/galley/pkg/runtime/publish"
 	"istio.io/istio/galley/pkg/runtime/resource"
 	"istio.io/istio/galley/pkg/testing/resources"
+	"istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/mcp/snapshot"
+	"istio.io/istio/pkg/util/wait"
+)
+
+const (
+	timeout = 5 * time.Second
 )
 
 func TestProcessor_Start(t *testing.T) {
@@ -115,7 +119,7 @@ func TestProcessor_EventAccumulation(t *testing.T) {
 	}
 	defer p.Stop()
 
-	p.AwaitFullSync()
+	awaitFullSync(t, p)
 
 	k1 := resource.Key{Collection: resources.EmptyInfo.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
@@ -147,7 +151,7 @@ func TestProcessor_EventAccumulation_WithFullSync(t *testing.T) {
 	}
 	defer p.Stop()
 
-	p.AwaitFullSync()
+	awaitFullSync(t, p)
 
 	k1 := resource.Key{Collection: info.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
@@ -171,7 +175,7 @@ func TestProcessor_Publishing(t *testing.T) {
 	distributor := NewInMemoryDistributor()
 	stateStrategy := publish.NewStrategy(time.Millisecond, time.Millisecond, time.Microsecond)
 
-	processCallCount := sync.WaitGroup{}
+	processCallCount := &sync.WaitGroup{}
 	hookFn := func() {
 		processCallCount.Done()
 	}
@@ -184,15 +188,24 @@ func TestProcessor_Publishing(t *testing.T) {
 	}
 	defer p.Stop()
 
-	p.AwaitFullSync()
+	awaitFullSync(t, p)
 
 	k1 := resource.Key{Collection: info.Collection, FullName: resource.FullNameFromNamespaceAndName("", "r1")}
 	src.Set(k1, resource.Metadata{}, &types.Empty{})
 
-	processCallCount.Wait()
+	// Wait for up to 5 seconds.
+	if err := wait.WithTimeout(processCallCount.Wait, timeout); err != nil {
+		t.Fatal(err)
+	}
 
 	if distributor.NumSnapshots() != 1 {
 		t.Fatalf("snapshot should have been distributed: %+v", distributor)
+	}
+}
+
+func awaitFullSync(t *testing.T, p *Processor) {
+	if err := p.AwaitFullSync(timeout); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"fmt"
+	"time"
+)
+
+// WithTimeout waits for the function to complete or the given timeout to expire.
+func WithTimeout(fn func(), timeout time.Duration) error {
+	c := make(chan struct{}, 1)
+	go func() {
+		defer close(c)
+		fn()
+	}()
+
+	select {
+	case <-c:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out while waiting for requested action to complete")
+	}
+}


### PR DESCRIPTION
This is to help in debugging #12628.