### PR TITLE
Support inline role definition in AuthorizationPolicy

### DIFF
--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -3679,7 +3679,7 @@ func TestValidateServiceRoleBinding(t *testing.T) {
 					{User: "User1", Group: "Group1", Properties: map[string]string{"prop1": "value1"}},
 				},
 			},
-			expectErrMsg: "roleRef must be specified",
+			expectErrMsg: "`roleRef` or `actions` must be specified",
 		},
 		{
 			name: "incorrect kind",
@@ -3742,6 +3742,126 @@ func TestValidateServiceRoleBinding(t *testing.T) {
 			}
 		} else if err.Error() != c.expectErrMsg {
 			t.Errorf("ValidateServiceRoleBinding(%v): got %q but want %q\n", c.name, err.Error(), c.expectErrMsg)
+		}
+	}
+}
+
+func TestValidateAuthorizationPolicy(t *testing.T) {
+	cases := []struct {
+		name         string
+		in           proto.Message
+		expectErrMsg string
+	}{
+		{
+			name:         "invalid proto",
+			expectErrMsg: "cannot cast to AuthorizationPolicy",
+		},
+		{
+			name: "proto with no roleRef or inline role definition",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+					},
+				},
+			},
+			expectErrMsg: "`roleRef` or `actions` must be specified",
+		},
+		{
+			name: "proto with both roleRef and inline role definition",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						RoleRef: &rbac.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+						Actions: []*rbac.AccessRule{
+							{
+								Ports: []int32{3000},
+							},
+						},
+					},
+				},
+			},
+			expectErrMsg: "only one of `roleRef` or `actions` can be specified",
+		},
+		{
+			name: "success proto with roleRef",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						RoleRef: &rbac.RoleRef{
+							Kind: "ServiceRole",
+							Name: "service-role-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "proto with inline but invalid role definition",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						Actions: []*rbac.AccessRule{
+							{
+								Ports:    []int32{3000},
+								NotPorts: []int32{8080},
+							},
+						},
+					},
+				},
+			},
+			expectErrMsg: "cannot have both regular and *not* attributes for the same kind (i.e. ports and not_ports) for rule 0",
+		},
+		{
+			name: "success proto with inline role definition",
+			in: &rbac.AuthorizationPolicy{
+				Allow: []*rbac.ServiceRoleBinding{
+					{
+						Subjects: []*rbac.Subject{
+							{
+								Namespaces: []string{"default, istio-system"},
+							},
+						},
+						Actions: []*rbac.AccessRule{
+							{
+								Methods: []string{"GET"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		err := ValidateAuthorizationPolicy(someName, someNamespace, c.in)
+		if err == nil {
+			if len(c.expectErrMsg) != 0 {
+				t.Errorf("ValidateAuthorizationPolicy(%v): got nil but want %q\n", c.name, c.expectErrMsg)
+			}
+		} else if err.Error() != c.expectErrMsg {
+			t.Errorf("ValidateAuthorizationPolicy(%v): got %q but want %q\n", c.name, err.Error(), c.expectErrMsg)
 		}
 	}
 }

--- a/pilot/pkg/networking/plugin/authz/rbac_v2_test.go
+++ b/pilot/pkg/networking/plugin/authz/rbac_v2_test.go
@@ -51,9 +51,10 @@ func TestConvertRbacRulesToFilterConfigV2(t *testing.T) {
 								Names: []string{"allUsers"},
 							},
 						},
-						RoleRef: &rbacproto.RoleRef{
-							Kind: "ServiceRole",
-							Name: "service-role-1",
+						Actions: []*rbacproto.AccessRule{
+							{
+								NotMethods: []string{"DELETE"},
+							},
 						},
 					},
 				},
@@ -85,9 +86,10 @@ func TestConvertRbacRulesToFilterConfigV2(t *testing.T) {
 								Namespaces: []string{"testing"},
 							},
 						},
-						RoleRef: &rbacproto.RoleRef{
-							Kind: "ServiceRole",
-							Name: "service-role-1",
+						Actions: []*rbacproto.AccessRule{
+							{
+								NotMethods: []string{"DELETE"},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Support [inline role](https://docs.google.com/document/d/1diwa9oYVwmLtarXb-kfWPq-Ul3O2Ic3b8Y21Z3R8DzQ/edit#heading=h.wtcqkror4ke9) definition in `AuthorizationPolicy`. 
Add a check in applying time to make sure at least one of `roleRef` or `actions` exists in an `AuthorizationPolicy`.
Add unit tests for `ValidateAuthorizationPolicy()`
Replace an existing `ServiceRole` in a `RBAC v2` unit test with inline role def.

For #12394