### PR TITLE
Replace scratch base docker image with gcr.io/distroless/static

### DIFF
--- a/mixer/docker/Dockerfile.mixer
+++ b/mixer/docker/Dockerfile.mixer
@@ -1,7 +1,5 @@
-FROM scratch
+FROM gcr.io/distroless/static
 
-# obtained from debian ca-certs deb using fetch_cacerts.sh
-ADD ca-certificates.tgz /
 ADD mixs /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/mixs", "server"]

--- a/mixer/docker/Dockerfile.mixer_codegen
+++ b/mixer/docker/Dockerfile.mixer_codegen
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/distroless/static
 
 ADD mixgen /usr/local/bin/
 

--- a/mixer/test/listbackend/cmd/Dockerfile
+++ b/mixer/test/listbackend/cmd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static
 
 ADD listadapter /usr/local/bin/
 

--- a/mixer/test/prometheus/cmd/Dockerfile
+++ b/mixer/test/prometheus/cmd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
+FROM gcr.io/distroless/static
 
 ADD prometheusadapter /usr/local/bin/
 

--- a/pilot/docker/Dockerfile.sidecar_injector
+++ b/pilot/docker/Dockerfile.sidecar_injector
@@ -1,3 +1,3 @@
-FROM scratch
+FROM gcr.io/distroless/static
 ADD sidecar-injector /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/sidecar-injector"]

--- a/samples/tcp-echo/src/Dockerfile
+++ b/samples/tcp-echo/src/Dockerfile
@@ -19,7 +19,7 @@ COPY main.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o tcp-echo main.go
 
 # copy the tcp-echo binary to a separate container based on scratch
-FROM scratch
+FROM gcr.io/distroless/static
 WORKDIR /bin/
 COPY --from=builder /go/src/istio.io/tcp-echo-server/tcp-echo .
 ENTRYPOINT [ "/bin/tcp-echo" ]

--- a/security/docker/Dockerfile.citadel
+++ b/security/docker/Dockerfile.citadel
@@ -1,7 +1,5 @@
-FROM scratch
+FROM gcr.io/distroless/static
 
-# obtained from debian ca-certs deb using fetch_cacerts.sh
-ADD ca-certificates.tgz /
 # All containers need a /tmp directory
 WORKDIR /tmp/
 ADD istio_ca /usr/local/bin/istio_ca

--- a/security/docker/Dockerfile.node-agent
+++ b/security/docker/Dockerfile.node-agent
@@ -1,4 +1,4 @@
-FROM scratch
+FROM gcr.io/distroless/static
 
 # All containers need a /tmp directory
 WORKDIR /tmp/

--- a/tools/istio-docker.mk
+++ b/tools/istio-docker.mk
@@ -158,7 +158,7 @@ ifeq ($(DEBUG_IMAGE),1)
 	# It is extremely helpful to debug from the test app. The savings in size are not worth the
 	# developer pain
 	cp $(ISTIO_DOCKER)/testapp/Dockerfile.app $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg
-	sed -e "s,FROM scratch,FROM $(HUB)/proxy_debug:$(TAG)," $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg > $(ISTIO_DOCKER)/testapp/Dockerfile.appd
+	sed -e "s,FROM gcr.io/distroless/static,FROM $(HUB)/proxy_debug:$(TAG)," $(ISTIO_DOCKER)/testapp/Dockerfile.appdbg > $(ISTIO_DOCKER)/testapp/Dockerfile.appd
 endif
 	time (cd $(ISTIO_DOCKER)/testapp && \
 		docker build -t $(HUB)/app:$(TAG) -f Dockerfile.app .)
@@ -175,7 +175,6 @@ docker.kubectl: docker/Dockerfile$$(suffix $$@)
 
 docker.mixer: mixer/docker/Dockerfile.mixer
 docker.mixer: $(ISTIO_DOCKER)/mixs
-docker.mixer: $(ISTIO_DOCKER)/ca-certificates.tgz
 	$(DOCKER_RULE)
 
 # mixer codegen docker images
@@ -193,7 +192,6 @@ docker.galley: $(ISTIO_DOCKER)/galley
 
 docker.citadel: security/docker/Dockerfile.citadel
 docker.citadel: $(ISTIO_DOCKER)/istio_ca
-docker.citadel: $(ISTIO_DOCKER)/ca-certificates.tgz
 	$(DOCKER_RULE)
 
 docker.citadel-test: security/docker/Dockerfile.citadel-test


### PR DESCRIPTION
We would like to have a minimal common base from `gcr.io/distroless` for all docker images.
The `gcr.io/distroless` also provide the ca-certificates required for mixer and citadel.

See also #12122.