### PR TITLE
Hide ServiceAccounts from PushContext log

### DIFF
--- a/pilot/pkg/model/push_context.go
+++ b/pilot/pkg/model/push_context.go
@@ -93,7 +93,7 @@ type PushContext struct {
 	ServicePort2Name map[string]PortList `json:"-"`
 
 	// ServiceAccounts contains a map of hostname and port to service accounts.
-	ServiceAccounts map[Hostname]map[int][]string
+	ServiceAccounts map[Hostname]map[int][]string `json:"-"`
 
 	initDone bool
 }


### PR DESCRIPTION
These generate a ton of logs, and aren't very useful