### PR TITLE
properly report errors on failure

### DIFF
--- a/tests/e2e/framework/kubernetes.go
+++ b/tests/e2e/framework/kubernetes.go
@@ -534,8 +534,10 @@ func (k *KubeInfo) Teardown() error {
 		}
 	}
 
-	// confirm the namespace is deleted as it will cause future creation to fail
-	maxAttempts := 600
+	// NB: Increasing maxAttempts much past 230 seconds causes the CI infrastructure
+	// to terminate the test run not reporting what actually failed in the deletion.
+	maxAttempts := 180
+
 	namespaceDeleted := false
 	validatingWebhookConfigurationExists := false
 	log.Infof("Deleting namespace %v", k.Namespace)


### PR DESCRIPTION
The CI Infrastructure times out after 10 minutes of no activity.  In
one of the test case runners, 10 miniutes is specified causing the CI
timeout to flush any debuggable output from the checks.  This results
in an in-exact error result to be returned.

Instead a vague reponse about the test case timing out is reported,
resulting in confusion for the PR authors.

The typical max I was able to achieve was ~230 seconds, but I trimmed
to 3 minutes so the test case fails in all conditions and properly
reports the errors.