### PR TITLE
add param to sidecar to ignore iptables changes

### DIFF
--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -62,17 +62,19 @@ if [ -z "${POD_NAME:-}" ]; then
   POD_NAME=$(hostname -s)
 fi
 
-# Init option will only initialize iptables. Can be used
-if [[ ${1-} == "init" || ${1-} == "-p" ]] ; then
-  # Update iptables, based on current config. This is for backward compatibility with the init image mode.
-  # The sidecar image can replace the k8s init image, to avoid downloading 2 different images.
-  "${ISTIO_BIN_BASE}/istio-iptables.sh" "${@}"
-  exit 0
-fi
+# Init option will only initialize iptables. set ISTIO_CUSTOM_IP_TABLES to true if you would like to ignore this step
+if [ "${ISTIO_CUSTOM_IP_TABLES}" != "true" ] ; then
+    if [[ ${1-} == "init" || ${1-} == "-p" ]] ; then
+      # Update iptables, based on current config. This is for backward compatibility with the init image mode.
+      # The sidecar image can replace the k8s init image, to avoid downloading 2 different images.
+      "${ISTIO_BIN_BASE}/istio-iptables.sh" "${@}"
+      exit 0
+    fi
 
-if [[ ${1-} != "run" ]] ; then
-  # Update iptables, based on config file
-  "${ISTIO_BIN_BASE}/istio-iptables.sh"
+    if [[ ${1-} != "run" ]] ; then
+      # Update iptables, based on config file
+      "${ISTIO_BIN_BASE}/istio-iptables.sh"
+    fi
 fi
 
 EXEC_USER=${EXEC_USER:-istio-proxy}

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -80,5 +80,5 @@
 # ISTIO_CFG=/var/lib/istio
 
 # Ignore Istio iptables custom rules
-# Use this flag if you would like to manage iptables yourself Default to false (true/false)
+# Enable this flag if you would like to manage iptables yourself. Default to false (true/false)
 # ISTIO_CUSTOM_IP_TABLES=false

--- a/tools/deb/sidecar.env
+++ b/tools/deb/sidecar.env
@@ -78,3 +78,7 @@
 
 # Location of istio configs.
 # ISTIO_CFG=/var/lib/istio
+
+# Ignore Istio iptables custom rules
+# Use this flag if you would like to manage iptables yourself Default to false (true/false)
+# ISTIO_CUSTOM_IP_TABLES=false


### PR DESCRIPTION
This PR is intended to ignore iptables changes triggered by istio service (istio-start.sh)
The assumption that some users are commonly using iptables and would like to manage iptables manually instead of Istio.