### PR TITLE
Set SAN as critical for workload certs.

### DIFF
--- a/security/pkg/pki/util/san.go
+++ b/security/pkg/pki/util/san.go
@@ -119,7 +119,8 @@ func BuildSANExtension(identites []Identity) (*pkix.Extension, error) {
 		return nil, fmt.Errorf("failed to marshal the raw values for SAN field (err: %s)", err)
 	}
 
-	return &pkix.Extension{Id: oidSubjectAlternativeName, Value: bs}, nil
+	// SAN is Critical because the subject is empty. This is compliant with X.509 and SPIFFE standards.
+	return &pkix.Extension{Id: oidSubjectAlternativeName, Critical: true, Value: bs}, nil
 }
 
 // ExtractIDsFromSAN takes a SAN extension and extracts the identities.

--- a/security/pkg/pki/util/san_test.go
+++ b/security/pkg/pki/util/san_test.go
@@ -85,6 +85,10 @@ func TestBuildAndExtractIdentities(t *testing.T) {
 	if !reflect.DeepEqual(actualIds, ids) {
 		t.Errorf("Unmatched identities: before encoding: %v, after decoding %v", ids, actualIds)
 	}
+
+	if san.Critical == false {
+		t.Errorf("SAN field is not critical.")
+	}
 }
 
 func TestBuildSANExtensionWithError(t *testing.T) {


### PR DESCRIPTION
Set SAN as critical for workload certs, because Citadel-generated Istio workload certs have empty subjects. This is required by X.509 and SPIFFE standards.