### PR TITLE
Restore TestMtlsHealthCheck in postsubmit, prow.

### DIFF
--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -24,6 +24,7 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
+	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -36,6 +37,7 @@ var (
 func TestMain(m *testing.M) {
 	framework.NewSuite("mtls_healthcheck", m).
 		RequireEnvironment(environment.Kube).
+		Label(label.Presubmit).
 		Setup(istio.SetupOnKube(&ist, setupConfig)).
 		Run()
 }

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -50,7 +50,7 @@ func setupConfig(cfg *istio.Config) {
 // TestMtlsHealthCheck verifies Kubernetes HTTP health check can work when mTLS
 // is enabled.
 func TestMtlsHealthCheck(t *testing.T) {
-	t.Skip("https://github.com/istio/istio/issues/12754")
+	// t.Skip("https://github.com/istio/istio/issues/12754")
 
 	ctx := framework.NewContext(t)
 	defer ctx.Done(t)

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -35,9 +35,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
+	// We only run this test in postsubmit since that runs on prow.
+	// Presubmit runs on CircleCI, using a Minikube environment, which seems
+	// causing healthcheck app deployment timeout.
+	// For more details, see https://github.com/istio/istio/issues/12754.
 	framework.NewSuite("mtls_healthcheck", m).
 		RequireEnvironment(environment.Kube).
-		Label(label.Presubmit).
+		Label(label.Postsubmit).
 		Setup(istio.SetupOnKube(&ist, setupConfig)).
 		Run()
 }
@@ -52,8 +56,6 @@ func setupConfig(cfg *istio.Config) {
 // TestMtlsHealthCheck verifies Kubernetes HTTP health check can work when mTLS
 // is enabled.
 func TestMtlsHealthCheck(t *testing.T) {
-	// t.Skip("https://github.com/istio/istio/issues/12754")
-
 	ctx := framework.NewContext(t)
 	defer ctx.Done(t)
 	ctx.RequireOrSkip(t, environment.Kube)

--- a/tests/integration/security/healthcheck/mtls_healthcheck_test.go
+++ b/tests/integration/security/healthcheck/mtls_healthcheck_test.go
@@ -24,7 +24,6 @@ import (
 	"istio.io/istio/pkg/test/framework/components/environment"
 	"istio.io/istio/pkg/test/framework/components/namespace"
 	"istio.io/istio/pkg/test/framework/components/pilot"
-	"istio.io/istio/pkg/test/framework/label"
 
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
@@ -35,13 +34,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	// We only run this test in postsubmit since that runs on prow.
-	// Presubmit runs on CircleCI, using a Minikube environment, which seems
-	// causing healthcheck app deployment timeout.
-	// For more details, see https://github.com/istio/istio/issues/12754.
 	framework.NewSuite("mtls_healthcheck", m).
 		RequireEnvironment(environment.Kube).
-		Label(label.Postsubmit).
 		Setup(istio.SetupOnKube(&ist, setupConfig)).
 		Run()
 }
@@ -55,6 +49,8 @@ func setupConfig(cfg *istio.Config) {
 
 // TestMtlsHealthCheck verifies Kubernetes HTTP health check can work when mTLS
 // is enabled.
+// Currently this test can only pass on Prow with a real GKE cluster, and fail
+// on CircleCI with a Minikube. For more details, see https://github.com/istio/istio/issues/12754.
 func TestMtlsHealthCheck(t *testing.T) {
 	ctx := framework.NewContext(t)
 	defer ctx.Done(t)


### PR DESCRIPTION
https://github.com/istio/istio/issues/12754

- I changed this to only run in post submit, using prow. This runs 4 times and all succeed. https://k8s-gubernator.appspot.com/builds/istio-prow/pr-logs/pull/istio_istio/12969/istio-integ-k8s-tests/
- Presubmit test, using circleci and minikube, continuously timeout in healthcheck app deployment.
Given that, I changed this to only run in postsubmit for now.