### PR TITLE
Introduce pkg/annotations

### DIFF
--- a/mixer/pkg/runtime/lang/lang.go
+++ b/mixer/pkg/runtime/lang/lang.go
@@ -21,6 +21,7 @@ import (
 	"istio.io/istio/mixer/pkg/lang/cel"
 	"istio.io/istio/mixer/pkg/lang/checker"
 	"istio.io/istio/mixer/pkg/lang/compiled"
+	"istio.io/istio/pkg/annotations"
 	"istio.io/istio/pkg/env"
 )
 
@@ -51,6 +52,8 @@ const (
 	// LanguageRuntimeAnnotation on config resources to select a language runtime
 	LanguageRuntimeAnnotation = "policy.istio.io/lang"
 )
+
+var _ = annotations.Register(LanguageRuntimeAnnotation, "Select a language runtime")
 
 var langVar = env.RegisterStringVar("ISTIO_LANG", "", "")
 

--- a/pilot/pkg/kube/inject/webhook.go
+++ b/pilot/pkg/kube/inject/webhook.go
@@ -490,7 +490,7 @@ var (
 func injectionStatus(pod *corev1.Pod) *SidecarInjectionStatus {
 	var statusBytes []byte
 	if pod.ObjectMeta.Annotations != nil {
-		if value, ok := pod.ObjectMeta.Annotations[annotationStatus.name]; ok {
+		if value, ok := pod.ObjectMeta.Annotations[annotationStatus]; ok {
 			statusBytes = []byte(value)
 		}
 	}
@@ -565,7 +565,7 @@ func (wh *Webhook) inject(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespons
 		return toAdmissionResponse(err)
 	}
 
-	annotations := map[string]string{annotationStatus.name: status}
+	annotations := map[string]string{annotationStatus: status}
 
 	patchBytes, err := createPatch(&pod, injectionStatus(&pod), annotations, spec)
 	if err != nil {

--- a/pilot/pkg/kube/inject/webhook_test.go
+++ b/pilot/pkg/kube/inject/webhook_test.go
@@ -167,7 +167,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "force-on-policy",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Annotations: map[string]string{annotationPolicy: "true"},
 			},
 			want: true,
 		},
@@ -179,7 +179,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "force-off-policy",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Annotations: map[string]string{annotationPolicy: "false"},
 			},
 			want: false,
 		},
@@ -214,7 +214,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "force-on-policy",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Annotations: map[string]string{annotationPolicy: "true"},
 			},
 			want: true,
 		},
@@ -226,7 +226,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "force-off-policy",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Annotations: map[string]string{annotationPolicy: "false"},
 			},
 			want: false,
 		},
@@ -431,7 +431,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "policy-enabled-annotation-true-never-inject",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Annotations: map[string]string{annotationPolicy: "true"},
 				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
 			},
 			want: true,
@@ -445,7 +445,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "policy-enabled-annotation-false-always-inject",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Annotations: map[string]string{annotationPolicy: "false"},
 				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
 			},
 			want: false,
@@ -459,7 +459,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "policy-disabled-annotation-false-always-inject",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "false"},
+				Annotations: map[string]string{annotationPolicy: "false"},
 				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
 			},
 			want: false,
