### PR TITLE
Don't fill test logs with "no provious log"

### DIFF
--- a/tests/util/common_utils.go
+++ b/tests/util/common_utils.go
@@ -137,6 +137,12 @@ func ShellMuteOutput(format string, args ...interface{}) (string, error) {
 	return sh(context.Background(), format, true, false, true, args...)
 }
 
+// ShellMuteOutput run command on shell and get back output and error if get one
+// without logging the output or errors
+func ShellMuteOutputError(format string, args ...interface{}) (string, error) {
+	return sh(context.Background(), format, true, false, false, args...)
+}
+
 // ShellSilent runs command on shell and get back output and error if get one
 // without logging the command or output.
 func ShellSilent(format string, args ...interface{}) (string, error) {

--- a/tests/util/kube_utils.go
+++ b/tests/util/kube_utils.go
@@ -675,7 +675,7 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string, kubeconfig string
 			dump, err := ShellMuteOutput(
 				fmt.Sprintf("kubectl logs %s -n %s -c %s --kubeconfig=%s", pod, namespace, container, kubeconfig))
 			if err != nil {
-				log.Warnf("Error gettings logs for pod %s/%s container %s: %v\n", namespace, pod, container, err)
+				log.Warnf("Error getting logs for pod %s/%s container %s: %v\n", namespace, pod, container, err)
 				// don't stop if we can't get the current log; keep going
 			}
 
@@ -684,10 +684,10 @@ func FetchAndSaveClusterLogs(namespace string, tempDir string, kubeconfig string
 				return err
 			}
 
-			dump1, err := ShellMuteOutput(
+			dump1, err := ShellMuteOutputError(
 				fmt.Sprintf("kubectl logs %s -n %s -c %s -p --kubeconfig=%s", pod, namespace, container, kubeconfig))
 			if err != nil {
-				log.Infof("No previous log %v", err)
+				log.Infof("No previous log for %s", pod)
 			} else if len(dump1) > 0 {
 				filePath = filepath.Join(tempDir, fmt.Sprintf("%s_container:%s.prev.log", pod, container))
 				f1, err := os.Create(filePath)


### PR DESCRIPTION
This isn't a real error, but it is misleading in the test output. We
have no reason to output all of these errors that there is no previous
container to get logs from.

Fix https://github.com/istio/istio/issues/12856