### PR TITLE
Fixed versioning information in the helm chart

### DIFF
--- a/install/kubernetes/helm/istio-init/Chart.yaml
+++ b/install/kubernetes/helm/istio-init/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio-init
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1
 tillerVersion: ">=2.7.2-0"
 description: Helm chart to initialize Istio CRDs
 keywords:

--- a/install/kubernetes/helm/istio/Chart.yaml
+++ b/install/kubernetes/helm/istio/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: istio
-version: 1.1.0
-appVersion: 1.1.0
+version: 1.1.1
+appVersion: 1.1.1
 tillerVersion: ">=2.7.2-0"
 description: Helm chart for all istio components
 keywords:


### PR DESCRIPTION
Issue: All values is helm have been updated
but 'helm ls' is still showing version 1.1.0
allthough all the images are version 1.1.1.