### PR TITLE
Add istioctl completion to the 'istioctl' make target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ security/cmd/node_agent/na/cert_file
 security/cmd/node_agent/na/pkey
 # Test artifacts
 tests/e2e/local/minikube/docker-machine-driver-hyperkit
+# istioctl bash completion file
+tools/istioctl.bash

--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,8 @@ $(foreach ITEM,$(PILOT_GO_BINS_SHORT),$(eval $(call pilotbuild,$(ITEM))))
 .PHONY: istioctl
 istioctl ${ISTIO_OUT}/istioctl:
 	bin/gobuild.sh ${ISTIO_OUT}/istioctl ./istioctl/cmd/istioctl
+	${ISTIO_OUT}/istioctl collateral --bash && \
+	mv istioctl.bash ${ISTIO_OUT}/tools
 
 # Non-static istioctls. These are typically a build artifact.
 ${ISTIO_OUT}/istioctl-linux: depend


### PR DESCRIPTION
Adds the `istioctl collateral --bash` command to automatically generate the istioctl.bash completion file as part of the `istioctl` make target.

Addresses: #12607 

Signed-off-by: Jason Clark <jason.clark.oss@gmail.com>