### PR TITLE
inject sds related param in pilot/mixer deployment

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -130,16 +130,6 @@
       {{- if $.Values.global.trustDomain }}
         - --trust-domain={{ $.Values.global.trustDomain }}
       {{- end }}
-      {{- if $.Values.global.sds.enabled }}
-        - --sdsEnabled=true
-      {{- else }}
-        - --sdsEnabled=false
-      {{- end }}
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
-        - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
-      {{- else }}
-        - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
-      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -317,16 +307,6 @@
       {{- else }}
         - --controlPlaneAuthPolicy
         - NONE
-      {{- end }}
-      {{- if $.Values.global.sds.enabled }}
-        - --sdsEnabled=true
-      {{- else }}
-        - --sdsEnabled=false
-      {{- end }}
-      {{- if $.Values.global.sds.useTrustworthyJwt }}
-        - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
-      {{- else }}
-        - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
       {{- end }}
         env:
         - name: POD_NAME

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -9,6 +9,21 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds/uds_path
+          type: Socket
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: uds-socket
         emptyDir: {}
       - name: policy-adapter-secret
@@ -115,6 +130,16 @@
       {{- if $.Values.global.trustDomain }}
         - --trust-domain={{ $.Values.global.trustDomain }}
       {{- end }}
+      {{- if $.Values.global.sds.enabled }}
+        - --sdsEnabled=true
+      {{- else }}
+        - --sdsEnabled=false
+      {{- end }}
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
+      {{- else }}
+        - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -141,6 +166,15 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        {{- if $.Values.global.sds.enabled }}
+        - name: sds-uds-path
+          mountPath: /var/run/sds/uds_path
+          readOnly: true
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - name: istio-token
+          mountPath: /var/run/secrets/tokens
+        {{- end }}
+        {{- end }}
         - name: uds-socket
           mountPath: /sock
         - name: policy-adapter-secret
@@ -156,6 +190,21 @@
         secret:
           secretName: istio.istio-mixer-service-account
           optional: true
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds/uds_path
+          type: Socket
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: uds-socket
         emptyDir: {}
       - name: telemetry-adapter-secret
@@ -269,6 +318,16 @@
         - --controlPlaneAuthPolicy
         - NONE
       {{- end }}
+      {{- if $.Values.global.sds.enabled }}
+        - --sdsEnabled=true
+      {{- else }}
+        - --sdsEnabled=false
+      {{- end }}
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
+      {{- else }}
+        - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
+      {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -295,6 +354,15 @@
         - name: istio-certs
           mountPath: /etc/certs
           readOnly: true
+        {{- if $.Values.global.sds.enabled }}
+        - name: sds-uds-path
+          mountPath: /var/run/sds/uds_path
+          readOnly: true
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+        - name: istio-token
+          mountPath: /var/run/secrets/tokens
+        {{- end }}
+        {{- end }}
         - name: uds-socket
           mountPath: /sock
 {{- end }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -156,6 +156,16 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
+        {{- if $.Values.global.sds.enabled }}
+          - --sdsEnabled=true
+        {{- else }}
+          - --sdsEnabled=false
+        {{- end }}
+        {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
+        {{- else }}
+          - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
+        {{- end }}
           env:
           - name: POD_NAME
             valueFrom:
@@ -182,8 +192,32 @@ spec:
           - name: istio-certs
             mountPath: /etc/certs
             readOnly: true
+          {{- if $.Values.global.sds.enabled }}
+          - name: sds-uds-path
+            mountPath: /var/run/sds/uds_path
+            readOnly: true
+          {{- if $.Values.global.sds.useTrustworthyJwt }}
+          - name: istio-token
+            mountPath: /var/run/secrets/tokens
+          {{- end }}
+          {{- end }}
 {{- end }}
       volumes:
+      {{- if $.Values.global.sds.enabled }}
+      - hostPath:
+          path: /var/run/sds/uds_path
+          type: Socket
+        name: sds-uds-path
+      {{- if $.Values.global.sds.useTrustworthyJwt }}
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: {{ $.Values.global.trustDomain }}
+              expirationSeconds: 43200
+              path: istio-token
+      {{- end }}
+      {{- end }}
       - name: config-volume
         configMap:
           name: istio

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -156,16 +156,6 @@ spec:
         {{- if .Values.global.trustDomain }}
           - --trust-domain={{ .Values.global.trustDomain }}
         {{- end }}
-        {{- if $.Values.global.sds.enabled }}
-          - --sdsEnabled=true
-        {{- else }}
-          - --sdsEnabled=false
-        {{- end }}
-        {{- if $.Values.global.sds.useTrustworthyJwt }}
-          - --k8sServiceAccountJWTPath="/var/run/secrets/tokens/istio-token"
-        {{- else }}
-          - --k8sServiceAccountJWTPath="/var/run/secrets/kubernetes.io/serviceaccount/token"
-        {{- end }}
           env:
           - name: POD_NAME
             valueFrom:


### PR DESCRIPTION
https://github.com/istio/istio/issues/5891

add sds related params like uds path to pilot/mixer deployment yaml file, this is required to switch from secret mount to sds for controlplane, asked from https://github.com/istio/istio/issues/11434

similar change to gateway was made in https://github.com/istio/istio/pull/9283, https://github.com/istio/istio/pull/10257
