### PR TITLE
Making tags requirement same as those in Kubernetes

### DIFF
--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -43,8 +43,10 @@ const (
 	// a wild-card prefix is an '*', a normal DNS1123 label with a leading '*' or '*-', or a normal DNS1123 label
 	wildcardPrefix string = `\*|(\*|\*-)?(` + dns1123LabelFmt + `)`
 
-	// TODO: there is a stricter regex for the labels from validation.go in k8s
-	qualifiedNameFmt string = "[-A-Za-z0-9_./]*"
+	// Using kubernetes requirement, a valid tag must be an empty string or consist
+	// of alphanumeric characters, '-', '_' or '.', and must start and end with an
+	// alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345'
+	qualifiedNameFmt string = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
 )
 
 // Constants for duration fields

--- a/pilot/pkg/model/validation.go
+++ b/pilot/pkg/model/validation.go
@@ -43,10 +43,10 @@ const (
 	// a wild-card prefix is an '*', a normal DNS1123 label with a leading '*' or '*-', or a normal DNS1123 label
 	wildcardPrefix string = `\*|(\*|\*-)?(` + dns1123LabelFmt + `)`
 
-	// Using kubernetes requirement, a valid tag must be an empty string or consist
+	// Using kubernetes requirement, a valid key must be a non-empty string consist
 	// of alphanumeric characters, '-', '_' or '.', and must start and end with an
 	// alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345'
-	qualifiedNameFmt string = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
+	qualifiedNameFmt string = "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
 )
 
 // Constants for duration fields
@@ -63,8 +63,10 @@ const (
 const UnixAddressPrefix = "unix://"
 
 var (
-	dns1123LabelRegexp   = regexp.MustCompile("^" + dns1123LabelFmt + "$")
-	tagRegexp            = regexp.MustCompile("^" + qualifiedNameFmt + "$")
+	dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
+	tagRegexp          = regexp.MustCompile("^" + qualifiedNameFmt + "$")
+	// label value can be an empty string
+	labelValueRegexp     = regexp.MustCompile("^" + "(" + qualifiedNameFmt + ")?" + "$")
 	wildcardPrefixRegexp = regexp.MustCompile("^" + wildcardPrefix + "$")
 )
 
@@ -237,7 +239,7 @@ func (l Labels) Validate() error {
 		if !tagRegexp.MatchString(k) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid tag key: %q", k))
 		}
-		if !tagRegexp.MatchString(v) {
+		if !labelValueRegexp.MatchString(v) {
 			errs = multierror.Append(errs, fmt.Errorf("invalid tag value: %q", v))
 		}
 	}

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -319,12 +319,37 @@ func TestLabelsValidate(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "bad tag",
-			tags: Labels{"_key": "value"},
+			name:  "good tag - empty value",
+			tags:  Labels{"key": ""},
+			valid: true,
 		},
 		{
-			name: "bad tag",
+			name: "bad tag - empty key",
+			tags: Labels{"": "value"},
+		},
+		{
+			name: "bad tag key 1",
+			tags: Labels{".key": "value"},
+		},
+		{
+			name: "bad tag key 2",
+			tags: Labels{"key_": "value"},
+		},
+		{
+			name: "bad tag key 3",
+			tags: Labels{"key$": "value"},
+		},
+		{
+			name: "bad tag value 1",
 			tags: Labels{"key": ".value"},
+		},
+		{
+			name: "bad tag value 2",
+			tags: Labels{"key": "value_"},
+		},
+		{
+			name: "bad tag value 3",
+			tags: Labels{"key": "value$"},
 		},
 	}
 	for _, c := range cases {

--- a/pilot/pkg/model/validation_test.go
+++ b/pilot/pkg/model/validation_test.go
@@ -318,6 +318,14 @@ func TestLabelsValidate(t *testing.T) {
 			tags:  Labels{"key": "value"},
 			valid: true,
 		},
+		{
+			name: "bad tag",
+			tags: Labels{"_key": "value"},
+		},
+		{
+			name: "bad tag",
+			tags: Labels{"key": ".value"},
+		},
 	}
 	for _, c := range cases {
 		if got := c.tags.Validate(); (got == nil) != c.valid {


### PR DESCRIPTION
Changing validation check to make sure non-empty tags start with an
alphanumeric character