### PR TITLE
Fix updateClusterInc for overlapping ports

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -27,9 +27,8 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
-
 	"istio.io/istio/pilot/pkg/model"
+	"istio.io/istio/pilot/pkg/networking/core/v1alpha3/loadbalancer"
 	"istio.io/istio/pilot/pkg/networking/util"
 	"istio.io/istio/pilot/pkg/serviceregistry/aggregate"
 	"istio.io/istio/pkg/features/pilot"

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -219,12 +219,15 @@ func (s *DiscoveryServer) updateClusterInc(push *model.PushContext, clusterName 
 	// arbitrary destination rule's subset labels!
 	labels := push.SubsetToLabels(nil, subsetName, hostname)
 
-	portMap, f := push.ServicePort2Name[string(hostname)]
+	ports, f := push.ServicePort2Name[string(hostname)]
 	if !f {
 		return s.updateCluster(push, clusterName, edsCluster)
 	}
-	svcPort, f := portMap.GetByPort(port)
-	if !f {
+
+	// Check that there is a matching port
+	// We don't use the port though, as there could be multiple matches
+	_, found := ports.GetByPort(port)
+	if !found {
 		return s.updateCluster(push, clusterName, edsCluster)
 	}
 
@@ -244,26 +247,28 @@ func (s *DiscoveryServer) updateClusterInc(push *model.PushContext, clusterName 
 	// for this cluster
 	for _, endpoints := range se.Shards {
 		for _, ep := range endpoints {
-			if svcPort.Name != ep.ServicePortName {
-				continue
-			}
-			// Port labels
-			if !labels.HasSubsetOf(model.Labels(ep.Labels)) {
-				continue
-			}
-			cnt++
-
-			locLbEps, found := localityEpMap[ep.Locality]
-			if !found {
-				locLbEps = &endpoint.LocalityLbEndpoints{
-					Locality: util.ConvertLocality(ep.Locality),
+			for _, port := range ports {
+				if port.Name != ep.ServicePortName {
+					continue
 				}
-				localityEpMap[ep.Locality] = locLbEps
+				// Port labels
+				if !labels.HasSubsetOf(model.Labels(ep.Labels)) {
+					continue
+				}
+				cnt++
+
+				locLbEps, found := localityEpMap[ep.Locality]
+				if !found {
+					locLbEps = &endpoint.LocalityLbEndpoints{
+						Locality: util.ConvertLocality(ep.Locality),
+					}
+					localityEpMap[ep.Locality] = locLbEps
+				}
+				if ep.EnvoyEndpoint == nil {
+					ep.EnvoyEndpoint = buildEnvoyLbEndpoint(ep.UID, ep.Family, ep.Address, ep.EndpointPort, ep.Network)
+				}
+				locLbEps.LbEndpoints = append(locLbEps.LbEndpoints, *ep.EnvoyEndpoint)
 			}
-			if ep.EnvoyEndpoint == nil {
-				ep.EnvoyEndpoint = buildEnvoyLbEndpoint(ep.UID, ep.Family, ep.Address, ep.EndpointPort, ep.Network)
-			}
-			locLbEps.LbEndpoints = append(locLbEps.LbEndpoints, *ep.EnvoyEndpoint)
 		}
 	}
 	se.mutex.RUnlock()

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -46,9 +46,6 @@ import (
 const (
 	asdcLocality  = "region1/zone1/subzone1"
 	asdc2Locality = "region2/zone2/subzone2"
-
-	// Service used to trigger an incremental update for the overlapping port test
-	overlapIncSvc = "eds-overlap-trigger.test.svc.cluster.local"
 )
 
 func TestEds(t *testing.T) {

--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -29,18 +29,27 @@ import (
 	"testing"
 	"time"
 
-	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+
+	"istio.io/istio/pkg/test/env"
 
 	"istio.io/istio/pilot/pkg/bootstrap"
 	"istio.io/istio/pilot/pkg/model"
 	v2 "istio.io/istio/pilot/pkg/proxy/envoy/v2"
 	"istio.io/istio/pkg/adsc"
-	"istio.io/istio/pkg/test/env"
 	"istio.io/istio/tests/util"
 )
 
 // The connect and reconnect tests are removed - ADS already has coverage, and the
 // StreamEndpoints is not used in 1.0+
+
+const (
+	asdcLocality  = "region1/zone1/subzone1"
+	asdc2Locality = "region2/zone2/subzone2"
+
+	// Service used to trigger an incremental update for the overlapping port test
+	overlapIncSvc = "eds-overlap-trigger.test.svc.cluster.local"
+)
 
 func TestEds(t *testing.T) {
 	server, tearDown := initLocalPilotTestEnv(t)
@@ -103,6 +112,19 @@ func TestEds(t *testing.T) {
 	})
 }
 
+func TestEDSOverlapping(t *testing.T) {
+
+	server, tearDown := initLocalPilotTestEnv(t)
+	defer tearDown()
+
+	// add endpoints with multiple ports with the same port number
+	addOverlappingEndpoints(server)
+
+	adsc := adsConnectAndWait(t, 0x0a0a0a0a)
+	defer adsc.Close()
+	testOverlappingPorts(server, adsc, t)
+}
+
 func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
 	adsc, err := adsc.Dial(util.MockPilotGrpcAddr, "", &adsc.Config{
 		IP: testIP(uint32(ip)),
@@ -121,9 +143,6 @@ func adsConnectAndWait(t *testing.T, ip int) *adsc.ADSC {
 	}
 	return adsc
 }
-
-var asdcLocality = "region1/zone1/subzone1"
-var asdc2Locality = "region2/zone2/subzone2"
 
 func addTestClientEndpoints(server *bootstrap.Server) {
 	server.EnvoyXdsServer.MemRegistry.AddService("test-1.default", &model.Service{
@@ -166,28 +185,50 @@ func addTestClientEndpoints(server *bootstrap.Server) {
 // Verify server sends the endpoint. This check for a single endpoint with the given
 // address.
 func testTCPEndpoints(expected string, adsc *adsc.ADSC, t *testing.T) {
-	lbe, f := adsc.EDS["outbound|8080||eds.test.svc.cluster.local"]
+	testEndpoints(expected, "outbound|8080||eds.test.svc.cluster.local", adsc, t)
+}
+
+// Verify server sends the endpoint. This check for a single endpoint with the given
+// address.
+func testEndpoints(expected string, cluster string, adsc *adsc.ADSC, t *testing.T) {
+	lbe, f := adsc.EDS[cluster]
 	if !f || len(lbe.Endpoints) == 0 {
-		t.Fatal("No lb endpoints ", adsc.EndpointsJSON())
+		t.Fatalf("No lb endpoints for %v, %v", cluster, adsc.EndpointsJSON())
 	}
-	total := 0
+	var found []string
 	for _, lbe := range lbe.Endpoints {
 		for _, e := range lbe.LbEndpoints {
-			total++
-			if expected == e.GetEndpoint().Address.GetSocketAddress().Address {
+			addr := e.GetEndpoint().Address.GetSocketAddress().Address
+			found = append(found, addr)
+			if expected == addr {
 				return
 			}
 		}
 	}
-	t.Errorf("Expecting %s got %v", expected, lbe.Endpoints[0].LbEndpoints)
-	if total != 1 {
-		t.Error("Expecting 1, got ", total)
+	t.Errorf("Expecting %s got %v", expected, found)
+	if len(found) != 1 {
+		t.Error("Expecting 1, got ", len(found))
 	}
 }
 
 func testLocalityPrioritizedEndpoints(adsc *adsc.ADSC, adsc2 *adsc.ADSC, t *testing.T) {
 	verifyLocalityPriorities(asdcLocality, adsc.EDS["outbound|80||locality.cluster.local"].GetEndpoints(), t)
 	verifyLocalityPriorities(asdc2Locality, adsc2.EDS["outbound|80||locality.cluster.local"].GetEndpoints(), t)
+}
+
+// Tests that Services with multiple ports sharing the same port number are properly sent endpoints.
+// Real world use case for this is kube-dns, which uses port 53 for TCP and UDP.
+func testOverlappingPorts(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
+	// Test initial state
+	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
+
+	server.EnvoyXdsServer.Push(false, map[string]struct{}{
+		"overlapping.cluster.local": {},
+	})
+	_, _ = adsc.Wait("", 5*time.Second)
+
+	// After the incremental push, we should still see the endpoint
+	testEndpoints("10.0.0.53", "outbound|53||overlapping.cluster.local", adsc, t)
 }
 
 func verifyLocalityPriorities(proxyLocality string, eps []endpoint.LocalityLbEndpoints, t *testing.T) {
@@ -532,6 +573,36 @@ func addLocalityEndpoints(server *bootstrap.Server) {
 			},
 		})
 	}
+	server.EnvoyXdsServer.Push(true, nil)
+}
+
+func addOverlappingEndpoints(server *bootstrap.Server) {
+	server.EnvoyXdsServer.MemRegistry.AddService("overlapping.cluster.local", &model.Service{
+		Hostname: "overlapping.cluster.local",
+		Ports: model.PortList{
+			{
+				Name:     "dns",
+				Port:     53,
+				Protocol: model.ProtocolUDP,
+			},
+			{
+				Name:     "tcp-dns",
+				Port:     53,
+				Protocol: model.ProtocolTCP,
+			},
+		},
+	})
+	server.EnvoyXdsServer.MemRegistry.AddInstance("overlapping.cluster.local", &model.ServiceInstance{
+		Endpoint: model.NetworkEndpoint{
+			Address: "10.0.0.53",
+			Port:    53,
+			ServicePort: &model.Port{
+				Name:     "tcp-dns",
+				Port:     53,
+				Protocol: model.ProtocolTCP,
+			},
+		},
+	})
 	server.EnvoyXdsServer.Push(true, nil)
 }
 


### PR DESCRIPTION
It is possible that a service will have multiple ports, with the same
port number. The typical example here is kube-dns, which uses port 53
for UDP and TCP. When we do an incremental push, we would select the
first port to match the port number, which would sometimes causes us to
ignore the correct port. This fix searches through all matching ports.

Hopefully fixes https://github.com/istio/istio/issues/11658