### PR TITLE
galley: support optional crds

### DIFF
--- a/galley/pkg/metadata/kube/types.go
+++ b/galley/pkg/metadata/kube/types.go
@@ -81,6 +81,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/apikeys"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -92,6 +94,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/authorizations"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -103,6 +107,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/bypasses"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -114,6 +120,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/checknothings"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -125,6 +133,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/circonuses"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -136,6 +146,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/cloudwatches"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -147,6 +159,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/deniers"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -158,6 +172,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/dogstatsds"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -169,6 +185,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/edges"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -180,6 +198,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/fluentds"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -191,6 +211,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/kubernetesenvs"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -202,6 +224,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/kuberneteses"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -213,6 +237,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/listcheckers"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -224,6 +250,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/listentries"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -235,6 +263,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/logentries"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -246,6 +276,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/memquotas"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -257,6 +289,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/metrics"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -268,6 +302,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/noops"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -279,6 +315,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/opas"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -290,6 +328,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/prometheuses"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -301,6 +341,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/quotas"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -312,6 +354,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/rbacs"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -323,6 +367,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/redisquotas"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -334,6 +380,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/reportnothings"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -345,6 +393,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/signalfxs"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -356,6 +406,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/solarwindses"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -367,6 +419,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/stackdrivers"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -378,6 +432,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/statsds"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -389,6 +445,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/stdios"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -400,6 +458,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/tracespans"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{
@@ -411,6 +471,8 @@ func init() {
 		Group:     "config.istio.io",
 		Target:    metadata.Types.Get("istio/config/v1alpha2/legacy/zipkins"),
 		Converter: converter.Get("identity"),
+
+		Optional: true,
 	})
 
 	b.Add(schema.ResourceSpec{

--- a/galley/pkg/server/server_test.go
+++ b/galley/pkg/server/server_test.go
@@ -104,8 +104,8 @@ func TestNewServer(t *testing.T) {
 	p.fsNew = func(string, *schema.Instance, *converter.Config) (runtime.Source, error) {
 		return runtime.NewInMemorySource(), nil
 	}
-	p.verifyResourceTypesPresence = func(client.Interfaces, []schema.ResourceSpec) error {
-		return nil
+	p.verifyResourceTypesPresence = func(_ client.Interfaces, specs []schema.ResourceSpec) ([]schema.ResourceSpec, error) {
+		return specs, nil
 	}
 
 	partialResourceList := sourceResourceSchemas[:len(sourceResourceSchemas)/2]
@@ -162,8 +162,8 @@ func TestServer_Basic(t *testing.T) {
 		return mcptestmon.NewInMemoryStatsContext()
 	}
 	p.newMeshConfigCache = func(path string) (meshconfig.Cache, error) { return meshconfig.NewInMemory(), nil }
-	p.verifyResourceTypesPresence = func(client.Interfaces, []schema.ResourceSpec) error {
-		return nil
+	p.verifyResourceTypesPresence = func(_ client.Interfaces, specs []schema.ResourceSpec) ([]schema.ResourceSpec, error) {
+		return specs, nil
 	}
 
 	args := DefaultArgs()

--- a/galley/pkg/source/kube/schema/check/check_test.go
+++ b/galley/pkg/source/kube/schema/check/check_test.go
@@ -107,7 +107,7 @@ func TestCheckCRDPresence(t *testing.T) {
 				cs.Resources = append(cs.Resources, resourceList)
 			}
 
-			found, err := resourceTypesPresence(cs, specs)
+			found, err := resourceTypesPresence(cs, specs, true)
 			if c.wantErr {
 				if err == nil {
 					tt.Fatal("expected error but got success")
@@ -186,7 +186,10 @@ func TestFindSupportedResourceSchemas(t *testing.T) {
 				}
 			}
 
-			got := findSupportedResourceSchemas(cs, specs)
+			got, err := resourceTypesPresence(cs, specs, false)
+			if err != nil {
+				tt.Fatalf("unexpected error: %v", err)
+			}
 
 			if len(got) != len(want) {
 				tt.Fatalf("wrong number of resource schemas found: \n got %v\nwant %v", got, want)

--- a/galley/pkg/source/kube/schema/check/check_test.go
+++ b/galley/pkg/source/kube/schema/check/check_test.go
@@ -44,19 +44,21 @@ func TestCheckCRDPresence(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		missing map[int]bool
+		missing map[string]bool
 		wantErr bool
+		count   int
 	}{
 		{
 			name:    "all present",
 			wantErr: false,
+			count:   len(specs),
 		},
 		{
 			name: "none ready",
-			missing: func() map[int]bool {
-				m := make(map[int]bool)
-				for i := 0; i < len(specs); i++ {
-					m[i] = true
+			missing: func() map[string]bool {
+				m := make(map[string]bool)
+				for _, spec := range specs {
+					m[spec.Plural] = true
 				}
 				return m
 			}(),
@@ -64,18 +66,24 @@ func TestCheckCRDPresence(t *testing.T) {
 		},
 		{
 			name:    "first missing",
-			missing: map[int]bool{0: true},
+			missing: map[string]bool{"meshpolicies": true},
 			wantErr: true,
 		},
 		{
-			name:    "middle not ready",
-			missing: map[int]bool{(len(specs) / 2): true},
+			name:    "pod not ready",
+			missing: map[string]bool{"pods": true},
 			wantErr: true,
 		},
 		{
-			name:    "last not ready",
-			missing: map[int]bool{(len(specs) - 1): true},
+			name:    "virtualservice not ready",
+			missing: map[string]bool{"virtualservices": true},
 			wantErr: true,
+		},
+		{
+			name:    "optional not ready",
+			missing: map[string]bool{"circonuses": true},
+			wantErr: false,
+			count:   len(specs) - 1,
 		},
 	}
 
@@ -84,8 +92,8 @@ func TestCheckCRDPresence(t *testing.T) {
 			cs := extfake.NewSimpleClientset()
 
 			byGroupVersion := map[string][]meta_v1.APIResource{}
-			for i, spec := range specs {
-				if c.missing[i] {
+			for _, spec := range specs {
+				if c.missing[spec.Plural] {
 					continue
 				}
 				gv := spec.GroupVersion().String()
@@ -99,7 +107,7 @@ func TestCheckCRDPresence(t *testing.T) {
 				cs.Resources = append(cs.Resources, resourceList)
 			}
 
-			err := resourceTypesPresence(cs, specs)
+			found, err := resourceTypesPresence(cs, specs)
 			if c.wantErr {
 				if err == nil {
 					tt.Fatal("expected error but got success")
@@ -107,6 +115,9 @@ func TestCheckCRDPresence(t *testing.T) {
 			} else {
 				if err != nil {
 					tt.Fatalf("expected success but got error: %v", err)
+				}
+				if len(found) != c.count {
+					tt.Fatalf("expected %d found resources but got %d", c.count, len(found))
 				}
 			}
 		})
@@ -204,7 +215,7 @@ func TestExportedFunctions(t *testing.T) {
 	// functions are tested covered by TestCheckCRDPresence and TestFindSupportedResourceSchemas
 	var emptySpecs []sourceSchema.ResourceSpec
 
-	if got := ResourceTypesPresence(m, emptySpecs); got != nil {
+	if _, got := ResourceTypesPresence(m, emptySpecs); got != nil {
 		t.Errorf("ResourceTypesPresence() returned unexpected error: %v", got)
 	}
 	if _, got := FindSupportedResourceSchemas(m, emptySpecs); got != nil {
@@ -212,7 +223,7 @@ func TestExportedFunctions(t *testing.T) {
 	}
 
 	m.err = errors.New("oops")
-	if got := ResourceTypesPresence(m, emptySpecs); got == nil {
+	if _, got := ResourceTypesPresence(m, emptySpecs); got == nil {
 		t.Error("ResourceTypesPresence() returned unexpected success")
 	}
 	if _, got := FindSupportedResourceSchemas(m, emptySpecs); got == nil {

--- a/galley/pkg/source/kube/schema/resourcespec.go
+++ b/galley/pkg/source/kube/schema/resourcespec.go
@@ -51,6 +51,9 @@ type ResourceSpec struct {
 
 	// The converter to use
 	Converter converter.Fn
+
+	// Indicates that the resource is not required to be present
+	Optional bool
 }
 
 // APIResource generated from this type.

--- a/galley/tools/gen-meta/main.go
+++ b/galley/tools/gen-meta/main.go
@@ -56,6 +56,7 @@ type entry struct {
 	ProtoGoPackage string `json:"protoPackage"`
 	Collection     string `json:"collection"`
 	Generated      string `json:"generated"`
+	Optional       bool   `json:"optional"`
 }
 
 // collection related metadata
@@ -272,6 +273,9 @@ func init() {
 		Group:      "{{.Group}}",
 		Target:     metadata.Types.Get("{{.Collection}}"),
 		Converter:  converter.Get("{{ if .Converter }}{{.Converter}}{{ else }}identity{{end}}"),
+		{{ if .Optional }}
+		Optional:   true,
+		{{end}}
     })
 	{{end}}
 {{end}}

--- a/galley/tools/gen-meta/metadata.yaml
+++ b/galley/tools/gen-meta/metadata.yaml
@@ -251,6 +251,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/bypasses"
+    optional:    true
 
   - kind:        "circonus"
     singular:    "circonus"
@@ -260,6 +261,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/circonuses"
+    optional:    true
 
   - kind:        "denier"
     singular:    "denier"
@@ -269,6 +271,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/deniers"
+    optional:    true
 
 
   - kind:        "fluentd"
@@ -279,6 +282,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/fluentds"
+    optional:    true
 
   - kind:        "kubernetesenv"
     singular:    "kubernetesenv"
@@ -288,6 +292,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/kubernetesenvs"
+    optional:    true
 
   - kind:        "listchecker"
     singular:    "listchecker"
@@ -297,6 +302,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/listcheckers"
+    optional:    true
 
   - kind:        "memquota"
     singular:    "memquota"
@@ -306,6 +312,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/memquotas"
+    optional:    true
 
   - kind:        "noop"
     singular:    "noop"
@@ -315,6 +322,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/noops"
+    optional:    true
 
   - kind:        "opa"
     singular:    "opa"
@@ -324,6 +332,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/opas"
+    optional:    true
 
   - kind:        "prometheus"
     singular:    "prometheus"
@@ -333,6 +342,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/prometheuses"
+    optional:    true
 
   - kind:        "redisquota"
     singular:    "redisquota"
@@ -342,6 +352,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/redisquotas"
+    optional:    true
 
   - kind:        "signalfx"
     group:       "config.istio.io"
@@ -351,6 +362,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/signalfxs"
+    optional:    true
 
   - kind:        "solarwinds"
     singular:    "solarwinds"
@@ -360,6 +372,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/solarwindses"
+    optional:    true
 
   - kind:        "stackdriver"
     singular:    "stackdriver"
@@ -369,6 +382,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/stackdrivers"
+    optional:    true
 
   - kind:        "statsd"
     singular:    "statsd"
@@ -378,6 +392,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/statsds"
+    optional:    true
 
   - kind:        "stdio"
     singular:    "stdio"
@@ -387,6 +402,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/stdios"
+    optional:    true
 
   - kind:        "apikey"
     singular:    "apikey"
@@ -396,6 +412,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/apikeys"
+    optional:    true
 
   - kind:        "authorization"
     singular:    "authorization"
@@ -405,6 +422,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/authorizations"
+    optional:    true
 
   - kind:        "checknothing"
     singular:    "checknothing"
@@ -414,6 +432,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/checknothings"
+    optional:    true
 
   - kind:        "kubernetes"
     singular:    "kubernetes"
@@ -423,6 +442,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/kuberneteses"
+    optional:    true
 
   - kind:        "listentry"
     singular:    "listentry"
@@ -432,6 +452,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/listentries"
+    optional:    true
 
   - kind:        "logentry"
     singular:    "logentry"
@@ -441,6 +462,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/logentries"
+    optional:    true
 
   - kind:        "metric"
     singular:    "metric"
@@ -450,6 +472,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/metrics"
+    optional:    true
 
   - kind:        "quota"
     singular:    "quota"
@@ -459,6 +482,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/quotas"
+    optional:    true
 
   - kind:        "reportnothing"
     singular:    "reportnothing"
@@ -468,6 +492,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/reportnothings"
+    optional:    true
 
   - kind:        "tracespan"
     singular:    "tracespan"
@@ -477,6 +502,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/tracespans"
+    optional:    true
 
   - kind:        "rbac"
     singular:    "rbac"
@@ -486,6 +512,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/rbacs"
+    optional:    true
 
   - kind:        "cloudwatch"
     singular:    "cloudwatch"
@@ -495,6 +522,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/cloudwatches"
+    optional:    true
 
   - kind:        "dogstatsd"
     singular:    "dogstatsd"
@@ -504,6 +532,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/dogstatsds"
+    optional:    true
 
   - kind:        "edge"
     singular:    "edge"
@@ -513,6 +542,7 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/edges"
+    optional:    true
 
   - kind:        "zipkin"
     singular:    "zipkin"
@@ -522,3 +552,4 @@ resources:
     proto:       "type.googleapis.com/google.protobuf.Struct"
     protoPackage: "github.com/gogo/protobuf/types"
     collection:  "istio/config/v1alpha2/legacy/zipkins"
+    optional:    true


### PR DESCRIPTION
This is a partial solution to issue raised in https://github.com/istio/istio/issues/12134 to support deprecation of custom Mixer CRDs.

The solution is to mark legacy CRDs as optional, so that their absence does not prevent galley from initialization. This is needed since Mixer 1.2 no longer needs or requests these CRDs. 

We do not expect legacy CRDs to be freshly installed from now on. This is merely a step to support a transitional state in which legacy CRDs are already installed and Mixer 1.1 still asks for them.

/assign @ozevren 

Signed-off-by: Kuat Yessenov <kuat@google.com>