### PR TITLE
Fixes #12873. Allow Sidecar to override Outbound Traffic Policy

### DIFF
--- a/pilot/pkg/model/sidecar.go
+++ b/pilot/pkg/model/sidecar.go
@@ -81,6 +81,11 @@ type SidecarScope struct {
 	// sidecarScope object. Contains the outbound clusters only, indexed
 	// by localities
 	CDSOutboundClusters map[string][]*xdsapi.Cluster
+
+	// OutboundTrafficPolicy defines the outbound traffic policy for this sidecar.
+	// If OutboundTrafficPolicy is ALLOW_ANY traffic to unknown destinations will
+	// be forwarded.
+	OutboundTrafficPolicy *networking.OutboundTrafficPolicy
 }
 
 // IstioEgressListenerWrapper is a wrapper for
@@ -195,6 +200,16 @@ func ConvertToSidecarScope(ps *PushContext, sidecarConfig *Config, configNamespa
 	out.destinationRules = make(map[Hostname]*Config)
 	for _, s := range out.services {
 		out.destinationRules[s.Hostname] = ps.DestinationRule(&dummyNode, s)
+	}
+
+	if r.OutboundTrafficPolicy == nil {
+		if ps.Env.Mesh.OutboundTrafficPolicy != nil {
+			out.OutboundTrafficPolicy = &networking.OutboundTrafficPolicy{
+				Mode: networking.OutboundTrafficPolicy_Mode(ps.Env.Mesh.OutboundTrafficPolicy.Mode),
+			}
+		}
+	} else {
+		out.OutboundTrafficPolicy = r.OutboundTrafficPolicy
 	}
 
 	out.Config = sidecarConfig


### PR DESCRIPTION
This PR fixes #12873.
It has to be used with the corresponding API change that is currently in https://github.com/istio/api/pull/887

It adds the field OutboundTrafficPolicy to the Sidecar configuration so that it is possible to override this policy per workload.

If I could use only one type in the change to the API, the code in sidecar.go would come a bit simpler and would not have to make a elementwise copy of the message.