### PR TITLE
Fix concurrent map access

### DIFF
--- a/mixer/pkg/config/mcp/backend.go
+++ b/mixer/pkg/config/mcp/backend.go
@@ -241,13 +241,15 @@ func (b *backend) WaitForSynced(timeout time.Duration) error {
 			return fmt.Errorf("exceeded timeout %v", timeout)
 		case <-tick.C:
 			ready := true
-
+			b.state.RLock()
 			for _, synced := range b.state.synced {
 				if !synced {
 					ready = false
 					break
 				}
 			}
+			b.state.RUnlock()
+
 			if ready {
 				return nil
 			}


### PR DESCRIPTION
Protected backend.state resource with a mutex.
It was left unprotected during map iteration. 

```
2019-03-22T18:24:54.723437Z     info    mcp     New MCP sink stream created
fatal error: concurrent map iteration and map write

goroutine 1 [running]:
runtime.throw(0x205917c, 0x26)
        /usr/local/go/src/runtime/panic.go:616 +0x81 fp=0xc420ae7408 sp=0xc420ae73e8 pc=0x42aca1
runtime.mapiternext(0xc420ae7528)
        /usr/local/go/src/runtime/hashmap.go:747 +0x55c fp=0xc420ae7498 sp=0xc420ae7408 pc=0x408b0c
runtime.mapiterinit(0x1cf5a00, 0xc420a826f0, 0xc420ae7528)
        /usr/local/go/src/runtime/hashmap.go:737 +0x1f1 fp=0xc420ae74c0 sp=0xc420ae7498 pc=0x4084c1
istio.io/istio/mixer/pkg/config/mcp.(*backend).WaitForSynced(0xc420294230, 0x6fc23ac00, 0x0, 0x0)
        /workspace/go/src/istio.io/istio/mixer/pkg/config/mcp/backend.go:245 +0x1d2 fp=0xc420ae7618 sp=0xc420ae74c0 pc=0x1a91472
```