### PR TITLE
Removing depencency on the order of returned IP addresses

### DIFF
--- a/pilot/pkg/proxy/resolve.go
+++ b/pilot/pkg/proxy/resolve.go
@@ -26,6 +26,8 @@ import (
 	"istio.io/istio/pkg/log"
 )
 
+type lookupIPAddrType = func(ctx context.Context, addr string) ([]net.IPAddr, error)
+
 // ErrResolveNoAddress error occurs when IP address resolution is attempted,
 // but no address was provided.
 var ErrResolveNoAddress = stderrors.New("no address specified")
@@ -35,13 +37,9 @@ var ErrResolveNoAddress = stderrors.New("no address specified")
 // part must be enclosed in square brackets.
 //
 // TODO: LookupIPAddr() may return multiple IP addresses, of which this function
-// returns the first entry. We're assuming that IPv4 addresses will be listed
-// first, meaning it has priority over IPv6. If this does not hold, then
-// additional logic will be needed to enforce an IP mode priority.
-//
-// To use this function in an IPv6 only environment, either provide an IPv6
-// address or ensure the hostname resolves to only IPv6 addresses.
-func ResolveAddr(addr string) (string, error) {
+// returns the first IPv4 entry. To use this function in an IPv6 only environment,
+// either provide an IPv6 address or ensure the hostname resolves to only IPv6 addresses.
+func ResolveAddr(addr string, lookupIPAddr ...lookupIPAddrType) (string, error) {
 	if addr == "" {
 		return "", ErrResolveNoAddress
 	}
@@ -54,16 +52,28 @@ func ResolveAddr(addr string) (string, error) {
 	// lookup the udp address with a timeout of 15 seconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	addrs, lookupErr := net.DefaultResolver.LookupIPAddr(ctx, host)
+	var addrs []net.IPAddr
+	var lookupErr error
+	if (len(lookupIPAddr) > 0) && (lookupIPAddr[0] != nil) {
+		// if there are more than one lookup function, ignore all but first
+		addrs, lookupErr = lookupIPAddr[0](ctx, host)
+	} else {
+		addrs, lookupErr = net.DefaultResolver.LookupIPAddr(ctx, host)
+	}
+
 	if lookupErr != nil || len(addrs) == 0 {
 		return "", errors.WithMessage(lookupErr, "lookup failed for IP address")
 	}
 	var resolvedAddr string
-	ip := addrs[0].IP
-	if ip.To4() == nil {
-		resolvedAddr = fmt.Sprintf("[%s]:%s", ip, port)
-	} else {
-		resolvedAddr = fmt.Sprintf("%s:%s", ip, port)
+
+	for _, address := range addrs {
+		ip := address.IP
+		if ip.To4() == nil {
+			resolvedAddr = fmt.Sprintf("[%s]:%s", ip, port)
+		} else {
+			resolvedAddr = fmt.Sprintf("%s:%s", ip, port)
+			break
+		}
 	}
 	log.Infof("Addr resolved to: %s", resolvedAddr)
 	return resolvedAddr, nil

--- a/pilot/pkg/proxy/resolve_test.go
+++ b/pilot/pkg/proxy/resolve_test.go
@@ -31,11 +31,15 @@ func determineLocalHostIPString(t *testing.T) string {
 	if err != nil || len(ips) == 0 {
 		t.Fatalf("Test setup failure - unable to determine IP of localhost: %v", err)
 	}
-	ip := ips[0]
-	if ip.To4() == nil {
-		return fmt.Sprintf("[%s]", ip.String())
+	var ret string
+	for _, ip := range ips {
+		if ip.To4() == nil {
+			ret = fmt.Sprintf("[%s]", ip.String())
+		} else {
+			return ip.String()
+		}
 	}
-	return ip.String()
+	return ret
 }
 
 func MockLookupIPAddr(ctx context.Context, addr string) ([]net.IPAddr, error) {

--- a/pilot/pkg/proxy/resolve_test.go
+++ b/pilot/pkg/proxy/resolve_test.go
@@ -15,6 +15,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -37,6 +38,21 @@ func determineLocalHostIPString(t *testing.T) string {
 	return ip.String()
 }
 
+func MockLookupIPAddr(ctx context.Context, addr string) ([]net.IPAddr, error) {
+	var ret = []net.IPAddr{
+		{IP: net.ParseIP("2001:db8::68")},
+		{IP: net.IPv4(1, 2, 3, 4)},
+		{IP: net.IPv4(1, 2, 3, 5)},
+	}
+	return ret, nil
+}
+
+func MockLookupIPAddrIPv6(ctx context.Context, addr string) ([]net.IPAddr, error) {
+	var ret = []net.IPAddr{
+		{IP: net.ParseIP("2001:db8::68")},
+	}
+	return ret, nil
+}
 func TestResolveAddr(t *testing.T) {
 	localIP := determineLocalHostIPString(t)
 
@@ -45,77 +61,103 @@ func TestResolveAddr(t *testing.T) {
 		input    string
 		expected string
 		errStr   string
+		lookup   func(ctx context.Context, addr string) ([]net.IPAddr, error)
 	}{
 		{
 			name:     "Host by name",
 			input:    "localhost:9080",
 			expected: fmt.Sprintf("%s:9080", localIP),
 			errStr:   "",
+			lookup:   nil,
 		},
 		{
 			name:     "Host by name w/brackets",
 			input:    "[localhost]:9080",
 			expected: fmt.Sprintf("%s:9080", localIP),
 			errStr:   "",
+			lookup:   nil,
 		},
 		{
 			name:     "Host by IPv4",
 			input:    "127.0.0.1:9080",
 			expected: "127.0.0.1:9080",
 			errStr:   "",
+			lookup:   nil,
 		},
 		{
 			name:     "Host by IPv6",
 			input:    "[::1]:9080",
 			expected: "[::1]:9080",
 			errStr:   "",
+			lookup:   nil,
 		},
 		{
 			name:     "Bad IPv4",
 			input:    "127.0.0.1.1:9080",
 			expected: "",
 			errStr:   "lookup failed for IP address: lookup 127.0.0.1.1: no such host",
+			lookup:   nil,
 		},
 		{
 			name:     "Bad IPv6",
 			input:    "[2001:db8::bad::1]:9080",
 			expected: "",
 			errStr:   "lookup failed for IP address: lookup 2001:db8::bad::1: no such host",
+			lookup:   nil,
 		},
 		{
 			name:     "Empty host",
 			input:    "",
 			expected: "",
 			errStr:   ErrResolveNoAddress.Error(),
+			lookup:   nil,
 		},
 		{
 			name:     "IPv6 missing brackets",
 			input:    "2001:db8::20:9080",
 			expected: "",
 			errStr:   "address 2001:db8::20:9080: too many colons in address",
+			lookup:   nil,
 		},
 		{
 			name:     "Colon, but no port",
 			input:    "localhost:",
 			expected: fmt.Sprintf("%s:", localIP),
 			errStr:   "",
+			lookup:   nil,
 		},
 		{
 			name:     "Missing port",
 			input:    "localhost",
 			expected: "",
 			errStr:   "address localhost: missing port in address",
+			lookup:   nil,
 		},
 		{
 			name:     "Missing host",
 			input:    ":9080",
 			expected: "",
 			errStr:   "lookup failed for IP address: lookup : no such host",
+			lookup:   nil,
+		},
+		{
+			name:     "Host by name - non local",
+			input:    "www.foo.com:9080",
+			expected: "1.2.3.4:9080",
+			errStr:   "",
+			lookup:   MockLookupIPAddr,
+		},
+		{
+			name:     "Host by name - non local 0 IPv6 only address",
+			input:    "www.foo.com:9080",
+			expected: "[2001:db8::68]:9080",
+			errStr:   "",
+			lookup:   MockLookupIPAddrIPv6,
 		},
 	}
 
 	for _, tc := range testCases {
-		actual, err := ResolveAddr(tc.input)
+		actual, err := ResolveAddr(tc.input, tc.lookup)
 		if err != nil {
 			if tc.errStr == "" {
 				t.Errorf("[%s] expected success, but saw error: %v", tc.name, err)


### PR DESCRIPTION
Allows returned addresses by the default resolver to be in any
order. The first IPv4 address returned by the resolver is used. If
there are no IPv4 address is found, an IPv6 address is used.

Added more unit tests.