### PR TITLE
Add wildcard route fallthrough (Fixes ALLOW_ANY, 404s)

### DIFF
--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -510,11 +510,6 @@ const (
 	// Alpha in 1.1, based on feedback may be turned into an API or change. Set to "1" to enable.
 	NodeMetadataHTTP10 = "HTTP10"
 
-	// NodeMetadataFallthroughRoute provides an option to add a final wildcard match for routes.
-	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
-	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
-	NodeMetadataFallthroughRoute = "sidecar.istio.io/enableFallthroughRoute"
-
 	// NodeMetadataConfigNamespace is the name of the metadata variable that carries info about
 	// the config namespace associated with the proxy
 	NodeMetadataConfigNamespace = "CONFIG_NAMESPACE"

--- a/pilot/pkg/model/context.go
+++ b/pilot/pkg/model/context.go
@@ -510,6 +510,11 @@ const (
 	// Alpha in 1.1, based on feedback may be turned into an API or change. Set to "1" to enable.
 	NodeMetadataHTTP10 = "HTTP10"
 
+	// NodeMetadataFallthroughRoute provides an option to add a final wildcard match for routes.
+	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
+	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
+	NodeMetadataFallthroughRoute = "sidecar.istio.io/enableFallthroughRoute"
+
 	// NodeMetadataConfigNamespace is the name of the metadata variable that carries info about
 	// the config namespace associated with the proxy
 	NodeMetadataConfigNamespace = "CONFIG_NAMESPACE"

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -22,10 +22,12 @@ import (
 	xdsapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
 	"istio.io/istio/pilot/pkg/networking/plugin"
 	"istio.io/istio/pilot/pkg/networking/util"
+	"istio.io/istio/pkg/features/pilot"
 	"istio.io/istio/pkg/proto"
 )
 
@@ -196,6 +198,46 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 	}
 
 	util.SortVirtualHosts(virtualHosts)
+
+	if pilot.EnableFallthroughRoute || node.Metadata[model.NodeMetadataFallthroughRoute] == "1" {
+		// This needs to be the last virtual host, as routes are evaluated in order.
+		if env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
+			virtualHosts = append(virtualHosts, route.VirtualHost{
+				Name:    "allow_any",
+				Domains: []string{"*"},
+				Routes: []route.Route{
+					{
+						Match: route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+						},
+						Action: &route.Route_Route{
+							Route: &route.RouteAction{
+								ClusterSpecifier: &route.RouteAction_Cluster{Cluster: util.PassthroughCluster},
+							},
+						},
+					},
+				},
+			})
+		} else {
+			virtualHosts = append(virtualHosts, route.VirtualHost{
+				Name:    "block_all",
+				Domains: []string{"*"},
+				Routes: []route.Route{
+					{
+						Match: route.RouteMatch{
+							PathSpecifier: &route.RouteMatch_Prefix{Prefix: "/"},
+						},
+						Action: &route.Route_DirectResponse{
+							DirectResponse: &route.DirectResponseAction{
+								Status: 502,
+							},
+						},
+					},
+				},
+			})
+		}
+	}
+
 	out := &xdsapi.RouteConfiguration{
 		Name:             routeName,
 		VirtualHosts:     virtualHosts,

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -199,7 +199,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 
 	util.SortVirtualHosts(virtualHosts)
 
-	if pilot.EnableFallthroughRoute || node.Metadata[model.NodeMetadataFallthroughRoute] == "1" {
+	if pilot.EnableFallthroughRoute {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
 			virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/httproute.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute.go
@@ -199,7 +199,7 @@ func (configgen *ConfigGeneratorImpl) buildSidecarOutboundHTTPRouteConfig(env *m
 
 	util.SortVirtualHosts(virtualHosts)
 
-	if pilot.EnableFallthroughRoute {
+	if pilot.EnableFallthroughRoute() {
 		// This needs to be the last virtual host, as routes are evaluated in order.
 		if env.Mesh.OutboundTrafficPolicy.Mode == meshconfig.MeshConfig_OutboundTrafficPolicy_ALLOW_ANY {
 			virtualHosts = append(virtualHosts, route.VirtualHost{

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -16,6 +16,7 @@ package v1alpha3
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
@@ -305,8 +306,9 @@ func testSidecarRDSVHosts(t *testing.T, testName string, services []*model.Servi
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
 	}
+	os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "")
 	if fallthroughRoute {
-		proxy.Metadata[model.NodeMetadataFallthroughRoute] = "1"
+		os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "1")
 	}
 	if registryOnly {
 		env.Mesh.OutboundTrafficPolicy = &meshconfig.MeshConfig_OutboundTrafficPolicy{Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}

--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -153,7 +154,9 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		routeName     string
 		sidecarConfig *model.Config
 		// virtualHost Name and domains
-		expectedHosts map[string]map[string]bool
+		expectedHosts    map[string]map[string]bool
+		fallthroughRoute bool
+		registryOnly     bool
 	}{
 		{
 			name:          "sidecar config port that is not in any service",
@@ -250,15 +253,44 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true},
 			},
 		},
+		{
+			name:          "no sidecar config - import public services from other namespaces: 80 with fallthrough",
+			routeName:     "80",
+			sidecarConfig: nil,
+			expectedHosts: map[string]map[string]bool{
+				"test-private.com:80": {
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+				},
+				"allow_any": {
+					"*": true,
+				},
+			},
+			fallthroughRoute: true,
+		},
+		{
+			name:          "no sidecar config - import public services from other namespaces: 80 with fallthrough and registry only",
+			routeName:     "80",
+			sidecarConfig: nil,
+			expectedHosts: map[string]map[string]bool{
+				"test-private.com:80": {
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+				},
+				"block_all": {
+					"*": true,
+				},
+			},
+			fallthroughRoute: true,
+			registryOnly:     true,
+		},
 	}
 
 	for _, c := range cases {
-		testSidecarRDSVHosts(t, c.name, services, c.sidecarConfig, c.routeName, c.expectedHosts)
+		testSidecarRDSVHosts(t, c.name, services, c.sidecarConfig, c.routeName, c.expectedHosts, c.fallthroughRoute, c.registryOnly)
 	}
 }
 
 func testSidecarRDSVHosts(t *testing.T, testName string, services []*model.Service, sidecarConfig *model.Config,
-	routeName string, expectedHosts map[string]map[string]bool) {
+	routeName string, expectedHosts map[string]map[string]bool, fallthroughRoute bool, registryOnly bool) {
 	t.Helper()
 	p := &fakePlugin{}
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
@@ -272,6 +304,12 @@ func testSidecarRDSVHosts(t *testing.T, testName string, services []*model.Servi
 		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
+	}
+	if fallthroughRoute {
+		proxy.Metadata[model.NodeMetadataFallthroughRoute] = "1"
+	}
+	if registryOnly {
+		env.Mesh.OutboundTrafficPolicy = &meshconfig.MeshConfig_OutboundTrafficPolicy{Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
 	}
 
 	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, proxyInstances, routeName)

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -132,6 +132,11 @@ var (
 	// for cache sync before Pilot bootstrap. Set env PILOT_ENABLE_WAIT_CACHE_SYNC = 0 to disable it.
 	EnableWaitCacheSync = os.Getenv("PILOT_ENABLE_WAIT_CACHE_SYNC") != "0"
 
+	// EnableFallthroughRoute provides an option to add a final wildcard match for routes.
+	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
+	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
+	EnableFallthroughRoute = os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
+
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	DisableXDSMarshalingToAny = func() bool {
 		return os.Getenv("PILOT_DISABLE_XDS_MARSHALING_TO_ANY") == "1"

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -135,7 +135,9 @@ var (
 	// EnableFallthroughRoute provides an option to add a final wildcard match for routes.
 	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
 	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
-	EnableFallthroughRoute = os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
+	EnableFallthroughRoute = func() bool {
+		return os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
+	}
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	DisableXDSMarshalingToAny = func() bool {


### PR DESCRIPTION
Currently, ALLOW_ANY doesn't actually allow any external traffic if there is an http service already present on a port. This change adds a wildcard PassthroughCluster as the final route, allowing external traffic even if there is already a service on the port.

Additionally, in REGISTRY_ONLY mode, we will return a 404 error if there
is already an http service. This is misleading, as it can be conflated
with a 404 error returned from the actual service. When in REGISTRY_ONLY
mode, we instead return a 502 error to indicate the request is blocked.

This change is behind a flag for Pilot as well as an annotation allowing it to be turned on per workload.


Related:

- istio/istio.io/issues/3883
- 12903
- 12952
- 12760
- 7669
- https://discuss.istio.io/t/cant-hit-anything-external-in-1-1-1/1688/2