### PR TITLE
Cherrypick: Add wildcard route fallthrough (Fixes ALLOW_ANY, 404s) (#12916)

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/httproute_test.go
+++ b/pilot/pkg/networking/core/v1alpha3/httproute_test.go
@@ -16,10 +16,12 @@ package v1alpha3
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"testing"
 
+	meshconfig "istio.io/api/mesh/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/plugin"
@@ -153,7 +155,9 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 		routeName     string
 		sidecarConfig *model.Config
 		// virtualHost Name and domains
-		expectedHosts map[string]map[string]bool
+		expectedHosts    map[string]map[string]bool
+		fallthroughRoute bool
+		registryOnly     bool
 	}{
 		{
 			name:          "sidecar config port that is not in any service",
@@ -250,15 +254,44 @@ func TestSidecarOutboundHTTPRouteConfig(t *testing.T) {
 				"bookinfo.com:70": {"bookinfo.com": true, "bookinfo.com:70": true},
 			},
 		},
+		{
+			name:          "no sidecar config - import public services from other namespaces: 80 with fallthrough",
+			routeName:     "80",
+			sidecarConfig: nil,
+			expectedHosts: map[string]map[string]bool{
+				"test-private.com:80": {
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+				},
+				"allow_any": {
+					"*": true,
+				},
+			},
+			fallthroughRoute: true,
+		},
+		{
+			name:          "no sidecar config - import public services from other namespaces: 80 with fallthrough and registry only",
+			routeName:     "80",
+			sidecarConfig: nil,
+			expectedHosts: map[string]map[string]bool{
+				"test-private.com:80": {
+					"test-private.com": true, "test-private.com:80": true, "9.9.9.9": true, "9.9.9.9:80": true,
+				},
+				"block_all": {
+					"*": true,
+				},
+			},
+			fallthroughRoute: true,
+			registryOnly:     true,
+		},
 	}
 
 	for _, c := range cases {
-		testSidecarRDSVHosts(t, c.name, services, c.sidecarConfig, c.routeName, c.expectedHosts)
+		testSidecarRDSVHosts(t, c.name, services, c.sidecarConfig, c.routeName, c.expectedHosts, c.fallthroughRoute, c.registryOnly)
 	}
 }
 
 func testSidecarRDSVHosts(t *testing.T, testName string, services []*model.Service, sidecarConfig *model.Config,
-	routeName string, expectedHosts map[string]map[string]bool) {
+	routeName string, expectedHosts map[string]map[string]bool, fallthroughRoute bool, registryOnly bool) {
 	t.Helper()
 	p := &fakePlugin{}
 	configgen := NewConfigGenerator([]plugin.Plugin{p})
@@ -272,6 +305,13 @@ func testSidecarRDSVHosts(t *testing.T, testName string, services []*model.Servi
 		proxy.SidecarScope = model.DefaultSidecarScopeForNamespace(env.PushContext, "not-default")
 	} else {
 		proxy.SidecarScope = model.ConvertToSidecarScope(env.PushContext, sidecarConfig, sidecarConfig.Namespace)
+	}
+	os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "")
+	if fallthroughRoute {
+		os.Setenv("PILOT_ENABLE_FALLTHROUGH_ROUTE", "1")
+	}
+	if registryOnly {
+		env.Mesh.OutboundTrafficPolicy = &meshconfig.MeshConfig_OutboundTrafficPolicy{Mode: meshconfig.MeshConfig_OutboundTrafficPolicy_REGISTRY_ONLY}
 	}
 
 	route := configgen.buildSidecarOutboundHTTPRouteConfig(&env, &proxy, env.PushContext, proxyInstances, routeName)

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -126,12 +126,12 @@ var (
 	// for cache sync before Pilot bootstrap. Set env PILOT_ENABLE_WAIT_CACHE_SYNC = 0 to disable it.
 	EnableWaitCacheSync = env.RegisterStringVar("PILOT_ENABLE_WAIT_CACHE_SYNC", "", "").Get() != "0"
 
-	// EnableFallthroughRoute provides an option to add a final wildcard match for routes.
-	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
-	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
-	EnableFallthroughRoute = func() bool {
-		return os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
-	}
+	enableFallthroughRouteVar = env.RegisterBoolVar(
+		"PILOT_ENABLE_FALLTHROUGH_ROUTE",
+		false,
+		"EnableFallthroughRoute provides an option to add a final wildcard match for routes. When ALLOW_ANY traffic policy is used, a Passthrough cluster is used. When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
+	)
+	EnableFallthroughRoute = enableFallthroughRouteVar.Get
 
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	disableXDSMarshalingToAnyVar = env.RegisterStringVar("PILOT_DISABLE_XDS_MARSHALING_TO_ANY", "", "")

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -129,7 +129,9 @@ var (
 	enableFallthroughRouteVar = env.RegisterBoolVar(
 		"PILOT_ENABLE_FALLTHROUGH_ROUTE",
 		false,
-		"EnableFallthroughRoute provides an option to add a final wildcard match for routes. When ALLOW_ANY traffic policy is used, a Passthrough cluster is used. When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
+		"EnableFallthroughRoute provides an option to add a final wildcard match for routes. "+
+			"When ALLOW_ANY traffic policy is used, a Passthrough cluster is used. "+
+			"When REGISTRY_ONLY traffic policy is used, a 502 error is returned.",
 	)
 	EnableFallthroughRoute = enableFallthroughRouteVar.Get
 

--- a/pkg/features/pilot/pilot.go
+++ b/pkg/features/pilot/pilot.go
@@ -126,6 +126,13 @@ var (
 	// for cache sync before Pilot bootstrap. Set env PILOT_ENABLE_WAIT_CACHE_SYNC = 0 to disable it.
 	EnableWaitCacheSync = env.RegisterStringVar("PILOT_ENABLE_WAIT_CACHE_SYNC", "", "").Get() != "0"
 
+	// EnableFallthroughRoute provides an option to add a final wildcard match for routes.
+	// When ALLOW_ANY traffic policy is used, a Passthrough cluster is used.
+	// When REGISTRY_ONLY traffic policy is used, a 502 error is returned.
+	EnableFallthroughRoute = func() bool {
+		return os.Getenv("PILOT_ENABLE_FALLTHROUGH_ROUTE") == "1"
+	}
+
 	// DisableXDSMarshalingToAny provides an option to disable the "xDS marshaling to Any" feature ("on" by default).
 	disableXDSMarshalingToAnyVar = env.RegisterStringVar("PILOT_DISABLE_XDS_MARSHALING_TO_ANY", "", "")
 	DisableXDSMarshalingToAny    = func() bool {


### PR DESCRIPTION
Cherry pick of: https://github.com/istio/istio/pull/12916

* Add wildcard route fallthrough

Currently, ALLOW_ANY doesn't actually allow any external traffic if there is an http service already present on a port. This change adds a wildcard PassthroughCluster as the final route, allowing external traffic even if there is already a service on the port.

Additionally, in REGISTRY_ONLY mode, we will return a 404 error if there
is already an http service. This is misleading, as it can be conflated
with a 404 error returned from the actual service. When in REGISTRY_ONLY
mode, we instead return a 502 error to indicate the request is blocked.

* add unit tests

* Remove node-level flag

* Fix tests