### PR TITLE
first change to apps/v1 for Install

### DIFF
--- a/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-        istio: citadel
+      istio: citadel
   template:
     metadata:
       labels:

--- a/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-plugin-certs.yaml.tmpl
@@ -7,13 +7,18 @@ metadata:
   name: istio-citadel-service-account
   namespace: {ISTIO_NAMESPACE}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-citadel
   namespace: {ISTIO_NAMESPACE}
+  labels:
+    istio: citadel
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+        istio: citadel
   template:
     metadata:
       labels:

--- a/install/kubernetes/citadel_extras/istio-citadel-standalone.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-standalone.yaml.tmpl
@@ -42,13 +42,18 @@ metadata:
   name: istio-citadel-service-account
   namespace: {ISTIO_NAMESPACE}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-standalone-citadel
   namespace: {ISTIO_NAMESPACE}
+  labels:
+    istio: standalone-citadel
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      istio: standalone-citadel
   template:
     metadata:
       labels:

--- a/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
+++ b/install/kubernetes/citadel_extras/istio-citadel-with-health-check.yaml.tmpl
@@ -22,13 +22,23 @@ spec:
     istio: citadel
 ---
 # Citadel watching all namespaces
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-citadel
   namespace: {ISTIO_NAMESPACE}
+  labels:
+    app: security
+    chart: security
+    heritage: Tiller
+    release: istio
+    istio: citadel
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: security
+      istio: citadel
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-galley
@@ -11,6 +11,9 @@ metadata:
     istio: galley
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      istio: galley
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{- range $key, $spec := .Values }}
 {{- if ne $key "enabled" }}
 {{- if $spec.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $key }}
@@ -21,6 +21,9 @@ spec:
   replicas: 1
 {{- end }}
 {{- end }}
+  selector:
+    matchLabels:
+        {{ $key }}: {{ $val }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/gateways/templates/deployment.yaml
@@ -23,7 +23,9 @@ spec:
 {{- end }}
   selector:
     matchLabels:
-        {{ $key }}: {{ $val }}
+      {{- range $key, $val := $spec.labels }}
+      {{ $key }}: {{ $val }}
+      {{- end }}
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/grafana/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: grafana
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/istiocoredns/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istiocoredns
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: istiocoredns
   template:
     metadata:
       name: istiocoredns

--- a/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/kiali/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kiali

--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -352,7 +352,7 @@
 {{- range $key, $spec := .Values }}
 {{- if or (eq $key "policy") (eq $key "telemetry") }}
 {{- if $spec.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-{{ $key }}

--- a/install/kubernetes/helm/istio/charts/nodeagent/templates/daemonset.yaml
+++ b/install/kubernetes/helm/istio/charts/nodeagent/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: istio-nodeagent
@@ -10,6 +10,9 @@ metadata:
     heritage: {{ .Release.Service }}
     istio: nodeagent
 spec:
+  selector:
+    matchLabels:
+      istio: nodeagent
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-pilot

--- a/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/prometheus/templates/deployment.yaml
@@ -1,5 +1,5 @@
 # TODO: the original template has service account, roles, etc
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus

--- a/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/security/templates/deployment.yaml
@@ -1,5 +1,5 @@
 # istio CA watching all namespaces
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-citadel
@@ -12,6 +12,9 @@ metadata:
     istio: citadel
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      istio: citadel
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/servicegraph/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: servicegraph
@@ -10,6 +10,9 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: servicegraph
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-sidecar-injector
@@ -11,6 +11,9 @@ metadata:
     istio: sidecar-injector
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      istio: sidecar-injector
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-jaeger.yaml
@@ -1,6 +1,6 @@
 {{ if eq .Values.provider "jaeger" }}
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-tracing
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: jaeger
   template:
     metadata:
       labels:

--- a/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
+++ b/install/kubernetes/helm/istio/charts/tracing/templates/deployment-zipkin.yaml
@@ -1,6 +1,6 @@
 {{ if eq .Values.provider "zipkin" }}
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: istio-tracing
@@ -11,6 +11,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 spec:
+  selector:
+    matchLabels:
+      app: zipkin
   template:
     metadata:
       labels:


### PR DESCRIPTION
First check in changes for installation yaml to consume K8s changes : 
These resources have been deprecated since k8s v1.9 and are planned to no longer be served starting in k8s v1.16 (c.f. kubernetes/kubernetes#43214)

details are in https://github.com/istio/istio/issues/12211