### PR TITLE
Allow Locality Distribute without outlierDetection

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/cluster.go
+++ b/pilot/pkg/networking/core/v1alpha3/cluster.go
@@ -845,17 +845,17 @@ func applyLocalityLBSetting(
 	// locality LB is being used. For now, we sacrifice memory and create clones of
 	// clusters for every proxy that asks for locality specific clusters
 	for i, cluster := range clusters {
+		// Failover should only be applied with outlier detection, or traffic will never failover.
+		enabledFailover := cluster.OutlierDetection != nil
 		if shared {
-			// update the locality settings only if the cluster has
-			// outlier detection settings
-			if cluster.LoadAssignment != nil && cluster.OutlierDetection != nil {
+			if cluster.LoadAssignment != nil {
 				clone := util.CloneCluster(cluster)
-				loadbalancer.ApplyLocalityLBSetting(locality, clone.LoadAssignment, localityLB)
+				loadbalancer.ApplyLocalityLBSetting(locality, clone.LoadAssignment, localityLB, enabledFailover)
 				clusters[i] = &clone
 			}
 		} else {
-			if cluster.LoadAssignment != nil && cluster.OutlierDetection != nil {
-				loadbalancer.ApplyLocalityLBSetting(locality, cluster.LoadAssignment, localityLB)
+			if cluster.LoadAssignment != nil {
+				loadbalancer.ApplyLocalityLBSetting(locality, cluster.LoadAssignment, localityLB, enabledFailover)
 			}
 		}
 	}

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer.go
@@ -31,6 +31,7 @@ func ApplyLocalityLBSetting(
 	locality *core.Locality,
 	loadAssignment *apiv2.ClusterLoadAssignment,
 	localityLB *meshconfig.LocalityLoadBalancerSetting,
+	enableFailover bool,
 ) {
 	if locality == nil || loadAssignment == nil {
 		return
@@ -39,7 +40,8 @@ func ApplyLocalityLBSetting(
 	// one of Distribute or Failover settings can be applied.
 	if localityLB.GetDistribute() != nil {
 		applyLocalityWeight(locality, loadAssignment, localityLB.GetDistribute())
-	} else {
+	} else if enableFailover {
+		// Failover needs outlier detection, otherwise Envoy will never drop down to a lower priority.
 		applyLocalityFailover(locality, loadAssignment, localityLB.GetFailover())
 	}
 }

--- a/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/loadbalancer/loadbalancer_test.go
@@ -48,7 +48,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				env := buildEnvForClustersWithDistribute(tt.distribute)
 				cluster := buildFakeCluster()
-				ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting)
+				ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting, true)
 				weights := []int{}
 				for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
 					weights = append(weights, int(localityEndpoint.LoadBalancingWeight.GetValue()))
@@ -64,7 +64,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 		g := NewGomegaWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildFakeCluster()
-		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting)
+		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting, true)
 		for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
 			if localityEndpoint.Locality.Region == locality.Region {
 				if localityEndpoint.Locality.Zone == locality.Zone {
@@ -90,7 +90,7 @@ func TestApplyLocalitySetting(t *testing.T) {
 		g := NewGomegaWithT(t)
 		env := buildEnvForClustersWithFailover()
 		cluster := buildSmallCluster()
-		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting)
+		ApplyLocalityLBSetting(locality, cluster.LoadAssignment, env.Mesh.LocalityLbSetting, true)
 		for _, localityEndpoint := range cluster.LoadAssignment.Endpoints {
 			if localityEndpoint.Locality.Region == locality.Region {
 				if localityEndpoint.Locality.Zone == locality.Zone {

--- a/pilot/pkg/proxy/envoy/v2/eds.go
+++ b/pilot/pkg/proxy/envoy/v2/eds.go
@@ -825,7 +825,11 @@ func (s *DiscoveryServer) pushEds(push *model.PushContext, con *XdsConnection, e
 			// Make a shallow copy of the cla as we are mutating the endpoints with priorities/weights relative to the calling proxy
 			clonedCLA := util.CloneClusterLoadAssignment(l)
 			l = &clonedCLA
-			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting)
+			// TODO(#12961) get outlierDetection from the cluster
+			// For now, we should default to allowing Failover rather than rejecting. Even if we do not know
+			// what the outlierDetection is for the Cluster, it is reasonable to require the user to provide
+			// outlier detection without enforcing this in code, as this is an alpha feature behind a flag.
+			loadbalancer.ApplyLocalityLBSetting(con.modelNode.Locality, l, s.Env.Mesh.LocalityLbSetting, true)
 		}
 
 		endpoints += len(l.Endpoints)


### PR DESCRIPTION
See https://github.com/istio/istio/issues/12961

Failover needs outlier detection to mark hosts unhealthy and fall down
to the next priority, but this is not needed for distribute. Currently,
we don't have access to the outlier detection in EDS. For now, it is
better to effectively disable this setting in EDS than give incorrect
behavior.