### PR TITLE
Re-enable sidecar_api_test

### DIFF
--- a/pkg/test/framework/components/pilot/native.go
+++ b/pkg/test/framework/components/pilot/native.go
@@ -121,7 +121,7 @@ func (c *nativeComponent) Close() (err error) {
 	}
 
 	if c.stopChan != nil {
-		c.stopChan <- struct{}{}
+		close(c.stopChan)
 	}
 	return
 }

--- a/tests/integration/pilot/sidecar_api_test.go
+++ b/tests/integration/pilot/sidecar_api_test.go
@@ -22,18 +22,12 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xdscore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 
-	"istio.io/istio/pkg/test/framework/components/istio"
-
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/galley"
 	"istio.io/istio/pkg/test/framework/components/pilot"
 	"istio.io/istio/pkg/test/util/structpath"
-)
-
-var (
-	ist istio.Instance
 )
 
 func TestSidecarListeners(t *testing.T) {
@@ -149,5 +143,5 @@ func validateMongoListener(t *testing.T, response *structpath.Instance) {
 // - Do cleanup before exit
 // - process testing specific flags
 func TestMain(m *testing.M) {
-	framework.Main("sidecar_api_test", m, istio.SetupOnKube(&ist, nil))
+	framework.Main("sidecar_api_test", m)
 }


### PR DESCRIPTION
Changes were required because:
* mgmtCluster was changed - I guess it used to be 2 ports 3333 and 9999, but now we create it as 15020 by default, but in the tests we never set the management ports. I am not sure if this should be removed, or if we should find a way to trigger a management port being created. I dug through the code a bit but wasn't sure how to do this. @costinm or @rshriram any ideas? I don't want to disable the test without cause
* BlackHoleCluster -> PassthroughCluster because ALLOW_ANY is default now