### PR TITLE
Update integration test env flag

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -37,7 +37,7 @@ When running tests, only one environment can be specified:
 
 ```console
 $ go test ./... -istio.test.env native
-$ go test ./... -istio.test.env kubernetes
+$ go test ./... -istio.test.env kube
 ```
 
 By default, the tests will be executed in the
@@ -62,7 +62,7 @@ file for the cluster you need to use. **Be aware that any existing Istio deploym
 removed**.
 
 ```console
-$ go test ./...  -istio.test.env kubernetes -istio.test.kube.config ~/.kube/config
+$ go test ./...  -istio.test.env kube -istio.test.kube.config ~/.kube/config
 ```
 
 ## Adding New Tests

--- a/tests/integration/tests.mk
+++ b/tests/integration/tests.mk
@@ -49,7 +49,7 @@ test.integration.all: test.integration test.integration.kube
 # Generate integration test targets for kubernetes environment.
 test.integration.%.kube:
 	$(GO) test -p 1 ${T} ./tests/integration/$*/... ${_INTEGRATION_TEST_WORKDIR_FLAG} ${_INTEGRATION_TEST_CIMODE_FLAG} -timeout 30m \
-	--istio.test.env kubernetes \
+	--istio.test.env kube \
 	--istio.test.kube.config ${INTEGRATION_TEST_KUBECONFIG} \
 	--istio.test.hub=${HUB} \
 	--istio.test.tag=${TAG} \


### PR DESCRIPTION
The flag should be "kube" not "kubernetes" but it was not updated in
some places before.