### PR TITLE
Fixing EDS unit tests

### DIFF
--- a/pilot/pkg/proxy/envoy/v2/eds_test.go
+++ b/pilot/pkg/proxy/envoy/v2/eds_test.go
@@ -244,6 +244,22 @@ func edsUpdates(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	testTCPEndpoints("127.0.0.3", adsc, t)
 }
 
+// edsFullUpdateCheck checks for updates required in a full push after the CDS update
+func edsFullUpdateCheck(adsc *adsc.ADSC, t *testing.T) {
+	upd, err := adsc.Wait("eds", 5*time.Second)
+	if err != nil {
+		t.Fatal("Expecting EDS update as part of a full push", err, upd)
+	}
+	upd, err = adsc.Wait("lds", 5*time.Second)
+	if err != nil {
+		t.Fatal("Expecting LDS update as part of a full push", err, upd)
+	}
+	upd, err = adsc.Wait("rds", 5*time.Second)
+	if err != nil {
+		t.Fatal("Expecting RDS update as part of a full push", err, upd)
+	}
+}
+
 // This test must be run in isolation, can't be parallelized with any other v2 test.
 // It makes different kind of updates, and checks that incremental or full push happens.
 // In particular:
@@ -285,9 +301,7 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	if upd != "cds" || err != nil {
 		t.Fatal("Expecting full push after service account update", err, upd)
 	}
-	adsc.Wait("rds", 5*time.Second)
-	// LDS also asks for an update
-	adsc.Wait("rds", 5*time.Second)
+	edsFullUpdateCheck(adsc, t)
 	testTCPEndpoints("127.0.0.3", adsc, t)
 
 	// Update the endpoint again, no SA change - expect incremental
@@ -307,11 +321,18 @@ func edsUpdateInc(server *bootstrap.Server, adsc *adsc.ADSC, t *testing.T) {
 	if upd != "cds" || err != nil {
 		t.Fatal("Expecting full push after label update", err, upd)
 	}
-	adsc.Wait("lds", 5*time.Second)
+	edsFullUpdateCheck(adsc, t)
 	testTCPEndpoints("127.0.0.4", adsc, t)
 
 	// Update the endpoint again, no label change - expect incremental
+	server.EnvoyXdsServer.MemRegistry.SetEndpoints(edsIncSvc,
+		newEndpointWithAccount("127.0.0.5", "account2", "v1"))
 
+	upd, err = adsc.Wait("", 5*time.Second)
+	if upd != "eds" || err != nil {
+		t.Fatal("Expecting eds push ", err, upd)
+	}
+	testTCPEndpoints("127.0.0.5", adsc, t)
 }
 
 // Make a direct EDS grpc request to pilot, verify the result is as expected.


### PR DESCRIPTION
The current EDS test is incorrect and passes because the check calls time
out rather than sucessfully completing. This PR fixes the problem and
add one more test.

fixes issue #12994