### PR TITLE
Specify istio-init user explicitly (#5453)

### DIFF
--- a/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
+++ b/install/kubernetes/helm/istio/templates/sidecar-injector-configmap.yaml
@@ -53,6 +53,7 @@ data:
             cpu: 100m
             memory: 50Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/daemonset.yaml.injected
@@ -133,6 +133,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig-multi.yaml.injected
@@ -136,6 +136,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/deploymentconfig.yaml.injected
@@ -136,6 +136,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/frontend.yaml.injected
@@ -138,6 +138,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-config-map-name.yaml.injected
@@ -134,6 +134,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-multi.yaml.injected
@@ -135,6 +135,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -286,6 +287,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/hello-probes.yaml.injected
@@ -154,6 +154,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/job.yaml.injected
@@ -132,6 +132,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list-frontend.yaml.injected
@@ -138,6 +138,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/list.yaml.injected
@@ -135,6 +135,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN
@@ -286,6 +287,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/multi-init.yaml.injected
@@ -144,6 +144,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicaset.yaml.injected
@@ -132,6 +132,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/replicationcontroller.yaml.injected
@@ -133,6 +133,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/resource_annotations.yaml.injected
@@ -131,6 +131,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/statefulset.yaml.injected
@@ -137,6 +137,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/status_annotations.yaml.injected
@@ -137,6 +137,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-empty-includes.yaml.injected
@@ -136,6 +136,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations-wildcards.yaml.injected
@@ -136,6 +136,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/traffic-annotations.yaml.injected
@@ -136,6 +136,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN

--- a/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
+++ b/pilot/pkg/kube/inject/testdata/webhook/user-volume.yaml.injected
@@ -141,6 +141,7 @@ spec:
             cpu: 10m
             memory: 10Mi
         securityContext:
+          runAsUser: 0
           capabilities:
             add:
             - NET_ADMIN


### PR DESCRIPTION
Istio-init is supposed to be run as a superuser so it can configure
iptables and this is the current default. However many popular Helm
charts typically define a single container pod and specify
`securityContext.runAsUser` on a pod level (rather than the container
level) and that is what istio-init inherits. As the result many Helm
charts aren't working with Istio auto-injection out of the box.

A simple fix would be explicitly setting `securityContext.runAsUser`
for istio-init on the container-level so it takes precedence.