### PR TITLE
Cherry-pick 'istioctl proxy-config clusters' cluster type column rendering (#12458)

### DIFF
--- a/istioctl/cmd/istioctl/proxyconfig_test.go
+++ b/istioctl/cmd/istioctl/proxyconfig_test.go
@@ -83,8 +83,8 @@ func TestProxyConfig(t *testing.T) {
 			execClientConfig: cannedConfig,
 			args:             strings.Split("proxy-config clusters details-v1-5b7f94f9bc-wp5tb", " "),
 			expectedOutput: `SERVICE FQDN                                    PORT      SUBSET     DIRECTION     TYPE
-istio-policy.istio-system.svc.cluster.local     15004     -          outbound      &{EDS}
-xds-grpc                                        -         -          -             &{STRICT_DNS}
+istio-policy.istio-system.svc.cluster.local     15004     -          outbound      EDS
+xds-grpc                                        -         -          -             STRICT_DNS
 `,
 		},
 		{ // case 7 listeners valid

--- a/istioctl/pkg/writer/envoy/configdump/cluster.go
+++ b/istioctl/pkg/writer/envoy/configdump/cluster.go
@@ -73,9 +73,9 @@ func (c *ConfigWriter) PrintClusterSummary(filter ClusterFilter) error {
 				if subset == "" {
 					subset = "-"
 				}
-				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", fqdn, port, subset, direction, cluster.ClusterDiscoveryType)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\n", fqdn, port, subset, direction, cluster.GetType())
 			} else {
-				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", cluster.Name, "-", "-", "-", cluster.ClusterDiscoveryType)
+				fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%s\n", cluster.Name, "-", "-", "-", cluster.GetType())
 			}
 		}
 	}

--- a/istioctl/pkg/writer/envoy/configdump/testdata/clustersummary.txt
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/clustersummary.txt
@@ -1,3 +1,3 @@
 SERVICE FQDN                                    PORT      SUBSET     DIRECTION     TYPE
-istio-policy.istio-system.svc.cluster.local     15004     -          outbound      &{EDS}
-xds-grpc                                        -         -          -             &{STRICT_DNS}
+istio-policy.istio-system.svc.cluster.local     15004     -          outbound      EDS
+xds-grpc                                        -         -          -             STRICT_DNS

--- a/istioctl/pkg/writer/envoy/configdump/testdata/clustersummaryfiltered.txt
+++ b/istioctl/pkg/writer/envoy/configdump/testdata/clustersummaryfiltered.txt
@@ -1,2 +1,2 @@
 SERVICE FQDN                                    PORT      SUBSET     DIRECTION     TYPE
-istio-policy.istio-system.svc.cluster.local     15004     -          outbound      &{EDS}
+istio-policy.istio-system.svc.cluster.local     15004     -          outbound      EDS


### PR DESCRIPTION
This is a bug in 1.1.x but the fix was merged to master. Cherry picking to release-1.1 branch. (If there's a better way to do this let me know.)

/cc @esnible 