### PR TITLE
fix kiali bind network port specs  

### DIFF
--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
           httpGet:
             path: /kiali/console
             port: 20001
+        livenessProbe:
+          httpGet:
+            path: /kiali/console
+            port: 20001
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -40,6 +40,12 @@ spec:
         - "/kiali-configuration/config.yaml"
         - "-v"
         - "4"
+        ports:
+        - containerPort: 20001
+        readinessProbe:
+          httpGet:
+            path: /kiali/console
+            port: 20001
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:


### PR DESCRIPTION
the port specification of Kiali sub-chart is missed on release 1.1.0.
this will cause not to be able to browse its Kiali dashboard nether via port-forward nor ingress gateways...