### PR TITLE
Introduce the default network to EDS

### DIFF
--- a/install/kubernetes/helm/istio/values.yaml
+++ b/install/kubernetes/helm/istio/values.yaml
@@ -414,22 +414,30 @@ global:
 
   # Configure the mesh networks to be used by the Split Horizon EDS.
   #
-  # The following example defines two networks with different endpoints association methods.
+  # The following example defines three networks with different endpoints association methods.
+  # The `local` network (`local` is the reserved name for the local network in Istio),
+  # does not specify the endpoints association method, so the local endpoints of this pilot will be
+  # associated with it. The gateway for this network example is specified by its public IP
+  # address and port.
   # For `network1` all endpoints that their IP belongs to the provided CIDR range will be
   # mapped to network1. The gateway for this network example is specified by its public IP
   # address and port.
-  # The second network, `network2`, in this example is defined differently with all endpoints
+  # The third network, `network2`, in this example is defined differently with all endpoints
   # retrieved through the specified Multi-Cluster registry being mapped to network2. The
   # gateway is also defined differently with the name of the gateway service on the remote
   # cluster. The public IP for the gateway will be determined from that remote service (not
   # supported yet).
   #
   # meshNetworks:
+  #   local:
+  #     gateways:
+  #     - address: 1.1.1.1
+  #       port: 80
   #   network1:
   #     endpoints:
   #     - fromCidr: "192.168.0.1/24"
   #     gateways:
-  #     - address: 1.1.1.1
+  #     - address: 2.2.2.2
   #       port: 80
   #   network2:
   #     endpoints:

--- a/pilot/pkg/model/context_test.go
+++ b/pilot/pkg/model/context_test.go
@@ -117,6 +117,10 @@ defaultConfig:
 func TestApplyMeshNetworksDefaults(t *testing.T) {
 	yml := fmt.Sprintf(`
 networks:
+  local:
+    gateways:
+    - address: 1.1.1.2
+      port: 80
   network1:
     endpoints:
     - fromCidr: "192.168.0.1/24"
@@ -133,6 +137,16 @@ networks:
 
 	want := model.EmptyMeshNetworks()
 	want.Networks = map[string]*meshconfig.Network{
+		"local": {
+			Gateways: []*meshconfig.Network_IstioNetworkGateway{
+				{
+					Gw: &meshconfig.Network_IstioNetworkGateway_Address{
+						Address: "1.1.1.2",
+					},
+					Port: 80,
+				},
+			},
+		},
 		"network1": {
 			Endpoints: []*meshconfig.Network_NetworkEndpoints{
 				{

--- a/pilot/pkg/proxy/envoy/v2/ep_filters.go
+++ b/pilot/pkg/proxy/envoy/v2/ep_filters.go
@@ -24,6 +24,8 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 )
 
+const LocalNetworkName = "local"
+
 // EndpointsFilterFunc is a function that filters data from the ClusterLoadAssignment and returns updated one
 type EndpointsFilterFunc func(endpoints []endpoint.LocalityLbEndpoints, conn *XdsConnection, env *model.Environment) []endpoint.LocalityLbEndpoints
 
@@ -36,7 +38,7 @@ func EndpointsByNetworkFilter(endpoints []endpoint.LocalityLbEndpoints, conn *Xd
 	network, found := conn.modelNode.Metadata[model.NodeMetadataNetwork]
 	if !found {
 		// Couldn't find the sidecar network, using default/local
-		network = ""
+		network = LocalNetworkName
 	}
 
 	// calculate the multiples of weight.
@@ -154,7 +156,7 @@ func istioMetadata(ep endpoint.LbEndpoint, key string) string {
 		ep.Metadata.FilterMetadata["istio"].Fields[key] != nil {
 		return ep.Metadata.FilterMetadata["istio"].Fields[key].GetStringValue()
 	}
-	return ""
+	return LocalNetworkName
 }
 
 func createLocalityLbEndpoints(base *endpoint.LocalityLbEndpoints, lbEndpoints []endpoint.LbEndpoint) *endpoint.LocalityLbEndpoints {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/12623.

If the sidecar does not specify its network, treat it as "local". If the endpoint doesn't have network metadata, treat it as "local". Allows defining the "local" network in the MeshNetworks with its gateways to send to remote sidecars.