### PR TITLE
Add e2e tests for Authz v2 (#12271)

### DIFF
--- a/tests/e2e/tests/pilot/istio_rbac_test.go
+++ b/tests/e2e/tests/pilot/istio_rbac_test.go
@@ -136,6 +136,16 @@ func TestRBACForSidecar(t *testing.T) {
 		{dst: "d", src: "c", port: 9090, allow: allow},
 	}
 
+	runRbacTestCases(t, cases)
+}
+
+func runRbacTestCases(t *testing.T, cases []struct {
+	dst   string
+	src   string
+	path  string
+	port  uint32
+	allow bool
+}) {
 	for _, req := range cases {
 		for cluster := range tc.Kube.Clusters {
 			port := ""

--- a/tests/e2e/tests/pilot/istio_rbac_v2_test.go
+++ b/tests/e2e/tests/pilot/istio_rbac_v2_test.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilot
+
+import (
+	"testing"
+
+	"istio.io/istio/tests/util"
+)
+
+const (
+	rbacV2RulesTmpl = "testdata/rbac/v1alpha1/istio-rbac-v2-rules.yaml.tmpl"
+)
+
+func TestRBACV2(t *testing.T) {
+	if !tc.Kube.RBACEnabled {
+		t.Skipf("Skipping %s: rbac_enable=false", t.Name())
+	}
+	// Fill out the templates.
+	params := map[string]string{
+		"IstioNamespace": tc.Kube.IstioSystemNamespace(),
+		"Namespace":      tc.Kube.Namespace,
+	}
+	rbacEnableYaml, err := util.CreateAndFill(tc.Info.TempDir, rbacEnableTmpl, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rbacV2RulesYaml, err := util.CreateAndFill(tc.Info.TempDir, rbacV2RulesTmpl, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Push all of the configs
+	cfgs := &deployableConfig{
+		Namespace:  tc.Kube.Namespace,
+		YamlFiles:  []string{rbacEnableYaml, rbacV2RulesYaml},
+		kubeconfig: tc.Kube.KubeConfig,
+	}
+	if err := cfgs.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer cfgs.Teardown()
+
+	// Some services are only accessible when auth is enabled.
+	allow := false
+	if tc.Kube.AuthEnabled {
+		allow = true
+	}
+
+	cases := []struct {
+		dst   string
+		src   string
+		path  string
+		port  uint32
+		allow bool
+	}{
+		{dst: "a", src: "b", path: "/xyz", allow: false},
+		{dst: "a", src: "b", port: 90, allow: false},
+		{dst: "a", src: "b", port: 9090, allow: false},
+		{dst: "a", src: "c", path: "/", allow: false},
+		{dst: "a", src: "c", port: 90, allow: false},
+		{dst: "a", src: "c", port: 9090, allow: false},
+		{dst: "a", src: "d", path: "/", allow: false},
+		{dst: "a", src: "d", port: 90, allow: false},
+		{dst: "a", src: "d", port: 9090, allow: false},
+
+		{dst: "b", src: "a", path: "/xyz", allow: allow},
+		{dst: "b", src: "a", path: "/secret", allow: false},
+		{dst: "b", src: "a", port: 90, allow: allow},
+		{dst: "b", src: "a", port: 9090, allow: allow},
+		{dst: "b", src: "c", path: "/", allow: allow},
+		{dst: "b", src: "c", port: 90, allow: allow},
+		{dst: "b", src: "c", port: 3000, allow: false},
+		{dst: "b", src: "d", path: "/", allow: allow},
+		{dst: "b", src: "d", port: 90, allow: allow},
+		{dst: "b", src: "d", port: 9090, allow: allow},
+
+		{dst: "c", src: "a", path: "/", allow: allow},
+		{dst: "c", src: "a", path: "/good", allow: allow},
+		{dst: "c", src: "a", path: "/credentials/admin", allow: false},
+		{dst: "c", src: "a", path: "/secrets/admin", allow: false},
+		{dst: "c", src: "a", port: 90, allow: false},
+		{dst: "c", src: "a", port: 9090, allow: false},
+
+		{dst: "c", src: "b", path: "/", allow: false},
+		{dst: "c", src: "b", path: "/good", allow: false},
+		{dst: "c", src: "b", path: "/prefixXYZ", allow: false},
+		{dst: "c", src: "b", path: "/xyz/suffix", allow: false},
+		{dst: "c", src: "b", port: 90, allow: false},
+		{dst: "c", src: "b", port: 9090, allow: false},
+
+		{dst: "c", src: "d", path: "/", allow: false},
+		{dst: "c", src: "d", path: "/xyz", allow: false},
+		{dst: "c", src: "d", path: "/good", allow: false},
+		{dst: "c", src: "d", path: "/prefixXYZ", allow: false},
+		{dst: "c", src: "d", path: "/xyz/suffix", allow: false},
+		{dst: "c", src: "d", port: 90, allow: false},
+		{dst: "c", src: "d", port: 9090, allow: false},
+
+		{dst: "d", src: "a", path: "/xyz", allow: true},
+		{dst: "d", src: "a", port: 90, allow: false},
+		{dst: "d", src: "a", port: 9090, allow: true},
+		{dst: "d", src: "b", path: "/", allow: true},
+		{dst: "d", src: "b", port: 90, allow: false},
+		{dst: "d", src: "b", port: 9090, allow: true},
+		{dst: "d", src: "c", path: "/", allow: true},
+		{dst: "d", src: "c", port: 90, allow: false},
+		{dst: "d", src: "c", port: 9090, allow: true},
+	}
+
+	runRbacTestCases(t, cases)
+}

--- a/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-rbac-v2-rules.yaml.tmpl
+++ b/tests/e2e/tests/pilot/testdata/rbac/v1alpha1/istio-rbac-v2-rules.yaml.tmpl
@@ -1,0 +1,127 @@
+# istio-rbac-v2-rules.yaml to enforce access control for both http and tcp services using Istio RBAC v2 rules.
+
+# For service a, allow no one to access it.
+# This will also result a default tcp rule for service a that denies all access.
+# This actually means nobody could access a.
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-a-http
+spec:
+  rules:
+    - methods: ["GET"]
+      constraints:
+      - key: "destination.labels[app]"
+        values: ["a"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-access-a-http
+spec:
+  allow:
+    - subjects:
+      - not_names: ["allUsers"]
+      roleRef:
+        kind: ServiceRole
+        name: "access-a-http"
+---
+
+# For service b, only allow authenticated user to access it with GET at any paths except /secret*
+# or only access it at tcp port 90 and 9090.
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-b-http-tcp
+spec:
+  rules:
+  - methods: ["GET"]
+    not_paths: ["/secret*"]
+  - constraints:
+    - key: "destination.port"
+      values: ["90", "9090"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-access-b-http-tcp
+spec:
+  workload_selector:
+    labels:
+      app: b
+  allow:
+    - subjects:
+      - names: ["allAuthenticatedUsers"]
+      roleRef:
+        kind: ServiceRole
+        name: "access-b-http-tcp"
+---
+
+# For service c:
+# * Allow GET requests for any path, except paths ending with /admin for service account a.
+# * Deny all requests for service account b.
+# * Deny anyone else (e.g. service d) by default.
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: deny-get-at-admin-prefix-path-rules
+spec:
+  rules:
+  - methods: ["GET"]
+    not_paths: ["*/admin"]
+    paths: ["*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: deny-all-access-rules
+spec:
+  rules:
+  - not_methods: ["*"]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-c
+spec:
+  workload_selector:
+    labels:
+      app: c
+  allow:
+    - subjects:
+      - names: ["cluster.local/ns/{{ .Namespace }}/sa/a"]
+      roleRef:
+        kind: ServiceRole
+        name: "deny-get-at-admin-prefix-path-rules"
+    - subjects:
+      - names: ["cluster.local/ns/{{ .Namespace }}/sa/b"]
+      roleRef:
+        kind: ServiceRole
+        name: "deny-all-access-rules"
+---
+
+# For service d, anyone can access it via HTTP requests or TCP at port 9090.
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: ServiceRole
+metadata:
+  name: access-d-http-tcp
+spec:
+  rules:
+  - methods: ["*"]
+  - ports: [9090]
+---
+apiVersion: "rbac.istio.io/v1alpha1"
+kind: AuthorizationPolicy
+metadata:
+  name: authz-policy-access-d-http-tcp
+spec:
+  workload_selector:
+    labels:
+      app: d
+  allow:
+    - subjects:
+      - names: ["allUsers"]
+      roleRef:
+        kind: ServiceRole
+        name: "access-d-http-tcp"
+---


### PR DESCRIPTION
Cherry-pick from #12271

Add e2e tests for additional fields in ServiceRole and ServiceRoleBinding.
Add e2e tests for workload selector.
Add e2e tests for new CRD AuthorizationPolicy.

For #12394