@@ -499,7 +499,7 @@ func TestInjectRequired(t *testing.T) {
 			meta: &metav1.ObjectMeta{
 				Name:        "policy-disabled-annotation-true-never-inject",
 				Namespace:   "test-namespace",
-				Annotations: map[string]string{annotationPolicy.name: "true"},
+				Annotations: map[string]string{annotationPolicy: "true"},
 				Labels:      map[string]string{"foo": "", "foo2": "bar2"},
 			},
 			want: true,
@@ -1027,7 +1027,7 @@ func deploymentToYaml(deployment *extv1beta1.Deployment, t *testing.T) []byte {
 func normalizeAndCompareDeployments(got, want *extv1beta1.Deployment, t *testing.T) error {
 	t.Helper()
 	// Scrub unimportant fields that tend to differ.
-	annotations(got)[annotationStatus.name] = annotations(want)[annotationStatus.name]
+	getAnnotations(got)[annotationStatus] = getAnnotations(want)[annotationStatus]
 	gotIstioCerts := istioCerts(got)
 	wantIstioCerts := istioCerts(want)
 	gotIstioCerts.Secret.DefaultMode = wantIstioCerts.Secret.DefaultMode
@@ -1077,7 +1077,7 @@ func normalizeAndCompareDeployments(got, want *extv1beta1.Deployment, t *testing
 	return util.Compare([]byte(gotString), []byte(wantString))
 }
 
-func annotations(d *extv1beta1.Deployment) map[string]string {
+func getAnnotations(d *extv1beta1.Deployment) map[string]string {
 	return d.Spec.Template.ObjectMeta.Annotations
 }
 
@@ -1132,7 +1132,7 @@ func makeTestData(t testing.TB, skip bool) []byte {
 	}
 
 	if skip {
-		pod.ObjectMeta.Annotations[annotationPolicy.name] = "false"
+		pod.ObjectMeta.Annotations[annotationPolicy] = "false"
 	}
 
 	raw, err := json.Marshal(&pod)

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"istio.io/istio/pkg/annotations"
+
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
@@ -580,7 +582,7 @@ const (
 	// NodeMetadataTLSClientRootCert is the absolute path to client root cert file
 	NodeMetadataTLSClientRootCert = "TLS_CLIENT_ROOT_CERT"
 
-	// NodeMetadataPolicyCheckRetries determines the policy for behavior when unable to connect to mixer
+	// NodeMetadataPolicyCheck determines the policy for behavior when unable to connect to mixer
 	// If not set, FAIL_CLOSE is set, rejecting requests.
 	NodeMetadataPolicyCheck = "policy.istio.io/check"
 
@@ -595,6 +597,17 @@ const (
 	// NodeMetadataPolicyCheckMaxRetryWaitTime for max time to wait between retries
 	// In duration format. If not set, this will be 1000ms.
 	NodeMetadataPolicyCheckMaxRetryWaitTime = "policy.istio.io/checkMaxRetryWaitTime"
+)
+
+var (
+	_ = annotations.Register(NodeMetadataPolicyCheck,
+		"Determines the policy for behavior when unable to connect to Mixer. If not set, FAIL_CLOSE is set, rejecting requests.")
+	_ = annotations.Register(NodeMetadataPolicyCheckRetries,
+		"The maximum number of retries on transport errors to Mixer. If not set, this will be 0, indicating no retries.")
+	_ = annotations.Register(NodeMetadataPolicyCheckBaseRetryWaitTime,
+		"Base time to wait between retries, will be adjusted by backoff and jitter. In duration format. If not set, this will be 80ms.")
+	_ = annotations.Register(NodeMetadataPolicyCheckMaxRetryWaitTime,
+		"Maximum time to wait between retries to Mixer. In duration format. If not set, this will be 1000ms.")
 )
 
 // TrafficInterceptionMode indicates how traffic to/from the workload is captured and

--- a/pkg/annotations/annotation.go
+++ b/pkg/annotations/annotation.go
@@ -1,0 +1,90 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package annotations makes it possible to track use of resource annotations within a procress
+// in order to generate documentation for these uses.
+package annotations
+
+import (
+	"sort"
+	"sync"
+
+	"istio.io/istio/pkg/log"
+)
+
+// Annotation describes a single resource annotation
+type Annotation struct {
+	// The name of the annotation.
+	Name string
+
+	// Description of the annotation.
+	Description string
+
+	// Hide the existence of this annotation when outputting usage information.
+	Hidden bool
+
+	// Mark this annotation as deprecated when generating usage information.
+	Deprecated bool
+}
+
+var allAnnotations = make(map[string]Annotation)
+var mutex sync.Mutex
+
+// Returns a description of this process' annotations, sorted by name.
+func Descriptions() []Annotation {
+	mutex.Lock()
+	sorted := make([]Annotation, 0, len(allAnnotations))
+	for _, v := range allAnnotations {
+		sorted = append(sorted, v)
+	}
+	mutex.Unlock()
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+
+	return sorted
+}
+
+// Register registers a new annotation.
+func Register(name string, description string) Annotation {
+	a := Annotation{Name: name, Description: description}
+	RegisterFull(a)
+
+	// get what's actually been registered
+	mutex.Lock()
+	result := allAnnotations[name]
+	mutex.Unlock()
+
+	return result
+}
+
+// RegisterFull registers a new annotation.
+func RegisterFull(a Annotation) {
+	mutex.Lock()
+
+	if old, ok := allAnnotations[a.Name]; ok {
+		if a.Description != "" {
+			allAnnotations[a.Name] = a // last one with a description wins if the same annotation name is registered multiple times
+		}
+
+		if old.Description != a.Description || old.Deprecated != a.Deprecated || old.Hidden != a.Hidden {
+			log.Warnf("The annotation %s was registered multiple times using different metadata: %v, %v", a.Name, old, a)
+		}
+	} else {
+		allAnnotations[a.Name] = a
+	}
+
+	mutex.Unlock()
+}

--- a/pkg/annotations/annotation_test.go
+++ b/pkg/annotations/annotation_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package env makes it possible to track use of environment variables within procress
+// in order to generate documentation for these uses.
+package annotations
+
+import (
+	"os"
+	"testing"
+)
+
+const testAnnotation = "TESTXYZ"
+
+func reset() {
+	_ = os.Unsetenv(testAnnotation)
+	mutex.Lock()
+	allAnnotations = make(map[string]Annotation)
+	mutex.Unlock()
+}
+
+func TestBasic(t *testing.T) {
+	reset()
+
+	_ = Register(testAnnotation+"2", "Two")
+	_ = Register(testAnnotation+"0", "Zero")
+	_ = Register(testAnnotation+"1", "One")
+
+	a := Descriptions()
+	if a[0].Name != "TESTXYZ0" {
+		t.Errorf("Expecting TESTXYZ0, got %s", a[0].Name)
+	}
+	if a[0].Description != "Zero" {
+		t.Errorf("Expected 'Zero', got '%s'", a[0].Description)
+	}
+
+	if a[1].Name != "TESTXYZ1" {
+		t.Errorf("Expecting TESTXYZ1, got %s", a[0].Name)
+	}
+	if a[1].Description != "One" {
+		t.Errorf("Expected 'One', got '%s'", a[0].Description)
+	}
+
+	if a[2].Name != "TESTXYZ2" {
+		t.Errorf("Expecting TESTXYZ2, got %s", a[0].Name)
+	}
+	if a[2].Description != "Two" {
+		t.Errorf("Expected '2', got '%s'", a[0].Description)
+	}
+}
+
+func TestDupes(t *testing.T) {
+	// make sure annotation without a description doesn't overwrite one with
+	reset()
+	_ = Register(testAnnotation, "XYZ")
+	a := Register(testAnnotation, "")
+	if a.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", a.Description)
+	}
+
+	// make sure annotation without a description doesn't overwrite one with
+	reset()
+	_ = Register(testAnnotation, "")
+	a = Register(testAnnotation, "XYZ")
+	if a.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", a.Description)
+	}
+}

--- a/pkg/bootstrap/bootstrap_config.go
+++ b/pkg/bootstrap/bootstrap_config.go
@@ -27,6 +27,8 @@ import (
 	"text/template"
 	"time"
 
+	"istio.io/istio/pkg/annotations"
+
 	"github.com/gogo/protobuf/types"
 
 	meshconfig "istio.io/api/mesh/v1alpha1"
@@ -53,6 +55,8 @@ const (
 	// statsPatterns gives the developer control over Envoy stats collection
 	EnvoyStatsMatcherInclusionPatterns = "sidecar.istio.io/statsInclusionPrefixes"
 )
+
+var _ = annotations.Register(EnvoyStatsMatcherInclusionPatterns, "Control over Envoy stats collection.")
 
 var (
 	// default value for EnvoyStatsMatcherInclusionPatterns

--- a/pkg/env/var.go
+++ b/pkg/env/var.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package env makes it possible to track use of environment variables within procress
+// Package env makes it possible to track use of environment variables within a procress
 // in order to generate documentation for these uses.
 package env
 
@@ -106,21 +106,21 @@ func VarDescriptions() []Var {
 func RegisterStringVar(name string, defaultValue string, description string) StringVar {
 	v := Var{Name: name, DefaultValue: defaultValue, Description: description, Type: STRING}
 	RegisterVar(v)
-	return StringVar{v}
+	return StringVar{getVar(name)}
 }
 
 // RegisterBoolVar registers a new boolean environment variable.
 func RegisterBoolVar(name string, defaultValue bool, description string) BoolVar {
 	v := Var{Name: name, DefaultValue: strconv.FormatBool(defaultValue), Description: description, Type: BOOL}
 	RegisterVar(v)
-	return BoolVar{v}
+	return BoolVar{getVar(name)}
 }
 
 // RegisterIntVar registers a new integer environment variable.
 func RegisterIntVar(name string, defaultValue int, description string) IntVar {
 	v := Var{Name: name, DefaultValue: strconv.FormatInt(int64(defaultValue), 10), Description: description, Type: INT}
 	RegisterVar(v)
-	return IntVar{v}
+	return IntVar{getVar(name)}
 }
 
 // RegisterFloatVar registers a new floating-point environment variable.
@@ -134,7 +134,7 @@ func RegisterFloatVar(name string, defaultValue float64, description string) Flo
 func RegisterDurationVar(name string, defaultValue time.Duration, description string) DurationVar {
 	v := Var{Name: name, DefaultValue: defaultValue.String(), Description: description, Type: DURATION}
 	RegisterVar(v)
-	return DurationVar{v}
+	return DurationVar{getVar(name)}
 }
 
 // RegisterVar registers a generic environment variable.
@@ -150,10 +150,18 @@ func RegisterVar(v Var) {
 			log.Warnf("The environment variable %s was registered multiple times using different metadata: %v, %v", v.Name, old, v)
 		}
 	} else {
-		allVars[v.Name] = v // last one with a description wins if the same variable name is registered multiple times
+		allVars[v.Name] = v
 	}
 
 	mutex.Unlock()
+}
+
+func getVar(name string) Var {
+	mutex.Lock()
+	result := allVars[name]
+	mutex.Unlock()
+
+	return result
 }
 
 func (v StringVar) Get() string {

--- a/pkg/env/var_test.go
+++ b/pkg/env/var_test.go
@@ -310,3 +310,22 @@ func TestDesc(t *testing.T) {
 		t.Errorf("Expected 'A duration', got '%s'", vars[0].Description)
 	}
 }
+
+func TestDupes(t *testing.T) {
+
+	// make sure var without a description doesn't overwrite one with
+	reset()
+	_ = RegisterStringVar(testVar, "123", "XYZ")
+	v := RegisterStringVar(testVar, "123", "")
+	if v.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", v.Description)
+	}
+
+	// make sure var without a description doesn't overwrite one with
+	reset()
+	_ = RegisterStringVar(testVar, "123", "")
+	v = RegisterStringVar(testVar, "123", "XYZ")
+	if v.Description != "XYZ" {
+		t.Errorf("Expected 'XYZ', got '%s'", v.Description)
+	}
+}


### PR DESCRIPTION
- pkg/annotations lets us track the annotations used by the calling process.

- pkg/collateral now outputs annotations if there are any. This will make annotations
show up on istio.io

- Adjusted how pkg/collateral handles deprecated environment variabes to match how we
handle deprecated fields in protos (by coloring them differently on istio.io)

- Added another test to pkg/env to cover a case I missed originally.

- Updated the sidecar injector and pilot to use pkg/annotations.

- Fixed some invalid HTML generated by pkg/collateral.

I'll file an issue to get descriptions added for the annotations.